### PR TITLE
Phase 3: validate and export runtime evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ omh install --from-skills-dir ./skills
 omh update --from-skills-dir ./skills
 omh apply --dry-run
 omh runtime record --skill oh-my-hermes --harness coding-handling --status started
+omh runtime validate
+omh runtime export
 omh runtime runs
 omh docs workflows
 omh list
@@ -117,10 +119,19 @@ or modify Hermes internals.
 - workflow run envelopes in `~/.omh/runtime/runs/<run-id>/run.json`
 - append-only run events in `events.jsonl`
 - delegation observation in `delegation.json`
+- wrapper observation in `wrapper.json`
 
 Delegation artifacts separate `requested` from `observed`. If Hermes or a bot
 wrapper cannot prove that a specialist lane actually ran, the result should stay
 `not_observed` or `not_available`.
+
+Bot wrappers can also record what they actually observed:
+
+```sh
+omh runtime wrapper --run <run-id> --prompt-dispatched --response-observed --completion-status completed
+omh runtime validate --run <run-id>
+omh runtime export --redacted
+```
 
 ## Routing Model
 
@@ -156,6 +167,9 @@ it could mean normal conversation.
 | `omh runtime status` | Inspect local runtime artifact state. |
 | `omh runtime record` | Create a metadata-only workflow run artifact. |
 | `omh runtime delegate` | Record observed or unavailable delegation for a run. |
+| `omh runtime wrapper` | Record what a bot or wrapper actually observed for a run. |
+| `omh runtime validate` | Validate runtime run, event, delegation, and wrapper artifacts. |
+| `omh runtime export` | Export runtime evidence, redacted by default. |
 | `omh state status` | Inspect file-backed workflow lifecycle state under `~/.omh/state`. |
 | `omh docs workflows` | Print or verify the generated workflow reference from catalog data. |
 | `omh snippet` | Print optional workspace guidance without applying it. |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -99,12 +99,13 @@ Runtime artifacts are local JSON/JSONL files under `.omh/runtime/`.
         run.json
         events.jsonl
         delegation.json
+        wrapper.json
         evidence/
 ```
 
 `state.json` records install, apply, and doctor summaries. A run directory
 records a workflow envelope, append-only events, delegation observation, and
-optional evidence files.
+wrapper observation plus optional evidence files.
 
 The runtime artifact layer is intentionally small:
 
@@ -114,10 +115,17 @@ The runtime artifact layer is intentionally small:
 - schema-versioned files
 - CLI inspection through `omh runtime status`, `omh runtime runs`, and
   `omh runtime show <run-id>`
+- schema validation through `omh runtime validate`
+- redacted export through `omh runtime export`
 
 Bot wrappers can call `omh runtime record` before invoking Hermes and
 `omh runtime delegate` after the response if delegation metadata is available.
 If not, they should record `not_observed` rather than guessing.
+
+Wrappers can also call `omh runtime wrapper` to record whether a prompt was
+dispatched, whether a Hermes response was observed, whether verification was
+observed, and which gaps remain unobserved. This keeps bot integration evidence
+separate from claims about Hermes internals.
 
 ## Workflow State
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -76,6 +76,8 @@ run_id="$(printf '%s' "$run_json" | python -c 'import json,sys; print(json.load(
 
 # After Hermes responds, record what the bot could actually observe.
 omh runtime delegate --run "$run_id" --requested --not-observed --result not_observed
+omh runtime wrapper --run "$run_id" --prompt-dispatched --response-observed --completion-status completed --gap "specialist lane metadata not exposed"
+omh runtime validate --run "$run_id"
 omh runtime show "$run_id"
 ```
 
@@ -83,6 +85,11 @@ For hosted bots, run these commands inside the same container, virtual
 environment, or user account that owns the bot runtime. If the wrapper can
 observe a specialist lane result, record it with `--observed`; otherwise keep
 the result as `not_observed`.
+
+Use `omh runtime export --redacted` when you need a portable support artifact.
+Exports redact prompt, response, token, secret, key, and password-shaped fields by
+default while preserving proof fields such as run status, event names, observed
+delegation flags, and wrapper completion status.
 
 ## Review Checklist
 

--- a/src/cli.py
+++ b/src/cli.py
@@ -17,12 +17,15 @@ from .runtime_artifacts import (
     PRIVACY_MODES,
     RUN_STATUSES,
     create_run,
+    export_runtime,
     list_runs,
     read_state,
     read_state_result,
     show_run,
     update_state,
+    validate_runtime,
     write_delegation,
+    write_wrapper_contract,
 )
 from .skills.render import workflow_reference_markdown
 from .skill_pack import builtin_harnesses, builtin_definitions
@@ -234,6 +237,40 @@ def cmd_runtime_delegate(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_runtime_wrapper(args: argparse.Namespace) -> int:
+    paths = _paths(args)
+    run_dir = paths.runtime_runs_dir / args.run_id
+    if not (run_dir / "run.json").exists():
+        raise OmhError(f"runtime run not found: {args.run_id}")
+    try:
+        wrapper = write_wrapper_contract(
+            run_dir,
+            {
+                "prompt_dispatched": args.prompt_dispatched,
+                "hermes_response_observed": args.response_observed,
+                "verification_observed": args.verification_observed,
+                "completion_status": args.completion_status,
+                "unobserved_gaps": args.gap or [],
+                "message": args.message or "",
+            },
+        )
+    except ValueError as exc:
+        raise OmhError(str(exc)) from exc
+    _print_json({"wrapper": wrapper})
+    return 0
+
+
+def cmd_runtime_validate(args: argparse.Namespace) -> int:
+    result = validate_runtime(_paths(args), args.run_id)
+    _print_json(result)
+    return 0 if result["ok"] else 1
+
+
+def cmd_runtime_export(args: argparse.Namespace) -> int:
+    _print_json(export_runtime(_paths(args), redacted=args.redacted))
+    return 0
+
+
 def cmd_snippet(args: argparse.Namespace) -> int:
     if args.dry_run or not args.output:
         print(WORKSPACE_SNIPPET.rstrip())
@@ -401,6 +438,25 @@ def build_parser() -> argparse.ArgumentParser:
     runtime_delegate.add_argument("--evidence-ref", action="append")
     runtime_delegate.add_argument("--message", default="")
     runtime_delegate.set_defaults(func=cmd_runtime_delegate)
+
+    runtime_wrapper = runtime_sub.add_parser("wrapper")
+    runtime_wrapper.add_argument("--run", dest="run_id", required=True)
+    runtime_wrapper.add_argument("--prompt-dispatched", action="store_true")
+    runtime_wrapper.add_argument("--response-observed", action="store_true")
+    runtime_wrapper.add_argument("--verification-observed", action="store_true")
+    runtime_wrapper.add_argument("--completion-status", choices=("started", "completed", "blocked", "failed", "unknown"), default="unknown")
+    runtime_wrapper.add_argument("--gap", action="append")
+    runtime_wrapper.add_argument("--message", default="")
+    runtime_wrapper.set_defaults(func=cmd_runtime_wrapper)
+
+    runtime_validate = runtime_sub.add_parser("validate")
+    runtime_validate.add_argument("--run", dest="run_id", default=None)
+    runtime_validate.set_defaults(func=cmd_runtime_validate)
+
+    runtime_export = runtime_sub.add_parser("export")
+    runtime_export.add_argument("--redacted", action="store_true", default=True)
+    runtime_export.add_argument("--no-redact", dest="redacted", action="store_false")
+    runtime_export.set_defaults(func=cmd_runtime_export)
 
     state = sub.add_parser("state")
     state_sub = state.add_subparsers(dest="state_command", required=True)

--- a/src/runtime_artifacts.py
+++ b/src/runtime_artifacts.py
@@ -17,6 +17,8 @@ PRIVACY_MODES = ("metadata_only",)
 DELEGATION_RESULTS = ("completed", "blocked", "failed", "not_available", "not_observed")
 OBSERVED_RESULTS = ("completed", "blocked", "failed")
 UNOBSERVED_RESULTS = ("not_available", "not_observed")
+EVENT_LEVELS = ("debug", "info", "warning", "error")
+WRAPPER_COMPLETION_STATUSES = ("started", "completed", "blocked", "failed", "unknown")
 
 
 def _ensure_private_dir(path: Path) -> None:
@@ -200,6 +202,91 @@ def write_delegation(run_dir: Path, delegation: dict[str, Any]) -> dict[str, Any
     return record
 
 
+def write_wrapper_contract(run_dir: Path, wrapper: dict[str, Any]) -> dict[str, Any]:
+    status = wrapper.get("completion_status", "unknown")
+    if status not in WRAPPER_COMPLETION_STATUSES:
+        raise ValueError(f"unsupported wrapper completion status: {status}")
+    record = {
+        "schema_version": SCHEMA_VERSION,
+        "updated_at": utc_now(),
+        "prompt_dispatched": bool(wrapper.get("prompt_dispatched", False)),
+        "hermes_response_observed": bool(wrapper.get("hermes_response_observed", False)),
+        "verification_observed": bool(wrapper.get("verification_observed", False)),
+        "completion_status": status,
+        "unobserved_gaps": list(wrapper.get("unobserved_gaps", [])),
+        "message": wrapper.get("message", ""),
+    }
+    _atomic_write_json(run_dir / "wrapper.json", record)
+    append_event(
+        run_dir,
+        {
+            "event": "wrapper_contract_recorded",
+            "level": "info",
+            "message": f"wrapper contract {status}",
+            "data": {
+                "prompt_dispatched": record["prompt_dispatched"],
+                "hermes_response_observed": record["hermes_response_observed"],
+                "verification_observed": record["verification_observed"],
+            },
+        },
+    )
+    return record
+
+
+def _require(condition: bool, errors: list[str], message: str) -> None:
+    if not condition:
+        errors.append(message)
+
+
+def validate_run_record(run: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    _require(run.get("schema_version") == SCHEMA_VERSION, errors, "run schema_version is invalid")
+    for key in ("run_id", "created_at", "updated_at", "skill", "harness", "status", "privacy"):
+        _require(isinstance(run.get(key), str) if key != "schema_version" else True, errors, f"run {key} must be a string")
+    _require(run.get("status") in RUN_STATUSES, errors, f"run status is invalid: {run.get('status')!r}")
+    _require(run.get("privacy") in PRIVACY_MODES, errors, f"run privacy is invalid: {run.get('privacy')!r}")
+    for key in ("trigger", "inputs_summary", "outputs_summary", "verification_summary"):
+        _require(isinstance(run.get(key, ""), str), errors, f"run {key} must be a string")
+    return errors
+
+
+def validate_event_record(event: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    _require(event.get("schema_version") == SCHEMA_VERSION, errors, "event schema_version is invalid")
+    for key in ("timestamp", "event", "level", "message"):
+        _require(isinstance(event.get(key), str), errors, f"event {key} must be a string")
+    _require(event.get("level") in EVENT_LEVELS, errors, f"event level is invalid: {event.get('level')!r}")
+    if "data" in event:
+        _require(isinstance(event["data"], dict), errors, "event data must be an object")
+    return errors
+
+
+def validate_delegation_record(delegation: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    _require(delegation.get("schema_version") == SCHEMA_VERSION, errors, "delegation schema_version is invalid")
+    _require(isinstance(delegation.get("requested"), bool), errors, "delegation requested must be boolean")
+    _require(isinstance(delegation.get("observed"), bool), errors, "delegation observed must be boolean")
+    _require(delegation.get("result") in DELEGATION_RESULTS, errors, f"delegation result is invalid: {delegation.get('result')!r}")
+    _require(isinstance(delegation.get("participants"), list), errors, "delegation participants must be a list")
+    _require(isinstance(delegation.get("evidence_refs"), list), errors, "delegation evidence_refs must be a list")
+    try:
+        _validate_delegation(bool(delegation.get("observed")), str(delegation.get("result")))
+    except ValueError as exc:
+        errors.append(str(exc))
+    return errors
+
+
+def validate_wrapper_record(wrapper: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    _require(wrapper.get("schema_version") == SCHEMA_VERSION, errors, "wrapper schema_version is invalid")
+    for key in ("prompt_dispatched", "hermes_response_observed", "verification_observed"):
+        _require(isinstance(wrapper.get(key), bool), errors, f"wrapper {key} must be boolean")
+    _require(wrapper.get("completion_status") in WRAPPER_COMPLETION_STATUSES, errors, f"wrapper completion_status is invalid: {wrapper.get('completion_status')!r}")
+    _require(isinstance(wrapper.get("unobserved_gaps"), list), errors, "wrapper unobserved_gaps must be a list")
+    _require(isinstance(wrapper.get("message", ""), str), errors, "wrapper message must be a string")
+    return errors
+
+
 def list_runs(paths: OmhPaths) -> list[dict[str, Any]]:
     if not paths.runtime_runs_dir.exists():
         return []
@@ -228,5 +315,88 @@ def show_run(paths: OmhPaths, run_id: str) -> dict[str, Any]:
         "run": run,
         "events": read_events(run_dir),
         "delegation": _read_json(run_dir / "delegation.json"),
+        "wrapper": _read_json(run_dir / "wrapper.json"),
         "evidence": sorted(path.name for path in evidence_dir.iterdir()) if evidence_dir.exists() else [],
     }
+
+
+def validate_run_dir(run_dir: Path) -> dict[str, Any]:
+    errors: list[str] = []
+    run_path = run_dir / "run.json"
+    try:
+        run = _read_json(run_path)
+    except (OSError, JSONDecodeError, ValueError) as exc:
+        run = None
+        errors.append(f"{run_path}: {exc}")
+    if not run:
+        errors.append(f"{run_path}: missing run.json")
+    else:
+        errors.extend(f"{run_path}: {error}" for error in validate_run_record(run))
+    events_path = run_dir / "events.jsonl"
+    if events_path.exists():
+        try:
+            for index, line in enumerate(events_path.read_text(encoding="utf-8").splitlines(), start=1):
+                if not line.strip():
+                    continue
+                event = json.loads(line)
+                if not isinstance(event, dict):
+                    errors.append(f"{events_path}:{index}: event must be an object")
+                    continue
+                errors.extend(f"{events_path}:{index}: {error}" for error in validate_event_record(event))
+        except (OSError, JSONDecodeError) as exc:
+            errors.append(f"{events_path}: {exc}")
+    else:
+        errors.append(f"{events_path}: missing events.jsonl")
+    for name, validator in (("delegation.json", validate_delegation_record), ("wrapper.json", validate_wrapper_record)):
+        path = run_dir / name
+        if not path.exists():
+            continue
+        try:
+            record = _read_json(path)
+        except (OSError, JSONDecodeError, ValueError) as exc:
+            record = None
+            errors.append(f"{path}: {exc}")
+        if record:
+            errors.extend(f"{path}: {error}" for error in validator(record))
+    return {"run_id": run_dir.name, "ok": not errors, "errors": errors}
+
+
+def validate_runtime(paths: OmhPaths, run_id: str | None = None) -> dict[str, Any]:
+    if run_id:
+        run_dirs = [paths.runtime_runs_dir / run_id]
+    else:
+        run_dirs = sorted(path for path in paths.runtime_runs_dir.glob("*") if path.is_dir()) if paths.runtime_runs_dir.exists() else []
+    results = [validate_run_dir(run_dir) for run_dir in run_dirs]
+    return {"ok": all(result["ok"] for result in results), "runs": results}
+
+
+SENSITIVE_KEY_PARTS = ("prompt", "response", "secret", "token", "api_key", "apikey", "password")
+
+
+def _redact(value: Any) -> Any:
+    if isinstance(value, dict):
+        redacted: dict[str, Any] = {}
+        for key, item in value.items():
+            if any(part in key.lower() for part in SENSITIVE_KEY_PARTS):
+                redacted[key] = "[redacted]"
+            else:
+                redacted[key] = _redact(item)
+        return redacted
+    if isinstance(value, list):
+        return [_redact(item) for item in value]
+    return value
+
+
+def export_runtime(paths: OmhPaths, redacted: bool = True) -> dict[str, Any]:
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "runtime_dir": str(paths.runtime_dir),
+        "state": read_state(paths),
+        "runs": [show_run(paths, run["run_id"]) for run in list_runs(paths)],
+    }
+    if redacted:
+        payload = _redact(payload)
+        payload["redacted"] = True
+    else:
+        payload["redacted"] = False
+    return payload

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -189,6 +189,40 @@ class CliTests(unittest.TestCase):
             self.assertTrue(shown["delegation"]["requested"])
             self.assertFalse(shown["delegation"]["observed"])
 
+            status, stdout, stderr = run_cli(
+                [
+                    "--omh-home",
+                    str(omh_home),
+                    "--hermes-home",
+                    str(hermes_home),
+                    "runtime",
+                    "wrapper",
+                    "--run",
+                    run["run_id"],
+                    "--prompt-dispatched",
+                    "--response-observed",
+                    "--completion-status",
+                    "completed",
+                    "--gap",
+                    "verification lane not exposed",
+                ]
+            )
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            self.assertTrue(json.loads(stdout)["wrapper"]["prompt_dispatched"])
+
+            status, stdout, stderr = run_cli(["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "runtime", "validate"])
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            self.assertTrue(json.loads(stdout)["ok"])
+
+            status, stdout, stderr = run_cli(["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "runtime", "export"])
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            exported = json.loads(stdout)
+            self.assertTrue(exported["redacted"])
+            self.assertEqual(exported["runs"][0]["wrapper"]["completion_status"], "completed")
+
     def test_docs_workflows_command_prints_writes_and_checks_generated_reference(self) -> None:
         status, stdout, stderr = run_cli(["docs", "workflows"])
         self.assertEqual(stderr, "")

--- a/tests/test_runtime_artifacts.py
+++ b/tests/test_runtime_artifacts.py
@@ -12,7 +12,18 @@ from _local_package import load_local_package
 
 load_local_package()
 from omh.paths import resolve_paths
-from omh.runtime_artifacts import create_run, list_runs, new_run_id, show_run, update_state, write_delegation
+from omh.runtime_artifacts import (
+    create_run,
+    export_runtime,
+    list_runs,
+    new_run_id,
+    show_run,
+    update_state,
+    validate_runtime,
+    validate_run_record,
+    write_delegation,
+    write_wrapper_contract,
+)
 
 
 class RuntimeArtifactTests(unittest.TestCase):
@@ -33,6 +44,7 @@ class RuntimeArtifactTests(unittest.TestCase):
             self.assertTrue((run_dir / "evidence").is_dir())
             self.assertEqual(json.loads(paths.runtime_state_path.read_text(encoding="utf-8"))["last_run_id"], run["run_id"])
             self.assertEqual(list_runs(paths)[0]["run_id"], run["run_id"])
+            self.assertEqual(validate_run_record(run), [])
 
     def test_create_run_does_not_collide_for_rapid_same_harness_records(self) -> None:
         with TemporaryDirectory() as tmp:
@@ -84,6 +96,66 @@ class RuntimeArtifactTests(unittest.TestCase):
                 write_delegation(paths.runtime_runs_dir / run["run_id"], {"observed": True, "result": "not_observed"})
             with self.assertRaises(ValueError):
                 write_delegation(paths.runtime_runs_dir / run["run_id"], {"observed": False, "result": "completed"})
+
+    def test_write_wrapper_contract_records_observed_boundaries(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            run = create_run(paths, {"skill": "oh-my-hermes", "harness": "coding-handling", "status": "started"})
+
+            wrapper = write_wrapper_contract(
+                paths.runtime_runs_dir / run["run_id"],
+                {
+                    "prompt_dispatched": True,
+                    "hermes_response_observed": True,
+                    "verification_observed": False,
+                    "completion_status": "blocked",
+                    "unobserved_gaps": ["separate specialist lane not exposed"],
+                },
+            )
+
+            self.assertTrue(wrapper["prompt_dispatched"])
+            self.assertFalse(wrapper["verification_observed"])
+            shown = show_run(paths, run["run_id"])
+            self.assertEqual(shown["wrapper"]["completion_status"], "blocked")
+            self.assertIn("wrapper_contract_recorded", {event["event"] for event in shown["events"]})
+
+    def test_validate_runtime_rejects_missing_and_invalid_artifacts(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            good = create_run(paths, {"skill": "oh-my-hermes", "harness": "coding-handling", "status": "started"})
+
+            self.assertTrue(validate_runtime(paths, good["run_id"])["ok"])
+
+            bad_dir = paths.runtime_runs_dir / "bad-run"
+            bad_dir.mkdir(parents=True)
+            (bad_dir / "run.json").write_text('{"schema_version": 1, "run_id": "bad-run", "status": "bogus"}', encoding="utf-8")
+            (bad_dir / "events.jsonl").write_text('{"schema_version": 1, "timestamp": "now", "event": "x", "level": "bad", "message": ""}\n', encoding="utf-8")
+
+            result = validate_runtime(paths)
+            self.assertFalse(result["ok"])
+            bad = next(item for item in result["runs"] if item["run_id"] == "bad-run")
+            self.assertTrue(any("status is invalid" in error for error in bad["errors"]))
+            self.assertTrue(any("event level is invalid" in error for error in bad["errors"]))
+
+    def test_export_runtime_redacts_sensitive_keys(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            run = create_run(paths, {"skill": "oh-my-hermes", "harness": "coding-handling", "status": "started"})
+            write_wrapper_contract(
+                paths.runtime_runs_dir / run["run_id"],
+                {
+                    "prompt_dispatched": True,
+                    "completion_status": "completed",
+                    "message": "safe summary",
+                    "prompt_body": "do not export",
+                },
+            )
+
+            exported = export_runtime(paths, redacted=True)
+
+            self.assertTrue(exported["redacted"])
+            self.assertEqual(exported["runs"][0]["wrapper"]["message"], "safe summary")
+            self.assertNotIn("do not export", json.dumps(exported))
 
     def test_update_state_merges_patch(self) -> None:
         with TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- Add runtime wrapper contracts, run/delegation/event validation, and redacted runtime export.
- Extend omh runtime with wrapper, validate, and export commands.
- Document the evidence model and add CLI/runtime regression tests.

## Verification
- python3 -m unittest discover -s tests -p 'test_runtime_artifacts.py'\n- python3 -m unittest discover -s tests -p 'test_cli.py'\n- python3 -m unittest discover -s tests -p 'test_router_content.py'\n- python3 -m compileall src\n\n## Stack\nBase: #5\nNext: release discipline