### PR TITLE
Add wrapper delivery status artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,10 +143,14 @@ message edits, dispatch, and platform credentials.
 - delegation observation in `delegation.json`
 - prepared coding handoffs in `coding_delegation.json`
 - wrapper observation in `wrapper.json`
+- review, CI, and merge evidence in `review.json`, `ci.json`, and
+  `merge.json`
 
 Prepared handoff is never treated as implementation, review, CI, or merge
 evidence by itself. If the wrapper cannot prove that a step happened, status
 should stay `prepared_not_observed`, `not_observed`, or `not_available`.
+Status readers evaluate the full run ledger conservatively: a later merge-ready
+artifact cannot override missing verification, review, or CI evidence.
 
 ## Routing Model
 

--- a/docs/DELEGATION_FIRST_COMPLETENESS.md
+++ b/docs/DELEGATION_FIRST_COMPLETENESS.md
@@ -34,7 +34,9 @@ evidence exists.
 | `omh coding delegate` | Prepares metadata-only coding handoffs and records `prepared_not_observed` evidence. | `src/coding_delegation.py`, `src/runtime_artifacts.py` |
 | `omh coding lifecycle` | Tracks Codex handoff dispatch, executor result, verification, and reportable status from existing runtime evidence. | `src/coding_lifecycle.py`, `tests/test_coding_lifecycle.py`, `tests/test_cli.py` |
 | `omh runtime wrapper` | Lets wrappers record what they actually observed after dispatch. | `src/runtime_artifacts.py`, `README.md` |
+| `omh runtime review`, `omh runtime ci`, `omh runtime merge` | Records observed review, CI, merge-readiness, and merge evidence under the run ledger. | `src/runtime_artifacts.py`, `src/runtime_records.py`, `tests/test_cli.py` |
 | `omh runtime validate/export` | Validates and exports local evidence without storing prompt bodies by default. | `src/runtime_artifacts.py`, `tests/test_runtime_artifacts.py` |
+| `examples/wrapper-golden/` | Provides platform-neutral golden chat responses for wrapper button/thread/status UX. | `examples/wrapper-golden/status-ladder.json`, `tests/test_wrapper_golden_examples.py` |
 
 The strongest existing path is:
 
@@ -55,8 +57,7 @@ The strongest existing path is:
 | Priority | Gap | Why it matters | Target story |
 | --- | --- | --- | --- |
 | P0 | Actual Discord and Slack adapters are not implemented in this repository. | The core contract is ready, but platform auth, retries, edits, and posting still belong to wrapper projects. | Build example adapter shims only after transport dependencies and packaging are approved. |
-| P0 | Review, CI, and merge evidence need richer first-class run-level records. | Session state now preserves plan decisions, so the next evidence gap is downstream delivery status. | Add explicit run-level review/CI/merge observation records without moving execution claims into sessions. |
-| P1 | Chat response examples are schema-level, not transport-level. | Adapter authors need clear button/thread/status update examples without duplicating policy. | Add Discord/Slack pseudocode fixtures and golden JSON examples. |
+| P1 | Adapter projects still need transport-specific examples. | Golden JSON locks the wrapper contract, but production bots need platform auth, retry, edit, and thread patterns. | Add adapter shims only after transport dependencies are approved. |
 | P2 | Lifecycle reporting is Codex-oriented only. | Future executor targets may need the same state machine without weakening the Codex default. | Generalize only after another executor contract exists. |
 
 ## First Implementation Contract
@@ -105,6 +106,9 @@ Wrappers should be able to express the chain in human terms:
    according to wrapper evidence.
 4. Review, verification, CI, and merge status stay separate from prepared
    delegation until observed.
+5. Status readers evaluate the full run ledger conservatively. A later
+   `merge.json` cannot make a run look merge-ready if verification, review, or
+   CI is missing, failed, blocked, or contradictory.
 
 This avoids the most dangerous failure mode: Hermes sounding like it performed
 coding work that only a prepared handoff requested.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -111,13 +111,16 @@ run_id="$(printf '%s' "$start_json" | python -c 'import json,sys; print(json.loa
 omh coding lifecycle dispatch --run "$run_id"
 omh coding lifecycle result --run "$run_id" --result completed --evidence-ref codex-log
 omh coding lifecycle verify --run "$run_id" --completion-status completed
+omh runtime review --run "$run_id" --status passed --reviewer code-review --evidence-ref review-comment
+omh runtime ci --run "$run_id" --status passed --check "unit:passed"
+omh runtime merge --run "$run_id" --ready --target-branch main
 omh coding lifecycle report --run "$run_id"
 ```
 
 The lifecycle commands write the same local runtime artifacts as the lower-level
 runtime commands. They reject invalid transitions, keep prepared handoff separate
 from execution evidence, and continue to block final completion copy when review
-or verification evidence is missing.
+verification, review, CI, or merge-readiness evidence is missing.
 
 Lower-level debug surfaces remain available when an adapter needs them:
 
@@ -144,6 +147,11 @@ For hosted bots, run these commands inside the same container, virtual
 environment, or user account that owns the wrapper runtime. If the wrapper can
 observe executor, review, verification, CI, or merge evidence, record it
 explicitly; otherwise keep the status conservative.
+
+Wrapper-facing golden examples live under `examples/wrapper-golden/`. They show
+the expected `chat_response/v1` copy and platform-neutral action ids for
+clarification, planning, handoff, review, CI, merge-ready, merged, and
+contradictory-evidence states.
 
 Use `omh runtime export --redacted` when you need a portable support artifact.
 Exports redact prompt, response, token, secret, key, and password-shaped fields by

--- a/examples/wrapper-golden/status-ladder.json
+++ b/examples/wrapper-golden/status-ladder.json
@@ -1,0 +1,136 @@
+{
+  "schema_version": "wrapper_golden_examples/v1",
+  "description": "Platform-neutral wrapper examples for chat status rendering. These are deterministic examples, not platform SDK fixtures.",
+  "scenarios": [
+    {
+      "scenario": "clarify_needed",
+      "source": "discord",
+      "input_kind": "natural_language",
+      "expected_response": {
+        "schema_version": "chat_response/v1",
+        "kind": "clarification",
+        "headline": "I need one clarification before routing this.",
+        "body": "The request is not specific enough for a safe workflow handoff.",
+        "action_ids": ["answer:clarify", "cancel"]
+      },
+      "claim_boundary": "No execution has started."
+    },
+    {
+      "scenario": "plan_presented",
+      "source": "slack",
+      "input_kind": "natural_language",
+      "expected_response": {
+        "schema_version": "chat_response/v1",
+        "kind": "plan",
+        "headline": "I drafted a plan for this request.",
+        "body": "The user can accept or revise the plan before any handoff is prepared.",
+        "action_ids": ["accept_plan", "revise_plan"]
+      },
+      "claim_boundary": "A draft plan is not execution evidence."
+    },
+    {
+      "scenario": "handoff_prepared",
+      "source": "discord",
+      "input_kind": "linked_run_status",
+      "expected_response": {
+        "schema_version": "chat_response/v1",
+        "kind": "handoff",
+        "headline": "A Codex handoff is ready.",
+        "body": "The handoff is prepared, but executor dispatch is not observed yet.",
+        "action_ids": ["send_to_codex", "show_status"]
+      },
+      "claim_boundary": "Prepared handoff is not execution evidence."
+    },
+    {
+      "scenario": "dispatched_executor_not_observed",
+      "source": "slack",
+      "input_kind": "linked_run_status",
+      "expected_response": {
+        "schema_version": "chat_response/v1",
+        "kind": "status",
+        "headline": "The handoff was dispatched.",
+        "body": "Executor completion is not observed yet.",
+        "action_ids": ["show_status"]
+      },
+      "claim_boundary": "Dispatch is not completion evidence."
+    },
+    {
+      "scenario": "review_pending",
+      "source": "discord",
+      "input_kind": "linked_run_status",
+      "expected_response": {
+        "schema_version": "chat_response/v1",
+        "kind": "status",
+        "headline": "Executor completion needs review evidence.",
+        "body": "Review evidence is required before completion is reported.",
+        "action_ids": ["show_status"]
+      },
+      "claim_boundary": "Execution is observed; review is not."
+    },
+    {
+      "scenario": "ci_pending",
+      "source": "slack",
+      "input_kind": "linked_run_status",
+      "expected_response": {
+        "schema_version": "chat_response/v1",
+        "kind": "status",
+        "headline": "Review passed; CI evidence is still missing.",
+        "body": "Merge readiness is not reported until CI evidence is observed.",
+        "action_ids": ["show_status"]
+      },
+      "claim_boundary": "Review is not CI evidence."
+    },
+    {
+      "scenario": "ci_failed",
+      "source": "discord",
+      "input_kind": "linked_run_status",
+      "expected_response": {
+        "schema_version": "chat_response/v1",
+        "kind": "blocker",
+        "headline": "CI is blocking completion.",
+        "body": "The failing or blocked CI checks are surfaced instead of claiming merge readiness.",
+        "action_ids": ["show_status"]
+      },
+      "claim_boundary": "Failed CI is not merge-ready."
+    },
+    {
+      "scenario": "merge_ready",
+      "source": "slack",
+      "input_kind": "linked_run_status",
+      "expected_response": {
+        "schema_version": "chat_response/v1",
+        "kind": "status",
+        "headline": "This is ready to merge.",
+        "body": "Execution, verification, review, CI, and merge-readiness evidence are observed.",
+        "action_ids": ["show_status"]
+      },
+      "claim_boundary": "Ready to merge is not the same as merged."
+    },
+    {
+      "scenario": "merged",
+      "source": "discord",
+      "input_kind": "linked_run_status",
+      "expected_response": {
+        "schema_version": "chat_response/v1",
+        "kind": "status",
+        "headline": "This has been merged.",
+        "body": "Merge evidence is observed in the runtime ledger.",
+        "action_ids": ["show_status"]
+      },
+      "claim_boundary": "Merged status is backed by runtime ledger evidence."
+    },
+    {
+      "scenario": "contradictory_merge_ready_without_ci",
+      "source": "slack",
+      "input_kind": "linked_run_status",
+      "expected_response": {
+        "schema_version": "chat_response/v1",
+        "kind": "status",
+        "headline": "Review passed; CI evidence is still missing.",
+        "body": "A later merge-ready artifact cannot override the missing CI gate.",
+        "action_ids": ["show_status"]
+      },
+      "claim_boundary": "The upstream CI blocker is shown instead of merge-ready."
+    }
+  ]
+}

--- a/src/cli.py
+++ b/src/cli.py
@@ -692,6 +692,9 @@ def cmd_runtime_review(args: argparse.Namespace) -> int:
     preflight = summarize_delegated_coding_status(paths, args.run_id)
     if args.status in {"passed", "not_required"} and preflight.get("next_action") != "record_review_evidence":
         raise OmhError(f"cannot record review {args.status} while next_action is {preflight.get('next_action')}")
+    review_status = preflight.get("review", {})
+    if args.status == "not_required" and isinstance(review_status, dict) and review_status.get("required"):
+        raise OmhError("cannot mark required review as not_required")
     try:
         review = write_review_record(
             run_dir,
@@ -717,6 +720,9 @@ def cmd_runtime_ci(args: argparse.Namespace) -> int:
     preflight = summarize_delegated_coding_status(paths, args.run_id)
     if args.status == "passed" and preflight.get("next_action") != "record_ci_evidence":
         raise OmhError(f"cannot record passed CI while next_action is {preflight.get('next_action')}")
+    ci_status = preflight.get("ci", {})
+    if args.status == "not_required" and isinstance(ci_status, dict) and ci_status.get("required"):
+        raise OmhError("cannot mark required CI as not_required")
     try:
         ci = write_ci_record(
             run_dir,

--- a/src/cli.py
+++ b/src/cli.py
@@ -40,8 +40,11 @@ from .probe import probe_capabilities
 from .recommend import recommend_skills
 from .release import RELEASE_CHANNELS, package_url_for
 from .runtime_artifacts import (
+    CI_STATUSES,
     DELEGATION_RESULTS,
+    MERGE_STATUSES,
     PRIVACY_MODES,
+    REVIEW_STATUSES,
     RUN_STATUSES,
     create_prepared_coding_delegation_run,
     create_run,
@@ -53,8 +56,11 @@ from .runtime_artifacts import (
     summarize_delegated_coding_status,
     update_state,
     validate_runtime,
+    write_ci_record,
     write_coding_delegation,
     write_delegation,
+    write_merge_record,
+    write_review_record,
     write_routing_decision,
     write_wrapper_contract,
 )
@@ -678,6 +684,104 @@ def cmd_runtime_wrapper(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_runtime_review(args: argparse.Namespace) -> int:
+    paths = _paths(args)
+    run_dir = paths.runtime_runs_dir / args.run_id
+    if not (run_dir / "run.json").exists():
+        raise OmhError(f"runtime run not found: {args.run_id}")
+    preflight = summarize_delegated_coding_status(paths, args.run_id)
+    if args.status in {"passed", "not_required"} and preflight.get("next_action") != "record_review_evidence":
+        raise OmhError(f"cannot record review {args.status} while next_action is {preflight.get('next_action')}")
+    try:
+        review = write_review_record(
+            run_dir,
+            {
+                "status": args.status,
+                "required": args.status != "not_required",
+                "reviewer": args.reviewer or "",
+                "evidence_refs": args.evidence_ref or [],
+                "summary": args.summary or "",
+            },
+        )
+    except ValueError as exc:
+        raise OmhError(str(exc)) from exc
+    _print_json({"review": review, "status": summarize_delegated_coding_status(paths, args.run_id)})
+    return 0
+
+
+def cmd_runtime_ci(args: argparse.Namespace) -> int:
+    paths = _paths(args)
+    run_dir = paths.runtime_runs_dir / args.run_id
+    if not (run_dir / "run.json").exists():
+        raise OmhError(f"runtime run not found: {args.run_id}")
+    preflight = summarize_delegated_coding_status(paths, args.run_id)
+    if args.status == "passed" and preflight.get("next_action") != "record_ci_evidence":
+        raise OmhError(f"cannot record passed CI while next_action is {preflight.get('next_action')}")
+    try:
+        ci = write_ci_record(
+            run_dir,
+            {
+                "status": args.status,
+                "required": args.status != "not_required",
+                "provider": args.provider or "",
+                "checks": args.check or [],
+                "evidence_refs": args.evidence_ref or [],
+                "summary": args.summary or "",
+            },
+        )
+    except ValueError as exc:
+        raise OmhError(str(exc)) from exc
+    _print_json({"ci": ci, "status": summarize_delegated_coding_status(paths, args.run_id)})
+    return 0
+
+
+def cmd_runtime_merge(args: argparse.Namespace) -> int:
+    paths = _paths(args)
+    run_dir = paths.runtime_runs_dir / args.run_id
+    if not (run_dir / "run.json").exists():
+        raise OmhError(f"runtime run not found: {args.run_id}")
+    selected_statuses = [
+        status
+        for status, selected in (
+            ("ready", args.ready),
+            ("merged", args.merged),
+            ("blocked", args.blocked),
+            (args.status, bool(args.status)),
+        )
+        if selected
+    ]
+    if len(selected_statuses) > 1:
+        raise OmhError("runtime merge accepts only one of --ready, --merged, --blocked, or --status")
+    status = selected_statuses[0] if selected_statuses else None
+    if not status:
+        raise OmhError("runtime merge requires --ready, --merged, --blocked, or --status")
+    preflight = summarize_delegated_coding_status(paths, args.run_id)
+    allowed_preflight = {
+        "ready": {"record_merge_readiness", "report_merge_ready"},
+        "merged": {"report_merge_ready"},
+        "blocked": {"record_merge_readiness", "report_merge_ready"},
+        "not_ready": {"record_merge_readiness", "report_merge_ready", "report_completion_with_evidence"},
+        "not_observed": {"record_merge_readiness", "report_merge_ready", "report_completion_with_evidence"},
+    }
+    if status in allowed_preflight and preflight.get("next_action") not in allowed_preflight[status]:
+        raise OmhError(f"cannot record merge {status} while next_action is {preflight.get('next_action')}")
+    try:
+        merge = write_merge_record(
+            run_dir,
+            {
+                "status": status,
+                "target_branch": args.target_branch or "",
+                "merge_commit": args.merge_commit or "",
+                "evidence_refs": args.evidence_ref or [],
+                "summary": args.summary or "",
+            },
+        )
+    except ValueError as exc:
+        raise OmhError(str(exc)) from exc
+    _print_json({"merge": merge, "status": summarize_delegated_coding_status(paths, args.run_id)})
+    return 0
+
+
 def cmd_runtime_validate(args: argparse.Namespace) -> int:
     result = validate_runtime(_paths(args), args.run_id)
     _print_json(result)
@@ -1125,6 +1229,36 @@ def _add_runtime_commands(sub) -> None:
     runtime_wrapper.add_argument("--gap", action="append")
     runtime_wrapper.add_argument("--message", default="")
     runtime_wrapper.set_defaults(func=cmd_runtime_wrapper)
+
+    runtime_review = runtime_sub.add_parser("review")
+    runtime_review.add_argument("--run", dest="run_id", required=True)
+    runtime_review.add_argument("--status", choices=REVIEW_STATUSES, required=True)
+    runtime_review.add_argument("--reviewer", default="")
+    runtime_review.add_argument("--evidence-ref", action="append")
+    runtime_review.add_argument("--summary", default="")
+    runtime_review.set_defaults(func=cmd_runtime_review)
+
+    runtime_ci = runtime_sub.add_parser("ci")
+    runtime_ci.add_argument("--run", dest="run_id", required=True)
+    runtime_ci.add_argument("--status", choices=CI_STATUSES, required=True)
+    runtime_ci.add_argument("--provider", default="")
+    runtime_ci.add_argument("--check", action="append")
+    runtime_ci.add_argument("--evidence-ref", action="append")
+    runtime_ci.add_argument("--summary", default="")
+    runtime_ci.set_defaults(func=cmd_runtime_ci)
+
+    runtime_merge = runtime_sub.add_parser("merge")
+    runtime_merge.add_argument("--run", dest="run_id", required=True)
+    merge_status = runtime_merge.add_mutually_exclusive_group()
+    merge_status.add_argument("--ready", action="store_true")
+    merge_status.add_argument("--merged", action="store_true")
+    merge_status.add_argument("--blocked", action="store_true")
+    merge_status.add_argument("--status", choices=MERGE_STATUSES, default=None)
+    runtime_merge.add_argument("--target-branch", default="")
+    runtime_merge.add_argument("--merge-commit", default="")
+    runtime_merge.add_argument("--evidence-ref", action="append")
+    runtime_merge.add_argument("--summary", default="")
+    runtime_merge.set_defaults(func=cmd_runtime_merge)
 
     runtime_validate = runtime_sub.add_parser("validate")
     runtime_validate.add_argument("--run", dest="run_id", default=None)

--- a/src/coding_lifecycle.py
+++ b/src/coding_lifecycle.py
@@ -163,13 +163,16 @@ def record_codex_verification(
 def report_codex_delegation_lifecycle(paths: OmhPaths, run_id: str) -> dict[str, object]:
     status = summarize_delegated_coding_status(paths, run_id)
     next_action = str(status.get("next_action", "unknown"))
+    completion_report_actions = {"report_completion_with_evidence"}
+    terminal_report_actions = {"report_completion_with_evidence", "report_merge_ready", "report_merged"}
     report = dict(status)
     report.update(
         {
             "lifecycle_schema_version": LIFECYCLE_SCHEMA_VERSION,
             "lifecycle_status": _lifecycle_status(next_action),
-            "can_report_completion": next_action == "report_completion_with_evidence",
-            "blocking_reason": "" if next_action == "report_completion_with_evidence" else _blocking_reason(next_action),
+            "can_report_completion": next_action in completion_report_actions,
+            "can_report_terminal_status": next_action in terminal_report_actions,
+            "blocking_reason": "" if next_action in terminal_report_actions else _blocking_reason(next_action),
             "artifact_paths": _artifact_paths(paths, run_id),
             "runtime_validation": validate_runtime(paths, run_id),
         }
@@ -192,9 +195,16 @@ def _lifecycle_status(next_action: str) -> str:
         "dispatch_to_executor": "prepared",
         "wait_for_executor_evidence": "dispatched",
         "surface_executor_blocker": "blocked",
+        "surface_review_blocker": "blocked",
+        "surface_ci_blocker": "blocked",
+        "surface_merge_blocker": "blocked",
         "record_review_evidence": "awaiting_review",
+        "record_ci_evidence": "awaiting_ci",
+        "record_merge_readiness": "awaiting_merge_readiness",
         "record_verification_evidence": "awaiting_verification",
         "report_completion_with_evidence": "reportable",
+        "report_merge_ready": "merge_ready",
+        "report_merged": "merged",
     }.get(next_action, "unknown")
 
 
@@ -206,7 +216,12 @@ def _blocking_reason(next_action: str) -> str:
         "dispatch_to_executor": "executor dispatch is not observed",
         "wait_for_executor_evidence": "executor evidence is not observed",
         "surface_executor_blocker": "executor reported blocked or failed",
+        "surface_review_blocker": "review failed or blocked completion",
+        "surface_ci_blocker": "CI failed or blocked completion",
+        "surface_merge_blocker": "merge is blocked",
         "record_review_evidence": "review evidence is required before completion can be reported",
+        "record_ci_evidence": "CI evidence is required before merge readiness can be reported",
+        "record_merge_readiness": "merge readiness evidence is required before merge-ready status can be reported",
         "record_verification_evidence": "verification evidence is required before completion can be reported",
     }.get(next_action, "lifecycle status is not reportable")
 
@@ -219,4 +234,7 @@ def _artifact_paths(paths: OmhPaths, run_id: str) -> dict[str, str]:
         "coding_delegation": str(run_dir / "coding_delegation.json"),
         "delegation": str(run_dir / "delegation.json"),
         "wrapper": str(run_dir / "wrapper.json"),
+        "review": str(run_dir / "review.json"),
+        "ci": str(run_dir / "ci.json"),
+        "merge": str(run_dir / "merge.json"),
     }

--- a/src/runtime_artifacts.py
+++ b/src/runtime_artifacts.py
@@ -453,12 +453,12 @@ def _review_status_summary(
     if record:
         status = str(record.get("status", "not_observed"))
         observed = bool(record.get("observed", False))
-        required = bool(record.get("required", required))
+        required = required or bool(record.get("required", required))
         return {
             "required": required,
             "observed": observed,
             "status": status,
-            "satisfied": observed and status in {"passed", "not_required"},
+            "satisfied": observed and (status == "passed" or (status == "not_required" and not required)),
             "reviewer": record.get("reviewer", ""),
             "evidence_refs": record.get("evidence_refs", []),
             "summary": record.get("summary", ""),
@@ -481,11 +481,13 @@ def _ci_status_summary(required: bool, record: dict[str, Any]) -> dict[str, Any]
         observed = bool(record.get("observed", False))
         checks = record.get("checks", [])
         checks_passed = bool(checks) and all(isinstance(check, dict) and check.get("status") == "passed" for check in checks)
+        checks_not_required = all(isinstance(check, dict) and check.get("status") == "not_required" for check in checks)
+        required = required or bool(record.get("required", required))
         return {
-            "required": bool(record.get("required", required)),
+            "required": required,
             "observed": observed,
             "status": status,
-            "satisfied": observed and (status == "not_required" or (status == "passed" and checks_passed)),
+            "satisfied": observed and ((status == "not_required" and not required and checks_not_required) or (status == "passed" and checks_passed)),
             "provider": record.get("provider", ""),
             "checks": checks,
             "evidence_refs": record.get("evidence_refs", []),
@@ -728,7 +730,8 @@ def _validate_run_status_gate_consistency(run_dir: Path) -> list[str]:
     handoff_review = _object_or_empty(handoff.get("review"))
     review_required = bool(handoff_review.get("required", coding.get("review_required", False)))
     review_status = _review_status_summary(review_required, handoff_review.get("workflow"), handoff_review, review_record)
-    ci_required = bool(ci_record) or review_status["status"] == "passed"
+    ci_required_by_ladder = review_status["status"] == "passed"
+    ci_required = bool(ci_record) or ci_required_by_ladder
     ci_status = _ci_status_summary(ci_required, ci_record)
 
     execution_satisfied = bool(delegation.get("observed", False)) and delegation.get("result") == "completed"
@@ -737,6 +740,10 @@ def _validate_run_status_gate_consistency(run_dir: Path) -> list[str]:
     ci_path = run_dir / "ci.json"
     merge_path = run_dir / "merge.json"
 
+    if review_required and review_record.get("status") == "not_required":
+        errors.append(f"{review_path}: review not_required cannot downgrade required review evidence")
+    if ci_required_by_ladder and ci_record.get("status") == "not_required":
+        errors.append(f"{ci_path}: ci not_required cannot downgrade required CI evidence")
     if review_record.get("status") == "passed" and not verification_satisfied:
         errors.append(f"{review_path}: review passed requires verification evidence")
     if ci_record.get("status") == "passed":

--- a/src/runtime_artifacts.py
+++ b/src/runtime_artifacts.py
@@ -16,6 +16,9 @@ from .runtime_records import (
     OBSERVED_RESULTS,
     OPTIONAL_RECORD_VALIDATORS,
     PRIVACY_MODES,
+    CI_STATUSES,
+    MERGE_STATUSES,
+    REVIEW_STATUSES,
     RUN_STATUSES,
     SCHEMA_VERSION,
     UNOBSERVED_RESULTS,
@@ -23,13 +26,19 @@ from .runtime_records import (
     build_delegation_record,
     build_coding_delegation_record,
     build_event_record,
+    build_ci_record,
     build_routing_record,
+    build_merge_record,
+    build_review_record,
     build_run_record,
     build_wrapper_record,
     validate_delegation_record,
     validate_coding_delegation_record,
+    validate_ci_record,
     validate_delegation_result,
     validate_event_record,
+    validate_merge_record,
+    validate_review_record,
     validate_routing_record,
     validate_run_record,
     validate_wrapper_record,
@@ -200,6 +209,56 @@ def write_coding_delegation(run_dir: Path, delegation: dict[str, Any]) -> dict[s
     return record
 
 
+def _run_id_for_dir(run_dir: Path) -> str:
+    run = read_json_object(run_dir / "run.json") if (run_dir / "run.json").exists() else None
+    return str(run.get("run_id", run_dir.name)) if isinstance(run, dict) else run_dir.name
+
+
+def write_review_record(run_dir: Path, review: dict[str, Any]) -> dict[str, Any]:
+    record = build_review_record({"run_id": _run_id_for_dir(run_dir), **review})
+    atomic_write_json(run_dir / "review.json", record, private=True)
+    append_event(
+        run_dir,
+        {
+            "event": "review_recorded",
+            "level": "info",
+            "message": f"review {record['status']}",
+            "data": {"status": record["status"], "observed": record["observed"], "required": record["required"]},
+        },
+    )
+    return record
+
+
+def write_ci_record(run_dir: Path, ci: dict[str, Any]) -> dict[str, Any]:
+    record = build_ci_record({"run_id": _run_id_for_dir(run_dir), **ci})
+    atomic_write_json(run_dir / "ci.json", record, private=True)
+    append_event(
+        run_dir,
+        {
+            "event": "ci_recorded",
+            "level": "info",
+            "message": f"ci {record['status']}",
+            "data": {"status": record["status"], "observed": record["observed"], "required": record["required"]},
+        },
+    )
+    return record
+
+
+def write_merge_record(run_dir: Path, merge: dict[str, Any]) -> dict[str, Any]:
+    record = build_merge_record({"run_id": _run_id_for_dir(run_dir), **merge})
+    atomic_write_json(run_dir / "merge.json", record, private=True)
+    append_event(
+        run_dir,
+        {
+            "event": "merge_recorded",
+            "level": "info",
+            "message": f"merge {record['status']}",
+            "data": {"status": record["status"], "observed": record["observed"], "ready": record["ready"], "merged": record["merged"]},
+        },
+    )
+    return record
+
+
 def list_runs(paths: OmhPaths) -> list[dict[str, Any]]:
     if not paths.runtime_runs_dir.exists():
         return []
@@ -231,6 +290,9 @@ def show_run(paths: OmhPaths, run_id: str) -> dict[str, Any]:
         "coding_delegation": read_json_object(run_dir / "coding_delegation.json"),
         "delegation": read_json_object(run_dir / "delegation.json"),
         "wrapper": read_json_object(run_dir / "wrapper.json"),
+        "review": read_json_object(run_dir / "review.json"),
+        "ci": read_json_object(run_dir / "ci.json"),
+        "merge": read_json_object(run_dir / "merge.json"),
         "evidence": sorted(path.name for path in evidence_dir.iterdir()) if evidence_dir.exists() else [],
     }
 
@@ -263,6 +325,9 @@ def summarize_delegated_coding_status(paths: OmhPaths, run_id: str) -> dict[str,
     coding = _object_or_empty(shown.get("coding_delegation"))
     delegation = _object_or_empty(shown.get("delegation"))
     wrapper = _object_or_empty(shown.get("wrapper"))
+    review_record = _object_or_empty(shown.get("review"))
+    ci_record = _object_or_empty(shown.get("ci"))
+    merge_record = _object_or_empty(shown.get("merge"))
     handoff = _object_or_empty(coding.get("executor_handoff"))
     review = _object_or_empty(handoff.get("review"))
 
@@ -278,6 +343,11 @@ def summarize_delegated_coding_status(paths: OmhPaths, run_id: str) -> dict[str,
     completion_status = str(wrapper.get("completion_status") or "unknown")
     review_required = bool(review.get("required", coding.get("review_required", False)))
     review_workflow = review.get("workflow") if review else coding.get("review_workflow")
+    review_status = _review_status_summary(review_required, review_workflow, review, review_record)
+    ci_required = bool(ci_record) or review_status["status"] == "passed"
+    ci_status = _ci_status_summary(ci_required, ci_record)
+    merge_required = bool(merge_record) or ci_status["status"] == "passed"
+    merge_status = _merge_status_summary(merge_required, merge_record)
 
     next_action = _delegated_status_next_action(
         prepared=prepared,
@@ -285,8 +355,10 @@ def summarize_delegated_coding_status(paths: OmhPaths, run_id: str) -> dict[str,
         prompt_dispatched=prompt_dispatched,
         execution_observed=execution_observed,
         execution_status=execution_status,
-        review_required=review_required,
         verification_observed=verification_observed,
+        review_status=review_status,
+        ci_status=ci_status,
+        merge_status=merge_status,
     )
     integrity_warnings = _delegated_status_integrity_warnings(
         run=run,
@@ -329,11 +401,20 @@ def summarize_delegated_coding_status(paths: OmhPaths, run_id: str) -> dict[str,
             "expected": coding.get("verification", []),
         },
         "review": {
-            "required": review_required,
+            **review_status,
             "workflow": review_workflow,
-            "status": "not_observed" if review_required else "not_required",
             "evidence_required": review.get("evidence_required", "Record review evidence separately before claiming review observed."),
         },
+        "ci": ci_status,
+        "merge_readiness": {
+            "required": merge_status["required"],
+            "status": "ready" if merge_status["status"] in {"ready", "merged"} else merge_status["status"],
+            "observed": merge_status["observed"],
+            "target_branch": merge_status["target_branch"],
+            "evidence_refs": merge_status["evidence_refs"],
+            "summary": merge_status["summary"],
+        },
+        "merge": merge_status,
         "next_action": next_action,
         "safe_summary": _delegated_status_summary(
             prepared=prepared,
@@ -342,8 +423,10 @@ def summarize_delegated_coding_status(paths: OmhPaths, run_id: str) -> dict[str,
             prompt_dispatched=prompt_dispatched,
             execution_observed=execution_observed,
             execution_status=execution_status,
-            review_required=review_required,
             verification_observed=verification_observed,
+            review_status=review_status,
+            ci_status=ci_status,
+            merge_status=merge_status,
         ),
         "integrity": {
             "ok": not integrity_warnings,
@@ -361,6 +444,105 @@ def _object_or_empty(value: Any) -> dict[str, Any]:
     return value if isinstance(value, dict) else {}
 
 
+def _review_status_summary(
+    required: bool,
+    workflow: Any,
+    handoff_review: dict[str, Any],
+    record: dict[str, Any],
+) -> dict[str, Any]:
+    if record:
+        status = str(record.get("status", "not_observed"))
+        observed = bool(record.get("observed", False))
+        required = bool(record.get("required", required))
+        return {
+            "required": required,
+            "observed": observed,
+            "status": status,
+            "satisfied": observed and status in {"passed", "not_required"},
+            "reviewer": record.get("reviewer", ""),
+            "evidence_refs": record.get("evidence_refs", []),
+            "summary": record.get("summary", ""),
+        }
+    status = "not_observed" if required else "not_required"
+    return {
+        "required": required,
+        "observed": not required,
+        "status": status,
+        "satisfied": not required,
+        "reviewer": "",
+        "evidence_refs": [],
+        "summary": "",
+    }
+
+
+def _ci_status_summary(required: bool, record: dict[str, Any]) -> dict[str, Any]:
+    if record:
+        status = str(record.get("status", "not_observed"))
+        observed = bool(record.get("observed", False))
+        checks = record.get("checks", [])
+        checks_passed = bool(checks) and all(isinstance(check, dict) and check.get("status") == "passed" for check in checks)
+        return {
+            "required": bool(record.get("required", required)),
+            "observed": observed,
+            "status": status,
+            "satisfied": observed and (status == "not_required" or (status == "passed" and checks_passed)),
+            "provider": record.get("provider", ""),
+            "checks": checks,
+            "evidence_refs": record.get("evidence_refs", []),
+            "summary": record.get("summary", ""),
+        }
+    status = "not_observed" if required else "not_required"
+    return {
+        "required": required,
+        "observed": not required,
+        "status": status,
+        "satisfied": not required,
+        "provider": "",
+        "checks": [],
+        "evidence_refs": [],
+        "summary": "",
+    }
+
+
+def _merge_status_summary(required: bool, record: dict[str, Any]) -> dict[str, Any]:
+    if record:
+        status = str(record.get("status", "not_observed"))
+        observed = bool(record.get("observed", False))
+        ready = bool(record.get("ready", False))
+        merged = bool(record.get("merged", False))
+        merge_commit = str(record.get("merge_commit", ""))
+        evidence_refs = record.get("evidence_refs", [])
+        has_merge_evidence = bool(merge_commit) or bool(evidence_refs)
+        return {
+            "required": bool(record.get("required", required)),
+            "observed": observed,
+            "ready": ready,
+            "merged": merged,
+            "status": status,
+            "satisfied": observed
+            and (
+                (status == "ready" and ready and not merged)
+                or (status == "merged" and ready and merged and has_merge_evidence)
+            ),
+            "target_branch": record.get("target_branch", ""),
+            "merge_commit": merge_commit,
+            "evidence_refs": evidence_refs,
+            "summary": record.get("summary", ""),
+        }
+    return {
+        "required": required,
+        "observed": not required,
+        "ready": False,
+        "merged": False,
+        "status": "not_observed" if required else "not_required",
+        "satisfied": not required,
+        "target_branch": "",
+        "merge_commit": "",
+        "evidence_refs": [],
+        "summary": "",
+    }
+
+
 def _delegated_status_next_action(
     *,
     prepared: bool,
@@ -368,8 +550,10 @@ def _delegated_status_next_action(
     prompt_dispatched: bool,
     execution_observed: bool,
     execution_status: str,
-    review_required: bool,
     verification_observed: bool,
+    review_status: dict[str, Any],
+    ci_status: dict[str, Any],
+    merge_status: dict[str, Any],
 ) -> str:
     if not prepared:
         return "prepare_coding_delegation"
@@ -385,10 +569,24 @@ def _delegated_status_next_action(
         return "wait_for_executor_evidence"
     if execution_status in {"blocked", "failed"}:
         return "surface_executor_blocker"
-    if review_required:
-        return "record_review_evidence"
     if not verification_observed:
         return "record_verification_evidence"
+    if not review_status["satisfied"]:
+        if review_status["status"] in {"failed", "blocked"}:
+            return "surface_review_blocker"
+        return "record_review_evidence"
+    if not ci_status["satisfied"]:
+        if ci_status["status"] in {"failed", "blocked"}:
+            return "surface_ci_blocker"
+        return "record_ci_evidence"
+    if merge_status["status"] == "blocked":
+        return "surface_merge_blocker"
+    if merge_status["status"] == "merged" and merge_status["satisfied"]:
+        return "report_merged"
+    if merge_status["status"] == "ready" and merge_status["satisfied"]:
+        return "report_merge_ready"
+    if merge_status["required"]:
+        return "record_merge_readiness"
     return "report_completion_with_evidence"
 
 
@@ -400,8 +598,10 @@ def _delegated_status_summary(
     prompt_dispatched: bool,
     execution_observed: bool,
     execution_status: str,
-    review_required: bool,
     verification_observed: bool,
+    review_status: dict[str, Any],
+    ci_status: dict[str, Any],
+    merge_status: dict[str, Any],
 ) -> str:
     if not prepared:
         return "No prepared coding delegation was found for this run."
@@ -417,10 +617,24 @@ def _delegated_status_summary(
         return f"A {executor_target} coding handoff was dispatched, but executor completion is not observed yet."
     if execution_status in {"blocked", "failed"}:
         return f"The {executor_target} executor reported {execution_status}; do not claim completion."
-    if review_required:
-        return f"The {executor_target} executor is observed as {execution_status}, but review evidence is still required."
     if not verification_observed:
         return f"The {executor_target} executor is observed as {execution_status}, but verification evidence is not observed yet."
+    if not review_status["satisfied"]:
+        if review_status["status"] in {"failed", "blocked"}:
+            return f"The {executor_target} executor is observed as {execution_status}, but review is {review_status['status']}."
+        return f"The {executor_target} executor is observed as {execution_status}, but review evidence is still required."
+    if not ci_status["satisfied"]:
+        if ci_status["status"] in {"failed", "blocked"}:
+            return f"The {executor_target} executor is reviewed, but CI is {ci_status['status']}."
+        return f"The {executor_target} executor is reviewed, but CI evidence is still required."
+    if merge_status["status"] == "blocked":
+        return f"The {executor_target} executor is reviewed and CI passed, but merge is blocked."
+    if merge_status["status"] == "merged" and merge_status["satisfied"]:
+        return f"The {executor_target} executor is reviewed, CI passed, and merge evidence is observed."
+    if merge_status["status"] == "ready" and merge_status["satisfied"]:
+        return f"The {executor_target} executor is reviewed, CI passed, and the run is ready to merge."
+    if merge_status["required"]:
+        return f"The {executor_target} executor is reviewed and CI passed, but merge readiness is not observed yet."
     return f"The {executor_target} executor is observed as {execution_status} with wrapper verification evidence."
 
 
@@ -494,7 +708,52 @@ def validate_run_dir(run_dir: Path) -> dict[str, Any]:
             errors.append(f"{path}: {exc}")
         if record:
             errors.extend(f"{path}: {error}" for error in validator(record))
+    errors.extend(_validate_run_status_gate_consistency(run_dir))
     return {"run_id": run_dir.name, "ok": not errors, "errors": errors}
+
+
+def _validate_run_status_gate_consistency(run_dir: Path) -> list[str]:
+    errors: list[str] = []
+    run = _object_or_empty(read_json_object(run_dir / "run.json"))
+    coding = _object_or_empty(read_json_object(run_dir / "coding_delegation.json"))
+    delegation = _object_or_empty(read_json_object(run_dir / "delegation.json"))
+    wrapper = _object_or_empty(read_json_object(run_dir / "wrapper.json"))
+    review_record = _object_or_empty(read_json_object(run_dir / "review.json"))
+    ci_record = _object_or_empty(read_json_object(run_dir / "ci.json"))
+    merge_record = _object_or_empty(read_json_object(run_dir / "merge.json"))
+    if not run:
+        return errors
+
+    handoff = _object_or_empty(coding.get("executor_handoff"))
+    handoff_review = _object_or_empty(handoff.get("review"))
+    review_required = bool(handoff_review.get("required", coding.get("review_required", False)))
+    review_status = _review_status_summary(review_required, handoff_review.get("workflow"), handoff_review, review_record)
+    ci_required = bool(ci_record) or review_status["status"] == "passed"
+    ci_status = _ci_status_summary(ci_required, ci_record)
+
+    execution_satisfied = bool(delegation.get("observed", False)) and delegation.get("result") == "completed"
+    verification_satisfied = bool(wrapper.get("verification_observed", False))
+    review_path = run_dir / "review.json"
+    ci_path = run_dir / "ci.json"
+    merge_path = run_dir / "merge.json"
+
+    if review_record.get("status") == "passed" and not verification_satisfied:
+        errors.append(f"{review_path}: review passed requires verification evidence")
+    if ci_record.get("status") == "passed":
+        if not verification_satisfied:
+            errors.append(f"{ci_path}: ci passed requires verification evidence")
+        if not review_status["satisfied"]:
+            errors.append(f"{ci_path}: ci passed requires review passed or not_required")
+    if merge_record.get("status") in {"ready", "merged"}:
+        if not execution_satisfied:
+            errors.append(f"{merge_path}: merge {merge_record.get('status')} requires completed executor evidence")
+        if not verification_satisfied:
+            errors.append(f"{merge_path}: merge {merge_record.get('status')} requires verification evidence")
+        if not review_status["satisfied"]:
+            errors.append(f"{merge_path}: merge {merge_record.get('status')} requires review passed or not_required")
+        if not ci_status["satisfied"]:
+            errors.append(f"{merge_path}: merge {merge_record.get('status')} requires CI passed or not_required")
+    return errors
 
 
 def validate_runtime(paths: OmhPaths, run_id: str | None = None) -> dict[str, Any]:

--- a/src/runtime_records.py
+++ b/src/runtime_records.py
@@ -662,6 +662,8 @@ def validate_ci_record(ci: dict[str, Any]) -> list[str]:
     if ci.get("status") == "not_required":
         _require(ci.get("required") is False, errors, "ci not_required status requires required=false")
         _require(ci.get("observed") is True, errors, "ci not_required status must be observed")
+        invalid_checks = [check for check in checks if isinstance(check, dict) and check.get("status") != "not_required"]
+        _require(not invalid_checks, errors, "ci not_required status requires checks to be empty or not_required")
     if ci.get("observed") is False:
         _require(ci.get("status") in {"pending", "not_observed"}, errors, "ci observed=false requires pending or not_observed")
     if ci.get("status") == "passed":

--- a/src/runtime_records.py
+++ b/src/runtime_records.py
@@ -18,6 +18,10 @@ OBSERVED_RESULTS = ("completed", "blocked", "failed")
 UNOBSERVED_RESULTS = ("not_available", "not_observed")
 EVENT_LEVELS = ("debug", "info", "warning", "error")
 WRAPPER_COMPLETION_STATUSES = ("started", "completed", "blocked", "failed", "unknown")
+REVIEW_STATUSES = ("not_required", "pending", "passed", "failed", "blocked", "not_observed")
+CI_STATUSES = ("not_required", "pending", "passed", "failed", "blocked", "not_observed")
+CI_CHECK_STATUSES = ("passed", "failed", "blocked", "pending", "not_required")
+MERGE_STATUSES = ("not_ready", "ready", "merged", "blocked", "not_observed")
 ROUTE_ACTIONS = ("dispatch", "clarify", "fallback")
 ROUTE_CONFIDENCES = ("low", "medium", "high")
 ROUTING_RECOMMENDATION_KEYS = ("skill", "score", "confidence", "matched")
@@ -218,6 +222,77 @@ def build_wrapper_record(wrapper: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def build_review_record(review: dict[str, Any]) -> dict[str, Any]:
+    status = str(review.get("status", "not_observed"))
+    if status not in REVIEW_STATUSES:
+        raise ValueError(f"unsupported review status: {status}")
+    required = bool(review.get("required", status != "not_required"))
+    observed = bool(review.get("observed", status not in {"pending", "not_observed"}))
+    record = {
+        "schema_version": SCHEMA_VERSION,
+        "run_id": str(review.get("run_id", "")),
+        "updated_at": str(review.get("updated_at") or utc_now()),
+        "required": required,
+        "observed": observed,
+        "status": status,
+        "reviewer": str(review.get("reviewer", "")),
+        "evidence_refs": _compact_string_list(review.get("evidence_refs", [])),
+        "summary": str(review.get("summary", "")),
+    }
+    errors = validate_review_record(record)
+    if errors:
+        raise ValueError(errors[0])
+    return record
+
+
+def build_ci_record(ci: dict[str, Any]) -> dict[str, Any]:
+    status = str(ci.get("status", "not_observed"))
+    if status not in CI_STATUSES:
+        raise ValueError(f"unsupported CI status: {status}")
+    required = bool(ci.get("required", status != "not_required"))
+    observed = bool(ci.get("observed", status not in {"pending", "not_observed"}))
+    record = {
+        "schema_version": SCHEMA_VERSION,
+        "run_id": str(ci.get("run_id", "")),
+        "updated_at": str(ci.get("updated_at") or utc_now()),
+        "required": required,
+        "observed": observed,
+        "status": status,
+        "provider": str(ci.get("provider", "")),
+        "checks": _compact_ci_checks(ci.get("checks", [])),
+        "evidence_refs": _compact_string_list(ci.get("evidence_refs", [])),
+        "summary": str(ci.get("summary", "")),
+    }
+    errors = validate_ci_record(record)
+    if errors:
+        raise ValueError(errors[0])
+    return record
+
+
+def build_merge_record(merge: dict[str, Any]) -> dict[str, Any]:
+    status = str(merge.get("status", "not_observed"))
+    if status not in MERGE_STATUSES:
+        raise ValueError(f"unsupported merge status: {status}")
+    observed = bool(merge.get("observed", status in {"ready", "merged", "blocked"}))
+    record = {
+        "schema_version": SCHEMA_VERSION,
+        "run_id": str(merge.get("run_id", "")),
+        "updated_at": str(merge.get("updated_at") or utc_now()),
+        "observed": observed,
+        "ready": bool(merge.get("ready", status in {"ready", "merged"})),
+        "merged": bool(merge.get("merged", status == "merged")),
+        "status": status,
+        "target_branch": str(merge.get("target_branch", "")),
+        "merge_commit": str(merge.get("merge_commit", "")),
+        "evidence_refs": _compact_string_list(merge.get("evidence_refs", [])),
+        "summary": str(merge.get("summary", "")),
+    }
+    errors = validate_merge_record(record)
+    if errors:
+        raise ValueError(errors[0])
+    return record
+
+
 def build_routing_record(routing: dict[str, Any]) -> dict[str, Any]:
     action = routing.get("action", "fallback")
     if action not in ROUTE_ACTIONS:
@@ -404,6 +479,22 @@ def _compact_string_list(values: Any) -> list[str]:
     return [str(value) for value in values if str(value)]
 
 
+def _compact_ci_checks(values: Any) -> list[dict[str, str]]:
+    if not isinstance(values, (list, tuple)):
+        return []
+    checks: list[dict[str, str]] = []
+    for value in values:
+        if isinstance(value, dict):
+            name = str(value.get("name", ""))
+            status = str(value.get("status", "pending"))
+        else:
+            text = str(value)
+            name, _, status = text.partition(":")
+            status = status or "pending"
+        checks.append({"name": name, "status": status})
+    return checks
+
+
 def _optional_string(value: Any) -> str | None:
     if value is None:
         return None
@@ -513,6 +604,128 @@ def validate_wrapper_record(wrapper: dict[str, Any]) -> list[str]:
     )
     _require(isinstance(wrapper.get("unobserved_gaps"), list), errors, "wrapper unobserved_gaps must be a list")
     _require(isinstance(wrapper.get("message", ""), str), errors, "wrapper message must be a string")
+    return errors
+
+
+def validate_review_record(review: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    extra_keys = sorted(
+        set(review)
+        - {"schema_version", "run_id", "updated_at", "required", "observed", "status", "reviewer", "evidence_refs", "summary"}
+    )
+    _require(not extra_keys, errors, f"review has unsupported keys: {extra_keys}")
+    _require(review.get("schema_version") == SCHEMA_VERSION, errors, "review schema_version is invalid")
+    for key in ("run_id", "updated_at", "status", "reviewer", "summary"):
+        _require(isinstance(review.get(key), str), errors, f"review {key} must be a string")
+    _require(isinstance(review.get("required"), bool), errors, "review required must be boolean")
+    _require(isinstance(review.get("observed"), bool), errors, "review observed must be boolean")
+    _require(review.get("status") in REVIEW_STATUSES, errors, f"review status is invalid: {review.get('status')!r}")
+    _require(isinstance(review.get("evidence_refs"), list), errors, "review evidence_refs must be a list")
+    for index, value in enumerate(review.get("evidence_refs", []) if isinstance(review.get("evidence_refs"), list) else []):
+        _require(isinstance(value, str), errors, f"review evidence_refs[{index}] must be a string")
+    if review.get("status") == "not_required":
+        _require(review.get("required") is False, errors, "review not_required status requires required=false")
+        _require(review.get("observed") is True, errors, "review not_required status must be observed")
+    if review.get("observed") is False:
+        _require(review.get("status") in {"pending", "not_observed"}, errors, "review observed=false requires pending or not_observed")
+    if review.get("status") == "passed":
+        _require(review.get("observed") is True, errors, "review passed status requires observed=true")
+    return errors
+
+
+def validate_ci_record(ci: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    extra_keys = sorted(
+        set(ci)
+        - {"schema_version", "run_id", "updated_at", "required", "observed", "status", "provider", "checks", "evidence_refs", "summary"}
+    )
+    _require(not extra_keys, errors, f"ci has unsupported keys: {extra_keys}")
+    _require(ci.get("schema_version") == SCHEMA_VERSION, errors, "ci schema_version is invalid")
+    for key in ("run_id", "updated_at", "status", "provider", "summary"):
+        _require(isinstance(ci.get(key), str), errors, f"ci {key} must be a string")
+    _require(isinstance(ci.get("required"), bool), errors, "ci required must be boolean")
+    _require(isinstance(ci.get("observed"), bool), errors, "ci observed must be boolean")
+    _require(ci.get("status") in CI_STATUSES, errors, f"ci status is invalid: {ci.get('status')!r}")
+    _require(isinstance(ci.get("checks"), list), errors, "ci checks must be a list")
+    checks = ci.get("checks", []) if isinstance(ci.get("checks"), list) else []
+    for index, check in enumerate(checks):
+        _require(isinstance(check, dict), errors, f"ci checks[{index}] must be an object")
+        if not isinstance(check, dict):
+            continue
+        _require(set(check) == {"name", "status"}, errors, f"ci checks[{index}] must contain only name and status")
+        _require(isinstance(check.get("name"), str), errors, f"ci checks[{index}].name must be a string")
+        _require(bool(str(check.get("name", "")).strip()), errors, f"ci checks[{index}].name must not be empty")
+        _require(check.get("status") in CI_CHECK_STATUSES, errors, f"ci checks[{index}].status is invalid: {check.get('status')!r}")
+    _require(isinstance(ci.get("evidence_refs"), list), errors, "ci evidence_refs must be a list")
+    for index, value in enumerate(ci.get("evidence_refs", []) if isinstance(ci.get("evidence_refs"), list) else []):
+        _require(isinstance(value, str), errors, f"ci evidence_refs[{index}] must be a string")
+    if ci.get("status") == "not_required":
+        _require(ci.get("required") is False, errors, "ci not_required status requires required=false")
+        _require(ci.get("observed") is True, errors, "ci not_required status must be observed")
+    if ci.get("observed") is False:
+        _require(ci.get("status") in {"pending", "not_observed"}, errors, "ci observed=false requires pending or not_observed")
+    if ci.get("status") == "passed":
+        _require(ci.get("observed") is True, errors, "ci passed status requires observed=true")
+        _require(bool(checks), errors, "ci passed status requires at least one check")
+        failed = [check for check in checks if isinstance(check, dict) and check.get("status") != "passed"]
+        _require(not failed, errors, "ci passed status requires all checks to be passed")
+    return errors
+
+
+def validate_merge_record(merge: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    extra_keys = sorted(
+        set(merge)
+        - {
+            "schema_version",
+            "run_id",
+            "updated_at",
+            "observed",
+            "ready",
+            "merged",
+            "status",
+            "target_branch",
+            "merge_commit",
+            "evidence_refs",
+            "summary",
+        }
+    )
+    _require(not extra_keys, errors, f"merge has unsupported keys: {extra_keys}")
+    _require(merge.get("schema_version") == SCHEMA_VERSION, errors, "merge schema_version is invalid")
+    for key in ("run_id", "updated_at", "status", "target_branch", "merge_commit", "summary"):
+        _require(isinstance(merge.get(key), str), errors, f"merge {key} must be a string")
+    for key in ("observed", "ready", "merged"):
+        _require(isinstance(merge.get(key), bool), errors, f"merge {key} must be boolean")
+    _require(merge.get("status") in MERGE_STATUSES, errors, f"merge status is invalid: {merge.get('status')!r}")
+    _require(isinstance(merge.get("evidence_refs"), list), errors, "merge evidence_refs must be a list")
+    for index, value in enumerate(merge.get("evidence_refs", []) if isinstance(merge.get("evidence_refs"), list) else []):
+        _require(isinstance(value, str), errors, f"merge evidence_refs[{index}] must be a string")
+    if merge.get("status") == "not_observed":
+        _require(merge.get("observed") is False, errors, "merge not_observed status requires observed=false")
+        _require(merge.get("ready") is False, errors, "merge not_observed status requires ready=false")
+        _require(merge.get("merged") is False, errors, "merge not_observed status requires merged=false")
+    if merge.get("status") == "not_ready":
+        _require(merge.get("ready") is False, errors, "merge not_ready status requires ready=false")
+        _require(merge.get("merged") is False, errors, "merge not_ready status requires merged=false")
+    if merge.get("status") == "blocked":
+        _require(merge.get("observed") is True, errors, "merge blocked status requires observed=true")
+        _require(merge.get("ready") is False, errors, "merge blocked status requires ready=false")
+        _require(merge.get("merged") is False, errors, "merge blocked status requires merged=false")
+    if merge.get("observed") is False:
+        _require(merge.get("status") in {"not_ready", "not_observed"}, errors, "merge observed=false requires not_ready or not_observed")
+    if merge.get("status") == "ready":
+        _require(merge.get("observed") is True, errors, "merge ready status requires observed=true")
+        _require(merge.get("ready") is True, errors, "merge ready status requires ready=true")
+        _require(merge.get("merged") is False, errors, "merge ready status requires merged=false")
+    if merge.get("status") == "merged":
+        _require(merge.get("observed") is True, errors, "merge merged status requires observed=true")
+        _require(merge.get("ready") is True, errors, "merge merged status requires ready=true")
+        _require(merge.get("merged") is True, errors, "merge merged status requires merged=true")
+        _require(
+            bool(str(merge.get("merge_commit", ""))) or bool(merge.get("evidence_refs")),
+            errors,
+            "merge merged status requires merge_commit or evidence_refs",
+        )
     return errors
 
 
@@ -753,4 +966,7 @@ OPTIONAL_RECORD_VALIDATORS = (
     ("coding_delegation.json", validate_coding_delegation_record),
     ("delegation.json", validate_delegation_record),
     ("wrapper.json", validate_wrapper_record),
+    ("review.json", validate_review_record),
+    ("ci.json", validate_ci_record),
+    ("merge.json", validate_merge_record),
 )

--- a/src/wrapper_contract.py
+++ b/src/wrapper_contract.py
@@ -65,17 +65,59 @@ _STATUS_COPY = {
         "I will not report completion until review evidence is observed.",
         "Execution is observed; review is not.",
     ),
+    "surface_review_blocker": (
+        "blocker",
+        "Review is blocking completion.",
+        "I will surface the review blocker instead of claiming completion.",
+        "Review did not pass.",
+    ),
     "record_verification_evidence": (
         "status",
         "Executor completion needs verification evidence.",
         "I will not report completion until verification evidence is observed.",
         "Execution is observed; verification is not.",
     ),
+    "record_ci_evidence": (
+        "status",
+        "Review passed; CI evidence is still missing.",
+        "I will not report merge readiness until CI evidence is observed.",
+        "Review is not CI evidence.",
+    ),
+    "surface_ci_blocker": (
+        "blocker",
+        "CI is blocking completion.",
+        "I will surface the failing or blocked CI checks instead of claiming merge readiness.",
+        "Failed CI is not merge-ready.",
+    ),
+    "record_merge_readiness": (
+        "status",
+        "Review and CI passed; merge readiness is still missing.",
+        "I will not report merge-ready until merge readiness evidence is observed.",
+        "CI passing is not merge evidence.",
+    ),
+    "surface_merge_blocker": (
+        "blocker",
+        "Merge is blocked.",
+        "I will surface the merge blocker instead of claiming the run is ready.",
+        "Blocked merge is not complete.",
+    ),
     "report_completion_with_evidence": (
         "status",
         "Executor completion is reportable.",
         "Execution and verification evidence are observed.",
         "Completion is backed by observed wrapper evidence.",
+    ),
+    "report_merge_ready": (
+        "status",
+        "This is ready to merge.",
+        "Execution, verification, review, CI, and merge-readiness evidence are observed.",
+        "Ready to merge is not the same as merged.",
+    ),
+    "report_merged": (
+        "status",
+        "This has been merged.",
+        "Execution, verification, review, CI, and merge evidence are observed.",
+        "Merged status is backed by runtime ledger evidence.",
     ),
 }
 
@@ -314,6 +356,10 @@ def build_chat_response_from_status(status_payload: dict[str, Any], *, thread_ke
             "execution_observed": _nested(status_payload, "execution").get("observed", False),
             "verification_observed": _nested(status_payload, "verification").get("observed", False),
             "review_required": _nested(status_payload, "review").get("required", False),
+            "review_status": _nested(status_payload, "review").get("status", "not_observed"),
+            "ci_status": _nested(status_payload, "ci").get("status", "not_observed"),
+            "merge_readiness_status": _nested(status_payload, "merge_readiness").get("status", "not_observed"),
+            "merge_status": _nested(status_payload, "merge").get("status", "not_observed"),
         },
     )
 
@@ -416,9 +462,16 @@ def _phase_for_next_action(next_action: str) -> str:
         "dispatch_to_executor": "handoff_prepared",
         "wait_for_executor_evidence": "dispatched",
         "surface_executor_blocker": "blocked",
+        "surface_review_blocker": "blocked",
+        "surface_ci_blocker": "blocked",
+        "surface_merge_blocker": "blocked",
         "record_review_evidence": "awaiting_review",
+        "record_ci_evidence": "awaiting_ci",
+        "record_merge_readiness": "awaiting_merge_readiness",
         "record_verification_evidence": "awaiting_verification",
         "report_completion_with_evidence": "reportable",
+        "report_merge_ready": "merge_ready",
+        "report_merged": "merged",
     }.get(next_action, "status")
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import json
 import unittest
+from argparse import Namespace
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from _cli_harness import run_cli
+from omh.cli import OmhError, cmd_runtime_merge
 
 
 class CliTests(unittest.TestCase):
@@ -558,6 +560,134 @@ class CliTests(unittest.TestCase):
             self.assertTrue(summary["review"]["required"])
             self.assertEqual(summary["next_action"], "record_review_evidence")
             self.assertIn("review evidence is still required", summary["safe_summary"])
+
+    def test_runtime_review_ci_merge_commands_advance_status_ladder(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / ".omh"
+            hermes_home = root / ".hermes"
+            base = ["--omh-home", str(omh_home), "--hermes-home", str(hermes_home)]
+
+            status, stdout, stderr = run_cli(base + ["coding", "lifecycle", "start", "--record", "risky", "refactor"])
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            run_id = json.loads(stdout)["run"]["run_id"]
+
+            self.assertEqual(run_cli(base + ["coding", "lifecycle", "dispatch", "--run", run_id])[0], 0)
+            self.assertEqual(run_cli(base + ["coding", "lifecycle", "result", "--run", run_id, "--result", "completed"])[0], 0)
+            self.assertEqual(run_cli(base + ["coding", "lifecycle", "verify", "--run", run_id])[0], 0)
+
+            status, stdout, stderr = run_cli(
+                base
+                + [
+                    "runtime",
+                    "review",
+                    "--run",
+                    run_id,
+                    "--status",
+                    "passed",
+                    "--reviewer",
+                    "code-review",
+                    "--evidence-ref",
+                    "review-comment",
+                ]
+            )
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            self.assertEqual(json.loads(stdout)["status"]["next_action"], "record_ci_evidence")
+
+            status, stdout, stderr = run_cli(
+                base + ["runtime", "ci", "--run", run_id, "--status", "passed", "--check", "unit:passed", "--check", "lint:passed"]
+            )
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            self.assertEqual(json.loads(stdout)["status"]["next_action"], "record_merge_readiness")
+
+            status, stdout, stderr = run_cli(base + ["runtime", "merge", "--run", run_id, "--ready", "--target-branch", "main"])
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            self.assertEqual(json.loads(stdout)["status"]["next_action"], "report_merge_ready")
+
+            status, stdout, stderr = run_cli(base + ["chat", "interact", "--run", run_id])
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            chat = json.loads(stdout)
+            self.assertEqual(chat["chat_response"]["state"]["merge_status"], "ready")
+            self.assertEqual(chat["chat_response"]["headline"], "This is ready to merge.")
+            self.assertNotIn("omh ", json.dumps(chat["chat_response"]).lower())
+
+            status, stdout, stderr = run_cli(base + ["runtime", "merge", "--run", run_id, "--merged", "--merge-commit", "abc123"])
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            self.assertEqual(json.loads(stdout)["status"]["next_action"], "report_merged")
+
+            status, stdout, stderr = run_cli(base + ["coding", "lifecycle", "report", "--run", run_id])
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            report = json.loads(stdout)
+            self.assertEqual(report["lifecycle_status"], "merged")
+            self.assertFalse(report["can_report_completion"])
+            self.assertTrue(report["can_report_terminal_status"])
+            self.assertEqual(report["merge"]["status"], "merged")
+
+            status, stdout, stderr = run_cli(base + ["runtime", "validate", "--run", run_id])
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            self.assertTrue(json.loads(stdout)["ok"])
+
+            status, stdout, stderr = run_cli(base + ["runtime", "show", run_id])
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            shown = json.loads(stdout)
+            self.assertEqual(shown["review"]["status"], "passed")
+            self.assertEqual(shown["ci"]["status"], "passed")
+            self.assertEqual(shown["merge"]["merge_commit"], "abc123")
+
+    def test_runtime_merge_ready_rejects_missing_upstream_evidence(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / ".omh"
+            hermes_home = root / ".hermes"
+            base = ["--omh-home", str(omh_home), "--hermes-home", str(hermes_home)]
+
+            status, stdout, stderr = run_cli(base + ["coding", "lifecycle", "start", "--record", "risky", "refactor"])
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            run_id = json.loads(stdout)["run"]["run_id"]
+
+            status, _, stderr = run_cli(base + ["runtime", "merge", "--run", run_id, "--ready", "--target-branch", "main"])
+
+            self.assertEqual(status, 2)
+            self.assertIn("cannot record merge ready while next_action is dispatch_to_executor", stderr)
+
+    def test_runtime_merge_rejects_conflicting_status_options(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / ".omh"
+            hermes_home = root / ".hermes"
+            base = ["--omh-home", str(omh_home), "--hermes-home", str(hermes_home)]
+
+            status, stdout, stderr = run_cli(base + ["runtime", "record", "--skill", "oh-my-hermes", "--harness", "coding-handling"])
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            run_id = json.loads(stdout)["run"]["run_id"]
+
+            args = Namespace(
+                omh_home=omh_home,
+                hermes_home=hermes_home,
+                run_id=run_id,
+                ready=True,
+                merged=False,
+                blocked=False,
+                status="blocked",
+                target_branch="main",
+                merge_commit="",
+                evidence_ref=None,
+                summary="",
+            )
+
+            with self.assertRaisesRegex(OmhError, "accepts only one"):
+                cmd_runtime_merge(args)
 
     def test_runtime_delegation_status_warns_on_missing_prepared_artifact(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -643,6 +643,64 @@ class CliTests(unittest.TestCase):
             self.assertEqual(shown["ci"]["status"], "passed")
             self.assertEqual(shown["merge"]["merge_commit"], "abc123")
 
+    def test_runtime_review_not_required_rejects_required_handoff(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / ".omh"
+            hermes_home = root / ".hermes"
+            base = ["--omh-home", str(omh_home), "--hermes-home", str(hermes_home)]
+
+            status, stdout, stderr = run_cli(base + ["coding", "lifecycle", "start", "--record", "risky", "refactor"])
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            run_id = json.loads(stdout)["run"]["run_id"]
+            self.assertEqual(run_cli(base + ["coding", "lifecycle", "dispatch", "--run", run_id])[0], 0)
+            self.assertEqual(run_cli(base + ["coding", "lifecycle", "result", "--run", run_id, "--result", "completed"])[0], 0)
+            self.assertEqual(run_cli(base + ["coding", "lifecycle", "verify", "--run", run_id])[0], 0)
+
+            status, _, stderr = run_cli(base + ["runtime", "review", "--run", run_id, "--status", "not_required"])
+
+            self.assertEqual(status, 2)
+            self.assertIn("cannot mark required review as not_required", stderr)
+
+    def test_runtime_ci_not_required_rejects_required_ladder(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / ".omh"
+            hermes_home = root / ".hermes"
+            base = ["--omh-home", str(omh_home), "--hermes-home", str(hermes_home)]
+
+            status, stdout, stderr = run_cli(base + ["coding", "lifecycle", "start", "--record", "risky", "refactor"])
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            run_id = json.loads(stdout)["run"]["run_id"]
+            self.assertEqual(run_cli(base + ["coding", "lifecycle", "dispatch", "--run", run_id])[0], 0)
+            self.assertEqual(run_cli(base + ["coding", "lifecycle", "result", "--run", run_id, "--result", "completed"])[0], 0)
+            self.assertEqual(run_cli(base + ["coding", "lifecycle", "verify", "--run", run_id])[0], 0)
+            self.assertEqual(
+                run_cli(
+                    base
+                    + [
+                        "runtime",
+                        "review",
+                        "--run",
+                        run_id,
+                        "--status",
+                        "passed",
+                        "--reviewer",
+                        "code-review",
+                        "--evidence-ref",
+                        "review-comment",
+                    ]
+                )[0],
+                0,
+            )
+
+            status, _, stderr = run_cli(base + ["runtime", "ci", "--run", run_id, "--status", "not_required", "--check", "unit:failed"])
+
+            self.assertEqual(status, 2)
+            self.assertIn("cannot mark required CI as not_required", stderr)
+
     def test_runtime_merge_ready_rejects_missing_upstream_evidence(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -164,6 +164,8 @@ class RouterContentTests(unittest.TestCase):
         ]
 
         for path in paths:
+            if path.is_dir():
+                continue
             text = path.read_text(encoding="utf-8").lower()
             for term in forbidden:
                 self.assertNotIn(term, text, f"{term!r} leaked in {path}")

--- a/tests/test_runtime_artifacts.py
+++ b/tests/test_runtime_artifacts.py
@@ -396,6 +396,23 @@ class RuntimeArtifactTests(unittest.TestCase):
             ),
         )
         self.assertIn(
+            "ci not_required status requires checks to be empty or not_required",
+            validate_ci_record(
+                {
+                    "schema_version": 1,
+                    "run_id": "run-1",
+                    "updated_at": "now",
+                    "required": False,
+                    "observed": True,
+                    "status": "not_required",
+                    "provider": "local",
+                    "checks": [{"name": "unit", "status": "failed"}],
+                    "evidence_refs": [],
+                    "summary": "",
+                }
+            ),
+        )
+        self.assertIn(
             "merge merged status requires merge_commit or evidence_refs",
             validate_merge_record(
                 {
@@ -511,6 +528,83 @@ class RuntimeArtifactTests(unittest.TestCase):
 
                 self.assertEqual(summary["next_action"], "record_merge_readiness")
                 self.assertFalse(summary["merge"]["satisfied"])
+
+    def test_status_reader_preserves_required_review_and_ci_gates(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            run = create_prepared_coding_delegation_run(
+                paths,
+                {"skill": "ai-slop-cleaner", "harness": "coding-handling"},
+            )
+            run_dir = paths.runtime_runs_dir / run["run_id"]
+            write_coding_delegation(run_dir, build_coding_delegation_payload("risky refactor", source="discord", include_message=True))
+            write_wrapper_contract(
+                run_dir,
+                {
+                    "prompt_dispatched": True,
+                    "hermes_response_observed": True,
+                    "verification_observed": True,
+                    "completion_status": "completed",
+                },
+            )
+            write_delegation(run_dir, {"requested": True, "observed": True, "result": "completed"})
+            (run_dir / "review.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "run_id": run["run_id"],
+                        "updated_at": "now",
+                        "required": False,
+                        "observed": True,
+                        "status": "not_required",
+                        "reviewer": "code-review",
+                        "evidence_refs": [],
+                        "summary": "",
+                    },
+                    sort_keys=True,
+                ),
+                encoding="utf-8",
+            )
+
+            summary = summarize_delegated_coding_status(paths, run["run_id"])
+            result = validate_runtime(paths, run["run_id"])
+
+            self.assertTrue(summary["review"]["required"])
+            self.assertFalse(summary["review"]["satisfied"])
+            self.assertEqual(summary["next_action"], "record_review_evidence")
+            self.assertFalse(result["ok"])
+            self.assertIn("review not_required cannot downgrade required review evidence", "\n".join(result["runs"][0]["errors"]))
+
+            write_review_record(run_dir, {"status": "passed", "reviewer": "code-review", "evidence_refs": ["review"]})
+            (run_dir / "ci.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "run_id": run["run_id"],
+                        "updated_at": "now",
+                        "required": False,
+                        "observed": True,
+                        "status": "not_required",
+                        "provider": "local",
+                        "checks": [{"name": "unit", "status": "failed"}],
+                        "evidence_refs": [],
+                        "summary": "",
+                    },
+                    sort_keys=True,
+                ),
+                encoding="utf-8",
+            )
+
+            summary = summarize_delegated_coding_status(paths, run["run_id"])
+            result = validate_runtime(paths, run["run_id"])
+            errors = "\n".join(result["runs"][0]["errors"])
+
+            self.assertTrue(summary["ci"]["required"])
+            self.assertFalse(summary["ci"]["satisfied"])
+            self.assertEqual(summary["next_action"], "record_ci_evidence")
+            self.assertFalse(result["ok"])
+            self.assertIn("ci not_required cannot downgrade required CI evidence", errors)
+            self.assertIn("ci not_required status requires checks to be empty or not_required", errors)
 
     def test_export_runtime_redacts_sensitive_text_and_preserves_evidence_booleans(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_runtime_artifacts.py
+++ b/tests/test_runtime_artifacts.py
@@ -21,15 +21,22 @@ from omh.runtime_artifacts import (
     list_runs,
     new_run_id,
     show_run,
+    summarize_delegated_coding_status,
     update_state,
     validate_coding_delegation_record,
+    validate_ci_record,
     validate_delegation_record,
+    validate_merge_record,
+    validate_review_record,
     validate_routing_record,
     validate_runtime,
     validate_run_record,
     validate_wrapper_record,
+    write_ci_record,
     write_coding_delegation,
     write_delegation,
+    write_merge_record,
+    write_review_record,
     write_routing_decision,
     write_wrapper_contract,
 )
@@ -323,6 +330,187 @@ class RuntimeArtifactTests(unittest.TestCase):
         self.assertTrue(any("routing action is invalid" in error for error in routing_errors))
         self.assertTrue(any("coding_delegation action is invalid" in error for error in coding_errors))
         self.assertTrue(any("source_metadata has unsupported keys" in error for error in coding_errors))
+
+    def test_review_ci_merge_records_validate_and_show_under_runtime_run(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            run = create_run(paths, {"skill": "oh-my-hermes", "harness": "coding-handling", "status": "started"})
+            run_dir = paths.runtime_runs_dir / run["run_id"]
+
+            review = write_review_record(
+                run_dir,
+                {"status": "pending", "reviewer": "code-review", "summary": "waiting for review"},
+            )
+            ci = write_ci_record(
+                run_dir,
+                {"status": "pending", "provider": "local", "checks": ["unit:pending"]},
+            )
+            merge = write_merge_record(
+                run_dir,
+                {"status": "not_observed", "target_branch": "main"},
+            )
+
+            self.assertEqual(validate_review_record(review), [])
+            self.assertEqual(validate_ci_record(ci), [])
+            self.assertEqual(validate_merge_record(merge), [])
+            shown = show_run(paths, run["run_id"])
+            self.assertEqual(shown["review"]["status"], "pending")
+            self.assertEqual(shown["ci"]["checks"][0]["name"], "unit")
+            self.assertEqual(shown["merge"]["status"], "not_observed")
+            self.assertIn("review_recorded", {event["event"] for event in shown["events"]})
+            self.assertIn("ci_recorded", {event["event"] for event in shown["events"]})
+            self.assertIn("merge_recorded", {event["event"] for event in shown["events"]})
+
+    def test_status_artifact_validators_reject_contradictory_success_claims(self) -> None:
+        self.assertIn(
+            "review observed=false requires pending or not_observed",
+            validate_review_record(
+                {
+                    "schema_version": 1,
+                    "run_id": "run-1",
+                    "updated_at": "now",
+                    "required": True,
+                    "observed": False,
+                    "status": "passed",
+                    "reviewer": "code-review",
+                    "evidence_refs": [],
+                    "summary": "",
+                }
+            ),
+        )
+        self.assertIn(
+            "ci passed status requires all checks to be passed",
+            validate_ci_record(
+                {
+                    "schema_version": 1,
+                    "run_id": "run-1",
+                    "updated_at": "now",
+                    "required": True,
+                    "observed": True,
+                    "status": "passed",
+                    "provider": "local",
+                    "checks": [{"name": "unit", "status": "failed"}],
+                    "evidence_refs": [],
+                    "summary": "",
+                }
+            ),
+        )
+        self.assertIn(
+            "merge merged status requires merge_commit or evidence_refs",
+            validate_merge_record(
+                {
+                    "schema_version": 1,
+                    "run_id": "run-1",
+                    "updated_at": "now",
+                    "observed": True,
+                    "ready": True,
+                    "merged": True,
+                    "status": "merged",
+                    "target_branch": "main",
+                    "merge_commit": "",
+                    "evidence_refs": [],
+                    "summary": "",
+                }
+            ),
+        )
+        self.assertIn(
+            "merge not_ready status requires ready=false",
+            validate_merge_record(
+                {
+                    "schema_version": 1,
+                    "run_id": "run-1",
+                    "updated_at": "now",
+                    "observed": False,
+                    "ready": True,
+                    "merged": False,
+                    "status": "not_ready",
+                    "target_branch": "main",
+                    "merge_commit": "",
+                    "evidence_refs": [],
+                    "summary": "",
+                }
+            ),
+        )
+        self.assertIn(
+            "merge blocked status requires merged=false",
+            validate_merge_record(
+                {
+                    "schema_version": 1,
+                    "run_id": "run-1",
+                    "updated_at": "now",
+                    "observed": True,
+                    "ready": False,
+                    "merged": True,
+                    "status": "blocked",
+                    "target_branch": "main",
+                    "merge_commit": "",
+                    "evidence_refs": [],
+                    "summary": "",
+                }
+            ),
+        )
+
+    def test_runtime_validation_rejects_merge_ready_before_upstream_gates(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            run = create_run(paths, {"skill": "oh-my-hermes", "harness": "coding-handling", "status": "started"})
+            run_dir = paths.runtime_runs_dir / run["run_id"]
+            write_merge_record(run_dir, {"status": "ready", "target_branch": "main"})
+
+            result = validate_runtime(paths, run["run_id"])
+
+            self.assertFalse(result["ok"])
+            errors = "\n".join(result["runs"][0]["errors"])
+            self.assertIn("merge ready requires completed executor evidence", errors)
+            self.assertIn("merge ready requires verification evidence", errors)
+
+    def test_status_reader_does_not_overclaim_contradictory_merge_artifacts(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            run = create_prepared_coding_delegation_run(
+                paths,
+                {"skill": "ai-slop-cleaner", "harness": "coding-handling"},
+            )
+            run_dir = paths.runtime_runs_dir / run["run_id"]
+            write_coding_delegation(run_dir, build_coding_delegation_payload("risky refactor", source="discord", include_message=True))
+            write_wrapper_contract(
+                run_dir,
+                {
+                    "prompt_dispatched": True,
+                    "hermes_response_observed": True,
+                    "verification_observed": True,
+                    "completion_status": "completed",
+                },
+            )
+            write_delegation(run_dir, {"requested": True, "observed": True, "result": "completed"})
+            write_review_record(run_dir, {"status": "passed", "reviewer": "code-review", "evidence_refs": ["review"]})
+            write_ci_record(run_dir, {"status": "passed", "provider": "local", "checks": ["unit:passed"]})
+
+            for status, ready, merged in (("ready", False, False), ("merged", True, False)):
+                (run_dir / "merge.json").write_text(
+                    json.dumps(
+                        {
+                            "schema_version": 1,
+                            "run_id": run["run_id"],
+                            "updated_at": "now",
+                            "observed": True,
+                            "ready": ready,
+                            "merged": merged,
+                            "status": status,
+                            "target_branch": "main",
+                            "merge_commit": "abc123",
+                            "evidence_refs": [],
+                            "summary": "",
+                        },
+                        sort_keys=True,
+                    ),
+                    encoding="utf-8",
+                )
+
+                summary = summarize_delegated_coding_status(paths, run["run_id"])
+
+                self.assertEqual(summary["next_action"], "record_merge_readiness")
+                self.assertFalse(summary["merge"]["satisfied"])
 
     def test_export_runtime_redacts_sensitive_text_and_preserves_evidence_booleans(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_wrapper_golden_examples.py
+++ b/tests/test_wrapper_golden_examples.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+
+class WrapperGoldenExampleTests(unittest.TestCase):
+    def test_status_ladder_golden_examples_cover_required_scenarios(self) -> None:
+        payload = json.loads(Path("examples/wrapper-golden/status-ladder.json").read_text(encoding="utf-8"))
+        self.assertEqual(payload["schema_version"], "wrapper_golden_examples/v1")
+        scenarios = {item["scenario"]: item for item in payload["scenarios"]}
+
+        required = {
+            "clarify_needed",
+            "plan_presented",
+            "handoff_prepared",
+            "dispatched_executor_not_observed",
+            "review_pending",
+            "ci_pending",
+            "ci_failed",
+            "merge_ready",
+            "merged",
+            "contradictory_merge_ready_without_ci",
+        }
+        self.assertEqual(set(scenarios), required)
+
+        for item in payload["scenarios"]:
+            response = item["expected_response"]
+            self.assertEqual(response["schema_version"], "chat_response/v1")
+            self.assertIn(item["source"], {"discord", "slack"})
+            self.assertTrue(item["claim_boundary"])
+            self.assertTrue(response["headline"])
+            self.assertTrue(response["body"])
+            self.assertIsInstance(response["action_ids"], list)
+            self.assertNotIn("omh ", json.dumps(item).lower())
+            self.assertNotIn("token", json.dumps(item).lower())
+
+    def test_discord_and_slack_examples_share_platform_neutral_action_ids(self) -> None:
+        payload = json.loads(Path("examples/wrapper-golden/status-ladder.json").read_text(encoding="utf-8"))
+        action_ids = {action_id for item in payload["scenarios"] for action_id in item["expected_response"]["action_ids"]}
+
+        self.assertLessEqual(action_ids, {"answer:clarify", "accept_plan", "revise_plan", "send_to_codex", "show_status", "cancel"})
+        self.assertIn("show_status", action_ids)
+
+    def test_contradictory_fixture_names_upstream_blocker(self) -> None:
+        payload = json.loads(Path("examples/wrapper-golden/status-ladder.json").read_text(encoding="utf-8"))
+        item = next(item for item in payload["scenarios"] if item["scenario"] == "contradictory_merge_ready_without_ci")
+
+        self.assertIn("CI evidence is still missing", item["expected_response"]["headline"])
+        self.assertIn("cannot override", item["expected_response"]["body"])
+        self.assertIn("upstream CI blocker", item["claim_boundary"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add deterministic runtime `review.json`, `ci.json`, and `merge.json` records plus CLI commands for observed review, CI, merge-readiness, and merge evidence.
- Extend delegated coding status, lifecycle reports, and wrapper chat responses so wrappers can show review/CI/merge states without treating prepared handoffs as execution.
- Add wrapper golden examples for clarification, planning, handoff, review, CI, merge-ready, merged, and contradictory-evidence states.
- Harden merge status algebra so later or contradictory merge artifacts cannot override missing or inconsistent upstream evidence.

## Tests
- `PYTHONPATH=tests uv run python -m unittest tests/test_runtime_artifacts.py tests/test_cli.py tests/test_coding_lifecycle.py -v`
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- `uv run python -m src.cli docs workflows --check`
- `uv run python -m compileall -q src tests`
- `git diff --check`
- Manual smoke via `uv run python -m src.cli`: lifecycle start/dispatch/result/verify, runtime review/ci/merge --ready, lifecycle report

## Review
- ai-slop-cleaner cleanup pass: passed/no masking fallback slop found.
- Independent code-reviewer: APPROVE, zero findings.
- Independent architect: CLEAR after reportability, merge matrix, and CLI status conflict hardening.

## Out of Scope
- No Discord/Slack/GitHub/CI provider integration.
- No LLM/API/network calls.
- No Hermes core behavior changes.