### PR TITLE
Add delegation-first Codex handoff contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,10 @@ omh apply --dry-run
 omh recommend "risky refactor"
 omh chat route --source discord --record "risky refactor"
 omh coding delegate --source discord --record "risky refactor"
+omh coding delegate --executor codex --source discord --record "risky refactor"
 omh hermes plan --record "risky refactor with review"
 omh runtime record --skill oh-my-hermes --harness coding-handling --status started
+omh runtime delegation-status --run <run-id>
 omh runtime validate
 omh runtime export
 omh runtime runs
@@ -155,6 +157,19 @@ companion `run.json` is bookkeeping for that prepared handoff and is marked
 `artifact_kind: prepared_coding_delegation`, `phase: prepared`, and
 `observation_status: prepared_not_observed`.
 
+For delegation-first coding flows, wrappers can request an explicit Codex
+handoff without asking `omh` to execute Codex:
+
+```sh
+omh coding delegate --executor codex --source discord --record "risky refactor"
+```
+
+The stdout and runtime record include a `coding_executor_handoff/v1` instruction
+payload with executor target `codex`, acceptance criteria, verification
+expectations, review expectations, and status `prepared_not_observed`. The raw
+message remains a `{message}` placeholder in templates unless
+`--include-message` is used for stdout-only wrapper dispatch.
+
 Delegation artifacts separate `requested` from `observed`. If Hermes or a bot
 wrapper cannot prove that a specialist lane actually ran, the result should stay
 `not_observed` or `not_available`.
@@ -166,6 +181,18 @@ omh runtime wrapper --run <run-id> --prompt-dispatched --response-observed --com
 omh runtime validate --run <run-id>
 omh runtime export --redacted
 ```
+
+To turn recorded evidence into a safe user-facing status, wrappers can ask for a
+deterministic summary:
+
+```sh
+omh runtime delegation-status --run <run-id>
+```
+
+The summary reports prepared handoff, executor observation, verification
+observation, review readiness, a `next_action`, and an `overclaim_guard`.
+Prepared handoff is never treated as implementation, review, CI, or merge
+evidence by itself.
 
 ## Routing Model
 
@@ -204,6 +231,9 @@ and a `delegation_prompt_template`. With `--record`, it writes
 `coding_delegation.json` evidence and a `prepared_coding_delegation` run
 envelope; validation treats those as a required pair. The wrapper still needs
 separate Hermes or bot evidence before claiming execution was observed.
+When the intended main coding executor is Codex, add `--executor codex` to
+include a `coding_executor_handoff/v1` instruction payload. `omh` still does not
+launch Codex; the wrapper is responsible for dispatch and later observation.
 
 For planning-shaped requests, wrappers or operators can run `omh hermes plan` to
 create a deterministic `hermes_plan/v1` scaffold. With `--record`, it writes a
@@ -236,6 +266,7 @@ to `false`, so wrappers ask the clarification instead of dispatching code.
 | `omh coding delegate <task>` | Prepare a deterministic coding handoff payload and optional metadata-only runtime record. |
 | `omh hermes plan <task>` | Prepare a deterministic Hermes-facing plan, wrapper handoff contract, and optional `.hermes/plans` artifact. |
 | `omh runtime status` | Inspect local runtime artifact state. |
+| `omh runtime delegation-status --run <run-id>` | Summarize prepared/observed delegated coding status without overclaiming execution. |
 | `omh runtime record` | Create a metadata-only workflow run artifact. |
 | `omh runtime delegate` | Record observed or unavailable delegation for a run. |
 | `omh runtime wrapper` | Record what a bot or wrapper actually observed for a run. |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -12,6 +12,8 @@ The architecture favors:
 - generated skill text from testable catalog data
 - explicit compatibility contracts
 - conservative routing behavior
+- delegation-first coding, where Hermes plans and narrates while Codex-like
+  executors perform main implementation work
 
 ## Package Layout
 
@@ -81,7 +83,9 @@ The routing and delegation surfaces read from the same catalog metadata. The cha
 with raw-message prompt expansion available only through `--include-message`.
 Coding delegation returns a `delegation_prompt_template`, recommended workflow,
 harness, acceptance criteria, verification expectations, and optional
-metadata-only `coding_delegation.json` evidence. That record stores a compact
+metadata-only `coding_delegation.json` evidence. With `--executor codex`, it also
+returns a `coding_executor_handoff/v1` instruction payload that names Codex as
+the executor target without launching Codex. That record stores a compact
 snapshot of the generated acceptance criteria and verification expectations, but
 not the raw prompt body. With `--record`, the companion `run.json` is marked as
 `artifact_kind: prepared_coding_delegation`, `phase: prepared`, and
@@ -110,6 +114,10 @@ execution from presentation text.
 
 Future routing work should deepen the catalog first, then render richer skill
 metadata from it.
+
+The delegation-first completion model is tracked in
+`docs/DELEGATION_FIRST_COMPLETENESS.md`. It is the product boundary for making
+OMHM feel more complete without turning Hermes into the main coding executor.
 
 ## Hermes Capability Boundary
 
@@ -210,6 +218,13 @@ Wrappers can also call `omh runtime wrapper` to record whether a prompt was
 dispatched, whether a Hermes response was observed, whether verification was
 observed, and which gaps remain unobserved. This keeps bot integration evidence
 separate from claims about Hermes internals.
+
+Wrappers can call `omh runtime delegation-status --run <run-id>` to combine the
+prepared coding delegation, delegation observation, and wrapper observation into
+a `delegated_coding_status/v1` summary. The summary exposes `safe_summary`,
+`next_action`, review readiness, verification observation, and an
+`overclaim_guard` so chat adapters can report progress without implying Hermes
+implemented the code.
 
 ## Hermes Planning Artifacts
 

--- a/docs/DELEGATION_FIRST_COMPLETENESS.md
+++ b/docs/DELEGATION_FIRST_COMPLETENESS.md
@@ -1,0 +1,109 @@
+# Delegation-First Completeness
+
+## Direction
+
+OMHM should raise Hermes toward a mature workflow-layer experience without
+pretending that Hermes is the primary coding executor.
+
+The intended boundary is:
+
+- Hermes owns chat intake, clarification, planning, routing, status narration,
+  and user-facing workflow continuity.
+- Codex-like coding agents own main implementation, code review, verification,
+  and merge-readiness work.
+- `omh` owns deterministic local contracts between those surfaces: it prepares
+  handoffs, records metadata-only evidence, and keeps observed execution
+  separate from prepared intent.
+
+This direction keeps OMHM useful for Discord, Slack, and hosted Hermes wrappers
+while preserving the current project constraints: no hidden Hermes core patching,
+no LLM/API/network calls inside `omh`, and no runtime claim unless local wrapper
+evidence exists.
+
+## Current Local Surfaces
+
+| Surface | Current role | Evidence |
+| --- | --- | --- |
+| `omh chat route` | Deterministically routes plain chat into a workflow decision before wrapper dispatch. | `src/chat_router.py`, `tests/test_cli.py` |
+| `omh hermes plan` | Produces Hermes-facing plan scaffolds and wrapper contracts under `.hermes/plans`. | `src/hermes_planning.py`, `docs/ARCHITECTURE.md` |
+| `omh coding delegate` | Prepares metadata-only coding handoffs and records `prepared_not_observed` evidence. | `src/coding_delegation.py`, `src/runtime_artifacts.py` |
+| `omh runtime wrapper` | Lets wrappers record what they actually observed after dispatch. | `src/runtime_artifacts.py`, `README.md` |
+| `omh runtime validate/export` | Validates and exports local evidence without storing prompt bodies by default. | `src/runtime_artifacts.py`, `tests/test_runtime_artifacts.py` |
+
+The strongest existing path is:
+
+1. A Discord or Slack wrapper receives a plain user message.
+2. The wrapper runs `omh chat route`.
+3. For planning-shaped work, the wrapper runs `omh hermes plan --record`.
+4. After plan acceptance, the wrapper uses the plan `wrapper_contract` to run
+   `omh coding delegate --record`.
+5. Separate wrapper/runtime evidence is required before OMHM can say execution,
+   review, verification, or merge-readiness was observed.
+
+## Completeness Gaps
+
+| Priority | Gap | Why it matters | Target story |
+| --- | --- | --- | --- |
+| P0 | Codex is implied as a generic `coding-agent`, not named as an executor target. | Wrappers still need to invent the Codex handoff shape, which weakens interoperability. | Implement Codex executor handoff contract. |
+| P0 | Prepared handoff and observed executor status are not connected by a Codex-oriented contract. | A wrapper cannot cleanly narrate "Hermes prepared this, Codex is now responsible, here is what is observed." | Expose wrapper-facing delegation status evidence. |
+| P1 | Planning quality is good locally, but the post-plan path should expose stricter executor acceptance fields. | Codex handoff quality should be closer to high-discipline implementation briefs: scope, constraints, verification, review, and stop condition. | Implement Codex executor handoff contract. |
+| P1 | Runtime exports validate local evidence, but do not yet summarize a delegation chain as a user-facing status. | Chat wrappers need concise status messages that do not overclaim. | Expose wrapper-facing delegation status evidence. |
+| P2 | Roadmap still speaks broadly about integration rather than delegation-first product completeness. | Future contributors may add Hermes-internal coding behavior instead of strengthening the safer contract boundary. | Complete docs, tests, review, and PR gate. |
+
+## First Implementation Contract
+
+The next deterministic feature should make Codex the explicit coding executor
+target without launching Codex from `omh`.
+
+Expected behavior:
+
+- `omh coding delegate` continues to work for generic wrappers.
+- A wrapper can request a Codex-oriented handoff payload, either through a new
+  option on the existing command or a narrowly named subcommand.
+- The payload names Codex as the executor target and includes:
+  - executor target and handoff mode
+  - a prompt template or instruction payload for Codex
+  - scope and non-goals
+  - acceptance criteria
+  - verification expectations
+  - review expectations
+  - recording status `prepared_not_observed`
+- The payload must not include a shell command string that interpolates raw
+  user text.
+- If an argv-like template is included, the raw user message must remain a
+  placeholder such as `{message}`.
+- `--record` should write metadata-only evidence and preserve message hash,
+  message length, source metadata, and prepared/observed separation.
+
+Non-goals:
+
+- Do not invoke Codex, Hermes, GitHub, Discord, Slack, or any network service.
+- Do not change Hermes core behavior.
+- Do not claim implementation, review, CI, or merge evidence.
+- Do not store raw prompt bodies unless an existing explicit include flag is
+  used for stdout-only wrapper dispatch.
+
+## Wrapper Narrative Contract
+
+Wrappers should be able to express the chain in human terms:
+
+1. Hermes received and clarified or planned the request.
+2. OMHM prepared a Codex coding handoff.
+3. Codex execution is pending, running, blocked, completed, or not observed
+   according to wrapper evidence.
+4. Review, verification, CI, and merge status stay separate from prepared
+   delegation until observed.
+
+This avoids the most dangerous failure mode: Hermes sounding like it performed
+coding work that only a prepared handoff requested.
+
+## Success Criteria
+
+- The next implementation PR adds an explicit Codex handoff contract while
+  preserving existing `coding_delegation/v1` callers.
+- Tests prove no raw prompt body is stored in runtime records by default.
+- Tests prove hostile shell text remains a placeholder in any argv/template
+  contract.
+- README and architecture docs describe Hermes as the orchestrator and Codex as
+  the main coding executor for implementation work.
+- Runtime validation remains local-only and deterministic.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -8,6 +8,9 @@
 - Imported skill conflict fixtures
 - Richer routing catalog fields
 - More artifact-backed application cases for bot wrappers
+- Explicit Codex executor handoff contracts for delegation-first coding flows
+- Wrapper-facing delegated coding status summaries that separate prepared
+  handoff from observed execution, review, CI, and merge evidence
 
 ## Mid Term
 
@@ -15,6 +18,7 @@
 - Generated reference docs for installed workflows
 - Safer config parsing for more Hermes config shapes
 - Release archives and update channels
+- Stronger post-plan executor acceptance fields for Codex-oriented handoffs
 
 ## Long Term
 

--- a/src/cli.py
+++ b/src/cli.py
@@ -15,6 +15,7 @@ from .chat_router import (
     routing_record_payload,
 )
 from .coding_delegation import (
+    CODING_EXECUTOR_TARGETS,
     build_coding_delegation_payload,
     coding_delegation_record_payload,
     extract_source_metadata,
@@ -41,6 +42,7 @@ from .runtime_artifacts import (
     read_state,
     read_state_result,
     show_run,
+    summarize_delegated_coding_status,
     update_state,
     validate_runtime,
     write_coding_delegation,
@@ -248,6 +250,7 @@ def cmd_coding_delegate(args: argparse.Namespace) -> int:
             limit=args.limit,
             include_message=args.include_message,
             source_metadata=source_metadata,
+            executor_target=args.executor,
         )
         if args.record:
             delegation = payload["delegation"]
@@ -377,6 +380,14 @@ def cmd_runtime_runs(args: argparse.Namespace) -> int:
 def cmd_runtime_show(args: argparse.Namespace) -> int:
     try:
         _print_json(show_run(_paths(args), args.run_id))
+    except FileNotFoundError as exc:
+        raise OmhError(f"runtime run not found: {args.run_id}") from exc
+    return 0
+
+
+def cmd_runtime_delegation_status(args: argparse.Namespace) -> int:
+    try:
+        _print_json(summarize_delegated_coding_status(_paths(args), args.run_id))
     except FileNotFoundError as exc:
         raise OmhError(f"runtime run not found: {args.run_id}") from exc
     return 0
@@ -664,6 +675,12 @@ def _add_coding_commands(sub) -> None:
         help="Source surface that received the coding request.",
     )
     delegate.add_argument("--limit", type=int, default=3, help="Maximum catalog recommendations to include.")
+    delegate.add_argument(
+        "--executor",
+        choices=CODING_EXECUTOR_TARGETS,
+        default="generic",
+        help="Optional coding executor target for wrapper handoff payloads.",
+    )
     delegate.add_argument("--stdin", action="store_true", help="Read the raw coding task from stdin.")
     delegate.add_argument(
         "--event-json",
@@ -721,6 +738,10 @@ def _add_runtime_commands(sub) -> None:
     runtime_show = runtime_sub.add_parser("show")
     runtime_show.add_argument("run_id")
     runtime_show.set_defaults(func=cmd_runtime_show)
+
+    runtime_delegation_status = runtime_sub.add_parser("delegation-status")
+    runtime_delegation_status.add_argument("--run", dest="run_id", required=True)
+    runtime_delegation_status.set_defaults(func=cmd_runtime_delegation_status)
 
     runtime_record = runtime_sub.add_parser("record")
     runtime_record.add_argument("--skill", required=True)

--- a/src/coding_contracts.py
+++ b/src/coding_contracts.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+
+EXECUTOR_HANDOFF_SCHEMA_VERSION = "coding_executor_handoff/v1"
+CODING_EXECUTOR_TARGETS = ("generic", "codex")
+CODING_EXECUTOR_HANDOFF_TARGETS = ("codex",)

--- a/src/coding_delegation.py
+++ b/src/coding_delegation.py
@@ -5,6 +5,7 @@ import hashlib
 from typing import Any
 
 from .chat_router import CHAT_SOURCES, extract_message_text
+from .coding_contracts import CODING_EXECUTOR_TARGETS, EXECUTOR_HANDOFF_SCHEMA_VERSION
 from .recommend import recommend_skills
 from .skills.catalog import (
     CODING_INTENT_PRIORITY,
@@ -53,12 +54,15 @@ def build_coding_delegation_payload(
     limit: int = 3,
     include_message: bool = False,
     source_metadata: dict[str, str] | None = None,
+    executor_target: str = "generic",
 ) -> dict[str, object]:
     message = message.strip()
     if not message:
         raise ValueError("coding delegate requires a task description")
     if source not in CHAT_SOURCES:
         raise ValueError(f"unsupported coding delegate source: {source}")
+    if executor_target not in CODING_EXECUTOR_TARGETS:
+        raise ValueError(f"unsupported coding delegate executor: {executor_target}")
     if limit < 1:
         raise ValueError("coding delegate --limit must be at least 1")
 
@@ -93,12 +97,17 @@ def build_coding_delegation_payload(
         "delegation": delegation.to_dict(),
         "recommendations": recommendations,
     }
+    if executor_target != "generic" and delegation.action == "delegate":
+        payload["executor_handoff"] = _executor_handoff(executor_target, delegation)
     metadata = {key: value for key, value in (source_metadata or {}).items() if value}
     if metadata:
         payload["source_metadata"] = metadata
     if include_message:
         payload["message"] = message
         payload["delegation_prompt"] = str(delegation.delegation_prompt_template).replace("{message}", message)
+        handoff = payload.get("executor_handoff")
+        if isinstance(handoff, dict) and "prompt_template" in handoff:
+            payload["executor_handoff_prompt"] = str(handoff["prompt_template"]).replace("{message}", message)
     return payload
 
 
@@ -147,6 +156,7 @@ def coding_delegation_record_payload(
         "message_length": len(message),
         "source_metadata": metadata,
         "recommendation_evidence": payload.get("recommendations", []),
+        "executor_handoff": payload.get("executor_handoff"),
         "acceptance_criteria": delegation.get("acceptance_criteria", []),
         "verification": delegation.get("verification", []),
         "status": "prepared_not_observed",
@@ -257,6 +267,59 @@ def _verification(intent: str, action: str) -> tuple[str, ...]:
         ("Run targeted tests for the changed behavior.", "Run static or compile checks when available."),
     )
     return checks
+
+
+def _executor_handoff(executor_target: str, delegation: CodingDelegation) -> dict[str, object]:
+    if executor_target != "codex":
+        raise ValueError(f"unsupported coding delegate executor: {executor_target}")
+    return {
+        "schema_version": EXECUTOR_HANDOFF_SCHEMA_VERSION,
+        "executor_target": "codex",
+        "handoff_mode": "instruction_payload",
+        "status": "prepared_not_observed",
+        "recording_contract": "prepared_not_observed",
+        "dispatch_contract": "wrapper_dispatches_to_codex; omh_does_not_execute_codex",
+        "prompt_template": _codex_prompt_template(delegation),
+        "scope": [
+            "Use the original task message as the implementation request.",
+            "Respect the recommended OMHM workflow and harness metadata.",
+            "Keep Hermes-facing status separate from Codex execution evidence.",
+        ],
+        "non_goals": [
+            "Do not claim Hermes implemented the code.",
+            "Do not claim review, CI, or merge status without wrapper evidence.",
+            "Do not call network services from omh while preparing this handoff.",
+        ],
+        "acceptance_criteria": list(delegation.acceptance_criteria),
+        "verification": list(delegation.verification),
+        "review": {
+            "required": delegation.review_required,
+            "workflow": delegation.review_workflow,
+            "evidence_required": "Record separate wrapper/runtime evidence before marking review observed.",
+        },
+    }
+
+
+def _codex_prompt_template(delegation: CodingDelegation) -> str:
+    return (
+        "You are Codex, acting as the coding executor for a Hermes-orchestrated request.\n\n"
+        "Executor target: codex\n"
+        "Recommended OMHM workflow: `{workflow}`\n"
+        "Recommended harness: `{harness}`\n"
+        "Intent: `{intent}`\n"
+        "Prepared status: `prepared_not_observed`\n\n"
+        "Rules:\n"
+        "- Implement only after inspecting the repository and confirming the scope.\n"
+        "- Preserve unrelated behavior and user changes.\n"
+        "- Run targeted verification and report exact evidence.\n"
+        "- Do not say Hermes performed the implementation; Hermes prepared this handoff.\n\n"
+        "Task:\n{message}"
+    ).format(
+        workflow=delegation.recommended_workflow,
+        harness=delegation.recommended_harness,
+        intent=delegation.intent,
+        message="{message}",
+    )
 
 
 def _delegation_prompt_template(action: str, intent: str, workflow: str, harness: str) -> str:

--- a/src/runtime_artifacts.py
+++ b/src/runtime_artifacts.py
@@ -234,6 +234,201 @@ def show_run(paths: OmhPaths, run_id: str) -> dict[str, Any]:
     }
 
 
+def summarize_delegated_coding_status(paths: OmhPaths, run_id: str) -> dict[str, Any]:
+    shown = show_run(paths, run_id)
+    run = _object_or_empty(shown.get("run"))
+    coding = _object_or_empty(shown.get("coding_delegation"))
+    delegation = _object_or_empty(shown.get("delegation"))
+    wrapper = _object_or_empty(shown.get("wrapper"))
+    handoff = _object_or_empty(coding.get("executor_handoff"))
+    review = _object_or_empty(handoff.get("review"))
+
+    prepared = run.get("artifact_kind") == "prepared_coding_delegation" and bool(coding)
+    action = str(coding.get("action", "unknown"))
+    handoff_available = bool(handoff)
+    executor_target = str(handoff.get("executor_target") or coding.get("executor_profile") or "generic")
+    execution_observed = bool(delegation.get("observed", False))
+    execution_status = str(delegation.get("result") or ("not_observed" if prepared else "unknown"))
+    prompt_dispatched = bool(wrapper.get("prompt_dispatched", False))
+    response_observed = bool(wrapper.get("hermes_response_observed", False))
+    verification_observed = bool(wrapper.get("verification_observed", False))
+    completion_status = str(wrapper.get("completion_status") or "unknown")
+    review_required = bool(review.get("required", coding.get("review_required", False)))
+    review_workflow = review.get("workflow") if review else coding.get("review_workflow")
+
+    next_action = _delegated_status_next_action(
+        prepared=prepared,
+        action=action,
+        prompt_dispatched=prompt_dispatched,
+        execution_observed=execution_observed,
+        execution_status=execution_status,
+        review_required=review_required,
+        verification_observed=verification_observed,
+    )
+    integrity_warnings = _delegated_status_integrity_warnings(
+        run=run,
+        coding=coding,
+        delegation=delegation,
+        wrapper=wrapper,
+        handoff=handoff,
+        prepared=prepared,
+        action=action,
+    )
+    return {
+        "schema_version": "delegated_coding_status/v1",
+        "run_id": run_id,
+        "source": coding.get("source", "generic"),
+        "prepared": {
+            "available": prepared,
+            "action": action,
+            "status": coding.get("status", run.get("observation_status", "unknown")),
+            "executor_target": executor_target,
+            "workflow": coding.get("recommended_workflow", run.get("skill", "unknown")),
+            "harness": coding.get("recommended_harness", run.get("harness", "unknown")),
+            "handoff_available": handoff_available,
+            "handoff_schema_version": handoff.get("schema_version"),
+        },
+        "execution": {
+            "observed": execution_observed,
+            "status": execution_status,
+            "participants": delegation.get("participants", []),
+            "evidence_refs": delegation.get("evidence_refs", []),
+        },
+        "wrapper": {
+            "prompt_dispatched": prompt_dispatched,
+            "hermes_response_observed": response_observed,
+            "completion_status": completion_status,
+            "unobserved_gaps": wrapper.get("unobserved_gaps", []),
+        },
+        "verification": {
+            "observed": verification_observed,
+            "expected": coding.get("verification", []),
+        },
+        "review": {
+            "required": review_required,
+            "workflow": review_workflow,
+            "status": "not_observed" if review_required else "not_required",
+            "evidence_required": review.get("evidence_required", "Record review evidence separately before claiming review observed."),
+        },
+        "next_action": next_action,
+        "safe_summary": _delegated_status_summary(
+            prepared=prepared,
+            action=action,
+            executor_target=executor_target,
+            prompt_dispatched=prompt_dispatched,
+            execution_observed=execution_observed,
+            execution_status=execution_status,
+            review_required=review_required,
+            verification_observed=verification_observed,
+        ),
+        "integrity": {
+            "ok": not integrity_warnings,
+            "warnings": integrity_warnings,
+        },
+        "overclaim_guard": [
+            "Prepared coding delegation is not execution evidence.",
+            "Hermes should not claim it implemented code from this record.",
+            "Review, verification, CI, and merge status require separate observed evidence.",
+        ],
+    }
+
+
+def _object_or_empty(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _delegated_status_next_action(
+    *,
+    prepared: bool,
+    action: str,
+    prompt_dispatched: bool,
+    execution_observed: bool,
+    execution_status: str,
+    review_required: bool,
+    verification_observed: bool,
+) -> str:
+    if not prepared:
+        return "prepare_coding_delegation"
+    if action == "clarify":
+        return "clarify_coding_request"
+    if action == "fallback":
+        return "route_coding_request"
+    if action != "delegate":
+        return "prepare_coding_delegation"
+    if not prompt_dispatched:
+        return "dispatch_to_executor"
+    if not execution_observed:
+        return "wait_for_executor_evidence"
+    if execution_status in {"blocked", "failed"}:
+        return "surface_executor_blocker"
+    if review_required:
+        return "record_review_evidence"
+    if not verification_observed:
+        return "record_verification_evidence"
+    return "report_completion_with_evidence"
+
+
+def _delegated_status_summary(
+    *,
+    prepared: bool,
+    action: str,
+    executor_target: str,
+    prompt_dispatched: bool,
+    execution_observed: bool,
+    execution_status: str,
+    review_required: bool,
+    verification_observed: bool,
+) -> str:
+    if not prepared:
+        return "No prepared coding delegation was found for this run."
+    if action == "clarify":
+        return "The coding request needs clarification before executor dispatch."
+    if action == "fallback":
+        return "The coding request fell back to the router; do not dispatch it to an executor yet."
+    if action != "delegate":
+        return "The coding delegation is not dispatchable yet."
+    if not prompt_dispatched:
+        return f"A {executor_target} coding handoff is prepared, but wrapper dispatch is not observed yet."
+    if not execution_observed:
+        return f"A {executor_target} coding handoff was dispatched, but executor completion is not observed yet."
+    if execution_status in {"blocked", "failed"}:
+        return f"The {executor_target} executor reported {execution_status}; do not claim completion."
+    if review_required:
+        return f"The {executor_target} executor is observed as {execution_status}, but review evidence is still required."
+    if not verification_observed:
+        return f"The {executor_target} executor is observed as {execution_status}, but verification evidence is not observed yet."
+    return f"The {executor_target} executor is observed as {execution_status} with wrapper verification evidence."
+
+
+def _delegated_status_integrity_warnings(
+    *,
+    run: dict[str, Any],
+    coding: dict[str, Any],
+    delegation: dict[str, Any],
+    wrapper: dict[str, Any],
+    handoff: dict[str, Any],
+    prepared: bool,
+    action: str,
+) -> list[str]:
+    warnings: list[str] = []
+    artifact_kind = run.get("artifact_kind")
+    if artifact_kind == "prepared_coding_delegation" and not coding:
+        warnings.append("prepared_coding_delegation run is missing coding_delegation.json")
+    if coding and artifact_kind != "prepared_coding_delegation":
+        warnings.append("coding_delegation.json exists but run artifact_kind is not prepared_coding_delegation")
+    if prepared and run.get("observation_status") != "prepared_not_observed":
+        warnings.append("prepared coding delegation run has unexpected observation_status")
+    if action != "delegate" and handoff:
+        warnings.append("non-delegate coding action must not include executor_handoff")
+    if action == "delegate" and handoff and handoff.get("status") != "prepared_not_observed":
+        warnings.append("executor_handoff has unexpected status")
+    if wrapper and wrapper.get("completion_status") == "completed" and not wrapper.get("prompt_dispatched"):
+        warnings.append("wrapper reports completed without prompt_dispatched")
+    if delegation.get("observed") and not wrapper.get("prompt_dispatched", False):
+        warnings.append("delegation is observed but wrapper dispatch is not observed")
+    return warnings
+
+
 def validate_run_dir(run_dir: Path) -> dict[str, Any]:
     errors: list[str] = []
     run_path = run_dir / "run.json"

--- a/src/runtime_records.py
+++ b/src/runtime_records.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 from typing import Any
 
+from .coding_contracts import CODING_EXECUTOR_HANDOFF_TARGETS, EXECUTOR_HANDOFF_SCHEMA_VERSION
 from .local_store import utc_now
 
 
@@ -43,9 +44,26 @@ CODING_DELEGATION_RECORD_KEYS = (
     "message_length",
     "source_metadata",
     "recommendation_evidence",
+    "executor_handoff",
     "acceptance_criteria",
     "verification",
     "status",
+)
+CODING_EXECUTOR_HANDOFF_SCHEMA_VERSION = EXECUTOR_HANDOFF_SCHEMA_VERSION
+CODING_EXECUTOR_TARGETS = CODING_EXECUTOR_HANDOFF_TARGETS
+CODING_EXECUTOR_HANDOFF_KEYS = (
+    "schema_version",
+    "executor_target",
+    "handoff_mode",
+    "status",
+    "recording_contract",
+    "dispatch_contract",
+    "prompt_template",
+    "scope",
+    "non_goals",
+    "acceptance_criteria",
+    "verification",
+    "review",
 )
 
 
@@ -203,6 +221,9 @@ def build_coding_delegation_record(delegation: dict[str, Any]) -> dict[str, Any]
         "verification": _compact_string_list(nested.get("verification", delegation.get("verification", []))),
         "status": str(delegation.get("status", "prepared_not_observed")),
     }
+    executor_handoff = _compact_executor_handoff(delegation.get("executor_handoff"))
+    if executor_handoff:
+        record["executor_handoff"] = executor_handoff
     if not record["message_sha256"] and message_text:
         record["message_sha256"] = hashlib.sha256(message_text.encode("utf-8")).hexdigest()
     errors = validate_coding_delegation_record(record)
@@ -266,6 +287,32 @@ def _optional_string(value: Any) -> str | None:
         return None
     text = str(value)
     return text if text else None
+
+
+def _compact_executor_handoff(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    compact: dict[str, Any] = {
+        "schema_version": str(value.get("schema_version", "")),
+        "executor_target": str(value.get("executor_target", "")),
+        "handoff_mode": str(value.get("handoff_mode", "")),
+        "status": str(value.get("status", "")),
+        "recording_contract": str(value.get("recording_contract", "")),
+        "dispatch_contract": str(value.get("dispatch_contract", "")),
+        "prompt_template": str(value.get("prompt_template", "")),
+        "scope": _compact_string_list(value.get("scope", [])),
+        "non_goals": _compact_string_list(value.get("non_goals", [])),
+        "acceptance_criteria": _compact_string_list(value.get("acceptance_criteria", [])),
+        "verification": _compact_string_list(value.get("verification", [])),
+    }
+    review = value.get("review")
+    if isinstance(review, dict):
+        compact["review"] = {
+            "required": bool(review.get("required", False)),
+            "workflow": _optional_string(review.get("workflow")),
+            "evidence_required": str(review.get("evidence_required", "")),
+        }
+    return compact
 
 
 def _require(condition: bool, errors: list[str], message: str) -> None:
@@ -447,6 +494,59 @@ def validate_coding_delegation_record(delegation: dict[str, Any]) -> list[str]:
             continue
         for index, value in enumerate(delegation[key]):
             _require(isinstance(value, str), errors, f"coding_delegation {key}[{index}] must be a string")
+    if "executor_handoff" in delegation:
+        errors.extend(validate_coding_executor_handoff(delegation["executor_handoff"]))
+    return errors
+
+
+def validate_coding_executor_handoff(handoff: Any) -> list[str]:
+    errors: list[str] = []
+    _require(isinstance(handoff, dict), errors, "coding_delegation executor_handoff must be an object")
+    if not isinstance(handoff, dict):
+        return errors
+    extra_keys = sorted(set(handoff) - set(CODING_EXECUTOR_HANDOFF_KEYS))
+    _require(not extra_keys, errors, f"coding_delegation executor_handoff has unsupported keys: {extra_keys}")
+    _require(
+        handoff.get("schema_version") == CODING_EXECUTOR_HANDOFF_SCHEMA_VERSION,
+        errors,
+        "coding_delegation executor_handoff schema_version is invalid",
+    )
+    _require(
+        handoff.get("executor_target") in CODING_EXECUTOR_TARGETS,
+        errors,
+        f"coding_delegation executor_handoff executor_target is invalid: {handoff.get('executor_target')!r}",
+    )
+    for key in ("handoff_mode", "status", "recording_contract", "dispatch_contract", "prompt_template"):
+        _require(isinstance(handoff.get(key), str), errors, f"coding_delegation executor_handoff {key} must be a string")
+    _require(
+        handoff.get("status") == "prepared_not_observed",
+        errors,
+        "coding_delegation executor_handoff status must be prepared_not_observed",
+    )
+    _require(
+        "{message}" in str(handoff.get("prompt_template", "")),
+        errors,
+        "coding_delegation executor_handoff prompt_template must keep {message} placeholder",
+    )
+    for key in ("scope", "non_goals", "acceptance_criteria", "verification"):
+        _require(isinstance(handoff.get(key), list), errors, f"coding_delegation executor_handoff {key} must be a list")
+        if isinstance(handoff.get(key), list):
+            for index, value in enumerate(handoff[key]):
+                _require(isinstance(value, str), errors, f"coding_delegation executor_handoff {key}[{index}] must be a string")
+    review = handoff.get("review")
+    _require(isinstance(review, dict), errors, "coding_delegation executor_handoff review must be an object")
+    if isinstance(review, dict):
+        _require(isinstance(review.get("required"), bool), errors, "coding_delegation executor_handoff review.required must be boolean")
+        _require(
+            review.get("workflow") is None or isinstance(review.get("workflow"), str),
+            errors,
+            "coding_delegation executor_handoff review.workflow must be a string or null",
+        )
+        _require(
+            isinstance(review.get("evidence_required"), str),
+            errors,
+            "coding_delegation executor_handoff review.evidence_required must be a string",
+        )
     return errors
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -174,6 +174,44 @@ class CliTests(unittest.TestCase):
         self.assertEqual(payload["source_metadata"]["channel_ref"], "c1")
         self.assertEqual(payload["source_metadata"]["user_ref"], "u1")
 
+    def test_coding_delegate_codex_executor_handoff_is_metadata_safe(self) -> None:
+        hostile = "refactor api; rm -rf / # nope"
+
+        status, stdout, stderr = run_cli(["coding", "delegate", "--executor", "codex", "--source", "discord", hostile])
+
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        payload = json.loads(stdout)
+        handoff = payload["executor_handoff"]
+        self.assertEqual(handoff["schema_version"], "coding_executor_handoff/v1")
+        self.assertEqual(handoff["executor_target"], "codex")
+        self.assertEqual(handoff["handoff_mode"], "instruction_payload")
+        self.assertEqual(handoff["status"], "prepared_not_observed")
+        self.assertEqual(handoff["recording_contract"], "prepared_not_observed")
+        self.assertIn("{message}", handoff["prompt_template"])
+        self.assertNotIn(hostile, json.dumps(handoff))
+        self.assertNotIn(hostile, json.dumps(payload))
+
+    def test_coding_delegate_codex_executor_include_message_expands_stdout_only(self) -> None:
+        status, stdout, stderr = run_cli(["coding", "delegate", "--executor", "codex", "--include-message", "risky", "refactor"])
+
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        payload = json.loads(stdout)
+        self.assertEqual(payload["message"], "risky refactor")
+        self.assertIn("Task:\nrisky refactor", payload["executor_handoff_prompt"])
+
+    def test_coding_delegate_codex_executor_does_not_handoff_fallback_or_clarify(self) -> None:
+        for message, action in (("zzzzunknownphrase", "fallback"), ("fix maybe", "clarify")):
+            with self.subTest(message=message):
+                status, stdout, stderr = run_cli(["coding", "delegate", "--executor", "codex", message])
+
+                self.assertEqual(stderr, "")
+                self.assertEqual(status, 0)
+                payload = json.loads(stdout)
+                self.assertEqual(payload["delegation"]["action"], action)
+                self.assertNotIn("executor_handoff", payload)
+
     def test_coding_delegate_weak_query_falls_back(self) -> None:
         status, stdout, stderr = run_cli(["coding", "delegate", "zzzzunknownphrase"])
 
@@ -244,6 +282,231 @@ class CliTests(unittest.TestCase):
             self.assertEqual(stderr, "")
             self.assertEqual(status, 0)
             self.assertTrue(json.loads(stdout)["ok"])
+
+    def test_coding_delegate_records_codex_executor_handoff_without_raw_message(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / ".omh"
+            hermes_home = root / ".hermes"
+            hostile = "refactor api; rm -rf / # nope"
+
+            status, stdout, stderr = run_cli(
+                [
+                    "--omh-home",
+                    str(omh_home),
+                    "--hermes-home",
+                    str(hermes_home),
+                    "coding",
+                    "delegate",
+                    "--record",
+                    "--executor",
+                    "codex",
+                    "--source",
+                    "discord",
+                    hostile,
+                ]
+            )
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            payload = json.loads(stdout)
+            run_id = payload["runtime"]["run"]["run_id"]
+            record = payload["runtime"]["coding_delegation"]
+            handoff = record["executor_handoff"]
+            self.assertEqual(handoff["executor_target"], "codex")
+            self.assertIn("{message}", handoff["prompt_template"])
+            self.assertNotIn(hostile, json.dumps(record))
+
+            status, stdout, stderr = run_cli(["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "runtime", "show", run_id])
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            shown = json.loads(stdout)
+            self.assertEqual(shown["coding_delegation"]["executor_handoff"]["executor_target"], "codex")
+            self.assertNotIn(hostile, json.dumps(shown["coding_delegation"]))
+
+    def test_runtime_delegation_status_summarizes_prepared_codex_handoff(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / ".omh"
+            hermes_home = root / ".hermes"
+
+            status, stdout, stderr = run_cli(
+                [
+                    "--omh-home",
+                    str(omh_home),
+                    "--hermes-home",
+                    str(hermes_home),
+                    "coding",
+                    "delegate",
+                    "--record",
+                    "--executor",
+                    "codex",
+                    "risky",
+                    "refactor",
+                ]
+            )
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            run_id = json.loads(stdout)["runtime"]["run"]["run_id"]
+
+            status, stdout, stderr = run_cli(
+                ["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "runtime", "delegation-status", "--run", run_id]
+            )
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            summary = json.loads(stdout)
+            self.assertEqual(summary["schema_version"], "delegated_coding_status/v1")
+            self.assertEqual(summary["prepared"]["executor_target"], "codex")
+            self.assertEqual(summary["prepared"]["action"], "delegate")
+            self.assertTrue(summary["prepared"]["handoff_available"])
+            self.assertFalse(summary["execution"]["observed"])
+            self.assertEqual(summary["execution"]["status"], "not_observed")
+            self.assertEqual(summary["next_action"], "dispatch_to_executor")
+            self.assertTrue(summary["integrity"]["ok"])
+            self.assertIn("not execution evidence", " ".join(summary["overclaim_guard"]))
+
+    def test_runtime_delegation_status_does_not_dispatch_fallback_or_clarify(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / ".omh"
+            hermes_home = root / ".hermes"
+            base = ["--omh-home", str(omh_home), "--hermes-home", str(hermes_home)]
+
+            for message, next_action in (("zzzzunknownphrase", "route_coding_request"), ("fix maybe", "clarify_coding_request")):
+                with self.subTest(message=message):
+                    status, stdout, stderr = run_cli(base + ["coding", "delegate", "--record", "--executor", "codex", message])
+                    self.assertEqual(stderr, "")
+                    self.assertEqual(status, 0)
+                    payload = json.loads(stdout)
+                    self.assertNotIn("executor_handoff", payload)
+                    run_id = payload["runtime"]["run"]["run_id"]
+
+                    status, stdout, stderr = run_cli(base + ["runtime", "delegation-status", "--run", run_id])
+
+                    self.assertEqual(stderr, "")
+                    self.assertEqual(status, 0)
+                    summary = json.loads(stdout)
+                    self.assertEqual(summary["next_action"], next_action)
+                    self.assertFalse(summary["prepared"]["handoff_available"])
+                    self.assertNotEqual(summary["next_action"], "dispatch_to_executor")
+                    self.assertTrue(summary["integrity"]["ok"])
+
+    def test_runtime_delegation_status_reports_review_followup_after_observed_execution(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / ".omh"
+            hermes_home = root / ".hermes"
+
+            status, stdout, _ = run_cli(
+                [
+                    "--omh-home",
+                    str(omh_home),
+                    "--hermes-home",
+                    str(hermes_home),
+                    "coding",
+                    "delegate",
+                    "--record",
+                    "--executor",
+                    "codex",
+                    "risky",
+                    "refactor",
+                ]
+            )
+            self.assertEqual(status, 0)
+            run_id = json.loads(stdout)["runtime"]["run"]["run_id"]
+            self.assertEqual(
+                run_cli(
+                    [
+                        "--omh-home",
+                        str(omh_home),
+                        "--hermes-home",
+                        str(hermes_home),
+                        "runtime",
+                        "wrapper",
+                        "--run",
+                        run_id,
+                        "--prompt-dispatched",
+                        "--response-observed",
+                        "--verification-observed",
+                        "--completion-status",
+                        "completed",
+                    ]
+                )[0],
+                0,
+            )
+            self.assertEqual(
+                run_cli(
+                    [
+                        "--omh-home",
+                        str(omh_home),
+                        "--hermes-home",
+                        str(hermes_home),
+                        "runtime",
+                        "delegate",
+                        "--run",
+                        run_id,
+                        "--requested",
+                        "--observed",
+                        "--result",
+                        "completed",
+                        "--participants",
+                        "codex",
+                    ]
+                )[0],
+                0,
+            )
+
+            status, stdout, stderr = run_cli(
+                ["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "runtime", "delegation-status", "--run", run_id]
+            )
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            summary = json.loads(stdout)
+            self.assertTrue(summary["execution"]["observed"])
+            self.assertEqual(summary["execution"]["status"], "completed")
+            self.assertTrue(summary["verification"]["observed"])
+            self.assertTrue(summary["review"]["required"])
+            self.assertEqual(summary["next_action"], "record_review_evidence")
+            self.assertIn("review evidence is still required", summary["safe_summary"])
+
+    def test_runtime_delegation_status_warns_on_missing_prepared_artifact(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / ".omh"
+            hermes_home = root / ".hermes"
+
+            status, stdout, stderr = run_cli(
+                [
+                    "--omh-home",
+                    str(omh_home),
+                    "--hermes-home",
+                    str(hermes_home),
+                    "coding",
+                    "delegate",
+                    "--record",
+                    "--executor",
+                    "codex",
+                    "risky",
+                    "refactor",
+                ]
+            )
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            run_id = json.loads(stdout)["runtime"]["run"]["run_id"]
+            (omh_home / "runtime" / "runs" / run_id / "coding_delegation.json").unlink()
+
+            status, stdout, stderr = run_cli(
+                ["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "runtime", "delegation-status", "--run", run_id]
+            )
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            summary = json.loads(stdout)
+            self.assertFalse(summary["integrity"]["ok"])
+            self.assertTrue(any("missing coding_delegation.json" in warning for warning in summary["integrity"]["warnings"]))
 
     def test_hermes_plan_returns_review_gated_scaffold(self) -> None:
         status, stdout, stderr = run_cli(["hermes", "plan", "risky", "refactor", "with", "review"])

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -109,14 +109,14 @@ class RouterContentTests(unittest.TestCase):
         self.assertIn("coding_delegation_recorded", reference)
 
     def test_generated_public_content_avoids_external_runtime_branding(self) -> None:
-        forbidden = ("om" + "x", "oh-my-" + "co" + "dex", "co" + "dex")
+        forbidden = ("om" + "x", "oh-my-" + "co" + "dex")
         combined = "\n".join(skill.content for skill in builtin_skill_templates()).lower()
 
         for term in forbidden:
             self.assertNotIn(term, combined)
 
     def test_public_project_files_avoid_external_runtime_branding(self) -> None:
-        forbidden = ("om" + "x", "oh-my-" + "co" + "dex", "co" + "dex")
+        forbidden = ("om" + "x", "oh-my-" + "co" + "dex")
         paths = [
             Path("README.md"),
             Path("pyproject.toml"),


### PR DESCRIPTION
## Summary
- Add a delegation-first completion model that frames Hermes as chat/planning/status orchestrator and Codex as the main coding executor.
- Add `omh coding delegate --executor codex` for deterministic `coding_executor_handoff/v1` instruction payloads without executing Codex or calling any network/API.
- Add `omh runtime delegation-status --run <run-id>` to summarize prepared/observed delegated coding status with `next_action`, integrity warnings, and overclaim guards.
- Persist executor handoff metadata safely through runtime records, using a neutral `src/coding_contracts.py` contract module.
- Document the wrapper flow and preserve the public branding guardrails.

## Safety boundaries
- No Hermes core behavior changes.
- No Codex/Hermes process execution from `omh`.
- No LLM/API/network calls.
- No raw prompt body stored in runtime records by default.
- `fallback` and `clarify` actions do not emit Codex handoffs or executor dispatch next actions.

## Verification
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` -> PASS, 96 tests.
- `uv run python -m compileall -q src tests` -> PASS.
- `git diff --check` -> PASS.
- Docs ASCII/no-tab check -> PASS.
- Harness smoke for `coding delegate --record --executor codex` plus `runtime delegation-status` -> PASS.

## Review
- Independent code-reviewer lane: APPROVE.
- Independent architect lane: CLEAR.
- Addressed review blocker: non-delegate fallback/clarify requests no longer emit Codex handoffs.
- Addressed architecture watch: status summaries now include artifact integrity warnings and shared constants live in `src/coding_contracts.py`.

## Known local note
- Direct `uv run omh ...` in this checkout still fails in the current `.venv` because the generated entrypoint cannot import `omh`; the existing unittest harness loads the local package source and verifies CLI behavior.