### PR TITLE
Add repository links to site header and footer

### DIFF
--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -15,6 +15,16 @@
       <a class="brand brand--link" href="../">OMH</a>
       <nav class="nav" aria-label="Primary navigation">
         <a aria-current="page" href="./">Docs</a>
+        <a
+          class="nav__icon"
+          href="https://github.com/rlaope/oh-my-hermes-agent"
+          aria-label="Open OMH repository on GitHub"
+          title="GitHub repository"
+        >
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M12 2C6.48 2 2 6.58 2 12.22c0 4.52 2.87 8.35 6.85 9.7.5.09.68-.22.68-.49v-1.73c-2.78.62-3.37-1.37-3.37-1.37-.45-1.18-1.11-1.5-1.11-1.5-.91-.64.07-.63.07-.63 1 .07 1.53 1.06 1.53 1.06.9 1.56 2.35 1.11 2.92.85.09-.66.35-1.11.63-1.37-2.22-.26-4.55-1.14-4.55-5.06 0-1.12.39-2.03 1.03-2.75-.1-.26-.45-1.31.1-2.71 0 0 .84-.28 2.75 1.05A9.37 9.37 0 0 1 12 6.92c.85 0 1.7.12 2.5.35 1.9-1.33 2.74-1.05 2.74-1.05.55 1.4.2 2.45.1 2.71.64.72 1.03 1.63 1.03 2.75 0 3.93-2.34 4.79-4.57 5.05.36.32.68.94.68 1.9v2.8c0 .27.18.58.69.48A10.06 10.06 0 0 0 22 12.22C22 6.58 17.52 2 12 2Z"></path>
+          </svg>
+        </a>
       </nav>
     </header>
 
@@ -473,8 +483,13 @@ omh harness validate</code>
     </main>
 
     <footer class="footer">
-      OMH documentation is served directly from this site. Source docs remain in the repository
-      as the versioned source of truth.
+      <span>
+        OMH documentation is served directly from this site. Source docs remain in the repository
+        as the versioned source of truth.
+      </span>
+      <span>
+        Developed by <a href="https://github.com/rlaope">rlaope</a>.
+      </span>
     </footer>
   </body>
 </html>

--- a/site/index.html
+++ b/site/index.html
@@ -15,6 +15,16 @@
       <div class="brand">OMH</div>
       <nav class="nav" aria-label="Primary navigation">
         <a href="docs/">Docs</a>
+        <a
+          class="nav__icon"
+          href="https://github.com/rlaope/oh-my-hermes-agent"
+          aria-label="Open OMH repository on GitHub"
+          title="GitHub repository"
+        >
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M12 2C6.48 2 2 6.58 2 12.22c0 4.52 2.87 8.35 6.85 9.7.5.09.68-.22.68-.49v-1.73c-2.78.62-3.37-1.37-3.37-1.37-.45-1.18-1.11-1.5-1.11-1.5-.91-.64.07-.63.07-.63 1 .07 1.53 1.06 1.53 1.06.9 1.56 2.35 1.11 2.92.85.09-.66.35-1.11.63-1.37-2.22-.26-4.55-1.14-4.55-5.06 0-1.12.39-2.03 1.03-2.75-.1-.26-.45-1.31.1-2.71 0 0 .84-.28 2.75 1.05A9.37 9.37 0 0 1 12 6.92c.85 0 1.7.12 2.5.35 1.9-1.33 2.74-1.05 2.74-1.05.55 1.4.2 2.45.1 2.71.64.72 1.03 1.63 1.03 2.75 0 3.93-2.34 4.79-4.57 5.05.36.32.68.94.68 1.9v2.8c0 .27.18.58.69.48A10.06 10.06 0 0 0 22 12.22C22 6.58 17.52 2 12 2Z"></path>
+          </svg>
+        </a>
       </nav>
     </header>
 
@@ -429,8 +439,13 @@ omh demo orchestration</code>
     </main>
 
     <footer class="footer">
-      OMH is deterministic local contract tooling. It does not patch Hermes core,
-      run platform bots, call LLM APIs, or launch coding executors by itself.
+      <span>
+        OMH is deterministic local contract tooling. It does not patch Hermes core,
+        run platform bots, call LLM APIs, or launch coding executors by itself.
+      </span>
+      <span>
+        Developed by <a href="https://github.com/rlaope">rlaope</a>.
+      </span>
     </footer>
   </body>
 </html>

--- a/site/styles.css
+++ b/site/styles.css
@@ -101,6 +101,7 @@ a {
   min-height: 36px;
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   padding: 7px 12px;
   border: 1px solid rgba(255, 255, 255, 0.2);
   border-radius: 999px;
@@ -120,6 +121,17 @@ a {
   border-color: rgba(255, 255, 255, 0.42);
   background: rgba(255, 255, 255, 0.15);
   box-shadow: 0 12px 28px rgba(0, 0, 0, 0.18);
+}
+
+.nav__icon {
+  width: 38px;
+  padding: 0;
+}
+
+.nav__icon svg {
+  width: 18px;
+  height: 18px;
+  fill: currentColor;
 }
 
 .nav a:active {
@@ -877,10 +889,25 @@ h1 {
 }
 
 .footer {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 10px 28px;
   padding: 30px clamp(20px, 5vw, 72px);
   border-top: 1px solid var(--line);
   color: var(--muted);
   font-size: 14px;
+}
+
+.footer a {
+  color: var(--ink);
+  font-weight: 700;
+  text-decoration-color: rgba(39, 68, 59, 0.28);
+  text-underline-offset: 3px;
+}
+
+.footer a:hover {
+  color: #167b67;
 }
 
 .docs-page {

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -498,7 +498,13 @@ class RouterContentTests(unittest.TestCase):
         self.assertIn('href="docs/"', topbar)
         self.assertNotIn('href="#architecture"', topbar)
         self.assertNotIn('href="#install"', topbar)
-        self.assertNotIn("GitHub", topbar)
+        self.assertIn('class="nav__icon"', topbar)
+        self.assertIn('href="https://github.com/rlaope/oh-my-hermes-agent"', topbar)
+        self.assertNotIn(">GitHub<", topbar)
+        docs_topbar = site_docs.split('<header class="topbar topbar--solid"', 1)[1].split("</header>", 1)[0]
+        self.assertIn('class="nav__icon"', docs_topbar)
+        self.assertIn('href="https://github.com/rlaope/oh-my-hermes-agent"', docs_topbar)
+        self.assertNotIn(">GitHub<", docs_topbar)
         hero_command = site.split('aria-label="OMH quick start commands"', 1)[1].split("</code>", 1)[0]
         self.assertIn("curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes-agent/main/install.sh | sh", hero_command)
         self.assertIn("omh setup", hero_command)


### PR DESCRIPTION
## Summary
- Adds a compact GitHub icon link to the public site and docs header.
- Adds a footer developer credit linking `rlaope` to the GitHub profile.
- Updates the site content test so the contract allows the icon link while keeping visible topbar navigation minimal.

## Verification
- `PYTHONPATH=tests uv run python -m unittest tests/test_router_content.py -v`
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- `uv run python -m compileall -q src tests`
- `git diff --check`
- Local Playwright render checks for `/` and `/docs/` at desktop and mobile widths.

## Notes
- No network/API/LLM/runtime behavior changes.
- Unrelated untracked files `assets/agent-era-dev-checklist.*` and `uv.lock` were left untouched.
