### PR TITLE
Phase 1: enrich workflow catalog evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ omh update --from-skills-dir ./skills
 omh apply --dry-run
 omh runtime record --skill oh-my-hermes --harness coding-handling --status started
 omh runtime runs
+omh docs workflows
 omh list
 omh snippet --dry-run
 omh uninstall
@@ -154,6 +155,7 @@ it could mean normal conversation.
 | `omh runtime status` | Inspect local runtime artifact state. |
 | `omh runtime record` | Create a metadata-only workflow run artifact. |
 | `omh runtime delegate` | Record observed or unavailable delegation for a run. |
+| `omh docs workflows` | Print or verify the generated workflow reference from catalog data. |
 | `omh snippet` | Print optional workspace guidance without applying it. |
 | `omh uninstall` | Remove Hermes config registration, optionally removing files. |
 

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -1,0 +1,639 @@
+# Workflow Reference
+
+This file is generated from `src/skills/catalog.py`. Update the catalog first, then refresh this document.
+
+The reference describes prompt-level Hermes workflow guidance and local evidence expectations. It does not claim hidden Hermes runtime behavior.
+
+## Skills
+
+### oh-my-hermes
+
+Router guidance for using oh-my-hermes workflow skills inside Hermes Agent.
+
+- Category: `router`
+- Phase: `routing`
+- Use when: Use as the top-level router when a request references oh-my-hermes, installed workflows, or ambiguous workflow routing.
+- Strong routing signals: `oh-my-hermes`, `omh`, `skill routing`, `workflow routing`
+- Required inputs:
+  - user request
+  - installed skill descriptions
+  - Hermes skill discovery context
+- Expected outputs:
+  - selected workflow guidance
+  - clarification question when routing is ambiguous
+- Artifact expectations:
+  - runtime run record when a wrapper can observe request handling
+- Safety rules:
+  - Prefer explicit skill invocation over weak keyword inference.
+  - Ask one concise question when routing signals conflict.
+  - Do not claim to override Hermes core routing.
+
+### ralph
+
+Hermes Ralph workflow: persistent execution with verification and review.
+
+- Category: `execution`
+- Phase: `completion`
+- Use when: Use after scope is concrete and the user wants one owner to continue through implementation and verification.
+- Strong routing signals: `ralph`, `$ralph`, `finish until done`, `persistent execution`, `self-referential loop`
+- Required inputs:
+  - concrete scope
+  - acceptance criteria
+  - verification commands
+- Expected outputs:
+  - completed work summary
+  - verification evidence
+  - remaining risks
+- Artifact expectations:
+  - goal-execution run record
+  - checkpoint or final evidence when available
+- Safety rules:
+  - Do not imply hidden Hermes runtime behavior.
+  - Use the smallest verification that can prove the claim.
+
+### ultragoal
+
+Hermes Ultragoal workflow: file-backed durable goal ledgers.
+
+- Category: `execution`
+- Phase: `durable-goals`
+- Use when: Use when work needs durable goal artifacts, checkpointed progress, and final quality gates.
+- Strong routing signals: `ultragoal`, `$ultragoal`, `durable goal`, `multi-goal`, `goal ledger`
+- Required inputs:
+  - goal statement
+  - acceptance criteria
+  - current checkpoint
+- Expected outputs:
+  - goal ledger updates
+  - checkpoint evidence
+  - completion or blocker summary
+- Artifact expectations:
+  - goal ledger or checklist
+  - runtime run record for each major checkpoint
+- Safety rules:
+  - Do not imply hidden Hermes runtime behavior.
+  - Use the smallest verification that can prove the claim.
+
+### deep-interview
+
+Hermes Deep Interview workflow: one-question-at-a-time clarification.
+
+- Category: `clarification`
+- Phase: `discovery`
+- Use when: Use before planning or execution when requirements are materially ambiguous.
+- Strong routing signals: `deep-interview`, `$deep-interview`, `interview`, `don't assume`, `clarify`
+- Required inputs:
+  - initial request
+  - known repo facts
+  - current ambiguity
+- Expected outputs:
+  - clarified brief
+  - non-goals
+  - decision boundaries
+- Artifact expectations:
+  - clarity summary or transcript when the wrapper supports it
+- Safety rules:
+  - Ask one question at a time.
+  - Gather discoverable repo facts before asking the user.
+  - Stop interviewing once ambiguity is low enough to plan.
+
+### team
+
+Hermes Team workflow: coordinated parallel or sequential work lanes.
+
+- Category: `execution`
+- Phase: `coordination`
+- Use when: Use when multiple independent lanes materially improve throughput or verification.
+- Strong routing signals: `team`, `$team`, `swarm`, `parallel agents`, `coordinated workers`
+- Required inputs:
+  - bounded lane definitions
+  - ownership boundaries
+  - verification target
+- Expected outputs:
+  - lane results
+  - integration summary
+  - combined verification evidence
+- Artifact expectations:
+  - delegation record only when separate participants are observed
+- Safety rules:
+  - Use parallel lanes only when work is independent.
+  - Keep shared-file edits under one owner.
+  - Record unobserved delegation as not_observed.
+
+### ultraqa
+
+Hermes UltraQA workflow: adversarial QA and fix loops.
+
+- Category: `verification`
+- Phase: `qa`
+- Use when: Use when the task needs adversarial test scenarios, verification, and fix loops.
+- Strong routing signals: `ultraqa`, `$ultraqa`, `adversarial qa`, `hostile scenarios`, `e2e qa`
+- Required inputs:
+  - changed behavior
+  - acceptance criteria
+  - known risk areas
+- Expected outputs:
+  - adversarial scenarios
+  - pass/fail evidence
+  - fix recommendations
+- Artifact expectations:
+  - QA scenario evidence
+  - runtime verification summary
+- Safety rules:
+  - Do not imply hidden Hermes runtime behavior.
+  - Use the smallest verification that can prove the claim.
+
+### plan
+
+Hermes Plan workflow: structured planning before execution.
+
+- Category: `planning`
+- Phase: `plan`
+- Use when: Use for structured planning when implementation is not ready to start safely.
+- Strong routing signals: `plan`, `$plan`, `implementation plan`, `strategy`, `task breakdown`
+- Required inputs:
+  - requirements
+  - constraints
+  - known facts
+  - non-goals
+- Expected outputs:
+  - plan
+  - acceptance criteria
+  - verification strategy
+- Artifact expectations:
+  - plan artifact when durable execution will follow
+- Safety rules:
+  - Do not imply hidden Hermes runtime behavior.
+  - Use the smallest verification that can prove the claim.
+
+### ralplan
+
+Hermes Ralplan workflow: consensus planning with review gates.
+
+- Category: `planning`
+- Phase: `reviewed-plan`
+- Use when: Use when requirements are clear enough for planning but architecture, risks, or tests need review.
+- Strong routing signals: `ralplan`, `$ralplan`, `consensus plan`, `reviewed plan`
+- Required inputs:
+  - requirements
+  - options
+  - tradeoffs
+  - test shape
+- Expected outputs:
+  - approved plan
+  - risk review
+  - handoff guidance
+- Artifact expectations:
+  - plan and review artifacts when a wrapper supports file-backed planning
+- Safety rules:
+  - Do not implement directly from the planning lane.
+  - Make acceptance criteria testable.
+  - Record unresolved tradeoffs explicitly.
+
+### code-review
+
+Hermes Code Review workflow: bug-first review with evidence.
+
+- Category: `review`
+- Phase: `critique`
+- Use when: Use for review-shaped requests; findings come first and must cite concrete evidence.
+- Strong routing signals: `code-review`, `$code-review`, `review`, `audit`, `find bugs`
+- Required inputs:
+  - diff or files
+  - expected behavior
+  - test evidence
+- Expected outputs:
+  - ranked findings
+  - open questions
+  - test gaps
+- Artifact expectations:
+  - critic run record when review evidence is captured
+- Safety rules:
+  - Findings come before summaries.
+  - Cite concrete evidence for every finding.
+  - Say clearly when no issue is found.
+
+### ai-slop-cleaner
+
+Hermes AI slop cleaner workflow: behavior-preserving cleanup.
+
+- Category: `maintenance`
+- Phase: `cleanup`
+- Use when: Use for behavior-preserving cleanup with tests before and after edits.
+- Strong routing signals: `ai-slop-cleaner`, `$ai-slop-cleaner`, `cleanup`, `deslop`, `refactor`
+- Required inputs:
+  - target smell
+  - current behavior
+  - regression checks
+- Expected outputs:
+  - small cleanup diff
+  - before/after verification
+  - residual risk
+- Artifact expectations:
+  - cleanup plan and regression evidence for non-trivial work
+- Safety rules:
+  - Lock behavior with tests before risky cleanup.
+  - Prefer deletion and existing utilities over new layers.
+  - Do not add dependencies for cleanup unless explicitly requested.
+
+### best-practice-research
+
+Hermes adaptation for bounded official/upstream best-practice research.
+
+- Category: `research`
+- Phase: `evidence`
+- Use when: Use when correctness depends on current official or upstream guidance.
+- Strong routing signals: `best-practice-research`, `best practice`, `official docs`, `upstream guidance`
+- Required inputs:
+  - chosen technology
+  - question
+  - version or environment constraints
+- Expected outputs:
+  - source-backed guidance
+  - applicability notes
+  - residual uncertainty
+- Artifact expectations:
+  - research notes or citations when the wrapper captures them
+- Safety rules:
+  - Do not imply hidden Hermes runtime behavior.
+  - Use the smallest verification that can prove the claim.
+
+### autoresearch-goal
+
+Hermes adaptation for durable research-goal execution.
+
+- Category: `research`
+- Phase: `durable-research`
+- Use when: Use for validator-gated research that needs durable artifacts.
+- Strong routing signals: `autoresearch-goal`, `research goal`, `durable research`, `critic research`
+- Required inputs:
+  - research objective
+  - validator criteria
+  - source boundaries
+- Expected outputs:
+  - research artifact
+  - validator result
+  - next questions
+- Artifact expectations:
+  - durable research ledger or checklist
+- Safety rules:
+  - Do not imply hidden Hermes runtime behavior.
+  - Use the smallest verification that can prove the claim.
+
+### performance-goal
+
+Hermes adaptation for measurable performance-goal execution.
+
+- Category: `optimization`
+- Phase: `measurement`
+- Use when: Use when the goal is measurable performance improvement with evaluator evidence.
+- Strong routing signals: `performance-goal`, `performance goal`, `latency`, `throughput`, `benchmark`
+- Required inputs:
+  - metric
+  - baseline
+  - budget
+  - benchmark command
+- Expected outputs:
+  - measurement delta
+  - implementation summary
+  - benchmark evidence
+- Artifact expectations:
+  - baseline and final benchmark evidence
+- Safety rules:
+  - Do not imply hidden Hermes runtime behavior.
+  - Use the smallest verification that can prove the claim.
+
+### wiki
+
+Hermes adaptation for maintaining a project-local markdown wiki.
+
+- Category: `knowledge`
+- Phase: `capture`
+- Use when: Use to capture durable project knowledge in markdown artifacts.
+- Strong routing signals: `wiki`, `project wiki`, `memory`, `notes`
+- Required inputs:
+  - project fact
+  - source evidence
+  - target topic
+- Expected outputs:
+  - markdown note
+  - retrieval hint
+  - staleness warning when needed
+- Artifact expectations:
+  - repo-local markdown knowledge artifact
+- Safety rules:
+  - Do not imply hidden Hermes runtime behavior.
+  - Use the smallest verification that can prove the claim.
+
+### ask
+
+Hermes adaptation for consulting an external advisor when configured.
+
+- Category: `review`
+- Phase: `external-advice`
+- Use when: Use only when an external advisor is configured and would materially improve the answer.
+- Strong routing signals: `ask`, `$ask`, `external advisor`, `claude`, `gemini`
+- Required inputs:
+  - question
+  - context summary
+  - why external advice helps
+- Expected outputs:
+  - advisor summary
+  - accepted/rejected advice
+  - decision note
+- Artifact expectations:
+  - advisor transcript reference only when explicitly captured
+- Safety rules:
+  - Use only when configured and materially useful.
+  - Treat advisor output as evidence to evaluate, not authority.
+  - Do not send secrets or private prompts without explicit opt-in.
+
+### cancel
+
+Hermes adaptation for ending active workflow state cleanly.
+
+- Category: `operator`
+- Phase: `state-cleanup`
+- Use when: Use to cleanly end active adapted workflow state.
+- Strong routing signals: `cancel`, `$cancel`, `stop`, `abort`
+- Required inputs:
+  - active workflow state
+  - cancellation intent
+- Expected outputs:
+  - cleared state
+  - safe stop summary
+- Artifact expectations:
+  - state clear record when state exists
+- Safety rules:
+  - Do not imply hidden Hermes runtime behavior.
+  - Use the smallest verification that can prove the claim.
+
+### skill
+
+Hermes adaptation for managing local skills.
+
+- Category: `operator`
+- Phase: `skill-management`
+- Use when: Use for local skill listing, search, add, remove, or edit tasks.
+- Strong routing signals: `skill`, `$skill`, `skills`, `manage skills`
+- Required inputs:
+  - skill action
+  - target skill name or directory
+- Expected outputs:
+  - skill inventory or mutation result
+  - verification note
+- Artifact expectations:
+  - manifest update when managed skills change
+- Safety rules:
+  - Do not imply hidden Hermes runtime behavior.
+  - Use the smallest verification that can prove the claim.
+
+### doctor
+
+Hermes adaptation for diagnosing oh-my-hermes installation health.
+
+- Category: `operator`
+- Phase: `diagnostics`
+- Use when: Use to diagnose OMH installation and Hermes config registration.
+- Strong routing signals: `doctor`, `$doctor`, `diagnose omh`, `installation health`
+- Required inputs:
+  - omh home
+  - Hermes home
+  - observed issue
+- Expected outputs:
+  - health checks
+  - fix guidance
+  - known proof boundary
+- Artifact expectations:
+  - doctor state summary when runtime artifacts are writable
+- Safety rules:
+  - Do not imply hidden Hermes runtime behavior.
+  - Use the smallest verification that can prove the claim.
+
+## Representative Harnesses
+
+### coding-handling
+
+Route implementation requests through scoped context, edit discipline, tests, review, and evidence.
+
+- Use when: Use when the user asks Hermes to write, modify, debug, refactor, or review code.
+- Inputs:
+  - task statement
+  - repo context
+  - constraints
+  - target files or discovered touchpoints
+- Outputs:
+  - changed files
+  - verification evidence
+  - remaining risks
+- Stop conditions:
+  - requested behavior is implemented
+  - tests or checks pass
+  - known gaps are reported
+- Verification:
+  - run the smallest relevant tests
+  - inspect generated skill output when routing changed
+- Artifact events:
+  - `run_started`
+  - `files_changed`
+  - `verification_recorded`
+- Delegation expectation: Record delegation only when Hermes exposes a separate coding, review, or verification lane.
+- Privacy default: `metadata_only`
+- Fallback: If the request is underspecified, ask one concise clarification question before editing.
+
+### goal-execution
+
+Keep long-running work tied to explicit goals, checkpoints, and durable evidence.
+
+- Use when: Use when the task has multiple milestones, durable state, or finish-until-done pressure.
+- Inputs:
+  - goal statement
+  - acceptance criteria
+  - current checkpoint
+  - blocked or pending stories
+- Outputs:
+  - goal ledger updates
+  - checkpoint evidence
+  - completion or blocker summary
+- Stop conditions:
+  - current goal is complete or explicitly blocked
+  - checkpoint evidence is recorded
+- Verification:
+  - compare artifacts against acceptance criteria
+  - record fresh evidence before completion
+- Artifact events:
+  - `goal_started`
+  - `checkpoint_recorded`
+  - `goal_completed_or_blocked`
+- Delegation expectation: Record goal/delegation participants only when the active Hermes runtime exposes them.
+- Privacy default: `metadata_only`
+- Fallback: If Hermes has no goal tool, use a local checklist or file-backed ledger.
+
+### planning
+
+Turn clarified requirements into an execution-ready plan with tradeoffs and tests.
+
+- Use when: Use before implementation when architecture, sequencing, or validation shape matters.
+- Inputs:
+  - requirements
+  - constraints
+  - known facts
+  - non-goals
+- Outputs:
+  - PRD or plan
+  - test strategy
+  - handoff guidance
+- Stop conditions:
+  - plan has acceptance criteria
+  - risks and alternatives are explicit
+- Verification:
+  - review option consistency
+  - verify testability before execution
+- Artifact events:
+  - `plan_started`
+  - `options_reviewed`
+  - `handoff_recorded`
+- Delegation expectation: Record planner, architect, or reviewer delegation only when observed in Hermes metadata or wrapper logs.
+- Privacy default: `metadata_only`
+- Fallback: If consensus review is unavailable, do a sequential planner -> reviewer pass.
+
+### deep-interview
+
+Clarify intent and boundaries one question at a time before planning or execution.
+
+- Use when: Use when intent, scope, non-goals, or decision authority are unclear.
+- Inputs:
+  - initial idea
+  - current ambiguity
+  - known repo facts
+- Outputs:
+  - clarified spec
+  - non-goals
+  - decision boundaries
+  - acceptance criteria
+- Stop conditions:
+  - ambiguity is low enough
+  - non-goals and decision boundaries are explicit
+- Verification:
+  - pressure-test assumptions
+  - capture transcript or summary
+- Artifact events:
+  - `interview_started`
+  - `question_asked`
+  - `clarity_recorded`
+- Delegation expectation: Record a delegated interviewer only when Hermes exposes that lane; otherwise record sequential clarification.
+- Privacy default: `metadata_only`
+- Fallback: If structured question UI is unavailable, ask one direct question in the current surface.
+
+### architect
+
+Evaluate system boundaries, integration choices, and long-term maintainability.
+
+- Use when: Use when a plan touches architecture, runtime integration, extension boundaries, or shared contracts.
+- Inputs:
+  - plan
+  - context
+  - constraints
+  - existing architecture evidence
+- Outputs:
+  - architecture verdict
+  - tradeoff tension
+  - required changes or clear approval
+- Stop conditions:
+  - boundary risks are addressed
+  - chosen approach fits current architecture
+- Verification:
+  - steelman the strongest antithesis
+  - check integration claims against evidence
+- Artifact events:
+  - `architecture_review_started`
+  - `tradeoff_recorded`
+  - `verdict_recorded`
+- Delegation expectation: Record architect delegation only when Hermes exposes an architect lane or wrapper-side role result.
+- Privacy default: `metadata_only`
+- Fallback: If delegation is unavailable, run a separate self-review pass before coding.
+
+### critic
+
+Challenge plan consistency, quality criteria, and missing verification.
+
+- Use when: Use after planning or before release when a bad assumption would be costly.
+- Inputs:
+  - plan
+  - test spec
+  - architect review
+  - user constraints
+- Outputs:
+  - approval or requested changes
+  - critical findings
+  - residual risks
+- Stop conditions:
+  - quality criteria are testable
+  - risks have mitigations
+  - alternatives are fair
+- Verification:
+  - check principle-option consistency
+  - reject vague acceptance criteria
+- Artifact events:
+  - `critic_review_started`
+  - `finding_recorded`
+  - `verdict_recorded`
+- Delegation expectation: Record critic delegation only when Hermes exposes a critic lane or wrapper-side role result.
+- Privacy default: `metadata_only`
+- Fallback: If no critic role exists, do a bug-first checklist review and cite concrete evidence.
+
+### qa-specialist
+
+Design adversarial scenarios and verify user-visible behavior before completion.
+
+- Use when: Use when changes affect workflows, installer behavior, docs examples, or routing claims.
+- Inputs:
+  - acceptance criteria
+  - changed behavior
+  - fixtures or runnable commands
+- Outputs:
+  - test matrix
+  - hostile scenarios
+  - pass/fail evidence
+- Stop conditions:
+  - critical scenarios pass
+  - known manual gaps are listed
+- Verification:
+  - run targeted tests
+  - cover failure modes and recovery paths
+- Artifact events:
+  - `qa_started`
+  - `scenario_recorded`
+  - `pass_fail_recorded`
+- Delegation expectation: Record QA delegation only when Hermes exposes a QA lane or wrapper-side QA result.
+- Privacy default: `metadata_only`
+- Fallback: If runtime automation is unavailable, use fixtures and document manual checks.
+
+### docs-specialist
+
+Keep public docs accurate, installable, and aligned with actual behavior.
+
+- Use when: Use whenever user-facing commands, routing behavior, examples, or release posture change.
+- Inputs:
+  - changed behavior
+  - commands
+  - limitations
+  - audience
+- Outputs:
+  - README/docs updates
+  - examples
+  - troubleshooting notes
+- Stop conditions:
+  - docs match behavior
+  - claims are conservative
+  - examples are reproducible
+- Verification:
+  - run public-content scans
+  - verify commands and file references
+- Artifact events:
+  - `docs_review_started`
+  - `claim_checked`
+  - `docs_updated`
+- Delegation expectation: Record docs delegation only when Hermes exposes a docs lane or wrapper-side docs result.
+- Privacy default: `metadata_only`
+- Fallback: If behavior is not implemented yet, label it as roadmap instead of current capability.

--- a/src/cli.py
+++ b/src/cli.py
@@ -24,6 +24,7 @@ from .runtime_artifacts import (
     update_state,
     write_delegation,
 )
+from .skills.render import workflow_reference_markdown
 from .skill_pack import builtin_harnesses, builtin_definitions
 from .snippet import WORKSPACE_SNIPPET
 
@@ -235,6 +236,27 @@ def cmd_snippet(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_docs_workflows(args: argparse.Namespace) -> int:
+    content = workflow_reference_markdown()
+    output = Path(args.output).expanduser().resolve() if args.output else Path("docs/WORKFLOWS.md").resolve()
+    if args.check:
+        try:
+            current = output.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise OmhError(f"workflow docs check failed: {exc}") from exc
+        if current != content:
+            raise OmhError(f"workflow docs are stale: {output}")
+        _print_json({"ok": True, "checked": str(output)})
+        return 0
+    if args.output:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(content, encoding="utf-8")
+        _print_json({"written": str(output)})
+        return 0
+    print(content.rstrip())
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="omh", description="Install oh-my-hermes skills for Hermes Agent.")
     parser.add_argument("--omh-home", default=None)
@@ -280,6 +302,14 @@ def build_parser() -> argparse.ArgumentParser:
     snippet.add_argument("--dry-run", action="store_true")
     snippet.add_argument("--output", default=None)
     snippet.set_defaults(func=cmd_snippet)
+
+    docs = sub.add_parser("docs")
+    docs_sub = docs.add_subparsers(dest="docs_command", required=True)
+
+    docs_workflows = docs_sub.add_parser("workflows")
+    docs_workflows.add_argument("--output", default=None)
+    docs_workflows.add_argument("--check", action="store_true")
+    docs_workflows.set_defaults(func=cmd_docs_workflows)
 
     runtime = sub.add_parser("runtime")
     runtime_sub = runtime.add_subparsers(dest="runtime_command", required=True)

--- a/src/skills/catalog.py
+++ b/src/skills/catalog.py
@@ -9,6 +9,15 @@ class SkillDefinition:
     description: str
     triggers: tuple[str, ...]
     use_when: str
+    category: str = "workflow"
+    phase: str = "general"
+    required_inputs: tuple[str, ...] = ("task statement", "available Hermes context")
+    expected_outputs: tuple[str, ...] = ("workflow-shaped response", "verification or explicit gap")
+    artifact_expectations: tuple[str, ...] = ("metadata-only runtime record when a wrapper or shell is available",)
+    safety_rules: tuple[str, ...] = (
+        "Do not imply hidden Hermes runtime behavior.",
+        "Use the smallest verification that can prove the claim.",
+    )
 
 
 @dataclass(frozen=True)
@@ -16,8 +25,8 @@ class HarnessDefinition:
     name: str
     purpose: str
     use_when: str
-    inputs: tuple[str, ...]
-    outputs: tuple[str, ...]
+    required_inputs: tuple[str, ...]
+    expected_outputs: tuple[str, ...]
     stop_conditions: tuple[str, ...]
     verification: tuple[str, ...]
     fallback: str
@@ -32,108 +41,233 @@ _DEFINITIONS = [
         "Router guidance for using oh-my-hermes workflow skills inside Hermes Agent.",
         ("oh-my-hermes", "omh", "skill routing", "workflow routing"),
         "Use as the top-level router when a request references oh-my-hermes, installed workflows, or ambiguous workflow routing.",
+        category="router",
+        phase="routing",
+        required_inputs=("user request", "installed skill descriptions", "Hermes skill discovery context"),
+        expected_outputs=("selected workflow guidance", "clarification question when routing is ambiguous"),
+        artifact_expectations=("runtime run record when a wrapper can observe request handling",),
+        safety_rules=(
+            "Prefer explicit skill invocation over weak keyword inference.",
+            "Ask one concise question when routing signals conflict.",
+            "Do not claim to override Hermes core routing.",
+        ),
     ),
     SkillDefinition(
         "ralph",
         "Hermes Ralph workflow: persistent execution with verification and review.",
         ("ralph", "$ralph", "finish until done", "persistent execution", "self-referential loop"),
         "Use after scope is concrete and the user wants one owner to continue through implementation and verification.",
+        category="execution",
+        phase="completion",
+        required_inputs=("concrete scope", "acceptance criteria", "verification commands"),
+        expected_outputs=("completed work summary", "verification evidence", "remaining risks"),
+        artifact_expectations=("goal-execution run record", "checkpoint or final evidence when available"),
     ),
     SkillDefinition(
         "ultragoal",
         "Hermes Ultragoal workflow: file-backed durable goal ledgers.",
         ("ultragoal", "$ultragoal", "durable goal", "multi-goal", "goal ledger"),
         "Use when work needs durable goal artifacts, checkpointed progress, and final quality gates.",
+        category="execution",
+        phase="durable-goals",
+        required_inputs=("goal statement", "acceptance criteria", "current checkpoint"),
+        expected_outputs=("goal ledger updates", "checkpoint evidence", "completion or blocker summary"),
+        artifact_expectations=("goal ledger or checklist", "runtime run record for each major checkpoint"),
     ),
     SkillDefinition(
         "deep-interview",
         "Hermes Deep Interview workflow: one-question-at-a-time clarification.",
         ("deep-interview", "$deep-interview", "interview", "don't assume", "clarify"),
         "Use before planning or execution when requirements are materially ambiguous.",
+        category="clarification",
+        phase="discovery",
+        required_inputs=("initial request", "known repo facts", "current ambiguity"),
+        expected_outputs=("clarified brief", "non-goals", "decision boundaries"),
+        artifact_expectations=("clarity summary or transcript when the wrapper supports it",),
+        safety_rules=(
+            "Ask one question at a time.",
+            "Gather discoverable repo facts before asking the user.",
+            "Stop interviewing once ambiguity is low enough to plan.",
+        ),
     ),
     SkillDefinition(
         "team",
         "Hermes Team workflow: coordinated parallel or sequential work lanes.",
         ("team", "$team", "swarm", "parallel agents", "coordinated workers"),
         "Use when multiple independent lanes materially improve throughput or verification.",
+        category="execution",
+        phase="coordination",
+        required_inputs=("bounded lane definitions", "ownership boundaries", "verification target"),
+        expected_outputs=("lane results", "integration summary", "combined verification evidence"),
+        artifact_expectations=("delegation record only when separate participants are observed",),
+        safety_rules=(
+            "Use parallel lanes only when work is independent.",
+            "Keep shared-file edits under one owner.",
+            "Record unobserved delegation as not_observed.",
+        ),
     ),
     SkillDefinition(
         "ultraqa",
         "Hermes UltraQA workflow: adversarial QA and fix loops.",
         ("ultraqa", "$ultraqa", "adversarial qa", "hostile scenarios", "e2e qa"),
         "Use when the task needs adversarial test scenarios, verification, and fix loops.",
+        category="verification",
+        phase="qa",
+        required_inputs=("changed behavior", "acceptance criteria", "known risk areas"),
+        expected_outputs=("adversarial scenarios", "pass/fail evidence", "fix recommendations"),
+        artifact_expectations=("QA scenario evidence", "runtime verification summary"),
     ),
     SkillDefinition(
         "plan",
         "Hermes Plan workflow: structured planning before execution.",
         ("plan", "$plan", "implementation plan", "strategy", "task breakdown"),
         "Use for structured planning when implementation is not ready to start safely.",
+        category="planning",
+        phase="plan",
+        required_inputs=("requirements", "constraints", "known facts", "non-goals"),
+        expected_outputs=("plan", "acceptance criteria", "verification strategy"),
+        artifact_expectations=("plan artifact when durable execution will follow",),
     ),
     SkillDefinition(
         "ralplan",
         "Hermes Ralplan workflow: consensus planning with review gates.",
         ("ralplan", "$ralplan", "consensus plan", "reviewed plan"),
         "Use when requirements are clear enough for planning but architecture, risks, or tests need review.",
+        category="planning",
+        phase="reviewed-plan",
+        required_inputs=("requirements", "options", "tradeoffs", "test shape"),
+        expected_outputs=("approved plan", "risk review", "handoff guidance"),
+        artifact_expectations=("plan and review artifacts when a wrapper supports file-backed planning",),
+        safety_rules=(
+            "Do not implement directly from the planning lane.",
+            "Make acceptance criteria testable.",
+            "Record unresolved tradeoffs explicitly.",
+        ),
     ),
     SkillDefinition(
         "code-review",
         "Hermes Code Review workflow: bug-first review with evidence.",
         ("code-review", "$code-review", "review", "audit", "find bugs"),
         "Use for review-shaped requests; findings come first and must cite concrete evidence.",
+        category="review",
+        phase="critique",
+        required_inputs=("diff or files", "expected behavior", "test evidence"),
+        expected_outputs=("ranked findings", "open questions", "test gaps"),
+        artifact_expectations=("critic run record when review evidence is captured",),
+        safety_rules=(
+            "Findings come before summaries.",
+            "Cite concrete evidence for every finding.",
+            "Say clearly when no issue is found.",
+        ),
     ),
     SkillDefinition(
         "ai-slop-cleaner",
         "Hermes AI slop cleaner workflow: behavior-preserving cleanup.",
         ("ai-slop-cleaner", "$ai-slop-cleaner", "cleanup", "deslop", "refactor"),
         "Use for behavior-preserving cleanup with tests before and after edits.",
+        category="maintenance",
+        phase="cleanup",
+        required_inputs=("target smell", "current behavior", "regression checks"),
+        expected_outputs=("small cleanup diff", "before/after verification", "residual risk"),
+        artifact_expectations=("cleanup plan and regression evidence for non-trivial work",),
+        safety_rules=(
+            "Lock behavior with tests before risky cleanup.",
+            "Prefer deletion and existing utilities over new layers.",
+            "Do not add dependencies for cleanup unless explicitly requested.",
+        ),
     ),
     SkillDefinition(
         "best-practice-research",
         "Hermes adaptation for bounded official/upstream best-practice research.",
         ("best-practice-research", "best practice", "official docs", "upstream guidance"),
         "Use when correctness depends on current official or upstream guidance.",
+        category="research",
+        phase="evidence",
+        required_inputs=("chosen technology", "question", "version or environment constraints"),
+        expected_outputs=("source-backed guidance", "applicability notes", "residual uncertainty"),
+        artifact_expectations=("research notes or citations when the wrapper captures them",),
     ),
     SkillDefinition(
         "autoresearch-goal",
         "Hermes adaptation for durable research-goal execution.",
         ("autoresearch-goal", "research goal", "durable research", "critic research"),
         "Use for validator-gated research that needs durable artifacts.",
+        category="research",
+        phase="durable-research",
+        required_inputs=("research objective", "validator criteria", "source boundaries"),
+        expected_outputs=("research artifact", "validator result", "next questions"),
+        artifact_expectations=("durable research ledger or checklist",),
     ),
     SkillDefinition(
         "performance-goal",
         "Hermes adaptation for measurable performance-goal execution.",
         ("performance-goal", "performance goal", "latency", "throughput", "benchmark"),
         "Use when the goal is measurable performance improvement with evaluator evidence.",
+        category="optimization",
+        phase="measurement",
+        required_inputs=("metric", "baseline", "budget", "benchmark command"),
+        expected_outputs=("measurement delta", "implementation summary", "benchmark evidence"),
+        artifact_expectations=("baseline and final benchmark evidence",),
     ),
     SkillDefinition(
         "wiki",
         "Hermes adaptation for maintaining a project-local markdown wiki.",
         ("wiki", "project wiki", "memory", "notes"),
         "Use to capture durable project knowledge in markdown artifacts.",
+        category="knowledge",
+        phase="capture",
+        required_inputs=("project fact", "source evidence", "target topic"),
+        expected_outputs=("markdown note", "retrieval hint", "staleness warning when needed"),
+        artifact_expectations=("repo-local markdown knowledge artifact",),
     ),
     SkillDefinition(
         "ask",
         "Hermes adaptation for consulting an external advisor when configured.",
         ("ask", "$ask", "external advisor", "claude", "gemini"),
         "Use only when an external advisor is configured and would materially improve the answer.",
+        category="review",
+        phase="external-advice",
+        required_inputs=("question", "context summary", "why external advice helps"),
+        expected_outputs=("advisor summary", "accepted/rejected advice", "decision note"),
+        artifact_expectations=("advisor transcript reference only when explicitly captured",),
+        safety_rules=(
+            "Use only when configured and materially useful.",
+            "Treat advisor output as evidence to evaluate, not authority.",
+            "Do not send secrets or private prompts without explicit opt-in.",
+        ),
     ),
     SkillDefinition(
         "cancel",
         "Hermes adaptation for ending active workflow state cleanly.",
         ("cancel", "$cancel", "stop", "abort"),
         "Use to cleanly end active adapted workflow state.",
+        category="operator",
+        phase="state-cleanup",
+        required_inputs=("active workflow state", "cancellation intent"),
+        expected_outputs=("cleared state", "safe stop summary"),
+        artifact_expectations=("state clear record when state exists",),
     ),
     SkillDefinition(
         "skill",
         "Hermes adaptation for managing local skills.",
         ("skill", "$skill", "skills", "manage skills"),
         "Use for local skill listing, search, add, remove, or edit tasks.",
+        category="operator",
+        phase="skill-management",
+        required_inputs=("skill action", "target skill name or directory"),
+        expected_outputs=("skill inventory or mutation result", "verification note"),
+        artifact_expectations=("manifest update when managed skills change",),
     ),
     SkillDefinition(
         "doctor",
         "Hermes adaptation for diagnosing oh-my-hermes installation health.",
         ("doctor", "$doctor", "diagnose omh", "installation health"),
         "Use to diagnose OMH installation and Hermes config registration.",
+        category="operator",
+        phase="diagnostics",
+        required_inputs=("omh home", "Hermes home", "observed issue"),
+        expected_outputs=("health checks", "fix guidance", "known proof boundary"),
+        artifact_expectations=("doctor state summary when runtime artifacts are writable",),
     ),
 ]
 

--- a/src/skills/render.py
+++ b/src/skills/render.py
@@ -12,7 +12,15 @@ class SkillTemplate:
 
 
 def _frontmatter(name: str, description: str) -> str:
-    return f"---\nname: {name}\ndescription: {description}\nmetadata:\n  hermes:\n    tags: [workflow, oh-my-hermes]\n---\n"
+    definitions = {definition.name: definition for definition in builtin_definitions()}
+    definition = definitions.get(name)
+    category = definition.category if definition else "workflow"
+    phase = definition.phase if definition else "general"
+    return (
+        f"---\nname: {name}\ndescription: {description}\nmetadata:\n"
+        f"  hermes:\n    tags: [workflow, oh-my-hermes, {category}]\n"
+        f"    category: {category}\n    phase: {phase}\n---\n"
+    )
 
 
 def _trigger_table(definitions: list[SkillDefinition]) -> str:
@@ -26,8 +34,8 @@ def _trigger_table(definitions: list[SkillDefinition]) -> str:
 
 
 def _harness_summary(harness: HarnessDefinition) -> str:
-    inputs = ", ".join(harness.inputs[:3])
-    outputs = ", ".join(harness.outputs[:3])
+    inputs = ", ".join(harness.required_inputs[:3])
+    outputs = ", ".join(harness.expected_outputs[:3])
     verification = ", ".join(harness.verification[:2])
     artifact_events = ", ".join(f"`{event}`" for event in harness.artifact_events[:3])
     return (
@@ -67,6 +75,31 @@ def _primary_harness_for_skill(name: str) -> str:
         "doctor": "qa-specialist",
     }
     return mapping.get(name, "coding-handling")
+
+
+def _tuple_list(values: tuple[str, ...]) -> str:
+    return "\n".join(f"- {value}" for value in values)
+
+
+def _skill_metadata_block(definition: SkillDefinition) -> str:
+    return f"""Category: `{definition.category}`
+Phase: `{definition.phase}`
+
+Required inputs:
+
+{_tuple_list(definition.required_inputs)}
+
+Expected outputs:
+
+{_tuple_list(definition.expected_outputs)}
+
+Artifact expectations:
+
+{_tuple_list(definition.artifact_expectations)}
+
+Safety rules:
+
+{_tuple_list(definition.safety_rules)}"""
 
 
 def router_skill() -> SkillTemplate:
@@ -154,7 +187,11 @@ This is a Hermes-native `{name}` workflow skill.
 
 {definition.use_when}
 
-Strong routing signals: {triggers}
+    Strong routing signals: {triggers}
+
+## Catalog Metadata
+
+{_skill_metadata_block(definition)}
 
 ## Harness Discipline
 
@@ -200,3 +237,67 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 def builtin_skill_templates() -> list[SkillTemplate]:
     names = [definition.name for definition in builtin_definitions()]
     return [router_skill(), *[workflow_skill(name) for name in names if name != "oh-my-hermes"]]
+
+
+def workflow_reference_markdown() -> str:
+    definitions = builtin_definitions()
+    harnesses = builtin_harnesses()
+    lines = [
+        "# Workflow Reference",
+        "",
+        "This file is generated from `src/skills/catalog.py`. Update the catalog first, then refresh this document.",
+        "",
+        "The reference describes prompt-level Hermes workflow guidance and local evidence expectations. It does not claim hidden Hermes runtime behavior.",
+        "",
+        "## Skills",
+        "",
+    ]
+    for definition in definitions:
+        triggers = ", ".join(f"`{trigger}`" for trigger in definition.triggers)
+        lines.extend(
+            [
+                f"### {definition.name}",
+                "",
+                definition.description,
+                "",
+                f"- Category: `{definition.category}`",
+                f"- Phase: `{definition.phase}`",
+                f"- Use when: {definition.use_when}",
+                f"- Strong routing signals: {triggers}",
+                "- Required inputs:",
+                *[f"  - {item}" for item in definition.required_inputs],
+                "- Expected outputs:",
+                *[f"  - {item}" for item in definition.expected_outputs],
+                "- Artifact expectations:",
+                *[f"  - {item}" for item in definition.artifact_expectations],
+                "- Safety rules:",
+                *[f"  - {item}" for item in definition.safety_rules],
+                "",
+            ]
+        )
+    lines.extend(["## Representative Harnesses", ""])
+    for harness in harnesses:
+        lines.extend(
+            [
+                f"### {harness.name}",
+                "",
+                harness.purpose,
+                "",
+                f"- Use when: {harness.use_when}",
+                "- Inputs:",
+                *[f"  - {item}" for item in harness.required_inputs],
+                "- Outputs:",
+                *[f"  - {item}" for item in harness.expected_outputs],
+                "- Stop conditions:",
+                *[f"  - {item}" for item in harness.stop_conditions],
+                "- Verification:",
+                *[f"  - {item}" for item in harness.verification],
+                "- Artifact events:",
+                *[f"  - `{item}`" for item in harness.artifact_events],
+                f"- Delegation expectation: {harness.delegation_expectation}",
+                f"- Privacy default: `{harness.privacy_default}`",
+                f"- Fallback: {harness.fallback}",
+                "",
+            ]
+        )
+    return "\n".join(lines).rstrip() + "\n"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -188,6 +188,31 @@ class CliTests(unittest.TestCase):
             self.assertTrue(shown["delegation"]["requested"])
             self.assertFalse(shown["delegation"]["observed"])
 
+    def test_docs_workflows_command_prints_writes_and_checks_generated_reference(self) -> None:
+        status, stdout, stderr = run_cli(["docs", "workflows"])
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        self.assertIn("# Workflow Reference", stdout)
+        self.assertIn("### oh-my-hermes", stdout)
+
+        with TemporaryDirectory() as tmp:
+            output = Path(tmp) / "WORKFLOWS.md"
+            status, stdout, stderr = run_cli(["docs", "workflows", "--output", str(output)])
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            self.assertTrue(output.exists())
+            self.assertIn("written", stdout)
+
+            status, stdout, stderr = run_cli(["docs", "workflows", "--output", str(output), "--check"])
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            self.assertIn("checked", stdout)
+
+            output.write_text(output.read_text(encoding="utf-8") + "\nstale\n", encoding="utf-8")
+            status, _, stderr = run_cli(["docs", "workflows", "--output", str(output), "--check"])
+            self.assertEqual(status, 2)
+            self.assertIn("workflow docs are stale", stderr)
+
     def test_runtime_record_rejects_unknown_names(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -6,7 +6,8 @@ import unittest
 from _local_package import load_local_package
 
 load_local_package()
-from omh.skill_pack import builtin_harnesses, builtin_skill_templates
+from omh.skill_pack import builtin_definitions, builtin_harnesses, builtin_skill_templates
+from omh.skills.render import workflow_reference_markdown
 
 
 class RouterContentTests(unittest.TestCase):
@@ -62,10 +63,22 @@ class RouterContentTests(unittest.TestCase):
         self.assertIn("Delegation:", router.content)
         self.assertIn("Fallback:", router.content)
 
+    def test_catalog_definitions_expose_required_metadata_fields(self) -> None:
+        for definition in builtin_definitions():
+            self.assertTrue(definition.category, definition.name)
+            self.assertTrue(definition.phase, definition.name)
+            self.assertGreaterEqual(len(definition.required_inputs), 1, definition.name)
+            self.assertGreaterEqual(len(definition.expected_outputs), 1, definition.name)
+            self.assertGreaterEqual(len(definition.artifact_expectations), 1, definition.name)
+            self.assertGreaterEqual(len(definition.safety_rules), 1, definition.name)
+
     def test_workflow_skills_refer_to_harness_discipline(self) -> None:
         skills = {skill.name: skill for skill in builtin_skill_templates()}
 
         self.assertIn("Harness Discipline", skills["ultragoal"].content)
+        self.assertIn("Catalog Metadata", skills["ultragoal"].content)
+        self.assertIn("Category: `execution`", skills["ultragoal"].content)
+        self.assertIn("Phase: `durable-goals`", skills["ultragoal"].content)
         self.assertIn("Runtime Evidence", skills["ultragoal"].content)
         self.assertIn("omh runtime record --skill ultragoal --harness goal-execution --status started", skills["ultragoal"].content)
         self.assertIn("Prefer richer evidence and clearer stop conditions", skills["code-review"].content)
@@ -75,6 +88,20 @@ class RouterContentTests(unittest.TestCase):
             self.assertGreaterEqual(len(harness.artifact_events), 1)
             self.assertEqual(harness.privacy_default, "metadata_only")
             self.assertIn("Record", harness.delegation_expectation)
+
+    def test_generated_workflow_reference_matches_catalog(self) -> None:
+        reference = Path("docs/WORKFLOWS.md").read_text(encoding="utf-8")
+
+        self.assertEqual(reference, workflow_reference_markdown())
+        self.assertIn("This file is generated from `src/skills/catalog.py`", reference)
+        for definition in builtin_definitions():
+            self.assertIn(f"### {definition.name}", reference)
+            self.assertIn(f"- Category: `{definition.category}`", reference)
+            self.assertIn(f"- Phase: `{definition.phase}`", reference)
+        for harness in builtin_harnesses():
+            self.assertIn(f"### {harness.name}", reference)
+            for event in harness.artifact_events:
+                self.assertIn(f"`{event}`", reference)
 
     def test_generated_public_content_avoids_external_runtime_branding(self) -> None:
         forbidden = ("om" + "x", "oh-my-" + "co" + "dex", "co" + "dex")


### PR DESCRIPTION
## Summary
- Expand the built-in workflow skill catalog with category, phase, input/output, artifact, and safety metadata.
- Generate docs/WORKFLOWS.md from the catalog and add omh docs workflows --check for drift detection.
- Cover catalog rendering and CLI docs generation with tests.

## Verification
- python3 -m unittest discover -s tests -p 'test_router_content.py'\n- python3 -m unittest discover -s tests -p 'test_cli.py'\n\n## Stack\n1. Phase 1: catalog evidence\n2. Phase 2: workflow lifecycle state\n3. Phase 3: runtime evidence validation\n4. Phase 4: release discipline\n5. Phase 5: capability probe