### PR TITLE
Add deterministic situation playbooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ delegate coding, or report status.
 | Managed skills | Generated Hermes skill guidance under `~/.omh/skills`. |
 | Local installer | Reversible install, update, apply, doctor, and uninstall commands. |
 | Skill catalog | Deterministic routing metadata from `src/skills/catalog.py`. |
+| Playbooks | Situation-level pipelines for research, planning, wrapper UX, and coding handoff flows. |
 | Harness quality | Machine-readable quality bars, evidence ladders, wrapper actions, and overclaim guards. |
 | Wrapper contract | `chat_interaction/v1` responses for Discord, Slack, and hosted adapters. |
 | Planning artifacts | Hermes-facing Markdown plans under `~/.hermes/plans`. |
@@ -93,6 +94,16 @@ omh demo orchestration
 The demo is deterministic and transport-free. It shows the full
 recommend -> chat response -> Hermes plan -> Codex handoff -> status card path
 without calling an LLM, bot SDK, network API, or Hermes core patch.
+
+**Step 5: Pick a situation playbook**
+
+```sh
+omh playbook recommend "I want to safely add a feature to this repo"
+```
+
+Playbooks describe the wrapper-visible pipeline for situations such as
+source-backed research, deep interview to plan, safe feature change,
+release-readiness review, and local pipeline buildout.
 
 ### Stable Install
 
@@ -234,6 +245,8 @@ instead of presented as the first path.
 | Update | `omh update && omh apply && omh doctor` |
 | Inspect installed skills | `omh list` |
 | Pick a workflow locally | `omh recommend <task>` |
+| Pick a situation pipeline | `omh playbook recommend <task>` |
+| Inspect a pipeline | `omh playbook inspect <id>` |
 | Demo wrapper orchestration | `omh demo orchestration` |
 | Inspect workflow quality JSON | `omh docs workflows --json` |
 | Drive a chat wrapper turn | `omh chat interact <message>` |
@@ -253,6 +266,7 @@ fixtures, reapply, wrapper lifecycle, redacted export, and uninstall details.
 | Install, update, reapply, uninstall | [Installation](docs/INSTALLATION.md) |
 | Architecture and module ownership | [Architecture](docs/ARCHITECTURE.md) |
 | Delegation lifecycle completeness | [Delegation-First Completeness](docs/DELEGATION_FIRST_COMPLETENESS.md) |
+| Situation playbooks | [Playbooks](docs/PLAYBOOKS.md) |
 | Discord-style wrapper examples | [Chat Wrapper Examples](docs/CHAT_WRAPPER_EXAMPLES.md) |
 | Harness quality contracts | [Harness Quality Contract](docs/HARNESS_QUALITY.md) |
 | Representative workflows | [Application Cases](docs/APPLICATION_CASES.md) |

--- a/docs/APPLICATION_CASES.md
+++ b/docs/APPLICATION_CASES.md
@@ -212,6 +212,61 @@ If Hermes delegation is unavailable, the harness still improves response
 quality by making Hermes run the specialist checks sequentially in the current
 conversation.
 
+## Case 4: Situation Playbook Pipeline
+
+### Setup
+
+No additional setup is required beyond a working `omh` command.
+
+### User Prompt Shape
+
+Use this flow when a wrapper or maintainer wants to decide the whole pipeline
+for a natural request before choosing low-level commands.
+
+Strong signals include:
+
+- a safe feature or refactor request
+- a request for current source-backed research
+- an ambiguous goal that needs interview before planning
+- a recurring process or pipeline buildout
+- release-readiness, QA, CI, or merge-readiness review
+
+### Expected Hermes-Facing Behavior
+
+The playbook layer picks a situation-level path above individual skills:
+
+- `safe-feature-change` for plan-first coding handoff
+- `source-backed-research` for Hermes-owned research
+- `deep-interview-to-plan` for ambiguity reduction
+- `local-pipeline-buildout` for repeatable wrapper process design
+- `release-readiness-review` for review, QA, CI, and merge-readiness status
+
+The playbook response names which stages stay with Hermes, which stages become
+executor handoffs, and which claims must stay pending until evidence is
+observed.
+
+### Verification
+
+Inspect the playbook catalog:
+
+```sh
+omh playbook list
+omh playbook inspect safe-feature-change
+omh playbook recommend "I want to safely add a feature to this repo"
+```
+
+Repository maintainers can verify playbook behavior through tests:
+
+```sh
+PYTHONPATH=tests python3 -m unittest tests/test_cli.py -v
+```
+
+### Current Limit
+
+Playbooks are deterministic local contracts. They do not post messages,
+authenticate transport bots, launch coding executors, or prove that a later
+stage happened. Runtime status must still come from observed evidence records.
+
 ## Release Review Checklist
 
 Before using these cases as public release evidence, verify:
@@ -222,8 +277,12 @@ Before using these cases as public release evidence, verify:
 - The generated router includes the representative harness registry.
 - `omh docs workflows --json` exposes `harness_quality/v1` style quality data
   for wrapper rendering and status decisions.
-- The three cases above match actual generated skill behavior.
-- The three cases above can create `.omh/runtime/runs/<run-id>/` artifacts.
+- `omh playbook recommend` returns situation-level pipelines for safe coding,
+  source-backed research, deep interview to plan, local pipeline buildout, and
+  release-readiness review.
+- The four cases above match actual generated skill and playbook behavior.
+- Runtime-backed cases above can create `.omh/runtime/runs/<run-id>/`
+  artifacts.
 - `delegation.json` separates requested delegation from observed delegation.
 - `omh probe` output is captured before any native hook, plugin, app, MCP, or
   internal routing claim is made.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -29,7 +29,7 @@ separate runtime record exists.
 flowchart LR
   user["User in Discord, Slack, or hosted chat"]
   wrapper["Wrapper adapter\nbuttons, threads, edits"]
-  omh["OMH local contract layer\nrouting, plan, handoff, status"]
+  omh["OMH local contract layer\nplaybooks, routing, plan, handoff, status"]
   hermes["Hermes Agent\nclarify, research, plan, narrate"]
   executor["Codex-like executor\nimplementation, verification"]
   runtime["Local runtime artifacts\nprepared and observed evidence"]
@@ -50,7 +50,7 @@ flowchart LR
 ```text
 Chat user
   -> Wrapper owns transport UX
-  -> OMH owns deterministic routing contracts
+  -> OMH owns deterministic playbook and routing contracts
   -> Hermes owns conversation, planning, and status narration
   -> Executor owns main coding work when dispatched
   -> Runtime artifacts own observed evidence
@@ -73,6 +73,7 @@ src/
   installer.py
   manifest.py
   paths.py
+  playbooks.py
   ingress.py
   recommend.py                # compatibility adapter to routing/recommend.py
   routing/
@@ -150,6 +151,11 @@ small, heavily tested, and conservative.
 `skills/catalog.py` owns workflow names, descriptions, trigger phrases, and
 use-when rules as data.
 
+`playbooks.py` owns situation-level pipeline data. Playbooks sit above
+individual skills: they describe common wrapper-visible paths for research,
+interview, planning, coding handoff, local pipeline buildout, and
+release-readiness review.
+
 `skills/render.py` owns generated `SKILL.md` content. It should render from the
 catalog rather than becoming a second source of truth. `skills/packaging.py`
 owns assembly of the managed skill bundle from rendered templates.
@@ -166,19 +172,22 @@ Routing, planning, and delegation have six local surfaces:
 1. Prompt-level guidance. The router skill gives Hermes a structured map of
    workflow names and strong trigger phrases, but it does not override Hermes
    core behavior.
-2. Wrapper-native chat orchestration. `omh chat interact` lets Discord, Slack,
+2. Situation playbooks. `omh playbook recommend` lets wrappers map a natural
+   request to a higher-level pipeline before they choose a lower-level skill,
+   plan, research lane, or handoff.
+3. Wrapper-native chat orchestration. `omh chat interact` lets Discord, Slack,
    or hosted Hermes wrappers receive one platform-neutral `chat_interaction/v1`
    envelope with renderable chat copy, state, action buttons, and a thread key.
-3. Wrapper session persistence. `omh chat session` lets wrappers persist
+4. Wrapper session persistence. `omh chat session` lets wrappers persist
    metadata-only plan decisions, recover status by `session_id`, and link an
    accepted plan to a prepared coding run without owning execution evidence.
-4. Wrapper-assisted chat routing. `omh chat route` lets Discord, Slack, or
+5. Wrapper-assisted chat routing. `omh chat route` lets Discord, Slack, or
    hosted Hermes wrappers run a deterministic pre-dispatch decision before they
    forward a plain user message to Hermes.
-5. Wrapper-assisted coding delegation. `omh coding delegate` lets wrappers turn
+6. Wrapper-assisted coding delegation. `omh coding delegate` lets wrappers turn
    implementation-shaped messages into a deterministic `coding_delegation/v1`
    handoff payload for an executor lane.
-6. Hermes-facing planning artifacts. `omh hermes plan` lets wrappers or
+7. Hermes-facing planning artifacts. `omh hermes plan` lets wrappers or
    operators create deterministic `hermes_plan/v1` planning scaffolds under
    `.hermes/plans/` without claiming that execution or review already happened.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -167,7 +167,7 @@ so older imports keep working while the package grows internally.
 
 ## Routing
 
-Routing, planning, and delegation have six local surfaces:
+Routing, planning, and delegation have seven local surfaces:
 
 1. Prompt-level guidance. The router skill gives Hermes a structured map of
    workflow names and strong trigger phrases, but it does not override Hermes

--- a/docs/PLAYBOOKS.md
+++ b/docs/PLAYBOOKS.md
@@ -1,0 +1,81 @@
+# Playbooks
+
+Playbooks are situation-level pipelines for chat-facing Hermes wrappers.
+
+Skills answer "which workflow guidance should Hermes use?" Playbooks answer
+"what should the whole wrapper experience do next, and which layer owns each
+stage?"
+
+They are local, deterministic, and transport-free. A Discord, Slack, or hosted
+adapter can use playbooks to render a natural request as a plan, research lane,
+status card, or coding handoff without requiring the user to know command
+names.
+
+## Commands
+
+```sh
+omh playbook list
+omh playbook inspect safe-feature-change
+omh playbook recommend "I want to safely add a feature to this repo"
+omh playbook recommend "research latest official sources"
+```
+
+Each command returns JSON. The output is meant for wrappers, docs, demos, and
+maintainers who need to understand the product pipeline without reading source
+files.
+
+## Included Playbooks
+
+| Playbook | Use When | Primary Shape |
+| --- | --- | --- |
+| `safe-feature-change` | A user wants a safe feature, bug fix, or refactor flow. | Recommend -> plan -> accept -> coding handoff -> status card. |
+| `source-backed-research` | A user needs current, official, comparative, or citation-backed evidence. | Clarify scope -> gather sources -> synthesize -> report confidence. |
+| `deep-interview-to-plan` | A broad goal lacks scope, non-goals, or acceptance criteria. | One question -> clarified brief -> plan -> decision gate. |
+| `local-pipeline-buildout` | A maintainer wants a repeatable local process for recurring work. | Catalog route -> wrapper contract -> plan gate -> lifecycle status. |
+| `release-readiness-review` | A change needs public-facing quality, QA, CI, or merge-readiness review. | Review -> QA -> CI/status -> merge-readiness report. |
+
+## Ownership Boundary
+
+Playbooks deliberately separate ownership:
+
+- Wrappers own platform UX: buttons, threads, message edits, credentials, and
+  posting.
+- Hermes owns conversation, clarification, source-backed research, planning,
+  and status narration.
+- OMH owns deterministic local contracts, playbook selection, prepared handoff
+  payloads, and metadata-only evidence records.
+- Codex-like executors own main coding work after dispatch.
+
+Prepared handoff remains `prepared_not_observed` until the wrapper or operator
+records dispatch and result evidence. A playbook recommendation is not execution evidence.
+It is also not plan acceptance, review, CI, merge-readiness, or merge evidence.
+
+## Wrapper Rendering
+
+Wrappers should render these fields directly:
+
+| Field | Purpose |
+| --- | --- |
+| `recommendations[].id` | Stable playbook id for buttons, analytics, and session state. |
+| `recommendations[].pipeline` | Ordered high-level stages to show as a progress rail. |
+| `recommendations[].wrapper_actions` | Platform-neutral action ids for the current stage. |
+| `recommendations[].retained_by_hermes` | Work that should stay with Hermes. |
+| `recommendations[].delegated_to_executor` | Work that should become an explicit executor handoff. |
+| `recommendations[].not_evidence_until_observed` | Claims the wrapper must not make before evidence exists. |
+
+Use `omh playbook inspect <id>` when the wrapper needs full stage-level
+contracts, evidence requirements, and acceptance criteria.
+
+## Example
+
+```sh
+omh playbook recommend "I want to safely add a feature to this repo"
+```
+
+The top playbook is `safe-feature-change`. A wrapper can show a planning-first
+response, keep handoff disabled until plan acceptance, then show `Send to
+Codex` and `Show status` actions after a prepared handoff exists.
+
+The user-facing improvement is simple: the user describes the work naturally,
+and the wrapper turns it into the right pipeline without exposing shell
+commands.

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ repo-local contract for Codex agents working here.
 | Understand what OMHM is and is not | [Direction](DIRECTION.md) |
 | Understand module boundaries and local artifacts | [Architecture](ARCHITECTURE.md) |
 | Understand chat wrapper UX, sessions, and handoffs | [Delegation-First Completeness](DELEGATION_FIRST_COMPLETENESS.md) |
+| Choose a situation-level pipeline | [Playbooks](PLAYBOOKS.md) |
 | See Discord-style wrapper responses | [Chat Wrapper Examples](CHAT_WRAPPER_EXAMPLES.md) |
 | Render workflow quality gates in wrappers | [Harness Quality Contract](HARNESS_QUALITY.md) |
 | Run deterministic wrapper demos | [`omh demo orchestration`](../README.md#quick-start) and [fixture shims](../examples) |
@@ -48,6 +49,8 @@ merge.
 - Demo and shim examples should stay fixture-backed, deterministic, and
   transport-free unless a scoped integration explicitly opts into a real bot or
   network adapter.
+- Playbook docs should describe situation-level pipelines and ownership
+  boundaries rather than becoming a second skill catalog.
 - Coding-heavy requests should be described as delegated work unless there is
   observed evidence that a coding executor actually ran.
 - Generated workflow docs should come from `src/skills/catalog.py`; update the
@@ -69,6 +72,7 @@ When changing docs, check whether the same claim needs to be updated in:
 - [Direction](DIRECTION.md)
 - [Architecture](ARCHITECTURE.md)
 - [Delegation-First Completeness](DELEGATION_FIRST_COMPLETENESS.md)
+- [Playbooks](PLAYBOOKS.md)
 - [Harness Quality Contract](HARNESS_QUALITY.md)
 - [Application Cases](APPLICATION_CASES.md)
 - [Workflow Reference](WORKFLOWS.md)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -7,6 +7,8 @@
 - Uninstall and snippet command tests
 - Imported skill conflict fixtures
 - Richer routing catalog fields
+- More playbook-backed situation pipelines for wrapper UX, research, planning,
+  and release flows
 - More artifact-backed application cases for bot wrappers
 - Example Discord/Slack adapter shims that consume `chat_interaction/v1`
 - More public-site examples that mirror wrapper contracts without becoming a
@@ -40,3 +42,5 @@
 - Harness catalog inspection and validation through `omh harness list`,
   `omh harness inspect`, and `omh harness validate`
 - GitHub Pages source for the public OMH entry point
+- Situation playbooks exposed through `omh playbook list`, `inspect`, and
+  `recommend`

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -29,6 +29,7 @@
         <a href="#chat">Chat wrappers</a>
         <a href="#demo">Demo</a>
         <a href="#architecture">Architecture</a>
+        <a href="#playbooks">Playbooks</a>
         <a href="#discord-example">Chat example</a>
         <a href="#contracts">Contracts</a>
         <a href="#delegation">Delegation</a>
@@ -121,7 +122,7 @@ uv run python examples/slack-adapter-shim.py</code>
             <div class="arch-arrow" aria-hidden="true">-></div>
             <div class="arch-node arch-node--core">
               <span>OMH local contract layer</span>
-              <strong>Route, plan, handoff, status</strong>
+              <strong>Playbook, route, plan, handoff, status</strong>
             </div>
             <div class="arch-branch" aria-hidden="true"></div>
             <div class="arch-node arch-node--hermes">
@@ -141,6 +142,25 @@ uv run python examples/slack-adapter-shim.py</code>
             Prepared handoff is only a ready-to-dispatch state. Execution,
             verification, review, CI, and merge readiness stay separate until
             runtime evidence is observed.
+          </p>
+        </section>
+
+        <section class="docs-section" id="playbooks">
+          <h2>Playbooks</h2>
+          <p>
+            Playbooks sit above individual skills. They describe situation-level
+            pipelines for source-backed research, deep interview to plan, safe
+            coding handoff, local pipeline buildout, and release-readiness review.
+          </p>
+          <div class="command" role="region" aria-label="Playbook commands" tabindex="0">
+            <code>omh playbook list
+omh playbook inspect safe-feature-change
+omh playbook recommend "research latest official sources"</code>
+          </div>
+          <p>
+            Use playbooks when wrappers need to know which stages stay with
+            Hermes, which stages become executor handoffs, and which claims are
+            not evidence until runtime observations exist.
           </p>
         </section>
 

--- a/site/index.html
+++ b/site/index.html
@@ -15,6 +15,7 @@
       <div class="brand">OMH</div>
       <nav class="nav" aria-label="Primary navigation">
         <a href="#architecture">Architecture</a>
+        <a href="#playbooks">Playbooks</a>
         <a href="#flow">Flow</a>
         <a href="#example">Example</a>
         <a href="#contracts">Contracts</a>
@@ -62,7 +63,7 @@
           <div class="arch-arrow" aria-hidden="true">-></div>
           <div class="arch-node arch-node--core">
             <span>OMH local contract layer</span>
-            <strong>Route, plan, handoff, status</strong>
+            <strong>Playbook, route, plan, handoff, status</strong>
           </div>
           <div class="arch-branch" aria-hidden="true"></div>
           <div class="arch-node arch-node--hermes">
@@ -77,6 +78,44 @@
             <span>Runtime artifacts</span>
             <strong>Observed evidence and status cards</strong>
           </div>
+        </div>
+      </section>
+
+      <section class="section" id="playbooks">
+        <div class="section__header">
+          <h2>Situation playbooks for real wrapper work.</h2>
+          <p>
+            OMH can describe the whole local pipeline for common situations:
+            research, deep interview, planning, safe coding handoff, status, and
+            release-readiness review.
+          </p>
+        </div>
+        <div class="grid">
+          <article class="card">
+            <h3>Research first</h3>
+            <p>
+              Keep source-backed questions with Hermes until evidence, confidence,
+              and uncertainty are clear.
+            </p>
+          </article>
+          <article class="card">
+            <h3>Plan before handoff</h3>
+            <p>
+              Turn broad goals into one-question interviews, clarified briefs,
+              accepted plans, and only then prepared coding handoffs.
+            </p>
+          </article>
+          <article class="card">
+            <h3>Status without overclaiming</h3>
+            <p>
+              Show handoff, execution, verification, review, CI, and merge-readiness
+              as separate observed states.
+            </p>
+          </article>
+        </div>
+        <div class="command command--inline" role="region" aria-label="Playbook commands" tabindex="0">
+          <code>omh playbook recommend "I want to safely add a feature to this repo"
+omh playbook inspect safe-feature-change</code>
         </div>
       </section>
 

--- a/site/styles.css
+++ b/site/styles.css
@@ -244,6 +244,10 @@ h1 {
   white-space: pre;
 }
 
+.command--inline {
+  margin-top: 22px;
+}
+
 .steps {
   display: grid;
   gap: 12px;

--- a/src/commands/main.py
+++ b/src/commands/main.py
@@ -30,6 +30,7 @@ from ..installer import OmhError, install_skill_pack, uninstall_skill_pack
 from ..local_store import atomic_write_text
 from ..manifest import read_manifest
 from ..paths import resolve_paths
+from ..playbooks import inspect_playbook, list_playbooks, recommend_playbooks
 from ..probe import probe_capabilities
 from ..routing.recommend import recommend_skills
 from ..release import RELEASE_CHANNELS, package_url_for
@@ -203,6 +204,28 @@ def cmd_recommend(args: argparse.Namespace) -> int:
     if not query:
         raise OmhError("recommend requires a task description")
     _print_json({"query": query, "recommendations": recommend_skills(query, limit=args.limit)})
+    return 0
+
+
+def cmd_playbook_list(args: argparse.Namespace) -> int:
+    _print_json(list_playbooks())
+    return 0
+
+
+def cmd_playbook_inspect(args: argparse.Namespace) -> int:
+    try:
+        _print_json(inspect_playbook(args.id))
+    except KeyError as exc:
+        raise OmhError(f"unknown playbook: {args.id}") from exc
+    return 0
+
+
+def cmd_playbook_recommend(args: argparse.Namespace) -> int:
+    query = " ".join(args.task).strip()
+    try:
+        _print_json(recommend_playbooks(query, limit=args.limit))
+    except ValueError as exc:
+        raise OmhError(str(exc)) from exc
     return 0
 
 
@@ -991,6 +1014,23 @@ def _add_harness_commands(sub) -> None:
     harness_validate.set_defaults(func=cmd_harness_validate)
 
 
+def _add_playbook_commands(sub) -> None:
+    playbook = sub.add_parser("playbook")
+    playbook_sub = playbook.add_subparsers(dest="playbook_command", required=True)
+
+    playbook_list = playbook_sub.add_parser("list")
+    playbook_list.set_defaults(func=cmd_playbook_list)
+
+    playbook_inspect = playbook_sub.add_parser("inspect")
+    playbook_inspect.add_argument("id")
+    playbook_inspect.set_defaults(func=cmd_playbook_inspect)
+
+    playbook_recommend = playbook_sub.add_parser("recommend")
+    playbook_recommend.add_argument("task", nargs="+", help="Natural-language request to map to an OMH playbook.")
+    playbook_recommend.add_argument("--limit", type=int, default=3, help="Maximum playbooks to return.")
+    playbook_recommend.set_defaults(func=cmd_playbook_recommend)
+
+
 def _add_demo_commands(sub) -> None:
     demo = sub.add_parser("demo")
     demo_sub = demo.add_subparsers(dest="demo_command", required=True)
@@ -1370,6 +1410,7 @@ def build_parser() -> argparse.ArgumentParser:
     _add_top_level_commands(sub)
     _add_docs_commands(sub)
     _add_harness_commands(sub)
+    _add_playbook_commands(sub)
     _add_demo_commands(sub)
     _add_chat_commands(sub)
     _add_coding_commands(sub)

--- a/src/playbooks.py
+++ b/src/playbooks.py
@@ -1,0 +1,471 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+
+
+PLAYBOOK_CATALOG_SCHEMA_VERSION = "playbook_catalog/v1"
+PLAYBOOK_RECOMMENDATION_SCHEMA_VERSION = "playbook_recommendation/v1"
+_TOKEN_RE = re.compile(r"[a-z0-9][a-z0-9-]*")
+_STOPWORDS = {
+    "the",
+    "and",
+    "for",
+    "with",
+    "that",
+    "this",
+    "when",
+    "user",
+    "agent",
+    "hermes",
+    "request",
+    "workflow",
+}
+
+
+@dataclass(frozen=True)
+class PlaybookStage:
+    id: str
+    title: str
+    owner: str
+    purpose: str
+    contract: str
+    wrapper_actions: tuple[str, ...]
+    evidence_required: tuple[str, ...]
+    evidence_boundary: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "id": self.id,
+            "title": self.title,
+            "owner": self.owner,
+            "purpose": self.purpose,
+            "contract": self.contract,
+            "wrapper_actions": list(self.wrapper_actions),
+            "evidence_required": list(self.evidence_required),
+            "evidence_boundary": self.evidence_boundary,
+        }
+
+
+@dataclass(frozen=True)
+class Playbook:
+    id: str
+    title: str
+    summary: str
+    use_when: str
+    keywords: tuple[str, ...]
+    pipeline: tuple[str, ...]
+    retained_by_hermes: tuple[str, ...]
+    delegated_to_executor: tuple[str, ...]
+    stages: tuple[PlaybookStage, ...]
+    acceptance_criteria: tuple[str, ...]
+    not_evidence_until_observed: tuple[str, ...]
+
+    def summary_dict(self) -> dict[str, object]:
+        return {
+            "id": self.id,
+            "title": self.title,
+            "summary": self.summary,
+            "use_when": self.use_when,
+            "pipeline": list(self.pipeline),
+            "retained_by_hermes": list(self.retained_by_hermes),
+            "delegated_to_executor": list(self.delegated_to_executor),
+            "stage_count": len(self.stages),
+            "not_evidence_until_observed": list(self.not_evidence_until_observed),
+        }
+
+    def to_dict(self) -> dict[str, object]:
+        payload = self.summary_dict()
+        payload.update(
+            {
+                "keywords": list(self.keywords),
+                "stages": [stage.to_dict() for stage in self.stages],
+                "acceptance_criteria": list(self.acceptance_criteria),
+            }
+        )
+        return payload
+
+
+_COMMON_NOT_EVIDENCE = (
+    "executor_dispatch",
+    "executor_result",
+    "verification",
+    "review",
+    "ci",
+    "merge_readiness",
+    "merge",
+)
+
+
+_PLAYBOOKS = (
+    Playbook(
+        id="safe-feature-change",
+        title="Safe feature change",
+        summary="Turn a natural feature request into a plan-first coding handoff with status cards.",
+        use_when="A user wants to add, change, or refactor code safely without learning command names.",
+        keywords=("safe", "feature", "add", "change", "repo", "implementation", "refactor", "review", "verify"),
+        pipeline=("recommend", "chat_plan", "accept_plan", "prepare_handoff", "dispatch_executor", "status_card"),
+        retained_by_hermes=("conversation", "clarification", "planning", "status narration"),
+        delegated_to_executor=("implementation", "test execution", "review fix work"),
+        stages=(
+            PlaybookStage(
+                "recommend",
+                "Recommend a workflow lane",
+                "omh",
+                "Map the plain request to a planning-first route from local catalog metadata.",
+                "playbook_recommendation/v1",
+                ("show_recommendation",),
+                ("task text hash", "selected playbook id", "confidence"),
+                "Recommendation is not plan acceptance or execution evidence.",
+            ),
+            PlaybookStage(
+                "plan",
+                "Present a safe plan",
+                "hermes",
+                "Clarify scope, non-goals, acceptance criteria, and verification before coding starts.",
+                "hermes_plan/v1",
+                ("accept_plan", "revise_plan"),
+                ("plan artifact or wrapper plan state",),
+                "A draft plan is not implementation evidence.",
+            ),
+            PlaybookStage(
+                "handoff",
+                "Prepare coding handoff",
+                "omh",
+                "Create a metadata-safe handoff payload for a Codex-like executor after plan acceptance.",
+                "coding_delegation/v1",
+                ("send_to_codex", "show_status"),
+                ("prepared coding delegation record",),
+                "Prepared handoff is not executor dispatch or result evidence.",
+            ),
+            PlaybookStage(
+                "status",
+                "Report observed progress",
+                "wrapper",
+                "Render handoff, execution, verification, review, CI, and merge readiness separately.",
+                "status_card/v1",
+                ("refresh_status",),
+                ("runtime observation records",),
+                "Status only advances when the matching runtime evidence exists.",
+            ),
+        ),
+        acceptance_criteria=(
+            "The user can stay in chat and choose plan actions without knowing shell commands.",
+            "Coding work is represented as a prepared executor handoff until dispatch is observed.",
+            "Completion claims require observed verification and review evidence when required.",
+        ),
+        not_evidence_until_observed=_COMMON_NOT_EVIDENCE,
+    ),
+    Playbook(
+        id="source-backed-research",
+        title="Source-backed research",
+        summary="Keep current-information requests in Hermes as research before any later plan or handoff.",
+        use_when="A user asks for latest, official, comparative, legal, financial, or source-backed information.",
+        keywords=("research", "latest", "current", "official", "source", "compare", "evidence", "citation"),
+        pipeline=("clarify_scope", "gather_sources", "synthesize", "status_summary"),
+        retained_by_hermes=("source selection", "evidence synthesis", "confidence and uncertainty narration"),
+        delegated_to_executor=(),
+        stages=(
+            PlaybookStage(
+                "scope",
+                "Clarify source boundaries",
+                "hermes",
+                "Ask the smallest blocking question only when jurisdiction, recency, or source type changes the answer.",
+                "chat_response/v1",
+                ("answer_question", "revise_scope"),
+                ("research question", "source boundary"),
+                "Clarification is not research evidence.",
+            ),
+            PlaybookStage(
+                "research",
+                "Gather and compare sources",
+                "hermes",
+                "Prefer official or primary sources and separate direct evidence from inference.",
+                "research_notes/v1",
+                ("show_sources",),
+                ("source refs", "retrieval dates", "quoted evidence summary"),
+                "Research notes are not implementation or verification evidence.",
+            ),
+            PlaybookStage(
+                "status",
+                "Summarize confidence",
+                "hermes",
+                "Report conclusions, uncertainty, and what would change the answer.",
+                "chat_response/v1",
+                ("show_status",),
+                ("confidence summary", "remaining uncertainty"),
+                "A research conclusion is not a completed coding handoff.",
+            ),
+        ),
+        acceptance_criteria=(
+            "Official or primary sources are preferred when available.",
+            "The answer separates evidence, inference, confidence, and residual uncertainty.",
+            "No coding handoff is prepared unless the user asks for code changes after research.",
+        ),
+        not_evidence_until_observed=("implementation", "verification", "review", "ci", "merge"),
+    ),
+    Playbook(
+        id="deep-interview-to-plan",
+        title="Deep interview to plan",
+        summary="Reduce ambiguous goals into a clarified brief, then a plan, before any handoff.",
+        use_when="A broad goal has missing scope, non-goals, decision authority, or acceptance criteria.",
+        keywords=("ambiguous", "unclear", "interview", "clarify", "plan", "strategy", "goal", "non-goal"),
+        pipeline=("ask_one_question", "clarified_brief", "draft_plan", "decision_gate"),
+        retained_by_hermes=("one-question interview", "brief synthesis", "plan narration"),
+        delegated_to_executor=("implementation only after plan acceptance",),
+        stages=(
+            PlaybookStage(
+                "interview",
+                "Ask one blocking question",
+                "hermes",
+                "Resolve the decision that most changes the plan shape or stop condition.",
+                "chat_response/v1",
+                ("answer_question",),
+                ("blocking ambiguity", "user answer"),
+                "An unanswered question is not a plan.",
+            ),
+            PlaybookStage(
+                "brief",
+                "Synthesize clarified brief",
+                "hermes",
+                "Name goals, non-goals, constraints, and acceptance criteria.",
+                "clarified_brief/v1",
+                ("accept_brief", "revise_brief"),
+                ("clarified brief",),
+                "A clarified brief is not execution evidence.",
+            ),
+            PlaybookStage(
+                "plan",
+                "Draft execution plan",
+                "hermes",
+                "Produce a reviewable plan and only expose handoff actions after acceptance.",
+                "hermes_plan/v1",
+                ("accept_plan", "revise_plan"),
+                ("plan artifact",),
+                "A draft plan is not accepted work.",
+            ),
+        ),
+        acceptance_criteria=(
+            "Only one blocking question is asked at a time.",
+            "The plan contains goals, non-goals, risks, verification, and handoff guidance.",
+            "Coding delegation remains disabled until the user or wrapper accepts the plan.",
+        ),
+        not_evidence_until_observed=_COMMON_NOT_EVIDENCE,
+    ),
+    Playbook(
+        id="local-pipeline-buildout",
+        title="Local pipeline buildout",
+        summary="Design a repeatable local workflow from chat intake through plan, handoff, status, and review evidence.",
+        use_when="A maintainer wants to build or document a deterministic pipeline for a recurring work pattern.",
+        keywords=("pipeline", "buildout", "recurring", "workflow", "process", "status", "review", "automation"),
+        pipeline=("catalog_route", "wrapper_contract", "plan_gate", "executor_lifecycle", "review_ci_merge_status"),
+        retained_by_hermes=("process explanation", "planning", "status narration"),
+        delegated_to_executor=("pipeline code changes", "test implementation"),
+        stages=(
+            PlaybookStage(
+                "catalog",
+                "Select catalog route",
+                "omh",
+                "Use local skill and harness metadata to pick the workflow lane.",
+                "workflow_catalog/v1",
+                ("show_route",),
+                ("catalog match", "confidence"),
+                "Catalog selection is not runtime execution.",
+            ),
+            PlaybookStage(
+                "contract",
+                "Render wrapper contract",
+                "wrapper",
+                "Map route state to buttons, thread updates, and status cards.",
+                "chat_interaction/v1",
+                ("render_buttons", "show_status"),
+                ("wrapper action ids", "thread key"),
+                "Rendered UI is not executor evidence.",
+            ),
+            PlaybookStage(
+                "lifecycle",
+                "Track executor lifecycle",
+                "omh",
+                "Record dispatch, result, verification, review, CI, and merge readiness as separate observations.",
+                "delegated_coding_status/v1",
+                ("send_to_codex", "refresh_status"),
+                ("runtime run id", "observed lifecycle records"),
+                "A later green status cannot override missing upstream evidence.",
+            ),
+        ),
+        acceptance_criteria=(
+            "The pipeline identifies which layer owns each stage.",
+            "Wrapper actions are platform-neutral ids, not transport SDK calls.",
+            "Evidence stages are strict enough for repeated status reporting.",
+        ),
+        not_evidence_until_observed=_COMMON_NOT_EVIDENCE,
+    ),
+    Playbook(
+        id="release-readiness-review",
+        title="Release readiness review",
+        summary="Frame docs, QA, review, CI, and merge-readiness checks without treating them as code fixes.",
+        use_when="A change is public-facing, release-shaped, or needs confidence before merge.",
+        keywords=("release", "readiness", "review", "qa", "ci", "merge", "public", "docs", "quality"),
+        pipeline=("review_scope", "qa_checks", "ci_status", "merge_readiness", "report"),
+        retained_by_hermes=("review framing", "status narration", "risk synthesis"),
+        delegated_to_executor=("fix implementation", "test repair", "docs edits when accepted"),
+        stages=(
+            PlaybookStage(
+                "review",
+                "Run review gate",
+                "hermes",
+                "Separate review findings from any follow-up code changes.",
+                "review_gate/v1",
+                ("show_findings", "prepare_fix_handoff"),
+                ("review summary", "risk list"),
+                "Review findings are not fix evidence.",
+            ),
+            PlaybookStage(
+                "qa",
+                "Check adversarial scenarios",
+                "hermes",
+                "Name scenario coverage and record pass, fail, or not observed.",
+                "harness_quality/v1",
+                ("show_status",),
+                ("scenario list", "observed result"),
+                "A QA plan is not a passed test.",
+            ),
+            PlaybookStage(
+                "merge",
+                "Report merge readiness",
+                "omh",
+                "Combine review, verification, CI, and merge readiness without skipping missing gates.",
+                "status_card/v1",
+                ("refresh_status",),
+                ("review record", "ci record", "merge readiness record"),
+                "Merge-ready is not merged.",
+            ),
+        ),
+        acceptance_criteria=(
+            "Findings, fixes, verification, CI, and merge readiness remain separate.",
+            "Fix work becomes an executor handoff when code changes are required.",
+            "Merge status is never inferred from review or CI alone.",
+        ),
+        not_evidence_until_observed=("fix_result", "verification", "ci", "merge_readiness", "merge"),
+    ),
+)
+
+
+def list_playbooks() -> dict[str, object]:
+    return {
+        "schema_version": PLAYBOOK_CATALOG_SCHEMA_VERSION,
+        "playbooks": [playbook.summary_dict() for playbook in _PLAYBOOKS],
+    }
+
+
+def inspect_playbook(playbook_id: str) -> dict[str, object]:
+    playbook = _playbook_by_id(playbook_id)
+    return {
+        "schema_version": PLAYBOOK_CATALOG_SCHEMA_VERSION,
+        "playbook": playbook.to_dict(),
+    }
+
+
+def recommend_playbooks(query: str, *, limit: int = 3) -> dict[str, object]:
+    if limit < 1:
+        raise ValueError("playbook recommend --limit must be at least 1")
+    task = query.strip()
+    if not task:
+        raise ValueError("playbook recommend requires a task description")
+    scored = [_score_playbook(playbook, task) for playbook in _PLAYBOOKS]
+    scored.sort(key=lambda item: (-int(item["score"]), str(item["id"])))
+    matches = [item for item in scored if int(item["score"]) > 0] or [_fallback_playbook(task)]
+    return {
+        "schema_version": PLAYBOOK_RECOMMENDATION_SCHEMA_VERSION,
+        "query": task,
+        "recommendations": matches[:limit],
+    }
+
+
+def _playbook_by_id(playbook_id: str) -> Playbook:
+    for playbook in _PLAYBOOKS:
+        if playbook.id == playbook_id:
+            return playbook
+    raise KeyError(playbook_id)
+
+
+def _score_playbook(playbook: Playbook, query: str) -> dict[str, object]:
+    normalized_query = query.lower()
+    query_tokens = _tokens(query)
+    score = 0
+    matched: set[str] = set()
+
+    for keyword in playbook.keywords:
+        normalized_keyword = keyword.lower()
+        if normalized_keyword in normalized_query:
+            score += 5
+            matched.add(f"keyword:{normalized_keyword}")
+
+    metadata_tokens = _tokens(" ".join((playbook.id, playbook.title, playbook.summary, playbook.use_when, " ".join(playbook.pipeline))))
+    for token in sorted(query_tokens & metadata_tokens):
+        score += 2
+        matched.add(f"metadata:{token}")
+
+    if "coding" in query_tokens or "code" in query_tokens or "implement" in query_tokens:
+        if playbook.delegated_to_executor:
+            score += 2
+            matched.add("boundary:executor")
+    if "research" in query_tokens or "source" in query_tokens:
+        if not playbook.delegated_to_executor:
+            score += 2
+            matched.add("boundary:hermes")
+
+    return _recommendation_payload(playbook, score=score, matched=tuple(sorted(matched)))
+
+
+def _fallback_playbook(query: str) -> dict[str, object]:
+    playbook = _playbook_by_id("deep-interview-to-plan")
+    payload = _recommendation_payload(playbook, score=0, matched=())
+    payload["why"] = "No strong playbook match; start by clarifying the request before planning or handoff."
+    payload["suggested_prompt"] = f"Clarify and plan this request before delegation: {query}"
+    return payload
+
+
+def _recommendation_payload(playbook: Playbook, *, score: int, matched: tuple[str, ...]) -> dict[str, object]:
+    first_stage = playbook.stages[0]
+    return {
+        "id": playbook.id,
+        "title": playbook.title,
+        "summary": playbook.summary,
+        "score": score,
+        "confidence": _confidence(score),
+        "matched": list(matched),
+        "why": _why(matched),
+        "pipeline": list(playbook.pipeline),
+        "next_action": first_stage.id,
+        "wrapper_actions": list(first_stage.wrapper_actions),
+        "evidence_boundary": first_stage.evidence_boundary,
+        "retained_by_hermes": list(playbook.retained_by_hermes),
+        "delegated_to_executor": list(playbook.delegated_to_executor),
+        "not_evidence_until_observed": list(playbook.not_evidence_until_observed),
+        "suggested_prompt": f"Use the {playbook.id} playbook for this request.",
+    }
+
+
+def _tokens(value: str) -> set[str]:
+    tokens: set[str] = set()
+    for raw_token in _TOKEN_RE.findall(value.lower()):
+        for token in (raw_token, *raw_token.split("-")):
+            if len(token) >= 3 and token not in _STOPWORDS:
+                tokens.add(token)
+    return tokens
+
+
+def _confidence(score: int) -> str:
+    if score >= 10:
+        return "high"
+    if score >= 4:
+        return "medium"
+    return "low"
+
+
+def _why(matched: tuple[str, ...]) -> str:
+    if not matched:
+        return "No strong playbook match."
+    sources = sorted({item.split(":", 1)[0] for item in matched})
+    return f"Matched {'/'.join(sources)} playbook signals for this task."

--- a/src/playbooks.py
+++ b/src/playbooks.py
@@ -54,6 +54,7 @@ class Playbook:
     summary: str
     use_when: str
     keywords: tuple[str, ...]
+    intent_tags: tuple[str, ...]
     pipeline: tuple[str, ...]
     retained_by_hermes: tuple[str, ...]
     delegated_to_executor: tuple[str, ...]
@@ -67,6 +68,7 @@ class Playbook:
             "title": self.title,
             "summary": self.summary,
             "use_when": self.use_when,
+            "intent_tags": list(self.intent_tags),
             "pipeline": list(self.pipeline),
             "retained_by_hermes": list(self.retained_by_hermes),
             "delegated_to_executor": list(self.delegated_to_executor),
@@ -103,7 +105,25 @@ _PLAYBOOKS = (
         title="Safe feature change",
         summary="Turn a natural feature request into a plan-first coding handoff with status cards.",
         use_when="A user wants to add, change, or refactor code safely without learning command names.",
-        keywords=("safe", "feature", "add", "change", "repo", "implementation", "refactor", "review", "verify"),
+        keywords=(
+            "safe",
+            "safely",
+            "feature",
+            "add",
+            "change",
+            "repo",
+            "implementation",
+            "refactor",
+            "review",
+            "verify",
+        ),
+        intent_tags=(
+            "safe feature change",
+            "feature implementation",
+            "repo change",
+            "reviewed coding",
+            "executor handoff",
+        ),
         pipeline=("recommend", "chat_plan", "accept_plan", "prepare_handoff", "dispatch_executor", "status_card"),
         retained_by_hermes=("conversation", "clarification", "planning", "status narration"),
         delegated_to_executor=("implementation", "test execution", "review fix work"),
@@ -161,7 +181,29 @@ _PLAYBOOKS = (
         title="Source-backed research",
         summary="Keep current-information requests in Hermes as research before any later plan or handoff.",
         use_when="A user asks for latest, official, comparative, legal, financial, or source-backed information.",
-        keywords=("research", "latest", "current", "official", "source", "compare", "evidence", "citation"),
+        keywords=(
+            "research",
+            "latest",
+            "current",
+            "official",
+            "source",
+            "sources",
+            "compare",
+            "comparative",
+            "evidence",
+            "citation",
+            "legal",
+            "financial",
+            "information",
+        ),
+        intent_tags=(
+            "source backed research",
+            "official sources",
+            "current information",
+            "legal research",
+            "financial research",
+            "evidence synthesis",
+        ),
         pipeline=("clarify_scope", "gather_sources", "synthesize", "status_summary"),
         retained_by_hermes=("source selection", "evidence synthesis", "confidence and uncertainty narration"),
         delegated_to_executor=(),
@@ -210,6 +252,13 @@ _PLAYBOOKS = (
         summary="Reduce ambiguous goals into a clarified brief, then a plan, before any handoff.",
         use_when="A broad goal has missing scope, non-goals, decision authority, or acceptance criteria.",
         keywords=("ambiguous", "unclear", "interview", "clarify", "plan", "strategy", "goal", "non-goal"),
+        intent_tags=(
+            "deep interview",
+            "clarified brief",
+            "ambiguous goal",
+            "planning before handoff",
+            "acceptance criteria",
+        ),
         pipeline=("ask_one_question", "clarified_brief", "draft_plan", "decision_gate"),
         retained_by_hermes=("one-question interview", "brief synthesis", "plan narration"),
         delegated_to_executor=("implementation only after plan acceptance",),
@@ -258,6 +307,13 @@ _PLAYBOOKS = (
         summary="Design a repeatable local workflow from chat intake through plan, handoff, status, and review evidence.",
         use_when="A maintainer wants to build or document a deterministic pipeline for a recurring work pattern.",
         keywords=("pipeline", "buildout", "recurring", "workflow", "process", "status", "review", "automation"),
+        intent_tags=(
+            "local pipeline",
+            "wrapper orchestration",
+            "recurring workflow",
+            "status lifecycle",
+            "contract buildout",
+        ),
         pipeline=("catalog_route", "wrapper_contract", "plan_gate", "executor_lifecycle", "review_ci_merge_status"),
         retained_by_hermes=("process explanation", "planning", "status narration"),
         delegated_to_executor=("pipeline code changes", "test implementation"),
@@ -306,6 +362,13 @@ _PLAYBOOKS = (
         summary="Frame docs, QA, review, CI, and merge-readiness checks without treating them as code fixes.",
         use_when="A change is public-facing, release-shaped, or needs confidence before merge.",
         keywords=("release", "readiness", "review", "qa", "ci", "merge", "public", "docs", "quality"),
+        intent_tags=(
+            "release readiness",
+            "qa review",
+            "ci status",
+            "merge readiness",
+            "public docs quality",
+        ),
         pipeline=("review_scope", "qa_checks", "ci_status", "merge_readiness", "report"),
         retained_by_hermes=("review framing", "status narration", "risk synthesis"),
         delegated_to_executor=("fix implementation", "test repair", "docs edits when accepted"),
@@ -390,21 +453,27 @@ def _playbook_by_id(playbook_id: str) -> Playbook:
 
 
 def _score_playbook(playbook: Playbook, query: str) -> dict[str, object]:
-    normalized_query = query.lower()
     query_tokens = _tokens(query)
+    query_terms = _terms(query)
     score = 0
     matched: set[str] = set()
 
     for keyword in playbook.keywords:
         normalized_keyword = keyword.lower()
-        if normalized_keyword in normalized_query:
+        if _matches_term(normalized_keyword, query_terms):
             score += 5
             matched.add(f"keyword:{normalized_keyword}")
 
-    metadata_tokens = _tokens(" ".join((playbook.id, playbook.title, playbook.summary, playbook.use_when, " ".join(playbook.pipeline))))
-    for token in sorted(query_tokens & metadata_tokens):
+    intent_tokens = _tokens(" ".join((playbook.id, *playbook.intent_tags)))
+    for token in sorted(query_tokens & intent_tokens):
         score += 2
-        matched.add(f"metadata:{token}")
+        matched.add(f"intent:{token}")
+
+    for intent_tag in playbook.intent_tags:
+        normalized_intent = intent_tag.lower()
+        if _matches_term(normalized_intent, query_terms):
+            score += 3
+            matched.add(f"intent-tag:{normalized_intent}")
 
     if "coding" in query_tokens or "code" in query_tokens or "implement" in query_tokens:
         if playbook.delegated_to_executor:
@@ -449,11 +518,26 @@ def _recommendation_payload(playbook: Playbook, *, score: int, matched: tuple[st
 
 def _tokens(value: str) -> set[str]:
     tokens: set[str] = set()
-    for raw_token in _TOKEN_RE.findall(value.lower()):
+    for raw_token in _terms(value):
         for token in (raw_token, *raw_token.split("-")):
             if len(token) >= 3 and token not in _STOPWORDS:
                 tokens.add(token)
     return tokens
+
+
+def _terms(value: str) -> set[str]:
+    terms: set[str] = set()
+    for raw_token in _TOKEN_RE.findall(value.lower()):
+        terms.add(raw_token)
+        terms.update(raw_token.split("-"))
+    return terms
+
+
+def _matches_term(term: str, query_terms: set[str]) -> bool:
+    term_tokens = tuple(_terms(term))
+    if not term_tokens:
+        return False
+    return all(token in query_terms for token in term_tokens)
 
 
 def _confidence(score: int) -> str:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -85,6 +85,52 @@ class CliTests(unittest.TestCase):
         self.assertEqual(status, 2)
         self.assertIn("recommend --limit must be at least 1", stderr)
 
+    def test_playbook_list_exposes_situation_pipelines(self) -> None:
+        status, stdout, stderr = run_cli(["playbook", "list"])
+
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        payload = json.loads(stdout)
+        self.assertEqual(payload["schema_version"], "playbook_catalog/v1")
+        playbooks = {playbook["id"]: playbook for playbook in payload["playbooks"]}
+        self.assertIn("safe-feature-change", playbooks)
+        self.assertIn("source-backed-research", playbooks)
+        self.assertIn("local-pipeline-buildout", playbooks)
+        self.assertIn("prepare_handoff", playbooks["safe-feature-change"]["pipeline"])
+        self.assertIn("status_card", playbooks["safe-feature-change"]["pipeline"])
+
+    def test_playbook_inspect_shows_owners_and_evidence_boundaries(self) -> None:
+        status, stdout, stderr = run_cli(["playbook", "inspect", "safe-feature-change"])
+
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        playbook = json.loads(stdout)["playbook"]
+        self.assertEqual(playbook["id"], "safe-feature-change")
+        owners = {stage["owner"] for stage in playbook["stages"]}
+        self.assertTrue({"hermes", "omh", "wrapper"} <= owners)
+        self.assertIn("implementation", " ".join(playbook["delegated_to_executor"]))
+        boundaries = " ".join(stage["evidence_boundary"] for stage in playbook["stages"])
+        self.assertIn("not executor dispatch", boundaries)
+
+    def test_playbook_recommend_routes_feature_and_research_situations(self) -> None:
+        status, stdout, stderr = run_cli(["playbook", "recommend", "I", "want", "to", "safely", "add", "a", "feature", "to", "this", "repo"])
+
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        feature = json.loads(stdout)["recommendations"][0]
+        self.assertEqual(feature["id"], "safe-feature-change")
+        self.assertEqual(feature["confidence"], "high")
+        self.assertIn("executor_dispatch", feature["not_evidence_until_observed"])
+
+        status, stdout, stderr = run_cli(["playbook", "recommend", "research", "latest", "official", "sources"])
+
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        research = json.loads(stdout)["recommendations"][0]
+        self.assertEqual(research["id"], "source-backed-research")
+        self.assertEqual(research["delegated_to_executor"], [])
+        self.assertIn("source selection", " ".join(research["retained_by_hermes"]))
+
     def test_chat_route_dispatches_plain_chat_message(self) -> None:
         status, stdout, stderr = run_cli(["chat", "route", "--source", "discord", "risky", "refactor"])
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -131,6 +131,16 @@ class CliTests(unittest.TestCase):
         self.assertEqual(research["delegated_to_executor"], [])
         self.assertIn("source selection", " ".join(research["retained_by_hermes"]))
 
+        for task in ("financial", "legal financial information", "official"):
+            with self.subTest(task=task):
+                status, stdout, stderr = run_cli(["playbook", "recommend", task, "--limit", "3"])
+
+                self.assertEqual(stderr, "")
+                self.assertEqual(status, 0)
+                recommendation_ids = [item["id"] for item in json.loads(stdout)["recommendations"]]
+                self.assertEqual(recommendation_ids[0], "source-backed-research")
+                self.assertNotEqual(recommendation_ids[0], "release-readiness-review")
+
     def test_chat_route_dispatches_plain_chat_message(self) -> None:
         status, stdout, stderr = run_cli(["chat", "route", "--source", "discord", "risky", "refactor"])
 

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -232,6 +232,7 @@ class RouterContentTests(unittest.TestCase):
             Path("docs/HARNESS_QUALITY.md"),
             Path("docs/INSTALLATION.md"),
             Path("docs/APPLICATION_CASES.md"),
+            Path("docs/PLAYBOOKS.md"),
             Path("docs/RELEASE.md"),
             Path("install.sh"),
             Path("CONTRIBUTING.md"),
@@ -344,6 +345,7 @@ class RouterContentTests(unittest.TestCase):
             "## Case 1: Coding Request Handling",
             "## Case 2: Goal, Planning, and Deep Interview Flow",
             "## Case 3: Specialist Harness Flow",
+            "## Case 4: Situation Playbook Pipeline",
             "## Release Review Checklist",
         ):
             self.assertIn(heading, text)
@@ -355,8 +357,23 @@ class RouterContentTests(unittest.TestCase):
             self.assertIn(harness, text)
         self.assertIn("quality tier", text)
         self.assertIn("evidence ladder", text)
+        self.assertIn("omh playbook recommend", text)
+        self.assertIn("safe-feature-change", text)
         self.assertIn("omh docs workflows --json", text)
         self.assertIn("omh probe", text)
+
+    def test_playbook_docs_are_discoverable(self) -> None:
+        readme = Path("README.md").read_text(encoding="utf-8")
+        docs_index = Path("docs/README.md").read_text(encoding="utf-8")
+        playbooks = Path("docs/PLAYBOOKS.md").read_text(encoding="utf-8")
+        site = Path("site/index.html").read_text(encoding="utf-8")
+
+        self.assertIn("omh playbook recommend", readme)
+        self.assertIn("Playbooks", docs_index)
+        self.assertIn("safe-feature-change", playbooks)
+        self.assertIn("source-backed-research", playbooks)
+        self.assertIn("not execution evidence", playbooks)
+        self.assertIn("Situation playbooks", site)
 
     def test_discord_example_uses_wrapper_native_flow(self) -> None:
         text = Path("examples/discord-bot-runtime-flow.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Add deterministic `omh playbook list|inspect|recommend` commands for situation-level Hermes wrapper workflows.
- Define playbooks for safe feature changes, source-backed research, deep interview to plan, local pipeline buildout, and release readiness.
- Document the playbook surface in README, docs, application cases, architecture, roadmap, and the static site.
- Stabilize recommendation scoring with machine-facing intent tags and exact term matching so public prose edits do not change routing behavior.

## User Value
Users can send plain natural-language requests such as “I want to safely add a feature to this repo” and wrappers can show the right Hermes-native path: recommendation, plan, handoff, status, and evidence boundaries without asking users to know command names.

## Review Fixes
- Fixed substring scoring where `ci` could match inside words like `official` or `financial`.
- Added regression coverage for financial, legal financial information, official, and exact ci routing.
- Corrected the architecture surface count after adding playbooks.

## Verification
- `PYTHONPATH=tests uv run python -m unittest tests/test_cli.py -v`
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- `uv run python -m src.cli docs workflows --check`
- `uv run python -m src.cli harness validate`
- `uv run python -m compileall -q src tests`
- `git diff --check`
- `uv run python -m src.cli playbook recommend financial --limit 3`
- `uv run python -m src.cli playbook recommend "legal financial information" --limit 3`
- `uv run python -m src.cli playbook recommend official --limit 3`
- `uv run python -m src.cli playbook recommend ci --limit 3`

## Independent Review
- code-reviewer: APPROVE, 0 issues after review fixes.
- architect: CLEAR, docs/site generation noted as a non-blocking future maintenance follow-up.

## Boundaries
- No LLM/API/network/platform SDK calls.
- No Hermes core patching.
- Prepared handoffs remain distinct from observed execution, review, CI, merge-readiness, and merge evidence.