### PR TITLE
Enable first-run Pages deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   contents: read
+  pages: write
 
 concurrency:
   group: "pages"
@@ -34,6 +35,8 @@ jobs:
         run: python -m omh.cli harness validate
       - name: Configure Pages
         uses: actions/configure-pages@v5
+        with:
+          enablement: true
       - name: Prepare static site
         run: |
           rm -rf _site

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -292,6 +292,8 @@ class RouterContentTests(unittest.TestCase):
         self.assertIn("Capability probe smoke", ci)
         self.assertIn("actions/upload-pages-artifact@v4", pages)
         self.assertIn("actions/deploy-pages@v4", pages)
+        self.assertIn("pages: write", pages)
+        self.assertIn("enablement: true", pages)
         self.assertIn("site/**", pages)
         self.assertIn("docs workflows --check", pages)
         self.assertIn("harness validate", pages)


### PR DESCRIPTION
## Summary
- Allow the Pages workflow to bootstrap repositories that have not enabled GitHub Pages yet.
- Add a regression assertion so the workflow keeps `pages: write` and `enablement: true`.

## Context
After #30 merged, the main CI passed but the first Pages run failed in `actions/configure-pages@v5` because the repository Pages site returned 404. The action supports `enablement: true`, so this keeps the static Pages deployment self-bootstrapping.

## Verification
- `PYTHONPATH=tests uv run python -m unittest tests/test_router_content.py -v`
- `uv run python -m src.cli docs workflows --check`
- `git diff --check`
