### PR TITLE
Phase 2: add workflow lifecycle state

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Check or manage the installation with `omh`:
 omh doctor
 omh list
 omh runtime status
+omh state status
 omh update
 ```
 
@@ -155,6 +156,7 @@ it could mean normal conversation.
 | `omh runtime status` | Inspect local runtime artifact state. |
 | `omh runtime record` | Create a metadata-only workflow run artifact. |
 | `omh runtime delegate` | Record observed or unavailable delegation for a run. |
+| `omh state status` | Inspect file-backed workflow lifecycle state under `~/.omh/state`. |
 | `omh docs workflows` | Print or verify the generated workflow reference from catalog data. |
 | `omh snippet` | Print optional workspace guidance without applying it. |
 | `omh uninstall` | Remove Hermes config registration, optionally removing files. |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -119,6 +119,33 @@ Bot wrappers can call `omh runtime record` before invoking Hermes and
 `omh runtime delegate` after the response if delegation metadata is available.
 If not, they should record `not_observed` rather than guessing.
 
+## Workflow State
+
+Workflow lifecycle state is stored separately from runtime run evidence under
+`.omh/state/`.
+
+```text
+.omh/
+  state/
+    <workflow>-state.json
+```
+
+State files are the authoritative local lifecycle surface for adapted workflows:
+active status, lifecycle outcome, timestamps, notes, and allowed handoff
+metadata. Runtime runs under `.omh/runtime/` remain evidence envelopes for what a
+wrapper or operator observed.
+
+The CLI exposes the state layer through:
+
+- `omh state start --workflow <name>`
+- `omh state status`
+- `omh state finish --workflow <name> --outcome finished`
+- `omh state clear --workflow <name>`
+
+Initial transition policy is intentionally conservative: clarification can hand
+off to planning, and planning can hand off to execution or QA. Other active
+workflow conflicts must be finished or cleared explicitly.
+
 ## Safety Model
 
 - Managed files are tracked by manifest hashes.

--- a/src/cli.py
+++ b/src/cli.py
@@ -27,6 +27,14 @@ from .runtime_artifacts import (
 from .skills.render import workflow_reference_markdown
 from .skill_pack import builtin_harnesses, builtin_definitions
 from .snippet import WORKSPACE_SNIPPET
+from .workflow_state import (
+    LIFECYCLE_OUTCOMES,
+    WorkflowStateError,
+    clear_workflow_state,
+    finish_workflow_state,
+    list_workflow_states,
+    start_workflow_state,
+)
 
 
 def _paths(args: argparse.Namespace):
@@ -257,6 +265,53 @@ def cmd_docs_workflows(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_state_status(args: argparse.Namespace) -> int:
+    paths = _paths(args)
+    states, errors = list_workflow_states(paths)
+    if args.workflow:
+        states = [state for state in states if state.get("workflow") == args.workflow]
+        errors = [error for error in errors if f"{args.workflow}-state.json" in error["path"]]
+    active = [state for state in states if state.get("active")]
+    _print_json(
+        {
+            "schema_version": 1,
+            "state_dir": str(paths.workflow_state_dir),
+            "states": states,
+            "active": active,
+            "errors": errors,
+            "ok": not errors,
+        }
+    )
+    return 0 if not errors else 1
+
+
+def cmd_state_start(args: argparse.Namespace) -> int:
+    try:
+        state = start_workflow_state(_paths(args), args.workflow, args.note or "")
+    except WorkflowStateError as exc:
+        raise OmhError(str(exc)) from exc
+    _print_json({"state": state})
+    return 0
+
+
+def cmd_state_finish(args: argparse.Namespace) -> int:
+    try:
+        state = finish_workflow_state(_paths(args), args.workflow, args.outcome, args.note or "")
+    except WorkflowStateError as exc:
+        raise OmhError(str(exc)) from exc
+    _print_json({"state": state})
+    return 0
+
+
+def cmd_state_clear(args: argparse.Namespace) -> int:
+    try:
+        removed = clear_workflow_state(_paths(args), args.workflow)
+    except WorkflowStateError as exc:
+        raise OmhError(str(exc)) from exc
+    _print_json({"removed": removed, "workflow": args.workflow})
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="omh", description="Install oh-my-hermes skills for Hermes Agent.")
     parser.add_argument("--omh-home", default=None)
@@ -346,6 +401,28 @@ def build_parser() -> argparse.ArgumentParser:
     runtime_delegate.add_argument("--evidence-ref", action="append")
     runtime_delegate.add_argument("--message", default="")
     runtime_delegate.set_defaults(func=cmd_runtime_delegate)
+
+    state = sub.add_parser("state")
+    state_sub = state.add_subparsers(dest="state_command", required=True)
+
+    state_status = state_sub.add_parser("status")
+    state_status.add_argument("--workflow", default=None)
+    state_status.set_defaults(func=cmd_state_status)
+
+    state_start = state_sub.add_parser("start")
+    state_start.add_argument("--workflow", required=True)
+    state_start.add_argument("--note", default="")
+    state_start.set_defaults(func=cmd_state_start)
+
+    state_finish = state_sub.add_parser("finish")
+    state_finish.add_argument("--workflow", required=True)
+    state_finish.add_argument("--outcome", choices=LIFECYCLE_OUTCOMES, default="finished")
+    state_finish.add_argument("--note", default="")
+    state_finish.set_defaults(func=cmd_state_finish)
+
+    state_clear = state_sub.add_parser("clear")
+    state_clear.add_argument("--workflow", required=True)
+    state_clear.set_defaults(func=cmd_state_clear)
     return parser
 
 

--- a/src/doctor.py
+++ b/src/doctor.py
@@ -8,6 +8,7 @@ from .manifest import local_modifications, read_manifest
 from .paths import OmhPaths
 from .runtime_artifacts import read_state, read_state_error
 from .skill_pack import CORE_SKILLS
+from .workflow_state import list_workflow_states
 
 
 @dataclass(frozen=True)
@@ -50,6 +51,26 @@ def run_doctor(paths: OmhPaths) -> list[Check]:
     except OSError:
         runtime_writable = False
     checks.append(Check("runtime_artifacts", runtime_writable, f"{paths.runtime_dir} writable"))
+    try:
+        paths.workflow_state_dir.mkdir(parents=True, exist_ok=True)
+        state_probe = paths.workflow_state_dir / ".doctor-write-test"
+        state_probe.write_text("ok", encoding="utf-8")
+        state_probe.unlink()
+        workflow_state_writable = True
+    except OSError:
+        workflow_state_writable = False
+    states, state_errors = list_workflow_states(paths)
+    checks.append(
+        Check(
+            "workflow_state",
+            workflow_state_writable and not state_errors,
+            (
+                f"{paths.workflow_state_dir} writable; {len(states)} workflow state file(s) readable"
+                if workflow_state_writable and not state_errors
+                else f"{paths.workflow_state_dir} has unreadable state: {state_errors}"
+            ),
+        )
+    )
     if state_error:
         checks.append(Check("runtime_state", False, f"runtime state unreadable: {state_error}"))
     if manifest and state:

--- a/src/paths.py
+++ b/src/paths.py
@@ -31,6 +31,10 @@ class OmhPaths:
         return self.runtime_dir / "runs"
 
     @property
+    def workflow_state_dir(self) -> Path:
+        return self.omh_home / "state"
+
+    @property
     def hermes_config_path(self) -> Path:
         return self.hermes_home / "config.yaml"
 

--- a/src/workflow_state.py
+++ b/src/workflow_state.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import json
+from json import JSONDecodeError
+from pathlib import Path
+from typing import Any
+
+from .paths import OmhPaths
+from .runtime_artifacts import utc_now
+from .skill_pack import CORE_SKILLS
+
+SCHEMA_VERSION = 1
+LIFECYCLE_OUTCOMES = ("finished", "blocked", "failed", "user_interlude", "question_pending")
+
+ALLOWED_TRANSITIONS: dict[str, tuple[str, ...]] = {
+    "deep-interview": ("plan", "ralplan"),
+    "plan": ("ultragoal", "team", "ralph", "ultraqa"),
+    "ralplan": ("ultragoal", "team", "ralph", "ultraqa"),
+}
+
+
+class WorkflowStateError(ValueError):
+    pass
+
+
+def _ensure_private_dir(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    path.chmod(0o700)
+
+
+def _atomic_write_json(path: Path, data: dict[str, Any]) -> None:
+    _ensure_private_dir(path.parent)
+    tmp = path.with_name(f".{path.name}.tmp")
+    try:
+        tmp.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        tmp.chmod(0o600)
+        tmp.replace(path)
+        path.chmod(0o600)
+    except OSError:
+        if tmp.exists():
+            tmp.unlink()
+        raise
+
+
+def validate_workflow_name(workflow: str) -> None:
+    if workflow not in CORE_SKILLS:
+        raise WorkflowStateError(f"unknown workflow: {workflow}")
+
+
+def workflow_state_path(paths: OmhPaths, workflow: str) -> Path:
+    validate_workflow_name(workflow)
+    return paths.workflow_state_dir / f"{workflow}-state.json"
+
+
+def read_workflow_state(paths: OmhPaths, workflow: str) -> dict[str, Any] | None:
+    path = workflow_state_path(paths, workflow)
+    if not path.exists():
+        return None
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise WorkflowStateError(f"state for {workflow} must be a JSON object")
+    if data.get("workflow") not in {None, workflow}:
+        raise WorkflowStateError(f"state file {path} belongs to {data.get('workflow')!r}")
+    return data
+
+
+def read_workflow_state_result(paths: OmhPaths, workflow: str) -> tuple[dict[str, Any] | None, str | None]:
+    try:
+        return read_workflow_state(paths, workflow), None
+    except (OSError, JSONDecodeError, WorkflowStateError, ValueError) as exc:
+        return None, str(exc)
+
+
+def list_workflow_states(paths: OmhPaths) -> tuple[list[dict[str, Any]], list[dict[str, str]]]:
+    states: list[dict[str, Any]] = []
+    errors: list[dict[str, str]] = []
+    if not paths.workflow_state_dir.exists():
+        return states, errors
+    for path in sorted(paths.workflow_state_dir.glob("*-state.json")):
+        workflow = path.name[: -len("-state.json")]
+        state, error = read_workflow_state_result(paths, workflow)
+        if error:
+            errors.append({"path": str(path), "error": error})
+        elif state:
+            states.append(state)
+    return states, errors
+
+
+def active_workflow_states(paths: OmhPaths) -> tuple[list[dict[str, Any]], list[dict[str, str]]]:
+    states, errors = list_workflow_states(paths)
+    return [state for state in states if state.get("active")], errors
+
+
+def _terminal_state(workflow: str, state: dict[str, Any] | None, outcome: str, note: str = "", transition_target: str | None = None) -> dict[str, Any]:
+    if outcome not in LIFECYCLE_OUTCOMES:
+        raise WorkflowStateError(f"unsupported lifecycle outcome: {outcome}")
+    now = utc_now()
+    base = state or {"workflow": workflow, "started_at": now}
+    result = {
+        **base,
+        "schema_version": SCHEMA_VERSION,
+        "workflow": workflow,
+        "active": False,
+        "lifecycle_outcome": outcome,
+        "updated_at": now,
+    }
+    if note:
+        result["note"] = note
+    if transition_target:
+        result["transition_target"] = transition_target
+    return result
+
+
+def finish_workflow_state(paths: OmhPaths, workflow: str, outcome: str = "finished", note: str = "") -> dict[str, Any]:
+    state = read_workflow_state(paths, workflow)
+    result = _terminal_state(workflow, state, outcome, note)
+    _atomic_write_json(workflow_state_path(paths, workflow), result)
+    return result
+
+
+def _transition_allowed(source: str, destination: str) -> bool:
+    return destination in ALLOWED_TRANSITIONS.get(source, ())
+
+
+def start_workflow_state(paths: OmhPaths, workflow: str, note: str = "") -> dict[str, Any]:
+    validate_workflow_name(workflow)
+    active, errors = active_workflow_states(paths)
+    if errors:
+        first = errors[0]
+        raise WorkflowStateError(f"cannot start workflow while state is unreadable: {first['path']}: {first['error']}")
+    now = utc_now()
+    for current in active:
+        source = str(current.get("workflow", ""))
+        if source == workflow:
+            updated = {**current, "schema_version": SCHEMA_VERSION, "active": True, "updated_at": now}
+            if note:
+                updated["note"] = note
+            _atomic_write_json(workflow_state_path(paths, workflow), updated)
+            return updated
+        if not _transition_allowed(source, workflow):
+            raise WorkflowStateError(f"cannot start {workflow}; active workflow {source} must finish or be cleared first")
+    for current in active:
+        source = str(current["workflow"])
+        completed = _terminal_state(source, current, "finished", f"auto-completed before starting {workflow}", workflow)
+        _atomic_write_json(workflow_state_path(paths, source), completed)
+    state = {
+        "schema_version": SCHEMA_VERSION,
+        "workflow": workflow,
+        "active": True,
+        "lifecycle_outcome": None,
+        "started_at": now,
+        "updated_at": now,
+    }
+    if note:
+        state["note"] = note
+    _atomic_write_json(workflow_state_path(paths, workflow), state)
+    return state
+
+
+def clear_workflow_state(paths: OmhPaths, workflow: str) -> bool:
+    path = workflow_state_path(paths, workflow)
+    if not path.exists():
+        return False
+    path.unlink()
+    return True

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -51,6 +51,7 @@ class CliTests(unittest.TestCase):
             self.assertTrue(checks["manifest_skills_dir"]["ok"])
             self.assertTrue(checks["local_modifications"]["ok"])
             self.assertTrue(checks["runtime_artifacts"]["ok"])
+            self.assertTrue(checks["workflow_state"]["ok"])
 
     def test_install_is_idempotent_and_detects_local_modifications(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_workflow_state.py
+++ b/tests/test_workflow_state.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import json
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from io import StringIO
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.cli import main
+
+
+def run_cli(args: list[str]) -> tuple[int, str, str]:
+    stdout = StringIO()
+    stderr = StringIO()
+    with redirect_stdout(stdout), redirect_stderr(stderr):
+        status = main(args)
+    return status, stdout.getvalue(), stderr.getvalue()
+
+
+class WorkflowStateCliTests(unittest.TestCase):
+    def test_state_start_writes_authoritative_workflow_state(self) -> None:
+        with TemporaryDirectory() as tmp:
+            omh_home = Path(tmp) / ".omh"
+
+            status, stdout, stderr = run_cli(["--omh-home", str(omh_home), "state", "start", "--workflow", "deep-interview", "--note", "clarify"])
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            state = json.loads(stdout)["state"]
+            self.assertTrue(state["active"])
+            self.assertEqual(state["workflow"], "deep-interview")
+            self.assertEqual(state["note"], "clarify")
+            self.assertTrue((omh_home / "state" / "deep-interview-state.json").exists())
+            self.assertFalse((omh_home / "runtime" / "runs").exists())
+
+    def test_state_status_survives_new_cli_invocation(self) -> None:
+        with TemporaryDirectory() as tmp:
+            omh_home = Path(tmp) / ".omh"
+
+            self.assertEqual(run_cli(["--omh-home", str(omh_home), "state", "start", "--workflow", "deep-interview"])[0], 0)
+            status, stdout, stderr = run_cli(["--omh-home", str(omh_home), "state", "status"])
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            payload = json.loads(stdout)
+            self.assertEqual(payload["active"][0]["workflow"], "deep-interview")
+
+    def test_allowed_transition_auto_completes_source_state(self) -> None:
+        with TemporaryDirectory() as tmp:
+            omh_home = Path(tmp) / ".omh"
+
+            self.assertEqual(run_cli(["--omh-home", str(omh_home), "state", "start", "--workflow", "deep-interview"])[0], 0)
+            self.assertEqual(run_cli(["--omh-home", str(omh_home), "state", "start", "--workflow", "ralplan"])[0], 0)
+
+            deep = json.loads((omh_home / "state" / "deep-interview-state.json").read_text(encoding="utf-8"))
+            ralplan = json.loads((omh_home / "state" / "ralplan-state.json").read_text(encoding="utf-8"))
+            self.assertFalse(deep["active"])
+            self.assertEqual(deep["lifecycle_outcome"], "finished")
+            self.assertEqual(deep["transition_target"], "ralplan")
+            self.assertTrue(ralplan["active"])
+
+    def test_conflicting_transition_is_denied_with_diagnostic(self) -> None:
+        with TemporaryDirectory() as tmp:
+            omh_home = Path(tmp) / ".omh"
+
+            self.assertEqual(run_cli(["--omh-home", str(omh_home), "state", "start", "--workflow", "deep-interview"])[0], 0)
+            status, _, stderr = run_cli(["--omh-home", str(omh_home), "state", "start", "--workflow", "team"])
+
+            self.assertEqual(status, 2)
+            self.assertIn("active workflow deep-interview must finish or be cleared first", stderr)
+
+    def test_terminal_outcomes_are_recorded(self) -> None:
+        with TemporaryDirectory() as tmp:
+            omh_home = Path(tmp) / ".omh"
+
+            self.assertEqual(run_cli(["--omh-home", str(omh_home), "state", "start", "--workflow", "ralplan"])[0], 0)
+            status, stdout, stderr = run_cli(
+                ["--omh-home", str(omh_home), "state", "finish", "--workflow", "ralplan", "--outcome", "question_pending", "--note", "waiting"]
+            )
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            state = json.loads(stdout)["state"]
+            self.assertFalse(state["active"])
+            self.assertEqual(state["lifecycle_outcome"], "question_pending")
+            self.assertEqual(state["note"], "waiting")
+
+    def test_state_clear_removes_only_target_workflow(self) -> None:
+        with TemporaryDirectory() as tmp:
+            omh_home = Path(tmp) / ".omh"
+
+            self.assertEqual(run_cli(["--omh-home", str(omh_home), "state", "start", "--workflow", "deep-interview"])[0], 0)
+            self.assertEqual(run_cli(["--omh-home", str(omh_home), "state", "start", "--workflow", "ralplan"])[0], 0)
+            status, stdout, stderr = run_cli(["--omh-home", str(omh_home), "state", "clear", "--workflow", "ralplan"])
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            self.assertTrue(json.loads(stdout)["removed"])
+            self.assertTrue((omh_home / "state" / "deep-interview-state.json").exists())
+            self.assertFalse((omh_home / "state" / "ralplan-state.json").exists())
+
+    def test_state_reports_malformed_state_without_crashing(self) -> None:
+        with TemporaryDirectory() as tmp:
+            omh_home = Path(tmp) / ".omh"
+            state_dir = omh_home / "state"
+            state_dir.mkdir(parents=True)
+            (state_dir / "ralplan-state.json").write_text("{not-json", encoding="utf-8")
+
+            status, stdout, stderr = run_cli(["--omh-home", str(omh_home), "state", "status"])
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 1)
+            payload = json.loads(stdout)
+            self.assertFalse(payload["ok"])
+            self.assertIn("ralplan-state.json", payload["errors"][0]["path"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add file-backed workflow lifecycle state under the managed home directory.
- Introduce omh state status/start/finish/clear with explicit outcomes and guarded transitions.
- Surface workflow state in doctor output and document the local state boundary.

## Verification
- python3 -m unittest discover -s tests -p 'test_workflow_state.py'\n- python3 -m unittest discover -s tests -p 'test_cli.py'\n- python3 -m unittest discover -s tests -p 'test_router_content.py'\n- python3 -m compileall src\n\n## Stack\nBase: #4\nNext: runtime evidence validation