### PR TITLE
Define OMHM direction and agent delivery grain

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,100 @@
+# OMHM Agent Contract
+
+This file is the repo-local operating contract for Codex agents working on
+oh-my-hermes-agent.
+
+## Product Direction
+
+Read `docs/DIRECTION.md` before changing architecture, workflow behavior,
+wrapper contracts, generated skill guidance, or coding delegation semantics.
+
+OMHM is a Hermes-native wrapper orchestration layer. Keep Hermes responsible for
+chat intake, clarification, source-backed research, planning, and status
+narration. Keep main coding work delegated to Codex-like executors through
+explicit prepared handoffs and observed evidence.
+
+Do not turn OMHM into a hidden Hermes runtime patch, transport bot, network
+service, LLM router, or secret coding executor.
+
+## Delivery Grain
+
+One user goal should normally produce one PR.
+
+Use multiple focused commits inside the same goal PR when useful. Planning docs,
+tests, implementation, code-review fixes, CI fixes, and small follow-up docs
+belong in the same PR when they serve the same user goal.
+
+Do not split review feedback or small follow-up fixes into new PRs merely
+because a previous commit already exists. Split only when the next change is a
+different user-facing goal, has independent release or rollback value, would
+make the current PR too risky to review, is blocked by an external decision, or
+the user explicitly asks for separate PRs.
+
+When the user asks to merge, finish review fixes in the current PR first, rerun
+verification, wait for required checks, then merge if authority is clear.
+
+## Implementation Boundaries
+
+- No LLM, API, Discord, Slack, GitHub, or network calls inside core `omh`
+  features unless the user explicitly approves a scoped integration.
+- No Hermes core patching.
+- Runtime artifacts are local, deterministic, schema-versioned, and
+  metadata-only by default.
+- Preserve prepared versus observed boundaries. `prepared_not_observed` is not
+  execution, review, CI, merge-readiness, or merge evidence.
+- Wrapper sessions own chat continuity and plan decisions only. Linked runtime
+  runs own handoff, dispatch, execution, verification, review, CI, and merge
+  evidence.
+- Generated skills come from catalog data. Prefer updating
+  `src/skills/catalog.py` and regenerating docs over hand-editing generated
+  output.
+
+## Coding Style
+
+- Keep code, docs, commit messages, and PR text in English.
+- Reply to Korean user messages in Korean.
+- Prefer small, explicit Python functions and data structures over clever
+  string parsing.
+- Keep public claims conservative and test-backed.
+- Avoid adding dependencies unless the user explicitly approves the dependency
+  and its packaging story.
+
+## Verification
+
+Use the smallest check that proves the claim, then broaden when the touched
+surface is shared.
+
+Typical gates:
+
+```sh
+PYTHONPATH=tests uv run python -m unittest tests/test_cli.py -v
+PYTHONPATH=tests uv run python -m unittest tests/test_router_content.py -v
+PYTHONPATH=tests uv run python -m unittest discover -s tests -v
+uv run python -m compileall -q src tests
+uv run python -m src.cli docs workflows --check
+git diff --check
+```
+
+For direction, docs, generated skill, wrapper contract, lifecycle, or runtime
+artifact changes, add or update tests that lock the public contract.
+
+## Git And Commits
+
+Use `codex/` branch names unless the user requests another prefix.
+
+Every commit must include DCO signoff and the local Lore-style trailers used by
+this repository:
+
+```text
+Constraint: <external constraint that shaped the decision>
+Rejected: <alternative considered> | <reason>
+Confidence: <low|medium|high>
+Scope-risk: <narrow|moderate|broad>
+Directive: <forward-looking warning>
+Tested: <what was verified>
+Not-tested: <known gaps>
+Signed-off-by: <name> <email>
+```
+
+Never revert user changes or unrelated untracked files. If an unrelated file is
+dirty, leave it alone and report it.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ chat contracts, CI, and contributor guidance. The next direction is deeper
 adapter integration: example Discord/Slack shims, richer routing metadata,
 release packaging, and Hermes-specific workflow tests.
 
+For the product boundary and delivery philosophy, see
+[Direction](docs/DIRECTION.md).
+
 ## Quick Start
 
 Install and apply the managed Hermes skill pack without cloning the repository:

--- a/README.md
+++ b/README.md
@@ -49,7 +49,21 @@ adapter integration: example Discord/Slack shims, richer routing metadata,
 release packaging, and Hermes-specific workflow tests.
 
 For the product boundary and delivery philosophy, see
-[Direction](docs/DIRECTION.md).
+[Direction](docs/DIRECTION.md). For the full documentation map, see
+[Documentation](docs/README.md).
+
+## Documentation Map
+
+Start with these documents when evaluating or changing OMHM:
+
+| Need | Document |
+| --- | --- |
+| Product boundary, philosophy, and delivery grain | [Direction](docs/DIRECTION.md) |
+| Module ownership and artifact boundaries | [Architecture](docs/ARCHITECTURE.md) |
+| Wrapper lifecycle and delegation completeness | [Delegation-First Completeness](docs/DELEGATION_FIRST_COMPLETENESS.md) |
+| Generated workflow catalog reference | [Workflow Reference](docs/WORKFLOWS.md) |
+| Install, update, and wrapper smoke flows | [Installation](docs/INSTALLATION.md) |
+| Representative user-facing scenarios | [Application Cases](docs/APPLICATION_CASES.md) |
 
 ## Quick Start
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,6 +2,9 @@
 
 ## Goals
 
+The product direction is defined in `docs/DIRECTION.md`; this architecture
+document describes the current module boundaries that implement that direction.
+
 oh-my-hermes-agent should feel like a native Hermes workflow layer, not a pile
 of copied prompt files.
 

--- a/docs/DELEGATION_FIRST_COMPLETENESS.md
+++ b/docs/DELEGATION_FIRST_COMPLETENESS.md
@@ -2,6 +2,9 @@
 
 ## Direction
 
+The product charter is `docs/DIRECTION.md`. This document expands the
+delegation-first completion slice of that charter.
+
 OMHM should raise Hermes toward a mature workflow-layer experience without
 pretending that Hermes is the primary coding executor.
 

--- a/docs/DIRECTION.md
+++ b/docs/DIRECTION.md
@@ -1,0 +1,147 @@
+# Direction
+
+## Product Thesis
+
+OMHM is a Hermes-native wrapper orchestration layer.
+
+It should make Hermes feel mature in chat surfaces without pretending Hermes is
+the main coding executor. The product is not a clone of a Codex-side workflow
+runtime. It borrows the discipline of staged workflows, local state, and
+evidence gates, then translates that discipline into Hermes-native chat,
+planning, status, and handoff contracts.
+
+## Project Type
+
+OMHM is:
+
+- a local installer for managed Hermes skills
+- a deterministic skill catalog and router contract
+- a wrapper-native chat contract for Discord, Slack, and hosted adapters
+- a Hermes-facing planning artifact generator
+- a metadata-only evidence ledger for prepared and observed handoffs
+- a delegation-first bridge from Hermes requests to Codex-like coding executors
+
+OMHM is not:
+
+- a Hermes core patch
+- a Discord or Slack bot implementation
+- an LLM router or network service
+- a hidden coding runtime
+- a claim that Hermes executed work that only a handoff prepared
+
+## Ownership Boundary
+
+Hermes owns:
+
+- chat intake
+- clarification
+- source-backed research
+- planning
+- skill and workflow narration
+- user-facing status continuity
+
+OMH owns:
+
+- deterministic local contracts
+- generated Hermes skill content
+- metadata-only runtime artifacts
+- wrapper session state
+- prepared coding handoff payloads
+- derived status that separates prepared intent from observed evidence
+
+Codex-like executors own:
+
+- main implementation work
+- code changes
+- code review fixes
+- verification execution
+- merge-readiness work
+
+## Direction Rules
+
+1. Keep users command-agnostic in chat.
+   Discord, Slack, and hosted wrappers should accept natural language and render
+   skill, plan, status, and handoff UX without requiring users to know OMH
+   commands.
+
+2. Preserve prepared versus observed boundaries.
+   `prepared_not_observed` means a handoff exists. It does not mean execution,
+   review, CI, merge readiness, or merge happened.
+
+3. Keep Hermes retained work high quality.
+   Deep interview, source-backed research, planning, status narration, and
+   evidence synthesis should improve inside Hermes-facing surfaces.
+
+4. Delegate main coding deliberately.
+   Coding-heavy work should become a prepared Codex-like executor handoff with
+   scope, non-goals, acceptance criteria, verification expectations, and review
+   expectations.
+
+5. Prefer local deterministic artifacts over hidden magic.
+   Runtime records, wrapper sessions, and plans should be inspectable,
+   schema-versioned, redacted by default, and local-only unless a wrapper
+   outside this repository performs transport work.
+
+6. Do not widen into platform transports prematurely.
+   Transport adapters, auth, retries, message edits, and posting belong outside
+   this repository until their dependency and packaging story is explicitly
+   approved.
+
+7. Treat compatibility skill names as UX affordances.
+   Workflow names may remain installed for familiarity, but their generated
+   role and handoff policies must describe the Hermes-native boundary rather
+   than implying copied runtime behavior.
+
+## Delivery Grain
+
+One user goal should normally produce one PR.
+
+Inside that PR, multiple focused commits are fine: plan/documentation, tests,
+implementation, review fixes, and CI fixes can all live in the same goal PR.
+Do not split review feedback, follow-up test fixes, or small documentation
+adjustments into new PRs unless they are independently releasable goals or the
+user explicitly asks for a separate PR.
+
+Split into separate PRs only when:
+
+- the next change has a different user-facing goal
+- the work has independent release or rollback value
+- the current PR would become too risky to review coherently
+- a dependency or external decision blocks part of the work
+- the user explicitly requests stacked or separate PRs
+
+## Strategic Milestones
+
+1. Direction lock.
+   Keep this document, architecture docs, README, generated skills, examples,
+   and tests aligned around delegation-first wrapper orchestration.
+
+2. Wrapper-native UX depth.
+   Add golden JSON and pseudocode examples for Discord and Slack actions,
+   threads, buttons, and status updates without adding transport dependencies.
+
+3. Evidence completeness.
+   Add first-class review, CI, merge-readiness, and merge observation records at
+   the run level while keeping wrapper sessions as chat continuity only.
+
+4. Retained cognition quality.
+   Improve Hermes-side research, deep interview, and planning skills so
+   non-coding requests feel first-class rather than like coding handoff
+   leftovers.
+
+5. Adapter boundary readiness.
+   Only after the local contract is stable, consider example shims or adapter
+   packages that consume `chat_interaction/v1` without moving platform secrets
+   or network behavior into core OMH.
+
+## Review Checklist
+
+Before accepting direction-changing work, verify:
+
+- Does it keep Hermes as orchestrator and narrator, not hidden coder?
+- Does it keep coding execution in a Codex-like handoff when code changes are
+  required?
+- Does it preserve `prepared_not_observed` until wrapper evidence exists?
+- Does it avoid Hermes core patching, LLM/API calls, and transport networking?
+- Does it keep chat users free from command knowledge?
+- Does it fit one coherent goal PR unless there is a clear reason to split?

--- a/docs/DIRECTION.md
+++ b/docs/DIRECTION.md
@@ -10,6 +10,32 @@ runtime. It borrows the discipline of staged workflows, local state, and
 evidence gates, then translates that discipline into Hermes-native chat,
 planning, status, and handoff contracts.
 
+## Design Philosophy
+
+Raise the product's capability level by strengthening contracts, not by hiding
+more behavior behind prompts.
+
+The desirable shape is a wrapper-native system where a user can type natural
+language in Discord, Slack, or a hosted chat surface and receive a clear next
+step: direct answer, clarification, research, plan, status, or coding handoff.
+The user should not need to know command names, skill internals, or executor
+syntax.
+
+OMHM should keep familiar workflow names only when they help users and wrappers
+recognize intent. Those names are compatibility affordances, not permission to
+copy another runtime's internals or imply hidden execution.
+
+Quality should show up as:
+
+- better request classification from local catalog metadata
+- better Hermes-side interview, research, and planning output
+- clearer wrapper response states and actions
+- stronger prepared handoff payloads for coding executors
+- stricter evidence boundaries for dispatch, execution, review, CI, and merge
+- documentation and tests that keep public claims aligned with code
+
+The goal is parity of seriousness, not parity of implementation shape.
+
 ## Project Type
 
 OMHM is:
@@ -133,6 +159,21 @@ Split into separate PRs only when:
    Only after the local contract is stable, consider example shims or adapter
    packages that consume `chat_interaction/v1` without moving platform secrets
    or network behavior into core OMH.
+
+## First-PR Vertical Slice Rule
+
+When a goal is broad, keep the PR coherent rather than artificially tiny. A good
+first slice should carry one user-visible capability from contract to tests:
+
+- document the desired chat or handoff behavior
+- encode the deterministic schema or catalog metadata
+- expose the CLI or wrapper-facing surface
+- record local metadata-only artifacts when needed
+- add focused tests for the public contract
+- update README/docs so the capability is discoverable
+
+Do not split the docs, implementation, review fixes, and CI fixes for that same
+goal into separate PRs unless one of the Delivery Grain split conditions applies.
 
 ## Review Checklist
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,69 @@
+# Documentation
+
+This directory is the public operating map for oh-my-hermes-agent.
+
+Read `docs/DIRECTION.md` first when a change could affect product identity,
+wrapper behavior, planning quality, coding delegation, or public claims. Read
+`AGENTS.md` alongside it when changing code in this repository; it is the
+repo-local contract for Codex agents working here.
+
+## Reading Paths
+
+| Goal | Read |
+| --- | --- |
+| Understand what OMHM is and is not | [Direction](DIRECTION.md) |
+| Understand module boundaries and local artifacts | [Architecture](ARCHITECTURE.md) |
+| Understand chat wrapper UX, sessions, and handoffs | [Delegation-First Completeness](DELEGATION_FIRST_COMPLETENESS.md) |
+| Install or operate the preview package | [Installation](INSTALLATION.md) |
+| See realistic user-facing flows | [Application Cases](APPLICATION_CASES.md) |
+| Check generated skill and harness metadata | [Workflow Reference](WORKFLOWS.md) |
+| Prepare or verify a release | [Release](RELEASE.md) |
+| Track public sequencing | [Roadmap](ROADMAP.md) |
+
+## Direction Summary
+
+OMHM is a Hermes-native wrapper orchestration layer.
+
+The product should make chat surfaces feel capable without hiding who did what.
+Hermes should own intake, clarification, research, planning, status narration,
+and handoff UX. Codex-like executors should own main coding work. OMH should own
+the deterministic local contract between those worlds: generated skill guidance,
+wrapper sessions, prepared handoff payloads, and evidence records.
+
+The most important boundary is prepared versus observed evidence. A prepared
+handoff is useful, but it is not execution, review, CI, merge readiness, or a
+merge.
+
+## Documentation Contracts
+
+- Public docs should describe local deterministic behavior, not hidden runtime
+  magic.
+- Chat users should remain command-agnostic. Wrapper docs should describe
+  buttons, threads, status, and handoff states rather than asking end users to
+  run shell commands.
+- Coding-heavy requests should be described as delegated work unless there is
+  observed evidence that a coding executor actually ran.
+- Generated workflow docs should come from `src/skills/catalog.py`; update the
+  catalog before refreshing generated references.
+- Runtime and wrapper docs should preserve the separation between wrapper
+  session state and run-level evidence.
+
+## Update Checklist
+
+When changing docs, check whether the same claim needs to be updated in:
+
+- [README](../README.md)
+- [Direction](DIRECTION.md)
+- [Architecture](ARCHITECTURE.md)
+- [Delegation-First Completeness](DELEGATION_FIRST_COMPLETENESS.md)
+- [Application Cases](APPLICATION_CASES.md)
+- [Workflow Reference](WORKFLOWS.md)
+- [AGENTS](../AGENTS.md)
+
+Run the focused documentation checks before calling the change complete:
+
+```sh
+PYTHONPATH=tests uv run python -m unittest tests/test_router_content.py -v
+uv run python -m src.cli docs workflows --check
+git diff --check
+```

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -171,6 +171,8 @@ class RouterContentTests(unittest.TestCase):
     def test_first_release_trust_surfaces_are_present(self) -> None:
         required_paths = [
             Path("README.md"),
+            Path("AGENTS.md"),
+            Path("docs/DIRECTION.md"),
             Path("docs/INSTALLATION.md"),
             Path("docs/APPLICATION_CASES.md"),
             Path("docs/RELEASE.md"),
@@ -210,6 +212,21 @@ class RouterContentTests(unittest.TestCase):
         self.assertIn("Pinned stable install", release)
         self.assertIn("Runtime evidence smoke", release)
         self.assertIn("Capability probe status", release)
+
+    def test_direction_and_agent_contract_lock_product_boundary(self) -> None:
+        direction = Path("docs/DIRECTION.md").read_text(encoding="utf-8")
+        agents = Path("AGENTS.md").read_text(encoding="utf-8")
+
+        self.assertIn("OMHM is a Hermes-native wrapper orchestration layer.", direction)
+        self.assertIn("Hermes owns:", direction)
+        self.assertIn("OMH owns:", direction)
+        self.assertIn("Codex-like executors own:", direction)
+        self.assertIn("prepared_not_observed", direction)
+        self.assertIn("One user goal should normally produce one PR.", direction)
+        self.assertIn("Keep users command-agnostic in chat.", direction)
+        self.assertIn("Do not turn OMHM into a hidden Hermes runtime patch", agents)
+        self.assertIn("One user goal should normally produce one PR.", agents)
+        self.assertIn("review feedback or small follow-up fixes", agents)
 
     def test_application_cases_document_representative_flows(self) -> None:
         text = Path("docs/APPLICATION_CASES.md").read_text(encoding="utf-8")

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -172,6 +172,7 @@ class RouterContentTests(unittest.TestCase):
         required_paths = [
             Path("README.md"),
             Path("AGENTS.md"),
+            Path("docs/README.md"),
             Path("docs/DIRECTION.md"),
             Path("docs/INSTALLATION.md"),
             Path("docs/APPLICATION_CASES.md"),
@@ -200,6 +201,7 @@ class RouterContentTests(unittest.TestCase):
         release = Path("docs/RELEASE.md").read_text(encoding="utf-8")
 
         self.assertIn("curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes-agent/main/install.sh | sh", readme)
+        self.assertIn("[Documentation](docs/README.md)", readme)
         self.assertIn("[Installation](docs/INSTALLATION.md)", readme)
         self.assertIn("[Application Cases](docs/APPLICATION_CASES.md)", readme)
         self.assertIn("OMH_CHANNEL=stable OMH_VERSION=0.1.0", readme)
@@ -215,15 +217,21 @@ class RouterContentTests(unittest.TestCase):
 
     def test_direction_and_agent_contract_lock_product_boundary(self) -> None:
         direction = Path("docs/DIRECTION.md").read_text(encoding="utf-8")
+        docs_index = Path("docs/README.md").read_text(encoding="utf-8")
         agents = Path("AGENTS.md").read_text(encoding="utf-8")
 
         self.assertIn("OMHM is a Hermes-native wrapper orchestration layer.", direction)
+        self.assertIn("Raise the product's capability level by strengthening contracts", direction)
         self.assertIn("Hermes owns:", direction)
         self.assertIn("OMH owns:", direction)
         self.assertIn("Codex-like executors own:", direction)
         self.assertIn("prepared_not_observed", direction)
         self.assertIn("One user goal should normally produce one PR.", direction)
         self.assertIn("Keep users command-agnostic in chat.", direction)
+        self.assertIn("The goal is parity of seriousness, not parity of implementation shape.", direction)
+        self.assertIn("This directory is the public operating map", docs_index)
+        self.assertIn("prepared versus observed evidence", docs_index)
+        self.assertIn("Chat users should remain command-agnostic.", docs_index)
         self.assertIn("Do not turn OMHM into a hidden Hermes runtime patch", agents)
         self.assertIn("One user goal should normally produce one PR.", agents)
         self.assertIn("review feedback or small follow-up fixes", agents)


### PR DESCRIPTION
## Summary
- Add docs/DIRECTION.md as the product charter for Hermes-native wrapper orchestration.
- Add repo-local AGENTS.md to lock agent behavior, including one user goal per PR and keeping review/CI fixes in the active goal PR.
- Link the direction charter from README, architecture, and delegation-first docs.
- Add tests that keep the direction and agent contract present and aligned.

## Verification
- PYTHONPATH=tests uv run python -m unittest tests/test_router_content.py -v
- PYTHONPATH=tests uv run python -m unittest discover -s tests -v
- uv run python -m compileall -q src tests
- uv run python -m src.cli docs workflows --check
- git diff --check

## Boundary
- Documentation and contract guidance only.
- No Hermes core changes.
- No transport, LLM, API, or network behavior added.
- One coherent goal in one PR; follow-up review fixes should stay in this PR.