### PR TITLE
Deepen runtime evidence record logic

### DIFF
--- a/src/runtime_artifacts.py
+++ b/src/runtime_artifacts.py
@@ -10,16 +10,26 @@ from typing import Any
 
 from .local_store import atomic_write_json, ensure_dir, ensure_file, read_json_object, read_json_object_result, utc_now
 from .paths import OmhPaths
-
-
-SCHEMA_VERSION = 1
-RUN_STATUSES = ("started", "completed", "blocked", "failed", "unknown")
-PRIVACY_MODES = ("metadata_only",)
-DELEGATION_RESULTS = ("completed", "blocked", "failed", "not_available", "not_observed")
-OBSERVED_RESULTS = ("completed", "blocked", "failed")
-UNOBSERVED_RESULTS = ("not_available", "not_observed")
-EVENT_LEVELS = ("debug", "info", "warning", "error")
-WRAPPER_COMPLETION_STATUSES = ("started", "completed", "blocked", "failed", "unknown")
+from .runtime_records import (
+    DELEGATION_RESULTS,
+    EVENT_LEVELS,
+    OBSERVED_RESULTS,
+    OPTIONAL_RECORD_VALIDATORS,
+    PRIVACY_MODES,
+    RUN_STATUSES,
+    SCHEMA_VERSION,
+    UNOBSERVED_RESULTS,
+    WRAPPER_COMPLETION_STATUSES,
+    build_delegation_record,
+    build_event_record,
+    build_run_record,
+    build_wrapper_record,
+    validate_delegation_record,
+    validate_delegation_result,
+    validate_event_record,
+    validate_run_record,
+    validate_wrapper_record,
+)
 
 
 def _slugify(value: str) -> str:
@@ -75,49 +85,21 @@ def update_state(paths: OmhPaths, patch: dict[str, Any]) -> dict[str, Any]:
 
 
 def create_run(paths: OmhPaths, metadata: dict[str, Any]) -> dict[str, Any]:
-    status = metadata.get("status", "unknown")
-    if status not in RUN_STATUSES:
-        raise ValueError(f"unsupported run status: {status}")
-    privacy = metadata.get("privacy", "metadata_only")
-    if privacy not in PRIVACY_MODES:
-        raise ValueError(f"unsupported privacy mode: {privacy}")
     skill = str(metadata.get("skill", "unknown"))
     harness = str(metadata.get("harness", "unknown"))
     run_id = str(metadata.get("run_id") or _unique_run_id(paths, f"{skill}-{harness}"))
-    created_at = str(metadata.get("created_at") or utc_now())
-    run = {
-        "schema_version": SCHEMA_VERSION,
-        "run_id": run_id,
-        "created_at": created_at,
-        "updated_at": created_at,
-        "skill": skill,
-        "harness": harness,
-        "trigger": metadata.get("trigger", ""),
-        "status": status,
-        "privacy": privacy,
-        "inputs_summary": metadata.get("inputs_summary", ""),
-        "outputs_summary": metadata.get("outputs_summary", ""),
-        "verification_summary": metadata.get("verification_summary", ""),
-    }
+    run = build_run_record(metadata, run_id)
     run_dir = paths.runtime_runs_dir / run_id
     evidence_dir = run_dir / "evidence"
     ensure_dir(evidence_dir, private=True)
     atomic_write_json(run_dir / "run.json", run, private=True)
-    append_event(run_dir, {"event": "run_recorded", "level": "info", "message": f"{skill}/{harness} recorded as {status}"})
+    append_event(run_dir, {"event": "run_recorded", "level": "info", "message": f"{skill}/{harness} recorded as {run['status']}"})
     update_state(paths, {"last_run_id": run_id})
     return run
 
 
 def append_event(run_dir: Path, event: dict[str, Any]) -> dict[str, Any]:
-    item = {
-        "schema_version": SCHEMA_VERSION,
-        "timestamp": event.get("timestamp") or utc_now(),
-        "event": event.get("event", "event"),
-        "level": event.get("level", "info"),
-        "message": event.get("message", ""),
-    }
-    if "data" in event:
-        item["data"] = event["data"]
+    item = build_event_record(event)
     ensure_dir(run_dir, private=True)
     events_path = run_dir / "events.jsonl"
     ensure_file(events_path, private=True)
@@ -126,36 +108,15 @@ def append_event(run_dir: Path, event: dict[str, Any]) -> dict[str, Any]:
     return item
 
 
-def _validate_delegation(observed: bool, result: str) -> None:
-    if observed and result not in OBSERVED_RESULTS:
-        raise ValueError("observed delegation requires result completed, blocked, or failed")
-    if not observed and result not in UNOBSERVED_RESULTS:
-        raise ValueError("unobserved delegation requires result not_available or not_observed")
-
-
 def write_delegation(run_dir: Path, delegation: dict[str, Any]) -> dict[str, Any]:
-    result = delegation.get("result", "not_observed")
-    if result not in DELEGATION_RESULTS:
-        raise ValueError(f"unsupported delegation result: {result}")
-    observed = bool(delegation.get("observed", False))
-    _validate_delegation(observed, result)
-    record = {
-        "schema_version": SCHEMA_VERSION,
-        "updated_at": utc_now(),
-        "requested": bool(delegation.get("requested", False)),
-        "observed": observed,
-        "participants": list(delegation.get("participants", [])),
-        "result": result,
-        "evidence_refs": list(delegation.get("evidence_refs", [])),
-        "message": delegation.get("message", ""),
-    }
+    record = build_delegation_record(delegation)
     atomic_write_json(run_dir / "delegation.json", record, private=True)
     append_event(
         run_dir,
         {
             "event": "delegation_recorded",
             "level": "info",
-            "message": f"delegation {result}",
+            "message": f"delegation {record['result']}",
             "data": {"requested": record["requested"], "observed": record["observed"]},
         },
     )
@@ -163,26 +124,14 @@ def write_delegation(run_dir: Path, delegation: dict[str, Any]) -> dict[str, Any
 
 
 def write_wrapper_contract(run_dir: Path, wrapper: dict[str, Any]) -> dict[str, Any]:
-    status = wrapper.get("completion_status", "unknown")
-    if status not in WRAPPER_COMPLETION_STATUSES:
-        raise ValueError(f"unsupported wrapper completion status: {status}")
-    record = {
-        "schema_version": SCHEMA_VERSION,
-        "updated_at": utc_now(),
-        "prompt_dispatched": bool(wrapper.get("prompt_dispatched", False)),
-        "hermes_response_observed": bool(wrapper.get("hermes_response_observed", False)),
-        "verification_observed": bool(wrapper.get("verification_observed", False)),
-        "completion_status": status,
-        "unobserved_gaps": list(wrapper.get("unobserved_gaps", [])),
-        "message": wrapper.get("message", ""),
-    }
+    record = build_wrapper_record(wrapper)
     atomic_write_json(run_dir / "wrapper.json", record, private=True)
     append_event(
         run_dir,
         {
             "event": "wrapper_contract_recorded",
             "level": "info",
-            "message": f"wrapper contract {status}",
+            "message": f"wrapper contract {record['completion_status']}",
             "data": {
                 "prompt_dispatched": record["prompt_dispatched"],
                 "hermes_response_observed": record["hermes_response_observed"],
@@ -191,60 +140,6 @@ def write_wrapper_contract(run_dir: Path, wrapper: dict[str, Any]) -> dict[str, 
         },
     )
     return record
-
-
-def _require(condition: bool, errors: list[str], message: str) -> None:
-    if not condition:
-        errors.append(message)
-
-
-def validate_run_record(run: dict[str, Any]) -> list[str]:
-    errors: list[str] = []
-    _require(run.get("schema_version") == SCHEMA_VERSION, errors, "run schema_version is invalid")
-    for key in ("run_id", "created_at", "updated_at", "skill", "harness", "status", "privacy"):
-        _require(isinstance(run.get(key), str) if key != "schema_version" else True, errors, f"run {key} must be a string")
-    _require(run.get("status") in RUN_STATUSES, errors, f"run status is invalid: {run.get('status')!r}")
-    _require(run.get("privacy") in PRIVACY_MODES, errors, f"run privacy is invalid: {run.get('privacy')!r}")
-    for key in ("trigger", "inputs_summary", "outputs_summary", "verification_summary"):
-        _require(isinstance(run.get(key, ""), str), errors, f"run {key} must be a string")
-    return errors
-
-
-def validate_event_record(event: dict[str, Any]) -> list[str]:
-    errors: list[str] = []
-    _require(event.get("schema_version") == SCHEMA_VERSION, errors, "event schema_version is invalid")
-    for key in ("timestamp", "event", "level", "message"):
-        _require(isinstance(event.get(key), str), errors, f"event {key} must be a string")
-    _require(event.get("level") in EVENT_LEVELS, errors, f"event level is invalid: {event.get('level')!r}")
-    if "data" in event:
-        _require(isinstance(event["data"], dict), errors, "event data must be an object")
-    return errors
-
-
-def validate_delegation_record(delegation: dict[str, Any]) -> list[str]:
-    errors: list[str] = []
-    _require(delegation.get("schema_version") == SCHEMA_VERSION, errors, "delegation schema_version is invalid")
-    _require(isinstance(delegation.get("requested"), bool), errors, "delegation requested must be boolean")
-    _require(isinstance(delegation.get("observed"), bool), errors, "delegation observed must be boolean")
-    _require(delegation.get("result") in DELEGATION_RESULTS, errors, f"delegation result is invalid: {delegation.get('result')!r}")
-    _require(isinstance(delegation.get("participants"), list), errors, "delegation participants must be a list")
-    _require(isinstance(delegation.get("evidence_refs"), list), errors, "delegation evidence_refs must be a list")
-    try:
-        _validate_delegation(bool(delegation.get("observed")), str(delegation.get("result")))
-    except ValueError as exc:
-        errors.append(str(exc))
-    return errors
-
-
-def validate_wrapper_record(wrapper: dict[str, Any]) -> list[str]:
-    errors: list[str] = []
-    _require(wrapper.get("schema_version") == SCHEMA_VERSION, errors, "wrapper schema_version is invalid")
-    for key in ("prompt_dispatched", "hermes_response_observed", "verification_observed"):
-        _require(isinstance(wrapper.get(key), bool), errors, f"wrapper {key} must be boolean")
-    _require(wrapper.get("completion_status") in WRAPPER_COMPLETION_STATUSES, errors, f"wrapper completion_status is invalid: {wrapper.get('completion_status')!r}")
-    _require(isinstance(wrapper.get("unobserved_gaps"), list), errors, "wrapper unobserved_gaps must be a list")
-    _require(isinstance(wrapper.get("message", ""), str), errors, "wrapper message must be a string")
-    return errors
 
 
 def list_runs(paths: OmhPaths) -> list[dict[str, Any]]:
@@ -307,7 +202,7 @@ def validate_run_dir(run_dir: Path) -> dict[str, Any]:
             errors.append(f"{events_path}: {exc}")
     else:
         errors.append(f"{events_path}: missing events.jsonl")
-    for name, validator in (("delegation.json", validate_delegation_record), ("wrapper.json", validate_wrapper_record)):
+    for name, validator in OPTIONAL_RECORD_VALIDATORS:
         path = run_dir / name
         if not path.exists():
             continue

--- a/src/runtime_records.py
+++ b/src/runtime_records.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .local_store import utc_now
+
+
+SCHEMA_VERSION = 1
+RUN_STATUSES = ("started", "completed", "blocked", "failed", "unknown")
+PRIVACY_MODES = ("metadata_only",)
+DELEGATION_RESULTS = ("completed", "blocked", "failed", "not_available", "not_observed")
+OBSERVED_RESULTS = ("completed", "blocked", "failed")
+UNOBSERVED_RESULTS = ("not_available", "not_observed")
+EVENT_LEVELS = ("debug", "info", "warning", "error")
+WRAPPER_COMPLETION_STATUSES = ("started", "completed", "blocked", "failed", "unknown")
+
+
+def build_run_record(metadata: dict[str, Any], run_id: str) -> dict[str, Any]:
+    status = metadata.get("status", "unknown")
+    if status not in RUN_STATUSES:
+        raise ValueError(f"unsupported run status: {status}")
+    privacy = metadata.get("privacy", "metadata_only")
+    if privacy not in PRIVACY_MODES:
+        raise ValueError(f"unsupported privacy mode: {privacy}")
+    skill = str(metadata.get("skill", "unknown"))
+    harness = str(metadata.get("harness", "unknown"))
+    created_at = str(metadata.get("created_at") or utc_now())
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "run_id": run_id,
+        "created_at": created_at,
+        "updated_at": created_at,
+        "skill": skill,
+        "harness": harness,
+        "trigger": metadata.get("trigger", ""),
+        "status": status,
+        "privacy": privacy,
+        "inputs_summary": metadata.get("inputs_summary", ""),
+        "outputs_summary": metadata.get("outputs_summary", ""),
+        "verification_summary": metadata.get("verification_summary", ""),
+    }
+
+
+def build_event_record(event: dict[str, Any]) -> dict[str, Any]:
+    item = {
+        "schema_version": SCHEMA_VERSION,
+        "timestamp": event.get("timestamp") or utc_now(),
+        "event": event.get("event", "event"),
+        "level": event.get("level", "info"),
+        "message": event.get("message", ""),
+    }
+    if "data" in event:
+        item["data"] = event["data"]
+    return item
+
+
+def validate_delegation_result(observed: bool, result: str) -> None:
+    if observed and result not in OBSERVED_RESULTS:
+        raise ValueError("observed delegation requires result completed, blocked, or failed")
+    if not observed and result not in UNOBSERVED_RESULTS:
+        raise ValueError("unobserved delegation requires result not_available or not_observed")
+
+
+def build_delegation_record(delegation: dict[str, Any]) -> dict[str, Any]:
+    result = delegation.get("result", "not_observed")
+    if result not in DELEGATION_RESULTS:
+        raise ValueError(f"unsupported delegation result: {result}")
+    observed = bool(delegation.get("observed", False))
+    validate_delegation_result(observed, result)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "updated_at": utc_now(),
+        "requested": bool(delegation.get("requested", False)),
+        "observed": observed,
+        "participants": list(delegation.get("participants", [])),
+        "result": result,
+        "evidence_refs": list(delegation.get("evidence_refs", [])),
+        "message": delegation.get("message", ""),
+    }
+
+
+def build_wrapper_record(wrapper: dict[str, Any]) -> dict[str, Any]:
+    status = wrapper.get("completion_status", "unknown")
+    if status not in WRAPPER_COMPLETION_STATUSES:
+        raise ValueError(f"unsupported wrapper completion status: {status}")
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "updated_at": utc_now(),
+        "prompt_dispatched": bool(wrapper.get("prompt_dispatched", False)),
+        "hermes_response_observed": bool(wrapper.get("hermes_response_observed", False)),
+        "verification_observed": bool(wrapper.get("verification_observed", False)),
+        "completion_status": status,
+        "unobserved_gaps": list(wrapper.get("unobserved_gaps", [])),
+        "message": wrapper.get("message", ""),
+    }
+
+
+def _require(condition: bool, errors: list[str], message: str) -> None:
+    if not condition:
+        errors.append(message)
+
+
+def validate_run_record(run: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    _require(run.get("schema_version") == SCHEMA_VERSION, errors, "run schema_version is invalid")
+    for key in ("run_id", "created_at", "updated_at", "skill", "harness", "status", "privacy"):
+        _require(isinstance(run.get(key), str) if key != "schema_version" else True, errors, f"run {key} must be a string")
+    _require(run.get("status") in RUN_STATUSES, errors, f"run status is invalid: {run.get('status')!r}")
+    _require(run.get("privacy") in PRIVACY_MODES, errors, f"run privacy is invalid: {run.get('privacy')!r}")
+    for key in ("trigger", "inputs_summary", "outputs_summary", "verification_summary"):
+        _require(isinstance(run.get(key, ""), str), errors, f"run {key} must be a string")
+    return errors
+
+
+def validate_event_record(event: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    _require(event.get("schema_version") == SCHEMA_VERSION, errors, "event schema_version is invalid")
+    for key in ("timestamp", "event", "level", "message"):
+        _require(isinstance(event.get(key), str), errors, f"event {key} must be a string")
+    _require(event.get("level") in EVENT_LEVELS, errors, f"event level is invalid: {event.get('level')!r}")
+    if "data" in event:
+        _require(isinstance(event["data"], dict), errors, "event data must be an object")
+    return errors
+
+
+def validate_delegation_record(delegation: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    _require(delegation.get("schema_version") == SCHEMA_VERSION, errors, "delegation schema_version is invalid")
+    _require(isinstance(delegation.get("requested"), bool), errors, "delegation requested must be boolean")
+    _require(isinstance(delegation.get("observed"), bool), errors, "delegation observed must be boolean")
+    _require(delegation.get("result") in DELEGATION_RESULTS, errors, f"delegation result is invalid: {delegation.get('result')!r}")
+    _require(isinstance(delegation.get("participants"), list), errors, "delegation participants must be a list")
+    _require(isinstance(delegation.get("evidence_refs"), list), errors, "delegation evidence_refs must be a list")
+    try:
+        validate_delegation_result(bool(delegation.get("observed")), str(delegation.get("result")))
+    except ValueError as exc:
+        errors.append(str(exc))
+    return errors
+
+
+def validate_wrapper_record(wrapper: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    _require(wrapper.get("schema_version") == SCHEMA_VERSION, errors, "wrapper schema_version is invalid")
+    for key in ("prompt_dispatched", "hermes_response_observed", "verification_observed"):
+        _require(isinstance(wrapper.get(key), bool), errors, f"wrapper {key} must be boolean")
+    _require(
+        wrapper.get("completion_status") in WRAPPER_COMPLETION_STATUSES,
+        errors,
+        f"wrapper completion_status is invalid: {wrapper.get('completion_status')!r}",
+    )
+    _require(isinstance(wrapper.get("unobserved_gaps"), list), errors, "wrapper unobserved_gaps must be a list")
+    _require(isinstance(wrapper.get("message", ""), str), errors, "wrapper message must be a string")
+    return errors
+
+
+OPTIONAL_RECORD_VALIDATORS = (
+    ("delegation.json", validate_delegation_record),
+    ("wrapper.json", validate_wrapper_record),
+)

--- a/tests/test_runtime_artifacts.py
+++ b/tests/test_runtime_artifacts.py
@@ -19,8 +19,10 @@ from omh.runtime_artifacts import (
     new_run_id,
     show_run,
     update_state,
+    validate_delegation_record,
     validate_runtime,
     validate_run_record,
+    validate_wrapper_record,
     write_delegation,
     write_wrapper_contract,
 )
@@ -136,6 +138,31 @@ class RuntimeArtifactTests(unittest.TestCase):
             bad = next(item for item in result["runs"] if item["run_id"] == "bad-run")
             self.assertTrue(any("status is invalid" in error for error in bad["errors"]))
             self.assertTrue(any("event level is invalid" in error for error in bad["errors"]))
+
+    def test_record_validators_remain_available_from_runtime_artifacts(self) -> None:
+        delegation_errors = validate_delegation_record(
+            {
+                "schema_version": 1,
+                "requested": True,
+                "observed": False,
+                "participants": [],
+                "evidence_refs": [],
+                "result": "completed",
+            }
+        )
+        wrapper_errors = validate_wrapper_record(
+            {
+                "schema_version": 1,
+                "prompt_dispatched": True,
+                "hermes_response_observed": False,
+                "verification_observed": False,
+                "completion_status": "missing",
+                "unobserved_gaps": [],
+            }
+        )
+
+        self.assertIn("unobserved delegation requires result not_available or not_observed", delegation_errors)
+        self.assertTrue(any("completion_status is invalid" in error for error in wrapper_errors))
 
     def test_export_runtime_redacts_sensitive_keys(self) -> None:
         with TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- Add runtime_records for runtime evidence schema constants, record builders, and validators.
- Keep runtime_artifacts focused on persistence, run directories, JSONL events, validation traversal, and export.
- Preserve existing runtime_artifacts imports for CLI/caller compatibility while adding a regression test for validator re-exports.

## Verification
- python3 -m unittest discover -s tests
- python3 -m compileall src
- python3 -m src.cli docs workflows --check
- git diff --check HEAD

## Cleanup notes
- Fallback-like scan found only intentional not_available / not_observed evidence statuses and a POSIX permission-test skip; no masking fallback cleanup required.