### PR TITLE
Show the site install command first

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -14,12 +14,12 @@
     <header class="topbar" aria-label="Primary">
       <div class="brand">OMH</div>
       <nav class="nav" aria-label="Primary navigation">
+        <a href="#install">Install</a>
         <a href="#architecture">Architecture</a>
         <a href="#playbooks">Playbooks</a>
         <a href="#flow">Flow</a>
         <a href="#example">Example</a>
         <a href="#contracts">Contracts</a>
-        <a href="#install">Install</a>
         <a href="docs/">Docs</a>
         <a href="https://github.com/rlaope/oh-my-hermes-agent">GitHub</a>
       </nav>
@@ -34,8 +34,13 @@
             A local contract layer that helps Hermes turn chat messages into
             clarification, research, planning, status, or Codex-ready coding handoffs.
           </p>
+          <div class="hero-command" role="region" aria-label="Download OMH command" tabindex="0">
+            <span>Download OMH</span>
+            <code>curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes-agent/main/install.sh | sh
+omh doctor</code>
+          </div>
           <div class="actions" aria-label="Primary actions">
-            <a class="button button--primary" href="#install">Install</a>
+            <a class="button button--primary" href="#install">Install details</a>
             <a class="button" href="docs/">Read docs</a>
           </div>
         </div>

--- a/site/styles.css
+++ b/site/styles.css
@@ -132,9 +132,41 @@ h1 {
 
 .lead {
   max-width: 640px;
-  margin-bottom: 30px;
+  margin-bottom: 22px;
   color: rgba(255, 255, 255, 0.9);
   font-size: clamp(19px, 2vw, 25px);
+}
+
+.hero-command {
+  max-width: min(100%, 720px);
+  margin-bottom: 18px;
+  overflow-x: auto;
+  padding: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  border-radius: 8px;
+  background: rgba(8, 15, 24, 0.74);
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.18);
+}
+
+.hero-command span {
+  display: block;
+  margin-bottom: 8px;
+  color: rgba(255, 255, 255, 0.72);
+  font-size: 12px;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0;
+}
+
+.hero-command code {
+  font-family:
+    "SFMono-Regular",
+    Consolas,
+    "Liberation Mono",
+    monospace;
+  color: #f5fbff;
+  font-size: 14px;
+  white-space: pre;
 }
 
 .actions {


### PR DESCRIPTION
## Summary
- Move the Install nav item to the front of the homepage navigation.
- Add a first-viewport hero command block with the download command and `omh doctor`.
- Keep the detailed install section lower on the page for follow-up commands.

## Verification
- `PYTHONPATH=tests uv run python -m unittest tests/test_router_content.py -v`
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- `git diff --check`
- Local HTTP smoke confirmed `Download OMH`, the curl install command, `omh doctor`, and that the hero command appears before the architecture and install sections.