### PR TITLE
Phase 5: add conservative capability probe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
         run: python -m omh.cli --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke install --dry-run
       - name: Stable-channel dry-run smoke
         run: python -m omh.cli --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke install --dry-run --channel stable --version 0.1.0
+      - name: Capability probe smoke
+        run: python -m omh.cli --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke probe
       - name: Runtime artifact smoke
         run: |
           run_json="$(python -m omh.cli --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke runtime record --skill oh-my-hermes --harness coding-handling --status started)"

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ omh runtime validate
 omh runtime export
 omh runtime runs
 omh docs workflows
+omh probe
 omh list
 omh snippet --dry-run
 omh uninstall
@@ -180,6 +181,7 @@ it could mean normal conversation.
 | `omh runtime export` | Export runtime evidence, redacted by default. |
 | `omh state status` | Inspect file-backed workflow lifecycle state under `~/.omh/state`. |
 | `omh docs workflows` | Print or verify the generated workflow reference from catalog data. |
+| `omh probe` | Inspect observable Hermes capability surfaces without mutating internals. |
 | `omh snippet` | Print optional workspace guidance without applying it. |
 | `omh uninstall` | Remove Hermes config registration, optionally removing files. |
 

--- a/docs/APPLICATION_CASES.md
+++ b/docs/APPLICATION_CASES.md
@@ -221,6 +221,8 @@ Before using these cases as public release evidence, verify:
 - The three cases above match actual generated skill behavior.
 - The three cases above can create `.omh/runtime/runs/<run-id>/` artifacts.
 - `delegation.json` separates requested delegation from observed delegation.
+- `omh probe` output is captured before any native hook, plugin, app, MCP, or
+  internal routing claim is made.
 - Public docs avoid comparisons to other projects.
 - Any real Hermes runtime behavior that could not be automated is listed as a
   manual check.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -58,6 +58,23 @@ core behavior.
 Future routing work should deepen the catalog first, then render richer skill
 metadata from it.
 
+## Hermes Capability Boundary
+
+`omh probe` is the non-mutating capability inspection surface. It reports
+observable local evidence for:
+
+- external skill directory registration
+- managed skill installation
+- hook-like files
+- plugin, app, and MCP-like paths
+- wrapper observation artifacts
+- native skill metadata readiness
+
+Probe results use `available`, `missing`, `unknown`, or `unverified`. A file or
+directory probe marked `unverified` is not a native integration claim. Deeper
+Hermes integration requires both a stable Hermes extension contract and runtime
+evidence that the extension ran.
+
 ## Harness Contract
 
 Representative harnesses are preview metadata for generated prompt guidance.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -35,12 +35,14 @@ Check the installation:
 omh doctor
 omh list
 omh runtime status
+omh probe
 ```
 
 `omh doctor` should report a healthy installation. `omh list` should show the
 managed skills available to Hermes. `omh runtime status` should show the local
 runtime artifact directory and the latest install/apply/doctor state when those
-commands have run.
+commands have run. `omh probe` reports observable Hermes capability surfaces
+without mutating Hermes internals.
 
 For concrete examples that show how the installed skills should affect coding,
 planning, and specialist review flows, see
@@ -113,6 +115,8 @@ Before calling the bot integration ready, verify these points:
   skill descriptions available.
 - `omh runtime record` can create a run and `omh runtime show <run-id>` can read
   it from the same runtime context.
+- `omh probe` reports managed skills and external skill directory registration
+  as available before any deeper integration claim is made.
 - If skills do not appear, run `omh apply`, then `omh doctor`, then restart the
   bot again.
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -39,6 +39,7 @@ python3 -m unittest discover -s tests
 python3 -m compileall src
 python3 -m src.cli docs workflows --check
 python3 -m src.cli --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke install --dry-run --channel stable --version 0.1.0
+python3 -m src.cli --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke probe
 ```
 
 Runtime evidence smoke:
@@ -59,6 +60,7 @@ python3 -m src.cli --omh-home /tmp/omh-smoke runtime export --redacted
 - Update path tested.
 - Workflow docs generation status.
 - Runtime validation status.
+- Capability probe status.
 - Known manual Hermes checks that could not be automated.
 - Any public claim that depends on wrapper evidence rather than Hermes-native
   capability evidence.

--- a/src/cli.py
+++ b/src/cli.py
@@ -12,6 +12,7 @@ from .hashutil import sha256_file
 from .installer import OmhError, install_skill_pack, uninstall_skill_pack
 from .manifest import read_manifest
 from .paths import resolve_paths
+from .probe import probe_capabilities
 from .release import RELEASE_CHANNELS, package_url_for
 from .runtime_artifacts import (
     DELEGATION_RESULTS,
@@ -363,6 +364,11 @@ def cmd_state_clear(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_probe(args: argparse.Namespace) -> int:
+    _print_json(probe_capabilities(_paths(args)))
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="omh", description="Install oh-my-hermes skills for Hermes Agent.")
     parser.add_argument("--omh-home", default=None)
@@ -411,6 +417,9 @@ def build_parser() -> argparse.ArgumentParser:
     snippet.add_argument("--dry-run", action="store_true")
     snippet.add_argument("--output", default=None)
     snippet.set_defaults(func=cmd_snippet)
+
+    probe = sub.add_parser("probe")
+    probe.set_defaults(func=cmd_probe)
 
     docs = sub.add_parser("docs")
     docs_sub = docs.add_subparsers(dest="docs_command", required=True)

--- a/src/probe.py
+++ b/src/probe.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from .config_adapter import external_dirs, read_config
+from .paths import OmhPaths
+
+PROBE_STATUSES = ("available", "missing", "unknown", "unverified")
+
+
+@dataclass(frozen=True)
+class Capability:
+    name: str
+    status: str
+    evidence: str
+    message: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "name": self.name,
+            "status": self.status,
+            "evidence": self.evidence,
+            "message": self.message,
+        }
+
+
+def _has_file(path: Path) -> bool:
+    return path.exists() and path.is_file()
+
+
+def _has_dir(path: Path) -> bool:
+    return path.exists() and path.is_dir()
+
+
+def _wrapper_artifacts(paths: OmhPaths) -> list[Path]:
+    if not paths.runtime_runs_dir.exists():
+        return []
+    return sorted(paths.runtime_runs_dir.glob("*/wrapper.json"))
+
+
+def probe_capabilities(paths: OmhPaths) -> dict:
+    config_text = read_config(paths.hermes_config_path)
+    configured_dirs = external_dirs(config_text)
+    skills_registered = str(paths.skills_dir) in configured_dirs
+    capabilities: list[Capability] = []
+
+    capabilities.append(
+        Capability(
+            "external_skill_dirs",
+            "available" if skills_registered else ("missing" if paths.hermes_config_path.exists() else "unknown"),
+            str(paths.hermes_config_path),
+            "Hermes config registers the managed skill directory" if skills_registered else "Managed skill directory is not registered in this Hermes config",
+        )
+    )
+    capabilities.append(
+        Capability(
+            "managed_skills",
+            "available" if _has_file(paths.skills_dir / "oh-my-hermes" / "SKILL.md") else "missing",
+            str(paths.skills_dir),
+            "Managed oh-my-hermes skill is installed" if _has_file(paths.skills_dir / "oh-my-hermes" / "SKILL.md") else "Managed skills are not installed",
+        )
+    )
+    hooks_markers = [paths.hermes_home / "hooks.yaml", paths.hermes_home / "hooks.json"]
+    capabilities.append(
+        Capability(
+            "native_hooks",
+            "unverified" if any(_has_file(path) for path in hooks_markers) else "unknown",
+            ", ".join(str(path) for path in hooks_markers),
+            "Hook-like files exist, but omh has no stable Hermes hook contract to claim native integration"
+            if any(_has_file(path) for path in hooks_markers)
+            else "No stable Hermes hook surface detected by file probe",
+        )
+    )
+    capabilities.append(
+        Capability(
+            "plugin_bundles",
+            "unverified" if _has_dir(paths.hermes_home / "plugins") else "unknown",
+            str(paths.hermes_home / "plugins"),
+            "Plugin directory exists, but omh has no stable Hermes plugin bundle contract"
+            if _has_dir(paths.hermes_home / "plugins")
+            else "No Hermes plugin directory detected by file probe",
+        )
+    )
+    capabilities.append(
+        Capability(
+            "apps",
+            "unverified" if _has_dir(paths.hermes_home / "apps") else "unknown",
+            str(paths.hermes_home / "apps"),
+            "Apps directory exists, but omh has no stable Hermes app contract"
+            if _has_dir(paths.hermes_home / "apps")
+            else "No Hermes app directory detected by file probe",
+        )
+    )
+    mcp_markers = [paths.hermes_home / ".mcp.json", paths.hermes_home / "mcp.json"]
+    capabilities.append(
+        Capability(
+            "mcp",
+            "unverified" if any(_has_file(path) for path in mcp_markers) else "unknown",
+            ", ".join(str(path) for path in mcp_markers),
+            "MCP-like config exists, but omh has not verified a Hermes MCP extension contract"
+            if any(_has_file(path) for path in mcp_markers)
+            else "No Hermes MCP config detected by file probe",
+        )
+    )
+    capabilities.append(
+        Capability(
+            "native_skill_metadata",
+            "unknown",
+            str(paths.hermes_config_path),
+            "No stable Hermes-native skill metadata contract is known to omh yet",
+        )
+    )
+    wrappers = _wrapper_artifacts(paths)
+    capabilities.append(
+        Capability(
+            "wrapper_metadata",
+            "available" if wrappers else "missing",
+            ", ".join(str(path) for path in wrappers[:5]) if wrappers else str(paths.runtime_runs_dir),
+            "Wrapper observation artifacts are present" if wrappers else "No wrapper observation artifacts recorded yet",
+        )
+    )
+
+    return {
+        "schema_version": 1,
+        "omh_home": str(paths.omh_home),
+        "hermes_home": str(paths.hermes_home),
+        "capabilities": [capability.to_dict() for capability in capabilities],
+        "native_integration_claim_ready": False,
+        "claim_boundary": "Prompt-level routing is the default unless a future stable Hermes extension surface and runtime evidence prove deeper integration.",
+    }

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import json
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from io import StringIO
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.cli import main
+
+
+def run_cli(args: list[str]) -> tuple[int, str, str]:
+    stdout = StringIO()
+    stderr = StringIO()
+    with redirect_stdout(stdout), redirect_stderr(stderr):
+        status = main(args)
+    return status, stdout.getvalue(), stderr.getvalue()
+
+
+class ProbeCliTests(unittest.TestCase):
+    def test_probe_reports_unknown_and_missing_without_install(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            status, stdout, stderr = run_cli(["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes"), "probe"])
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            payload = json.loads(stdout)
+            caps = {capability["name"]: capability for capability in payload["capabilities"]}
+            self.assertEqual(caps["external_skill_dirs"]["status"], "unknown")
+            self.assertEqual(caps["managed_skills"]["status"], "missing")
+            self.assertEqual(caps["native_hooks"]["status"], "unknown")
+            self.assertFalse(payload["native_integration_claim_ready"])
+
+    def test_probe_reports_available_local_evidence_after_install_and_wrapper_record(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / ".omh"
+            hermes_home = root / ".hermes"
+
+            self.assertEqual(run_cli(["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "install"])[0], 0)
+            self.assertEqual(run_cli(["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "apply"])[0], 0)
+            status, stdout, _ = run_cli(
+                [
+                    "--omh-home",
+                    str(omh_home),
+                    "runtime",
+                    "record",
+                    "--skill",
+                    "oh-my-hermes",
+                    "--harness",
+                    "coding-handling",
+                ]
+            )
+            self.assertEqual(status, 0)
+            run_id = json.loads(stdout)["run"]["run_id"]
+            self.assertEqual(run_cli(["--omh-home", str(omh_home), "runtime", "wrapper", "--run", run_id, "--prompt-dispatched"])[0], 0)
+
+            status, stdout, stderr = run_cli(["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "probe"])
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            caps = {capability["name"]: capability for capability in json.loads(stdout)["capabilities"]}
+            self.assertEqual(caps["external_skill_dirs"]["status"], "available")
+            self.assertEqual(caps["managed_skills"]["status"], "available")
+            self.assertEqual(caps["wrapper_metadata"]["status"], "available")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -172,8 +172,10 @@ class RouterContentTests(unittest.TestCase):
         self.assertIn("python -m unittest discover -s tests", ci)
         self.assertIn("python -m compileall src", ci)
         self.assertIn("docs workflows --check", ci)
+        self.assertIn("Capability probe smoke", ci)
         self.assertIn("Pinned stable install", release)
         self.assertIn("Runtime evidence smoke", release)
+        self.assertIn("Capability probe status", release)
 
     def test_application_cases_document_representative_flows(self) -> None:
         text = Path("docs/APPLICATION_CASES.md").read_text(encoding="utf-8")
@@ -191,6 +193,7 @@ class RouterContentTests(unittest.TestCase):
 
         for harness in ("coding-handling", "goal-execution", "planning", "deep-interview", "architect", "critic", "qa-specialist", "docs-specialist"):
             self.assertIn(harness, text)
+        self.assertIn("omh probe", text)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add omh probe as a non-mutating capability inspection command.
- Report available/missing/unknown/unverified statuses for managed skills, external skill dirs, wrapper artifacts, and deeper native surfaces.
- Wire probe evidence into docs, release checks, CI smoke, and regression tests.

## Verification
- python3 -m unittest discover -s tests
- python3 -m compileall src
- python3 -m src.cli docs workflows --check
- python3 -m src.cli --omh-home /tmp/omh-final-stable-smoke --hermes-home /tmp/hermes-final-stable-smoke install --dry-run --channel stable --version 0.1.0
- runtime record/delegate/wrapper/validate/export/probe smoke using /tmp/omh-final-runtime-smoke

## Stack
Base: #7
This completes phases 1-5.