### PR TITLE
Clarify Hermes-agent wrapper operations

### DIFF
--- a/docs/CHAT_WRAPPER_EXAMPLES.md
+++ b/docs/CHAT_WRAPPER_EXAMPLES.md
@@ -5,6 +5,10 @@ Hermes Agent chat response. The example is generated from local fixtures; it
 does not require a bot SDK, credentials, network access, an LLM call, or Hermes
 core changes.
 
+For the operator runbook that ties these examples to state transitions,
+responsibilities, and evidence boundaries, read
+[Hermes Agent Integration Runbook](HERMES_AGENT_INTEGRATION_RUNBOOK.md).
+
 ## Commands Used
 
 ```sh

--- a/docs/HERMES_AGENT_INTEGRATION_RUNBOOK.md
+++ b/docs/HERMES_AGENT_INTEGRATION_RUNBOOK.md
@@ -1,0 +1,131 @@
+# Hermes Agent Integration Runbook
+
+This is an operator reference, not an `omh` command.
+
+Use this runbook when you operate a Hermes-agent wrapper that receives natural
+language from Discord, Slack, or another hosted chat surface and renders OMH's
+local deterministic contracts as native chat UX.
+
+The chat user should not need to know command names. The wrapper can use OMH
+commands internally, but user-facing replies should talk in terms of plans,
+clarifications, handoffs, status cards, blockers, and observed evidence.
+
+## Audience
+
+This document is for wrapper and agent operators who need to answer three
+questions:
+
+- Which local OMH contract should the Hermes-agent wrapper consume?
+- Which owner is responsible for each stage?
+- Which status claims are backed by observed evidence, and which are not?
+
+## Product Boundary
+
+| Owner | Owns | Does not own |
+| --- | --- | --- |
+| Hermes Agent | Chat continuity, clarification, research, planning, and status narration. | Platform auth, SDK posting, hidden coding execution, or CI/merge proof. |
+| Wrapper adapter | Discord/Slack or hosted-chat events, buttons, threads, edits, notifications, and adapter-local event/thread caches. | OMH-owned session or run records, or deciding that prepared artifacts prove execution. |
+| OMH | Deterministic local routing, playbook, planning, handoff, session, status, and fixture contracts. | Hermes core patches, platform SDKs, network calls, LLM calls, or executor launch. |
+| Codex-like executor | Main implementation work, verification output, review fixes, and execution evidence after dispatch. | Chat UX or OMH contract generation. |
+| Runtime artifacts | Metadata-only observed evidence for dispatch, result, verification, review, CI, merge readiness, and merge. | Raw chat secrets or unobserved assumptions. |
+
+## Contract Surfaces
+
+The wrapper normally starts with `chat_interaction/v1`.
+
+```sh
+omh chat interact --source discord --event-json event.json
+```
+
+The returned envelope is safe for a wrapper to render without parsing prose:
+
+- `thread_key`: stable wrapper thread identity.
+- `mode`: `clarify`, `plan`, `delegate`, `route`, or `status`.
+- `next_action`: the next operator or wrapper action.
+- `chat_response`: renderable response text, action ids, state, and claim
+  boundary.
+- `overclaim_guard`: invariant status rules the wrapper should preserve.
+- `plan`, `delegation`, or `status`: optional machine-readable payload for the
+  selected mode.
+
+Use `chat_response/v1` for the visible reply. Use `status_card/v1` when a linked
+runtime run exists and the wrapper needs a compact progress card.
+
+## Operator Flow
+
+1. Receive the platform event and store only the metadata needed by the wrapper.
+2. Ask OMH for a platform-neutral interaction envelope.
+3. Render `chat_response.headline`, `chat_response.body`,
+   `chat_response.actions`, and `chat_response.claim_boundary`.
+4. If the response is a plan, wait for the user to accept or revise the plan
+   before preparing a handoff.
+5. If a coding handoff is prepared, dispatch the `coding_executor_handoff/v1`
+   payload to the external executor outside OMH.
+6. Record only evidence the wrapper actually observed: dispatch, executor
+   result, verification, review, CI, merge readiness, and merge.
+7. Re-render status from OMH after each observed transition.
+
+## State Transition Reference
+
+| Scenario | From | To | Wrapper action | Evidence boundary |
+| --- | --- | --- | --- | --- |
+| Clarification needed | `message_received` | `clarifying` | Ask one blocking question. | No plan or execution is approved. |
+| Plan presented | `message_received` | `planning` | Show accept/revise actions. | A draft plan is not execution evidence. |
+| Handoff prepared | `plan_accepted` | `handoff_prepared` | Show send-to-executor action. | Prepared handoff is not execution evidence. |
+| Dispatched, waiting | `handoff_prepared` | `dispatched` | Wait for executor evidence. | Dispatch is not completion evidence. |
+| Review pending | `executor_completed` | `awaiting_review` | Show review-pending status. | Execution is observed; review is not. |
+| CI pending | `review_passed` | `awaiting_ci` | Show CI-pending status. | Review is not CI evidence. |
+| CI failed | `ci_started` | `blocked` | Surface the failing checks. | Failed CI is not merge-ready. |
+| Merge ready | `ci_passed` | `merge_ready` | Show merge-ready status. | Ready to merge is not the same as merged. |
+| Merged | `merge_ready` | `merged` | Show merged status. | Merged requires observed merge evidence. |
+
+The golden fixture at `examples/wrapper-golden/hermes-agent-integration.json`
+maps these transitions back to the status ladder scenarios in
+`examples/wrapper-golden/status-ladder.json`.
+
+## Evidence Rules
+
+- A route decision is not execution evidence.
+- A draft plan is not execution evidence.
+- A prepared handoff is not executor dispatch.
+- Executor dispatch is not executor completion.
+- Executor completion is not review evidence.
+- Review evidence is not CI evidence.
+- CI passing is not merge evidence.
+- Merge readiness is not merge evidence.
+- Missing or contradictory evidence should produce a blocker/status update, not
+  a completion claim.
+
+## Recovery And Troubleshooting
+
+Use wrapper sessions when the platform process can restart between user actions:
+
+```sh
+omh chat session start --source discord --source-event-id "$MESSAGE_ID" --channel-ref "$CHANNEL_ID" "risky refactor"
+omh chat session accept-plan "$SESSION_ID"
+omh chat session prepare-handoff "$SESSION_ID" "risky refactor"
+omh chat session status "$SESSION_ID"
+```
+
+Use coding lifecycle commands only after a linked handoff run exists:
+
+```sh
+omh coding lifecycle dispatch --run "$RUN_ID"
+omh coding lifecycle result --run "$RUN_ID" --result completed --evidence-ref codex-log
+omh coding lifecycle verify --run "$RUN_ID" --completion-status completed
+omh coding lifecycle report --run "$RUN_ID"
+```
+
+If a wrapper cannot prove a transition, keep the status at `not_observed` and
+show the next required evidence instead of inferring progress.
+
+## Release Check
+
+Before depending on the wrapper contract in a release candidate, run:
+
+```sh
+PYTHONPATH=tests uv run python -m unittest tests/test_wrapper_contract.py -v
+PYTHONPATH=tests uv run python -m unittest tests/test_wrapper_golden_examples.py -v
+uv run python -m src.cli harness validate
+git diff --check
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ repo-local contract for Codex agents working here.
 | Understand what OMHM is and is not | [Direction](DIRECTION.md) |
 | Understand module boundaries and local artifacts | [Architecture](ARCHITECTURE.md) |
 | Understand chat wrapper UX, sessions, and handoffs | [Delegation-First Completeness](DELEGATION_FIRST_COMPLETENESS.md) |
+| Operate a Hermes-agent wrapper safely | [Hermes Agent Integration Runbook](HERMES_AGENT_INTEGRATION_RUNBOOK.md) |
 | Choose a situation-level pipeline | [Playbooks](PLAYBOOKS.md) |
 | See Discord-style wrapper responses | [Chat Wrapper Examples](CHAT_WRAPPER_EXAMPLES.md) |
 | Render workflow quality gates in wrappers | [Harness Quality Contract](HARNESS_QUALITY.md) |
@@ -46,6 +47,8 @@ merge.
 - Chat users should remain command-agnostic. Wrapper docs should describe
   buttons, threads, status, and handoff states rather than asking end users to
   run shell commands.
+- Operator runbooks should use document titles, not command-like names, when
+  they describe wrapper responsibilities and status evidence.
 - Demo and shim examples should stay fixture-backed, deterministic, and
   transport-free unless a scoped integration explicitly opts into a real bot or
   network adapter.
@@ -72,6 +75,7 @@ When changing docs, check whether the same claim needs to be updated in:
 - [Direction](DIRECTION.md)
 - [Architecture](ARCHITECTURE.md)
 - [Delegation-First Completeness](DELEGATION_FIRST_COMPLETENESS.md)
+- [Hermes Agent Integration Runbook](HERMES_AGENT_INTEGRATION_RUNBOOK.md)
 - [Playbooks](PLAYBOOKS.md)
 - [Harness Quality Contract](HARNESS_QUALITY.md)
 - [Application Cases](APPLICATION_CASES.md)

--- a/examples/wrapper-golden/hermes-agent-integration.json
+++ b/examples/wrapper-golden/hermes-agent-integration.json
@@ -1,0 +1,324 @@
+{
+  "schema_version": "hermes_agent_integration_examples/v1",
+  "description": "Transport-free contract examples for Hermes-agent wrappers consuming OMH outputs.",
+  "runbook": "docs/HERMES_AGENT_INTEGRATION_RUNBOOK.md",
+  "transport_boundary": {
+    "wrapper_owns": [
+      "platform events",
+      "button rendering",
+      "thread lifecycle",
+      "message edits",
+      "notifications"
+    ],
+    "omh_owns": [
+      "chat_interaction/v1",
+      "chat_response/v1",
+      "status_card/v1",
+      "coding_executor_handoff/v1",
+      "metadata-only runtime evidence boundaries"
+    ],
+    "non_goals": [
+      "platform SDK implementation",
+      "bot authentication",
+      "network calls",
+      "Hermes core patching",
+      "hidden executor launch"
+    ]
+  },
+  "consumed_contracts": [
+    {
+      "schema_version": "chat_interaction/v1",
+      "consumed_by": "Hermes-agent wrapper",
+      "required_fields": [
+        "source",
+        "thread_key",
+        "mode",
+        "next_action",
+        "chat_response",
+        "overclaim_guard"
+      ],
+      "renderable_fields": [
+        "chat_response.headline",
+        "chat_response.body",
+        "chat_response.actions",
+        "chat_response.claim_boundary",
+        "chat_response.state"
+      ]
+    },
+    {
+      "schema_version": "chat_response/v1",
+      "consumed_by": "Hermes-agent wrapper",
+      "required_fields": [
+        "kind",
+        "visibility",
+        "headline",
+        "body",
+        "state",
+        "actions",
+        "claim_boundary"
+      ],
+      "renderable_fields": [
+        "headline",
+        "body",
+        "actions[].id",
+        "actions[].label",
+        "actions[].enabled",
+        "claim_boundary"
+      ]
+    },
+    {
+      "schema_version": "status_card/v1",
+      "consumed_by": "Hermes-agent wrapper",
+      "required_fields": [
+        "run_id",
+        "severity",
+        "headline",
+        "summary",
+        "next_action",
+        "primary_action",
+        "steps",
+        "claim_boundary"
+      ],
+      "renderable_fields": [
+        "headline",
+        "summary",
+        "steps[].label",
+        "steps[].state",
+        "primary_action",
+        "claim_boundary"
+      ]
+    },
+    {
+      "schema_version": "coding_executor_handoff/v1",
+      "consumed_by": "External coding executor lane",
+      "required_fields": [
+        "schema_version",
+        "executor_target",
+        "handoff_mode",
+        "status",
+        "recording_contract",
+        "dispatch_contract",
+        "scope",
+        "acceptance_criteria",
+        "verification",
+        "review",
+        "prompt_template",
+        "non_goals",
+        "harness_quality"
+      ],
+      "renderable_fields": [
+        "executor_target",
+        "status",
+        "recording_contract",
+        "acceptance_criteria",
+        "verification",
+        "review.required"
+      ]
+    }
+  ],
+  "state_transitions": [
+    {
+      "scenario": "clarification_needed",
+      "source_scenario": "clarify_needed",
+      "from_state": "message_received",
+      "to_state": "clarifying",
+      "wrapper_action": "answer:clarify",
+      "observed_evidence": [
+        "source metadata",
+        "message hash",
+        "clarification request"
+      ],
+      "not_evidence": [
+        "approved plan",
+        "executor dispatch",
+        "executor result"
+      ],
+      "claim_boundary": "No execution has started."
+    },
+    {
+      "scenario": "plan_presented",
+      "source_scenario": "plan_presented",
+      "from_state": "message_received",
+      "to_state": "planning",
+      "wrapper_action": "accept_plan",
+      "observed_evidence": [
+        "draft plan",
+        "selected workflow",
+        "wrapper actions"
+      ],
+      "not_evidence": [
+        "plan acceptance",
+        "prepared handoff",
+        "executor dispatch"
+      ],
+      "claim_boundary": "A draft plan is not execution evidence."
+    },
+    {
+      "scenario": "deep_interview_before_plan",
+      "source_scenario": "deep_interview_blocked_plan",
+      "from_state": "message_received",
+      "to_state": "clarifying",
+      "wrapper_action": "answer:clarify",
+      "observed_evidence": [
+        "missing decision list",
+        "one-question prompt",
+        "rerun-plan next action"
+      ],
+      "not_evidence": [
+        "approved plan",
+        "executor dispatch"
+      ],
+      "claim_boundary": "No plan or execution is approved."
+    },
+    {
+      "scenario": "handoff_prepared",
+      "source_scenario": "handoff_prepared",
+      "from_state": "plan_accepted",
+      "to_state": "handoff_prepared",
+      "wrapper_action": "send_to_codex",
+      "observed_evidence": [
+        "prepared handoff payload",
+        "linked run id",
+        "status card handoff step"
+      ],
+      "not_evidence": [
+        "executor dispatch",
+        "executor result",
+        "verification"
+      ],
+      "claim_boundary": "Prepared handoff is not execution evidence."
+    },
+    {
+      "scenario": "dispatched_waiting",
+      "source_scenario": "dispatched_executor_not_observed",
+      "from_state": "handoff_prepared",
+      "to_state": "dispatched",
+      "wrapper_action": "show_status",
+      "observed_evidence": [
+        "dispatch observed",
+        "linked run id"
+      ],
+      "not_evidence": [
+        "executor completion",
+        "verification",
+        "review"
+      ],
+      "claim_boundary": "Dispatch is not completion evidence."
+    },
+    {
+      "scenario": "review_pending",
+      "source_scenario": "review_pending",
+      "from_state": "executor_completed",
+      "to_state": "awaiting_review",
+      "wrapper_action": "show_status",
+      "observed_evidence": [
+        "executor result",
+        "verification evidence"
+      ],
+      "not_evidence": [
+        "review passed",
+        "CI passed",
+        "merge readiness"
+      ],
+      "claim_boundary": "Execution is observed; review is not."
+    },
+    {
+      "scenario": "status_card_review_pending",
+      "source_scenario": "status_card_review_pending",
+      "from_state": "executor_verified",
+      "to_state": "awaiting_review",
+      "wrapper_action": "show_status",
+      "observed_evidence": [
+        "status_card/v1",
+        "execution complete step",
+        "verification complete step"
+      ],
+      "not_evidence": [
+        "review passed",
+        "merge readiness",
+        "merged"
+      ],
+      "claim_boundary": "Execution and verification are not review evidence."
+    },
+    {
+      "scenario": "ci_pending",
+      "source_scenario": "ci_pending",
+      "from_state": "review_passed",
+      "to_state": "awaiting_ci",
+      "wrapper_action": "show_status",
+      "observed_evidence": [
+        "review passed"
+      ],
+      "not_evidence": [
+        "CI passed",
+        "merge readiness",
+        "merged"
+      ],
+      "claim_boundary": "Review is not CI evidence."
+    },
+    {
+      "scenario": "ci_failed",
+      "source_scenario": "ci_failed",
+      "from_state": "ci_started",
+      "to_state": "blocked",
+      "wrapper_action": "show_status",
+      "observed_evidence": [
+        "failing CI checks",
+        "blocked status card"
+      ],
+      "not_evidence": [
+        "merge readiness",
+        "merged"
+      ],
+      "claim_boundary": "Failed CI is not merge-ready."
+    },
+    {
+      "scenario": "merge_ready",
+      "source_scenario": "merge_ready",
+      "from_state": "ci_passed",
+      "to_state": "merge_ready",
+      "wrapper_action": "show_status",
+      "observed_evidence": [
+        "execution evidence",
+        "verification evidence",
+        "review evidence",
+        "CI evidence",
+        "merge-readiness evidence"
+      ],
+      "not_evidence": [
+        "merged"
+      ],
+      "claim_boundary": "Ready to merge is not the same as merged."
+    },
+    {
+      "scenario": "merged",
+      "source_scenario": "merged",
+      "from_state": "merge_ready",
+      "to_state": "merged",
+      "wrapper_action": "show_status",
+      "observed_evidence": [
+        "runtime ledger merge evidence"
+      ],
+      "not_evidence": [
+        "unobserved follow-up work"
+      ],
+      "claim_boundary": "Merged status is backed by runtime ledger evidence."
+    },
+    {
+      "scenario": "contradictory_merge_ready_without_ci",
+      "source_scenario": "contradictory_merge_ready_without_ci",
+      "from_state": "review_passed",
+      "to_state": "awaiting_ci",
+      "wrapper_action": "show_status",
+      "observed_evidence": [
+        "review passed",
+        "missing CI evidence"
+      ],
+      "not_evidence": [
+        "merge readiness",
+        "merged"
+      ],
+      "claim_boundary": "The upstream CI blocker is shown instead of merge-ready."
+    }
+  ]
+}

--- a/examples/wrapper-golden/status-ladder.json
+++ b/examples/wrapper-golden/status-ladder.json
@@ -13,7 +13,17 @@
         "body": "The request is not specific enough for a safe workflow handoff.",
         "action_ids": ["answer:clarify", "cancel"]
       },
-      "claim_boundary": "No execution has started."
+      "claim_boundary": "No execution has started.",
+      "observed_evidence": [
+        "source metadata",
+        "message hash",
+        "clarification request"
+      ],
+      "not_evidence": [
+        "approved plan",
+        "executor dispatch",
+        "executor result"
+      ]
     },
     {
       "scenario": "plan_presented",
@@ -26,7 +36,17 @@
         "body": "The user can accept or revise the plan before any handoff is prepared.",
         "action_ids": ["accept_plan", "revise_plan"]
       },
-      "claim_boundary": "A draft plan is not execution evidence."
+      "claim_boundary": "A draft plan is not execution evidence.",
+      "observed_evidence": [
+        "draft plan",
+        "selected workflow",
+        "wrapper actions"
+      ],
+      "not_evidence": [
+        "plan acceptance",
+        "prepared handoff",
+        "executor dispatch"
+      ]
     },
     {
       "scenario": "deep_interview_blocked_plan",
@@ -46,7 +66,16 @@
         "missing_decisions": ["target outcome", "success criteria", "scope boundary"],
         "after_answer_next_action": "rerun_hermes_plan"
       },
-      "claim_boundary": "No plan or execution is approved."
+      "claim_boundary": "No plan or execution is approved.",
+      "observed_evidence": [
+        "missing decision list",
+        "one-question prompt",
+        "rerun-plan next action"
+      ],
+      "not_evidence": [
+        "approved plan",
+        "executor dispatch"
+      ]
     },
     {
       "scenario": "handoff_prepared",
@@ -59,7 +88,17 @@
         "body": "The handoff is prepared, but executor dispatch is not observed yet.",
         "action_ids": ["send_to_codex", "show_status"]
       },
-      "claim_boundary": "Prepared handoff is not execution evidence."
+      "claim_boundary": "Prepared handoff is not execution evidence.",
+      "observed_evidence": [
+        "prepared handoff payload",
+        "linked run id",
+        "status card handoff step"
+      ],
+      "not_evidence": [
+        "executor dispatch",
+        "executor result",
+        "verification"
+      ]
     },
     {
       "scenario": "dispatched_executor_not_observed",
@@ -72,7 +111,16 @@
         "body": "Executor completion is not observed yet.",
         "action_ids": ["show_status"]
       },
-      "claim_boundary": "Dispatch is not completion evidence."
+      "claim_boundary": "Dispatch is not completion evidence.",
+      "observed_evidence": [
+        "dispatch observed",
+        "linked run id"
+      ],
+      "not_evidence": [
+        "executor completion",
+        "verification",
+        "review"
+      ]
     },
     {
       "scenario": "review_pending",
@@ -85,7 +133,16 @@
         "body": "Review evidence is required before completion is reported.",
         "action_ids": ["show_status"]
       },
-      "claim_boundary": "Execution is observed; review is not."
+      "claim_boundary": "Execution is observed; review is not.",
+      "observed_evidence": [
+        "executor result",
+        "verification evidence"
+      ],
+      "not_evidence": [
+        "review passed",
+        "CI passed",
+        "merge readiness"
+      ]
     },
     {
       "scenario": "status_card_review_pending",
@@ -111,7 +168,17 @@
           {"id": "merged", "state": "pending"}
         ]
       },
-      "claim_boundary": "Execution and verification are not review evidence."
+      "claim_boundary": "Execution and verification are not review evidence.",
+      "observed_evidence": [
+        "status_card/v1",
+        "execution complete step",
+        "verification complete step"
+      ],
+      "not_evidence": [
+        "review passed",
+        "merge readiness",
+        "merged"
+      ]
     },
     {
       "scenario": "ci_pending",
@@ -124,7 +191,15 @@
         "body": "Merge readiness is not reported until CI evidence is observed.",
         "action_ids": ["show_status"]
       },
-      "claim_boundary": "Review is not CI evidence."
+      "claim_boundary": "Review is not CI evidence.",
+      "observed_evidence": [
+        "review passed"
+      ],
+      "not_evidence": [
+        "CI passed",
+        "merge readiness",
+        "merged"
+      ]
     },
     {
       "scenario": "ci_failed",
@@ -137,7 +212,15 @@
         "body": "The failing or blocked CI checks are surfaced instead of claiming merge readiness.",
         "action_ids": ["show_status"]
       },
-      "claim_boundary": "Failed CI is not merge-ready."
+      "claim_boundary": "Failed CI is not merge-ready.",
+      "observed_evidence": [
+        "failing CI checks",
+        "blocked status card"
+      ],
+      "not_evidence": [
+        "merge readiness",
+        "merged"
+      ]
     },
     {
       "scenario": "merge_ready",
@@ -150,7 +233,17 @@
         "body": "Execution, verification, review, CI, and merge-readiness evidence are observed.",
         "action_ids": ["show_status"]
       },
-      "claim_boundary": "Ready to merge is not the same as merged."
+      "claim_boundary": "Ready to merge is not the same as merged.",
+      "observed_evidence": [
+        "execution evidence",
+        "verification evidence",
+        "review evidence",
+        "CI evidence",
+        "merge-readiness evidence"
+      ],
+      "not_evidence": [
+        "merged"
+      ]
     },
     {
       "scenario": "merged",
@@ -163,7 +256,13 @@
         "body": "Merge evidence is observed in the runtime ledger.",
         "action_ids": ["show_status"]
       },
-      "claim_boundary": "Merged status is backed by runtime ledger evidence."
+      "claim_boundary": "Merged status is backed by runtime ledger evidence.",
+      "observed_evidence": [
+        "runtime ledger merge evidence"
+      ],
+      "not_evidence": [
+        "unobserved follow-up work"
+      ]
     },
     {
       "scenario": "contradictory_merge_ready_without_ci",
@@ -176,7 +275,15 @@
         "body": "A later merge-ready artifact cannot override the missing CI gate.",
         "action_ids": ["show_status"]
       },
-      "claim_boundary": "The upstream CI blocker is shown instead of merge-ready."
+      "claim_boundary": "The upstream CI blocker is shown instead of merge-ready.",
+      "observed_evidence": [
+        "review passed",
+        "missing CI evidence"
+      ],
+      "not_evidence": [
+        "merge readiness",
+        "merged"
+      ]
     }
   ]
 }

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -23,6 +23,7 @@
         <a href="#overview">Overview</a>
         <a href="#install">Install</a>
         <a href="#chat">Chat wrappers</a>
+        <a href="#runbook">Runbook</a>
         <a href="#demo">Demo</a>
         <a href="#architecture">Architecture</a>
         <a href="#playbooks">Playbooks</a>
@@ -79,6 +80,26 @@ omh chat interact --source slack "diagnose installation health"</code>
             A response can be an answer, a clarification request, a plan, a status card, or a
             prepared handoff. The wrapper should render that response natively instead of
             asking users to memorize CLI commands.
+          </p>
+        </section>
+
+        <section class="docs-section" id="runbook">
+          <h2>Hermes Agent Integration Runbook</h2>
+          <p>
+            Operators should treat OMH as the local contract layer consumed by a
+            Hermes-agent wrapper, not as a transport bot. The runbook explains which
+            fields to render, which owner is responsible for each transition, and which
+            claims are still not evidence.
+          </p>
+          <ul class="docs-list">
+            <li>Wrapper owns platform events, buttons, threads, edits, and notifications.</li>
+            <li>OMH owns deterministic contracts, fixture examples, prepared handoffs, and status boundaries.</li>
+            <li>Codex-like executors own implementation evidence only after dispatch is observed.</li>
+          </ul>
+          <p>
+            Read the source runbook at
+            <code>docs/HERMES_AGENT_INTEGRATION_RUNBOOK.md</code> and validate the matching
+            golden fixture at <code>examples/wrapper-golden/hermes-agent-integration.json</code>.
           </p>
         </section>
 

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -230,6 +230,7 @@ class RouterContentTests(unittest.TestCase):
             Path("docs/README.md"),
             Path("docs/DIRECTION.md"),
             Path("docs/HARNESS_QUALITY.md"),
+            Path("docs/HERMES_AGENT_INTEGRATION_RUNBOOK.md"),
             Path("docs/INSTALLATION.md"),
             Path("docs/APPLICATION_CASES.md"),
             Path("docs/PLAYBOOKS.md"),
@@ -258,11 +259,13 @@ class RouterContentTests(unittest.TestCase):
             self.assertTrue(path.exists(), f"{path} should be present")
 
         readme = Path("README.md").read_text(encoding="utf-8")
+        docs_readme = Path("docs/README.md").read_text(encoding="utf-8")
         installation = Path("docs/INSTALLATION.md").read_text(encoding="utf-8")
         ci = Path(".github/workflows/ci.yml").read_text(encoding="utf-8")
         pages = Path(".github/workflows/pages.yml").read_text(encoding="utf-8")
         release = Path("docs/RELEASE.md").read_text(encoding="utf-8")
         harness_quality = Path("docs/HARNESS_QUALITY.md").read_text(encoding="utf-8")
+        runbook = Path("docs/HERMES_AGENT_INTEGRATION_RUNBOOK.md").read_text(encoding="utf-8")
         site = Path("site/index.html").read_text(encoding="utf-8")
         site_docs = Path("site/docs/index.html").read_text(encoding="utf-8")
         site_css = Path("site/styles.css").read_text(encoding="utf-8")
@@ -291,6 +294,11 @@ class RouterContentTests(unittest.TestCase):
         self.assertIn("wrapper_actions", harness_quality)
         self.assertIn("overclaim_guards", harness_quality)
         self.assertIn("harness_progress/v1", harness_quality)
+        self.assertIn("This is an operator reference, not an `omh` command.", runbook)
+        self.assertIn("Hermes-agent wrapper", runbook)
+        self.assertIn("Prepared handoff is not execution evidence", runbook)
+        self.assertIn("examples/wrapper-golden/hermes-agent-integration.json", runbook)
+        self.assertIn("Hermes Agent Integration Runbook", docs_readme)
         self.assertIn("python -m unittest discover -s tests", ci)
         self.assertIn("python -m compileall src", ci)
         self.assertIn("docs workflows --check", ci)
@@ -309,6 +317,8 @@ class RouterContentTests(unittest.TestCase):
         self.assertIn("Capability probe status", release)
         self.assertIn("OMH", site)
         self.assertIn('href="docs/">Read docs</a>', site)
+        self.assertIn("Hermes Agent Integration Runbook", site_docs)
+        self.assertIn("examples/wrapper-golden/hermes-agent-integration.json", site_docs)
         topbar = site.split('<header class="topbar"', 1)[1].split("</header>", 1)[0]
         self.assertIn('href="docs/"', topbar)
         self.assertNotIn('href="#architecture"', topbar)

--- a/tests/test_wrapper_golden_examples.py
+++ b/tests/test_wrapper_golden_examples.py
@@ -41,6 +41,8 @@ class WrapperGoldenExampleTests(unittest.TestCase):
             self.assertEqual(response["schema_version"], "chat_response/v1")
             self.assertIn(item["source"], {"discord", "slack"})
             self.assertTrue(item["claim_boundary"])
+            self.assertTrue(item["observed_evidence"])
+            self.assertTrue(item["not_evidence"])
             self.assertTrue(response["headline"])
             self.assertTrue(response["body"])
             self.assertIsInstance(response["action_ids"], list)
@@ -124,6 +126,55 @@ class WrapperGoldenExampleTests(unittest.TestCase):
                 source_quality = self._source_harness_quality(item)
                 for key, value in item["expected_quality"].items():
                     self.assertEqual(source_quality[key], value)
+
+    def test_hermes_agent_integration_examples_match_status_ladder(self) -> None:
+        payload = json.loads(Path("examples/wrapper-golden/hermes-agent-integration.json").read_text(encoding="utf-8"))
+        ladder = json.loads(Path("examples/wrapper-golden/status-ladder.json").read_text(encoding="utf-8"))
+        ladder_scenarios = {item["scenario"]: item for item in ladder["scenarios"]}
+
+        self.assertEqual(payload["schema_version"], "hermes_agent_integration_examples/v1")
+        self.assertTrue(Path(payload["runbook"]).exists())
+        self.assertIn("platform SDK implementation", payload["transport_boundary"]["non_goals"])
+        self.assertIn("network calls", payload["transport_boundary"]["non_goals"])
+        self.assertIn("Hermes core patching", payload["transport_boundary"]["non_goals"])
+
+        contracts = {item["schema_version"]: item for item in payload["consumed_contracts"]}
+        self.assertEqual(
+            set(contracts),
+            {"chat_interaction/v1", "chat_response/v1", "coding_executor_handoff/v1", "status_card/v1"},
+        )
+        self.assertIn("chat_interaction/v1", contracts)
+        self.assertIn("status_card/v1", contracts)
+        self.assertIn("coding_executor_handoff/v1", contracts)
+        self.assertIn("chat_response", contracts["chat_interaction/v1"]["required_fields"])
+        self.assertIn("claim_boundary", contracts["status_card/v1"]["required_fields"])
+        live_handoff = build_coding_delegation_payload("risky refactor", source="discord", executor_target="codex")[
+            "executor_handoff"
+        ]
+        for field in contracts["coding_executor_handoff/v1"]["required_fields"]:
+            self.assertIn(field, live_handoff)
+        self.assertNotIn("recommended_workflow", contracts["coding_executor_handoff/v1"]["required_fields"])
+        self.assertNotIn("verification_expectations", contracts["coding_executor_handoff/v1"]["required_fields"])
+
+        transitions = payload["state_transitions"]
+        source_scenarios = {item["source_scenario"] for item in transitions}
+        self.assertEqual(len(transitions), len(ladder_scenarios))
+        self.assertEqual(source_scenarios, set(ladder_scenarios))
+        self.assertIn("clarifying", {item["to_state"] for item in transitions})
+        self.assertIn("awaiting_review", {item["to_state"] for item in transitions})
+        self.assertIn("awaiting_ci", {item["to_state"] for item in transitions})
+        self.assertIn("blocked", {item["to_state"] for item in transitions})
+        self.assertIn("merge_ready", {item["to_state"] for item in transitions})
+        self.assertIn("merged", {item["to_state"] for item in transitions})
+
+        for item in transitions:
+            with self.subTest(item["scenario"]):
+                source = ladder_scenarios[item["source_scenario"]]
+                self.assertEqual(item["claim_boundary"], source["claim_boundary"])
+                self.assertEqual(item["observed_evidence"], source["observed_evidence"])
+                self.assertEqual(item["not_evidence"], source["not_evidence"])
+                self.assertIn(item["wrapper_action"], source["expected_response"]["action_ids"])
+                self.assertNotIn("token", json.dumps(item).lower())
 
     def test_transport_free_adapter_shims_render_fixture_events(self) -> None:
         cases = (


### PR DESCRIPTION
## Summary
- Add a Hermes Agent Integration Runbook for wrapper operators, explicitly framed as documentation rather than an omh command.
- Add a transport-free hermes-agent integration golden fixture that maps consumed contracts and state transitions.
- Make status-ladder evidence arrays canonical and assert the integration fixture matches live status/evidence boundaries and the live coding executor handoff shape.
- Link the runbook from docs, chat wrapper examples, and the docs site summary.

## Verification
- PYTHONPATH=tests uv run python -m unittest tests/test_cli.py -v
- PYTHONPATH=tests uv run python -m unittest discover -s tests -v
- uv run python -m src.cli docs workflows --check
- uv run python -m src.cli harness validate
- uv run python -m compileall -q src tests
- uv run python -m json.tool examples/wrapper-golden/hermes-agent-integration.json
- uv run python -m json.tool examples/wrapper-golden/status-ladder.json
- uv run python examples/discord-adapter-shim.py
- uv run python examples/slack-adapter-shim.py
- uv run python -m src.cli demo orchestration
- git diff --check

## Review
- Independent code-review lane: APPROVE after fixing the handoff fixture field mismatch.
- Independent architecture lane: CLEAR after narrowing wrapper persistence wording and canonicalizing evidence arrays.

## Boundaries
- No Discord/Slack SDK or bot transport implementation.
- No LLM/API/network calls.
- No Hermes core behavior changes.
- No new CLI UX surface.