### PR TITLE
Prepare deterministic coding delegation

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ omh update --from-skills-dir ./skills
 omh apply --dry-run
 omh recommend "risky refactor"
 omh chat route --source discord --record "risky refactor"
+omh coding delegate --source discord --record "risky refactor"
 omh runtime record --skill oh-my-hermes --harness coding-handling --status started
 omh runtime validate
 omh runtime export
@@ -134,7 +135,17 @@ or modify Hermes internals.
 - workflow run envelopes in `~/.omh/runtime/runs/<run-id>/run.json`
 - append-only run events in `events.jsonl`
 - delegation observation in `delegation.json`
+- prepared coding handoffs in `coding_delegation.json`
 - wrapper observation in `wrapper.json`
+
+Coding delegation artifacts separate a prepared executor handoff from observed
+execution. `omh coding delegate --record` stores the recommended workflow,
+harness, source references, recommendation evidence, `message_sha256`,
+`message_length`, and status `prepared_not_observed`; it does not store the raw
+prompt body by default. Its companion `run.json` is bookkeeping for that
+prepared handoff and is marked `status: prepared`,
+`artifact_kind: prepared_coding_delegation`, `phase: prepared`, and
+`observation_status: prepared_not_observed`.
 
 Delegation artifacts separate `requested` from `observed`. If Hermes or a bot
 wrapper cannot prove that a specialist lane actually ran, the result should stay
@@ -177,6 +188,15 @@ logs can stay metadata-only; use `--include-message` only when the wrapper needs
 `route.routing_prompt` pre-expanded. With `--record`, it writes metadata-only
 `routing.json` evidence under `.omh/runtime/` without storing the raw prompt.
 
+For implementation-shaped chat messages, wrappers can run `omh coding delegate`
+to prepare a deterministic executor handoff from the same local catalog
+metadata. It returns a `coding_delegation/v1` payload with action, intent,
+recommended workflow, harness, acceptance criteria, verification expectations,
+and a `delegation_prompt_template`. With `--record`, it writes
+`coding_delegation.json` evidence and a `prepared_coding_delegation` run
+envelope; the wrapper still needs separate Hermes or bot evidence before
+claiming execution was observed.
+
 ## Commands
 
 | Command | Purpose |
@@ -189,6 +209,7 @@ logs can stay metadata-only; use `--include-message` only when the wrapper needs
 | `omh doctor` | Verify managed files and Hermes config registration. |
 | `omh recommend <task>` | Deterministically suggest workflow skills from the local OMHM catalog. |
 | `omh chat route <message>` | Route a plain chat message before a Discord, Slack, or Hermes wrapper dispatches it. |
+| `omh coding delegate <task>` | Prepare a deterministic coding handoff payload and optional metadata-only runtime record. |
 | `omh runtime status` | Inspect local runtime artifact state. |
 | `omh runtime record` | Create a metadata-only workflow run artifact. |
 | `omh runtime delegate` | Record observed or unavailable delegation for a run. |
@@ -207,6 +228,7 @@ logs can stay metadata-only; use `--include-message` only when the wrapper needs
 src/
   chat_router.py          deterministic chat pre-dispatch routing
   cli.py                 command-line entrypoint
+  coding_delegation.py   deterministic coding handoff preparation
   config_adapter.py      Hermes config registration adapter
   converter.py           local skill import support
   doctor.py              installation health checks

--- a/README.md
+++ b/README.md
@@ -140,10 +140,11 @@ or modify Hermes internals.
 
 Coding delegation artifacts separate a prepared executor handoff from observed
 execution. `omh coding delegate --record` stores the recommended workflow,
-harness, source references, recommendation evidence, `message_sha256`,
-`message_length`, and status `prepared_not_observed`; it does not store the raw
-prompt body by default. Its companion `run.json` is bookkeeping for that
-prepared handoff and is marked `status: prepared`,
+harness, acceptance criteria, verification expectations, source references,
+recommendation evidence, `message_sha256`, `message_length`, and status
+`prepared_not_observed`; it does not store the raw prompt body by default. Its
+companion `run.json` is bookkeeping for that prepared handoff and is marked
+`status: prepared`,
 `artifact_kind: prepared_coding_delegation`, `phase: prepared`, and
 `observation_status: prepared_not_observed`.
 
@@ -194,8 +195,8 @@ metadata. It returns a `coding_delegation/v1` payload with action, intent,
 recommended workflow, harness, acceptance criteria, verification expectations,
 and a `delegation_prompt_template`. With `--record`, it writes
 `coding_delegation.json` evidence and a `prepared_coding_delegation` run
-envelope; the wrapper still needs separate Hermes or bot evidence before
-claiming execution was observed.
+envelope; validation treats those as a required pair. The wrapper still needs
+separate Hermes or bot evidence before claiming execution was observed.
 
 ## Commands
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -39,6 +39,11 @@ src/
 wrappers. It consumes plain messages or platform-shaped event payloads and
 returns `dispatch`, `clarify`, or `fallback` decisions from local catalog data.
 
+`coding_delegation.py` owns deterministic coding handoff preparation. It maps
+implementation-shaped task text to an action, intent, workflow, harness,
+executor profile, acceptance criteria, and verification expectations without
+LLM, API, or network calls.
+
 `installer.py` owns managed skill writes, manifest updates, update behavior, and
 uninstall behavior.
 
@@ -56,7 +61,7 @@ the package grows internally.
 
 ## Routing
 
-Routing has two local surfaces:
+Routing and delegation have three local surfaces:
 
 1. Prompt-level guidance. The router skill gives Hermes a structured map of
    workflow names and strong trigger phrases, but it does not override Hermes
@@ -64,12 +69,21 @@ Routing has two local surfaces:
 2. Wrapper-assisted chat routing. `omh chat route` lets Discord, Slack, or
    hosted Hermes wrappers run a deterministic pre-dispatch decision before they
    forward a plain user message to Hermes.
+3. Wrapper-assisted coding delegation. `omh coding delegate` lets wrappers turn
+   implementation-shaped messages into a deterministic `coding_delegation/v1`
+   handoff payload for an executor lane.
 
-Both surfaces read from the same catalog metadata. The chat router returns a
+All three surfaces read from the same catalog metadata. The chat router returns a
 `routing_instruction` and `routing_prompt_template` for the wrapper to forward,
 with raw-message prompt expansion available only through `--include-message`.
-It can record metadata-only `routing.json` evidence. It does not include a
-Discord or Slack SDK, open network connections, or patch Hermes internals.
+Coding delegation returns a `delegation_prompt_template`, recommended workflow,
+harness, acceptance criteria, verification expectations, and optional
+metadata-only `coding_delegation.json` evidence. With `--record`, the companion
+`run.json` is marked as `artifact_kind: prepared_coding_delegation`,
+`phase: prepared`, and `observation_status: prepared_not_observed`; the run
+envelope is implementation bookkeeping, not proof that Hermes executed the
+handoff. Neither surface includes a Discord or Slack SDK, opens network
+connections, or patches Hermes internals.
 
 Future routing work should deepen the catalog first, then render richer skill
 metadata from it.
@@ -132,14 +146,16 @@ Runtime artifacts are local JSON/JSONL files under `.omh/runtime/`.
         run.json
         events.jsonl
         routing.json
+        coding_delegation.json
         delegation.json
         wrapper.json
         evidence/
 ```
 
 `state.json` records install, apply, and doctor summaries. A run directory
-records a workflow envelope, append-only events, routing decisions, delegation
-observation, and wrapper observation plus optional evidence files.
+records a workflow envelope, append-only events, routing decisions, prepared
+coding delegation, delegation observation, and wrapper observation plus optional
+evidence files.
 
 The runtime artifact layer is intentionally small:
 
@@ -155,6 +171,13 @@ The runtime artifact layer is intentionally small:
 Bot wrappers can call `omh chat route --record` before invoking Hermes. The
 record stores the selected skill, confidence, score, message length, and message
 hash without storing the raw prompt body.
+
+Bot wrappers can call `omh coding delegate --record` for implementation-shaped
+messages. The record stores source metadata, action, intent, recommended
+workflow and harness, recommendation evidence, `message_sha256`,
+`message_length`, and status `prepared_not_observed`. That status means a
+handoff was prepared; the companion run envelope is also marked
+`prepared_coding_delegation`, not proof that Hermes executed the task.
 
 Bot wrappers can still call `omh runtime delegate` after the response if
 delegation metadata is available. If not, they should record `not_observed`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -78,12 +78,15 @@ All three surfaces read from the same catalog metadata. The chat router returns 
 with raw-message prompt expansion available only through `--include-message`.
 Coding delegation returns a `delegation_prompt_template`, recommended workflow,
 harness, acceptance criteria, verification expectations, and optional
-metadata-only `coding_delegation.json` evidence. With `--record`, the companion
-`run.json` is marked as `artifact_kind: prepared_coding_delegation`,
-`phase: prepared`, and `observation_status: prepared_not_observed`; the run
-envelope is implementation bookkeeping, not proof that Hermes executed the
-handoff. Neither surface includes a Discord or Slack SDK, opens network
-connections, or patches Hermes internals.
+metadata-only `coding_delegation.json` evidence. That record stores a compact
+snapshot of the generated acceptance criteria and verification expectations, but
+not the raw prompt body. With `--record`, the companion `run.json` is marked as
+`artifact_kind: prepared_coding_delegation`, `phase: prepared`, and
+`observation_status: prepared_not_observed`; validation treats the run envelope
+and `coding_delegation.json` as a required pair. The run envelope is
+implementation bookkeeping, not proof that Hermes executed the handoff. Neither
+surface includes a Discord or Slack SDK, opens network connections, or patches
+Hermes internals.
 
 Future routing work should deepen the catalog first, then render richer skill
 metadata from it.
@@ -174,9 +177,9 @@ hash without storing the raw prompt body.
 
 Bot wrappers can call `omh coding delegate --record` for implementation-shaped
 messages. The record stores source metadata, action, intent, recommended
-workflow and harness, recommendation evidence, `message_sha256`,
-`message_length`, and status `prepared_not_observed`. That status means a
-handoff was prepared; the companion run envelope is also marked
+workflow and harness, acceptance criteria, verification expectations,
+recommendation evidence, `message_sha256`, `message_length`, and status
+`prepared_not_observed`. That status means a handoff was prepared; the companion run envelope is also marked
 `prepared_coding_delegation`, not proof that Hermes executed the task.
 
 Bot wrappers can still call `omh runtime delegate` after the response if

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -58,17 +58,21 @@ The flow is:
 1. The Discord bot receives a user message.
 2. The bot can run `omh chat route --source discord --record "<message>"` to
    choose `dispatch`, `clarify`, or `fallback` before forwarding the request.
-3. The bot forwards `route.routing_prompt_template` with `{message}` replaced by
+3. For implementation-shaped messages, the bot can run
+   `omh coding delegate --source discord --record "<message>"` to prepare a
+   deterministic executor handoff with metadata-only evidence.
+4. The bot forwards `route.routing_prompt_template` or
+   `delegation.delegation_prompt_template` with `{message}` replaced by
    the received message, or runs with `--include-message` and forwards
-   `route.routing_prompt` when stdout is not logged.
-4. Hermes starts with its normal config and reads `skills.external_dirs`.
-5. `omh apply` makes sure `~/.omh/skills` is included in that discovery list.
-6. Hermes sees the managed skills, including the `oh-my-hermes` router skill.
-7. The router skill gives Hermes prompt-level routing guidance for workflow
+   `route.routing_prompt` / `delegation_prompt` when stdout is not logged.
+5. Hermes starts with its normal config and reads `skills.external_dirs`.
+6. `omh apply` makes sure `~/.omh/skills` is included in that discovery list.
+7. Hermes sees the managed skills, including the `oh-my-hermes` router skill.
+8. The router skill gives Hermes prompt-level routing guidance for workflow
    names, trigger phrases, fallback rules, and recovery behavior.
-8. Hermes selects the relevant installed skill and continues the response inside
+9. Hermes selects the relevant installed skill and continues the response inside
    the Discord bot flow.
-9. The bot or operator can record local evidence with `omh runtime record` and
+10. The bot or operator can record local evidence with `omh runtime record` and
    `omh runtime delegate`.
 
 `omh` does not replace the Discord bot, modify Discord commands, or patch Hermes
@@ -89,11 +93,11 @@ Optional artifact-backed flow:
 
 ```sh
 message='risky refactor'
-route_json="$(omh chat route --source discord --record --include-message "$message")"
-run_id="$(printf '%s' "$route_json" | python -c 'import json,sys; print(json.load(sys.stdin)["runtime"]["run"]["run_id"])')"
-route_prompt="$(printf '%s' "$route_json" | python -c 'import json,sys; print(json.load(sys.stdin)["route"]["routing_prompt"])')"
+delegate_json="$(omh coding delegate --source discord --record --include-message "$message")"
+run_id="$(printf '%s' "$delegate_json" | python -c 'import json,sys; print(json.load(sys.stdin)["runtime"]["run"]["run_id"])')"
+delegate_prompt="$(printf '%s' "$delegate_json" | python -c 'import json,sys; print(json.load(sys.stdin)["delegation_prompt"])')"
 
-# Forward "$route_prompt" to Hermes.
+# Forward "$delegate_prompt" to Hermes.
 # After Hermes responds, record what the bot could actually observe.
 omh runtime delegate --run "$run_id" --requested --not-observed --result not_observed
 omh runtime wrapper --run "$run_id" --prompt-dispatched --response-observed --completion-status completed --gap "specialist lane metadata not exposed"
@@ -121,6 +125,13 @@ Before calling the bot integration ready, verify these points:
 - The bot was restarted after installation or update.
 - `omh chat route --source discord --record "<message>"` returns a route action
   and writes `routing.json` in the same runtime context as the bot.
+- `omh coding delegate --source discord --record "<message>"` returns a
+  `coding_delegation/v1` payload and writes `coding_delegation.json` with
+  status `prepared_not_observed` for implementation-shaped requests.
+- The companion `run.json` for that command is marked
+  `artifact_kind: prepared_coding_delegation`, `phase: prepared`, and
+  `observation_status: prepared_not_observed`; the run envelope is bookkeeping,
+  not observed Hermes execution.
 - A Discord message that strongly names a workflow reaches Hermes with installed
   skill descriptions available.
 - `omh runtime record` can create a run and `omh runtime show <run-id>` can read
@@ -131,10 +142,10 @@ Before calling the bot integration ready, verify these points:
   bot again.
 
 Current limitation: deeper execution still depends on Hermes loading and
-exposing installed skills to the model. `omh chat route` chooses the prompt and
-records metadata before dispatch, but the bot adapter must forward the returned
-prompt template or opt into `--include-message`, and Hermes must still load the
-managed skills.
+exposing installed skills to the model. `omh chat route` and
+`omh coding delegate` choose prompts and record metadata before dispatch, but the
+bot adapter must forward the returned prompt template or opt into
+`--include-message`, and Hermes must still load the managed skills.
 
 ## Update
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -131,7 +131,8 @@ Before calling the bot integration ready, verify these points:
 - The companion `run.json` for that command is marked
   `artifact_kind: prepared_coding_delegation`, `phase: prepared`, and
   `observation_status: prepared_not_observed`; the run envelope is bookkeeping,
-  not observed Hermes execution.
+  not observed Hermes execution. Runtime validation treats that run envelope and
+  `coding_delegation.json` as a required pair.
 - A Discord message that strongly names a workflow reaches Hermes with installed
   skill descriptions available.
 - `omh runtime record` can create a run and `omh runtime show <run-id>` can read

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -435,9 +435,9 @@ Route implementation requests through scoped context, edit discipline, tests, re
   - inspect generated skill output when routing changed
 - Artifact events:
   - `run_started`
-  - `files_changed`
+  - `coding_delegation_recorded`
   - `verification_recorded`
-- Delegation expectation: Record delegation only when Hermes exposes a separate coding, review, or verification lane.
+- Delegation expectation: Record prepared coding delegation with omh coding delegate; record observed execution only when Hermes exposes a separate coding, review, or verification lane.
 - Privacy default: `metadata_only`
 - Fallback: If the request is underspecified, ask one concise clarification question before editing.
 

--- a/src/cli.py
+++ b/src/cli.py
@@ -14,6 +14,11 @@ from .chat_router import (
     route_chat_message,
     routing_record_payload,
 )
+from .coding_delegation import (
+    build_coding_delegation_payload,
+    coding_delegation_record_payload,
+    extract_source_metadata,
+)
 from .config_adapter import ensure_external_dir, read_config, remove_external_dir, write_config
 from .doctor import doctor_ok, run_doctor
 from .hashutil import sha256_file
@@ -28,6 +33,7 @@ from .runtime_artifacts import (
     DELEGATION_RESULTS,
     PRIVACY_MODES,
     RUN_STATUSES,
+    create_prepared_coding_delegation_run,
     create_run,
     export_runtime,
     list_runs,
@@ -36,6 +42,7 @@ from .runtime_artifacts import (
     show_run,
     update_state,
     validate_runtime,
+    write_coding_delegation,
     write_delegation,
     write_routing_decision,
     write_wrapper_contract,
@@ -215,6 +222,70 @@ def cmd_chat_route(args: argparse.Namespace) -> int:
         payload["runtime"] = {"run": run, "routing": routing}
     _print_json(payload)
     return 0
+
+
+def cmd_coding_delegate(args: argparse.Namespace) -> int:
+    try:
+        source_metadata: dict[str, str] = {}
+        if args.event_json:
+            raw = (
+                sys.stdin.read()
+                if args.event_json == "-"
+                else Path(args.event_json).expanduser().read_text(encoding="utf-8")
+            )
+            event = json.loads(raw)
+            message = extract_message_text(event)
+            source_metadata = extract_source_metadata(event)
+        elif args.stdin:
+            message = sys.stdin.read().strip()
+        else:
+            message = " ".join(args.message).strip()
+        source_metadata.update(_explicit_source_metadata(args))
+        payload = build_coding_delegation_payload(
+            message,
+            source=args.source,
+            limit=args.limit,
+            include_message=args.include_message,
+            source_metadata=source_metadata,
+        )
+        if args.record:
+            delegation = payload["delegation"]
+            if not isinstance(delegation, dict):
+                raise OmhError("coding delegation payload is missing delegation")
+            paths = _paths(args)
+            run = create_prepared_coding_delegation_run(
+                paths,
+                {
+                    "skill": str(delegation["recommended_workflow"]),
+                    "harness": str(delegation["recommended_harness"]),
+                    "trigger": f"coding:{args.source}:{delegation['action']}",
+                    "privacy": "metadata_only",
+                    "inputs_summary": f"{args.source} coding delegation request; message_length={len(message)}",
+                    "outputs_summary": f"prepared {delegation['action']} for {delegation['recommended_workflow']}",
+                    "verification_summary": "prepared_not_observed; executor work is not observed by omh",
+                },
+            )
+            record = write_coding_delegation(
+                paths.runtime_runs_dir / run["run_id"],
+                coding_delegation_record_payload(payload, message, source_metadata=source_metadata),
+            )
+            payload["runtime"] = {"run": run, "coding_delegation": record}
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        raise OmhError(str(exc)) from exc
+    _print_json(payload)
+    return 0
+
+
+def _explicit_source_metadata(args: argparse.Namespace) -> dict[str, str]:
+    return {
+        key: value
+        for key, value in {
+            "source_event_id": args.source_event_id,
+            "channel_ref": args.channel_ref,
+            "user_ref": args.user_ref,
+        }.items()
+        if value
+    }
 
 
 def _chat_message(args: argparse.Namespace) -> str:
@@ -546,6 +617,37 @@ def _add_chat_commands(sub) -> None:
     route.set_defaults(func=cmd_chat_route)
 
 
+def _add_coding_commands(sub) -> None:
+    coding = sub.add_parser("coding")
+    coding_sub = coding.add_subparsers(dest="coding_command", required=True)
+
+    delegate = coding_sub.add_parser("delegate")
+    delegate.add_argument("message", nargs="*", help="Coding task description to prepare for executor delegation.")
+    delegate.add_argument(
+        "--source",
+        choices=CHAT_SOURCES,
+        default="generic",
+        help="Source surface that received the coding request.",
+    )
+    delegate.add_argument("--limit", type=int, default=3, help="Maximum catalog recommendations to include.")
+    delegate.add_argument("--stdin", action="store_true", help="Read the raw coding task from stdin.")
+    delegate.add_argument(
+        "--event-json",
+        default=None,
+        help="Read a Slack/Discord/Hermes-like JSON event from this path, or '-' for stdin.",
+    )
+    delegate.add_argument(
+        "--include-message",
+        action="store_true",
+        help="Include raw message and expanded delegation prompt in stdout for non-logging wrappers.",
+    )
+    delegate.add_argument("--record", action="store_true", help="Record a metadata-only coding delegation artifact under .omh/runtime.")
+    delegate.add_argument("--source-event-id", default="", help="Optional source message/event id to store as metadata.")
+    delegate.add_argument("--channel-ref", default="", help="Optional channel reference to store as metadata.")
+    delegate.add_argument("--user-ref", default="", help="Optional user reference to store as metadata.")
+    delegate.set_defaults(func=cmd_coding_delegate)
+
+
 def _add_runtime_commands(sub) -> None:
     runtime = sub.add_parser("runtime")
     runtime_sub = runtime.add_subparsers(dest="runtime_command", required=True)
@@ -636,6 +738,7 @@ def build_parser() -> argparse.ArgumentParser:
     _add_top_level_commands(sub)
     _add_docs_commands(sub)
     _add_chat_commands(sub)
+    _add_coding_commands(sub)
     _add_runtime_commands(sub)
     _add_state_commands(sub)
     return parser

--- a/src/coding_delegation.py
+++ b/src/coding_delegation.py
@@ -1,0 +1,310 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import hashlib
+from typing import Any
+
+from .chat_router import CHAT_SOURCES, extract_message_text
+from .recommend import recommend_skills
+from .skills.catalog import (
+    CODING_INTENT_PRIORITY,
+    CODING_REVIEW_TERMS,
+    coding_intent_for_skill,
+    coding_skills_for_intent,
+    coding_terms_for_intent,
+    primary_harness_for_skill,
+)
+
+
+SCHEMA_VERSION = "coding_delegation/v1"
+DELEGATION_ACTIONS = ("delegate", "clarify", "fallback")
+_SOURCE_METADATA_PATHS: dict[str, tuple[tuple[str, ...], ...]] = {
+    "source_event_id": (("id",), ("event_id",), ("message", "id"), ("event", "id"), ("event", "client_msg_id")),
+    "channel_ref": (("channel",), ("channel_id",), ("message", "channel"), ("event", "channel"), ("channel", "id")),
+    "user_ref": (("user",), ("user_id",), ("author", "id"), ("message", "author", "id"), ("event", "user")),
+    "timestamp": (("timestamp",), ("created_at",), ("ts",), ("message", "timestamp"), ("event", "ts"), ("event", "event_ts")),
+}
+
+
+@dataclass(frozen=True)
+class CodingDelegation:
+    action: str
+    intent: str
+    recommended_workflow: str
+    recommended_harness: str
+    executor_profile: str
+    acceptance_criteria: tuple[str, ...]
+    verification: tuple[str, ...]
+    review_required: bool
+    review_workflow: str | None
+    delegation_prompt_template: str
+
+    def to_dict(self) -> dict[str, object]:
+        data = asdict(self)
+        data["acceptance_criteria"] = list(self.acceptance_criteria)
+        data["verification"] = list(self.verification)
+        return data
+
+
+def build_coding_delegation_payload(
+    message: str,
+    *,
+    source: str = "generic",
+    limit: int = 3,
+    include_message: bool = False,
+    source_metadata: dict[str, str] | None = None,
+) -> dict[str, object]:
+    message = message.strip()
+    if not message:
+        raise ValueError("coding delegate requires a task description")
+    if source not in CHAT_SOURCES:
+        raise ValueError(f"unsupported coding delegate source: {source}")
+    if limit < 1:
+        raise ValueError("coding delegate --limit must be at least 1")
+
+    full_recommendations = recommend_skills(message, limit=max(limit, 5))
+    recommendations = _compact_recommendations(full_recommendations[:limit])
+    top = full_recommendations[0]
+    workflow = str(top["skill"])
+    score = int(top["score"])
+    intent = _intent_for(message, workflow, score)
+    action = _action_for(intent, score)
+    if action == "fallback":
+        workflow = "oh-my-hermes"
+    elif action == "clarify":
+        workflow = "oh-my-hermes"
+    harness = primary_harness_for_skill(workflow)
+    review_required = _review_required(message, intent, workflow)
+    delegation = CodingDelegation(
+        action=action,
+        intent=intent,
+        recommended_workflow=workflow,
+        recommended_harness=harness,
+        executor_profile=_executor_profile(intent, action),
+        acceptance_criteria=_acceptance_criteria(intent, action),
+        verification=_verification(intent, action),
+        review_required=review_required,
+        review_workflow="code-review" if review_required else None,
+        delegation_prompt_template=_delegation_prompt_template(action, intent, workflow, harness),
+    )
+    payload: dict[str, object] = {
+        "schema_version": SCHEMA_VERSION,
+        "source": source,
+        "delegation": delegation.to_dict(),
+        "recommendations": recommendations,
+    }
+    metadata = {key: value for key, value in (source_metadata or {}).items() if value}
+    if metadata:
+        payload["source_metadata"] = metadata
+    if include_message:
+        payload["message"] = message
+        payload["delegation_prompt"] = str(delegation.delegation_prompt_template).replace("{message}", message)
+    return payload
+
+
+def build_coding_delegation_event_payload(
+    event: dict[str, Any] | str,
+    *,
+    source: str = "generic",
+    limit: int = 3,
+    include_message: bool = False,
+) -> dict[str, object]:
+    message = extract_message_text(event)
+    return build_coding_delegation_payload(
+        message,
+        source=source,
+        limit=limit,
+        include_message=include_message,
+        source_metadata=extract_source_metadata(event),
+    )
+
+
+def coding_delegation_record_payload(
+    payload: dict[str, object],
+    message: str,
+    *,
+    source_metadata: dict[str, str] | None = None,
+) -> dict[str, object]:
+    delegation = payload.get("delegation")
+    if not isinstance(delegation, dict):
+        raise ValueError("coding delegation payload is missing delegation")
+    metadata = dict(source_metadata or {})
+    payload_metadata = payload.get("source_metadata")
+    if isinstance(payload_metadata, dict):
+        metadata.update({str(key): str(value) for key, value in payload_metadata.items() if str(value)})
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "record_type": "coding_delegation",
+        "source": payload.get("source", "generic"),
+        "action": delegation.get("action", "fallback"),
+        "intent": delegation.get("intent", "unknown"),
+        "recommended_workflow": delegation.get("recommended_workflow", "oh-my-hermes"),
+        "recommended_harness": delegation.get("recommended_harness", "coding-handling"),
+        "executor_profile": delegation.get("executor_profile", "router"),
+        "review_required": bool(delegation.get("review_required", False)),
+        "review_workflow": delegation.get("review_workflow"),
+        "message_sha256": hashlib.sha256(message.encode("utf-8")).hexdigest(),
+        "message_length": len(message),
+        "source_metadata": metadata,
+        "recommendation_evidence": payload.get("recommendations", []),
+        "status": "prepared_not_observed",
+    }
+
+
+def extract_source_metadata(event: dict[str, Any] | str) -> dict[str, str]:
+    if not isinstance(event, dict):
+        return {}
+    metadata: dict[str, str] = {}
+    for output_key, paths in _SOURCE_METADATA_PATHS.items():
+        for path in paths:
+            value = _value_at_path(event, path)
+            if isinstance(value, (str, int, float)) and str(value).strip():
+                metadata[output_key] = str(value).strip()
+                break
+    return metadata
+
+
+def _intent_for(message: str, workflow: str, score: int) -> str:
+    if score == 0:
+        return "unknown"
+    lowered = message.lower()
+    for intent in CODING_INTENT_PRIORITY:
+        if workflow in coding_skills_for_intent(intent) or _has_any(lowered, coding_terms_for_intent(intent)):
+            return intent
+    return coding_intent_for_skill(workflow)
+
+
+def _action_for(intent: str, score: int) -> str:
+    if intent == "unknown":
+        return "fallback"
+    if score < 4:
+        return "clarify"
+    return "delegate"
+
+
+def _review_required(message: str, intent: str, workflow: str) -> bool:
+    lowered = message.lower()
+    if workflow == "code-review" or intent == "review":
+        return True
+    return _has_any(lowered, CODING_REVIEW_TERMS)
+
+
+def _executor_profile(intent: str, action: str) -> str:
+    if action == "fallback":
+        return "router"
+    if action == "clarify":
+        return "planner"
+    return {
+        "planning": "planner",
+        "review": "reviewer",
+        "diagnostics": "qa-verifier",
+        "docs": "docs-writer",
+    }.get(intent, "coding-agent")
+
+
+def _acceptance_criteria(intent: str, action: str) -> tuple[str, ...]:
+    if action == "fallback":
+        return (
+            "Clarify the desired coding outcome before dispatching to an executor.",
+            "Do not claim code was implemented or reviewed.",
+        )
+    if action == "clarify":
+        return (
+            "Ask the smallest blocking clarification before executor dispatch.",
+            "Preserve the original task constraints in the eventual handoff.",
+        )
+    criteria = {
+        "planning": (
+            "Produce an execution-ready plan with goals, non-goals, risks, and acceptance criteria.",
+            "Identify the verification commands or evidence required before implementation starts.",
+        ),
+        "review": (
+            "Review the referenced code or plan with findings first and concrete evidence.",
+            "State clearly when no actionable issue is found.",
+        ),
+        "diagnostics": (
+            "Reproduce or inspect the reported failure before proposing a fix.",
+            "Record the smallest evidence that proves the diagnosis.",
+        ),
+        "docs": (
+            "Update documentation to match implemented behavior and known limitations.",
+            "Keep examples reproducible and conservative.",
+        ),
+    }.get(
+        intent,
+        (
+            "Implement only the requested coding change within the discovered scope.",
+            "Preserve existing behavior outside the requested change.",
+        ),
+    )
+    return criteria
+
+
+def _verification(intent: str, action: str) -> tuple[str, ...]:
+    if action == "fallback":
+        return ("No executor verification until the task is clarified.",)
+    if action == "clarify":
+        return ("Verify the clarified handoff includes scope, constraints, and stop condition.",)
+    checks = {
+        "planning": ("Review the plan for testable acceptance criteria.", "Run implementation checks only after execution starts."),
+        "review": ("Cite file, diff, command, or test evidence for every finding.",),
+        "diagnostics": ("Run the smallest diagnostic or health check that can prove the claim.",),
+        "docs": ("Run docs generation/check commands when docs are generated.",),
+    }.get(
+        intent,
+        ("Run targeted tests for the changed behavior.", "Run static or compile checks when available."),
+    )
+    return checks
+
+
+def _delegation_prompt_template(action: str, intent: str, workflow: str, harness: str) -> str:
+    if action == "fallback":
+        return (
+            "Use the `oh-my-hermes` router before coding delegation.\n\n"
+            "Ask one concise clarification question for this task:\n{message}"
+        )
+    if action == "clarify":
+        return (
+            "Clarify this {intent} request before executor dispatch.\n\n"
+            "Candidate workflow: `{workflow}` / `{harness}`.\n\n"
+            "Task:\n{message}"
+        ).format(intent=intent, workflow=workflow, harness=harness, message="{message}")
+    return (
+        "Delegate this {intent} request to a {workflow} executor lane.\n\n"
+        "Recommended workflow: `{workflow}`\n"
+        "Recommended harness: `{harness}`\n"
+        "Do not claim execution is observed unless wrapper/runtime evidence proves it.\n\n"
+        "Task:\n{message}"
+    ).format(intent=intent, workflow=workflow, harness=harness, message="{message}")
+
+
+def _compact_recommendations(recommendations: object) -> list[dict[str, object]]:
+    if not isinstance(recommendations, list):
+        return []
+    compact: list[dict[str, object]] = []
+    for item in recommendations:
+        if not isinstance(item, dict):
+            continue
+        matched = item.get("matched", [])
+        compact.append(
+            {
+                "skill": str(item.get("skill", "")),
+                "score": int(item.get("score", 0)),
+                "confidence": str(item.get("confidence", "low")),
+                "matched": [str(value) for value in matched] if isinstance(matched, list) else [],
+            }
+        )
+    return compact
+
+
+def _value_at_path(event: dict[str, Any], path: tuple[str, ...]) -> Any:
+    current: Any = event
+    for part in path:
+        if not isinstance(current, dict):
+            return None
+        current = current.get(part)
+    return current
+
+
+def _has_any(value: str, terms: tuple[str, ...]) -> bool:
+    return any(term in value for term in terms)

--- a/src/coding_delegation.py
+++ b/src/coding_delegation.py
@@ -147,6 +147,8 @@ def coding_delegation_record_payload(
         "message_length": len(message),
         "source_metadata": metadata,
         "recommendation_evidence": payload.get("recommendations", []),
+        "acceptance_criteria": delegation.get("acceptance_criteria", []),
+        "verification": delegation.get("verification", []),
         "status": "prepared_not_observed",
     }
 

--- a/src/runtime_artifacts.py
+++ b/src/runtime_artifacts.py
@@ -21,11 +21,13 @@ from .runtime_records import (
     UNOBSERVED_RESULTS,
     WRAPPER_COMPLETION_STATUSES,
     build_delegation_record,
+    build_coding_delegation_record,
     build_event_record,
     build_routing_record,
     build_run_record,
     build_wrapper_record,
     validate_delegation_record,
+    validate_coding_delegation_record,
     validate_delegation_result,
     validate_event_record,
     validate_routing_record,
@@ -100,6 +102,17 @@ def create_run(paths: OmhPaths, metadata: dict[str, Any]) -> dict[str, Any]:
     return run
 
 
+def create_prepared_coding_delegation_run(paths: OmhPaths, metadata: dict[str, Any]) -> dict[str, Any]:
+    prepared_metadata = {
+        **metadata,
+        "status": "prepared",
+        "artifact_kind": "prepared_coding_delegation",
+        "phase": "prepared",
+        "observation_status": "prepared_not_observed",
+    }
+    return create_run(paths, prepared_metadata)
+
+
 def append_event(run_dir: Path, event: dict[str, Any]) -> dict[str, Any]:
     item = build_event_record(event)
     ensure_dir(run_dir, private=True)
@@ -165,6 +178,27 @@ def write_routing_decision(run_dir: Path, routing: dict[str, Any]) -> dict[str, 
     return record
 
 
+def write_coding_delegation(run_dir: Path, delegation: dict[str, Any]) -> dict[str, Any]:
+    record = build_coding_delegation_record(delegation)
+    atomic_write_json(run_dir / "coding_delegation.json", record, private=True)
+    append_event(
+        run_dir,
+        {
+            "event": "coding_delegation_recorded",
+            "level": "info",
+            "message": f"coding delegation {record['action']} {record['recommended_workflow']}",
+            "data": {
+                "source": record["source"],
+                "action": record["action"],
+                "intent": record["intent"],
+                "recommended_workflow": record["recommended_workflow"],
+                "status": record["status"],
+            },
+        },
+    )
+    return record
+
+
 def list_runs(paths: OmhPaths) -> list[dict[str, Any]]:
     if not paths.runtime_runs_dir.exists():
         return []
@@ -193,6 +227,7 @@ def show_run(paths: OmhPaths, run_id: str) -> dict[str, Any]:
         "run": run,
         "events": read_events(run_dir),
         "routing": read_json_object(run_dir / "routing.json"),
+        "coding_delegation": read_json_object(run_dir / "coding_delegation.json"),
         "delegation": read_json_object(run_dir / "delegation.json"),
         "wrapper": read_json_object(run_dir / "wrapper.json"),
         "evidence": sorted(path.name for path in evidence_dir.iterdir()) if evidence_dir.exists() else [],

--- a/src/runtime_artifacts.py
+++ b/src/runtime_artifacts.py
@@ -246,6 +246,9 @@ def validate_run_dir(run_dir: Path) -> dict[str, Any]:
         errors.append(f"{run_path}: missing run.json")
     else:
         errors.extend(f"{run_path}: {error}" for error in validate_run_record(run))
+        coding_delegation_path = run_dir / "coding_delegation.json"
+        if run.get("artifact_kind") == "prepared_coding_delegation" and not coding_delegation_path.exists():
+            errors.append(f"{coding_delegation_path}: missing coding_delegation.json for prepared_coding_delegation run")
     events_path = run_dir / "events.jsonl"
     if events_path.exists():
         try:

--- a/src/runtime_records.py
+++ b/src/runtime_records.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
+import hashlib
 from typing import Any
 
 from .local_store import utc_now
 
 
 SCHEMA_VERSION = 1
-RUN_STATUSES = ("started", "completed", "blocked", "failed", "unknown")
+RUN_STATUSES = ("started", "prepared", "completed", "blocked", "failed", "unknown")
 PRIVACY_MODES = ("metadata_only",)
+RUN_ARTIFACT_KINDS = ("workflow_run", "prepared_coding_delegation")
+RUN_PHASES = ("runtime", "prepared", "unknown")
+RUN_OBSERVATION_STATUSES = ("unknown", "observed", "not_observed", "prepared_not_observed")
 DELEGATION_RESULTS = ("completed", "blocked", "failed", "not_available", "not_observed")
 OBSERVED_RESULTS = ("completed", "blocked", "failed")
 UNOBSERVED_RESULTS = ("not_available", "not_observed")
@@ -16,6 +20,13 @@ WRAPPER_COMPLETION_STATUSES = ("started", "completed", "blocked", "failed", "unk
 ROUTE_ACTIONS = ("dispatch", "clarify", "fallback")
 ROUTE_CONFIDENCES = ("low", "medium", "high")
 ROUTING_RECOMMENDATION_KEYS = ("skill", "score", "confidence", "matched")
+CODING_DELEGATION_SCHEMA_VERSION = "coding_delegation/v1"
+CODING_DELEGATION_RECORD_TYPE = "coding_delegation"
+CODING_DELEGATION_ACTIONS = ("delegate", "clarify", "fallback")
+CODING_DELEGATION_INTENTS = ("coding", "cleanup", "review", "planning", "diagnostics", "docs", "unknown")
+CODING_DELEGATION_STATUSES = ("prepared_not_observed",)
+CODING_SOURCE_METADATA_KEYS = ("source_event_id", "channel_ref", "user_ref", "timestamp")
+CODING_RECOMMENDATION_KEYS = ("skill", "score", "confidence", "matched")
 
 
 def build_run_record(metadata: dict[str, Any], run_id: str) -> dict[str, Any]:
@@ -28,6 +39,15 @@ def build_run_record(metadata: dict[str, Any], run_id: str) -> dict[str, Any]:
     skill = str(metadata.get("skill", "unknown"))
     harness = str(metadata.get("harness", "unknown"))
     created_at = str(metadata.get("created_at") or utc_now())
+    artifact_kind = str(metadata.get("artifact_kind", "workflow_run"))
+    phase = str(metadata.get("phase", "runtime"))
+    observation_status = str(metadata.get("observation_status", "unknown"))
+    if artifact_kind not in RUN_ARTIFACT_KINDS:
+        raise ValueError(f"unsupported run artifact_kind: {artifact_kind}")
+    if phase not in RUN_PHASES:
+        raise ValueError(f"unsupported run phase: {phase}")
+    if observation_status not in RUN_OBSERVATION_STATUSES:
+        raise ValueError(f"unsupported run observation_status: {observation_status}")
     return {
         "schema_version": SCHEMA_VERSION,
         "run_id": run_id,
@@ -37,6 +57,9 @@ def build_run_record(metadata: dict[str, Any], run_id: str) -> dict[str, Any]:
         "harness": harness,
         "trigger": metadata.get("trigger", ""),
         "status": status,
+        "artifact_kind": artifact_kind,
+        "phase": phase,
+        "observation_status": observation_status,
         "privacy": privacy,
         "inputs_summary": metadata.get("inputs_summary", ""),
         "outputs_summary": metadata.get("outputs_summary", ""),
@@ -132,6 +155,40 @@ def build_routing_record(routing: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def build_coding_delegation_record(delegation: dict[str, Any]) -> dict[str, Any]:
+    nested = delegation.get("delegation", {})
+    if not isinstance(nested, dict):
+        nested = {}
+    message = delegation.get("message", "")
+    message_text = message if isinstance(message, str) else ""
+    record = {
+        "schema_version": CODING_DELEGATION_SCHEMA_VERSION,
+        "record_type": CODING_DELEGATION_RECORD_TYPE,
+        "updated_at": utc_now(),
+        "source": str(delegation.get("source", "generic")),
+        "action": str(nested.get("action", delegation.get("action", "fallback"))),
+        "intent": str(nested.get("intent", delegation.get("intent", "unknown"))),
+        "recommended_workflow": str(nested.get("recommended_workflow", delegation.get("recommended_workflow", "oh-my-hermes"))),
+        "recommended_harness": str(nested.get("recommended_harness", delegation.get("recommended_harness", "coding-handling"))),
+        "executor_profile": str(nested.get("executor_profile", delegation.get("executor_profile", "router"))),
+        "review_required": bool(nested.get("review_required", delegation.get("review_required", False))),
+        "review_workflow": _optional_string(nested.get("review_workflow", delegation.get("review_workflow"))),
+        "message_sha256": str(delegation.get("message_sha256", "")),
+        "message_length": int(delegation.get("message_length", len(message_text))),
+        "source_metadata": _compact_source_metadata(delegation.get("source_metadata", {})),
+        "recommendation_evidence": _compact_coding_recommendations(
+            delegation.get("recommendation_evidence", delegation.get("recommendations", []))
+        ),
+        "status": str(delegation.get("status", "prepared_not_observed")),
+    }
+    if not record["message_sha256"] and message_text:
+        record["message_sha256"] = hashlib.sha256(message_text.encode("utf-8")).hexdigest()
+    errors = validate_coding_delegation_record(record)
+    if errors:
+        raise ValueError(errors[0])
+    return record
+
+
 def _compact_routing_recommendations(recommendations: Any) -> list[dict[str, Any]]:
     if not isinstance(recommendations, list):
         return []
@@ -151,6 +208,38 @@ def _compact_routing_recommendations(recommendations: Any) -> list[dict[str, Any
     return compact
 
 
+def _compact_coding_recommendations(recommendations: Any) -> list[dict[str, Any]]:
+    if not isinstance(recommendations, list):
+        return []
+    compact: list[dict[str, Any]] = []
+    for item in recommendations:
+        if not isinstance(item, dict):
+            continue
+        matched = item.get("matched", [])
+        compact.append(
+            {
+                "skill": str(item.get("skill", "")),
+                "score": int(item.get("score", 0)),
+                "confidence": str(item.get("confidence", "low")),
+                "matched": [str(value) for value in matched] if isinstance(matched, list) else [],
+            }
+        )
+    return compact
+
+
+def _compact_source_metadata(metadata: Any) -> dict[str, str]:
+    if not isinstance(metadata, dict):
+        return {}
+    return {key: str(metadata[key]) for key in CODING_SOURCE_METADATA_KEYS if key in metadata and str(metadata[key])}
+
+
+def _optional_string(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value)
+    return text if text else None
+
+
 def _require(condition: bool, errors: list[str], message: str) -> None:
     if not condition:
         errors.append(message)
@@ -163,6 +252,27 @@ def validate_run_record(run: dict[str, Any]) -> list[str]:
         _require(isinstance(run.get(key), str) if key != "schema_version" else True, errors, f"run {key} must be a string")
     _require(run.get("status") in RUN_STATUSES, errors, f"run status is invalid: {run.get('status')!r}")
     _require(run.get("privacy") in PRIVACY_MODES, errors, f"run privacy is invalid: {run.get('privacy')!r}")
+    if "artifact_kind" in run:
+        _require(isinstance(run.get("artifact_kind"), str), errors, "run artifact_kind must be a string")
+        _require(run.get("artifact_kind") in RUN_ARTIFACT_KINDS, errors, f"run artifact_kind is invalid: {run.get('artifact_kind')!r}")
+    if "phase" in run:
+        _require(isinstance(run.get("phase"), str), errors, "run phase must be a string")
+        _require(run.get("phase") in RUN_PHASES, errors, f"run phase is invalid: {run.get('phase')!r}")
+    if "observation_status" in run:
+        _require(isinstance(run.get("observation_status"), str), errors, "run observation_status must be a string")
+        _require(
+            run.get("observation_status") in RUN_OBSERVATION_STATUSES,
+            errors,
+            f"run observation_status is invalid: {run.get('observation_status')!r}",
+        )
+    if run.get("artifact_kind") == "prepared_coding_delegation":
+        _require(run.get("status") == "prepared", errors, "prepared coding delegation run status must be prepared")
+        _require(run.get("phase") == "prepared", errors, "prepared coding delegation run phase must be prepared")
+        _require(
+            run.get("observation_status") == "prepared_not_observed",
+            errors,
+            "prepared coding delegation run observation_status must be prepared_not_observed",
+        )
     for key in ("trigger", "inputs_summary", "outputs_summary", "verification_summary"):
         _require(isinstance(run.get(key, ""), str), errors, f"run {key} must be a string")
     return errors
@@ -250,8 +360,60 @@ def validate_routing_record(routing: dict[str, Any]) -> list[str]:
     return errors
 
 
+def validate_coding_delegation_record(delegation: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    _require(
+        delegation.get("schema_version") == CODING_DELEGATION_SCHEMA_VERSION,
+        errors,
+        "coding_delegation schema_version is invalid",
+    )
+    _require(delegation.get("record_type") == CODING_DELEGATION_RECORD_TYPE, errors, "coding_delegation record_type is invalid")
+    for key in (
+        "updated_at",
+        "source",
+        "action",
+        "intent",
+        "recommended_workflow",
+        "recommended_harness",
+        "executor_profile",
+        "message_sha256",
+        "status",
+    ):
+        _require(isinstance(delegation.get(key), str), errors, f"coding_delegation {key} must be a string")
+    _require(delegation.get("action") in CODING_DELEGATION_ACTIONS, errors, f"coding_delegation action is invalid: {delegation.get('action')!r}")
+    _require(delegation.get("intent") in CODING_DELEGATION_INTENTS, errors, f"coding_delegation intent is invalid: {delegation.get('intent')!r}")
+    _require(delegation.get("status") in CODING_DELEGATION_STATUSES, errors, f"coding_delegation status is invalid: {delegation.get('status')!r}")
+    _require(isinstance(delegation.get("review_required"), bool), errors, "coding_delegation review_required must be boolean")
+    _require(
+        delegation.get("review_workflow") is None or isinstance(delegation.get("review_workflow"), str),
+        errors,
+        "coding_delegation review_workflow must be a string or null",
+    )
+    _require(isinstance(delegation.get("message_length"), int), errors, "coding_delegation message_length must be an integer")
+    _require(isinstance(delegation.get("source_metadata"), dict), errors, "coding_delegation source_metadata must be an object")
+    metadata = delegation.get("source_metadata", {})
+    if isinstance(metadata, dict):
+        extra_metadata_keys = sorted(set(metadata) - set(CODING_SOURCE_METADATA_KEYS))
+        _require(not extra_metadata_keys, errors, f"coding_delegation source_metadata has unsupported keys: {extra_metadata_keys}")
+        for key, value in metadata.items():
+            _require(isinstance(value, str), errors, f"coding_delegation source_metadata.{key} must be a string")
+    _require(isinstance(delegation.get("recommendation_evidence"), list), errors, "coding_delegation recommendation_evidence must be a list")
+    for index, recommendation in enumerate(delegation.get("recommendation_evidence", [])):
+        _require(isinstance(recommendation, dict), errors, f"coding_delegation recommendation_evidence[{index}] must be an object")
+        if not isinstance(recommendation, dict):
+            continue
+        extra_keys = sorted(set(recommendation) - set(CODING_RECOMMENDATION_KEYS))
+        _require(not extra_keys, errors, f"coding_delegation recommendation_evidence[{index}] has unsupported keys: {extra_keys}")
+        _require(isinstance(recommendation.get("skill"), str), errors, f"coding_delegation recommendation_evidence[{index}].skill must be a string")
+        _require(isinstance(recommendation.get("score"), int), errors, f"coding_delegation recommendation_evidence[{index}].score must be an integer")
+        _require(isinstance(recommendation.get("confidence"), str), errors, f"coding_delegation recommendation_evidence[{index}].confidence must be a string")
+        _require(isinstance(recommendation.get("matched"), list), errors, f"coding_delegation recommendation_evidence[{index}].matched must be a list")
+    return errors
+
+
 OPTIONAL_RECORD_VALIDATORS = (
     ("routing.json", validate_routing_record),
+    ("coding_delegation.json", validate_coding_delegation_record),
     ("delegation.json", validate_delegation_record),
     ("wrapper.json", validate_wrapper_record),
 )

--- a/src/runtime_records.py
+++ b/src/runtime_records.py
@@ -27,6 +27,26 @@ CODING_DELEGATION_INTENTS = ("coding", "cleanup", "review", "planning", "diagnos
 CODING_DELEGATION_STATUSES = ("prepared_not_observed",)
 CODING_SOURCE_METADATA_KEYS = ("source_event_id", "channel_ref", "user_ref", "timestamp")
 CODING_RECOMMENDATION_KEYS = ("skill", "score", "confidence", "matched")
+CODING_DELEGATION_RECORD_KEYS = (
+    "schema_version",
+    "record_type",
+    "updated_at",
+    "source",
+    "action",
+    "intent",
+    "recommended_workflow",
+    "recommended_harness",
+    "executor_profile",
+    "review_required",
+    "review_workflow",
+    "message_sha256",
+    "message_length",
+    "source_metadata",
+    "recommendation_evidence",
+    "acceptance_criteria",
+    "verification",
+    "status",
+)
 
 
 def build_run_record(metadata: dict[str, Any], run_id: str) -> dict[str, Any]:
@@ -179,6 +199,8 @@ def build_coding_delegation_record(delegation: dict[str, Any]) -> dict[str, Any]
         "recommendation_evidence": _compact_coding_recommendations(
             delegation.get("recommendation_evidence", delegation.get("recommendations", []))
         ),
+        "acceptance_criteria": _compact_string_list(nested.get("acceptance_criteria", delegation.get("acceptance_criteria", []))),
+        "verification": _compact_string_list(nested.get("verification", delegation.get("verification", []))),
         "status": str(delegation.get("status", "prepared_not_observed")),
     }
     if not record["message_sha256"] and message_text:
@@ -231,6 +253,12 @@ def _compact_source_metadata(metadata: Any) -> dict[str, str]:
     if not isinstance(metadata, dict):
         return {}
     return {key: str(metadata[key]) for key in CODING_SOURCE_METADATA_KEYS if key in metadata and str(metadata[key])}
+
+
+def _compact_string_list(values: Any) -> list[str]:
+    if not isinstance(values, (list, tuple)):
+        return []
+    return [str(value) for value in values if str(value)]
 
 
 def _optional_string(value: Any) -> str | None:
@@ -362,6 +390,8 @@ def validate_routing_record(routing: dict[str, Any]) -> list[str]:
 
 def validate_coding_delegation_record(delegation: dict[str, Any]) -> list[str]:
     errors: list[str] = []
+    extra_keys = sorted(set(delegation) - set(CODING_DELEGATION_RECORD_KEYS))
+    _require(not extra_keys, errors, f"coding_delegation has unsupported keys: {extra_keys}")
     _require(
         delegation.get("schema_version") == CODING_DELEGATION_SCHEMA_VERSION,
         errors,
@@ -390,6 +420,9 @@ def validate_coding_delegation_record(delegation: dict[str, Any]) -> list[str]:
         "coding_delegation review_workflow must be a string or null",
     )
     _require(isinstance(delegation.get("message_length"), int), errors, "coding_delegation message_length must be an integer")
+    if isinstance(delegation.get("message_length"), int):
+        _require(delegation["message_length"] >= 0, errors, "coding_delegation message_length must be non-negative")
+    _require(_is_sha256(str(delegation.get("message_sha256", ""))), errors, "coding_delegation message_sha256 must be a sha256 hex digest")
     _require(isinstance(delegation.get("source_metadata"), dict), errors, "coding_delegation source_metadata must be an object")
     metadata = delegation.get("source_metadata", {})
     if isinstance(metadata, dict):
@@ -408,7 +441,17 @@ def validate_coding_delegation_record(delegation: dict[str, Any]) -> list[str]:
         _require(isinstance(recommendation.get("score"), int), errors, f"coding_delegation recommendation_evidence[{index}].score must be an integer")
         _require(isinstance(recommendation.get("confidence"), str), errors, f"coding_delegation recommendation_evidence[{index}].confidence must be a string")
         _require(isinstance(recommendation.get("matched"), list), errors, f"coding_delegation recommendation_evidence[{index}].matched must be a list")
+    for key in ("acceptance_criteria", "verification"):
+        _require(isinstance(delegation.get(key), list), errors, f"coding_delegation {key} must be a list")
+        if not isinstance(delegation.get(key), list):
+            continue
+        for index, value in enumerate(delegation[key]):
+            _require(isinstance(value, str), errors, f"coding_delegation {key}[{index}] must be a string")
     return errors
+
+
+def _is_sha256(value: str) -> bool:
+    return len(value) == 64 and all(character in "0123456789abcdef" for character in value.lower())
 
 
 OPTIONAL_RECORD_VALIDATORS = (

--- a/src/skills/catalog.py
+++ b/src/skills/catalog.py
@@ -35,6 +35,28 @@ class HarnessDefinition:
     privacy_default: str
 
 
+CODING_INTENTS = ("coding", "cleanup", "review", "planning", "diagnostics", "docs", "unknown")
+CODING_INTENT_PRIORITY = ("cleanup", "review", "planning", "diagnostics", "docs", "coding")
+CODING_INTENT_TERMS = {
+    "cleanup": ("cleanup", "clean", "refactor", "deslop"),
+    "review": ("review", "audit", "critic", "critique"),
+    "planning": ("plan", "planning", "strategy", "architecture", "design", "proposal"),
+    "diagnostics": ("diagnose", "doctor", "debug", "health", "broken", "failing"),
+    "docs": ("docs", "documentation", "readme", "guide", "wiki"),
+    "coding": ("code", "implement", "build", "fix", "change", "modify", "add", "write"),
+}
+CODING_REVIEW_TERMS = (*CODING_INTENT_TERMS["review"], "risky", "risk", "migration", "security", "public api")
+_CODING_INTENT_BY_SKILL = {
+    "ai-slop-cleaner": "cleanup",
+    "code-review": "review",
+    "plan": "planning",
+    "ralplan": "planning",
+    "best-practice-research": "planning",
+    "doctor": "diagnostics",
+    "wiki": "docs",
+}
+
+
 _DEFINITIONS = [
     SkillDefinition(
         "oh-my-hermes",
@@ -282,8 +304,8 @@ _HARNESSES = [
         ("requested behavior is implemented", "tests or checks pass", "known gaps are reported"),
         ("run the smallest relevant tests", "inspect generated skill output when routing changed"),
         "If the request is underspecified, ask one concise clarification question before editing.",
-        ("run_started", "files_changed", "verification_recorded"),
-        "Record delegation only when Hermes exposes a separate coding, review, or verification lane.",
+        ("run_started", "coding_delegation_recorded", "verification_recorded"),
+        "Record prepared coding delegation with omh coding delegate; record observed execution only when Hermes exposes a separate coding, review, or verification lane.",
         "metadata_only",
     ),
     HarnessDefinition(
@@ -411,6 +433,18 @@ def builtin_harnesses() -> list[HarnessDefinition]:
 
 def primary_harness_for_skill(name: str) -> str:
     return _PRIMARY_HARNESSES.get(name, "coding-handling")
+
+
+def coding_intent_for_skill(name: str) -> str:
+    return _CODING_INTENT_BY_SKILL.get(name, "coding")
+
+
+def coding_skills_for_intent(intent: str) -> tuple[str, ...]:
+    return tuple(name for name, mapped_intent in _CODING_INTENT_BY_SKILL.items() if mapped_intent == intent)
+
+
+def coding_terms_for_intent(intent: str) -> tuple[str, ...]:
+    return CODING_INTENT_TERMS.get(intent, ())
 
 
 CORE_SKILLS = [definition.name for definition in _DEFINITIONS]

--- a/src/skills/render.py
+++ b/src/skills/render.py
@@ -110,6 +110,18 @@ Use `route.routing_prompt_template` with `{{message}}` replaced by the received 
 
 This is a deterministic wrapper-side decision layer. By default, stdout and runtime artifacts avoid duplicating the raw prompt body. It does not patch Hermes core or require platform network access from `omh`.
 
+## Wrapper-Assisted Coding Delegation
+
+When a chat message is implementation-shaped and the wrapper wants a concrete executor handoff, run `omh coding delegate` after or instead of generic chat routing:
+
+```sh
+omh coding delegate --source discord --record "risky refactor"
+```
+
+The command returns a `coding_delegation/v1` payload with a recommended workflow, harness, executor profile, acceptance criteria, verification expectations, and a `delegation_prompt_template` that the wrapper can forward with the user message substituted. It is deterministic and uses only local catalog metadata.
+
+With `--record`, `omh` writes `coding_delegation.json` under `.omh/runtime/runs/<run-id>/`. The companion `run.json` is marked with `status: prepared`, `artifact_kind: prepared_coding_delegation`, `phase: prepared`, and `observation_status: prepared_not_observed`. These artifacts store only allowlisted metadata, recommendation evidence, source references, `message_sha256`, and `message_length`. They mean a coding handoff was prepared; they do not mean Hermes executed the work or that a specialist lane was observed.
+
 ## Automatic Routing Registry
 
 When Hermes exposes installed skill descriptions to the model, use this registry as the routing map:
@@ -148,16 +160,16 @@ Recovery:
 
 ## Runtime Evidence
 
-When local shell access or a bot wrapper is available, record observed workflow evidence under `.omh/runtime/` through `omh runtime`.
+When local shell access or a bot wrapper is available, record prepared handoffs and observed workflow evidence under `.omh/runtime/`.
 
 Examples:
 
 ```sh
-omh runtime record --skill oh-my-hermes --harness coding-handling --status started
+omh coding delegate --source discord --record "risky refactor"
 omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
-Record only what is observed. If Hermes does not expose delegation metadata, use `not_observed` or `not_available` instead of implying a specialist lane ran.
+Record only what is observed. A `coding_delegation.json` record and its `prepared_coding_delegation` run envelope prove a prepared handoff, not execution. If Hermes does not expose delegation metadata, use `not_observed` or `not_available` instead of implying a specialist lane ran.
 """
     return SkillTemplate("oh-my-hermes", _frontmatter("oh-my-hermes", DESCRIPTIONS["oh-my-hermes"]) + "\n" + body)
 

--- a/src/skills/render.py
+++ b/src/skills/render.py
@@ -120,7 +120,7 @@ omh coding delegate --source discord --record "risky refactor"
 
 The command returns a `coding_delegation/v1` payload with a recommended workflow, harness, executor profile, acceptance criteria, verification expectations, and a `delegation_prompt_template` that the wrapper can forward with the user message substituted. It is deterministic and uses only local catalog metadata.
 
-With `--record`, `omh` writes `coding_delegation.json` under `.omh/runtime/runs/<run-id>/`. The companion `run.json` is marked with `status: prepared`, `artifact_kind: prepared_coding_delegation`, `phase: prepared`, and `observation_status: prepared_not_observed`. These artifacts store only allowlisted metadata, recommendation evidence, source references, `message_sha256`, and `message_length`. They mean a coding handoff was prepared; they do not mean Hermes executed the work or that a specialist lane was observed.
+With `--record`, `omh` writes `coding_delegation.json` under `.omh/runtime/runs/<run-id>/`. The companion `run.json` is marked with `status: prepared`, `artifact_kind: prepared_coding_delegation`, `phase: prepared`, and `observation_status: prepared_not_observed`. These artifacts store only allowlisted metadata, acceptance criteria, verification expectations, recommendation evidence, source references, `message_sha256`, and `message_length`. Validation treats the run envelope and `coding_delegation.json` as a required pair. They mean a coding handoff was prepared; they do not mean Hermes executed the work or that a specialist lane was observed.
 
 ## Automatic Routing Registry
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -124,6 +124,125 @@ class CliTests(unittest.TestCase):
         self.assertEqual(shown["routing"]["action"], "dispatch")
         self.assertNotIn("risky refactor", json.dumps(shown["routing"]))
 
+    def test_coding_delegate_returns_public_contract_without_raw_message(self) -> None:
+        status, stdout, stderr = run_cli(["coding", "delegate", "--source", "discord", "risky", "refactor"])
+
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        payload = json.loads(stdout)
+        delegation = payload["delegation"]
+        self.assertEqual(payload["schema_version"], "coding_delegation/v1")
+        self.assertEqual(payload["source"], "discord")
+        self.assertEqual(delegation["action"], "delegate")
+        self.assertEqual(delegation["intent"], "cleanup")
+        self.assertEqual(delegation["recommended_workflow"], "ai-slop-cleaner")
+        self.assertEqual(delegation["recommended_harness"], "coding-handling")
+        self.assertEqual(delegation["executor_profile"], "coding-agent")
+        self.assertTrue(delegation["review_required"])
+        self.assertIn("{message}", delegation["delegation_prompt_template"])
+        self.assertNotIn("suggested_prompt", json.dumps(payload))
+        self.assertNotIn("risky refactor", json.dumps(payload))
+
+    def test_coding_delegate_include_message_expands_prompt_for_non_logging_wrappers(self) -> None:
+        status, stdout, stderr = run_cli(["coding", "delegate", "--include-message", "risky", "refactor"])
+
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        payload = json.loads(stdout)
+        self.assertEqual(payload["message"], "risky refactor")
+        self.assertIn("Task:\nrisky refactor", payload["delegation_prompt"])
+
+    def test_coding_delegate_reads_event_json_and_metadata(self) -> None:
+        with TemporaryDirectory() as tmp:
+            event = Path(tmp) / "event.json"
+            event.write_text(
+                '{"event": {"id": "m1", "text": "implementation plan with review", "channel": "c1", "user": "u1", "ts": "123.4"}}',
+                encoding="utf-8",
+            )
+
+            status, stdout, stderr = run_cli(["coding", "delegate", "--source", "slack", "--event-json", str(event), "--limit", "2"])
+
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        payload = json.loads(stdout)
+        delegation = payload["delegation"]
+        self.assertEqual(payload["source"], "slack")
+        self.assertEqual(delegation["intent"], "review")
+        self.assertTrue(delegation["review_required"])
+        self.assertEqual(len(payload["recommendations"]), 2)
+        self.assertEqual(payload["source_metadata"]["source_event_id"], "m1")
+        self.assertEqual(payload["source_metadata"]["channel_ref"], "c1")
+        self.assertEqual(payload["source_metadata"]["user_ref"], "u1")
+
+    def test_coding_delegate_weak_query_falls_back(self) -> None:
+        status, stdout, stderr = run_cli(["coding", "delegate", "zzzzunknownphrase"])
+
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        delegation = json.loads(stdout)["delegation"]
+        self.assertEqual(delegation["action"], "fallback")
+        self.assertEqual(delegation["intent"], "unknown")
+        self.assertEqual(delegation["recommended_workflow"], "oh-my-hermes")
+
+    def test_coding_delegate_records_metadata_only_artifact(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / ".omh"
+            hermes_home = root / ".hermes"
+
+            status, stdout, stderr = run_cli(
+                [
+                    "--omh-home",
+                    str(omh_home),
+                    "--hermes-home",
+                    str(hermes_home),
+                    "coding",
+                    "delegate",
+                    "--record",
+                    "--source",
+                    "discord",
+                    "--source-event-id",
+                    "m1",
+                    "risky",
+                    "refactor",
+                ]
+            )
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            payload = json.loads(stdout)
+            run_id = payload["runtime"]["run"]["run_id"]
+            run = payload["runtime"]["run"]
+            record = payload["runtime"]["coding_delegation"]
+            self.assertEqual(run["status"], "prepared")
+            self.assertEqual(run["artifact_kind"], "prepared_coding_delegation")
+            self.assertEqual(run["phase"], "prepared")
+            self.assertEqual(run["observation_status"], "prepared_not_observed")
+            self.assertEqual(record["schema_version"], "coding_delegation/v1")
+            self.assertEqual(record["record_type"], "coding_delegation")
+            self.assertEqual(record["source"], "discord")
+            self.assertEqual(record["action"], "delegate")
+            self.assertEqual(record["intent"], "cleanup")
+            self.assertEqual(record["status"], "prepared_not_observed")
+            self.assertEqual(record["message_length"], len("risky refactor"))
+            self.assertEqual(record["source_metadata"]["source_event_id"], "m1")
+            self.assertNotIn("risky refactor", json.dumps(record))
+
+            status, stdout, stderr = run_cli(["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "runtime", "show", run_id])
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            shown = json.loads(stdout)
+            self.assertEqual(shown["run"]["artifact_kind"], "prepared_coding_delegation")
+            self.assertEqual(shown["run"]["phase"], "prepared")
+            self.assertEqual(shown["run"]["observation_status"], "prepared_not_observed")
+            self.assertEqual(shown["coding_delegation"]["recommended_workflow"], "ai-slop-cleaner")
+            self.assertNotIn("risky refactor", json.dumps(shown["coding_delegation"]))
+
+            status, stdout, stderr = run_cli(["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "runtime", "validate", "--run", run_id])
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            self.assertTrue(json.loads(stdout)["ok"])
+
     def test_install_apply_doctor_and_list(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -226,6 +226,8 @@ class CliTests(unittest.TestCase):
             self.assertEqual(record["status"], "prepared_not_observed")
             self.assertEqual(record["message_length"], len("risky refactor"))
             self.assertEqual(record["source_metadata"]["source_event_id"], "m1")
+            self.assertTrue(record["acceptance_criteria"])
+            self.assertTrue(record["verification"])
             self.assertNotIn("risky refactor", json.dumps(record))
 
             status, stdout, stderr = run_cli(["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "runtime", "show", run_id])

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -17,7 +17,9 @@ class RouterContentTests(unittest.TestCase):
         self.assertIn("best-effort Hermes prompt guidance", router.content)
         self.assertIn("does not override Hermes core routing", router.content)
         self.assertIn("omh chat route", router.content)
+        self.assertIn("omh coding delegate", router.content)
         self.assertIn("deterministic wrapper-side decision layer", router.content)
+        self.assertIn("prepared_not_observed", router.content)
         self.assertIn("skills_list", router.content)
         self.assertIn("skill_view", router.content)
         self.assertIn("name collides", router.content)
@@ -104,6 +106,7 @@ class RouterContentTests(unittest.TestCase):
             self.assertIn(f"### {harness.name}", reference)
             for event in harness.artifact_events:
                 self.assertIn(f"`{event}`", reference)
+        self.assertIn("coding_delegation_recorded", reference)
 
     def test_generated_public_content_avoids_external_runtime_branding(self) -> None:
         forbidden = ("om" + "x", "oh-my-" + "co" + "dex", "co" + "dex")

--- a/tests/test_runtime_artifacts.py
+++ b/tests/test_runtime_artifacts.py
@@ -13,18 +13,22 @@ from _local_package import load_local_package
 load_local_package()
 from omh.paths import resolve_paths
 from omh.chat_router import route_chat_message, routing_record_payload
+from omh.coding_delegation import build_coding_delegation_payload
 from omh.runtime_artifacts import (
+    create_prepared_coding_delegation_run,
     create_run,
     export_runtime,
     list_runs,
     new_run_id,
     show_run,
     update_state,
+    validate_coding_delegation_record,
     validate_delegation_record,
     validate_routing_record,
     validate_runtime,
     validate_run_record,
     validate_wrapper_record,
+    write_coding_delegation,
     write_delegation,
     write_routing_decision,
     write_wrapper_contract,
@@ -49,6 +53,21 @@ class RuntimeArtifactTests(unittest.TestCase):
             self.assertTrue((run_dir / "evidence").is_dir())
             self.assertEqual(json.loads(paths.runtime_state_path.read_text(encoding="utf-8"))["last_run_id"], run["run_id"])
             self.assertEqual(list_runs(paths)[0]["run_id"], run["run_id"])
+            self.assertEqual(validate_run_record(run), [])
+
+    def test_create_prepared_coding_delegation_run_has_explicit_boundary(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+
+            run = create_prepared_coding_delegation_run(
+                paths,
+                {"skill": "ai-slop-cleaner", "harness": "coding-handling", "trigger": "coding:discord:delegate"},
+            )
+
+            self.assertEqual(run["status"], "prepared")
+            self.assertEqual(run["artifact_kind"], "prepared_coding_delegation")
+            self.assertEqual(run["phase"], "prepared")
+            self.assertEqual(run["observation_status"], "prepared_not_observed")
             self.assertEqual(validate_run_record(run), [])
 
     def test_create_run_does_not_collide_for_rapid_same_harness_records(self) -> None:
@@ -159,6 +178,31 @@ class RuntimeArtifactTests(unittest.TestCase):
             self.assertNotIn("suggested_prompt", serialized)
             self.assertEqual(set(routing["recommendations"][0]), {"skill", "score", "confidence", "matched"})
 
+    def test_write_coding_delegation_sanitizes_full_payload(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            run = create_run(paths, {"skill": "ai-slop-cleaner", "harness": "coding-handling", "status": "started"})
+            secret_message = "risky refactor with private-token-123"
+            payload = build_coding_delegation_payload(
+                secret_message,
+                source="discord",
+                include_message=True,
+                source_metadata={"source_event_id": "m1", "unsupported": "drop-me"},
+            )
+            payload["suggested_prompt"] = "do not store"
+
+            coding_delegation = write_coding_delegation(paths.runtime_runs_dir / run["run_id"], payload)
+
+            serialized = json.dumps(coding_delegation)
+            self.assertNotIn(secret_message, serialized)
+            self.assertNotIn("delegation_prompt", serialized)
+            self.assertNotIn("suggested_prompt", serialized)
+            self.assertNotIn("drop-me", serialized)
+            self.assertEqual(coding_delegation["message_length"], len(secret_message))
+            self.assertEqual(coding_delegation["source_metadata"], {"source_event_id": "m1"})
+            self.assertEqual(set(coding_delegation["recommendation_evidence"][0]), {"skill", "score", "confidence", "matched"})
+            self.assertTrue(validate_runtime(paths, run["run_id"])["ok"])
+
     def test_validate_runtime_rejects_missing_and_invalid_artifacts(self) -> None:
         with TemporaryDirectory() as tmp:
             paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
@@ -199,10 +243,32 @@ class RuntimeArtifactTests(unittest.TestCase):
             }
         )
         routing_errors = validate_routing_record({"schema_version": 1, "action": "missing", "recommendations": []})
+        coding_errors = validate_coding_delegation_record(
+            {
+                "schema_version": "coding_delegation/v1",
+                "record_type": "coding_delegation",
+                "updated_at": "now",
+                "source": "discord",
+                "action": "missing",
+                "intent": "cleanup",
+                "recommended_workflow": "ai-slop-cleaner",
+                "recommended_harness": "coding-handling",
+                "executor_profile": "coding-agent",
+                "review_required": True,
+                "review_workflow": "code-review",
+                "message_sha256": "",
+                "message_length": 13,
+                "source_metadata": {"raw_message": "nope"},
+                "recommendation_evidence": [],
+                "status": "prepared_not_observed",
+            }
+        )
 
         self.assertIn("unobserved delegation requires result not_available or not_observed", delegation_errors)
         self.assertTrue(any("completion_status is invalid" in error for error in wrapper_errors))
         self.assertTrue(any("routing action is invalid" in error for error in routing_errors))
+        self.assertTrue(any("coding_delegation action is invalid" in error for error in coding_errors))
+        self.assertTrue(any("source_metadata has unsupported keys" in error for error in coding_errors))
 
     def test_export_runtime_redacts_sensitive_keys(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_runtime_artifacts.py
+++ b/tests/test_runtime_artifacts.py
@@ -201,7 +201,61 @@ class RuntimeArtifactTests(unittest.TestCase):
             self.assertEqual(coding_delegation["message_length"], len(secret_message))
             self.assertEqual(coding_delegation["source_metadata"], {"source_event_id": "m1"})
             self.assertEqual(set(coding_delegation["recommendation_evidence"][0]), {"skill", "score", "confidence", "matched"})
+            self.assertTrue(coding_delegation["acceptance_criteria"])
+            self.assertTrue(coding_delegation["verification"])
             self.assertTrue(validate_runtime(paths, run["run_id"])["ok"])
+
+    def test_validate_coding_delegation_rejects_top_level_raw_prompt(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            run = create_prepared_coding_delegation_run(
+                paths,
+                {"skill": "ai-slop-cleaner", "harness": "coding-handling"},
+            )
+            record = write_coding_delegation(
+                paths.runtime_runs_dir / run["run_id"],
+                build_coding_delegation_payload("risky refactor", source="discord", include_message=True),
+            )
+            record["message"] = "risky refactor"
+
+            errors = validate_coding_delegation_record(record)
+
+            self.assertTrue(any("unsupported keys" in error and "message" in error for error in errors))
+
+    def test_validate_runtime_requires_coding_delegation_for_prepared_runs(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            run = create_prepared_coding_delegation_run(
+                paths,
+                {"skill": "ai-slop-cleaner", "harness": "coding-handling"},
+            )
+
+            result = validate_runtime(paths, run["run_id"])
+
+            self.assertFalse(result["ok"])
+            self.assertTrue(any("missing coding_delegation.json" in error for error in result["runs"][0]["errors"]))
+
+    def test_validate_runtime_rejects_raw_top_level_coding_delegation_key(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            run = create_prepared_coding_delegation_run(
+                paths,
+                {"skill": "ai-slop-cleaner", "harness": "coding-handling"},
+            )
+            run_dir = paths.runtime_runs_dir / run["run_id"]
+            write_coding_delegation(
+                run_dir,
+                build_coding_delegation_payload("risky refactor", source="discord", include_message=True),
+            )
+            artifact_path = run_dir / "coding_delegation.json"
+            artifact = json.loads(artifact_path.read_text(encoding="utf-8"))
+            artifact["message"] = "risky refactor"
+            artifact_path.write_text(json.dumps(artifact), encoding="utf-8")
+
+            result = validate_runtime(paths, run["run_id"])
+
+            self.assertFalse(result["ok"])
+            self.assertTrue(any("unsupported keys" in error and "message" in error for error in result["runs"][0]["errors"]))
 
     def test_validate_runtime_rejects_missing_and_invalid_artifacts(self) -> None:
         with TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Why

Hermes needs a deterministic, local-only handoff surface for implementation-shaped chat messages. This PR adds a standalone `omh coding delegate` command that prepares a Codex/skill delegation prompt without calling an LLM, hitting the network, or changing Hermes core behavior.

## What Changed

- Added deterministic coding delegation in `src/coding_delegation.py`.
- Added `omh coding delegate <task>` with `--source`, event metadata, `--include-message`, and `--record` options.
- Reused catalog metadata from `src/skills/catalog.py` for intent, workflow, harness, acceptance criteria, verification expectations, and review routing.
- Added metadata-only `coding_delegation.json` runtime evidence plus a companion `prepared_coding_delegation` run envelope.
- Kept raw prompt text out of persisted records by default, storing `message_sha256` and `message_length` instead.
- Updated README and architecture/install/workflow docs conservatively.

## Review Fixes Addressed

- `coding_delegation.json` validation now rejects unsupported top-level keys, including accidental raw prompt fields such as `message`.
- `prepared_coding_delegation` runtime validation now requires the companion `coding_delegation.json` artifact.
- Persisted coding delegation records now snapshot acceptance criteria and verification expectations so historical runtime evidence does not drift with later catalog changes.

## Non-goals

- No LLM/API/network calls.
- No Discord or Slack SDK integration.
- No Hermes core behavior changes.
- No richer doctor, HUD/status, or observed executor dispatch implementation.

## Verification

- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — 80 tests passed.
- `uv run python -m compileall src` — passed.
- `uv run python -m omh.cli docs workflows --check` — passed.
- `git diff --check` / `git diff --cached --check` — passed.
- `uv run omh coding delegate "risky refactor"` — passed.
- `uv run omh coding delegate implementation plan with review --limit 2` — passed.
- `uv run omh coding delegate zzzzunknownphrase` — passed.
- Temp runtime smoke for `coding delegate --record`, `runtime show`, and `runtime validate --run` — passed.
- `uv build` — passed with existing setuptools license deprecation warnings.

## Status

Ready for CI/review on PR #15. This PR prepares delegation artifacts only; it still does not claim Hermes or Codex executed the delegated work.
