### PR TITLE
Phase 4: define release channels and readiness checks

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,11 +6,18 @@
 
 - [ ] `python -m unittest discover -s tests`
 - [ ] `python -m compileall src`
+- [ ] `python -m omh.cli docs workflows --check`
 - [ ] Relevant dry-run or smoke command:
 
 ## Risk
 
 - 
+
+## Release / Claims
+
+- [ ] Release-channel impact considered (`stable`, `preview`, or `local`)
+- [ ] Runtime/native capability claims are backed by evidence or marked as not observed
+- [ ] Known manual Hermes checks are listed
 
 ## Notes
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,12 +22,19 @@ jobs:
         run: python -m unittest discover -s tests
       - name: Compile package
         run: python -m compileall src
+      - name: Generated workflow docs check
+        run: python -m omh.cli docs workflows --check
       - name: Dry-run install smoke
         run: python -m omh.cli --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke install --dry-run
+      - name: Stable-channel dry-run smoke
+        run: python -m omh.cli --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke install --dry-run --channel stable --version 0.1.0
       - name: Runtime artifact smoke
         run: |
           run_json="$(python -m omh.cli --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke runtime record --skill oh-my-hermes --harness coding-handling --status started)"
           run_id="$(printf '%s' "$run_json" | python -c 'import json,sys; print(json.load(sys.stdin)["run"]["run_id"])')"
           python -m omh.cli --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke runtime delegate --run "$run_id" --requested --not-observed --result not_observed
+          python -m omh.cli --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke runtime wrapper --run "$run_id" --prompt-dispatched --response-observed --completion-status completed
+          python -m omh.cli --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke runtime validate --run "$run_id"
+          python -m omh.cli --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke runtime export --redacted
           python -m omh.cli --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke runtime show "$run_id"
           python -m omh.cli --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke runtime runs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,12 @@ PYTHONPATH=src python -m unittest discover -s tests
 - The change is scoped and explained.
 - Tests pass locally.
 - Public docs were updated when behavior changed.
+- Generated docs were refreshed or `python -m omh.cli docs workflows --check`
+  was run when catalog data changed.
+- Release-channel impact was considered for installer, update, or packaging
+  changes.
+- Runtime or native capability claims are backed by artifact evidence, wrapper
+  evidence, or explicit "not observed" language.
 - The PR description includes risk, validation, and known gaps.
 - New public strings avoid coupling the project to another agent runtime.
 
@@ -35,4 +41,3 @@ PYTHONPATH=src python -m unittest discover -s tests
 
 Use concise decision-oriented messages. Mention why the change exists, not just
 what files changed.
-

--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@ Install and apply the managed Hermes skill pack without cloning the repository:
 curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes-agent/main/install.sh | sh
 ```
 
+The default installer target is the preview channel from `main`. For a pinned
+stable install, use a tagged release:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes-agent/main/install.sh | OMH_CHANNEL=stable OMH_VERSION=0.1.0 sh
+```
+
 Then open Hermes Agent and use the installed skills through Hermes' normal skill
 surfaces.
 
@@ -76,6 +83,7 @@ Installer options:
 ```sh
 curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes-agent/main/install.sh | OMH_AUTO_APPLY=0 sh
 curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes-agent/main/install.sh | OMH_RUN_DOCTOR=0 sh
+curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes-agent/main/install.sh | OMH_CHANNEL=stable OMH_VERSION=0.1.0 sh
 curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes-agent/main/install.sh | OMH_PIP_ARGS= sh
 ```
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -11,6 +11,16 @@ Run the installer:
 curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes-agent/main/install.sh | sh
 ```
 
+By default this installs the preview channel from the `main` branch archive.
+For pinned stable installs, pass a release version:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes-agent/main/install.sh | OMH_CHANNEL=stable OMH_VERSION=0.1.0 sh
+```
+
+For custom release archives or local package sources accepted by `pip`, pass
+`OMH_PACKAGE_URL`.
+
 The installer prepares the `omh` command, installs the managed Hermes skills,
 registers the managed skill directory with Hermes, and checks the result.
 
@@ -117,13 +127,16 @@ path.
 Update the installed skill pack:
 
 ```sh
-omh update
+omh update --channel preview
 omh apply
 omh doctor
 ```
 
+Use `omh update --channel stable --version <version>` to record a pinned stable
+update intent, or `omh update --channel local --from-skills-dir ./skills` for a
+local fixture. Local modifications block updates unless `--force` is supplied.
 Use `omh apply` after an update to make sure Hermes still has the managed skill
-directory registered.
+directory registered, then restart Hermes Agent.
 
 ## Reapply
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,75 @@
+# Release Process
+
+This project ships a conservative Hermes skill layer. A release is ready only
+when install behavior, generated workflow docs, runtime evidence validation, and
+public claims are all checked.
+
+## Channels
+
+| Channel | Purpose | Install target |
+| --- | --- | --- |
+| `stable` | Pinned user installs and support reproduction | Git tag archive such as `v0.1.0` |
+| `preview` | Latest `main` for early testing | `main` branch archive |
+| `local` | Maintainer smoke tests from local fixtures | Explicit local source or package URL |
+
+Pinned stable install:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes-agent/main/install.sh | OMH_CHANNEL=stable OMH_VERSION=0.1.0 sh
+```
+
+Preview install:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes-agent/main/install.sh | sh
+```
+
+Custom archive:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes-agent/main/install.sh | OMH_PACKAGE_URL=https://github.com/rlaope/oh-my-hermes-agent/archive/refs/tags/v0.1.0.zip sh
+```
+
+## Required Checks
+
+Run before tagging:
+
+```sh
+python3 -m unittest discover -s tests
+python3 -m compileall src
+python3 -m src.cli docs workflows --check
+python3 -m src.cli --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke install --dry-run --channel stable --version 0.1.0
+```
+
+Runtime evidence smoke:
+
+```sh
+run_json="$(python3 -m src.cli --omh-home /tmp/omh-smoke runtime record --skill oh-my-hermes --harness coding-handling --status started)"
+run_id="$(printf '%s' "$run_json" | python3 -c 'import json,sys; print(json.load(sys.stdin)["run"]["run_id"])')"
+python3 -m src.cli --omh-home /tmp/omh-smoke runtime delegate --run "$run_id" --requested --not-observed --result not_observed
+python3 -m src.cli --omh-home /tmp/omh-smoke runtime wrapper --run "$run_id" --prompt-dispatched --response-observed --completion-status completed
+python3 -m src.cli --omh-home /tmp/omh-smoke runtime validate --run "$run_id"
+python3 -m src.cli --omh-home /tmp/omh-smoke runtime export --redacted
+```
+
+## Release Notes Must Include
+
+- Release version and channel.
+- Install target used for smoke testing.
+- Update path tested.
+- Workflow docs generation status.
+- Runtime validation status.
+- Known manual Hermes checks that could not be automated.
+- Any public claim that depends on wrapper evidence rather than Hermes-native
+  capability evidence.
+
+## Known Gap Language
+
+Use explicit proof-boundary language:
+
+- "Prompt-level routing guidance" when only installed skills are involved.
+- "Wrapper-observed" when evidence comes from a bot or shell wrapper.
+- "Not observed" when specialist delegation metadata is unavailable.
+
+Do not claim native Hermes hooks, plugins, apps, or internal routing until a
+future capability probe and runtime evidence both support that claim.

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env sh
 set -eu
 
-OMH_PACKAGE_URL="${OMH_PACKAGE_URL:-https://github.com/rlaope/oh-my-hermes-agent/archive/refs/heads/main.zip}"
+OMH_REPO_ARCHIVE_ROOT="${OMH_REPO_ARCHIVE_ROOT:-https://github.com/rlaope/oh-my-hermes-agent/archive/refs}"
+OMH_CHANNEL="${OMH_CHANNEL:-preview}"
+OMH_VERSION="${OMH_VERSION:-}"
+OMH_PACKAGE_URL="${OMH_PACKAGE_URL:-}"
 OMH_PYTHON="${OMH_PYTHON:-python3}"
 OMH_PIP_ARGS="${OMH_PIP_ARGS:---user}"
 OMH_AUTO_APPLY="${OMH_AUTO_APPLY:-1}"
@@ -21,7 +24,34 @@ if ! command -v "$OMH_PYTHON" >/dev/null 2>&1; then
   exit 1
 fi
 
-say "Installing oh-my-hermes-agent..."
+if [ -z "$OMH_PACKAGE_URL" ]; then
+  case "$OMH_CHANNEL" in
+    preview)
+      OMH_PACKAGE_URL="$OMH_REPO_ARCHIVE_ROOT/heads/main.zip"
+      ;;
+    stable)
+      if [ -z "$OMH_VERSION" ]; then
+        say "omh installer: OMH_CHANNEL=stable requires OMH_VERSION, for example OMH_VERSION=0.1.0."
+        exit 1
+      fi
+      case "$OMH_VERSION" in
+        v*) OMH_TAG="$OMH_VERSION" ;;
+        *) OMH_TAG="v$OMH_VERSION" ;;
+      esac
+      OMH_PACKAGE_URL="$OMH_REPO_ARCHIVE_ROOT/tags/$OMH_TAG.zip"
+      ;;
+    local)
+      say "omh installer: OMH_CHANNEL=local requires OMH_PACKAGE_URL to point at a local archive or path accepted by pip."
+      exit 1
+      ;;
+    *)
+      say "omh installer: unsupported OMH_CHANNEL '$OMH_CHANNEL' (expected preview, stable, or local)."
+      exit 1
+      ;;
+  esac
+fi
+
+say "Installing oh-my-hermes-agent from $OMH_CHANNEL channel..."
 "$OMH_PYTHON" -m pip install $OMH_PIP_ARGS --upgrade "$OMH_PACKAGE_URL"
 
 say "Installing managed Hermes skills..."

--- a/src/cli.py
+++ b/src/cli.py
@@ -12,6 +12,7 @@ from .hashutil import sha256_file
 from .installer import OmhError, install_skill_pack, uninstall_skill_pack
 from .manifest import read_manifest
 from .paths import resolve_paths
+from .release import RELEASE_CHANNELS, package_url_for
 from .runtime_artifacts import (
     DELEGATION_RESULTS,
     PRIVACY_MODES,
@@ -50,9 +51,16 @@ def _print_json(data: object) -> None:
 
 def cmd_install(args: argparse.Namespace) -> int:
     paths = _paths(args)
+    try:
+        release = package_url_for(args.channel, args.version or "", args.package_url or "")
+    except ValueError as exc:
+        raise OmhError(str(exc)) from exc
+    if args.channel == "local" and not (args.from_skills_dir or args.source):
+        raise OmhError("local channel requires --from-skills-dir or --source")
     source_dir = Path(args.from_skills_dir or args.source).expanduser().resolve() if (args.from_skills_dir or args.source) else None
     source = str(source_dir) if source_dir else "builtin"
     result = install_skill_pack(paths, source=source, source_dir=source_dir, force=args.force, dry_run=args.dry_run)
+    result.update({"release_channel": release.channel, "release_version": release.version, "release_package_url": release.package_url})
     if not args.dry_run:
         update_state(
             paths,
@@ -62,6 +70,9 @@ def cmd_install(args: argparse.Namespace) -> int:
                 "manifest_path": str(paths.manifest_path),
                 "manifest_sha256": sha256_file(paths.manifest_path),
                 "source": source,
+                "release_channel": release.channel,
+                "release_version": release.version,
+                "release_package_url": release.package_url,
                 "installed_skills": len(result.get("skills", [])),
                 "skills_dir": str(paths.skills_dir),
             },
@@ -76,6 +87,9 @@ def cmd_update(args: argparse.Namespace) -> int:
 
 def cmd_convert(args: argparse.Namespace) -> int:
     args.source = args.from_skills_dir
+    args.channel = "local"
+    args.version = ""
+    args.package_url = ""
     return cmd_install(args)
 
 
@@ -358,6 +372,9 @@ def build_parser() -> argparse.ArgumentParser:
     def add_common_install(p: argparse.ArgumentParser) -> None:
         p.add_argument("--from-skills-dir", default=None, help="Import skills from a local skill directory.")
         p.add_argument("--source", default=None, help="Mockable local source directory for install/update.")
+        p.add_argument("--channel", choices=RELEASE_CHANNELS, default="preview", help="Release channel metadata for this install/update.")
+        p.add_argument("--version", default="", help="Stable release version such as 0.1.0 or v0.1.0.")
+        p.add_argument("--package-url", default="", help="Explicit release archive URL for support and audit metadata.")
         p.add_argument("--force", action="store_true")
         p.add_argument("--dry-run", action="store_true")
 

--- a/src/release.py
+++ b/src/release.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+REPOSITORY_ARCHIVE_ROOT = "https://github.com/rlaope/oh-my-hermes-agent/archive/refs"
+RELEASE_CHANNELS = ("stable", "preview", "local")
+
+
+@dataclass(frozen=True)
+class ReleaseSelection:
+    channel: str
+    version: str
+    package_url: str
+    source_label: str
+
+
+def package_url_for(channel: str, version: str = "", package_url: str = "") -> ReleaseSelection:
+    if channel not in RELEASE_CHANNELS:
+        raise ValueError(f"unsupported release channel: {channel}")
+    if package_url:
+        return ReleaseSelection(channel, version, package_url, "custom-url")
+    if channel == "stable":
+        if not version:
+            raise ValueError("stable channel requires --version or OMH_VERSION")
+        tag = version if version.startswith("v") else f"v{version}"
+        return ReleaseSelection(channel, version, f"{REPOSITORY_ARCHIVE_ROOT}/tags/{tag}.zip", tag)
+    if channel == "preview":
+        return ReleaseSelection(channel, version, f"{REPOSITORY_ARCHIVE_ROOT}/heads/main.zip", "main")
+    return ReleaseSelection(channel, version, "local", "local")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -42,6 +42,7 @@ class CliTests(unittest.TestCase):
             state = json.loads((omh_home / "runtime" / "state.json").read_text(encoding="utf-8"))
             self.assertEqual(state["installed_skills"], len(manifest["skills"]))
             self.assertEqual(state["last_applied_skills_dir"], str((omh_home / "skills").resolve()))
+            self.assertEqual(state["release_channel"], "preview")
 
             _, doctor_stdout, _ = run_cli(["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "doctor"])
             doctor = json.loads(doctor_stdout)
@@ -129,6 +130,26 @@ class CliTests(unittest.TestCase):
             self.assertEqual(run_cli(["--omh-home", str(omh_home), "update", "--source", str(root / "release-archive")])[0], 0)
             updated = (omh_home / "skills" / "team" / "SKILL.md").read_text(encoding="utf-8")
             self.assertIn("Updated.", updated)
+
+    def test_release_channel_metadata_and_validation(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / ".omh"
+
+            status, stdout, stderr = run_cli(["--omh-home", str(omh_home), "install", "--dry-run", "--channel", "stable", "--version", "0.1.0"])
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            dry_run = json.loads(stdout)
+            self.assertEqual(dry_run["release_channel"], "stable")
+            self.assertIn("/tags/v0.1.0.zip", dry_run["release_package_url"])
+
+            status, _, stderr = run_cli(["--omh-home", str(omh_home), "install", "--dry-run", "--channel", "stable"])
+            self.assertEqual(status, 2)
+            self.assertIn("stable channel requires", stderr)
+
+            status, _, stderr = run_cli(["--omh-home", str(omh_home), "update", "--channel", "local"])
+            self.assertEqual(status, 2)
+            self.assertIn("local channel requires", stderr)
 
     def test_runtime_commands_record_show_and_delegate(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -140,6 +140,7 @@ class RouterContentTests(unittest.TestCase):
             Path("README.md"),
             Path("docs/INSTALLATION.md"),
             Path("docs/APPLICATION_CASES.md"),
+            Path("docs/RELEASE.md"),
             Path("install.sh"),
             Path("CONTRIBUTING.md"),
             Path("CHANGELOG.md"),
@@ -161,13 +162,18 @@ class RouterContentTests(unittest.TestCase):
         readme = Path("README.md").read_text(encoding="utf-8")
         installation = Path("docs/INSTALLATION.md").read_text(encoding="utf-8")
         ci = Path(".github/workflows/ci.yml").read_text(encoding="utf-8")
+        release = Path("docs/RELEASE.md").read_text(encoding="utf-8")
 
         self.assertIn("curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes-agent/main/install.sh | sh", readme)
         self.assertIn("[Installation](docs/INSTALLATION.md)", readme)
         self.assertIn("[Application Cases](docs/APPLICATION_CASES.md)", readme)
+        self.assertIn("OMH_CHANNEL=stable OMH_VERSION=0.1.0", readme)
         self.assertIn("Discord Bot Flow", installation)
         self.assertIn("python -m unittest discover -s tests", ci)
         self.assertIn("python -m compileall src", ci)
+        self.assertIn("docs workflows --check", ci)
+        self.assertIn("Pinned stable install", release)
+        self.assertIn("Runtime evidence smoke", release)
 
     def test_application_cases_document_representative_flows(self) -> None:
         text = Path("docs/APPLICATION_CASES.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Add stable, preview, and local release channels to install/update paths.
- Require pinned stable installs and support explicit package URLs for local/private package flows.
- Add release docs, PR checklist items, and CI smoke checks for docs, stable install, and runtime evidence.

## Verification
- python3 -m unittest discover -s tests -p 'test_cli.py'\n- python3 -m unittest discover -s tests -p 'test_router_content.py'\n- python3 -m src.cli docs workflows --check\n- python3 -m src.cli --omh-home /tmp/omh-phase4-smoke --hermes-home /tmp/hermes-phase4-smoke install --dry-run --channel stable --version 0.1.0\n- python3 -m compileall src\n\n## Stack\nBase: #6\nNext: capability probe