### PR TITLE
Add wrapper-assisted chat routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,10 +167,11 @@ it could mean normal conversation.
 
 Wrappers for Discord, Slack, or hosted Hermes chats can run `omh chat route`
 before forwarding a plain user message. The command returns a deterministic
-`dispatch`, `clarify`, or `fallback` decision plus a `routing_prompt` that the
-wrapper can send to Hermes. With `--record`, it writes metadata-only
-`routing.json` evidence under `.omh/runtime/` without storing the raw prompt
-body.
+`dispatch`, `clarify`, or `fallback` decision plus a `routing_instruction` and
+`routing_prompt_template`. The default JSON omits the raw prompt body so wrapper
+logs can stay metadata-only; use `--include-message` only when the wrapper needs
+`route.routing_prompt` pre-expanded. With `--record`, it writes metadata-only
+`routing.json` evidence under `.omh/runtime/` without storing the raw prompt.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ omh install --from-skills-dir ./skills
 omh update --from-skills-dir ./skills
 omh apply --dry-run
 omh recommend "risky refactor"
+omh chat route --source discord --record "risky refactor"
 omh runtime record --skill oh-my-hermes --harness coding-handling --status started
 omh runtime validate
 omh runtime export
@@ -164,6 +165,13 @@ Routing priority:
 A bare common word such as `team`, `ask`, `wiki`, or `review` is not enough when
 it could mean normal conversation.
 
+Wrappers for Discord, Slack, or hosted Hermes chats can run `omh chat route`
+before forwarding a plain user message. The command returns a deterministic
+`dispatch`, `clarify`, or `fallback` decision plus a `routing_prompt` that the
+wrapper can send to Hermes. With `--record`, it writes metadata-only
+`routing.json` evidence under `.omh/runtime/` without storing the raw prompt
+body.
+
 ## Commands
 
 | Command | Purpose |
@@ -175,6 +183,7 @@ it could mean normal conversation.
 | `omh list` | Print the installed manifest. |
 | `omh doctor` | Verify managed files and Hermes config registration. |
 | `omh recommend <task>` | Deterministically suggest workflow skills from the local OMHM catalog. |
+| `omh chat route <message>` | Route a plain chat message before a Discord, Slack, or Hermes wrapper dispatches it. |
 | `omh runtime status` | Inspect local runtime artifact state. |
 | `omh runtime record` | Create a metadata-only workflow run artifact. |
 | `omh runtime delegate` | Record observed or unavailable delegation for a run. |
@@ -191,6 +200,7 @@ it could mean normal conversation.
 
 ```text
 src/
+  chat_router.py          deterministic chat pre-dispatch routing
   cli.py                 command-line entrypoint
   config_adapter.py      Hermes config registration adapter
   converter.py           local skill import support

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -17,6 +17,7 @@ The architecture favors:
 
 ```text
 src/
+  chat_router.py
   cli.py
   config_adapter.py
   converter.py
@@ -33,6 +34,10 @@ src/
 ## Main Modules
 
 `cli.py` owns command parsing and user-facing JSON output.
+
+`chat_router.py` owns deterministic pre-dispatch routing decisions for chat
+wrappers. It consumes plain messages or platform-shaped event payloads and
+returns `dispatch`, `clarify`, or `fallback` decisions from local catalog data.
 
 `installer.py` owns managed skill writes, manifest updates, update behavior, and
 uninstall behavior.
@@ -51,9 +56,19 @@ the package grows internally.
 
 ## Routing
 
-Routing is prompt-level guidance. The router skill gives Hermes a structured map
-of workflow names and strong trigger phrases, but it does not override Hermes
-core behavior.
+Routing has two local surfaces:
+
+1. Prompt-level guidance. The router skill gives Hermes a structured map of
+   workflow names and strong trigger phrases, but it does not override Hermes
+   core behavior.
+2. Wrapper-assisted chat routing. `omh chat route` lets Discord, Slack, or
+   hosted Hermes wrappers run a deterministic pre-dispatch decision before they
+   forward a plain user message to Hermes.
+
+Both surfaces read from the same catalog metadata. The chat router returns a
+`routing_prompt` for the wrapper to forward and can record metadata-only
+`routing.json` evidence. It does not include a Discord or Slack SDK, open network
+connections, or patch Hermes internals.
 
 Future routing work should deepen the catalog first, then render richer skill
 metadata from it.
@@ -115,29 +130,34 @@ Runtime artifacts are local JSON/JSONL files under `.omh/runtime/`.
       <run-id>/
         run.json
         events.jsonl
+        routing.json
         delegation.json
         wrapper.json
         evidence/
 ```
 
 `state.json` records install, apply, and doctor summaries. A run directory
-records a workflow envelope, append-only events, delegation observation, and
-wrapper observation plus optional evidence files.
+records a workflow envelope, append-only events, routing decisions, delegation
+observation, and wrapper observation plus optional evidence files.
 
 The runtime artifact layer is intentionally small:
 
 - JSON/JSONL only
 - no external service
-- no prompt body capture by default
+- no prompt body capture in runtime artifacts by default
 - schema-versioned files
 - CLI inspection through `omh runtime status`, `omh runtime runs`, and
   `omh runtime show <run-id>`
 - schema validation through `omh runtime validate`
 - redacted export through `omh runtime export`
 
-Bot wrappers can call `omh runtime record` before invoking Hermes and
-`omh runtime delegate` after the response if delegation metadata is available.
-If not, they should record `not_observed` rather than guessing.
+Bot wrappers can call `omh chat route --record` before invoking Hermes. The
+record stores the selected skill, confidence, score, message length, and message
+hash without storing the raw prompt body.
+
+Bot wrappers can still call `omh runtime delegate` after the response if
+delegation metadata is available. If not, they should record `not_observed`
+rather than guessing.
 
 Wrappers can also call `omh runtime wrapper` to record whether a prompt was
 dispatched, whether a Hermes response was observed, whether verification was

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -66,9 +66,10 @@ Routing has two local surfaces:
    forward a plain user message to Hermes.
 
 Both surfaces read from the same catalog metadata. The chat router returns a
-`routing_prompt` for the wrapper to forward and can record metadata-only
-`routing.json` evidence. It does not include a Discord or Slack SDK, open network
-connections, or patch Hermes internals.
+`routing_instruction` and `routing_prompt_template` for the wrapper to forward,
+with raw-message prompt expansion available only through `--include-message`.
+It can record metadata-only `routing.json` evidence. It does not include a
+Discord or Slack SDK, open network connections, or patch Hermes internals.
 
 Future routing work should deepen the catalog first, then render richer skill
 metadata from it.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -58,7 +58,9 @@ The flow is:
 1. The Discord bot receives a user message.
 2. The bot can run `omh chat route --source discord --record "<message>"` to
    choose `dispatch`, `clarify`, or `fallback` before forwarding the request.
-3. The bot forwards the returned `route.routing_prompt` to Hermes Agent.
+3. The bot forwards `route.routing_prompt_template` with `{message}` replaced by
+   the received message, or runs with `--include-message` and forwards
+   `route.routing_prompt` when stdout is not logged.
 4. Hermes starts with its normal config and reads `skills.external_dirs`.
 5. `omh apply` makes sure `~/.omh/skills` is included in that discovery list.
 6. Hermes sees the managed skills, including the `oh-my-hermes` router skill.
@@ -87,7 +89,7 @@ Optional artifact-backed flow:
 
 ```sh
 message='risky refactor'
-route_json="$(omh chat route --source discord --record "$message")"
+route_json="$(omh chat route --source discord --record --include-message "$message")"
 run_id="$(printf '%s' "$route_json" | python -c 'import json,sys; print(json.load(sys.stdin)["runtime"]["run"]["run_id"])')"
 route_prompt="$(printf '%s' "$route_json" | python -c 'import json,sys; print(json.load(sys.stdin)["route"]["routing_prompt"])')"
 
@@ -131,7 +133,8 @@ Before calling the bot integration ready, verify these points:
 Current limitation: deeper execution still depends on Hermes loading and
 exposing installed skills to the model. `omh chat route` chooses the prompt and
 records metadata before dispatch, but the bot adapter must forward the returned
-`routing_prompt`, and Hermes must still load the managed skills.
+prompt template or opt into `--include-message`, and Hermes must still load the
+managed skills.
 
 ## Update
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -56,20 +56,23 @@ the same machine, container, or runtime image that starts the bot.
 The flow is:
 
 1. The Discord bot receives a user message.
-2. The bot forwards that request to Hermes Agent.
-3. Hermes starts with its normal config and reads `skills.external_dirs`.
-4. `omh apply` makes sure `~/.omh/skills` is included in that discovery list.
-5. Hermes sees the managed skills, including the `oh-my-hermes` router skill.
-6. The router skill gives Hermes prompt-level routing guidance for workflow
+2. The bot can run `omh chat route --source discord --record "<message>"` to
+   choose `dispatch`, `clarify`, or `fallback` before forwarding the request.
+3. The bot forwards the returned `route.routing_prompt` to Hermes Agent.
+4. Hermes starts with its normal config and reads `skills.external_dirs`.
+5. `omh apply` makes sure `~/.omh/skills` is included in that discovery list.
+6. Hermes sees the managed skills, including the `oh-my-hermes` router skill.
+7. The router skill gives Hermes prompt-level routing guidance for workflow
    names, trigger phrases, fallback rules, and recovery behavior.
-7. Hermes selects the relevant installed skill and continues the response inside
+8. Hermes selects the relevant installed skill and continues the response inside
    the Discord bot flow.
-8. The bot or operator can record local evidence with `omh runtime record` and
+9. The bot or operator can record local evidence with `omh runtime record` and
    `omh runtime delegate`.
 
 `omh` does not replace the Discord bot, modify Discord commands, or patch Hermes
 internals. It prepares the skill layer that Hermes can load when the bot invokes
-Hermes.
+Hermes, and it can make a local deterministic pre-dispatch routing decision for
+the wrapper.
 
 For a hosted bot, the practical deployment shape is usually:
 
@@ -83,9 +86,12 @@ Then restart the bot process so Hermes reloads its config and skill directory.
 Optional artifact-backed flow:
 
 ```sh
-run_json="$(omh runtime record --skill oh-my-hermes --harness coding-handling --status started)"
-run_id="$(printf '%s' "$run_json" | python -c 'import json,sys; print(json.load(sys.stdin)["run"]["run_id"])')"
+message='risky refactor'
+route_json="$(omh chat route --source discord --record "$message")"
+run_id="$(printf '%s' "$route_json" | python -c 'import json,sys; print(json.load(sys.stdin)["runtime"]["run"]["run_id"])')"
+route_prompt="$(printf '%s' "$route_json" | python -c 'import json,sys; print(json.load(sys.stdin)["route"]["routing_prompt"])')"
 
+# Forward "$route_prompt" to Hermes.
 # After Hermes responds, record what the bot could actually observe.
 omh runtime delegate --run "$run_id" --requested --not-observed --result not_observed
 omh runtime wrapper --run "$run_id" --prompt-dispatched --response-observed --completion-status completed --gap "specialist lane metadata not exposed"
@@ -111,6 +117,8 @@ Before calling the bot integration ready, verify these points:
 - `omh doctor` reports the managed skill directory as installed and registered.
 - The bot process can read the same Hermes home/config that `omh apply` updated.
 - The bot was restarted after installation or update.
+- `omh chat route --source discord --record "<message>"` returns a route action
+  and writes `routing.json` in the same runtime context as the bot.
 - A Discord message that strongly names a workflow reaches Hermes with installed
   skill descriptions available.
 - `omh runtime record` can create a run and `omh runtime show <run-id>` can read
@@ -120,11 +128,10 @@ Before calling the bot integration ready, verify these points:
 - If skills do not appear, run `omh apply`, then `omh doctor`, then restart the
   bot again.
 
-Current limitation: routing is prompt-level guidance. It depends on Hermes
-loading and exposing installed skills to the model. If the Discord bot runs
-Hermes in a restricted mode that does not load external skill directories, the
-bot adapter or Hermes startup config must be updated to allow that discovery
-path.
+Current limitation: deeper execution still depends on Hermes loading and
+exposing installed skills to the model. `omh chat route` chooses the prompt and
+records metadata before dispatch, but the bot adapter must forward the returned
+`routing_prompt`, and Hermes must still load the managed skills.
 
 ## Update
 

--- a/src/chat_router.py
+++ b/src/chat_router.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import hashlib
+from typing import Any
+
+from .recommend import recommend_skills
+from .skills.catalog import SkillDefinition, builtin_definitions, primary_harness_for_skill
+
+
+CHAT_SOURCES = ("generic", "discord", "slack", "hermes")
+ROUTE_ACTIONS = ("dispatch", "clarify", "fallback")
+CONFIDENCE_LEVELS = ("low", "medium", "high")
+_CONFIDENCE_RANK = {name: index for index, name in enumerate(CONFIDENCE_LEVELS, start=1)}
+_EVENT_TEXT_PATHS = (
+    ("message", "content"),
+    ("message", "text"),
+    ("event", "text"),
+    ("body", "text"),
+    ("body", "content"),
+    ("data", "text"),
+    ("data", "content"),
+    ("content",),
+    ("text",),
+    ("prompt",),
+    ("input",),
+)
+
+
+@dataclass(frozen=True)
+class ChatRouteDecision:
+    schema_version: int
+    source: str
+    action: str
+    selected_skill: str
+    selected_harness: str
+    candidate_skill: str
+    candidate_harness: str
+    confidence: str
+    score: int
+    threshold: str
+    explicit: bool
+    ambiguous: bool
+    reason: str
+    clarification: str
+    routing_prompt: str
+    recommendations: tuple[dict[str, object], ...]
+
+    def to_dict(self) -> dict[str, object]:
+        data = asdict(self)
+        data["recommendations"] = list(self.recommendations)
+        return data
+
+
+def route_chat_message(
+    message: str,
+    *,
+    source: str = "generic",
+    limit: int = 3,
+    min_confidence: str = "high",
+) -> dict[str, object]:
+    message = message.strip()
+    if not message:
+        raise ValueError("chat route requires a message")
+    if source not in CHAT_SOURCES:
+        raise ValueError(f"unsupported chat source: {source}")
+    if limit < 1:
+        raise ValueError("chat route --limit must be at least 1")
+    if min_confidence not in CONFIDENCE_LEVELS:
+        raise ValueError(f"unsupported chat route confidence threshold: {min_confidence}")
+
+    definitions = builtin_definitions()
+    full_recommendations = recommend_skills(message, limit=len(definitions))
+    recommendations = tuple(full_recommendations[:limit])
+    top = full_recommendations[0]
+    explicit_skill = explicit_skill_invocation(message, definitions)
+    candidate_skill = str(top["skill"])
+    candidate_harness = primary_harness_for_skill(candidate_skill)
+    candidate_score = int(top["score"])
+    candidate_confidence = str(top["confidence"])
+    ambiguous = _is_ambiguous(full_recommendations)
+
+    if explicit_skill:
+        selected_skill = explicit_skill
+        action = "dispatch"
+        reason = "Explicit workflow invocation wins over heuristic routing."
+        ambiguous = False
+    elif candidate_score == 0:
+        selected_skill = "oh-my-hermes"
+        candidate_skill = selected_skill
+        candidate_harness = primary_harness_for_skill(candidate_skill)
+        action = "fallback"
+        reason = "No strong catalog metadata match; use the router to clarify the workflow."
+    elif ambiguous:
+        selected_skill = "oh-my-hermes"
+        action = "clarify"
+        reason = "Top catalog matches are tied; ask one concise clarification before dispatch."
+    elif _meets_threshold(candidate_confidence, min_confidence):
+        selected_skill = candidate_skill
+        action = "dispatch"
+        reason = str(top["why"])
+    else:
+        selected_skill = "oh-my-hermes"
+        action = "clarify"
+        reason = f"Best match confidence {candidate_confidence} is below {min_confidence}; clarify before dispatch."
+
+    selected_harness = primary_harness_for_skill(selected_skill)
+    clarification = _clarification(action, candidate_skill, candidate_confidence, min_confidence)
+    decision = ChatRouteDecision(
+        schema_version=1,
+        source=source,
+        action=action,
+        selected_skill=selected_skill,
+        selected_harness=selected_harness,
+        candidate_skill=candidate_skill,
+        candidate_harness=candidate_harness,
+        confidence="high" if explicit_skill else candidate_confidence,
+        score=max(candidate_score, 1) if explicit_skill else candidate_score,
+        threshold=min_confidence,
+        explicit=bool(explicit_skill),
+        ambiguous=ambiguous,
+        reason=reason,
+        clarification=clarification,
+        routing_prompt=_routing_prompt(action, selected_skill, candidate_skill, reason, message),
+        recommendations=recommendations,
+    )
+    return decision.to_dict()
+
+
+def route_chat_event(
+    event: dict[str, Any] | str,
+    *,
+    source: str = "generic",
+    limit: int = 3,
+    min_confidence: str = "high",
+) -> dict[str, object]:
+    return route_chat_message(extract_message_text(event), source=source, limit=limit, min_confidence=min_confidence)
+
+
+def extract_message_text(event: dict[str, Any] | str) -> str:
+    if isinstance(event, str):
+        return event.strip()
+    if not isinstance(event, dict):
+        raise ValueError("chat event must be an object or string")
+    for path in _EVENT_TEXT_PATHS:
+        value = _value_at_path(event, path)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    raise ValueError("chat event does not contain a supported text field")
+
+
+def explicit_skill_invocation(message: str, definitions: list[SkillDefinition] | None = None) -> str | None:
+    definitions = definitions or builtin_definitions()
+    names = {definition.name for definition in definitions}
+    first = message.strip().split(maxsplit=1)[0].strip(":,")
+    for prefix in ("/", "$", "@"):
+        if first.startswith(prefix):
+            first = first[len(prefix) :]
+            break
+    first = first.lower().strip(":,")
+    return first if first in names else None
+
+
+def routing_record_payload(
+    decision: dict[str, object],
+    message: str,
+    *,
+    source_event_id: str = "",
+    channel_ref: str = "",
+    user_ref: str = "",
+) -> dict[str, object]:
+    return {
+        "source": decision["source"],
+        "action": decision["action"],
+        "selected_skill": decision["selected_skill"],
+        "selected_harness": decision["selected_harness"],
+        "candidate_skill": decision["candidate_skill"],
+        "candidate_harness": decision["candidate_harness"],
+        "confidence": decision["confidence"],
+        "score": decision["score"],
+        "threshold": decision["threshold"],
+        "explicit": decision["explicit"],
+        "ambiguous": decision["ambiguous"],
+        "reason": decision["reason"],
+        "message_sha256": hashlib.sha256(message.encode("utf-8")).hexdigest(),
+        "message_length": len(message),
+        "source_event_id": source_event_id,
+        "channel_ref": channel_ref,
+        "user_ref": user_ref,
+        "recommendations": _compact_recommendations(decision.get("recommendations", [])),
+    }
+
+
+def _value_at_path(event: dict[str, Any], path: tuple[str, ...]) -> Any:
+    current: Any = event
+    for part in path:
+        if not isinstance(current, dict):
+            return None
+        current = current.get(part)
+    return current
+
+
+def _is_ambiguous(recommendations: list[dict[str, object]]) -> bool:
+    if len(recommendations) < 2:
+        return False
+    first = int(recommendations[0]["score"])
+    second = int(recommendations[1]["score"])
+    return first > 0 and first == second
+
+
+def _meets_threshold(confidence: str, threshold: str) -> bool:
+    return _CONFIDENCE_RANK[confidence] >= _CONFIDENCE_RANK[threshold]
+
+
+def _clarification(action: str, candidate_skill: str, candidate_confidence: str, threshold: str) -> str:
+    if action == "dispatch":
+        return ""
+    if action == "fallback":
+        return "Ask which workflow or outcome the user wants before choosing a specialist skill."
+    return f"Ask whether to use `{candidate_skill}`; confidence was {candidate_confidence}, below threshold {threshold}."
+
+
+def _routing_prompt(action: str, selected_skill: str, candidate_skill: str, reason: str, message: str) -> str:
+    if action == "dispatch":
+        instruction = f"Use the `{selected_skill}` workflow for this chat message."
+    elif action == "clarify":
+        instruction = f"Use the `oh-my-hermes` router before dispatching to `{candidate_skill}`."
+    else:
+        instruction = "Use the `oh-my-hermes` router and ask one concise clarification question."
+    return f"{instruction}\n\nRouting reason: {reason}\n\nUser message:\n{message}"
+
+
+def _compact_recommendations(recommendations: object) -> list[dict[str, object]]:
+    if not isinstance(recommendations, list):
+        return []
+    compact: list[dict[str, object]] = []
+    for item in recommendations:
+        if not isinstance(item, dict):
+            continue
+        compact.append(
+            {
+                "skill": str(item.get("skill", "")),
+                "score": int(item.get("score", 0)),
+                "confidence": str(item.get("confidence", "low")),
+                "matched": list(item.get("matched", [])),
+            }
+        )
+    return compact

--- a/src/chat_router.py
+++ b/src/chat_router.py
@@ -137,6 +137,25 @@ def route_chat_event(
     return route_chat_message(extract_message_text(event), source=source, limit=limit, min_confidence=min_confidence)
 
 
+def public_route_payload(decision: dict[str, object], *, include_message: bool = False) -> dict[str, object]:
+    route = dict(decision)
+    route["recommendations"] = _compact_recommendations(route.get("recommendations", []))
+    route["routing_instruction"] = _routing_instruction(
+        str(route["action"]),
+        str(route["selected_skill"]),
+        str(route["candidate_skill"]),
+    )
+    route["routing_prompt_template"] = _routing_prompt_template(
+        str(route["action"]),
+        str(route["selected_skill"]),
+        str(route["candidate_skill"]),
+        str(route["reason"]),
+    )
+    if not include_message:
+        route.pop("routing_prompt", None)
+    return route
+
+
 def extract_message_text(event: dict[str, Any] | str) -> str:
     if isinstance(event, str):
         return event.strip()
@@ -221,13 +240,19 @@ def _clarification(action: str, candidate_skill: str, candidate_confidence: str,
 
 
 def _routing_prompt(action: str, selected_skill: str, candidate_skill: str, reason: str, message: str) -> str:
+    return _routing_prompt_template(action, selected_skill, candidate_skill, reason).replace("{message}", message)
+
+
+def _routing_prompt_template(action: str, selected_skill: str, candidate_skill: str, reason: str) -> str:
+    return f"{_routing_instruction(action, selected_skill, candidate_skill)}\n\nRouting reason: {reason}\n\nUser message:\n{{message}}"
+
+
+def _routing_instruction(action: str, selected_skill: str, candidate_skill: str) -> str:
     if action == "dispatch":
-        instruction = f"Use the `{selected_skill}` workflow for this chat message."
+        return f"Use the `{selected_skill}` workflow for this chat message."
     elif action == "clarify":
-        instruction = f"Use the `oh-my-hermes` router before dispatching to `{candidate_skill}`."
-    else:
-        instruction = "Use the `oh-my-hermes` router and ask one concise clarification question."
-    return f"{instruction}\n\nRouting reason: {reason}\n\nUser message:\n{message}"
+        return f"Use the `oh-my-hermes` router before dispatching to `{candidate_skill}`."
+    return "Use the `oh-my-hermes` router and ask one concise clarification question."
 
 
 def _compact_recommendations(recommendations: object) -> list[dict[str, object]]:

--- a/src/chat_router.py
+++ b/src/chat_router.py
@@ -76,7 +76,7 @@ def route_chat_message(
     explicit_skill = explicit_skill_invocation(message, definitions)
     candidate_skill = str(top["skill"])
     candidate_harness = primary_harness_for_skill(candidate_skill)
-    candidate_score = int(top["score"])
+    candidate_score = _int_value(top["score"])
     candidate_confidence = str(top["confidence"])
     ambiguous = _is_ambiguous(full_recommendations)
 
@@ -222,8 +222,8 @@ def _value_at_path(event: dict[str, Any], path: tuple[str, ...]) -> Any:
 def _is_ambiguous(recommendations: list[dict[str, object]]) -> bool:
     if len(recommendations) < 2:
         return False
-    first = int(recommendations[0]["score"])
-    second = int(recommendations[1]["score"])
+    first = _int_value(recommendations[0]["score"])
+    second = _int_value(recommendations[1]["score"])
     return first > 0 and first == second
 
 
@@ -265,9 +265,30 @@ def _compact_recommendations(recommendations: object) -> list[dict[str, object]]
         compact.append(
             {
                 "skill": str(item.get("skill", "")),
-                "score": int(item.get("score", 0)),
+                "score": _int_value(item.get("score", 0)),
                 "confidence": str(item.get("confidence", "low")),
-                "matched": list(item.get("matched", [])),
+                "matched": _string_list(item.get("matched", [])),
             }
         )
     return compact
+
+
+def _int_value(value: object, default: int = 0) -> int:
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return default
+    return default
+
+
+def _string_list(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value]

--- a/src/cli.py
+++ b/src/cli.py
@@ -10,6 +10,7 @@ from .chat_router import (
     CHAT_SOURCES,
     CONFIDENCE_LEVELS,
     extract_message_text,
+    public_route_payload,
     route_chat_message,
     routing_record_payload,
 )
@@ -182,7 +183,7 @@ def cmd_chat_route(args: argparse.Namespace) -> int:
         decision = route_chat_message(message, source=args.source, limit=args.limit, min_confidence=args.min_confidence)
     except ValueError as exc:
         raise OmhError(str(exc)) from exc
-    payload = {"route": decision}
+    payload = {"route": public_route_payload(decision, include_message=args.include_message)}
     if args.record:
         paths = _paths(args)
         selected_skill = str(decision["selected_skill"])
@@ -534,6 +535,11 @@ def _add_chat_commands(sub) -> None:
         help="Read a Slack/Discord/Hermes-like JSON event from this path, or '-' for stdin.",
     )
     route.add_argument("--record", action="store_true", help="Record a metadata-only routing artifact under .omh/runtime.")
+    route.add_argument(
+        "--include-message",
+        action="store_true",
+        help="Include a complete routing_prompt with the raw message in stdout.",
+    )
     route.add_argument("--source-event-id", default="", help="Optional source message/event id to store as metadata.")
     route.add_argument("--channel-ref", default="", help="Optional channel reference to store as metadata.")
     route.add_argument("--user-ref", default="", help="Optional user reference to store as metadata.")

--- a/src/cli.py
+++ b/src/cli.py
@@ -6,6 +6,13 @@ import sys
 from pathlib import Path
 
 from . import __version__
+from .chat_router import (
+    CHAT_SOURCES,
+    CONFIDENCE_LEVELS,
+    extract_message_text,
+    route_chat_message,
+    routing_record_payload,
+)
 from .config_adapter import ensure_external_dir, read_config, remove_external_dir, write_config
 from .doctor import doctor_ok, run_doctor
 from .hashutil import sha256_file
@@ -29,6 +36,7 @@ from .runtime_artifacts import (
     update_state,
     validate_runtime,
     write_delegation,
+    write_routing_decision,
     write_wrapper_contract,
 )
 from .skills.render import workflow_reference_markdown
@@ -166,6 +174,62 @@ def cmd_recommend(args: argparse.Namespace) -> int:
         raise OmhError("recommend requires a task description")
     _print_json({"query": query, "recommendations": recommend_skills(query, limit=args.limit)})
     return 0
+
+
+def cmd_chat_route(args: argparse.Namespace) -> int:
+    message = _chat_message(args)
+    try:
+        decision = route_chat_message(message, source=args.source, limit=args.limit, min_confidence=args.min_confidence)
+    except ValueError as exc:
+        raise OmhError(str(exc)) from exc
+    payload = {"route": decision}
+    if args.record:
+        paths = _paths(args)
+        selected_skill = str(decision["selected_skill"])
+        selected_harness = str(decision["selected_harness"])
+        _validate_runtime_names(selected_skill, selected_harness)
+        run = create_run(
+            paths,
+            {
+                "skill": selected_skill,
+                "harness": selected_harness,
+                "status": "started",
+                "trigger": f"chat:{args.source}:{decision['action']}",
+                "privacy": "metadata_only",
+                "inputs_summary": f"chat route from {args.source}; {len(message)} characters; prompt body not stored",
+                "outputs_summary": f"routing action {decision['action']} selected {selected_skill}",
+                "verification_summary": "routing decision recorded before Hermes dispatch",
+            },
+        )
+        routing = write_routing_decision(
+            paths.runtime_runs_dir / run["run_id"],
+            routing_record_payload(
+                decision,
+                message,
+                source_event_id=args.source_event_id or "",
+                channel_ref=args.channel_ref or "",
+                user_ref=args.user_ref or "",
+            ),
+        )
+        payload["runtime"] = {"run": run, "routing": routing}
+    _print_json(payload)
+    return 0
+
+
+def _chat_message(args: argparse.Namespace) -> str:
+    try:
+        if args.event_json:
+            raw = (
+                sys.stdin.read()
+                if args.event_json == "-"
+                else Path(args.event_json).expanduser().read_text(encoding="utf-8")
+            )
+            return extract_message_text(json.loads(raw))
+        if args.stdin:
+            return sys.stdin.read().strip()
+        return " ".join(args.message).strip()
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        raise OmhError(str(exc)) from exc
 
 
 def _valid_skill_names() -> set[str]:
@@ -444,6 +508,38 @@ def _add_docs_commands(sub) -> None:
     docs_workflows.set_defaults(func=cmd_docs_workflows)
 
 
+def _add_chat_commands(sub) -> None:
+    chat = sub.add_parser("chat")
+    chat_sub = chat.add_subparsers(dest="chat_command", required=True)
+
+    route = chat_sub.add_parser("route")
+    route.add_argument("message", nargs="*", help="Chat message to route before dispatching to Hermes.")
+    route.add_argument(
+        "--source",
+        choices=CHAT_SOURCES,
+        default="generic",
+        help="Source surface that received the chat message.",
+    )
+    route.add_argument("--limit", type=int, default=3, help="Maximum catalog recommendations to include.")
+    route.add_argument(
+        "--min-confidence",
+        choices=CONFIDENCE_LEVELS,
+        default="high",
+        help="Minimum confidence for automatic workflow dispatch.",
+    )
+    route.add_argument("--stdin", action="store_true", help="Read the raw chat message from stdin.")
+    route.add_argument(
+        "--event-json",
+        default=None,
+        help="Read a Slack/Discord/Hermes-like JSON event from this path, or '-' for stdin.",
+    )
+    route.add_argument("--record", action="store_true", help="Record a metadata-only routing artifact under .omh/runtime.")
+    route.add_argument("--source-event-id", default="", help="Optional source message/event id to store as metadata.")
+    route.add_argument("--channel-ref", default="", help="Optional channel reference to store as metadata.")
+    route.add_argument("--user-ref", default="", help="Optional user reference to store as metadata.")
+    route.set_defaults(func=cmd_chat_route)
+
+
 def _add_runtime_commands(sub) -> None:
     runtime = sub.add_parser("runtime")
     runtime_sub = runtime.add_subparsers(dest="runtime_command", required=True)
@@ -533,6 +629,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     _add_top_level_commands(sub)
     _add_docs_commands(sub)
+    _add_chat_commands(sub)
     _add_runtime_commands(sub)
     _add_state_commands(sub)
     return parser

--- a/src/recommend.py
+++ b/src/recommend.py
@@ -56,6 +56,7 @@ def recommend_skills(query: str, *, limit: int = 5) -> list[dict[str, object]]:
     matches = [recommendation for recommendation in scored if recommendation.score > 0]
     if not matches:
         matches = _fallback_recommendations(definitions, query)
+        return [recommendation.to_dict() for recommendation in matches[:limit]]
     matches.sort(key=lambda recommendation: (-recommendation.score, recommendation.skill))
     return [recommendation.to_dict() for recommendation in matches[:limit]]
 

--- a/src/runtime_artifacts.py
+++ b/src/runtime_artifacts.py
@@ -22,11 +22,13 @@ from .runtime_records import (
     WRAPPER_COMPLETION_STATUSES,
     build_delegation_record,
     build_event_record,
+    build_routing_record,
     build_run_record,
     build_wrapper_record,
     validate_delegation_record,
     validate_delegation_result,
     validate_event_record,
+    validate_routing_record,
     validate_run_record,
     validate_wrapper_record,
 )
@@ -142,6 +144,27 @@ def write_wrapper_contract(run_dir: Path, wrapper: dict[str, Any]) -> dict[str, 
     return record
 
 
+def write_routing_decision(run_dir: Path, routing: dict[str, Any]) -> dict[str, Any]:
+    record = build_routing_record(routing)
+    atomic_write_json(run_dir / "routing.json", record, private=True)
+    append_event(
+        run_dir,
+        {
+            "event": "routing_decision_recorded",
+            "level": "info",
+            "message": f"routing {record['action']} {record['selected_skill']}",
+            "data": {
+                "source": record["source"],
+                "action": record["action"],
+                "selected_skill": record["selected_skill"],
+                "confidence": record["confidence"],
+                "score": record["score"],
+            },
+        },
+    )
+    return record
+
+
 def list_runs(paths: OmhPaths) -> list[dict[str, Any]]:
     if not paths.runtime_runs_dir.exists():
         return []
@@ -169,6 +192,7 @@ def show_run(paths: OmhPaths, run_id: str) -> dict[str, Any]:
     return {
         "run": run,
         "events": read_events(run_dir),
+        "routing": read_json_object(run_dir / "routing.json"),
         "delegation": read_json_object(run_dir / "delegation.json"),
         "wrapper": read_json_object(run_dir / "wrapper.json"),
         "evidence": sorted(path.name for path in evidence_dir.iterdir()) if evidence_dir.exists() else [],

--- a/src/runtime_records.py
+++ b/src/runtime_records.py
@@ -13,6 +13,8 @@ OBSERVED_RESULTS = ("completed", "blocked", "failed")
 UNOBSERVED_RESULTS = ("not_available", "not_observed")
 EVENT_LEVELS = ("debug", "info", "warning", "error")
 WRAPPER_COMPLETION_STATUSES = ("started", "completed", "blocked", "failed", "unknown")
+ROUTE_ACTIONS = ("dispatch", "clarify", "fallback")
+ROUTE_CONFIDENCES = ("low", "medium", "high")
 
 
 def build_run_record(metadata: dict[str, Any], run_id: str) -> dict[str, Any]:
@@ -95,6 +97,40 @@ def build_wrapper_record(wrapper: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def build_routing_record(routing: dict[str, Any]) -> dict[str, Any]:
+    action = routing.get("action", "fallback")
+    if action not in ROUTE_ACTIONS:
+        raise ValueError(f"unsupported routing action: {action}")
+    confidence = routing.get("confidence", "low")
+    if confidence not in ROUTE_CONFIDENCES:
+        raise ValueError(f"unsupported routing confidence: {confidence}")
+    threshold = routing.get("threshold", "high")
+    if threshold not in ROUTE_CONFIDENCES:
+        raise ValueError(f"unsupported routing threshold: {threshold}")
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "updated_at": utc_now(),
+        "source": str(routing.get("source", "generic")),
+        "action": action,
+        "selected_skill": str(routing.get("selected_skill", "oh-my-hermes")),
+        "selected_harness": str(routing.get("selected_harness", "coding-handling")),
+        "candidate_skill": str(routing.get("candidate_skill", "")),
+        "candidate_harness": str(routing.get("candidate_harness", "")),
+        "confidence": confidence,
+        "score": int(routing.get("score", 0)),
+        "threshold": threshold,
+        "explicit": bool(routing.get("explicit", False)),
+        "ambiguous": bool(routing.get("ambiguous", False)),
+        "reason": str(routing.get("reason", "")),
+        "message_sha256": str(routing.get("message_sha256", "")),
+        "message_length": int(routing.get("message_length", 0)),
+        "source_event_id": str(routing.get("source_event_id", "")),
+        "channel_ref": str(routing.get("channel_ref", "")),
+        "user_ref": str(routing.get("user_ref", "")),
+        "recommendations": list(routing.get("recommendations", [])),
+    }
+
+
 def _require(condition: bool, errors: list[str], message: str) -> None:
     if not condition:
         errors.append(message)
@@ -153,7 +189,39 @@ def validate_wrapper_record(wrapper: dict[str, Any]) -> list[str]:
     return errors
 
 
+def validate_routing_record(routing: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    _require(routing.get("schema_version") == SCHEMA_VERSION, errors, "routing schema_version is invalid")
+    for key in (
+        "updated_at",
+        "source",
+        "action",
+        "selected_skill",
+        "selected_harness",
+        "candidate_skill",
+        "candidate_harness",
+        "confidence",
+        "threshold",
+        "reason",
+        "message_sha256",
+        "source_event_id",
+        "channel_ref",
+        "user_ref",
+    ):
+        _require(isinstance(routing.get(key), str), errors, f"routing {key} must be a string")
+    _require(routing.get("action") in ROUTE_ACTIONS, errors, f"routing action is invalid: {routing.get('action')!r}")
+    _require(routing.get("confidence") in ROUTE_CONFIDENCES, errors, f"routing confidence is invalid: {routing.get('confidence')!r}")
+    _require(routing.get("threshold") in ROUTE_CONFIDENCES, errors, f"routing threshold is invalid: {routing.get('threshold')!r}")
+    _require(isinstance(routing.get("score"), int), errors, "routing score must be an integer")
+    _require(isinstance(routing.get("message_length"), int), errors, "routing message_length must be an integer")
+    _require(isinstance(routing.get("explicit"), bool), errors, "routing explicit must be boolean")
+    _require(isinstance(routing.get("ambiguous"), bool), errors, "routing ambiguous must be boolean")
+    _require(isinstance(routing.get("recommendations"), list), errors, "routing recommendations must be a list")
+    return errors
+
+
 OPTIONAL_RECORD_VALIDATORS = (
+    ("routing.json", validate_routing_record),
     ("delegation.json", validate_delegation_record),
     ("wrapper.json", validate_wrapper_record),
 )

--- a/src/runtime_records.py
+++ b/src/runtime_records.py
@@ -15,6 +15,7 @@ EVENT_LEVELS = ("debug", "info", "warning", "error")
 WRAPPER_COMPLETION_STATUSES = ("started", "completed", "blocked", "failed", "unknown")
 ROUTE_ACTIONS = ("dispatch", "clarify", "fallback")
 ROUTE_CONFIDENCES = ("low", "medium", "high")
+ROUTING_RECOMMENDATION_KEYS = ("skill", "score", "confidence", "matched")
 
 
 def build_run_record(metadata: dict[str, Any], run_id: str) -> dict[str, Any]:
@@ -127,8 +128,27 @@ def build_routing_record(routing: dict[str, Any]) -> dict[str, Any]:
         "source_event_id": str(routing.get("source_event_id", "")),
         "channel_ref": str(routing.get("channel_ref", "")),
         "user_ref": str(routing.get("user_ref", "")),
-        "recommendations": list(routing.get("recommendations", [])),
+        "recommendations": _compact_routing_recommendations(routing.get("recommendations", [])),
     }
+
+
+def _compact_routing_recommendations(recommendations: Any) -> list[dict[str, Any]]:
+    if not isinstance(recommendations, list):
+        return []
+    compact: list[dict[str, Any]] = []
+    for item in recommendations:
+        if not isinstance(item, dict):
+            continue
+        matched = item.get("matched", [])
+        compact.append(
+            {
+                "skill": str(item.get("skill", "")),
+                "score": int(item.get("score", 0)),
+                "confidence": str(item.get("confidence", "low")),
+                "matched": [str(value) for value in matched] if isinstance(matched, list) else [],
+            }
+        )
+    return compact
 
 
 def _require(condition: bool, errors: list[str], message: str) -> None:
@@ -217,6 +237,16 @@ def validate_routing_record(routing: dict[str, Any]) -> list[str]:
     _require(isinstance(routing.get("explicit"), bool), errors, "routing explicit must be boolean")
     _require(isinstance(routing.get("ambiguous"), bool), errors, "routing ambiguous must be boolean")
     _require(isinstance(routing.get("recommendations"), list), errors, "routing recommendations must be a list")
+    for index, recommendation in enumerate(routing.get("recommendations", [])):
+        _require(isinstance(recommendation, dict), errors, f"routing recommendations[{index}] must be an object")
+        if not isinstance(recommendation, dict):
+            continue
+        extra_keys = sorted(set(recommendation) - set(ROUTING_RECOMMENDATION_KEYS))
+        _require(not extra_keys, errors, f"routing recommendations[{index}] has unsupported keys: {extra_keys}")
+        _require(isinstance(recommendation.get("skill"), str), errors, f"routing recommendations[{index}].skill must be a string")
+        _require(isinstance(recommendation.get("score"), int), errors, f"routing recommendations[{index}].score must be an integer")
+        _require(isinstance(recommendation.get("confidence"), str), errors, f"routing recommendations[{index}].confidence must be a string")
+        _require(isinstance(recommendation.get("matched"), list), errors, f"routing recommendations[{index}].matched must be a list")
     return errors
 
 

--- a/src/skills/render.py
+++ b/src/skills/render.py
@@ -98,6 +98,18 @@ Priority:
 4. Persistence or finish-until-done requests route to `ralph` only after scope is concrete.
 5. Unknown or conflicting signals stay in this router and ask one concise clarification question.
 
+## Wrapper-Assisted Chat Routing
+
+Discord, Slack, or hosted Hermes wrappers can run `omh chat route` before dispatching a plain chat message to Hermes:
+
+```sh
+omh chat route --source discord --record "risky refactor"
+```
+
+Use the returned `route.routing_prompt` as the message forwarded to Hermes. A `dispatch` action targets the selected workflow skill; `clarify` and `fallback` target this router so Hermes can ask one concise follow-up instead of guessing.
+
+This is a deterministic wrapper-side decision layer. It does not patch Hermes core or require platform network access from `omh`.
+
 ## Automatic Routing Registry
 
 When Hermes exposes installed skill descriptions to the model, use this registry as the routing map:

--- a/src/skills/render.py
+++ b/src/skills/render.py
@@ -106,9 +106,9 @@ Discord, Slack, or hosted Hermes wrappers can run `omh chat route` before dispat
 omh chat route --source discord --record "risky refactor"
 ```
 
-Use the returned `route.routing_prompt` as the message forwarded to Hermes. A `dispatch` action targets the selected workflow skill; `clarify` and `fallback` target this router so Hermes can ask one concise follow-up instead of guessing.
+Use `route.routing_prompt_template` with `{{message}}` replaced by the received chat message as the prompt forwarded to Hermes. If the wrapper does not log stdout and wants a pre-expanded prompt, pass `--include-message` and forward `route.routing_prompt`. A `dispatch` action targets the selected workflow skill; `clarify` and `fallback` target this router so Hermes can ask one concise follow-up instead of guessing.
 
-This is a deterministic wrapper-side decision layer. It does not patch Hermes core or require platform network access from `omh`.
+This is a deterministic wrapper-side decision layer. By default, stdout and runtime artifacts avoid duplicating the raw prompt body. It does not patch Hermes core or require platform network access from `omh`.
 
 ## Automatic Routing Registry
 

--- a/tests/test_chat_router.py
+++ b/tests/test_chat_router.py
@@ -6,7 +6,13 @@ import unittest
 from _local_package import load_local_package
 
 load_local_package()
-from omh.chat_router import extract_message_text, route_chat_event, route_chat_message, routing_record_payload
+from omh.chat_router import (
+    extract_message_text,
+    public_route_payload,
+    route_chat_event,
+    route_chat_message,
+    routing_record_payload,
+)
 
 
 class ChatRouterTests(unittest.TestCase):
@@ -64,6 +70,20 @@ class ChatRouterTests(unittest.TestCase):
         self.assertEqual(record["source_event_id"], "m1")
         self.assertNotIn(message, json.dumps(record))
         self.assertRegex(str(record["message_sha256"]), r"^[a-f0-9]{64}$")
+
+    def test_public_route_payload_omits_raw_message_by_default(self) -> None:
+        message = "risky refactor"
+        decision = route_chat_message(message, source="discord")
+
+        public = public_route_payload(decision)
+
+        self.assertNotIn("routing_prompt", public)
+        self.assertIn("routing_prompt_template", public)
+        self.assertIn("{message}", str(public["routing_prompt_template"]))
+        self.assertNotIn(message, json.dumps(public))
+
+        expanded = public_route_payload(decision, include_message=True)
+        self.assertIn(message, str(expanded["routing_prompt"]))
 
 
 if __name__ == "__main__":

--- a/tests/test_chat_router.py
+++ b/tests/test_chat_router.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import json
+import unittest
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.chat_router import extract_message_text, route_chat_event, route_chat_message, routing_record_payload
+
+
+class ChatRouterTests(unittest.TestCase):
+    def test_high_confidence_chat_dispatches_to_workflow(self) -> None:
+        decision = route_chat_message("risky refactor", source="discord")
+
+        self.assertEqual(decision["action"], "dispatch")
+        self.assertEqual(decision["selected_skill"], "ai-slop-cleaner")
+        self.assertEqual(decision["selected_harness"], "coding-handling")
+        self.assertEqual(decision["confidence"], "high")
+        self.assertIn("User message:\nrisky refactor", decision["routing_prompt"])
+
+    def test_low_signal_chat_falls_back_to_router(self) -> None:
+        decision = route_chat_message("zzzzunknownphrase", source="slack")
+
+        self.assertEqual(decision["action"], "fallback")
+        self.assertEqual(decision["selected_skill"], "oh-my-hermes")
+        self.assertEqual(decision["candidate_skill"], "oh-my-hermes")
+        self.assertEqual(decision["confidence"], "low")
+        self.assertIn("Ask which workflow", decision["clarification"])
+
+    def test_below_threshold_chat_clarifies_before_dispatch(self) -> None:
+        decision = route_chat_message("architecture", min_confidence="high")
+
+        self.assertEqual(decision["action"], "clarify")
+        self.assertEqual(decision["selected_skill"], "oh-my-hermes")
+        self.assertEqual(decision["candidate_skill"], "ralplan")
+        self.assertEqual(decision["confidence"], "medium")
+
+    def test_explicit_chat_invocation_dispatches_even_when_router_would_clarify(self) -> None:
+        decision = route_chat_message("/plan implementation")
+
+        self.assertEqual(decision["action"], "dispatch")
+        self.assertEqual(decision["selected_skill"], "plan")
+        self.assertTrue(decision["explicit"])
+        self.assertEqual(decision["confidence"], "high")
+
+    def test_event_text_extraction_supports_discord_slack_and_generic_shapes(self) -> None:
+        self.assertEqual(extract_message_text({"message": {"content": "risky refactor"}}), "risky refactor")
+        self.assertEqual(extract_message_text({"message": {"text": "risky refactor"}}), "risky refactor")
+        self.assertEqual(extract_message_text({"event": {"text": "implementation plan"}}), "implementation plan")
+        self.assertEqual(extract_message_text({"data": {"text": "implementation plan"}}), "implementation plan")
+        self.assertEqual(extract_message_text({"prompt": "diagnose installation health"}), "diagnose installation health")
+
+        decision = route_chat_event({"content": "diagnose installation health"}, source="hermes")
+        self.assertEqual(decision["selected_skill"], "doctor")
+
+    def test_routing_record_payload_does_not_store_raw_message(self) -> None:
+        message = "risky refactor"
+        decision = route_chat_message(message, source="discord")
+
+        record = routing_record_payload(decision, message, source_event_id="m1", channel_ref="c1", user_ref="u1")
+
+        self.assertEqual(record["message_length"], len(message))
+        self.assertEqual(record["source_event_id"], "m1")
+        self.assertNotIn(message, json.dumps(record))
+        self.assertRegex(str(record["message_sha256"]), r"^[a-f0-9]{64}$")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -63,6 +63,16 @@ class CliTests(unittest.TestCase):
         route = json.loads(stdout)["route"]
         self.assertEqual(route["action"], "dispatch")
         self.assertEqual(route["selected_skill"], "ai-slop-cleaner")
+        self.assertIn("routing_prompt_template", route)
+        self.assertIn("{message}", route["routing_prompt_template"])
+        self.assertNotIn("risky refactor", json.dumps(route))
+
+    def test_chat_route_can_emit_complete_prompt_for_non_logging_wrappers(self) -> None:
+        status, stdout, stderr = run_cli(["chat", "route", "--include-message", "--source", "discord", "risky", "refactor"])
+
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        route = json.loads(stdout)["route"]
         self.assertIn("User message:\nrisky refactor", route["routing_prompt"])
 
     def test_chat_route_reads_platform_event_json(self) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -44,6 +44,7 @@ class CliTests(unittest.TestCase):
         self.assertEqual(stderr, "")
         self.assertEqual(status, 0)
         recommendations = json.loads(stdout)["recommendations"]
+        self.assertEqual(recommendations[0]["skill"], "oh-my-hermes")
         self.assertIn("oh-my-hermes", {recommendation["skill"] for recommendation in recommendations})
         self.assertEqual(recommendations[0]["confidence"], "low")
         self.assertIn("No strong catalog metadata match", recommendations[0]["why"])
@@ -53,6 +54,65 @@ class CliTests(unittest.TestCase):
 
         self.assertEqual(status, 2)
         self.assertIn("recommend --limit must be at least 1", stderr)
+
+    def test_chat_route_dispatches_plain_chat_message(self) -> None:
+        status, stdout, stderr = run_cli(["chat", "route", "--source", "discord", "risky", "refactor"])
+
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        route = json.loads(stdout)["route"]
+        self.assertEqual(route["action"], "dispatch")
+        self.assertEqual(route["selected_skill"], "ai-slop-cleaner")
+        self.assertIn("User message:\nrisky refactor", route["routing_prompt"])
+
+    def test_chat_route_reads_platform_event_json(self) -> None:
+        with TemporaryDirectory() as tmp:
+            event = Path(tmp) / "event.json"
+            event.write_text('{"event": {"text": "diagnose installation health"}}', encoding="utf-8")
+
+            status, stdout, stderr = run_cli(["chat", "route", "--source", "slack", "--event-json", str(event)])
+
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        route = json.loads(stdout)["route"]
+        self.assertEqual(route["source"], "slack")
+        self.assertEqual(route["selected_skill"], "doctor")
+
+    def test_chat_route_records_runtime_routing_artifact(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            status, stdout, stderr = run_cli(
+                [
+                    "--omh-home",
+                    str(root / ".omh"),
+                    "--hermes-home",
+                    str(root / ".hermes"),
+                    "chat",
+                    "route",
+                    "--source",
+                    "discord",
+                    "--record",
+                    "--source-event-id",
+                    "m1",
+                    "risky",
+                    "refactor",
+                ]
+            )
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            payload = json.loads(stdout)
+            run_id = payload["runtime"]["run"]["run_id"]
+            self.assertEqual(payload["runtime"]["routing"]["selected_skill"], "ai-slop-cleaner")
+
+            status, stdout, stderr = run_cli(["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes"), "runtime", "show", run_id])
+
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        shown = json.loads(stdout)
+        self.assertEqual(shown["routing"]["source_event_id"], "m1")
+        self.assertEqual(shown["routing"]["action"], "dispatch")
+        self.assertNotIn("risky refactor", json.dumps(shown["routing"]))
 
     def test_install_apply_doctor_and_list(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -16,6 +16,8 @@ class RouterContentTests(unittest.TestCase):
 
         self.assertIn("best-effort Hermes prompt guidance", router.content)
         self.assertIn("does not override Hermes core routing", router.content)
+        self.assertIn("omh chat route", router.content)
+        self.assertIn("deterministic wrapper-side decision layer", router.content)
         self.assertIn("skills_list", router.content)
         self.assertIn("skill_view", router.content)
         self.assertIn("name collides", router.content)

--- a/tests/test_runtime_artifacts.py
+++ b/tests/test_runtime_artifacts.py
@@ -12,6 +12,7 @@ from _local_package import load_local_package
 
 load_local_package()
 from omh.paths import resolve_paths
+from omh.chat_router import route_chat_message, routing_record_payload
 from omh.runtime_artifacts import (
     create_run,
     export_runtime,
@@ -20,10 +21,12 @@ from omh.runtime_artifacts import (
     show_run,
     update_state,
     validate_delegation_record,
+    validate_routing_record,
     validate_runtime,
     validate_run_record,
     validate_wrapper_record,
     write_delegation,
+    write_routing_decision,
     write_wrapper_contract,
 )
 
@@ -121,6 +124,25 @@ class RuntimeArtifactTests(unittest.TestCase):
             self.assertEqual(shown["wrapper"]["completion_status"], "blocked")
             self.assertIn("wrapper_contract_recorded", {event["event"] for event in shown["events"]})
 
+    def test_write_routing_decision_records_pre_dispatch_metadata(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            run = create_run(paths, {"skill": "ai-slop-cleaner", "harness": "coding-handling", "status": "started"})
+            message = "risky refactor"
+            decision = route_chat_message(message, source="discord")
+
+            routing = write_routing_decision(
+                paths.runtime_runs_dir / run["run_id"],
+                routing_record_payload(decision, message, source_event_id="m1"),
+            )
+
+            self.assertEqual(routing["selected_skill"], "ai-slop-cleaner")
+            self.assertEqual(routing["source_event_id"], "m1")
+            self.assertTrue(validate_runtime(paths, run["run_id"])["ok"])
+            shown = show_run(paths, run["run_id"])
+            self.assertEqual(shown["routing"]["action"], "dispatch")
+            self.assertIn("routing_decision_recorded", {event["event"] for event in shown["events"]})
+
     def test_validate_runtime_rejects_missing_and_invalid_artifacts(self) -> None:
         with TemporaryDirectory() as tmp:
             paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
@@ -160,9 +182,11 @@ class RuntimeArtifactTests(unittest.TestCase):
                 "unobserved_gaps": [],
             }
         )
+        routing_errors = validate_routing_record({"schema_version": 1, "action": "missing", "recommendations": []})
 
         self.assertIn("unobserved delegation requires result not_available or not_observed", delegation_errors)
         self.assertTrue(any("completion_status is invalid" in error for error in wrapper_errors))
+        self.assertTrue(any("routing action is invalid" in error for error in routing_errors))
 
     def test_export_runtime_redacts_sensitive_keys(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_runtime_artifacts.py
+++ b/tests/test_runtime_artifacts.py
@@ -143,6 +143,22 @@ class RuntimeArtifactTests(unittest.TestCase):
             self.assertEqual(shown["routing"]["action"], "dispatch")
             self.assertIn("routing_decision_recorded", {event["event"] for event in shown["events"]})
 
+    def test_write_routing_decision_sanitizes_full_route_decision(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            run = create_run(paths, {"skill": "ai-slop-cleaner", "harness": "coding-handling", "status": "started"})
+            secret_message = "risky refactor with private-token-123"
+
+            routing = write_routing_decision(
+                paths.runtime_runs_dir / run["run_id"],
+                route_chat_message(secret_message, source="discord"),
+            )
+
+            serialized = json.dumps(routing)
+            self.assertNotIn(secret_message, serialized)
+            self.assertNotIn("suggested_prompt", serialized)
+            self.assertEqual(set(routing["recommendations"][0]), {"skill", "score", "confidence", "matched"})
+
     def test_validate_runtime_rejects_missing_and_invalid_artifacts(self) -> None:
         with TemporaryDirectory() as tmp:
             paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")


### PR DESCRIPTION
## Summary
- Add deterministic `omh chat route` for wrapper-side chat pre-dispatch decisions.
- Support plain argv, stdin, and Discord/Slack/Hermes-like event JSON extraction.
- Record metadata-only `routing.json` runtime evidence with message hash/length, not prompt bodies.
- Update router skill content, README, architecture, and installation docs for Discord/Slack wrapper flows.

## Verification
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- `PYTHONPATH=tests uv run python -m unittest tests/test_cli.py -v`
- `uv run python -m compileall src`
- `git diff --check`
- `uv sync --no-editable --reinstall-package oh-my-hermes-agent`
- `uv run --no-sync omh chat route --source discord "risky refactor"`
- `uv run --no-sync omh chat route --source slack --min-confidence high architecture`
- `uv run --no-sync omh recommend zzzzunknownphrase`
- `uv run --no-sync omh --omh-home "$tmpdir/.omh" --hermes-home "$tmpdir/.hermes" chat route --source discord --record --source-event-id m1 "risky refactor"`
- `uv run --no-sync python -m omh.cli docs workflows --check`

## Review Expectations
- Confirm router behavior stays deterministic and local.
- Confirm runtime artifacts do not store raw prompt bodies.
- Confirm this remains wrapper-assisted and does not imply live Discord/Slack SDK coverage.

## Known Risks
- Not live-tested against a real Discord, Slack, or hosted Hermes network adapter.
- Wrappers must forward `route.routing_prompt` for the routing decision to affect Hermes execution.
