### PR TITLE
Align setup and doctor install flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,14 +68,15 @@ curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes-agent/main/inst
 **Step 2: Set Up OMH**
 
 The installer runs setup automatically. Re-run it any time you want to reinstall
-managed skills, reapply Hermes config, and verify the result:
+managed skills and reapply Hermes config:
 
 ```sh
 omh setup
+omh doctor
 ```
 
-Then open Hermes Agent and use the installed skills through Hermes' normal skill
-surfaces.
+`omh doctor` is the separate health check. Then open Hermes Agent and use the
+installed skills through Hermes' normal skill surfaces.
 
 **Step 3: Try one wrapper-shaped turn**
 
@@ -123,6 +124,7 @@ exists.
 ```sh
 omh update
 omh setup
+omh doctor
 ```
 
 ## Mental Model
@@ -243,7 +245,7 @@ instead of presented as the first path.
 | Install | `curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes-agent/main/install.sh \| sh` |
 | Set up or repair | `omh setup` |
 | Verify only | `omh doctor` |
-| Update | `omh update && omh setup` |
+| Update | `omh update && omh setup && omh doctor` |
 | Inspect installed skills | `omh list` |
 | Pick a workflow locally | `omh recommend <task>` |
 | Pick a situation pipeline | `omh playbook recommend <task>` |

--- a/docs/APPLICATION_CASES.md
+++ b/docs/APPLICATION_CASES.md
@@ -13,6 +13,7 @@ Install and apply the managed skill pack:
 ```sh
 curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes-agent/main/install.sh | sh
 omh setup
+omh doctor
 ```
 
 Restart Hermes Agent after installation so it can reload its configured skill
@@ -84,6 +85,7 @@ Confirm the skill pack is installed and registered:
 
 ```sh
 omh setup
+omh doctor
 ```
 
 ### User Prompt Shape
@@ -151,6 +153,7 @@ Install the skill pack and make sure Hermes can read the same config that
 
 ```sh
 omh setup
+omh doctor
 ```
 
 For Discord bot deployments, install in the same runtime context that starts
@@ -274,6 +277,7 @@ Before using these cases as public release evidence, verify:
 - The one-command installer still works.
 - `omh setup` reports the managed skill directory and Hermes config
   registration clearly.
+- `omh doctor` reports the managed skill directory as healthy after setup.
 - The generated router includes the representative harness registry.
 - `omh docs workflows --json` exposes `harness_quality/v1` style quality data
   for wrapper rendering and status decisions.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -22,9 +22,9 @@ curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes-agent/main/inst
 For custom release archives or local package sources accepted by `pip`, pass
 `OMH_PACKAGE_URL`.
 
-The installer prepares the `omh` command and runs `omh setup`, which installs
-the managed Hermes skills, registers the managed skill directory with Hermes,
-and checks the result.
+The installer prepares the `omh` command, runs `omh setup` to install managed
+Hermes skills and register the managed skill directory with Hermes, then runs
+`omh doctor` as a separate health check.
 
 After it finishes, restart Hermes Agent so it can reload the registered skill
 directory.
@@ -36,13 +36,14 @@ refresh the local Hermes skill registration:
 
 ```sh
 omh setup
+omh doctor
 omh list
 omh runtime status
 omh probe
 ```
 
-`omh setup` should report a healthy setup result with install, apply, and doctor
-steps. `omh list` should show the managed skills available to Hermes.
+`omh setup` should report install and apply steps. `omh doctor` should report a
+healthy setup result. `omh list` should show the managed skills available to Hermes.
 `omh runtime status` should show the local runtime artifact directory and the
 latest install/apply/doctor state when those commands have run. `omh probe`
 reports observable Hermes capability surfaces without mutating Hermes internals.
@@ -96,6 +97,7 @@ For a hosted bot, the practical deployment shape is usually:
 ```sh
 curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes-agent/main/install.sh | sh
 omh setup
+omh doctor
 ```
 
 Then restart the bot process so Hermes reloads its config and skill directory.
@@ -227,7 +229,8 @@ Before calling the bot integration ready, verify these points:
   it from the same runtime context.
 - `omh probe` reports managed skills and external skill directory registration
   as available before any deeper integration claim is made.
-- If skills do not appear, run `omh setup`, then restart the bot again.
+- If skills do not appear, run `omh setup`, then `omh doctor`, then restart the
+  bot again.
 
 Current limitation: actual Discord, Slack, Hermes, Codex, GitHub, CI, and merge
 operations still happen outside OMHM. `omh chat interact`, `omh chat route`,
@@ -242,13 +245,14 @@ Update the installed skill pack:
 ```sh
 omh update --channel preview
 omh setup
+omh doctor
 ```
 
 Use `omh update --channel stable --version <version>` to record a pinned stable
 update intent, or `omh update --channel local --from-skills-dir ./skills` for a
 local fixture. Local modifications block updates unless `--force` is supplied.
-Use `omh setup` after an update to reinstall managed skills, reapply Hermes
-registration, run doctor, then restart Hermes Agent.
+Use `omh setup` after an update to reinstall managed skills and reapply Hermes
+registration. Then run `omh doctor` and restart Hermes Agent.
 
 ## Reapply
 
@@ -256,6 +260,7 @@ If Hermes does not show the installed skills, reapply the config registration:
 
 ```sh
 omh setup
+omh doctor
 ```
 
 Then restart Hermes Agent.

--- a/install.sh
+++ b/install.sh
@@ -60,10 +60,6 @@ if [ "$OMH_AUTO_APPLY" = "0" ]; then
   set -- "$@" --skip-apply
 fi
 
-if [ "$OMH_RUN_DOCTOR" = "0" ]; then
-  set -- "$@" --skip-doctor
-fi
-
 if [ -n "$OMH_VERSION" ]; then
   set -- "$@" --version "$OMH_VERSION"
 fi
@@ -71,5 +67,12 @@ fi
 say "Setting up managed Hermes skills..."
 run_omh "$@"
 
+if [ "$OMH_RUN_DOCTOR" = "0" ]; then
+  say "Skipped doctor check because OMH_RUN_DOCTOR=0."
+else
+  say "Verifying installation..."
+  run_omh doctor
+fi
+
 say "oh-my-hermes-agent is installed."
-say "Run 'omh list' to inspect installed skills."
+say "Run 'omh list' to inspect installed skills, or 'omh setup' to reapply Hermes registration."

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -51,12 +51,13 @@
         <section class="docs-section" id="install">
           <h2>Install</h2>
           <p>
-            Install the preview channel from the main branch, then run setup before
-            wiring wrappers or handoff flows.
+            Install the preview channel from the main branch, then run setup and
+            doctor before wiring wrappers or handoff flows.
           </p>
           <div class="command" role="region" aria-label="Install commands" tabindex="0">
             <code>curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes-agent/main/install.sh | sh
-omh setup</code>
+omh setup
+omh doctor</code>
           </div>
           <p>
             Stable installs are pinned explicitly with a released tag.

--- a/site/index.html
+++ b/site/index.html
@@ -37,7 +37,8 @@
           <div class="hero-command" role="region" aria-label="Download OMH command" tabindex="0">
             <span>Download OMH</span>
             <code>curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes-agent/main/install.sh | sh
-omh setup</code>
+omh setup
+omh doctor</code>
           </div>
           <div class="actions" aria-label="Primary actions">
             <a class="button button--primary" href="#install">Install details</a>
@@ -277,6 +278,7 @@ omh playbook inspect safe-feature-change</code>
           <div class="command" role="region" aria-label="Install command" tabindex="0">
             <code>curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes-agent/main/install.sh | sh
 omh setup
+omh doctor
 omh demo orchestration</code>
           </div>
         </div>

--- a/src/commands/main.py
+++ b/src/commands/main.py
@@ -217,28 +217,18 @@ def cmd_setup(args: argparse.Namespace) -> int:
     else:
         steps["apply"] = _apply_result(args)
 
-    if args.skip_doctor:
-        doctor_payload: dict[str, object] = {"ok": True, "skipped": True, "message": "Skipped doctor check because --skip-doctor was set."}
-    elif args.dry_run:
-        doctor_payload = {"ok": True, "skipped": True, "message": "Skipped doctor check because setup --dry-run does not write install artifacts."}
-    else:
-        doctor_payload = _doctor_result(args)
-    steps["doctor"] = doctor_payload
-
-    ok = bool(doctor_payload["ok"])
     if not args.dry_run:
         update_state(
             _paths(args),
             {
                 "last_setup": {
-                    "ok": ok,
+                    "ok": True,
                     "apply_skipped": bool(args.skip_apply),
-                    "doctor_skipped": bool(args.skip_doctor),
                 }
             },
         )
-    _print_json({"ok": ok, "steps": steps, "dry_run": args.dry_run})
-    return 0 if ok else 1
+    _print_json({"ok": True, "steps": steps, "dry_run": args.dry_run})
+    return 0
 
 
 def cmd_recommend(args: argparse.Namespace) -> int:
@@ -992,7 +982,6 @@ def _add_top_level_commands(sub) -> None:
     setup = sub.add_parser("setup")
     _add_common_install_options(setup)
     setup.add_argument("--skip-apply", action="store_true", help="Install skills without registering them in Hermes config.")
-    setup.add_argument("--skip-doctor", action="store_true", help="Skip the final doctor check.")
     setup.set_defaults(func=cmd_setup)
 
     install = sub.add_parser("install")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1308,7 +1308,7 @@ class CliTests(unittest.TestCase):
             self.assertTrue(checks["runtime_artifacts"]["ok"])
             self.assertTrue(checks["workflow_state"]["ok"])
 
-    def test_setup_runs_install_apply_and_doctor(self) -> None:
+    def test_setup_runs_install_and_apply(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)
             omh_home = root / ".omh"
@@ -1322,11 +1322,15 @@ class CliTests(unittest.TestCase):
             self.assertTrue(payload["ok"])
             self.assertIn("install", payload["steps"])
             self.assertIn("apply", payload["steps"])
-            self.assertIn("doctor", payload["steps"])
-            self.assertTrue(payload["steps"]["doctor"]["ok"])
+            self.assertNotIn("doctor", payload["steps"])
             self.assertIn(str(omh_home / "skills"), (hermes_home / "config.yaml").read_text(encoding="utf-8"))
             state = json.loads((omh_home / "runtime" / "state.json").read_text(encoding="utf-8"))
             self.assertTrue(state["last_setup"]["ok"])
+
+            doctor_status, doctor_stdout, doctor_stderr = run_cli(["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "doctor"])
+            self.assertEqual(doctor_stderr, "")
+            self.assertEqual(doctor_status, 0)
+            self.assertTrue(json.loads(doctor_stdout)["ok"])
 
     def test_install_is_idempotent_and_detects_local_modifications(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -277,6 +277,7 @@ class RouterContentTests(unittest.TestCase):
         self.assertIn("v<version>", readme)
         self.assertIn("The installer runs setup automatically", readme)
         self.assertIn("omh setup", readme)
+        self.assertIn("omh doctor", readme)
         self.assertIn("## Command Surface", readme)
         self.assertIn("omh docs workflows --json", readme)
         self.assertIn("omh harness validate", readme)


### PR DESCRIPTION
## Summary
- Keep omh setup focused on managed skill install plus Hermes config registration.
- Run omh doctor as a separate installer verification step, while OMH_RUN_DOCTOR=0 still skips installer verification.
- Update README, installation docs, application cases, and site install snippets to show install -> setup -> doctor.

## Verification
- PYTHONPATH=tests uv run python -m unittest discover -s tests -v
- PYTHONPATH=tests uv run python -m unittest tests/test_cli.py tests/test_router_content.py -v
- uv run python -m compileall -q src tests
- uv run python -m src.cli docs workflows --check
- uv run python -m src.cli harness validate
- uv run python -m src.cli setup --help
- uv run python -m src.cli --omh-home /tmp/omh-setup-align/.omh --hermes-home /tmp/omh-setup-align/.hermes setup
- uv run python -m src.cli --omh-home /tmp/omh-setup-align/.omh --hermes-home /tmp/omh-setup-align/.hermes doctor
- sh -n install.sh
- git diff --check
- Local site smoke: curl -fsS http://localhost:9990/ and /docs/ while a local server was running

## Source reference
Checked upstream-style install flow from oh-my-codex/install.sh: bootstrap runs setup first, then doctor as a separate step.