### PR TITLE
Add deterministic OMHM workflow recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ omh install --dry-run
 omh install --from-skills-dir ./skills
 omh update --from-skills-dir ./skills
 omh apply --dry-run
+omh recommend "risky refactor"
 omh runtime record --skill oh-my-hermes --harness coding-handling --status started
 omh runtime validate
 omh runtime export
@@ -173,6 +174,7 @@ it could mean normal conversation.
 | `omh apply` | Register `~/.omh/skills` in Hermes `skills.external_dirs`. |
 | `omh list` | Print the installed manifest. |
 | `omh doctor` | Verify managed files and Hermes config registration. |
+| `omh recommend <task>` | Deterministically suggest workflow skills from the local OMHM catalog. |
 | `omh runtime status` | Inspect local runtime artifact state. |
 | `omh runtime record` | Create a metadata-only workflow run artifact. |
 | `omh runtime delegate` | Record observed or unavailable delegation for a run. |
@@ -196,6 +198,7 @@ src/
   installer.py           managed skill pack install/update/uninstall
   manifest.py            installed file manifest and conflict checks
   paths.py               home/config path resolution
+  recommend.py           deterministic workflow skill recommender
   snippet.py             optional workspace guidance
   skill_pack.py          compatibility facade for generated skills
   core/

--- a/src/cli.py
+++ b/src/cli.py
@@ -14,6 +14,7 @@ from .local_store import atomic_write_text
 from .manifest import read_manifest
 from .paths import resolve_paths
 from .probe import probe_capabilities
+from .recommend import recommend_skills
 from .release import RELEASE_CHANNELS, package_url_for
 from .runtime_artifacts import (
     DELEGATION_RESULTS,
@@ -155,6 +156,16 @@ def cmd_doctor(args: argparse.Namespace) -> int:
         )
     _print_json({"ok": doctor_ok(checks), "checks": [check.__dict__ for check in checks]})
     return 0 if doctor_ok(checks) else 1
+
+
+def cmd_recommend(args: argparse.Namespace) -> int:
+    if args.limit < 1:
+        raise OmhError("recommend --limit must be at least 1")
+    query = " ".join(args.task).strip()
+    if not query:
+        raise OmhError("recommend requires a task description")
+    _print_json({"query": query, "recommendations": recommend_skills(query, limit=args.limit)})
+    return 0
 
 
 def _valid_skill_names() -> set[str]:
@@ -408,6 +419,11 @@ def _add_top_level_commands(sub) -> None:
 
     doctor = sub.add_parser("doctor")
     doctor.set_defaults(func=cmd_doctor)
+
+    recommend = sub.add_parser("recommend")
+    recommend.add_argument("task", nargs="+", help="Task description to map to OMHM workflow skills.")
+    recommend.add_argument("--limit", type=int, default=5, help="Maximum recommendations to return.")
+    recommend.set_defaults(func=cmd_recommend)
 
     snippet = sub.add_parser("snippet")
     snippet.add_argument("--dry-run", action="store_true")

--- a/src/recommend.py
+++ b/src/recommend.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import re
+
+from .skills.catalog import SkillDefinition, builtin_definitions
+
+
+_TOKEN_RE = re.compile(r"[a-z0-9][a-z0-9-]*")
+_STOPWORDS = {
+    "the",
+    "and",
+    "for",
+    "with",
+    "that",
+    "this",
+    "when",
+    "use",
+    "task",
+    "request",
+    "workflow",
+    "skill",
+    "agent",
+    "hermes",
+}
+_FALLBACK_SKILLS = ("oh-my-hermes", "plan", "deep-interview")
+_FALLBACK_WHY = "No strong catalog metadata match; start with general routing/planning guidance."
+
+
+@dataclass(frozen=True)
+class Recommendation:
+    skill: str
+    description: str
+    category: str
+    phase: str
+    score: int
+    confidence: str
+    matched: tuple[str, ...]
+    why: str
+    suggested_prompt: str
+
+    def to_dict(self) -> dict[str, object]:
+        data = asdict(self)
+        data["matched"] = list(self.matched)
+        return data
+
+
+def recommend_skills(query: str, *, limit: int = 5) -> list[dict[str, object]]:
+    if limit < 1:
+        raise ValueError("recommend --limit must be at least 1")
+
+    normalized_query = query.strip().lower()
+    query_tokens = _tokens(normalized_query)
+    definitions = list(builtin_definitions())
+    scored = [_score_definition(definition, normalized_query, query_tokens, query) for definition in definitions]
+    matches = [recommendation for recommendation in scored if recommendation.score > 0]
+    if not matches:
+        matches = _fallback_recommendations(definitions, query)
+    matches.sort(key=lambda recommendation: (-recommendation.score, recommendation.skill))
+    return [recommendation.to_dict() for recommendation in matches[:limit]]
+
+
+def _score_definition(
+    definition: SkillDefinition,
+    normalized_query: str,
+    query_tokens: set[str],
+    original_query: str,
+) -> Recommendation:
+    score = 0
+    matched: set[str] = set()
+
+    for trigger in definition.triggers:
+        trigger_normalized = trigger.lower()
+        if _phrase_match(normalized_query, trigger_normalized):
+            score += 6
+            matched.add(f"trigger:{trigger_normalized}")
+
+    name_normalized = definition.name.lower()
+    if _phrase_match(normalized_query, name_normalized):
+        score += 5
+        matched.add(f"name:{name_normalized}")
+
+    description_normalized = definition.description.lower()
+    if _phrase_match(normalized_query, description_normalized):
+        score += 3
+        matched.add("description:phrase")
+
+    use_when_normalized = definition.use_when.lower()
+    if _phrase_match(normalized_query, use_when_normalized):
+        score += 3
+        matched.add("use_when:phrase")
+
+    for field_name, value in (("category", definition.category), ("phase", definition.phase)):
+        normalized_value = value.lower()
+        if _phrase_match(normalized_query, normalized_value):
+            score += 2
+            matched.add(f"{field_name}:{normalized_value}")
+
+    trigger_tokens = _tokens(" ".join(definition.triggers))
+    for token in sorted(query_tokens & trigger_tokens):
+        score += 3
+        matched.add(f"trigger:{token}")
+
+    metadata_tokens = _tokens(" ".join((definition.name, definition.description, definition.use_when)))
+    for token in sorted(query_tokens & metadata_tokens):
+        score += 1
+        matched.add(f"metadata:{token}")
+
+    matched_tuple = tuple(sorted(matched))
+    return Recommendation(
+        skill=definition.name,
+        description=definition.description,
+        category=definition.category,
+        phase=definition.phase,
+        score=score,
+        confidence=_confidence(score),
+        matched=matched_tuple,
+        why=_why(matched_tuple),
+        suggested_prompt=_suggested_prompt(definition.name, original_query),
+    )
+
+
+def _fallback_recommendations(definitions: list[SkillDefinition], query: str) -> list[Recommendation]:
+    by_name = {definition.name: definition for definition in definitions}
+    recommendations = []
+    for name in _FALLBACK_SKILLS:
+        definition = by_name.get(name)
+        if definition is None:
+            continue
+        recommendations.append(
+            Recommendation(
+                skill=definition.name,
+                description=definition.description,
+                category=definition.category,
+                phase=definition.phase,
+                score=0,
+                confidence="low",
+                matched=(),
+                why=_FALLBACK_WHY,
+                suggested_prompt=_suggested_prompt(definition.name, query),
+            )
+        )
+    return recommendations
+
+
+def _tokens(value: str) -> set[str]:
+    tokens: set[str] = set()
+    for raw_token in _TOKEN_RE.findall(value.lower()):
+        for token in (raw_token, *raw_token.split("-")):
+            if len(token) >= 3 and token not in _STOPWORDS:
+                tokens.add(token)
+    return tokens
+
+
+def _phrase_match(query: str, value: str) -> bool:
+    return bool(query and value and (query in value or value in query))
+
+
+def _confidence(score: int) -> str:
+    if score >= 8:
+        return "high"
+    if score >= 4:
+        return "medium"
+    return "low"
+
+
+def _why(matched: tuple[str, ...]) -> str:
+    if not matched:
+        return _FALLBACK_WHY
+    sources = sorted({item.split(":", 1)[0] for item in matched})
+    return f"Matched {'/'.join(sources)} metadata for this task."
+
+
+def _suggested_prompt(skill: str, query: str) -> str:
+    return f"Use {skill} for: {query}"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,6 +9,51 @@ from _cli_harness import run_cli
 
 
 class CliTests(unittest.TestCase):
+    def test_recommend_risky_refactor_includes_cleanup_workflow(self) -> None:
+        status, stdout, stderr = run_cli(["recommend", "risky", "refactor"])
+
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        payload = json.loads(stdout)
+        self.assertEqual(payload["query"], "risky refactor")
+        recommendations = payload["recommendations"]
+        self.assertTrue(recommendations)
+        self.assertIn("ai-slop-cleaner", {recommendation["skill"] for recommendation in recommendations[:3]})
+        self.assertTrue(any(recommendation["why"] and recommendation["suggested_prompt"] for recommendation in recommendations))
+
+    def test_recommend_implementation_plan_includes_planning_workflow(self) -> None:
+        status, stdout, stderr = run_cli(["recommend", "implementation", "plan", "with", "review"])
+
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        recommendations = json.loads(stdout)["recommendations"]
+        top_names = {recommendation["skill"] for recommendation in recommendations[:3]}
+        self.assertTrue({"plan", "ralplan"} & top_names)
+
+    def test_recommend_diagnose_installation_health_includes_doctor(self) -> None:
+        status, stdout, stderr = run_cli(["recommend", "diagnose", "installation", "health"])
+
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        top_names = {recommendation["skill"] for recommendation in json.loads(stdout)["recommendations"][:3]}
+        self.assertIn("doctor", top_names)
+
+    def test_recommend_weak_query_uses_fallback(self) -> None:
+        status, stdout, stderr = run_cli(["recommend", "zzzzunknownphrase"])
+
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        recommendations = json.loads(stdout)["recommendations"]
+        self.assertIn("oh-my-hermes", {recommendation["skill"] for recommendation in recommendations})
+        self.assertEqual(recommendations[0]["confidence"], "low")
+        self.assertIn("No strong catalog metadata match", recommendations[0]["why"])
+
+    def test_recommend_rejects_invalid_limit(self) -> None:
+        status, _, stderr = run_cli(["recommend", "refactor", "--limit", "0"])
+
+        self.assertEqual(status, 2)
+        self.assertIn("recommend --limit must be at least 1", stderr)
+
     def test_install_apply_doctor_and_list(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## Summary
- Add standalone deterministic `omh recommend <task description>` using local catalog metadata only.
- Wire the command into the CLI with `--limit` validation and stable JSON output.
- Cover cleanup/planning/diagnosis/fallback/invalid-limit cases in the existing unittest CLI harness.
- Document the command conservatively without claiming Hermes runtime routing changes.

## Verification
- `PYTHONPATH=tests uv run python -m unittest tests/test_cli.py -v` -> passed, 18 tests.
- `uv run omh recommend "risky refactor"` -> passed, top recommendation `ai-slop-cleaner`.
- `uv run omh recommend implementation plan with review --limit 2` -> passed, two recommendations: `plan`, `code-review`.
- `uv run omh recommend diagnose installation health` -> passed, top recommendation `doctor`.
- `uv run python -m compileall src` -> passed.
- `git diff --check` -> passed.

Not merged per request; awaiting explicit merge approval.