### PR TITLE
Serve documentation directly on the Pages site

### DIFF
--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -1,0 +1,155 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>OMH Documentation</title>
+    <meta
+      name="description"
+      content="Documentation for OMH installation, chat routing, wrapper contracts, harness evidence, and delegation-first coding handoffs."
+    >
+    <link rel="stylesheet" href="../styles.css">
+  </head>
+  <body class="docs-page">
+    <header class="topbar topbar--solid" aria-label="Primary">
+      <a class="brand brand--link" href="../">OMH</a>
+      <nav class="nav" aria-label="Primary navigation">
+        <a href="../#flow">Flow</a>
+        <a href="../#contracts">Contracts</a>
+        <a href="../#install">Install</a>
+        <a aria-current="page" href="./">Docs</a>
+        <a href="https://github.com/rlaope/oh-my-hermes-agent">GitHub</a>
+      </nav>
+    </header>
+
+    <main class="docs-shell">
+      <aside class="docs-toc" aria-label="Documentation sections">
+        <a href="#overview">Overview</a>
+        <a href="#install">Install</a>
+        <a href="#chat">Chat wrappers</a>
+        <a href="#contracts">Contracts</a>
+        <a href="#delegation">Delegation</a>
+        <a href="#quality">Quality gates</a>
+        <a href="#boundaries">Boundaries</a>
+      </aside>
+
+      <article class="docs-content">
+        <header class="docs-hero" id="overview">
+          <p class="eyebrow">Documentation</p>
+          <h1>Use OMH as a local contract layer for Hermes.</h1>
+          <p>
+            OMH helps a chat-facing Hermes agent turn natural language into deterministic
+            routing, clarification, planning, status narration, or Codex-ready coding handoffs.
+            It does this with local CLI contracts and schema-versioned artifacts.
+          </p>
+        </header>
+
+        <section class="docs-section" id="install">
+          <h2>Install</h2>
+          <p>
+            Install the preview channel from the main branch, then run one health check before
+            wiring wrappers or handoff flows.
+          </p>
+          <div class="command" role="region" aria-label="Install commands" tabindex="0">
+            <code>curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes-agent/main/install.sh | sh
+omh doctor</code>
+          </div>
+          <p>
+            Stable installs are pinned explicitly with a released tag.
+          </p>
+          <div class="command" role="region" aria-label="Stable install command" tabindex="0">
+            <code>OMH_CHANNEL=stable OMH_VERSION=&lt;version&gt; \
+  sh -c "$(curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes-agent/v&lt;version&gt;/install.sh)"</code>
+          </div>
+        </section>
+
+        <section class="docs-section" id="chat">
+          <h2>Chat wrappers</h2>
+          <p>
+            Wrappers own platform-specific work: Discord or Slack auth, incoming events,
+            buttons, threads, edits, and notifications. OMH owns the deterministic response
+            contract that tells the wrapper what kind of UX to render.
+          </p>
+          <div class="command" role="region" aria-label="Chat interaction command" tabindex="0">
+            <code>omh chat interact --source discord "risky refactor"
+omh chat interact --source slack "diagnose installation health"</code>
+          </div>
+          <p>
+            A response can be an answer, a clarification request, a plan, a status card, or a
+            prepared handoff. The wrapper should render that response natively instead of
+            asking users to memorize CLI commands.
+          </p>
+        </section>
+
+        <section class="docs-section" id="contracts">
+          <h2>Contracts</h2>
+          <div class="docs-grid">
+            <article class="card">
+              <h3>chat_interaction/v1</h3>
+              <p>Input envelope for natural messages, source metadata, thread context, and user intent.</p>
+            </article>
+            <article class="card">
+              <h3>chat_response/v1</h3>
+              <p>Output envelope for wrapper-facing text, action hints, status snippets, and handoff prompts.</p>
+            </article>
+            <article class="card">
+              <h3>status_card/v1</h3>
+              <p>Readable status summary for plan, dispatch, implementation, review, CI, and merge readiness.</p>
+            </article>
+            <article class="card">
+              <h3>harness_progress/v1</h3>
+              <p>Evidence-based progress ladder that advances only when required observations are present.</p>
+            </article>
+          </div>
+        </section>
+
+        <section class="docs-section" id="delegation">
+          <h2>Delegation-first coding</h2>
+          <p>
+            OMH does not hide a coding executor inside Hermes. Coding-heavy requests are shaped
+            into prepared handoffs for Codex-like agents with scope, acceptance criteria,
+            verification commands, review expectations, and merge-readiness evidence.
+          </p>
+          <ul class="docs-list">
+            <li>Prepared handoff means "ready to dispatch", not "work completed".</li>
+            <li>Observed implementation requires linked runtime evidence.</li>
+            <li>Review, CI, and merge-readiness require explicit observed records.</li>
+          </ul>
+        </section>
+
+        <section class="docs-section" id="quality">
+          <h2>Quality gates</h2>
+          <p>
+            OMH keeps skill and harness metadata inspectable through the CLI so wrappers and
+            operators can validate contract coverage before depending on it.
+          </p>
+          <div class="command" role="region" aria-label="Quality commands" tabindex="0">
+            <code>omh docs workflows --json
+omh harness list
+omh harness inspect planning
+omh harness validate</code>
+          </div>
+        </section>
+
+        <section class="docs-section" id="boundaries">
+          <h2>Boundaries</h2>
+          <p>
+            OMH is deterministic local tooling. It does not patch Hermes core, run platform
+            bots, call LLM APIs, create network integrations inside core commands, or launch
+            Codex by itself. Those responsibilities stay explicit at the wrapper, executor, or
+            operator layer.
+          </p>
+          <p>
+            For source files, release notes, and contribution workflow, use the repository after
+            you understand the public contract from this page.
+          </p>
+        </section>
+      </article>
+    </main>
+
+    <footer class="footer">
+      OMH documentation is served directly from this site. Source docs remain in the repository
+      as the versioned source of truth.
+    </footer>
+  </body>
+</html>

--- a/site/index.html
+++ b/site/index.html
@@ -17,6 +17,7 @@
         <a href="#flow">Flow</a>
         <a href="#contracts">Contracts</a>
         <a href="#install">Install</a>
+        <a href="docs/">Docs</a>
         <a href="https://github.com/rlaope/oh-my-hermes-agent">GitHub</a>
       </nav>
     </header>
@@ -32,7 +33,7 @@
           </p>
           <div class="actions" aria-label="Primary actions">
             <a class="button button--primary" href="#install">Install</a>
-            <a class="button" href="https://github.com/rlaope/oh-my-hermes-agent/tree/main/docs">Read docs</a>
+            <a class="button" href="docs/">Read docs</a>
           </div>
         </div>
       </section>

--- a/site/styles.css
+++ b/site/styles.css
@@ -55,6 +55,10 @@ a {
   font-size: 18px;
 }
 
+.brand--link {
+  text-decoration: none;
+}
+
 .nav {
   display: flex;
   flex-wrap: wrap;
@@ -69,6 +73,23 @@ a {
 
 .nav a:hover {
   color: #ffffff;
+}
+
+.topbar--solid {
+  position: sticky;
+  color: var(--ink);
+  background: rgba(250, 248, 243, 0.96);
+  border-bottom: 1px solid var(--line);
+  backdrop-filter: blur(12px);
+}
+
+.topbar--solid .nav {
+  color: var(--muted);
+}
+
+.topbar--solid .nav a:hover,
+.topbar--solid .nav a[aria-current="page"] {
+  color: var(--ink);
 }
 
 .hero {
@@ -278,6 +299,89 @@ h1 {
   font-size: 14px;
 }
 
+.docs-page {
+  background: #ffffff;
+}
+
+.docs-shell {
+  display: grid;
+  grid-template-columns: minmax(170px, 220px) minmax(0, 880px);
+  gap: 40px;
+  max-width: 1240px;
+  margin: 0 auto;
+  padding: 44px clamp(20px, 5vw, 72px) 84px;
+}
+
+.docs-toc {
+  position: sticky;
+  top: 86px;
+  align-self: start;
+  display: grid;
+  gap: 8px;
+  padding: 14px 0;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.docs-toc a {
+  padding: 7px 0;
+  text-decoration: none;
+}
+
+.docs-toc a:hover {
+  color: var(--ink);
+}
+
+.docs-content {
+  min-width: 0;
+}
+
+.docs-hero {
+  padding-bottom: 34px;
+  border-bottom: 1px solid var(--line);
+}
+
+.docs-hero h1 {
+  max-width: 820px;
+  margin-bottom: 18px;
+  font-size: clamp(42px, 6vw, 72px);
+  line-height: 0.98;
+}
+
+.docs-hero p,
+.docs-section p,
+.docs-list {
+  color: var(--muted);
+  font-size: 17px;
+}
+
+.docs-section {
+  padding: 44px 0;
+  border-bottom: 1px solid var(--line);
+}
+
+.docs-section h2 {
+  margin-bottom: 12px;
+  font-size: clamp(28px, 4vw, 42px);
+  line-height: 1.08;
+}
+
+.docs-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+  margin-top: 22px;
+}
+
+.docs-list {
+  margin: 16px 0 0;
+  padding-left: 22px;
+}
+
+.docs-list li + li {
+  margin-top: 8px;
+}
+
 @media (max-width: 840px) {
   .topbar {
     position: absolute;
@@ -295,8 +399,28 @@ h1 {
   }
 
   .grid,
-  .band {
+  .band,
+  .docs-shell,
+  .docs-grid {
     grid-template-columns: 1fr;
+  }
+
+  .topbar--solid {
+    position: sticky;
+  }
+
+  .docs-shell {
+    gap: 20px;
+    padding-top: 28px;
+  }
+
+  .docs-toc {
+    position: static;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px 16px;
+    padding-bottom: 8px;
+    border-bottom: 1px solid var(--line);
   }
 }
 

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -248,6 +248,7 @@ class RouterContentTests(unittest.TestCase):
             Path(".github/ISSUE_TEMPLATE/feature_request.yml"),
             Path(".github/ISSUE_TEMPLATE/config.yml"),
             Path("site/index.html"),
+            Path("site/docs/index.html"),
             Path("site/styles.css"),
             Path("site/assets/hermes-agent-hero.png"),
         ]
@@ -262,6 +263,7 @@ class RouterContentTests(unittest.TestCase):
         release = Path("docs/RELEASE.md").read_text(encoding="utf-8")
         harness_quality = Path("docs/HARNESS_QUALITY.md").read_text(encoding="utf-8")
         site = Path("site/index.html").read_text(encoding="utf-8")
+        site_docs = Path("site/docs/index.html").read_text(encoding="utf-8")
         site_css = Path("site/styles.css").read_text(encoding="utf-8")
 
         self.assertIn("curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes-agent/main/install.sh | sh", readme)
@@ -303,6 +305,13 @@ class RouterContentTests(unittest.TestCase):
         self.assertIn("GitHub Pages workflow status", release)
         self.assertIn("Capability probe status", release)
         self.assertIn("OMH", site)
+        self.assertIn('href="docs/">Read docs</a>', site)
+        self.assertNotIn("github.com/rlaope/oh-my-hermes-agent/tree/main/docs", site)
+        self.assertIn("OMH Documentation", site_docs)
+        self.assertIn("omh chat interact --source discord", site_docs)
+        self.assertIn("chat_response/v1", site_docs)
+        self.assertIn("harness_progress/v1", site_docs)
+        self.assertIn("omh harness validate", site_docs)
         self.assertIn("harness_progress/v1", site)
         self.assertIn("assets/hermes-agent-hero.png", site_css)
 


### PR DESCRIPTION
## Summary
- Replace the public `Read docs` CTA with a site-local `docs/` link.
- Add a first-class `site/docs/index.html` documentation page for install, chat wrappers, contracts, delegation, quality gates, and boundaries.
- Extend content tests so the Pages site cannot regress back to the GitHub `tree/main/docs` URL as the primary docs UX.

## Why
The Pages site should let users read documentation directly instead of sending them to repository source files on the first docs click.

## Verification
- `PYTHONPATH=tests uv run python -m unittest tests/test_router_content.py -v`
- `uv run python -m src.cli docs workflows --check`
- Local HTTP smoke for `/`, `/docs/`, and `/styles.css`
- Content smoke for local `Read docs`, `OMH Documentation`, `chat_response/v1`, `harness_progress/v1`, and `omh harness validate`
- Playwright Chromium screenshots for `/docs/` desktop and mobile
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- `uv run python -m compileall -q src tests`
- `git diff --check`
