### PR TITLE
Add opt-in Hermes plugin distribution bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ delegate coding, or report status.
 | --- | --- |
 | Hermes skill tap | Tap-compatible skills under `skills/<name>/SKILL.md` for Hermes-native install. |
 | Bootstrap setup | `omh setup` installs the same generated skills under `~/.omh/skills` and registers `skills.external_dirs`. |
+| Optional Hermes plugin | `omh setup --with-plugin` installs a thin native bridge under `~/.hermes/plugins/omhm`. |
 | Skill catalog | Deterministic routing metadata from `src/skills/catalog.py`. |
 | Playbooks | Situation-level pipelines for research, planning, wrapper UX, and coding handoff flows. |
 | Harness quality | Machine-readable quality bars, evidence ladders, wrapper actions, and overclaim guards. |
@@ -139,6 +140,19 @@ omh doctor
 directory through Hermes' `skills.external_dirs`. The intended final state is
 the same from the user's point of view: Hermes sees OMH skills, and the user
 talks to Hermes.
+
+**Optional native plugin bridge**
+
+```sh
+omh setup --with-plugin
+omh doctor
+```
+
+This installs a small `~/.hermes/plugins/omhm` bundle that registers an
+`omhm_status` tool and a passive `pre_llm_call` status-context hook. It is
+operator opt-in: skills remain the default user-facing surface, and Hermes may
+still require its own plugin enable/reload step before the bundle is used.
+Local plugin import/register smoke is not proof that Hermes loaded the plugin.
 
 **Optional operator smoke test**
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -11,6 +11,7 @@ of copied prompt files.
 The architecture favors:
 
 - Hermes-native skill installation as the primary user-facing entry point
+- an optional thin Hermes plugin bridge for metadata-only status context
 - a small support command interface for bootstrap, verification, and wrappers
 - reversible local bootstrap installation
 - generated skill text from testable catalog data
@@ -30,6 +31,7 @@ separate runtime record exists.
 flowchart LR
   user["User in Hermes, Discord, Slack, or hosted chat"]
   skills["Installed OMH skills\nHermes skill tap or omh setup"]
+  plugin["Optional OMHM plugin\n~/.hermes/plugins/omhm"]
   wrapper["Wrapper adapter\nbuttons, threads, edits"]
   omh["OMH local contract layer\nplaybooks, routing, plan, handoff, status"]
   hermes["Hermes Agent\nclarify, research, plan, narrate"]
@@ -39,6 +41,7 @@ flowchart LR
 
   user --> hermes
   skills --> hermes
+  plugin -->|"omhm_status, pre_llm_call"| hermes
   user --> wrapper
   wrapper -->|"chat_interaction/v1"| omh
   omh -->|"answer, clarify, plan, or status"| wrapper
@@ -102,6 +105,13 @@ src/
     catalog.py
     packaging.py
     render.py
+  plugin_bundle/
+    omhm/
+      plugin.yaml
+      config.yaml
+      __init__.py
+      hooks/
+      tools/
 skills/
   <skill-name>/SKILL.md       # tap-compatible Hermes skill pack generated from the same catalog
 ```
@@ -111,6 +121,12 @@ skills/
 `skills/` is the Hermes-native distribution surface. It mirrors the generated
 skill templates so `hermes skills tap add rlaope/oh-my-hermes-agent` can expose
 OMH directly when Hermes taps are available.
+
+`plugin_bundle/omhm/` is the optional Hermes plugin payload installed by
+`omh setup --with-plugin` to `~/.hermes/plugins/omhm`. The v1 plugin registers
+only a metadata-only `omhm_status` tool and a passive `pre_llm_call` hook. It
+does not run verification commands, install transports, patch Hermes core, or
+claim execution evidence from prepared handoffs.
 
 `cli.py` is a compatibility adapter. `commands/main.py` owns command parsing
 and support JSON output for bootstrap, repair, verification, wrapper backends,

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -20,6 +20,19 @@ The installer normally runs setup automatically, but `omh setup` is kept here
 as the explicit repairable step: it installs generated managed skills and
 registers them with Hermes through `skills.external_dirs`.
 
+Plugin support is optional. Use it when an operator wants OMHM to provide a
+thin Hermes plugin bridge in addition to the skill pack:
+
+```sh
+omh setup --with-plugin
+omh doctor
+```
+
+That installs `~/.hermes/plugins/omhm` with metadata-only status support. It
+does not execute code, install Discord or Slack transports, patch Hermes core,
+or prove Hermes has loaded the plugin. If the target Hermes runtime requires a
+separate plugin enable command, follow that runtime's plugin enable/reload step.
+
 ## Install Path A: Hermes-Native Skill Tap
 
 Use this path when the target Hermes environment supports skill taps:
@@ -109,6 +122,11 @@ managed skills available to Hermes.
 `omh runtime status` should show the local runtime artifact directory and the
 latest install/apply/doctor state when those commands have run. `omh probe`
 reports observable Hermes capability surfaces without mutating Hermes internals.
+When `omh setup --with-plugin` has run, `omh doctor` also checks the managed
+plugin manifest plus local import/register smoke. `omh probe` reports
+`plugin_distribution_ready` separately from `native_integration_claim_ready` so
+operators do not mistake local install readiness for observed Hermes runtime
+use.
 
 For concrete examples that show how the installed skills should affect coding,
 planning, and specialist review flows, see

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -48,6 +48,7 @@ python3 -m src.cli docs workflows --check
 python3 -m src.cli harness validate
 python3 -m src.cli --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke install --dry-run --channel stable --version 0.1.0
 python3 -m src.cli --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke setup --dry-run --channel stable --version 0.1.0
+python3 -m src.cli --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke setup --with-plugin --dry-run --channel stable --version 0.1.0
 python3 -m src.cli --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke probe
 ```
 
@@ -71,6 +72,7 @@ python3 -m src.cli --omh-home /tmp/omh-smoke runtime export --redacted
 - Harness catalog validation status.
 - Runtime validation status.
 - Capability probe status.
+- Optional plugin bundle status when `omh setup --with-plugin` changed.
 - GitHub Pages workflow status when public site copy changed.
 - Known manual Hermes checks that could not be automated.
 - Any public claim that depends on wrapper evidence rather than Hermes-native
@@ -84,5 +86,7 @@ Use explicit proof-boundary language:
 - "Wrapper-observed" when evidence comes from a bot or shell wrapper.
 - "Not observed" when specialist delegation metadata is unavailable.
 
-Do not claim native Hermes hooks, plugins, apps, or internal routing until a
-future capability probe and runtime evidence both support that claim.
+Do not claim native Hermes runtime use from plugin installation alone.
+`plugin_distribution_ready` means the local bundle exists and passed local
+import/register smoke; `native_integration_claim_ready` still requires observed
+Hermes runtime-load or hook/tool-use evidence.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -13,6 +13,7 @@
 - Example Discord/Slack adapter shims that consume `chat_interaction/v1`
 - More public-site examples that mirror wrapper contracts without becoming a
   separate documentation source
+- Optional `~/.hermes/plugins/omhm` bridge hardening after v1 install smoke
 
 ## Mid Term
 
@@ -24,9 +25,9 @@
 
 ## Long Term
 
-- Hermes-native runtime hooks if Hermes exposes a stable extension surface
+- Hermes plugin enablement automation when the runtime contract is stable
 - Deeper workflow telemetry that remains local and inspectable
-- Plugin-style distribution if Hermes supports plugin bundles
+- Richer plugin hooks and tools after observed runtime-load evidence exists
 
 ## Recently Landed
 
@@ -44,3 +45,5 @@
 - GitHub Pages source for the public OMH entry point
 - Situation playbooks exposed through `omh playbook list`, `inspect`, and
   `recommend`
+- Optional plugin distribution path through `omh setup --with-plugin`, with
+  local import/register smoke and conservative runtime-claim boundaries

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,10 @@ packages = [
   "omh",
   "omh.commands",
   "omh.core",
+  "omh.plugin_bundle",
+  "omh.plugin_bundle.omhm",
+  "omh.plugin_bundle.omhm.hooks",
+  "omh.plugin_bundle.omhm.tools",
   "omh.routing",
   "omh.runtime",
   "omh.skills",
@@ -49,3 +53,6 @@ omh = "src"
 "omh.runtime" = "src/runtime"
 "omh.skills" = "src/skills"
 "omh.wrapper" = "src/wrapper"
+
+[tool.setuptools.package-data]
+"omh.plugin_bundle.omhm" = ["plugin.yaml", "config.yaml"]

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -43,7 +43,8 @@
             OMH gives Hermes installed skill guidance for turning natural language into deterministic
             routing, clarification, planning, status narration, or Codex-ready coding handoffs.
             Local backend contracts and schema-versioned artifacts support wrappers and operators
-            without becoming the normal user UX.
+            without becoming the normal user UX. Operators can optionally add a thin
+            plugin bridge for metadata-only status context.
           </p>
         </header>
 
@@ -59,6 +60,12 @@
 omh setup
 omh doctor</code>
           </div>
+          <p>
+            Operators who need a plugin payload can run
+            <code>omh setup --with-plugin</code>. Skills remain the default UX;
+            the plugin only adds local status context after Hermes enables and
+            loads it.
+          </p>
           <p>
             When Hermes skill taps are available, the native skill front door is:
           </p>
@@ -163,6 +170,10 @@ uv run python examples/slack-adapter-shim.py</code>
             <div class="arch-node arch-node--hermes">
               <span>Installed OMH skills</span>
               <strong>Tap install or omh setup</strong>
+            </div>
+            <div class="arch-node arch-node--hermes">
+              <span>Optional OMHM plugin</span>
+              <strong>omhm_status, passive context</strong>
             </div>
             <div class="arch-node arch-node--executor">
               <span>Codex-like executor</span>

--- a/site/index.html
+++ b/site/index.html
@@ -48,9 +48,9 @@ omh setup</code>
         <div class="section__header">
           <h2>Architecture at a glance.</h2>
           <p>
-            OMH starts as installed Hermes skills. Optional wrappers render UX,
-            backend contracts shape buttons and status, and runtime artifacts decide
-            what is actually observed.
+            OMH starts as installed Hermes skills. An optional plugin bridge can
+            surface metadata-only status inside Hermes, while runtime artifacts
+            decide what is actually observed.
           </p>
         </div>
         <div class="architecture-map" aria-label="OMH architecture diagram">
@@ -78,6 +78,10 @@ omh setup</code>
             <span>Installed OMH skills</span>
             <strong>Tap install or omh setup</strong>
           </div>
+          <div class="arch-node arch-node--hermes">
+            <span>Optional OMHM plugin</span>
+            <strong>omhm_status, passive context</strong>
+          </div>
           <div class="arch-node arch-node--executor">
             <span>Codex-like executor</span>
             <strong>Implementation after dispatch</strong>
@@ -96,6 +100,8 @@ omh setup</code>
               Hermes sees the installed skills first. Wrapper operators can inspect the
               same local pipeline contracts for research, deep interview, planning,
               safe coding handoff, status, and release-readiness review.
+              Operators can opt into <code>omh setup --with-plugin</code> for a
+              local Hermes plugin bridge that only surfaces metadata-backed status.
           </p>
         </div>
         <div class="grid">

--- a/src/commands/main.py
+++ b/src/commands/main.py
@@ -31,6 +31,7 @@ from ..local_store import atomic_write_text
 from ..manifest import read_manifest
 from ..paths import resolve_paths
 from ..playbooks import inspect_playbook, list_playbooks, recommend_playbooks
+from ..plugin_pack import PluginPackError, install_plugin_bundle
 from ..probe import probe_capabilities
 from ..routing.recommend import recommend_skills
 from ..release import RELEASE_CHANNELS, package_url_for
@@ -217,6 +218,8 @@ def cmd_setup(args: argparse.Namespace) -> int:
         steps["apply"] = {"skipped": True, "message": "Skipped Hermes config registration because --skip-apply was set."}
     else:
         steps["apply"] = _apply_result(args)
+    if args.with_plugin:
+        steps["plugin"] = _plugin_setup_result(args, paths)
     if args.dry_run:
         bootstrap_final_state = (
             "dry run would install generated skills and register the managed OMH skills directory for Hermes discovery"
@@ -265,8 +268,21 @@ def cmd_setup(args: argparse.Namespace) -> int:
                 }
             },
         )
-    _print_json({"ok": True, "steps": steps, "dry_run": args.dry_run, "hermes_native": hermes_native})
+    payload: dict[str, object] = {"ok": True, "steps": steps, "dry_run": args.dry_run, "hermes_native": hermes_native}
+    if args.with_plugin:
+        payload["plugin_distribution"] = steps["plugin"]
+    _print_json(payload)
     return 0
+
+
+def _plugin_setup_result(args: argparse.Namespace, paths) -> dict[str, object]:
+    try:
+        result = install_plugin_bundle(paths, force=args.force, dry_run=args.dry_run)
+    except PluginPackError as exc:
+        raise OmhError(str(exc)) from exc
+    if not args.dry_run:
+        update_state(paths, {"last_plugin_distribution": result})
+    return result
 
 
 def cmd_recommend(args: argparse.Namespace) -> int:
@@ -1044,6 +1060,11 @@ def _add_top_level_commands(sub) -> None:
     setup = sub.add_parser("setup")
     _add_common_install_options(setup)
     setup.add_argument("--skip-apply", action="store_true", help="Install skills without registering them in Hermes config.")
+    setup.add_argument(
+        "--with-plugin",
+        action="store_true",
+        help="Also install the optional OMHM Hermes plugin bundle under ~/.hermes/plugins/omhm.",
+    )
     setup.set_defaults(func=cmd_setup)
 
     install = sub.add_parser("install")

--- a/src/doctor.py
+++ b/src/doctor.py
@@ -7,6 +7,7 @@ from .hashutil import sha256_file
 from .local_store import can_write_dir
 from .manifest import local_modifications, read_manifest
 from .paths import OmhPaths
+from .plugin_pack import inspect_plugin_bundle
 from .runtime.artifacts import read_state, read_state_error
 from .skill_pack import CORE_SKILLS
 from .workflow_state import list_workflow_states
@@ -91,6 +92,36 @@ def run_doctor(paths: OmhPaths) -> list[Check]:
             ),
         )
     )
+    plugin = inspect_plugin_bundle(paths)
+    plugin_expected = bool(plugin["plugin_dir_installed"]) or bool(state and state.get("last_plugin_distribution"))
+    if not plugin_expected:
+        checks.append(Check("plugin_bundle", True, f"optional OMHM plugin is not installed at {paths.hermes_plugin_dir}"))
+    else:
+        checks.extend(
+            [
+                Check("plugin_bundle", bool(plugin["plugin_dir_installed"]), f"{paths.hermes_plugin_dir}"),
+                Check("plugin_manifest", bool(plugin["plugin_manifest_valid"]), str(plugin["plugin_manifest_path"])),
+                Check(
+                    "plugin_import_smoke",
+                    bool(plugin["plugin_import_smoke"]),
+                    "installed plugin imports without side effects" if plugin["plugin_import_smoke"] else "; ".join(plugin["errors"]),
+                ),
+                Check(
+                    "plugin_register_smoke",
+                    bool(plugin["plugin_register_smoke"]),
+                    (
+                        f"registered tools={plugin['registered_tools']} hooks={plugin['registered_hooks']}"
+                        if plugin["plugin_register_smoke"]
+                        else "; ".join(plugin["errors"])
+                    ),
+                ),
+                Check(
+                    "plugin_runtime_observed",
+                    True,
+                    "not required for doctor; Hermes runtime load/use must be observed separately before claiming native runtime readiness",
+                ),
+            ]
+        )
     return checks
 
 

--- a/src/paths.py
+++ b/src/paths.py
@@ -42,6 +42,14 @@ class OmhPaths:
     def hermes_config_path(self) -> Path:
         return self.hermes_home / "config.yaml"
 
+    @property
+    def hermes_plugins_dir(self) -> Path:
+        return self.hermes_home / "plugins"
+
+    @property
+    def hermes_plugin_dir(self) -> Path:
+        return self.hermes_plugins_dir / "omhm"
+
 
 def expand_path(value: str | Path) -> Path:
     return Path(os.path.expandvars(str(value))).expanduser().resolve()

--- a/src/plugin_bundle/__init__.py
+++ b/src/plugin_bundle/__init__.py
@@ -1,0 +1,2 @@
+from __future__ import annotations
+

--- a/src/plugin_bundle/omhm/__init__.py
+++ b/src/plugin_bundle/omhm/__init__.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+_TOOLSET = "omhm"
+
+
+def register(ctx):
+    """Register the OMHM thin native bridge with Hermes."""
+    from .hooks.llm_hooks import pre_llm_call
+    from .tools.status_tool import OMHM_STATUS_SCHEMA, omhm_status_handler
+
+    ctx.register_tool(
+        "omhm_status",
+        _TOOLSET,
+        OMHM_STATUS_SCHEMA,
+        omhm_status_handler,
+        description=OMHM_STATUS_SCHEMA["description"],
+    )
+    ctx.register_hook("pre_llm_call", pre_llm_call)

--- a/src/plugin_bundle/omhm/config.yaml
+++ b/src/plugin_bundle/omhm/config.yaml
@@ -1,0 +1,5 @@
+omh_home: "~/.omh"
+status_limit: 3
+inject_context: true
+privacy: metadata_only
+claim_boundary: "Prepared handoffs are not execution, review, CI, merge-readiness, or merge evidence."

--- a/src/plugin_bundle/omhm/hooks/__init__.py
+++ b/src/plugin_bundle/omhm/hooks/__init__.py
@@ -1,0 +1,2 @@
+from __future__ import annotations
+

--- a/src/plugin_bundle/omhm/hooks/llm_hooks.py
+++ b/src/plugin_bundle/omhm/hooks/llm_hooks.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from ..runtime_reader import read_omhm_status
+
+
+def pre_llm_call(**kwargs) -> dict[str, str] | None:
+    """Inject bounded OMHM status context without reading or storing prompts."""
+    try:
+        omh_home = str(kwargs.get("omh_home", "") or "") or None
+        status = read_omhm_status(omh_home=omh_home, limit=3)
+    except Exception:
+        return None
+
+    if not status.get("runtime_state_present") and not status.get("runs"):
+        return None
+
+    lines = [
+        "[OMHM] Native bridge status context.",
+        "Evidence boundary: prepared handoffs are not execution, review, CI, merge-readiness, or merge evidence.",
+    ]
+    latest_run_id = status.get("latest_run_id")
+    if latest_run_id:
+        lines.append(f"Latest runtime run: {latest_run_id}.")
+    for run in status.get("runs", [])[:3]:
+        run_id = run.get("run_id", "unknown")
+        workflow = run.get("workflow", "unknown")
+        phase = run.get("phase", "unknown")
+        observation = run.get("observation_status", "unknown")
+        execution = run.get("execution_observed", False)
+        review = run.get("review_observed", False)
+        ci = run.get("ci_observed", False)
+        merge = run.get("merge_observed", False)
+        lines.append(
+            f"- {run_id}: workflow={workflow}, phase={phase}, observation={observation}, "
+            f"execution_observed={execution}, review_observed={review}, ci_observed={ci}, merge_observed={merge}."
+        )
+    lines.append("Use omhm_status for the full metadata-only status payload.")
+    return {"context": "\n".join(lines)}

--- a/src/plugin_bundle/omhm/plugin.yaml
+++ b/src/plugin_bundle/omhm/plugin.yaml
@@ -1,0 +1,8 @@
+name: omhm
+version: "0.1.0"
+description: "Oh My Hermes Agent native bridge for metadata-only runtime status and evidence-boundary context."
+author: oh-my-hermes maintainers
+provides_tools:
+  - omhm_status
+provides_hooks:
+  - pre_llm_call

--- a/src/plugin_bundle/omhm/runtime_reader.py
+++ b/src/plugin_bundle/omhm/runtime_reader.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+STATUS_SCHEMA_VERSION = "omhm_status/v1"
+
+
+def _expand_path(value: str | Path) -> Path:
+    return Path(os.path.expandvars(str(value))).expanduser().resolve()
+
+
+def _default_omh_home() -> Path:
+    return _expand_path(os.environ.get("OMH_HOME", "~/.omh"))
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _bool_from_record(record: dict[str, Any], key: str = "observed") -> bool:
+    return bool(record.get(key, False)) if record else False
+
+
+def _summarize_run(run_dir: Path) -> dict[str, Any]:
+    run = _read_json(run_dir / "run.json")
+    coding = _read_json(run_dir / "coding_delegation.json")
+    delegation = _read_json(run_dir / "delegation.json")
+    wrapper = _read_json(run_dir / "wrapper.json")
+    review = _read_json(run_dir / "review.json")
+    ci = _read_json(run_dir / "ci.json")
+    merge = _read_json(run_dir / "merge.json")
+    return {
+        "run_id": str(run.get("run_id", run_dir.name)),
+        "workflow": str(coding.get("recommended_workflow") or run.get("skill", "unknown")),
+        "harness": str(coding.get("recommended_harness") or run.get("harness", "unknown")),
+        "phase": str(run.get("phase", run.get("status", "unknown"))),
+        "artifact_kind": str(run.get("artifact_kind", "")),
+        "observation_status": str(run.get("observation_status", coding.get("status", "unknown"))),
+        "prepared_handoff": bool(coding) and str(coding.get("status", "")) == "prepared_not_observed",
+        "prompt_dispatched": _bool_from_record(wrapper, "prompt_dispatched"),
+        "execution_observed": _bool_from_record(delegation),
+        "verification_observed": _bool_from_record(wrapper, "verification_observed"),
+        "review_observed": _bool_from_record(review),
+        "review_status": str(review.get("status", "not_observed" if review else "unknown")),
+        "ci_observed": _bool_from_record(ci),
+        "ci_status": str(ci.get("status", "not_observed" if ci else "unknown")),
+        "merge_observed": _bool_from_record(merge),
+        "merge_status": str(merge.get("status", "not_observed" if merge else "unknown")),
+    }
+
+
+def read_omhm_status(omh_home: str | Path | None = None, limit: int = 5) -> dict[str, Any]:
+    safe_limit = max(0, min(int(limit), 20))
+    home = _expand_path(omh_home) if omh_home else _default_omh_home()
+    runtime_dir = home / "runtime"
+    runs_dir = runtime_dir / "runs"
+    state = _read_json(runtime_dir / "state.json")
+    runs: list[dict[str, Any]] = []
+    if runs_dir.exists():
+        for run_json in sorted(runs_dir.glob("*/run.json"), reverse=True)[:safe_limit]:
+            runs.append(_summarize_run(run_json.parent))
+    return {
+        "schema_version": STATUS_SCHEMA_VERSION,
+        "omh_home": str(home),
+        "runtime_dir": str(runtime_dir),
+        "runtime_state_present": bool(state),
+        "latest_run_id": str(state.get("last_run_id", "")) if state else "",
+        "runs": runs,
+        "evidence_boundary": {
+            "prepared_handoff": "not execution evidence",
+            "execution": "requires observed delegation result",
+            "verification": "requires observed wrapper verification",
+            "review": "requires separate review record",
+            "ci": "requires separate CI record",
+            "merge": "requires separate merge record",
+        },
+        "privacy": "metadata_only",
+    }

--- a/src/plugin_bundle/omhm/tools/__init__.py
+++ b/src/plugin_bundle/omhm/tools/__init__.py
@@ -1,0 +1,2 @@
+from __future__ import annotations
+

--- a/src/plugin_bundle/omhm/tools/status_tool.py
+++ b/src/plugin_bundle/omhm/tools/status_tool.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import json
+
+from ..runtime_reader import read_omhm_status
+
+OMHM_STATUS_SCHEMA = {
+    "name": "omhm_status",
+    "description": (
+        "Read OMHM metadata-only runtime status. Prepared handoffs are kept separate "
+        "from observed execution, review, CI, and merge evidence."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "omh_home": {
+                "type": "string",
+                "description": "Optional OMH_HOME override. Defaults to $OMH_HOME or ~/.omh.",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum recent runtime runs to summarize.",
+            },
+        },
+    },
+}
+
+
+def omhm_status_handler(args: dict, **kwargs) -> str:
+    payload = read_omhm_status(
+        omh_home=str(args.get("omh_home", "") or "") or None,
+        limit=int(args.get("limit") or 5),
+    )
+    return json.dumps(payload, sort_keys=True)

--- a/src/plugin_pack.py
+++ b/src/plugin_pack.py
@@ -1,0 +1,292 @@
+from __future__ import annotations
+
+import importlib.resources as resources
+import importlib.util
+import shutil
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from . import __version__
+from .hashutil import sha256_file, sha256_text
+from .local_store import atomic_write_json, ensure_dir, read_json_object, utc_now
+from .paths import OmhPaths
+
+PLUGIN_NAME = "omhm"
+PLUGIN_SCHEMA_VERSION = "plugin_distribution/v1"
+PLUGIN_MANAGED_MANIFEST = ".omhm-plugin-manifest.json"
+PLUGIN_ENABLE_HINT = "Hermes may require `hermes plugins enable omhm` after the bundle is installed."
+
+
+class PluginPackError(Exception):
+    pass
+
+
+@dataclass(frozen=True)
+class PluginFileRecord:
+    path: str
+    sha256: str
+
+
+class _SmokeContext:
+    def __init__(self) -> None:
+        self.tools: list[str] = []
+        self.hooks: list[str] = []
+
+    def register_tool(self, name: str, *args: object, **kwargs: object) -> None:
+        self.tools.append(name)
+
+    def register_hook(self, name: str, *args: object, **kwargs: object) -> None:
+        self.hooks.append(name)
+
+
+def install_plugin_bundle(paths: OmhPaths, *, force: bool = False, dry_run: bool = False) -> dict[str, Any]:
+    target = paths.hermes_plugin_dir
+    source_records = bundled_plugin_records()
+    existing_manifest = read_plugin_manifest(target)
+    dirty = plugin_local_modifications(existing_manifest, target)
+    unmanaged = target.exists() and existing_manifest is None
+    if unmanaged and not force:
+        raise PluginPackError(f"{target} exists without an OMHM plugin manifest; use --force to replace it")
+    if dirty and not force:
+        raise PluginPackError(f"managed plugin files changed: {', '.join(dirty)}; use --force to replace them")
+
+    changed = force or unmanaged or existing_manifest is None or _manifest_file_map(existing_manifest) != _record_file_map(source_records)
+    result = _plugin_distribution_payload(
+        paths,
+        dry_run=dry_run,
+        observed=False if dry_run else True,
+        changed=changed,
+        file_records=source_records,
+        dirty_files=dirty,
+    )
+    if dry_run:
+        result["observed_scope"] = "dry run only; no plugin files were written"
+        return result
+    _copy_plugin_bundle(target, source_records)
+    smoke = inspect_plugin_bundle(paths)
+    result.update(
+        {
+            "import_smoke": smoke["plugin_import_smoke"],
+            "register_smoke": smoke["plugin_register_smoke"],
+            "registered_tools": smoke["registered_tools"],
+            "registered_hooks": smoke["registered_hooks"],
+        }
+    )
+    return result
+
+
+def inspect_plugin_bundle(paths: OmhPaths) -> dict[str, Any]:
+    target = paths.hermes_plugin_dir
+    manifest = read_plugin_manifest(target)
+    plugin_yaml = target / "plugin.yaml"
+    init_py = target / "__init__.py"
+    errors: list[str] = []
+    if target.exists() and not target.is_dir():
+        errors.append(f"{target} is not a directory")
+    if target.exists() and not manifest:
+        errors.append(f"{target / PLUGIN_MANAGED_MANIFEST} is missing or unreadable")
+    manifest_valid = _manifest_valid(manifest, target)
+    if target.exists() and not manifest_valid:
+        errors.append("plugin manifest is invalid or stale")
+    if target.exists() and not plugin_yaml.exists():
+        errors.append(f"{plugin_yaml} is missing")
+    if target.exists() and not init_py.exists():
+        errors.append(f"{init_py} is missing")
+    smoke = _register_smoke(target) if target.exists() and plugin_yaml.exists() and init_py.exists() else {}
+    import_smoke = bool(smoke.get("import_smoke", False))
+    register_smoke = bool(smoke.get("register_smoke", False))
+    if target.exists() and smoke.get("error"):
+        errors.append(str(smoke["error"]))
+    return {
+        "schema_version": PLUGIN_SCHEMA_VERSION,
+        "plugin_name": PLUGIN_NAME,
+        "plugin_dir": str(target),
+        "plugin_dir_installed": target.exists() and target.is_dir(),
+        "plugin_manifest_path": str(target / PLUGIN_MANAGED_MANIFEST),
+        "plugin_manifest_present": manifest is not None,
+        "plugin_manifest_valid": manifest_valid,
+        "plugin_yaml_present": plugin_yaml.exists(),
+        "plugin_import_smoke": import_smoke,
+        "plugin_register_smoke": register_smoke,
+        "registered_tools": smoke.get("registered_tools", []),
+        "registered_hooks": smoke.get("registered_hooks", []),
+        "plugin_distribution_ready": bool(target.exists() and manifest_valid and import_smoke and register_smoke),
+        "plugin_runtime_observed": False,
+        "requires_hermes_plugin_enable": target.exists(),
+        "enable_hint": PLUGIN_ENABLE_HINT,
+        "errors": errors,
+    }
+
+
+def bundled_plugin_records() -> list[dict[str, str]]:
+    root = resources.files("omh.plugin_bundle.omhm")
+    records: list[PluginFileRecord] = []
+    _collect_resource_records(root, Path("."), records)
+    return [record.__dict__ for record in sorted(records, key=lambda item: item.path)]
+
+
+def read_plugin_manifest(plugin_dir: Path) -> dict[str, Any] | None:
+    try:
+        return read_json_object(plugin_dir / PLUGIN_MANAGED_MANIFEST)
+    except (OSError, ValueError):
+        return None
+
+
+def plugin_local_modifications(manifest: dict[str, Any] | None, plugin_dir: Path) -> list[str]:
+    if not manifest:
+        return []
+    modified: list[str] = []
+    for record in manifest.get("files", []):
+        rel = str(record.get("path", ""))
+        expected = str(record.get("sha256", ""))
+        if not rel or not expected:
+            continue
+        path = plugin_dir / rel
+        if not path.exists():
+            modified.append(rel)
+        elif sha256_file(path) != expected:
+            modified.append(rel)
+    return modified
+
+
+def _collect_resource_records(root: Any, rel: Path, records: list[PluginFileRecord]) -> None:
+    for item in root.iterdir():
+        if item.name == "__pycache__" or item.name.endswith(".pyc"):
+            continue
+        item_rel = rel / item.name
+        if item.is_dir():
+            _collect_resource_records(item, item_rel, records)
+        elif item.is_file():
+            records.append(PluginFileRecord(str(item_rel), sha256_text(item.read_text(encoding="utf-8"))))
+
+
+def _copy_plugin_bundle(target: Path, file_records: list[dict[str, str]]) -> None:
+    root = resources.files("omh.plugin_bundle.omhm")
+    parent = target.parent
+    tmp = parent / f".{target.name}.installing"
+    backup = parent / f".{target.name}.previous"
+    ensure_dir(parent)
+    shutil.rmtree(tmp, ignore_errors=True)
+    shutil.rmtree(backup, ignore_errors=True)
+    try:
+        _copy_resource_tree(root, tmp)
+        atomic_write_json(tmp / PLUGIN_MANAGED_MANIFEST, _new_plugin_manifest(target, file_records))
+        if target.exists():
+            target.rename(backup)
+        tmp.rename(target)
+        shutil.rmtree(backup, ignore_errors=True)
+    except OSError:
+        shutil.rmtree(tmp, ignore_errors=True)
+        if backup.exists() and not target.exists():
+            backup.rename(target)
+        raise
+
+
+def _copy_resource_tree(root: Any, dest: Path) -> None:
+    ensure_dir(dest)
+    for item in root.iterdir():
+        if item.name == "__pycache__" or item.name.endswith(".pyc"):
+            continue
+        target = dest / item.name
+        if item.is_dir():
+            _copy_resource_tree(item, target)
+        elif item.is_file():
+            target.write_text(item.read_text(encoding="utf-8"), encoding="utf-8")
+
+
+def _new_plugin_manifest(target: Path, file_records: list[dict[str, str]]) -> dict[str, Any]:
+    return {
+        "schema_version": PLUGIN_SCHEMA_VERSION,
+        "package": "oh-my-hermes-agent",
+        "version": __version__,
+        "plugin_name": PLUGIN_NAME,
+        "plugin_dir": str(target),
+        "installed_at": utc_now(),
+        "source": "builtin",
+        "files": file_records,
+        "requires_hermes_plugin_enable": True,
+        "enable_hint": PLUGIN_ENABLE_HINT,
+    }
+
+
+def _plugin_distribution_payload(
+    paths: OmhPaths,
+    *,
+    dry_run: bool,
+    observed: bool,
+    changed: bool,
+    file_records: list[dict[str, str]],
+    dirty_files: list[str],
+) -> dict[str, Any]:
+    return {
+        "schema_version": PLUGIN_SCHEMA_VERSION,
+        "plugin_name": PLUGIN_NAME,
+        "plugin_dir": str(paths.hermes_plugin_dir),
+        "dry_run": dry_run,
+        "observed": observed,
+        "changed": changed,
+        "files": len(file_records),
+        "dirty_files": dirty_files,
+        "requires_hermes_plugin_enable": True,
+        "enable_hint": PLUGIN_ENABLE_HINT,
+        "observed_scope": (
+            "local plugin bundle install and import/register smoke only; this does not prove Hermes loaded or used the plugin"
+        ),
+    }
+
+
+def _manifest_valid(manifest: dict[str, Any] | None, target: Path) -> bool:
+    if not manifest:
+        return False
+    if manifest.get("schema_version") != PLUGIN_SCHEMA_VERSION or manifest.get("plugin_name") != PLUGIN_NAME:
+        return False
+    return not plugin_local_modifications(manifest, target)
+
+
+def _register_smoke(plugin_dir: Path) -> dict[str, Any]:
+    module_name = "_omhm_plugin_smoke"
+    _clear_smoke_modules(module_name)
+    try:
+        spec = importlib.util.spec_from_file_location(
+            module_name,
+            plugin_dir / "__init__.py",
+            submodule_search_locations=[str(plugin_dir)],
+        )
+        if spec is None or spec.loader is None:
+            return {"import_smoke": False, "register_smoke": False, "error": "could not load plugin spec"}
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+        spec.loader.exec_module(module)
+        ctx = _SmokeContext()
+        register = getattr(module, "register", None)
+        if not callable(register):
+            return {"import_smoke": True, "register_smoke": False, "error": "register(ctx) is missing"}
+        register(ctx)
+        return {
+            "import_smoke": True,
+            "register_smoke": "omhm_status" in ctx.tools and "pre_llm_call" in ctx.hooks,
+            "registered_tools": sorted(ctx.tools),
+            "registered_hooks": sorted(ctx.hooks),
+        }
+    except Exception as exc:
+        return {"import_smoke": False, "register_smoke": False, "error": f"plugin smoke failed: {exc}"}
+    finally:
+        _clear_smoke_modules(module_name)
+
+
+def _clear_smoke_modules(module_name: str) -> None:
+    for name in list(sys.modules):
+        if name == module_name or name.startswith(f"{module_name}."):
+            sys.modules.pop(name, None)
+
+
+def _manifest_file_map(manifest: dict[str, Any] | None) -> dict[str, str]:
+    if not manifest:
+        return {}
+    return {str(item.get("path", "")): str(item.get("sha256", "")) for item in manifest.get("files", [])}
+
+
+def _record_file_map(records: list[dict[str, str]]) -> dict[str, str]:
+    return {record["path"]: record["sha256"] for record in records}

--- a/src/probe.py
+++ b/src/probe.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from .config_adapter import external_dirs, read_config
 from .paths import OmhPaths
+from .plugin_pack import inspect_plugin_bundle
 
 PROBE_STATUSES = ("available", "missing", "unknown", "unverified")
 
@@ -129,6 +130,46 @@ def probe_capabilities(paths: OmhPaths) -> dict:
         )
     )
     wrappers = _wrapper_artifacts(paths)
+    plugin = inspect_plugin_bundle(paths)
+    plugins_dir_exists = _has_dir(paths.hermes_plugins_dir)
+    capabilities.extend(
+        [
+            Capability(
+                "plugin_dir_exists",
+                "available" if plugins_dir_exists else "unknown",
+                str(paths.hermes_plugins_dir),
+                "Hermes plugin directory exists" if plugins_dir_exists else "No Hermes plugin directory detected by file probe",
+            ),
+            Capability(
+                "omhm_plugin_bundle",
+                "available" if plugin["plugin_dir_installed"] else "missing",
+                str(paths.hermes_plugin_dir),
+                "Managed OMHM plugin bundle is installed" if plugin["plugin_dir_installed"] else "Managed OMHM plugin bundle is not installed",
+            ),
+            Capability(
+                "plugin_import_smoke",
+                "available" if plugin["plugin_import_smoke"] else ("missing" if plugin["plugin_dir_installed"] else "unknown"),
+                str(paths.hermes_plugin_dir / "__init__.py"),
+                "Installed OMHM plugin imports locally" if plugin["plugin_import_smoke"] else "Installed OMHM plugin has not passed local import smoke",
+            ),
+            Capability(
+                "plugin_register_smoke",
+                "available" if plugin["plugin_register_smoke"] else ("missing" if plugin["plugin_dir_installed"] else "unknown"),
+                str(paths.hermes_plugin_dir),
+                (
+                    f"Installed OMHM plugin registers tools={plugin['registered_tools']} hooks={plugin['registered_hooks']}"
+                    if plugin["plugin_register_smoke"]
+                    else "Installed OMHM plugin has not passed fake Hermes register smoke"
+                ),
+            ),
+            Capability(
+                "plugin_runtime_observed",
+                "unverified",
+                str(paths.hermes_plugin_dir),
+                "No Hermes runtime load/use observation is recorded; local install smoke is not native runtime evidence",
+            ),
+        ]
+    )
     capabilities.append(
         Capability(
             "wrapper_metadata",
@@ -143,6 +184,7 @@ def probe_capabilities(paths: OmhPaths) -> dict:
         "omh_home": str(paths.omh_home),
         "hermes_home": str(paths.hermes_home),
         "capabilities": [capability.to_dict() for capability in capabilities],
+        "plugin_distribution_ready": bool(plugin["plugin_distribution_ready"]),
         "native_integration_claim_ready": False,
         "claim_boundary": "Prompt-level routing is the default unless a future stable Hermes extension surface and runtime evidence prove deeper integration.",
     }

--- a/tests/test_plugin_distribution.py
+++ b/tests/test_plugin_distribution.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import importlib.resources as resources
+import importlib.util
+import json
+import sys
+import tomllib
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from _cli_harness import run_cli
+from _local_package import load_local_package
+
+load_local_package()
+
+from omh.paths import resolve_paths
+from omh.plugin_pack import inspect_plugin_bundle
+
+
+class FakeHermesContext:
+    def __init__(self) -> None:
+        self.tools: dict[str, object] = {}
+        self.hooks: dict[str, object] = {}
+
+    def register_tool(self, name: str, *args: object, **kwargs: object) -> None:
+        self.tools[name] = {"args": args, "kwargs": kwargs}
+
+    def register_hook(self, name: str, handler: object) -> None:
+        self.hooks[name] = handler
+
+
+def load_installed_plugin(plugin_dir: Path):
+    module_name = "_test_omhm_installed_plugin"
+    for name in list(sys.modules):
+        if name == module_name or name.startswith(f"{module_name}."):
+            sys.modules.pop(name, None)
+    spec = importlib.util.spec_from_file_location(
+        module_name,
+        plugin_dir / "__init__.py",
+        submodule_search_locations=[str(plugin_dir)],
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError("failed to load installed plugin")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class PluginDistributionTests(unittest.TestCase):
+    def test_bundled_plugin_resource_is_packaged(self) -> None:
+        root = resources.files("omh.plugin_bundle.omhm")
+        self.assertTrue(root.joinpath("plugin.yaml").is_file())
+        self.assertTrue(root.joinpath("config.yaml").is_file())
+        pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+        packages = set(pyproject["tool"]["setuptools"]["packages"])
+        self.assertIn("omh.plugin_bundle.omhm", packages)
+        self.assertIn("omh.plugin_bundle.omhm", pyproject["tool"]["setuptools"]["package-data"])
+
+    def test_setup_default_does_not_install_plugin(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / ".omh"
+            hermes_home = root / ".hermes"
+
+            status, stdout, stderr = run_cli(["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "setup"])
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            payload = json.loads(stdout)
+            self.assertNotIn("plugin", payload["steps"])
+            self.assertFalse((hermes_home / "plugins" / "omhm").exists())
+            self.assertEqual(run_cli(["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "doctor"])[0], 0)
+
+    def test_setup_with_plugin_installs_and_registers_smoke(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / ".omh"
+            hermes_home = root / ".hermes"
+
+            status, stdout, stderr = run_cli(["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "setup", "--with-plugin"])
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            payload = json.loads(stdout)
+            plugin = payload["plugin_distribution"]
+            plugin_dir = hermes_home / "plugins" / "omhm"
+            self.assertEqual(plugin["schema_version"], "plugin_distribution/v1")
+            self.assertTrue(plugin["observed"])
+            self.assertTrue(plugin["requires_hermes_plugin_enable"])
+            self.assertTrue((plugin_dir / "plugin.yaml").exists())
+            self.assertTrue((plugin_dir / ".omhm-plugin-manifest.json").exists())
+            self.assertEqual(plugin["registered_tools"], ["omhm_status"])
+            self.assertEqual(plugin["registered_hooks"], ["pre_llm_call"])
+
+            inspection = inspect_plugin_bundle(resolve_paths(omh_home, hermes_home))
+            self.assertTrue(inspection["plugin_distribution_ready"])
+
+            doctor_status, doctor_stdout, doctor_stderr = run_cli(["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "doctor"])
+            self.assertEqual(doctor_stderr, "")
+            self.assertEqual(doctor_status, 0)
+            checks = {check["name"]: check for check in json.loads(doctor_stdout)["checks"]}
+            self.assertTrue(checks["plugin_import_smoke"]["ok"])
+            self.assertTrue(checks["plugin_register_smoke"]["ok"])
+
+    def test_setup_with_plugin_dry_run_writes_nothing(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / ".omh"
+            hermes_home = root / ".hermes"
+
+            status, stdout, stderr = run_cli(
+                ["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "setup", "--with-plugin", "--dry-run"]
+            )
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            payload = json.loads(stdout)
+            self.assertTrue(payload["plugin_distribution"]["dry_run"])
+            self.assertFalse(payload["plugin_distribution"]["observed"])
+            self.assertFalse((hermes_home / "plugins" / "omhm").exists())
+
+    def test_setup_with_plugin_refuses_dirty_managed_files_without_force(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / ".omh"
+            hermes_home = root / ".hermes"
+            self.assertEqual(run_cli(["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "setup", "--with-plugin"])[0], 0)
+            plugin_yaml = hermes_home / "plugins" / "omhm" / "plugin.yaml"
+            plugin_yaml.write_text(plugin_yaml.read_text(encoding="utf-8") + "\n# local edit\n", encoding="utf-8")
+
+            status, _, stderr = run_cli(["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "setup", "--with-plugin"])
+
+            self.assertEqual(status, 2)
+            self.assertIn("managed plugin files changed", stderr)
+            self.assertEqual(run_cli(["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "setup", "--with-plugin", "--force"])[0], 0)
+
+    def test_doctor_fails_for_malformed_installed_plugin(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / ".omh"
+            hermes_home = root / ".hermes"
+            self.assertEqual(run_cli(["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "setup", "--with-plugin"])[0], 0)
+            (hermes_home / "plugins" / "omhm" / "__init__.py").unlink()
+
+            status, stdout, stderr = run_cli(["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "doctor"])
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 1)
+            checks = {check["name"]: check for check in json.loads(stdout)["checks"]}
+            self.assertFalse(checks["plugin_manifest"]["ok"])
+            self.assertFalse(checks["plugin_import_smoke"]["ok"])
+
+    def test_installed_plugin_status_tool_and_hook_keep_evidence_boundary(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / ".omh"
+            hermes_home = root / ".hermes"
+            self.assertEqual(run_cli(["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "setup", "--with-plugin"])[0], 0)
+            status, stdout, _ = run_cli(
+                [
+                    "--omh-home",
+                    str(omh_home),
+                    "--hermes-home",
+                    str(hermes_home),
+                    "coding",
+                    "delegate",
+                    "--record",
+                    "Safely add feature without overclaiming.",
+                ]
+            )
+            self.assertEqual(status, 0)
+            run_id = json.loads(stdout)["runtime"]["run"]["run_id"]
+
+            module = load_installed_plugin(hermes_home / "plugins" / "omhm")
+            ctx = FakeHermesContext()
+            module.register(ctx)
+            self.assertIn("omhm_status", ctx.tools)
+            self.assertIn("pre_llm_call", ctx.hooks)
+
+            handler = ctx.tools["omhm_status"]["args"][2]
+            payload = json.loads(handler({"omh_home": str(omh_home), "limit": 1}))
+            self.assertEqual(payload["schema_version"], "omhm_status/v1")
+            self.assertEqual(payload["runs"][0]["run_id"], run_id)
+            self.assertTrue(payload["runs"][0]["prepared_handoff"])
+            self.assertFalse(payload["runs"][0]["execution_observed"])
+            self.assertIn("not execution evidence", payload["evidence_boundary"]["prepared_handoff"])
+
+            hook_payload = ctx.hooks["pre_llm_call"](
+                omh_home=str(omh_home),
+                user_message="this raw prompt should not leak",
+                is_first_turn=True,
+            )
+            self.assertIsNotNone(hook_payload)
+            context = hook_payload["context"]
+            self.assertIn("prepared handoffs are not execution", context)
+            self.assertNotIn("this raw prompt should not leak", context)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -21,6 +21,9 @@ class ProbeCliTests(unittest.TestCase):
             self.assertEqual(caps["external_skill_dirs"]["status"], "unknown")
             self.assertEqual(caps["managed_skills"]["status"], "missing")
             self.assertEqual(caps["native_hooks"]["status"], "unknown")
+            self.assertEqual(caps["omhm_plugin_bundle"]["status"], "missing")
+            self.assertEqual(caps["plugin_import_smoke"]["status"], "unknown")
+            self.assertFalse(payload["plugin_distribution_ready"])
             self.assertFalse(payload["native_integration_claim_ready"])
 
     def test_probe_reports_available_local_evidence_after_install_and_wrapper_record(self) -> None:
@@ -55,6 +58,29 @@ class ProbeCliTests(unittest.TestCase):
             self.assertEqual(caps["external_skill_dirs"]["status"], "available")
             self.assertEqual(caps["managed_skills"]["status"], "available")
             self.assertEqual(caps["wrapper_metadata"]["status"], "available")
+            self.assertEqual(caps["omhm_plugin_bundle"]["status"], "missing")
+            self.assertFalse(json.loads(stdout)["plugin_distribution_ready"])
+
+    def test_probe_reports_plugin_distribution_without_native_runtime_claim(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / ".omh"
+            hermes_home = root / ".hermes"
+
+            self.assertEqual(run_cli(["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "setup", "--with-plugin"])[0], 0)
+
+            status, stdout, stderr = run_cli(["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "probe"])
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            payload = json.loads(stdout)
+            caps = {capability["name"]: capability for capability in payload["capabilities"]}
+            self.assertEqual(caps["omhm_plugin_bundle"]["status"], "available")
+            self.assertEqual(caps["plugin_import_smoke"]["status"], "available")
+            self.assertEqual(caps["plugin_register_smoke"]["status"], "available")
+            self.assertEqual(caps["plugin_runtime_observed"]["status"], "unverified")
+            self.assertTrue(payload["plugin_distribution_ready"])
+            self.assertFalse(payload["native_integration_claim_ready"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add an optional OMHM Hermes plugin bundle that installs to `~/.hermes/plugins/omhm` through `omh setup --with-plugin`.
- Register a thin `omhm_status` tool and passive `pre_llm_call` hook for metadata-only runtime status context.
- Extend setup, doctor, and probe so plugin distribution readiness stays separate from native Hermes runtime-use claims.
- Update README, docs, release notes, roadmap, and site copy to frame the plugin as an optional native bridge while keeping skills as the default UX.

## Boundaries
- No Hermes core patching.
- No Discord/Slack SDK or network transport.
- No hidden coding execution.
- No evidence command runner in v1.
- `plugin_distribution_ready` does not make `native_integration_claim_ready` true.

## Verification
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — 190 tests passed.
- `uv run python -m compileall -q src tests` — passed.
- `uv run python -m src.cli docs workflows --check` — passed; 20/20 tap skills checked.
- `uv build` — passed; plugin payload included in sdist/wheel; existing setuptools license deprecation warnings only.
- Manual smoke: `omh setup --with-plugin` + `omh doctor` + `omh probe` — setup ok, plugin_distribution/v1, registered `omhm_status`, registered `pre_llm_call`, doctor ok, plugin_distribution_ready=true, native_integration_claim_ready=false.
- `git diff --check` — passed.

## Not Tested
- Real Hermes plugin enable/load inside a live Hermes runtime; v1 only verifies local install/import/register smoke.