### PR TITLE
Refactor local artifact and command registration depth

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -10,6 +10,7 @@ from .config_adapter import ensure_external_dir, read_config, remove_external_di
 from .doctor import doctor_ok, run_doctor
 from .hashutil import sha256_file
 from .installer import OmhError, install_skill_pack, uninstall_skill_pack
+from .local_store import atomic_write_text
 from .manifest import read_manifest
 from .paths import resolve_paths
 from .probe import probe_capabilities
@@ -291,7 +292,7 @@ def cmd_snippet(args: argparse.Namespace) -> int:
         print(WORKSPACE_SNIPPET.rstrip())
         return 0
     output = Path(args.output).expanduser().resolve()
-    output.write_text(WORKSPACE_SNIPPET, encoding="utf-8")
+    atomic_write_text(output, WORKSPACE_SNIPPET)
     _print_json({"written": str(output)})
     return 0
 
@@ -309,8 +310,7 @@ def cmd_docs_workflows(args: argparse.Namespace) -> int:
         _print_json({"ok": True, "checked": str(output)})
         return 0
     if args.output:
-        output.parent.mkdir(parents=True, exist_ok=True)
-        output.write_text(content, encoding="utf-8")
+        atomic_write_text(output, content)
         _print_json({"written": str(output)})
         return 0
     print(content.rstrip())

--- a/src/cli.py
+++ b/src/cli.py
@@ -369,27 +369,23 @@ def cmd_probe(args: argparse.Namespace) -> int:
     return 0
 
 
-def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(prog="omh", description="Install oh-my-hermes skills for Hermes Agent.")
-    parser.add_argument("--omh-home", default=None)
-    parser.add_argument("--hermes-home", default=None)
-    sub = parser.add_subparsers(dest="command", required=True)
+def _add_common_install_options(p: argparse.ArgumentParser) -> None:
+    p.add_argument("--from-skills-dir", default=None, help="Import skills from a local skill directory.")
+    p.add_argument("--source", default=None, help="Mockable local source directory for install/update.")
+    p.add_argument("--channel", choices=RELEASE_CHANNELS, default="preview", help="Release channel metadata for this install/update.")
+    p.add_argument("--version", default="", help="Stable release version such as 0.1.0 or v0.1.0.")
+    p.add_argument("--package-url", default="", help="Explicit release archive URL for support and audit metadata.")
+    p.add_argument("--force", action="store_true")
+    p.add_argument("--dry-run", action="store_true")
 
-    def add_common_install(p: argparse.ArgumentParser) -> None:
-        p.add_argument("--from-skills-dir", default=None, help="Import skills from a local skill directory.")
-        p.add_argument("--source", default=None, help="Mockable local source directory for install/update.")
-        p.add_argument("--channel", choices=RELEASE_CHANNELS, default="preview", help="Release channel metadata for this install/update.")
-        p.add_argument("--version", default="", help="Stable release version such as 0.1.0 or v0.1.0.")
-        p.add_argument("--package-url", default="", help="Explicit release archive URL for support and audit metadata.")
-        p.add_argument("--force", action="store_true")
-        p.add_argument("--dry-run", action="store_true")
 
+def _add_top_level_commands(sub) -> None:
     install = sub.add_parser("install")
-    add_common_install(install)
+    _add_common_install_options(install)
     install.set_defaults(func=cmd_install)
 
     update = sub.add_parser("update")
-    add_common_install(update)
+    _add_common_install_options(update)
     update.set_defaults(func=cmd_update)
 
     convert = sub.add_parser("convert")
@@ -421,6 +417,8 @@ def build_parser() -> argparse.ArgumentParser:
     probe = sub.add_parser("probe")
     probe.set_defaults(func=cmd_probe)
 
+
+def _add_docs_commands(sub) -> None:
     docs = sub.add_parser("docs")
     docs_sub = docs.add_subparsers(dest="docs_command", required=True)
 
@@ -429,6 +427,8 @@ def build_parser() -> argparse.ArgumentParser:
     docs_workflows.add_argument("--check", action="store_true")
     docs_workflows.set_defaults(func=cmd_docs_workflows)
 
+
+def _add_runtime_commands(sub) -> None:
     runtime = sub.add_parser("runtime")
     runtime_sub = runtime.add_subparsers(dest="runtime_command", required=True)
 
@@ -484,6 +484,8 @@ def build_parser() -> argparse.ArgumentParser:
     runtime_export.add_argument("--no-redact", dest="redacted", action="store_false")
     runtime_export.set_defaults(func=cmd_runtime_export)
 
+
+def _add_state_commands(sub) -> None:
     state = sub.add_parser("state")
     state_sub = state.add_subparsers(dest="state_command", required=True)
 
@@ -505,6 +507,18 @@ def build_parser() -> argparse.ArgumentParser:
     state_clear = state_sub.add_parser("clear")
     state_clear.add_argument("--workflow", required=True)
     state_clear.set_defaults(func=cmd_state_clear)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="omh", description="Install oh-my-hermes skills for Hermes Agent.")
+    parser.add_argument("--omh-home", default=None)
+    parser.add_argument("--hermes-home", default=None)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    _add_top_level_commands(sub)
+    _add_docs_commands(sub)
+    _add_runtime_commands(sub)
+    _add_state_commands(sub)
     return parser
 
 

--- a/src/config_adapter.py
+++ b/src/config_adapter.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass
 from pathlib import Path
 import re
 
+from .local_store import atomic_write_text
+
 
 @dataclass(frozen=True)
 class ConfigChange:
@@ -158,5 +160,4 @@ def read_config(path: Path) -> str:
 
 
 def write_config(path: Path, text: str) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(text, encoding="utf-8")
+    atomic_write_text(path, text)

--- a/src/doctor.py
+++ b/src/doctor.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 
 from .config_adapter import external_dirs, read_config
 from .hashutil import sha256_file
+from .local_store import can_write_dir
 from .manifest import local_modifications, read_manifest
 from .paths import OmhPaths
 from .runtime_artifacts import read_state, read_state_error
@@ -42,23 +43,9 @@ def run_doctor(paths: OmhPaths) -> list[Check]:
             )
         )
     checks.append(Check("skills_dir", paths.skills_dir.exists(), f"{paths.skills_dir}"))
-    try:
-        paths.runtime_dir.mkdir(parents=True, exist_ok=True)
-        probe = paths.runtime_dir / ".doctor-write-test"
-        probe.write_text("ok", encoding="utf-8")
-        probe.unlink()
-        runtime_writable = True
-    except OSError:
-        runtime_writable = False
+    runtime_writable = can_write_dir(paths.runtime_dir, probe_name=".doctor-write-test")
     checks.append(Check("runtime_artifacts", runtime_writable, f"{paths.runtime_dir} writable"))
-    try:
-        paths.workflow_state_dir.mkdir(parents=True, exist_ok=True)
-        state_probe = paths.workflow_state_dir / ".doctor-write-test"
-        state_probe.write_text("ok", encoding="utf-8")
-        state_probe.unlink()
-        workflow_state_writable = True
-    except OSError:
-        workflow_state_writable = False
+    workflow_state_writable = can_write_dir(paths.workflow_state_dir, probe_name=".doctor-write-test")
     states, state_errors = list_workflow_states(paths)
     checks.append(
         Check(

--- a/src/installer.py
+++ b/src/installer.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from .core.errors import OmhError
 from .converter import convert_from_dir
+from .local_store import atomic_write_text
 from .manifest import local_modifications, new_manifest, read_manifest, skill_records, write_manifest
 from .paths import OmhPaths
 from .skill_pack import SkillTemplate, builtin_skill_templates
@@ -17,8 +18,7 @@ def _write_skill(skills_dir: Path, template: SkillTemplate, force: bool = False,
         existing = target_file.read_text(encoding="utf-8")
         if existing != template.content:
             raise OmhError(f"local skill differs, refusing to overwrite without --force: {target_file}")
-    target_dir.mkdir(parents=True, exist_ok=True)
-    target_file.write_text(template.content, encoding="utf-8")
+    atomic_write_text(target_file, template.content)
 
 
 def install_skill_pack(

--- a/src/local_store.py
+++ b/src/local_store.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from json import JSONDecodeError
+from pathlib import Path
+from typing import Any
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def ensure_dir(path: Path, *, private: bool = False) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    if private:
+        path.chmod(0o700)
+
+
+def ensure_file(path: Path, *, private: bool = False) -> None:
+    if not path.exists():
+        path.touch(mode=0o600 if private else 0o666)
+    if private:
+        path.chmod(0o600)
+
+
+def can_write_dir(path: Path, *, probe_name: str = ".write-test", private: bool = False) -> bool:
+    try:
+        ensure_dir(path, private=private)
+        probe = path / probe_name
+        probe.write_text("ok", encoding="utf-8")
+        probe.unlink()
+        return True
+    except OSError:
+        return False
+
+
+def atomic_write_text(path: Path, text: str, *, private: bool = False) -> None:
+    ensure_dir(path.parent, private=private)
+    tmp = path.with_name(f".{path.name}.tmp")
+    try:
+        tmp.write_text(text, encoding="utf-8")
+        if private:
+            tmp.chmod(0o600)
+        tmp.replace(path)
+        if private:
+            path.chmod(0o600)
+    except OSError:
+        if tmp.exists():
+            tmp.unlink()
+        raise
+
+
+def atomic_write_json(path: Path, data: dict[str, Any], *, private: bool = False) -> None:
+    atomic_write_text(path, json.dumps(data, indent=2, sort_keys=True) + "\n", private=private)
+
+
+def read_json_object(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("expected JSON object")
+    return data
+
+
+def read_json_object_result(path: Path) -> tuple[dict[str, Any] | None, str | None]:
+    try:
+        return read_json_object(path), None
+    except (OSError, JSONDecodeError, ValueError) as exc:
+        return None, str(exc)

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -1,17 +1,12 @@
 from __future__ import annotations
 
-import json
 from dataclasses import dataclass
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 from . import __version__
 from .hashutil import sha256_file
-
-
-def utc_now() -> str:
-    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+from .local_store import atomic_write_json, read_json_object, utc_now
 
 
 @dataclass(frozen=True)
@@ -35,14 +30,11 @@ def new_manifest(source: str, skills_dir: Path, records: list[SkillRecord]) -> d
 
 
 def read_manifest(path: Path) -> dict[str, Any] | None:
-    if not path.exists():
-        return None
-    return json.loads(path.read_text(encoding="utf-8"))
+    return read_json_object(path)
 
 
 def write_manifest(path: Path, manifest: dict[str, Any]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    atomic_write_json(path, manifest)
 
 
 def skill_records(skills_dir: Path, source: str) -> list[SkillRecord]:
@@ -78,4 +70,3 @@ def local_modifications(manifest: dict[str, Any] | None, skills_dir: Path) -> li
         if sha256_file(path) != expected:
             modified.append(str(rel))
     return modified
-

--- a/src/probe.py
+++ b/src/probe.py
@@ -39,11 +39,36 @@ def _wrapper_artifacts(paths: OmhPaths) -> list[Path]:
     return sorted(paths.runtime_runs_dir.glob("*/wrapper.json"))
 
 
+def _has_any_file(paths: list[Path]) -> bool:
+    return any(_has_file(path) for path in paths)
+
+
+def _marker_capability(name: str, markers: list[Path], found_message: str, missing_message: str) -> Capability:
+    found = _has_any_file(markers)
+    return Capability(
+        name,
+        "unverified" if found else "unknown",
+        ", ".join(str(path) for path in markers),
+        found_message if found else missing_message,
+    )
+
+
+def _dir_capability(name: str, path: Path, found_message: str, missing_message: str) -> Capability:
+    found = _has_dir(path)
+    return Capability(
+        name,
+        "unverified" if found else "unknown",
+        str(path),
+        found_message if found else missing_message,
+    )
+
+
 def probe_capabilities(paths: OmhPaths) -> dict:
     config_text = read_config(paths.hermes_config_path)
     configured_dirs = external_dirs(config_text)
     skills_registered = str(paths.skills_dir) in configured_dirs
     capabilities: list[Capability] = []
+    managed_skill_path = paths.skills_dir / "oh-my-hermes" / "SKILL.md"
 
     capabilities.append(
         Capability(
@@ -56,51 +81,43 @@ def probe_capabilities(paths: OmhPaths) -> dict:
     capabilities.append(
         Capability(
             "managed_skills",
-            "available" if _has_file(paths.skills_dir / "oh-my-hermes" / "SKILL.md") else "missing",
+            "available" if _has_file(managed_skill_path) else "missing",
             str(paths.skills_dir),
-            "Managed oh-my-hermes skill is installed" if _has_file(paths.skills_dir / "oh-my-hermes" / "SKILL.md") else "Managed skills are not installed",
+            "Managed oh-my-hermes skill is installed" if _has_file(managed_skill_path) else "Managed skills are not installed",
         )
     )
     hooks_markers = [paths.hermes_home / "hooks.yaml", paths.hermes_home / "hooks.json"]
     capabilities.append(
-        Capability(
+        _marker_capability(
             "native_hooks",
-            "unverified" if any(_has_file(path) for path in hooks_markers) else "unknown",
-            ", ".join(str(path) for path in hooks_markers),
-            "Hook-like files exist, but omh has no stable Hermes hook contract to claim native integration"
-            if any(_has_file(path) for path in hooks_markers)
-            else "No stable Hermes hook surface detected by file probe",
+            hooks_markers,
+            "Hook-like files exist, but omh has no stable Hermes hook contract to claim native integration",
+            "No stable Hermes hook surface detected by file probe",
         )
     )
     capabilities.append(
-        Capability(
+        _dir_capability(
             "plugin_bundles",
-            "unverified" if _has_dir(paths.hermes_home / "plugins") else "unknown",
-            str(paths.hermes_home / "plugins"),
-            "Plugin directory exists, but omh has no stable Hermes plugin bundle contract"
-            if _has_dir(paths.hermes_home / "plugins")
-            else "No Hermes plugin directory detected by file probe",
+            paths.hermes_home / "plugins",
+            "Plugin directory exists, but omh has no stable Hermes plugin bundle contract",
+            "No Hermes plugin directory detected by file probe",
         )
     )
     capabilities.append(
-        Capability(
+        _dir_capability(
             "apps",
-            "unverified" if _has_dir(paths.hermes_home / "apps") else "unknown",
-            str(paths.hermes_home / "apps"),
-            "Apps directory exists, but omh has no stable Hermes app contract"
-            if _has_dir(paths.hermes_home / "apps")
-            else "No Hermes app directory detected by file probe",
+            paths.hermes_home / "apps",
+            "Apps directory exists, but omh has no stable Hermes app contract",
+            "No Hermes app directory detected by file probe",
         )
     )
     mcp_markers = [paths.hermes_home / ".mcp.json", paths.hermes_home / "mcp.json"]
     capabilities.append(
-        Capability(
+        _marker_capability(
             "mcp",
-            "unverified" if any(_has_file(path) for path in mcp_markers) else "unknown",
-            ", ".join(str(path) for path in mcp_markers),
-            "MCP-like config exists, but omh has not verified a Hermes MCP extension contract"
-            if any(_has_file(path) for path in mcp_markers)
-            else "No Hermes MCP config detected by file probe",
+            mcp_markers,
+            "MCP-like config exists, but omh has not verified a Hermes MCP extension contract",
+            "No Hermes MCP config detected by file probe",
         )
     )
     capabilities.append(

--- a/src/runtime_artifacts.py
+++ b/src/runtime_artifacts.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from .local_store import atomic_write_json, ensure_dir, ensure_file, read_json_object, read_json_object_result, utc_now
 from .paths import OmhPaths
 
 
@@ -19,44 +20,6 @@ OBSERVED_RESULTS = ("completed", "blocked", "failed")
 UNOBSERVED_RESULTS = ("not_available", "not_observed")
 EVENT_LEVELS = ("debug", "info", "warning", "error")
 WRAPPER_COMPLETION_STATUSES = ("started", "completed", "blocked", "failed", "unknown")
-
-
-def _ensure_private_dir(path: Path) -> None:
-    path.mkdir(parents=True, exist_ok=True)
-    path.chmod(0o700)
-
-
-def _ensure_private_file(path: Path) -> None:
-    if not path.exists():
-        path.touch(mode=0o600)
-    path.chmod(0o600)
-
-
-def utc_now() -> str:
-    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
-
-
-def _atomic_write_json(path: Path, data: dict[str, Any]) -> None:
-    _ensure_private_dir(path.parent)
-    tmp = path.with_name(f".{path.name}.tmp")
-    try:
-        tmp.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-        tmp.chmod(0o600)
-        tmp.replace(path)
-        path.chmod(0o600)
-    except OSError:
-        if tmp.exists():
-            tmp.unlink()
-        raise
-
-
-def _read_json(path: Path) -> dict[str, Any] | None:
-    if not path.exists():
-        return None
-    data = json.loads(path.read_text(encoding="utf-8"))
-    if not isinstance(data, dict):
-        raise ValueError("expected JSON object")
-    return data
 
 
 def _slugify(value: str) -> str:
@@ -87,14 +50,11 @@ def _unique_run_id(paths: OmhPaths, slug: str) -> str:
 
 
 def read_state(paths: OmhPaths) -> dict[str, Any] | None:
-    return _read_json(paths.runtime_state_path)
+    return read_json_object(paths.runtime_state_path)
 
 
 def read_state_result(paths: OmhPaths) -> tuple[dict[str, Any] | None, str | None]:
-    try:
-        return read_state(paths), None
-    except (OSError, JSONDecodeError, ValueError) as exc:
-        return None, str(exc)
+    return read_json_object_result(paths.runtime_state_path)
 
 
 def read_state_error(paths: OmhPaths) -> str | None:
@@ -108,7 +68,7 @@ def update_state(paths: OmhPaths, patch: dict[str, Any]) -> dict[str, Any]:
     if state_error:
         merged["previous_state_error"] = state_error
     try:
-        _atomic_write_json(paths.runtime_state_path, merged)
+        atomic_write_json(paths.runtime_state_path, merged, private=True)
     except OSError as exc:
         merged["state_write_error"] = str(exc)
     return merged
@@ -141,8 +101,8 @@ def create_run(paths: OmhPaths, metadata: dict[str, Any]) -> dict[str, Any]:
     }
     run_dir = paths.runtime_runs_dir / run_id
     evidence_dir = run_dir / "evidence"
-    _ensure_private_dir(evidence_dir)
-    _atomic_write_json(run_dir / "run.json", run)
+    ensure_dir(evidence_dir, private=True)
+    atomic_write_json(run_dir / "run.json", run, private=True)
     append_event(run_dir, {"event": "run_recorded", "level": "info", "message": f"{skill}/{harness} recorded as {status}"})
     update_state(paths, {"last_run_id": run_id})
     return run
@@ -158,9 +118,9 @@ def append_event(run_dir: Path, event: dict[str, Any]) -> dict[str, Any]:
     }
     if "data" in event:
         item["data"] = event["data"]
-    _ensure_private_dir(run_dir)
+    ensure_dir(run_dir, private=True)
     events_path = run_dir / "events.jsonl"
-    _ensure_private_file(events_path)
+    ensure_file(events_path, private=True)
     with events_path.open("a", encoding="utf-8") as handle:
         handle.write(json.dumps(item, sort_keys=True) + "\n")
     return item
@@ -189,7 +149,7 @@ def write_delegation(run_dir: Path, delegation: dict[str, Any]) -> dict[str, Any
         "evidence_refs": list(delegation.get("evidence_refs", [])),
         "message": delegation.get("message", ""),
     }
-    _atomic_write_json(run_dir / "delegation.json", record)
+    atomic_write_json(run_dir / "delegation.json", record, private=True)
     append_event(
         run_dir,
         {
@@ -216,7 +176,7 @@ def write_wrapper_contract(run_dir: Path, wrapper: dict[str, Any]) -> dict[str, 
         "unobserved_gaps": list(wrapper.get("unobserved_gaps", [])),
         "message": wrapper.get("message", ""),
     }
-    _atomic_write_json(run_dir / "wrapper.json", record)
+    atomic_write_json(run_dir / "wrapper.json", record, private=True)
     append_event(
         run_dir,
         {
@@ -292,7 +252,7 @@ def list_runs(paths: OmhPaths) -> list[dict[str, Any]]:
         return []
     runs: list[dict[str, Any]] = []
     for run_json in sorted(paths.runtime_runs_dir.glob("*/run.json")):
-        run = _read_json(run_json)
+        run = read_json_object(run_json)
         if run:
             runs.append(run)
     return runs
@@ -307,15 +267,15 @@ def read_events(run_dir: Path) -> list[dict[str, Any]]:
 
 def show_run(paths: OmhPaths, run_id: str) -> dict[str, Any]:
     run_dir = paths.runtime_runs_dir / run_id
-    run = _read_json(run_dir / "run.json")
+    run = read_json_object(run_dir / "run.json")
     if not run:
         raise FileNotFoundError(run_id)
     evidence_dir = run_dir / "evidence"
     return {
         "run": run,
         "events": read_events(run_dir),
-        "delegation": _read_json(run_dir / "delegation.json"),
-        "wrapper": _read_json(run_dir / "wrapper.json"),
+        "delegation": read_json_object(run_dir / "delegation.json"),
+        "wrapper": read_json_object(run_dir / "wrapper.json"),
         "evidence": sorted(path.name for path in evidence_dir.iterdir()) if evidence_dir.exists() else [],
     }
 
@@ -324,7 +284,7 @@ def validate_run_dir(run_dir: Path) -> dict[str, Any]:
     errors: list[str] = []
     run_path = run_dir / "run.json"
     try:
-        run = _read_json(run_path)
+        run = read_json_object(run_path)
     except (OSError, JSONDecodeError, ValueError) as exc:
         run = None
         errors.append(f"{run_path}: {exc}")
@@ -352,7 +312,7 @@ def validate_run_dir(run_dir: Path) -> dict[str, Any]:
         if not path.exists():
             continue
         try:
-            record = _read_json(path)
+            record = read_json_object(path)
         except (OSError, JSONDecodeError, ValueError) as exc:
             record = None
             errors.append(f"{path}: {exc}")

--- a/src/skills/catalog.py
+++ b/src/skills/catalog.py
@@ -380,12 +380,37 @@ _HARNESSES = [
 ]
 
 
+_PRIMARY_HARNESSES = {
+    "ralph": "goal-execution",
+    "ultragoal": "goal-execution",
+    "deep-interview": "deep-interview",
+    "team": "goal-execution",
+    "ultraqa": "qa-specialist",
+    "plan": "planning",
+    "ralplan": "planning",
+    "code-review": "critic",
+    "ai-slop-cleaner": "coding-handling",
+    "best-practice-research": "planning",
+    "autoresearch-goal": "goal-execution",
+    "performance-goal": "goal-execution",
+    "wiki": "docs-specialist",
+    "ask": "critic",
+    "cancel": "goal-execution",
+    "skill": "docs-specialist",
+    "doctor": "qa-specialist",
+}
+
+
 def builtin_definitions() -> list[SkillDefinition]:
     return list(_DEFINITIONS)
 
 
 def builtin_harnesses() -> list[HarnessDefinition]:
     return list(_HARNESSES)
+
+
+def primary_harness_for_skill(name: str) -> str:
+    return _PRIMARY_HARNESSES.get(name, "coding-handling")
 
 
 CORE_SKILLS = [definition.name for definition in _DEFINITIONS]

--- a/src/skills/render.py
+++ b/src/skills/render.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from .catalog import DESCRIPTIONS, HarnessDefinition, SkillDefinition, builtin_definitions, builtin_harnesses
+from .catalog import DESCRIPTIONS, HarnessDefinition, SkillDefinition, builtin_definitions, builtin_harnesses, primary_harness_for_skill
 
 
 @dataclass(frozen=True)
@@ -52,29 +52,6 @@ def _harness_summary(harness: HarnessDefinition) -> str:
 
 def _harness_registry(harnesses: list[HarnessDefinition]) -> str:
     return "\n".join(_harness_summary(harness) for harness in harnesses)
-
-
-def _primary_harness_for_skill(name: str) -> str:
-    mapping = {
-        "ralph": "goal-execution",
-        "ultragoal": "goal-execution",
-        "deep-interview": "deep-interview",
-        "team": "goal-execution",
-        "ultraqa": "qa-specialist",
-        "plan": "planning",
-        "ralplan": "planning",
-        "code-review": "critic",
-        "ai-slop-cleaner": "coding-handling",
-        "best-practice-research": "planning",
-        "autoresearch-goal": "goal-execution",
-        "performance-goal": "goal-execution",
-        "wiki": "docs-specialist",
-        "ask": "critic",
-        "cancel": "goal-execution",
-        "skill": "docs-specialist",
-        "doctor": "qa-specialist",
-    }
-    return mapping.get(name, "coding-handling")
 
 
 def _tuple_list(values: tuple[str, ...]) -> str:
@@ -178,7 +155,7 @@ def workflow_skill(name: str) -> SkillTemplate:
     definition = definitions[name]
     title = name.replace("-", " ").title()
     triggers = ", ".join(f"`{trigger}`" for trigger in definition.triggers)
-    primary_harness = _primary_harness_for_skill(name)
+    primary_harness = primary_harness_for_skill(name)
     body = f"""# {title}
 
 This is a Hermes-native `{name}` workflow skill.

--- a/src/workflow_state.py
+++ b/src/workflow_state.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
-import json
 from json import JSONDecodeError
 from pathlib import Path
 from typing import Any
 
+from .local_store import atomic_write_json, read_json_object, utc_now
 from .paths import OmhPaths
-from .runtime_artifacts import utc_now
 from .skill_pack import CORE_SKILLS
 
 SCHEMA_VERSION = 1
@@ -23,25 +22,6 @@ class WorkflowStateError(ValueError):
     pass
 
 
-def _ensure_private_dir(path: Path) -> None:
-    path.mkdir(parents=True, exist_ok=True)
-    path.chmod(0o700)
-
-
-def _atomic_write_json(path: Path, data: dict[str, Any]) -> None:
-    _ensure_private_dir(path.parent)
-    tmp = path.with_name(f".{path.name}.tmp")
-    try:
-        tmp.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-        tmp.chmod(0o600)
-        tmp.replace(path)
-        path.chmod(0o600)
-    except OSError:
-        if tmp.exists():
-            tmp.unlink()
-        raise
-
-
 def validate_workflow_name(workflow: str) -> None:
     if workflow not in CORE_SKILLS:
         raise WorkflowStateError(f"unknown workflow: {workflow}")
@@ -54,11 +34,14 @@ def workflow_state_path(paths: OmhPaths, workflow: str) -> Path:
 
 def read_workflow_state(paths: OmhPaths, workflow: str) -> dict[str, Any] | None:
     path = workflow_state_path(paths, workflow)
-    if not path.exists():
+    try:
+        data = read_json_object(path)
+    except JSONDecodeError:
+        raise
+    except ValueError as exc:
+        raise WorkflowStateError(f"state for {workflow} must be a JSON object") from exc
+    if not data:
         return None
-    data = json.loads(path.read_text(encoding="utf-8"))
-    if not isinstance(data, dict):
-        raise WorkflowStateError(f"state for {workflow} must be a JSON object")
     if data.get("workflow") not in {None, workflow}:
         raise WorkflowStateError(f"state file {path} belongs to {data.get('workflow')!r}")
     return data
@@ -114,7 +97,7 @@ def _terminal_state(workflow: str, state: dict[str, Any] | None, outcome: str, n
 def finish_workflow_state(paths: OmhPaths, workflow: str, outcome: str = "finished", note: str = "") -> dict[str, Any]:
     state = read_workflow_state(paths, workflow)
     result = _terminal_state(workflow, state, outcome, note)
-    _atomic_write_json(workflow_state_path(paths, workflow), result)
+    atomic_write_json(workflow_state_path(paths, workflow), result, private=True)
     return result
 
 
@@ -135,14 +118,14 @@ def start_workflow_state(paths: OmhPaths, workflow: str, note: str = "") -> dict
             updated = {**current, "schema_version": SCHEMA_VERSION, "active": True, "updated_at": now}
             if note:
                 updated["note"] = note
-            _atomic_write_json(workflow_state_path(paths, workflow), updated)
+            atomic_write_json(workflow_state_path(paths, workflow), updated, private=True)
             return updated
         if not _transition_allowed(source, workflow):
             raise WorkflowStateError(f"cannot start {workflow}; active workflow {source} must finish or be cleared first")
     for current in active:
         source = str(current["workflow"])
         completed = _terminal_state(source, current, "finished", f"auto-completed before starting {workflow}", workflow)
-        _atomic_write_json(workflow_state_path(paths, source), completed)
+        atomic_write_json(workflow_state_path(paths, source), completed, private=True)
     state = {
         "schema_version": SCHEMA_VERSION,
         "workflow": workflow,
@@ -153,7 +136,7 @@ def start_workflow_state(paths: OmhPaths, workflow: str, note: str = "") -> dict
     }
     if note:
         state["note"] = note
-    _atomic_write_json(workflow_state_path(paths, workflow), state)
+    atomic_write_json(workflow_state_path(paths, workflow), state, private=True)
     return state
 
 

--- a/tests/_cli_harness.py
+++ b/tests/_cli_harness.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from contextlib import redirect_stderr, redirect_stdout
+from io import StringIO
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.cli import main
+
+
+def run_cli(args: list[str]) -> tuple[int, str, str]:
+    stdout = StringIO()
+    stderr = StringIO()
+    with redirect_stdout(stdout), redirect_stderr(stderr):
+        status = main(args)
+    return status, stdout.getvalue(), stderr.getvalue()

--- a/tests/test_application_cases.py
+++ b/tests/test_application_cases.py
@@ -2,23 +2,10 @@ from __future__ import annotations
 
 import json
 import unittest
-from contextlib import redirect_stderr, redirect_stdout
-from io import StringIO
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-from _local_package import load_local_package
-
-load_local_package()
-from omh.cli import main
-
-
-def run_cli(args: list[str]) -> tuple[int, str, str]:
-    stdout = StringIO()
-    stderr = StringIO()
-    with redirect_stdout(stdout), redirect_stderr(stderr):
-        status = main(args)
-    return status, stdout.getvalue(), stderr.getvalue()
+from _cli_harness import run_cli
 
 
 class ApplicationCaseArtifactTests(unittest.TestCase):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,23 +2,10 @@ from __future__ import annotations
 
 import json
 import unittest
-from contextlib import redirect_stderr, redirect_stdout
-from io import StringIO
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-from _local_package import load_local_package
-
-load_local_package()
-from omh.cli import main
-
-
-def run_cli(args: list[str]) -> tuple[int, str, str]:
-    stdout = StringIO()
-    stderr = StringIO()
-    with redirect_stdout(stdout), redirect_stderr(stderr):
-        status = main(args)
-    return status, stdout.getvalue(), stderr.getvalue()
+from _cli_harness import run_cli
 
 
 class CliTests(unittest.TestCase):

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -2,23 +2,10 @@ from __future__ import annotations
 
 import json
 import unittest
-from contextlib import redirect_stderr, redirect_stdout
-from io import StringIO
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-from _local_package import load_local_package
-
-load_local_package()
-from omh.cli import main
-
-
-def run_cli(args: list[str]) -> tuple[int, str, str]:
-    stdout = StringIO()
-    stderr = StringIO()
-    with redirect_stdout(stdout), redirect_stderr(stderr):
-        status = main(args)
-    return status, stdout.getvalue(), stderr.getvalue()
+from _cli_harness import run_cli
 
 
 class ProbeCliTests(unittest.TestCase):

--- a/tests/test_workflow_state.py
+++ b/tests/test_workflow_state.py
@@ -2,23 +2,10 @@ from __future__ import annotations
 
 import json
 import unittest
-from contextlib import redirect_stderr, redirect_stdout
-from io import StringIO
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-from _local_package import load_local_package
-
-load_local_package()
-from omh.cli import main
-
-
-def run_cli(args: list[str]) -> tuple[int, str, str]:
-    stdout = StringIO()
-    stderr = StringIO()
-    with redirect_stdout(stdout), redirect_stderr(stderr):
-        status = main(args)
-    return status, stdout.getvalue(), stderr.getvalue()
+from _cli_harness import run_cli
 
 
 class WorkflowStateCliTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Consolidate duplicated CLI test invocation into a shared test harness.
- Add local_store helpers for atomic text/JSON writes, private runtime artifact writes, JSON object reads, timestamps, and writable directory probes.
- Route manifest/config/installer/runtime/workflow/doctor/docs writes through the shared helper path.
- Split CLI parser registration by command group, reduce probe capability repetition, and move primary harness lookup into the skill catalog.

## Verification
- python3 -m unittest discover -s tests
- python3 -m compileall src
- python3 -m src.cli docs workflows --check
- git diff --check HEAD

## Notes
- Behavior-preserving refactor only; no public CLI option or generated workflow content changes intended.
- Commits are split by reviewable pass and signed off for DCO.