### PR TITLE
Add wrapper contract for Hermes plan handoffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,13 @@ wrapper or human review supplies evidence. Weak requests also write a
 `.hermes/context/` artifact so Hermes can ask one blocking clarification before
 planning.
 
+The same stdout payload includes `wrapper_contract`, a machine-readable bridge
+for Discord, Slack, or hosted Hermes adapters. For implementation-shaped draft
+plans, `wrapper_contract.coding_delegate.argv_template` tells the wrapper how to
+call `omh coding delegate --record` with the original message and source
+metadata after the plan is accepted. Blocked plans set `coding_delegate.available`
+to `false`, so wrappers ask the clarification instead of dispatching code.
+
 ## Commands
 
 | Command | Purpose |
@@ -227,7 +234,7 @@ planning.
 | `omh recommend <task>` | Deterministically suggest workflow skills from the local OMHM catalog. |
 | `omh chat route <message>` | Route a plain chat message before a Discord, Slack, or Hermes wrapper dispatches it. |
 | `omh coding delegate <task>` | Prepare a deterministic coding handoff payload and optional metadata-only runtime record. |
-| `omh hermes plan <task>` | Prepare a deterministic Hermes-facing plan and optionally write it under `.hermes/plans`. |
+| `omh hermes plan <task>` | Prepare a deterministic Hermes-facing plan, wrapper handoff contract, and optional `.hermes/plans` artifact. |
 | `omh runtime status` | Inspect local runtime artifact state. |
 | `omh runtime record` | Create a metadata-only workflow run artifact. |
 | `omh runtime delegate` | Record observed or unavailable delegation for a run. |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -99,6 +99,15 @@ default to `not_observed` unless wrapper metadata proves a separate review ran.
 Weak requests create a companion `.hermes/context/` artifact and keep the plan
 `blocked` until Hermes asks the smallest blocking clarification.
 
+The machine-readable planning bridge is stdout JSON, not the Markdown file. Each
+`hermes_plan/v1` payload includes `wrapper_contract` with the current wrapper
+step, decision gate, optional recorded plan artifact path, and coding-delegation
+handoff template. For implementation-shaped draft plans,
+`wrapper_contract.coding_delegate.argv_template` is the adapter contract for
+calling `omh coding delegate --record` after plan acceptance. Blocked or
+non-coding plans keep `coding_delegate.available` false so wrappers do not infer
+execution from presentation text.
+
 Future routing work should deepen the catalog first, then render richer skill
 metadata from it.
 
@@ -220,6 +229,12 @@ surface, and a review gate with `architect` and `critic` statuses. The command i
 deterministic and local-only; it does not run review agents, call services, or
 execute the plan. A `not_observed` review gate means the artifact is a planning
 scaffold, not consensus approval.
+
+The stdout `wrapper_contract.plan_artifact` mirrors the recorded artifact path
+when `--record` is used. Wrappers should preserve the original message for later
+delegation and use `wrapper_contract.message_field` only as the JSON pointer to
+the message text inside the payload; they should not scrape the Markdown plan
+body to recover commands or state.
 
 ## Workflow State
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -64,18 +64,23 @@ The flow is:
 4. For planning-shaped messages, the bot can run
    `omh hermes plan --source discord --record "<message>"` to prepare a
    Hermes-facing draft plan under the configured Hermes home.
-5. The bot forwards `route.routing_prompt_template` or
+5. For implementation-shaped draft plans, the bot reads
+   `wrapper_contract.coding_delegate.argv_template` and runs
+   `omh coding delegate --record` with the original message after the plan is
+   accepted. For blocked plans, it asks the clarification named by the plan
+   instead of dispatching code.
+6. The bot forwards `route.routing_prompt_template` or
    `delegation.delegation_prompt_template` with `{message}` replaced by
    the received message, or runs with `--include-message` and forwards
    `route.routing_prompt` / `delegation_prompt` when stdout is not logged.
-6. Hermes starts with its normal config and reads `skills.external_dirs`.
-7. `omh apply` makes sure `~/.omh/skills` is included in that discovery list.
-8. Hermes sees the managed skills, including the `oh-my-hermes` router skill.
-9. The router skill gives Hermes prompt-level routing guidance for workflow
+7. Hermes starts with its normal config and reads `skills.external_dirs`.
+8. `omh apply` makes sure `~/.omh/skills` is included in that discovery list.
+9. Hermes sees the managed skills, including the `oh-my-hermes` router skill.
+10. The router skill gives Hermes prompt-level routing guidance for workflow
    names, trigger phrases, fallback rules, and recovery behavior.
-10. Hermes selects the relevant installed skill and continues the response inside
+11. Hermes selects the relevant installed skill and continues the response inside
    the Discord bot flow.
-11. The bot or operator can record local evidence with `omh runtime record` and
+12. The bot or operator can record local evidence with `omh runtime record` and
    `omh runtime delegate`.
 
 `omh` does not replace the Discord bot, modify Discord commands, or patch Hermes
@@ -119,6 +124,12 @@ Weak planning requests may also write `.hermes/context/` so Hermes can ask one
 blocking clarification. Review gates remain `not_observed` unless the wrapper can
 prove a separate review happened.
 
+The stdout JSON also includes `wrapper_contract`. Wrappers should use that JSON,
+not the Markdown body, to decide the next local action. If
+`wrapper_contract.coding_delegate.available` is `true`, run the listed
+`argv_template` after plan acceptance to prepare the `coding_delegation/v1`
+payload. If it is `false`, follow `next_action` and do not dispatch coding work.
+
 For hosted bots, run these commands inside the same container, virtual
 environment, or user account that owns the bot runtime. If the wrapper can
 observe a specialist lane result, record it with `--observed`; otherwise keep
@@ -150,6 +161,10 @@ Before calling the bot integration ready, verify these points:
 - If a wrapper needs machine-readable planning fields, use the stdout
   `hermes_plan/v1` JSON payload as the contract and treat the Markdown file as
   presentation.
+- For implementation-shaped draft plans, the stdout
+  `wrapper_contract.coding_delegate.argv_template` is the handoff bridge to
+  `omh coding delegate --record`; run it only after plan acceptance and with the
+  original message preserved.
 - A Discord message that strongly names a workflow reaches Hermes with installed
   skill descriptions available.
 - `omh runtime record` can create a run and `omh runtime show <run-id>` can read

--- a/src/cli.py
+++ b/src/cli.py
@@ -22,7 +22,7 @@ from .coding_delegation import (
 from .config_adapter import ensure_external_dir, read_config, remove_external_dir, write_config
 from .doctor import doctor_ok, run_doctor
 from .hashutil import sha256_file
-from .hermes_planning import build_hermes_plan_payload, write_hermes_plan
+from .hermes_planning import attach_plan_artifact_to_wrapper_contract, build_hermes_plan_payload, write_hermes_plan
 from .installer import OmhError, install_skill_pack, uninstall_skill_pack
 from .local_store import atomic_write_text
 from .manifest import read_manifest
@@ -301,7 +301,9 @@ def cmd_hermes_plan(args: argparse.Namespace) -> int:
             source_metadata=source_metadata,
         )
         if args.record:
-            payload["artifact"] = write_hermes_plan(_paths(args), payload)
+            artifact = write_hermes_plan(_paths(args), payload)
+            payload["artifact"] = artifact
+            attach_plan_artifact_to_wrapper_contract(payload, artifact)
     except (OSError, json.JSONDecodeError, ValueError) as exc:
         raise OmhError(str(exc)) from exc
     _print_json(payload)

--- a/src/hermes_planning.py
+++ b/src/hermes_planning.py
@@ -5,7 +5,6 @@ from datetime import datetime, timezone
 import json
 import re
 import secrets
-import shlex
 from pathlib import Path
 from typing import Any
 
@@ -501,7 +500,6 @@ def _wrapper_contract(plan: HermesPlan, *, source: str, source_metadata: dict[st
                         *metadata_args,
                         "{message}",
                     ],
-                    "command_template": _coding_delegate_command_template(source, metadata_args),
                     "prompt_template_field": "delegation.delegation_prompt_template",
                     "include_message_flag": "--include-message",
                     "recorded_run_field": "runtime.run.run_id",
@@ -536,20 +534,13 @@ def _source_metadata_argv(metadata: dict[str, str]) -> list[str]:
     return args
 
 
-def _coding_delegate_command_template(source: str, metadata_args: list[str]) -> str:
-    parts = ["omh", "coding", "delegate", "--source", source, "--record", *metadata_args, "{message}"]
-    return " ".join(_shell_token(part) for part in parts)
-
-
-def _shell_token(value: str) -> str:
-    if value == "{message}":
-        return value
-    return shlex.quote(value)
-
-
 def _is_coding_shaped(task: str) -> bool:
-    lowered = task.lower()
-    return any(term in lowered for term in ("code", "coding", "implement", "fix", "debug", "test", "feature", "refactor"))
+    return bool(
+        re.search(
+            r"\b(code|coding|implement|implementation|fix|fixed|fixes|debug|debugging|test|tests|testing|refactor|refactoring|bug)\b",
+            task.lower(),
+        )
+    )
 
 
 def _markdown_list(values: object) -> list[str]:

--- a/src/hermes_planning.py
+++ b/src/hermes_planning.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 import json
 import re
 import secrets
+import shlex
 from pathlib import Path
 from typing import Any
 
@@ -16,6 +17,7 @@ from .recommend import recommend_skills
 
 
 SCHEMA_VERSION = "hermes_plan/v1"
+WRAPPER_CONTRACT_VERSION = "hermes_plan_wrapper/v1"
 _REVIEW_TERMS = (
     "architecture",
     "architect",
@@ -90,13 +92,14 @@ def build_hermes_plan_payload(
     recommendations = _compact_recommendations(recommend_skills(task, limit=max(limit, 5))[:limit])
     top = recommendations[0] if recommendations else {"skill": "oh-my-hermes", "score": 0, "confidence": "low"}
     plan = _plan_for(task, top)
+    metadata = {key: value for key, value in (source_metadata or {}).items() if value}
     payload: dict[str, object] = {
         "schema_version": SCHEMA_VERSION,
         "source": source,
         "plan": plan.to_dict(),
+        "wrapper_contract": _wrapper_contract(plan, source=source, source_metadata=metadata),
         "recommendations": recommendations,
     }
-    metadata = {key: value for key, value in (source_metadata or {}).items() if value}
     if metadata:
         payload["source_metadata"] = metadata
     return payload
@@ -135,6 +138,22 @@ def write_hermes_plan(paths: OmhPaths, payload: dict[str, object]) -> dict[str, 
         atomic_write_text(context_path, render_context_markdown(payload, context_path.name), private=True)
         artifact["context_path"] = str(context_path)
     return artifact
+
+
+def attach_plan_artifact_to_wrapper_contract(payload: dict[str, object], artifact: dict[str, object]) -> None:
+    contract = payload.get("wrapper_contract")
+    if not isinstance(contract, dict):
+        return
+    plan_artifact: dict[str, object] = {
+        "recorded": True,
+        "kind": artifact.get("kind", "hermes_plan"),
+        "schema_version": artifact.get("schema_version", SCHEMA_VERSION),
+        "status": artifact.get("status", "draft"),
+        "path": artifact.get("path", ""),
+    }
+    if artifact.get("context_path"):
+        plan_artifact["context_path"] = artifact["context_path"]
+    contract["plan_artifact"] = plan_artifact
 
 
 def render_plan_markdown(payload: dict[str, object], artifact_name: str = "plan.md") -> str:
@@ -278,7 +297,7 @@ def _plan_for(task: str, top: dict[str, object]) -> HermesPlan:
     score = _int_value(top.get("score", 0))
     weak = len(task.split()) <= 2 and (score == 0 or any(term in lowered for term in _CLARIFY_TERMS))
     review_shaped = any(term in lowered for term in _REVIEW_TERMS)
-    coding_shaped = any(term in lowered for term in ("code", "coding", "implement", "fix", "debug", "test", "feature", "refactor"))
+    coding_shaped = _is_coding_shaped(task)
 
     if weak:
         return HermesPlan(
@@ -434,6 +453,103 @@ def _compact_recommendations(recommendations: object) -> list[dict[str, object]]
             }
         )
     return compact
+
+
+def _wrapper_contract(plan: HermesPlan, *, source: str, source_metadata: dict[str, str]) -> dict[str, object]:
+    coding_available = plan.status == "draft" and _is_coding_shaped(plan.task_statement)
+    metadata_args = _source_metadata_argv(source_metadata)
+    contract: dict[str, object] = {
+        "schema_version": WRAPPER_CONTRACT_VERSION,
+        "source": source,
+        "current_step": "ask_clarification" if plan.status == "blocked" else "present_plan",
+        "next_action": _wrapper_next_action(plan, coding_available),
+        "message_field": "plan.task_statement",
+        "plan_artifact": {
+            "recorded": False,
+            "kind": "hermes_plan",
+            "schema_version": SCHEMA_VERSION,
+        },
+        "decision_gate": {
+            "required": plan.status == "draft",
+            "condition": "plan.status is draft and the wrapper or a human accepts the plan",
+            "do_not_delegate_when": [
+                "plan.status is blocked",
+                "the wrapper cannot preserve the original task message",
+                "the wrapper would claim review or execution without evidence",
+            ],
+        },
+        "coding_delegate": {
+            "available": coding_available,
+            "requires_plan_acceptance": coding_available,
+            "stdout_schema_version": "coding_delegation/v1",
+            "recording_contract": "prepared_not_observed",
+            "input_policy": "Pass the original task message directly; do not parse the Markdown plan body.",
+        },
+    }
+    coding_delegate = contract["coding_delegate"]
+    if isinstance(coding_delegate, dict):
+        if coding_available:
+            coding_delegate.update(
+                {
+                    "argv_template": [
+                        "omh",
+                        "coding",
+                        "delegate",
+                        "--source",
+                        source,
+                        "--record",
+                        *metadata_args,
+                        "{message}",
+                    ],
+                    "command_template": _coding_delegate_command_template(source, metadata_args),
+                    "prompt_template_field": "delegation.delegation_prompt_template",
+                    "include_message_flag": "--include-message",
+                    "recorded_run_field": "runtime.run.run_id",
+                }
+            )
+        else:
+            coding_delegate["unavailable_reason"] = (
+                "plan is blocked" if plan.status == "blocked" else "task is not implementation-shaped"
+            )
+    return contract
+
+
+def _wrapper_next_action(plan: HermesPlan, coding_available: bool) -> str:
+    if plan.status == "blocked":
+        return "ask_clarification"
+    if coding_available:
+        return "prepare_coding_delegation_after_plan_acceptance"
+    return "forward_plan_to_selected_workflow"
+
+
+def _source_metadata_argv(metadata: dict[str, str]) -> list[str]:
+    flags = {
+        "source_event_id": "--source-event-id",
+        "channel_ref": "--channel-ref",
+        "user_ref": "--user-ref",
+    }
+    args: list[str] = []
+    for key in ("source_event_id", "channel_ref", "user_ref"):
+        value = metadata.get(key)
+        if value:
+            args.extend([flags[key], value])
+    return args
+
+
+def _coding_delegate_command_template(source: str, metadata_args: list[str]) -> str:
+    parts = ["omh", "coding", "delegate", "--source", source, "--record", *metadata_args, "{message}"]
+    return " ".join(_shell_token(part) for part in parts)
+
+
+def _shell_token(value: str) -> str:
+    if value == "{message}":
+        return value
+    return shlex.quote(value)
+
+
+def _is_coding_shaped(task: str) -> bool:
+    lowered = task.lower()
+    return any(term in lowered for term in ("code", "coding", "implement", "fix", "debug", "test", "feature", "refactor"))
 
 
 def _markdown_list(values: object) -> list[str]:

--- a/src/skills/render.py
+++ b/src/skills/render.py
@@ -132,6 +132,8 @@ omh hermes plan --source discord --record "risky refactor with review"
 
 With `--record`, `omh` writes a Markdown draft under `.hermes/plans/`. Weak requests also write `.hermes/context/` so Hermes can ask one blocking clarification before a final plan. The plan includes goals, non-goals, options, risks, acceptance criteria, verification, execution handoff guidance, and a review gate. Review gate entries default to `not_observed`; do not call the plan approved unless wrapper or human evidence proves the review happened.
 
+The stdout `wrapper_contract` is the adapter contract for follow-on wrapper work. Use it instead of parsing the Markdown file. For implementation-shaped draft plans, `wrapper_contract.coding_delegate.argv_template` gives the exact `omh coding delegate --record` argv shape to run with the original message after plan acceptance. For blocked or non-coding plans, `coding_delegate.available` is `false`; follow `wrapper_contract.next_action` and do not dispatch a coding handoff.
+
 ## Automatic Routing Registry
 
 When Hermes exposes installed skill descriptions to the model, use this registry as the routing map:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -274,7 +274,32 @@ class CliTests(unittest.TestCase):
         self.assertEqual(coding_delegate["stdout_schema_version"], "coding_delegation/v1")
         self.assertEqual(coding_delegate["recording_contract"], "prepared_not_observed")
         self.assertIn("{message}", coding_delegate["argv_template"])
-        self.assertIn("omh coding delegate --source generic --record {message}", coding_delegate["command_template"])
+        self.assertNotIn("command_template", coding_delegate)
+
+    def test_hermes_plan_wrapper_contract_uses_only_argv_for_hostile_messages(self) -> None:
+        hostile = "refactor api; rm -rf / # nope"
+
+        status, stdout, stderr = run_cli(["hermes", "plan", "--source", "discord", hostile])
+
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        payload = json.loads(stdout)
+        coding_delegate = payload["wrapper_contract"]["coding_delegate"]
+        self.assertTrue(coding_delegate["available"])
+        self.assertNotIn("command_template", coding_delegate)
+        self.assertEqual(coding_delegate["argv_template"][-1], "{message}")
+        self.assertNotIn(hostile, json.dumps(coding_delegate))
+
+    def test_hermes_plan_wrapper_contract_rejects_substring_coding_matches(self) -> None:
+        for message in ("plan a contest announcement", "write a prefix migration guide", "feature request template"):
+            with self.subTest(message=message):
+                status, stdout, stderr = run_cli(["hermes", "plan", message])
+
+                self.assertEqual(stderr, "")
+                self.assertEqual(status, 0)
+                coding_delegate = json.loads(stdout)["wrapper_contract"]["coding_delegate"]
+                self.assertFalse(coding_delegate["available"])
+                self.assertEqual(coding_delegate["unavailable_reason"], "task is not implementation-shaped")
 
     def test_hermes_plan_records_under_hermes_home(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -261,6 +261,20 @@ class CliTests(unittest.TestCase):
         self.assertTrue(plan["acceptance_criteria"])
         self.assertTrue(plan["verification_plan"])
         self.assertIn("omh coding delegate --record", plan["execution_handoff"])
+        contract = payload["wrapper_contract"]
+        self.assertEqual(contract["schema_version"], "hermes_plan_wrapper/v1")
+        self.assertEqual(contract["current_step"], "present_plan")
+        self.assertEqual(contract["next_action"], "prepare_coding_delegation_after_plan_acceptance")
+        self.assertEqual(contract["message_field"], "plan.task_statement")
+        self.assertFalse(contract["plan_artifact"]["recorded"])
+        self.assertTrue(contract["decision_gate"]["required"])
+        coding_delegate = contract["coding_delegate"]
+        self.assertTrue(coding_delegate["available"])
+        self.assertTrue(coding_delegate["requires_plan_acceptance"])
+        self.assertEqual(coding_delegate["stdout_schema_version"], "coding_delegation/v1")
+        self.assertEqual(coding_delegate["recording_contract"], "prepared_not_observed")
+        self.assertIn("{message}", coding_delegate["argv_template"])
+        self.assertIn("omh coding delegate --source generic --record {message}", coding_delegate["command_template"])
 
     def test_hermes_plan_records_under_hermes_home(self) -> None:
         with TemporaryDirectory() as tmp:
@@ -289,6 +303,10 @@ class CliTests(unittest.TestCase):
             plan_path = Path(artifact["path"])
             self.assertEqual(artifact["kind"], "hermes_plan")
             self.assertEqual(artifact["status"], "draft")
+            contract_artifact = payload["wrapper_contract"]["plan_artifact"]
+            self.assertTrue(contract_artifact["recorded"])
+            self.assertEqual(contract_artifact["path"], artifact["path"])
+            self.assertEqual(contract_artifact["status"], "draft")
             self.assertEqual(plan_path.parent.resolve(), (hermes_home / "plans").resolve())
             self.assertTrue(plan_path.exists())
             self.assertFalse((root / ("." + "om" + "x") / "plans").exists())
@@ -310,8 +328,14 @@ class CliTests(unittest.TestCase):
             self.assertEqual(status, 0)
             payload = json.loads(stdout)
             self.assertEqual(payload["plan"]["status"], "blocked")
+            contract = payload["wrapper_contract"]
+            self.assertEqual(contract["current_step"], "ask_clarification")
+            self.assertEqual(contract["next_action"], "ask_clarification")
+            self.assertFalse(contract["coding_delegate"]["available"])
+            self.assertEqual(contract["coding_delegate"]["unavailable_reason"], "plan is blocked")
             artifact = payload["artifact"]
             self.assertIn("context_path", artifact)
+            self.assertEqual(payload["wrapper_contract"]["plan_artifact"]["context_path"], artifact["context_path"])
             plan_path = Path(artifact["path"])
             context_path = Path(artifact["context_path"])
             self.assertEqual(plan_path.parent.resolve(), (hermes_home / "plans").resolve())
@@ -324,7 +348,7 @@ class CliTests(unittest.TestCase):
         with TemporaryDirectory() as tmp:
             event = Path(tmp) / "event.json"
             event.write_text(
-                '{"event": {"id": "m1", "text": "risky architecture plan", "channel": "c1", "user": "u1", "ts": "123.4"}}',
+                '{"event": {"id": "m1", "text": "risky refactor architecture plan", "channel": "c1", "user": "u1", "ts": "123.4"}}',
                 encoding="utf-8",
             )
 
@@ -338,6 +362,15 @@ class CliTests(unittest.TestCase):
         self.assertEqual(payload["source_metadata"]["channel_ref"], "c1")
         self.assertEqual(payload["source_metadata"]["user_ref"], "u1")
         self.assertEqual(payload["plan"]["recommended_workflow"], "ralplan")
+        contract = payload["wrapper_contract"]
+        argv = contract["coding_delegate"]["argv_template"]
+        self.assertEqual(contract["source"], "slack")
+        self.assertIn("--source-event-id", argv)
+        self.assertIn("m1", argv)
+        self.assertIn("--channel-ref", argv)
+        self.assertIn("c1", argv)
+        self.assertIn("--user-ref", argv)
+        self.assertIn("u1", argv)
 
     def test_hermes_plan_frontmatter_quotes_untrusted_metadata(self) -> None:
         with TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- Add `wrapper_contract` to `hermes_plan/v1` stdout payloads so Discord, Slack, and hosted Hermes adapters can make deterministic next-step decisions.
- Expose `coding_delegate.argv_template` for implementation-shaped draft plans, bridging accepted plans to `omh coding delegate --record` without parsing Markdown or constructing shell strings.
- Mark blocked/non-coding plans as unavailable for coding delegation, preserving the clarification-first and no-false-execution boundaries.
- Mirror recorded `.hermes/plans` artifact paths into `wrapper_contract.plan_artifact` when `--record` is used.
- Update README, installation, architecture, and router guidance docs for the wrapper-facing contract.

## Context
Follow-up to #16. PR #16 has already been merged, so this continues the same feature line in a new PR rather than adding commits to the closed PR.

## Review Fixes
- Removed `command_template`; `coding_delegate.argv_template` is now the only executable wrapper handoff contract.
- Made coding-shape detection word-boundary based and removed broad `feature` matching to avoid false positives such as `contest`, `prefix`, and `feature request template`.
- Added regression tests for hostile shell-shaped messages and substring false positives.

## Verification
- `PYTHONPATH=tests uv run --no-sync python -m unittest discover -s tests -v` — PASS, 88 tests.
- `uv run --no-sync omh hermes plan --source slack --source-event-id m1 --channel-ref c1 --user-ref u1 "risky refactor with review"` — PASS, contract includes metadata-preserving `coding_delegate.argv_template` and no `command_template`.
- `uv run --no-sync omh hermes plan "plan a contest announcement"` — PASS, `coding_delegate.available` is `false`.
- `uv run --no-sync omh --hermes-home <tmp> hermes plan --source discord --record "risky refactor with review"` — PASS, contract mirrors recorded plan artifact path.
- `uv run --no-sync python -m compileall src` — PASS.
- `uv run --no-sync python -m omh.cli docs workflows --check` — PASS.
- `git diff --check` — PASS.
- `uv build` — PASS, with existing setuptools license deprecation warnings only.

## Risks
- Live Discord, Slack, or hosted Hermes wrapper integration was not tested.
- `wrapper_contract` is a new stdout contract; wrappers should treat it as additive and keep preserving the original user message for `{message}` substitution.
