### PR TITLE
Lead quick start with bootstrap setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,26 @@ delegate coding, or report status.
 
 ## Quick Start
 
-**Step 1: Install the Hermes skills**
+**Step 1: Install OMH and apply the Hermes setup**
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes-agent/main/install.sh | sh
+omh setup
+```
+
+The installer normally runs setup for you. Keep `omh setup` in the quick start
+because it is the repairable, repeatable step that installs generated skills
+under `~/.omh/skills` and registers them with Hermes through
+`skills.external_dirs`.
+
+Optionally verify the local install:
+
+```sh
+omh doctor
+```
+
+If your Hermes environment supports native skill taps, this is the equivalent
+Hermes-native front door:
 
 ```sh
 hermes skills tap add rlaope/oh-my-hermes-agent

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -5,6 +5,21 @@ skill pack. Normal users should talk to Hermes through Hermes' skill and chat
 surfaces. The `omh` command is bootstrap, repair, verification, and wrapper
 backend infrastructure.
 
+## Quick Start
+
+Use this when you just want Hermes to see OMH skills and have the local
+maintenance command available:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes-agent/main/install.sh | sh
+omh setup
+omh doctor
+```
+
+The installer normally runs setup automatically, but `omh setup` is kept here
+as the explicit repairable step: it installs generated managed skills and
+registers them with Hermes through `skills.external_dirs`.
+
 ## Install Path A: Hermes-Native Skill Tap
 
 Use this path when the target Hermes environment supports skill taps:

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -49,21 +49,21 @@
         <section class="docs-section" id="install">
           <h2>Install</h2>
           <p>
-            Install through Hermes skill taps when available. This keeps the
-            main experience inside Hermes.
-          </p>
-          <div class="command" role="region" aria-label="Install commands" tabindex="0">
-            <code>hermes skills tap add rlaope/oh-my-hermes-agent
-hermes skills install oh-my-hermes</code>
-          </div>
-          <p>
-            Use the OMH bootstrap path when you need generated managed skills,
-            local doctor checks, or wrapper/backend commands in the same runtime.
+            Start with the OMH bootstrap path when you want the `omh` command,
+            generated managed skills, local doctor checks, and wrapper/backend
+            commands in the same runtime.
           </p>
           <div class="command" role="region" aria-label="Bootstrap commands" tabindex="0">
             <code>curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes-agent/main/install.sh | sh
 omh setup
 omh doctor</code>
+          </div>
+          <p>
+            When Hermes skill taps are available, the native skill front door is:
+          </p>
+          <div class="command" role="region" aria-label="Hermes skill install commands" tabindex="0">
+            <code>hermes skills tap add rlaope/oh-my-hermes-agent
+hermes skills install oh-my-hermes</code>
           </div>
           <p>
             Stable installs are pinned explicitly with a released tag.

--- a/site/index.html
+++ b/site/index.html
@@ -27,10 +27,10 @@
             A skill-first contract layer that helps Hermes turn chat messages into
             clarification, research, planning, status, or Codex-ready coding handoffs.
           </p>
-          <div class="hero-command" role="region" aria-label="Hermes skill install commands" tabindex="0">
-            <span>Install for Hermes</span>
-            <code>hermes skills tap add rlaope/oh-my-hermes-agent
-hermes skills install oh-my-hermes</code>
+          <div class="hero-command" role="region" aria-label="OMH quick start commands" tabindex="0">
+            <span>Quick start</span>
+            <code>curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes-agent/main/install.sh | sh
+omh setup</code>
           </div>
           <div class="hero-proof" aria-label="Core OMH contracts">
             <span>Natural chat routing</span>

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -297,6 +297,10 @@ class RouterContentTests(unittest.TestCase):
         self.assertIn("`omh setup` installs generated skills", readme)
         self.assertIn("omh setup", readme)
         self.assertIn("omh doctor", readme)
+        quick_start = readme.split("## Quick Start", 1)[1].split("## Two Install Paths", 1)[0]
+        self.assertIn("curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes-agent/main/install.sh | sh", quick_start)
+        self.assertIn("omh setup", quick_start)
+        self.assertLess(quick_start.index("curl -fsSL"), quick_start.index("hermes skills tap add"))
         self.assertIn("## Backend / Operator Surface", readme)
         self.assertIn("omh docs workflows --json", readme)
         self.assertIn("omh harness validate", readme)
@@ -342,10 +346,9 @@ class RouterContentTests(unittest.TestCase):
         self.assertNotIn('href="#architecture"', topbar)
         self.assertNotIn('href="#install"', topbar)
         self.assertNotIn("GitHub", topbar)
-        hero_command = site.split('aria-label="Hermes skill install commands"', 1)[1].split("</code>", 1)[0]
-        self.assertIn("hermes skills tap add rlaope/oh-my-hermes-agent", hero_command)
-        self.assertIn("hermes skills install oh-my-hermes", hero_command)
-        self.assertNotIn("omh setup", hero_command)
+        hero_command = site.split('aria-label="OMH quick start commands"', 1)[1].split("</code>", 1)[0]
+        self.assertIn("curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes-agent/main/install.sh | sh", hero_command)
+        self.assertIn("omh setup", hero_command)
         self.assertNotIn("omh doctor", hero_command)
         self.assertNotIn("github.com/rlaope/oh-my-hermes-agent/tree/main/docs", site)
         self.assertIn("OMH Documentation", site_docs)


### PR DESCRIPTION
## Summary
- Put the copyable quick start back on `curl ... | sh` plus `omh setup`.
- Keep Hermes skill tap commands as the equivalent native path instead of the first command users see.
- Align the GitHub Pages hero/docs install copy and lock the expectation in content tests.

## Verification
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- `uv run python -m src.cli docs workflows --check`
- `git diff --check`

Signed-off-by: rlaope <piyrw9754@gmail.com>