### PR TITLE
Add Hermes target topology drift handling

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -157,6 +157,11 @@ handlers should be added to the matching domain module rather than growing
 `ingress.py` owns platform-neutral message text and source metadata extraction
 for Discord, Slack, Hermes, and generic wrapper event shapes.
 
+`targets.py` owns the deterministic Hermes target registry. It records which
+Hermes home, wrapper target, or agent reference was observed, derives
+`omh_target_topology/v1`, and keeps single-target versus multi-target behavior
+as setup evidence rather than runtime execution proof.
+
 `routing/chat.py` owns deterministic pre-dispatch routing decisions for chat
 wrappers. It consumes plain messages or platform-shaped event payloads and
 returns `dispatch`, `clarify`, or `fallback` decisions from local catalog data.
@@ -373,6 +378,7 @@ Runtime artifacts are local JSON/JSONL files under `.omh/runtime/`.
 
 ```text
 .omh/
+  targets.json
   runtime/
     state.json
     runs/
@@ -390,7 +396,9 @@ Runtime artifacts are local JSON/JSONL files under `.omh/runtime/`.
         events.jsonl
 ```
 
-`state.json` records install, apply, and doctor summaries. A run directory
+`targets.json` records observed Hermes target topology for setup drift, including
+single-to-multi and multi-to-single changes. `state.json` records install,
+apply, and doctor summaries. A run directory
 records a workflow envelope, append-only events, routing decisions, prepared
 coding delegation, delegation observation, and wrapper observation plus optional
 evidence files. A wrapper session directory records chat-thread continuity and

--- a/docs/HERMES_AGENT_INTEGRATION_RUNBOOK.md
+++ b/docs/HERMES_AGENT_INTEGRATION_RUNBOOK.md
@@ -45,6 +45,10 @@ The returned envelope is safe for a wrapper to render without parsing prose:
 - `chat_response`: renderable response text, action ids, state, and claim
   boundary.
 - `overclaim_guard`: invariant status rules the wrapper should preserve.
+- `target_notice`: optional concise notice when the observed Hermes target
+  topology changed from one target to many or many to one.
+- `target_topology`: optional `omh_target_topology/v1` summary with
+  `active_agent_count`, `current_target_id`, and `requires_skill_scope_awareness`.
 - `plan`, `delegation`, or `status`: optional machine-readable payload for the
   selected mode.
 
@@ -57,15 +61,22 @@ runtime run exists and the wrapper needs a compact progress card.
 2. Ask OMH for a platform-neutral interaction envelope.
 3. Render `chat_response.headline`, `chat_response.body`,
    `chat_response.actions`, and `chat_response.claim_boundary`.
-4. If the response is a plan, wait for the user to accept or revise the plan
+4. If `target_notice.action` is `ask_to_apply_target_change`, render a short
+   setup-change comment and an apply action. Until accepted or auto-applied,
+   keep the workflow scoped to the current thread target. The
+   `apply_target_change` action payload carries
+   `target_observation.source_metadata`; pass that sanitized metadata back to
+   the wrapper backend with target-change apply enabled to persist the same
+   target update.
+5. If the response is a plan, wait for the user to accept or revise the plan
    before preparing a handoff.
-5. If a coding handoff is prepared, dispatch the `coding_executor_handoff/v1`
+6. If a coding handoff is prepared, dispatch the `coding_executor_handoff/v1`
    payload to the external executor outside OMH. For Codex targets, use
    `codex_skill` and `codex_invocation.dispatch_text_template`; this is the
    `$skill {message}` surface Codex actually receives.
-6. Record only evidence the wrapper actually observed: dispatch, executor
+7. Record only evidence the wrapper actually observed: dispatch, executor
    result, verification, review, CI, merge readiness, and merge.
-7. Re-render status from OMH after each observed transition.
+8. Re-render status from OMH after each observed transition.
 
 ## State Transition Reference
 
@@ -73,6 +84,7 @@ runtime run exists and the wrapper needs a compact progress card.
 | --- | --- | --- | --- | --- |
 | Clarification needed | `message_received` | `clarifying` | Ask one blocking question. | No plan or execution is approved. |
 | Plan presented | `message_received` | `planning` | Show accept/revise actions. | A draft plan is not execution evidence. |
+| Target topology changed | `single_agent_target` or `multi_agent_targets` | pending target update | Show `apply_target_change` or auto-apply only when the wrapper is configured to do so. | Setup topology is not proof another Hermes agent observed the workflow. |
 | Handoff prepared | `plan_accepted` | `handoff_prepared` | Show send-to-executor action. | Prepared handoff is not execution evidence. |
 | Dispatched, waiting | `handoff_prepared` | `dispatched` | Wait for executor evidence. | Dispatch is not completion evidence. |
 | Review pending | `executor_completed` | `awaiting_review` | Show review-pending status. | Execution is observed; review is not. |

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -169,9 +169,16 @@ The backend flow is:
    lifecycle path; Claude Code, OMH-style runtime profiles, generic agents, and
    Hermes-retained work use prompt-only or retained handoff paths in Phase 1.
    The wrapper records only what it actually observes.
-8. Status updates use `omh coding lifecycle report` or
+8. If the wrapper observes Hermes target metadata such as `agent_ref`,
+   `agent_count`, or `hermes_home`, `chat_interaction/v1` may include
+   `target_notice` and `target_topology`. Render the concise notice or
+   `apply_target_change` action before treating single-to-multi or
+   multi-to-single target changes as persistent setup state. When target
+   identity metadata is present, `thread_key` is scoped by that target so two
+   Hermes agents in the same channel do not share wrapper session state.
+9. Status updates use `omh coding lifecycle report` or
    `omh chat interact --run <run-id>` and stay in the same thread.
-9. Hermes still starts with its normal config and reads `skills.external_dirs`;
+10. Hermes still starts with its normal config and reads `skills.external_dirs`;
    `omh apply` makes sure `~/.omh/skills` is included in that discovery list.
 
 `omh` does not replace the Discord bot, modify Slack commands, open network
@@ -196,6 +203,25 @@ omh chat interact --source discord --event-json event.json
 omh chat interact --source slack "risky refactor"
 printf '%s' "$SLACK_TEXT" | omh chat interact --source slack --stdin
 ```
+
+If the wrapper can identify the current Hermes agent target, include that as
+metadata rather than asking the user to choose a command:
+
+```json
+{
+  "message": {"id": "m1", "content": "risky refactor", "channel": "dev"},
+  "agent": {"id": "hermes-dev-1"},
+  "runtime": {"hermes_home": "/srv/hermes/dev", "agent_count": 2}
+}
+```
+
+With `--auto-apply-target-change`, OMH persists the observed target registry
+update and registers the managed skill directory for the reported
+`hermes_home`. Without that flag, the wrapper gets a pending
+`apply_target_change` action and should ask the user before persisting the
+single-to-multi or multi-to-single setup change. The action payload includes
+`target_observation.source_metadata`, which is the sanitized metadata needed to
+apply that exact target update without storing or replaying the raw chat prompt.
 
 Choose an executor profile for an accepted coding handoff:
 

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -6,6 +6,8 @@ The reference describes prompt-level Hermes workflow guidance and local evidence
 
 Workflow names are kept for compatibility, but each skill declares advisory wrapper guidance for whether Hermes should retain the work directly, ask the user to choose an executor, or prepare a coding handoff for coding-heavy execution.
 
+When wrapper metadata reports `omh_target_topology/v1`, skills bind workflow state to the current Hermes target/thread, adapt only the steps that benefit from multiple targets, and fall back to single-target behavior when the active agent count is one.
+
 ## Skills
 
 ### oh-my-hermes

--- a/skills/ai-slop-cleaner/SKILL.md
+++ b/skills/ai-slop-cleaner/SKILL.md
@@ -83,6 +83,8 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Preserve the workflow intent, stop conditions, and verification discipline.
 - Use Hermes-native tools, file operations, and subagent/delegation features when available.
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
+- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers or explicit checklists,
   - question renderers -> one concise question in the current Hermes interface,

--- a/skills/ask/SKILL.md
+++ b/skills/ask/SKILL.md
@@ -82,6 +82,8 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Preserve the workflow intent, stop conditions, and verification discipline.
 - Use Hermes-native tools, file operations, and subagent/delegation features when available.
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
+- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers or explicit checklists,
   - question renderers -> one concise question in the current Hermes interface,

--- a/skills/autoresearch-goal/SKILL.md
+++ b/skills/autoresearch-goal/SKILL.md
@@ -82,6 +82,8 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Preserve the workflow intent, stop conditions, and verification discipline.
 - Use Hermes-native tools, file operations, and subagent/delegation features when available.
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
+- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers or explicit checklists,
   - question renderers -> one concise question in the current Hermes interface,

--- a/skills/best-practice-research/SKILL.md
+++ b/skills/best-practice-research/SKILL.md
@@ -82,6 +82,8 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Preserve the workflow intent, stop conditions, and verification discipline.
 - Use Hermes-native tools, file operations, and subagent/delegation features when available.
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
+- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers or explicit checklists,
   - question renderers -> one concise question in the current Hermes interface,

--- a/skills/cancel/SKILL.md
+++ b/skills/cancel/SKILL.md
@@ -79,6 +79,8 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Preserve the workflow intent, stop conditions, and verification discipline.
 - Use Hermes-native tools, file operations, and subagent/delegation features when available.
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
+- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers or explicit checklists,
   - question renderers -> one concise question in the current Hermes interface,

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -83,6 +83,8 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Preserve the workflow intent, stop conditions, and verification discipline.
 - Use Hermes-native tools, file operations, and subagent/delegation features when available.
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
+- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers or explicit checklists,
   - question renderers -> one concise question in the current Hermes interface,

--- a/skills/cto-loop/SKILL.md
+++ b/skills/cto-loop/SKILL.md
@@ -87,6 +87,8 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Preserve the workflow intent, stop conditions, and verification discipline.
 - Use Hermes-native tools, file operations, and subagent/delegation features when available.
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
+- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers or explicit checklists,
   - question renderers -> one concise question in the current Hermes interface,

--- a/skills/deep-interview/SKILL.md
+++ b/skills/deep-interview/SKILL.md
@@ -83,6 +83,8 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Preserve the workflow intent, stop conditions, and verification discipline.
 - Use Hermes-native tools, file operations, and subagent/delegation features when available.
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
+- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers or explicit checklists,
   - question renderers -> one concise question in the current Hermes interface,

--- a/skills/deploy-and-monitor/SKILL.md
+++ b/skills/deploy-and-monitor/SKILL.md
@@ -87,6 +87,8 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Preserve the workflow intent, stop conditions, and verification discipline.
 - Use Hermes-native tools, file operations, and subagent/delegation features when available.
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
+- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers or explicit checklists,
   - question renderers -> one concise question in the current Hermes interface,

--- a/skills/doctor/SKILL.md
+++ b/skills/doctor/SKILL.md
@@ -81,6 +81,8 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Preserve the workflow intent, stop conditions, and verification discipline.
 - Use Hermes-native tools, file operations, and subagent/delegation features when available.
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
+- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers or explicit checklists,
   - question renderers -> one concise question in the current Hermes interface,

--- a/skills/feedback-triage/SKILL.md
+++ b/skills/feedback-triage/SKILL.md
@@ -83,6 +83,8 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Preserve the workflow intent, stop conditions, and verification discipline.
 - Use Hermes-native tools, file operations, and subagent/delegation features when available.
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
+- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers or explicit checklists,
   - question renderers -> one concise question in the current Hermes interface,

--- a/skills/idea-to-deploy/SKILL.md
+++ b/skills/idea-to-deploy/SKILL.md
@@ -86,6 +86,8 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Preserve the workflow intent, stop conditions, and verification discipline.
 - Use Hermes-native tools, file operations, and subagent/delegation features when available.
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
+- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers or explicit checklists,
   - question renderers -> one concise question in the current Hermes interface,

--- a/skills/meeting-brief/SKILL.md
+++ b/skills/meeting-brief/SKILL.md
@@ -85,6 +85,8 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Preserve the workflow intent, stop conditions, and verification discipline.
 - Use Hermes-native tools, file operations, and subagent/delegation features when available.
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
+- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers or explicit checklists,
   - question renderers -> one concise question in the current Hermes interface,

--- a/skills/oh-my-hermes/SKILL.md
+++ b/skills/oh-my-hermes/SKILL.md
@@ -68,6 +68,12 @@ Keep compatible workflow names installed, but use this advisory wrapper guidance
 
 General rule: Hermes should retain routing, web/source research, deep interview, planning, status, and evidence narration. This role metadata is advisory unless a wrapper/runtime artifact records observed enforcement. When the accepted next action mutates code, the wrapper should ask for or apply the selected executor profile, prepare the matching handoff, and track only evidence it actually observes instead of implying Hermes coded secretly.
 
+## Multi-Agent Target Awareness
+
+Wrappers may report `omh_target_topology/v1` when a workspace moves between one Hermes agent target and multiple Hermes agent targets. Treat that topology as setup evidence only. If `active_agent_count` is greater than one, bind this workflow to the current target and thread, name the target boundary in status, and do not claim another Hermes agent observed, accepted, or executed the workflow unless target-specific evidence exists.
+
+If a wrapper reports `single_to_multi` or `multi_to_single`, answer with one concise target-change comment. If the wrapper exposes an `apply_target_change` action and the user accepts it, persist the target registry update; otherwise keep the workflow scoped to the current thread target and ask before assuming multi-agent behavior. A skill that does not need multiple agents should continue as a single-target workflow even when multiple targets are known.
+
 ## Responsibility Roles
 
 OMH role names are responsibility descriptors, not runtime agents. They help Hermes and wrappers explain who owns the next step without implying a hidden worker ran.

--- a/skills/ops-review/SKILL.md
+++ b/skills/ops-review/SKILL.md
@@ -86,6 +86,8 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Preserve the workflow intent, stop conditions, and verification discipline.
 - Use Hermes-native tools, file operations, and subagent/delegation features when available.
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
+- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers or explicit checklists,
   - question renderers -> one concise question in the current Hermes interface,

--- a/skills/performance-goal/SKILL.md
+++ b/skills/performance-goal/SKILL.md
@@ -83,6 +83,8 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Preserve the workflow intent, stop conditions, and verification discipline.
 - Use Hermes-native tools, file operations, and subagent/delegation features when available.
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
+- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers or explicit checklists,
   - question renderers -> one concise question in the current Hermes interface,

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -83,6 +83,8 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Preserve the workflow intent, stop conditions, and verification discipline.
 - Use Hermes-native tools, file operations, and subagent/delegation features when available.
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
+- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers or explicit checklists,
   - question renderers -> one concise question in the current Hermes interface,

--- a/skills/ralph/SKILL.md
+++ b/skills/ralph/SKILL.md
@@ -83,6 +83,8 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Preserve the workflow intent, stop conditions, and verification discipline.
 - Use Hermes-native tools, file operations, and subagent/delegation features when available.
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
+- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers or explicit checklists,
   - question renderers -> one concise question in the current Hermes interface,

--- a/skills/ralplan/SKILL.md
+++ b/skills/ralplan/SKILL.md
@@ -84,6 +84,8 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Preserve the workflow intent, stop conditions, and verification discipline.
 - Use Hermes-native tools, file operations, and subagent/delegation features when available.
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
+- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers or explicit checklists,
   - question renderers -> one concise question in the current Hermes interface,

--- a/skills/research-brief/SKILL.md
+++ b/skills/research-brief/SKILL.md
@@ -83,6 +83,8 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Preserve the workflow intent, stop conditions, and verification discipline.
 - Use Hermes-native tools, file operations, and subagent/delegation features when available.
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
+- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers or explicit checklists,
   - question renderers -> one concise question in the current Hermes interface,

--- a/skills/skill/SKILL.md
+++ b/skills/skill/SKILL.md
@@ -79,6 +79,8 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Preserve the workflow intent, stop conditions, and verification discipline.
 - Use Hermes-native tools, file operations, and subagent/delegation features when available.
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
+- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers or explicit checklists,
   - question renderers -> one concise question in the current Hermes interface,

--- a/skills/strategy-brief/SKILL.md
+++ b/skills/strategy-brief/SKILL.md
@@ -85,6 +85,8 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Preserve the workflow intent, stop conditions, and verification discipline.
 - Use Hermes-native tools, file operations, and subagent/delegation features when available.
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
+- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers or explicit checklists,
   - question renderers -> one concise question in the current Hermes interface,

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -83,6 +83,8 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Preserve the workflow intent, stop conditions, and verification discipline.
 - Use Hermes-native tools, file operations, and subagent/delegation features when available.
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
+- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers or explicit checklists,
   - question renderers -> one concise question in the current Hermes interface,

--- a/skills/ultragoal/SKILL.md
+++ b/skills/ultragoal/SKILL.md
@@ -83,6 +83,8 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Preserve the workflow intent, stop conditions, and verification discipline.
 - Use Hermes-native tools, file operations, and subagent/delegation features when available.
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
+- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers or explicit checklists,
   - question renderers -> one concise question in the current Hermes interface,

--- a/skills/ultraqa/SKILL.md
+++ b/skills/ultraqa/SKILL.md
@@ -83,6 +83,8 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Preserve the workflow intent, stop conditions, and verification discipline.
 - Use Hermes-native tools, file operations, and subagent/delegation features when available.
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
+- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers or explicit checklists,
   - question renderers -> one concise question in the current Hermes interface,

--- a/skills/ultrawork/SKILL.md
+++ b/skills/ultrawork/SKILL.md
@@ -84,6 +84,8 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Preserve the workflow intent, stop conditions, and verification discipline.
 - Use Hermes-native tools, file operations, and subagent/delegation features when available.
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
+- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers or explicit checklists,
   - question renderers -> one concise question in the current Hermes interface,

--- a/skills/web-research/SKILL.md
+++ b/skills/web-research/SKILL.md
@@ -83,6 +83,8 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Preserve the workflow intent, stop conditions, and verification discipline.
 - Use Hermes-native tools, file operations, and subagent/delegation features when available.
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
+- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers or explicit checklists,
   - question renderers -> one concise question in the current Hermes interface,

--- a/skills/wiki/SKILL.md
+++ b/skills/wiki/SKILL.md
@@ -82,6 +82,8 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Preserve the workflow intent, stop conditions, and verification discipline.
 - Use Hermes-native tools, file operations, and subagent/delegation features when available.
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
+- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers or explicit checklists,
   - question renderers -> one concise question in the current Hermes interface,

--- a/src/commands/chat.py
+++ b/src/commands/chat.py
@@ -8,6 +8,7 @@ from ..ingress import CHAT_SOURCES
 from ..installer import OmhError
 from ..routing.chat import CONFIDENCE_LEVELS, public_route_payload, route_chat_message, routing_record_payload
 from ..runtime.artifacts import create_run, summarize_delegated_coding_status, write_routing_decision
+from ..targets import TARGET_METADATA_KEYS, build_target_change_notice, inspect_target_observation, record_target_observation
 from ..wrapper.contract import INTERACTION_MODES, build_chat_interaction_payload, build_chat_status_interaction
 from ..wrapper.sessions import (
     WrapperSessionError,
@@ -83,6 +84,7 @@ def cmd_chat_interact(args: argparse.Namespace) -> int:
                 include_message=args.include_message,
                 executor_target=_resolved_executor(args, default="choose"),
                 source_metadata=source_metadata,
+                target_notice=_target_notice(args, source_metadata),
             )
     except FileNotFoundError as exc:
         raise OmhError(f"runtime run not found: {args.run_id}") from exc
@@ -103,6 +105,7 @@ def cmd_chat_session_start(args: argparse.Namespace) -> int:
             min_confidence=args.min_confidence,
             source_metadata=source_metadata,
             executor_target=_resolved_executor(args, default="choose"),
+            target_notice=_target_notice(args, source_metadata),
         )
     except (OSError, json.JSONDecodeError, ValueError, WrapperSessionError) as exc:
         raise OmhError(str(exc)) from exc
@@ -138,6 +141,40 @@ def cmd_chat_session_prepare_handoff(args: argparse.Namespace) -> int:
         raise OmhError(str(exc)) from exc
     _print_json(payload)
     return 0
+
+
+def _target_notice(args: argparse.Namespace, source_metadata: dict[str, str]) -> dict[str, object] | None:
+    if not _has_target_metadata(source_metadata):
+        return None
+    paths = _paths(args)
+    auto_apply = bool(getattr(args, "auto_apply_target_change", False))
+    if auto_apply:
+        observation = record_target_observation(
+            paths,
+            source=f"chat:{args.source}",
+            source_metadata=source_metadata,
+            ensure_config=bool(source_metadata.get("hermes_home")),
+        )
+    else:
+        observation = inspect_target_observation(paths, source=f"chat:{args.source}", source_metadata=source_metadata)
+    return build_target_change_notice(observation, auto_applied=auto_apply)
+
+
+def _has_target_metadata(source_metadata: dict[str, str]) -> bool:
+    return any(source_metadata.get(key) for key in TARGET_METADATA_KEYS)
+
+
+def _add_target_metadata_options(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--agent-ref", default="", help="Optional Hermes agent id/name observed by the wrapper.")
+    parser.add_argument("--target-ref", default="", help="Optional Hermes workspace/target id observed by the wrapper.")
+    parser.add_argument("--runtime-ref", default="", help="Optional Hermes runtime id observed by the wrapper.")
+    parser.add_argument("--agent-count", default="", help="Optional active Hermes agent count observed by the wrapper.")
+    parser.add_argument("--target-count", default="", help="Optional active Hermes target count observed by the wrapper.")
+    parser.add_argument(
+        "--auto-apply-target-change",
+        action="store_true",
+        help="Persist observed Hermes target topology changes and register the managed skill dir when hermes_home metadata is present.",
+    )
 
 
 def cmd_chat_session_select_executor(args: argparse.Namespace) -> int:
@@ -244,6 +281,7 @@ def _add_chat_commands(sub) -> None:
     interact.add_argument("--source-event-id", default="", help="Optional source message/event id to store as metadata.")
     interact.add_argument("--channel-ref", default="", help="Optional channel reference to store as metadata.")
     interact.add_argument("--user-ref", default="", help="Optional user reference to store as metadata.")
+    _add_target_metadata_options(interact)
     interact.set_defaults(func=cmd_chat_interact)
 
     session = chat_sub.add_parser("session")
@@ -260,6 +298,7 @@ def _add_chat_commands(sub) -> None:
     session_start.add_argument("--channel-ref", default="")
     session_start.add_argument("--user-ref", default="")
     session_start.add_argument("--executor", choices=CODING_EXECUTOR_TARGETS, default=None)
+    _add_target_metadata_options(session_start)
     session_start.set_defaults(func=cmd_chat_session_start)
 
     session_accept = session_sub.add_parser("accept-plan")

--- a/src/commands/common.py
+++ b/src/commands/common.py
@@ -9,6 +9,7 @@ from ..ingress import extract_message_text, extract_source_metadata
 from ..installer import OmhError
 from ..paths import resolve_paths
 from ..setup_profiles import read_setup_profile
+from ..targets import TARGET_METADATA_KEYS
 
 
 def _paths(args: argparse.Namespace):
@@ -20,15 +21,13 @@ def _print_json(data: object) -> None:
 
 
 def _explicit_source_metadata(args: argparse.Namespace) -> dict[str, str]:
-    return {
-        key: value
-        for key, value in {
-            "source_event_id": args.source_event_id,
-            "channel_ref": args.channel_ref,
-            "user_ref": args.user_ref,
-        }.items()
-        if value
+    values = {
+        "source_event_id": getattr(args, "source_event_id", ""),
+        "channel_ref": getattr(args, "channel_ref", ""),
+        "user_ref": getattr(args, "user_ref", ""),
     }
+    values.update({key: getattr(args, key, "") for key in TARGET_METADATA_KEYS if key != "hermes_home"})
+    return {key: str(value) for key, value in values.items() if value}
 
 
 def _resolved_executor(args: argparse.Namespace, *, default: str) -> str:

--- a/src/commands/setup.py
+++ b/src/commands/setup.py
@@ -17,6 +17,7 @@ from ..routing.recommend import recommend_skills
 from ..runtime.artifacts import update_state
 from ..setup_profiles import build_setup_profile, write_setup_profile
 from ..snippet import WORKSPACE_SNIPPET
+from ..targets import record_target_observation
 from ..team_profiles import TeamProfileError, inspect_team_profile_pack, install_team_profile_pack, list_team_profile_packs
 from .common import _paths, _print_json
 
@@ -158,6 +159,18 @@ def cmd_setup(args: argparse.Namespace) -> int:
     if args.profile_pack:
         steps["team_profiles"] = _team_profile_setup_result(args, paths)
     steps["profile"] = _setup_profile_result(args, paths)
+    steps["targets"] = record_target_observation(
+        paths,
+        source="setup",
+        dry_run=args.dry_run,
+        ensure_config=not args.skip_apply,
+        setup_context={
+            "apply_skipped": bool(args.skip_apply),
+            "with_plugin": bool(args.with_plugin),
+            "profile_packs": list(args.profile_pack),
+            "setup_profiles": list(args.profile),
+        },
+    )
     if args.dry_run:
         bootstrap_final_state = (
             "dry run would install generated skills and register the managed OMH skills directory for Hermes discovery"
@@ -192,6 +205,7 @@ def cmd_setup(args: argparse.Namespace) -> int:
         "skills_dir": str(paths.skills_dir),
         "hermes_config_path": str(paths.hermes_config_path),
         "hermes_config_key": "skills.external_dirs",
+        "target_topology": steps["targets"]["topology"],
         "wrapper_backend_surface": "omh chat interact and runtime commands are adapter/operator contracts, not the normal chat UX",
     }
 
@@ -205,6 +219,7 @@ def cmd_setup(args: argparse.Namespace) -> int:
                     "hermes_native": hermes_native,
                     "setup_profile": steps["profile"],
                     "team_profiles": steps.get("team_profiles", []),
+                    "target_observation": steps["targets"],
                 }
             },
         )

--- a/src/doctor.py
+++ b/src/doctor.py
@@ -11,6 +11,7 @@ from .paths import OmhPaths
 from .plugin_pack import inspect_plugin_bundle
 from .runtime.artifacts import read_state, read_state_error
 from .skill_pack import CORE_SKILLS
+from .targets import read_target_registry_result, summarize_target_registry
 from .workflow_state import list_workflow_states
 
 
@@ -105,6 +106,43 @@ def run_doctor(paths: OmhPaths) -> list[Check]:
             ),
         )
     )
+    target_registry, target_registry_error = read_target_registry_result(paths)
+    target_topology = summarize_target_registry(paths)
+    if target_registry_error:
+        checks.append(Check("target_registry", False, f"target registry unreadable: {target_registry_error}"))
+    else:
+        known_count = int(target_topology.get("known_target_count") or 0)
+        active_count = int(target_topology.get("active_agent_count") or 0)
+        mode = str(target_topology.get("mode", "unknown"))
+        if target_registry:
+            checks.append(
+                Check(
+                    "target_registry",
+                    True,
+                    f"{known_count} known Hermes target(s); active_agent_count={active_count}; mode={mode}",
+                )
+            )
+        else:
+            checks.append(
+                Check(
+                    "target_registry",
+                    True,
+                    "no target registry yet; `omh setup` or wrapper target metadata will create it when needed",
+                    observed=False,
+                )
+            )
+    checks.append(
+        Check(
+            "target_topology",
+            target_topology.get("status") != "unreadable",
+            (
+                f"mode={target_topology.get('mode')}; transition={target_topology.get('transition')}; "
+                f"skill_scope_awareness={target_topology.get('requires_skill_scope_awareness')}"
+            ),
+            severity="warning" if target_topology.get("requires_skill_scope_awareness") else "auto",
+            observed=target_topology.get("status") == "available",
+        )
+    )
     plugin = inspect_plugin_bundle(paths)
     plugin_expected = bool(plugin["plugin_dir_installed"]) or bool(state and state.get("last_plugin_distribution"))
     if not plugin_expected:
@@ -187,6 +225,8 @@ def _default_remediation(name: str) -> str:
         return "Repair the local OMH runtime directory or rerun with an --omh-home path that can store metadata-only artifacts."
     if name.startswith("plugin_"):
         return "Run `omh setup --with-plugin` to reinstall the optional plugin bundle, or skip plugin checks if the plugin is not part of this setup."
+    if name.startswith("target_"):
+        return "Repair the OMH target registry or rerun `omh setup` with the Hermes home used by the wrapper runtime."
     if name == "hermes_config":
         return "Run `omh setup` to create or update the Hermes configuration for managed skill discovery."
     return "Run `omh doctor` after repairing the reported path or configuration."
@@ -201,6 +241,8 @@ def _default_next_action(name: str) -> str:
         return "Run `omh setup`, then `omh doctor` again."
     if name.startswith("plugin_"):
         return "Run `omh setup --with-plugin --force`, then `omh doctor` again, or leave the plugin uninstalled if using skills only."
+    if name.startswith("target_"):
+        return "Run `omh setup` for the current Hermes target, then rerun `omh doctor`."
     if name in {"runtime_artifacts", "workflow_state", "runtime_state"}:
         return "Fix the OMH runtime path or choose a writable --omh-home, then rerun `omh doctor`."
     return "Fix the reported check and rerun `omh doctor`."

--- a/src/ingress.py
+++ b/src/ingress.py
@@ -4,7 +4,18 @@ from typing import Any
 
 
 CHAT_SOURCES = ("generic", "discord", "slack", "hermes")
-SOURCE_METADATA_KEYS = ("source_event_id", "channel_ref", "user_ref", "timestamp")
+SOURCE_METADATA_KEYS = (
+    "source_event_id",
+    "channel_ref",
+    "user_ref",
+    "timestamp",
+    "agent_ref",
+    "target_ref",
+    "runtime_ref",
+    "hermes_home",
+    "agent_count",
+    "target_count",
+)
 
 _EVENT_TEXT_PATHS = (
     ("message", "content"),
@@ -25,6 +36,12 @@ _SOURCE_METADATA_PATHS: dict[str, tuple[tuple[str, ...], ...]] = {
     "channel_ref": (("channel",), ("channel_id",), ("message", "channel"), ("event", "channel"), ("channel", "id")),
     "user_ref": (("user",), ("user_id",), ("author", "id"), ("message", "author", "id"), ("event", "user")),
     "timestamp": (("timestamp",), ("created_at",), ("ts",), ("message", "timestamp"), ("event", "ts"), ("event", "event_ts")),
+    "agent_ref": (("agent_ref",), ("agent", "id"), ("bot", "id"), ("message", "agent", "id"), ("event", "agent", "id")),
+    "target_ref": (("target_ref",), ("target", "id"), ("workspace", "id"), ("team", "id"), ("guild_id",)),
+    "runtime_ref": (("runtime_ref",), ("runtime", "id"), ("hermes", "runtime_id"), ("hermes_runtime", "id")),
+    "hermes_home": (("hermes_home",), ("runtime", "hermes_home"), ("hermes", "home")),
+    "agent_count": (("agent_count",), ("agents_count",), ("target", "agent_count"), ("runtime", "agent_count"), ("hermes", "agent_count")),
+    "target_count": (("target_count",), ("targets_count",), ("runtime", "target_count"), ("hermes", "target_count")),
 }
 
 

--- a/src/paths.py
+++ b/src/paths.py
@@ -39,6 +39,10 @@ class OmhPaths:
         return self.omh_home / "setup-profile.json"
 
     @property
+    def target_registry_path(self) -> Path:
+        return self.omh_home / "targets.json"
+
+    @property
     def workflow_state_dir(self) -> Path:
         return self.omh_home / "state"
 

--- a/src/probe.py
+++ b/src/probe.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from .config_adapter import external_dirs, read_config
 from .paths import OmhPaths
 from .plugin_pack import inspect_plugin_bundle
+from .targets import summarize_target_registry
 
 PROBE_STATUSES = ("available", "missing", "unknown", "unverified")
 
@@ -178,12 +179,34 @@ def probe_capabilities(paths: OmhPaths) -> dict:
             "Wrapper observation artifacts are present" if wrappers else "No wrapper observation artifacts recorded yet",
         )
     )
+    target_topology = summarize_target_registry(paths)
+    capabilities.extend(
+        [
+            Capability(
+                "target_registry",
+                "available" if target_topology["status"] == "available" else ("missing" if target_topology["status"] == "missing" else "unknown"),
+                str(paths.target_registry_path),
+                (
+                    f"{target_topology['known_target_count']} Hermes target(s) known"
+                    if target_topology["status"] == "available"
+                    else "No OMH target registry has been recorded yet"
+                ),
+            ),
+            Capability(
+                "target_topology",
+                "available" if target_topology["mode"] in {"single_agent_target", "multi_agent_targets"} else "unknown",
+                str(paths.target_registry_path),
+                f"mode={target_topology['mode']}; active_agent_count={target_topology['active_agent_count']}; transition={target_topology['transition']}",
+            ),
+        ]
+    )
 
     return {
         "schema_version": 1,
         "omh_home": str(paths.omh_home),
         "hermes_home": str(paths.hermes_home),
         "capabilities": [capability.to_dict() for capability in capabilities],
+        "target_topology": target_topology,
         "plugin_distribution_ready": bool(plugin["plugin_distribution_ready"]),
         "native_integration_claim_ready": False,
         "claim_boundary": "Prompt-level routing is the default unless a future stable Hermes extension surface and runtime evidence prove deeper integration.",

--- a/src/runtime/records.py
+++ b/src/runtime/records.py
@@ -35,7 +35,15 @@ CODING_DELEGATION_STATUSES = ("prepared_not_observed",)
 CODING_WORK_OWNER_MODES = WORK_OWNER_MODES
 CODING_SELECTED_EXECUTOR_PROFILES = EXECUTOR_PROFILES
 CODING_DISPATCH_POLICIES = DISPATCH_POLICIES
-CODING_SOURCE_METADATA_KEYS = ("source_event_id", "channel_ref", "user_ref", "timestamp")
+TARGET_SOURCE_METADATA_KEYS = (
+    "agent_ref",
+    "target_ref",
+    "runtime_ref",
+    "hermes_home",
+    "agent_count",
+    "target_count",
+)
+CODING_SOURCE_METADATA_KEYS = ("source_event_id", "channel_ref", "user_ref", "timestamp", *TARGET_SOURCE_METADATA_KEYS)
 CODING_RECOMMENDATION_KEYS = ("skill", "score", "confidence", "matched")
 CODING_EXECUTOR_SELECTION_KEYS = ("status", "choice_required", "options")
 CODING_EXECUTOR_SELECTION_STATUSES = (

--- a/src/skills/render.py
+++ b/src/skills/render.py
@@ -20,6 +20,56 @@ class SkillTemplate:
     content: str
 
 
+TARGET_TOPOLOGY_SCHEMA = "omh_target_topology/v1"
+TARGET_TOPOLOGY_ROUTER_CONTEXT = (
+    f"Wrappers may report `{TARGET_TOPOLOGY_SCHEMA}` when a workspace moves between one Hermes "
+    "agent target and multiple Hermes agent targets. Treat that topology as setup evidence only. "
+    "If `active_agent_count` is greater than one, bind this workflow to the current target and "
+    "thread, name the target boundary in status, and do not claim another Hermes agent observed, "
+    "accepted, or executed the workflow unless target-specific evidence exists."
+)
+TARGET_TOPOLOGY_CHANGE_CONTEXT = (
+    "If a wrapper reports `single_to_multi` or `multi_to_single`, answer with one concise "
+    "target-change comment. If the wrapper exposes an `apply_target_change` action and the user "
+    "accepts it, persist the target registry update; otherwise keep the workflow scoped to the "
+    "current thread target and ask before assuming multi-agent behavior. A skill that does not need "
+    "multiple agents should continue as a single-target workflow even when multiple targets are known."
+)
+TARGET_TOPOLOGY_SKILL_CONTRACT = (
+    f"Respect `{TARGET_TOPOLOGY_SCHEMA}` when a wrapper reports it: bind state to the current "
+    "target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, "
+    "and fall back to single-target behavior when `active_agent_count` is one."
+)
+TARGET_TOPOLOGY_SKILL_CHANGE_CONTRACT = (
+    "When target topology changes from one to many or many to one, give a concise setup-change "
+    "comment or use the wrapper's apply action before treating the new topology as persistent."
+)
+TARGET_TOPOLOGY_REFERENCE_CONTEXT = (
+    f"When wrapper metadata reports `{TARGET_TOPOLOGY_SCHEMA}`, skills bind workflow state to the "
+    "current Hermes target/thread, adapt only the steps that benefit from multiple targets, and fall "
+    "back to single-target behavior when the active agent count is one."
+)
+
+
+def _target_topology_router_section() -> str:
+    return "\n\n".join(
+        [
+            "## Multi-Agent Target Awareness",
+            TARGET_TOPOLOGY_ROUTER_CONTEXT,
+            TARGET_TOPOLOGY_CHANGE_CONTEXT,
+        ]
+    )
+
+
+def _target_topology_skill_contract_bullets() -> str:
+    return "\n".join(
+        [
+            f"- {TARGET_TOPOLOGY_SKILL_CONTRACT}",
+            f"- {TARGET_TOPOLOGY_SKILL_CHANGE_CONTRACT}",
+        ]
+    )
+
+
 def _frontmatter(name: str, description: str) -> str:
     definitions = {definition.name: definition for definition in builtin_definitions()}
     definition = definitions.get(name)
@@ -150,11 +200,7 @@ Keep compatible workflow names installed, but use this advisory wrapper guidance
 
 General rule: Hermes should retain routing, web/source research, deep interview, planning, status, and evidence narration. This role metadata is advisory unless a wrapper/runtime artifact records observed enforcement. When the accepted next action mutates code, the wrapper should ask for or apply the selected executor profile, prepare the matching handoff, and track only evidence it actually observes instead of implying Hermes coded secretly.
 
-## Multi-Agent Target Awareness
-
-Wrappers may report `omh_target_topology/v1` when a workspace moves between one Hermes agent target and multiple Hermes agent targets. Treat that topology as setup evidence only. If `active_agent_count` is greater than one, bind this workflow to the current target and thread, name the target boundary in status, and do not claim another Hermes agent observed, accepted, or executed the workflow unless target-specific evidence exists.
-
-If a wrapper reports `single_to_multi` or `multi_to_single`, answer with one concise target-change comment. If the wrapper exposes an `apply_target_change` action and the user accepts it, persist the target registry update; otherwise keep the workflow scoped to the current thread target and ask before assuming multi-agent behavior. A skill that does not need multiple agents should continue as a single-target workflow even when multiple targets are known.
+{_target_topology_router_section()}
 
 ## Responsibility Roles
 
@@ -293,8 +339,7 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Preserve the workflow intent, stop conditions, and verification discipline.
 - Use Hermes-native tools, file operations, and subagent/delegation features when available.
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+{_target_topology_skill_contract_bullets()}
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers or explicit checklists,
   - question renderers -> one concise question in the current Hermes interface,
@@ -330,7 +375,7 @@ def workflow_reference_markdown() -> str:
         "",
         "Workflow names are kept for compatibility, but each skill declares advisory wrapper guidance for whether Hermes should retain the work directly, ask the user to choose an executor, or prepare a coding handoff for coding-heavy execution.",
         "",
-        "When wrapper metadata reports `omh_target_topology/v1`, skills bind workflow state to the current Hermes target/thread, adapt only the steps that benefit from multiple targets, and fall back to single-target behavior when the active agent count is one.",
+        TARGET_TOPOLOGY_REFERENCE_CONTEXT,
         "",
         "## Skills",
         "",

--- a/src/skills/render.py
+++ b/src/skills/render.py
@@ -150,6 +150,12 @@ Keep compatible workflow names installed, but use this advisory wrapper guidance
 
 General rule: Hermes should retain routing, web/source research, deep interview, planning, status, and evidence narration. This role metadata is advisory unless a wrapper/runtime artifact records observed enforcement. When the accepted next action mutates code, the wrapper should ask for or apply the selected executor profile, prepare the matching handoff, and track only evidence it actually observes instead of implying Hermes coded secretly.
 
+## Multi-Agent Target Awareness
+
+Wrappers may report `omh_target_topology/v1` when a workspace moves between one Hermes agent target and multiple Hermes agent targets. Treat that topology as setup evidence only. If `active_agent_count` is greater than one, bind this workflow to the current target and thread, name the target boundary in status, and do not claim another Hermes agent observed, accepted, or executed the workflow unless target-specific evidence exists.
+
+If a wrapper reports `single_to_multi` or `multi_to_single`, answer with one concise target-change comment. If the wrapper exposes an `apply_target_change` action and the user accepts it, persist the target registry update; otherwise keep the workflow scoped to the current thread target and ask before assuming multi-agent behavior. A skill that does not need multiple agents should continue as a single-target workflow even when multiple targets are known.
+
 ## Responsibility Roles
 
 {role_summary_markdown()}
@@ -287,6 +293,8 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Preserve the workflow intent, stop conditions, and verification discipline.
 - Use Hermes-native tools, file operations, and subagent/delegation features when available.
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
+- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers or explicit checklists,
   - question renderers -> one concise question in the current Hermes interface,
@@ -321,6 +329,8 @@ def workflow_reference_markdown() -> str:
         "The reference describes prompt-level Hermes workflow guidance and local evidence expectations. It does not claim hidden Hermes runtime behavior.",
         "",
         "Workflow names are kept for compatibility, but each skill declares advisory wrapper guidance for whether Hermes should retain the work directly, ask the user to choose an executor, or prepare a coding handoff for coding-heavy execution.",
+        "",
+        "When wrapper metadata reports `omh_target_topology/v1`, skills bind workflow state to the current Hermes target/thread, adapt only the steps that benefit from multiple targets, and fall back to single-target behavior when the active agent count is one.",
         "",
         "## Skills",
         "",

--- a/src/targets.py
+++ b/src/targets.py
@@ -1,0 +1,366 @@
+from __future__ import annotations
+
+import hashlib
+import re
+from pathlib import Path
+from typing import Any
+
+from .config_adapter import ensure_external_dir, read_config, write_config
+from .local_store import atomic_write_json, read_json_object_result, utc_now
+from .paths import OmhPaths, expand_path
+
+
+TARGET_REGISTRY_SCHEMA_VERSION = "omh_target_registry/v1"
+TARGET_OBSERVATION_SCHEMA_VERSION = "omh_target_observation/v1"
+TARGET_TOPOLOGY_SCHEMA_VERSION = "omh_target_topology/v1"
+TARGET_NOTICE_SCHEMA_VERSION = "omh_target_change_notice/v1"
+
+TARGET_METADATA_KEYS = (
+    "agent_ref",
+    "target_ref",
+    "runtime_ref",
+    "hermes_home",
+    "agent_count",
+    "target_count",
+)
+
+
+def read_target_registry_result(paths: OmhPaths) -> tuple[dict[str, Any] | None, str | None]:
+    registry, error = read_json_object_result(paths.target_registry_path)
+    if registry is None or error:
+        return registry, error
+    if registry.get("schema_version") != TARGET_REGISTRY_SCHEMA_VERSION:
+        return None, f"unsupported target registry schema: {registry.get('schema_version')!r}"
+    if not isinstance(registry.get("targets", {}), dict):
+        return None, "target registry targets must be an object"
+    return registry, None
+
+
+def inspect_target_observation(
+    paths: OmhPaths,
+    *,
+    source: str,
+    source_metadata: dict[str, str] | None = None,
+) -> dict[str, object]:
+    registry, error = read_target_registry_result(paths)
+    target = build_target_record(paths, source=source, source_metadata=source_metadata)
+    return _observation_payload(paths, registry, error, target, dry_run=True, persisted=False, config_changed=False)
+
+
+def record_target_observation(
+    paths: OmhPaths,
+    *,
+    source: str,
+    source_metadata: dict[str, str] | None = None,
+    dry_run: bool = False,
+    ensure_config: bool = False,
+    setup_context: dict[str, object] | None = None,
+) -> dict[str, object]:
+    registry, error = read_target_registry_result(paths)
+    target = build_target_record(paths, source=source, source_metadata=source_metadata, setup_context=setup_context)
+    config_changed = False
+    if dry_run:
+        return _observation_payload(paths, registry, error, target, dry_run=True, persisted=False, config_changed=False)
+    if error:
+        registry = None
+    if ensure_config:
+        config_path = Path(str(target["hermes_config_path"]))
+        current = read_config(config_path)
+        change = ensure_external_dir(current, paths.skills_dir)
+        if change.changed:
+            write_config(config_path, change.text)
+            config_changed = True
+    next_registry = _merge_registry(registry, target)
+    atomic_write_json(paths.target_registry_path, next_registry, private=True)
+    return _observation_payload(paths, registry, error, target, dry_run=False, persisted=True, config_changed=config_changed)
+
+
+def build_target_record(
+    paths: OmhPaths,
+    *,
+    source: str,
+    source_metadata: dict[str, str] | None = None,
+    setup_context: dict[str, object] | None = None,
+) -> dict[str, object]:
+    metadata = {str(key): str(value) for key, value in (source_metadata or {}).items() if str(value)}
+    hermes_home = expand_path(metadata.get("hermes_home") or paths.hermes_home)
+    agent_ref = metadata.get("agent_ref", "")
+    target_ref = metadata.get("target_ref", "")
+    runtime_ref = metadata.get("runtime_ref", "")
+    target_id = target_id_for(hermes_home, agent_ref=agent_ref, target_ref=target_ref, runtime_ref=runtime_ref)
+    reported_count = _coerce_count(metadata.get("agent_count") or metadata.get("target_count"))
+    record: dict[str, object] = {
+        "target_id": target_id,
+        "display_name": _display_name(hermes_home, agent_ref=agent_ref, target_ref=target_ref, runtime_ref=runtime_ref),
+        "hermes_home": str(hermes_home),
+        "hermes_config_path": str(hermes_home / "config.yaml"),
+        "skills_dir": str(paths.skills_dir),
+        "source": source,
+        "agent_ref": agent_ref,
+        "target_ref": target_ref,
+        "runtime_ref": runtime_ref,
+        "reported_agent_count": reported_count,
+        "observed_at": utc_now(),
+    }
+    if setup_context:
+        record["setup_context"] = setup_context
+    return record
+
+
+def target_id_for(hermes_home: Path, *, agent_ref: str = "", target_ref: str = "", runtime_ref: str = "") -> str:
+    basis = "|".join(
+        [
+            str(hermes_home),
+            f"agent={agent_ref}",
+            f"target={target_ref}",
+            f"runtime={runtime_ref}",
+        ]
+    )
+    return f"hermes-{hashlib.sha256(basis.encode('utf-8')).hexdigest()[:12]}"
+
+
+def build_target_change_notice(observation: dict[str, object], *, auto_applied: bool = False) -> dict[str, object] | None:
+    topology = observation.get("topology")
+    if not isinstance(topology, dict):
+        return None
+    changed = bool(topology.get("changed"))
+    transition = str(topology.get("transition", "none"))
+    target = observation.get("target")
+    target_id = str(target.get("target_id", "")) if isinstance(target, dict) else ""
+    apply_payload = _apply_payload(target if isinstance(target, dict) else {}, topology)
+    if not changed and transition not in {"initial_target_observed"}:
+        return None
+    if auto_applied and bool(observation.get("persisted")):
+        action = "target_change_applied"
+        headline = "Hermes target setup was updated."
+        body = _notice_body(topology, applied=True)
+    else:
+        action = "ask_to_apply_target_change"
+        headline = "Hermes target setup changed."
+        body = _notice_body(topology, applied=False)
+    return {
+        "schema_version": TARGET_NOTICE_SCHEMA_VERSION,
+        "action": action,
+        "headline": headline,
+        "body": body,
+        "target_id": target_id,
+        "topology": topology,
+        "apply_payload": apply_payload,
+        "persistence": "persisted" if auto_applied and bool(observation.get("persisted")) else "pending_user_confirmation",
+        "claim_boundary": (
+            "Target topology is setup evidence only; it does not prove another Hermes agent observed, accepted, or executed this workflow."
+        ),
+    }
+
+
+def summarize_target_registry(paths: OmhPaths) -> dict[str, object]:
+    registry, error = read_target_registry_result(paths)
+    if error:
+        return {
+            "schema_version": TARGET_TOPOLOGY_SCHEMA_VERSION,
+            "registry_path": str(paths.target_registry_path),
+            "status": "unreadable",
+            "error": error,
+            "mode": "unknown",
+            "known_target_count": 0,
+            "active_agent_count": 0,
+            "changed": False,
+            "transition": "registry_unreadable",
+        }
+    if not registry:
+        return {
+            "schema_version": TARGET_TOPOLOGY_SCHEMA_VERSION,
+            "registry_path": str(paths.target_registry_path),
+            "status": "missing",
+            "mode": "unknown",
+            "known_target_count": 0,
+            "active_agent_count": 0,
+            "changed": False,
+            "transition": "registry_missing",
+        }
+    existing_topology = registry.get("topology", {})
+    return _topology_for(registry, existing_topology if isinstance(existing_topology, dict) else None)
+
+
+def _observation_payload(
+    paths: OmhPaths,
+    previous_registry: dict[str, Any] | None,
+    registry_error: str | None,
+    target: dict[str, object],
+    *,
+    dry_run: bool,
+    persisted: bool,
+    config_changed: bool,
+) -> dict[str, object]:
+    preview_registry = _merge_registry(previous_registry, target)
+    if previous_registry:
+        existing_topology = previous_registry.get("topology", {})
+        previous_topology = _topology_for(previous_registry, existing_topology if isinstance(existing_topology, dict) else None)
+    else:
+        previous_topology = _empty_topology(paths, registry_error)
+    topology = _topology_for(preview_registry, previous_topology)
+    if previous_registry is None and not registry_error:
+        topology["transition"] = "initial_target_observed"
+        topology["changed"] = False
+    current_id = str(target["target_id"])
+    known_ids = topology.get("known_target_ids")
+    if isinstance(known_ids, list) and current_id not in known_ids:
+        known_ids.append(current_id)
+    return {
+        "schema_version": TARGET_OBSERVATION_SCHEMA_VERSION,
+        "registry_path": str(paths.target_registry_path),
+        "dry_run": dry_run,
+        "persisted": persisted,
+        "config_changed": config_changed,
+        "target": target,
+        "topology": topology,
+        "registry_error": registry_error or "",
+        "skill_scope_rule": _skill_scope_rule(topology),
+    }
+
+
+def _merge_registry(registry: dict[str, Any] | None, target: dict[str, object]) -> dict[str, object]:
+    targets = dict(registry.get("targets", {})) if isinstance(registry, dict) else {}
+    target_id = str(target["target_id"])
+    targets[target_id] = target
+    reported_count = _coerce_count(target.get("reported_agent_count"))
+    previous_topology = registry.get("topology", {}) if isinstance(registry, dict) else {}
+    topology = _topology_for(
+        {
+            "schema_version": TARGET_REGISTRY_SCHEMA_VERSION,
+            "targets": targets,
+            "last_seen_target_id": target_id,
+            "last_reported_agent_count": reported_count,
+            "topology": previous_topology,
+        },
+        previous_topology if isinstance(previous_topology, dict) else None,
+    )
+    return {
+        "schema_version": TARGET_REGISTRY_SCHEMA_VERSION,
+        "targets": targets,
+        "last_seen_target_id": target_id,
+        "last_reported_agent_count": reported_count,
+        "topology": topology,
+        "updated_at": utc_now(),
+    }
+
+
+def _topology_for(registry: dict[str, Any] | None, previous_topology: dict[str, Any] | None) -> dict[str, object]:
+    targets = registry.get("targets", {}) if isinstance(registry, dict) else {}
+    targets = targets if isinstance(targets, dict) else {}
+    reported_count = _coerce_count(registry.get("last_reported_agent_count")) if isinstance(registry, dict) else None
+    known_count = len(targets)
+    active_count = reported_count or known_count
+    previous_count = _coerce_count((previous_topology or {}).get("active_agent_count")) or 0
+    mode = "multi_agent_targets" if active_count > 1 else "single_agent_target"
+    previous_mode = str((previous_topology or {}).get("mode", "unknown"))
+    transition = _transition(previous_count, active_count, previous_mode, mode)
+    current_id = str(registry.get("last_seen_target_id", "")) if isinstance(registry, dict) else ""
+    return {
+        "schema_version": TARGET_TOPOLOGY_SCHEMA_VERSION,
+        "status": "available" if registry else "missing",
+        "mode": mode if active_count else "unknown",
+        "previous_mode": previous_mode,
+        "changed": transition not in {"none", "initial_target_observed"},
+        "transition": transition,
+        "known_target_count": known_count,
+        "active_agent_count": active_count,
+        "active_agent_count_source": "source_metadata" if reported_count else "target_registry",
+        "current_target_id": current_id,
+        "known_target_ids": sorted(str(key) for key in targets),
+        "stale_known_target_count": max(known_count - active_count, 0) if reported_count else 0,
+        "requires_skill_scope_awareness": active_count > 1,
+    }
+
+
+def _empty_topology(paths: OmhPaths, error: str | None) -> dict[str, object]:
+    return {
+        "schema_version": TARGET_TOPOLOGY_SCHEMA_VERSION,
+        "registry_path": str(paths.target_registry_path),
+        "status": "unreadable" if error else "missing",
+        "mode": "unknown",
+        "previous_mode": "unknown",
+        "changed": False,
+        "transition": "registry_unreadable" if error else "registry_missing",
+        "known_target_count": 0,
+        "active_agent_count": 0,
+        "active_agent_count_source": "none",
+        "current_target_id": "",
+        "known_target_ids": [],
+        "stale_known_target_count": 0,
+        "requires_skill_scope_awareness": False,
+    }
+
+
+def _transition(previous_count: int, active_count: int, previous_mode: str, mode: str) -> str:
+    if previous_count == 0 and active_count > 0:
+        return "initial_target_observed"
+    if previous_count <= 1 and active_count > 1:
+        return "single_to_multi"
+    if previous_count > 1 and active_count <= 1:
+        return "multi_to_single"
+    if previous_mode != "unknown" and previous_mode != mode:
+        return f"{previous_mode}_to_{mode}"
+    return "none"
+
+
+def _notice_body(topology: dict[str, object], *, applied: bool) -> str:
+    transition = str(topology.get("transition", "none"))
+    if transition == "single_to_multi":
+        base = "I now see multiple Hermes agent targets for this workspace."
+    elif transition == "multi_to_single":
+        base = "I now see this workspace back on a single Hermes agent target."
+    elif transition == "initial_target_observed":
+        base = "I found a Hermes agent target for this workspace."
+    else:
+        base = "The Hermes agent target topology changed."
+    suffix = (
+        "I updated the persistent target registry and will bind this workflow to the current thread target."
+        if applied
+        else "Please confirm before I persist the target registry update; until then I will bind this workflow only to the current thread target."
+    )
+    return f"{base} {suffix}"
+
+
+def _apply_payload(target: dict[str, object], topology: dict[str, object]) -> dict[str, object]:
+    source_metadata: dict[str, str] = {}
+    for key in ("agent_ref", "target_ref", "runtime_ref", "hermes_home"):
+        value = str(target.get(key, ""))
+        if value:
+            source_metadata[key] = value
+    reported_count = target.get("reported_agent_count") or topology.get("active_agent_count")
+    if reported_count:
+        source_metadata["agent_count"] = str(reported_count)
+    return {
+        "schema_version": "omh_target_apply_payload/v1",
+        "source": str(target.get("source", "")),
+        "source_metadata": source_metadata,
+        "persistence_contract": "Pass this source_metadata back to the OMH wrapper backend with target-change apply enabled; no raw chat prompt is required.",
+    }
+
+
+def _skill_scope_rule(topology: dict[str, object]) -> str:
+    if int(topology.get("active_agent_count") or 0) > 1:
+        return (
+            "Multiple Hermes targets are known. Bind workflow state to the current target/thread, and do not claim other agents saw it "
+            "unless their target evidence is recorded."
+        )
+    return "Use single-target workflow behavior unless source metadata reports multiple Hermes targets."
+
+
+def _display_name(hermes_home: Path, *, agent_ref: str, target_ref: str, runtime_ref: str) -> str:
+    value = target_ref or agent_ref or runtime_ref or hermes_home.name or "hermes"
+    slug = re.sub(r"\s+", " ", value).strip()
+    return slug[:80] or "hermes"
+
+
+def _coerce_count(value: Any) -> int | None:
+    if value is None or value == "":
+        return None
+    try:
+        count = int(value)
+    except (TypeError, ValueError):
+        return None
+    if count < 1:
+        return None
+    return min(count, 128)

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -26,6 +26,8 @@ VISIBLE_ACTIONS = (
     "send_to_executor",
     "send_to_codex",
     "show_status",
+    "show_target_status",
+    "apply_target_change",
     "cancel",
 )
 _ROUTE_TO_MODE = {"dispatch": "plan", "clarify": "clarify", "fallback": "clarify"}
@@ -152,6 +154,7 @@ def build_chat_interaction_payload(
     include_message: bool = False,
     executor_target: str = "choose",
     source_metadata: dict[str, str] | None = None,
+    target_notice: dict[str, object] | None = None,
 ) -> dict[str, object]:
     if source not in CHAT_SOURCES:
         raise ValueError(f"unsupported chat interaction source: {source}")
@@ -170,12 +173,12 @@ def build_chat_interaction_payload(
     if resolved_mode == "clarify" or route["action"] != "dispatch":
         base["next_action"] = "answer_clarification"
         base["chat_response"] = build_chat_response_from_route(route, thread_key=str(base["thread_key"]))
-        return base
+        return _finish_interaction(base, target_notice)
 
     if resolved_mode == "route":
         base["chat_response"] = build_chat_response_from_route(route, thread_key=str(base["thread_key"]))
         base["next_action"] = str(_nested(base["chat_response"], "state").get("next_action", "dispatch_to_workflow"))
-        return base
+        return _finish_interaction(base, target_notice)
 
     if resolved_mode == "delegate":
         delegation = build_coding_delegation_payload(
@@ -199,7 +202,7 @@ def build_chat_interaction_payload(
         else:
             base["next_action"] = "route_coding_request"
         base["chat_response"] = build_chat_response_from_delegation(delegation, thread_key=str(base["thread_key"]))
-        return base
+        return _finish_interaction(base, target_notice)
 
     plan = build_hermes_plan_payload(message, source=source, limit=limit, source_metadata=metadata)
     base["plan"] = _public_plan_payload(plan, include_message=include_message)
@@ -207,7 +210,7 @@ def build_chat_interaction_payload(
     next_action = str(contract.get("next_action", "present_plan"))
     base["next_action"] = "present_plan" if next_action == "prepare_coding_delegation_after_plan_acceptance" else next_action
     base["chat_response"] = build_chat_response_from_plan(plan, thread_key=str(base["thread_key"]))
-    return base
+    return _finish_interaction(base, target_notice)
 
 
 def build_chat_status_interaction(
@@ -561,6 +564,57 @@ def _base_interaction(
     return payload
 
 
+def _finish_interaction(payload: dict[str, object], target_notice: dict[str, object] | None) -> dict[str, object]:
+    if not target_notice:
+        return payload
+    payload["target_notice"] = target_notice
+    topology = target_notice.get("topology")
+    if isinstance(topology, dict):
+        payload["target_topology"] = topology
+    response = payload.get("chat_response")
+    if isinstance(response, dict):
+        payload["chat_response"] = _chat_response_with_target_notice(response, target_notice)
+    return payload
+
+
+def _chat_response_with_target_notice(response: dict[str, object], target_notice: dict[str, object]) -> dict[str, object]:
+    updated = dict(response)
+    state = dict(_nested(updated, "state"))
+    topology = target_notice.get("topology")
+    if isinstance(topology, dict):
+        state["target_topology"] = topology
+    state["target_notice"] = {
+        "action": target_notice.get("action", ""),
+        "persistence": target_notice.get("persistence", ""),
+        "transition": topology.get("transition", "") if isinstance(topology, dict) else "",
+    }
+    updated["state"] = state
+    body = str(updated.get("body", ""))
+    notice_body = str(target_notice.get("body", ""))
+    if notice_body and notice_body not in body:
+        updated["body"] = f"{body} {notice_body}".strip()
+    actions = list(updated.get("actions", []))
+    action_ids = {str(action.get("id", "")) for action in actions if isinstance(action, dict)}
+    if "show_target_status" not in action_ids:
+        actions.append(_action("show_target_status", "Show target status", "secondary"))
+    if target_notice.get("action") == "ask_to_apply_target_change" and "apply_target_change" not in action_ids:
+        action_payload: dict[str, object] = {"target_id": str(target_notice.get("target_id", ""))}
+        apply_payload = target_notice.get("apply_payload")
+        if isinstance(apply_payload, dict):
+            action_payload["target_observation"] = apply_payload
+        actions.append(
+            _action(
+                "apply_target_change",
+                "Apply target setup",
+                "secondary",
+                payload=action_payload,
+            )
+        )
+    updated["actions"] = actions
+    updated["claim_boundary"] = f"{updated.get('claim_boundary', '')} {target_notice.get('claim_boundary', '')}".strip()
+    return updated
+
+
 def _resolve_mode(mode: str, route: dict[str, object]) -> str:
     if mode != "auto":
         return mode
@@ -615,7 +669,23 @@ def _thread_key(source: str, metadata: dict[str, str], *, message: str = "", run
     event = metadata.get("source_event_id") or run_id
     if not event:
         event = hashlib.sha256(message.encode("utf-8")).hexdigest()[:12]
+    target_scope = _target_scope_key(metadata)
+    if target_scope:
+        return f"{source}:{channel}:{target_scope}:{event}"
     return f"{source}:{channel}:{event}"
+
+
+def _target_scope_key(metadata: dict[str, str]) -> str:
+    parts = [
+        metadata.get("hermes_home", ""),
+        metadata.get("agent_ref", ""),
+        metadata.get("target_ref", ""),
+        metadata.get("runtime_ref", ""),
+    ]
+    if not any(parts):
+        return ""
+    basis = "|".join(parts)
+    return f"target-{hashlib.sha256(basis.encode('utf-8')).hexdigest()[:12]}"
 
 
 def _chat_response(

--- a/src/wrapper/sessions.py
+++ b/src/wrapper/sessions.py
@@ -51,6 +51,7 @@ def create_or_resume_wrapper_session(
     min_confidence: str = "high",
     source_metadata: dict[str, str] | None = None,
     executor_target: str = "choose",
+    target_notice: dict[str, object] | None = None,
 ) -> dict[str, object]:
     if source not in CHAT_SOURCES:
         raise WrapperSessionError(f"unsupported wrapper session source: {source}")
@@ -64,6 +65,7 @@ def create_or_resume_wrapper_session(
         include_message=False,
         source_metadata=source_metadata,
         executor_target=executor_target,
+        target_notice=target_notice,
     )
     thread_key = str(interaction["thread_key"])
     session_id = session_id_for_thread_key(thread_key)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1758,6 +1758,90 @@ class CliTests(unittest.TestCase):
             self.assertEqual(doctor_status, 0)
             self.assertTrue(json.loads(doctor_stdout)["ok"])
 
+    def test_setup_and_chat_detect_persisted_hermes_target_topology_drift(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / ".omh"
+            hermes_a = root / ".hermes-a"
+            hermes_b = root / ".hermes-b"
+            base = ["--omh-home", str(omh_home), "--hermes-home", str(hermes_a)]
+
+            status, stdout, stderr = run_cli(base + ["setup"])
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            setup = json.loads(stdout)
+            self.assertEqual(setup["steps"]["targets"]["topology"]["mode"], "single_agent_target")
+            self.assertEqual(setup["hermes_native"]["target_topology"]["mode"], "single_agent_target")
+
+            event_b = root / "event-b.json"
+            event_b.write_text(
+                json.dumps(
+                    {
+                        "message": {"id": "m1", "content": "risky refactor", "channel": "c1"},
+                        "agent": {"id": "agent-b"},
+                        "runtime": {"hermes_home": str(hermes_b), "agent_count": 2},
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            status, stdout, stderr = run_cli(base + ["chat", "interact", "--source", "discord", "--event-json", str(event_b)])
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            pending = json.loads(stdout)
+            self.assertEqual(pending["target_notice"]["action"], "ask_to_apply_target_change")
+            self.assertEqual(pending["target_topology"]["transition"], "single_to_multi")
+            self.assertIn("apply_target_change", {action["id"] for action in pending["chat_response"]["actions"]})
+            apply_action = next(action for action in pending["chat_response"]["actions"] if action["id"] == "apply_target_change")
+            self.assertEqual(
+                apply_action["payload"]["target_observation"]["source_metadata"]["hermes_home"],
+                str(hermes_b.resolve()),
+            )
+            self.assertNotIn("message", json.dumps(apply_action["payload"]))
+            registry = json.loads((omh_home / "targets.json").read_text(encoding="utf-8"))
+            self.assertEqual(len(registry["targets"]), 1)
+
+            status, stdout, stderr = run_cli(
+                base
+                + [
+                    "chat",
+                    "interact",
+                    "--source",
+                    "discord",
+                    "--event-json",
+                    str(event_b),
+                    "--auto-apply-target-change",
+                ]
+            )
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            applied = json.loads(stdout)
+            self.assertEqual(applied["target_notice"]["action"], "target_change_applied")
+            self.assertEqual(applied["target_notice"]["persistence"], "persisted")
+            self.assertIn(str(omh_home / "skills"), (hermes_b / "config.yaml").read_text(encoding="utf-8"))
+            registry = json.loads((omh_home / "targets.json").read_text(encoding="utf-8"))
+            self.assertEqual(registry["topology"]["mode"], "multi_agent_targets")
+            self.assertEqual(len(registry["targets"]), 2)
+
+            event_a_single = root / "event-a-single.json"
+            event_a_single.write_text(
+                json.dumps(
+                    {
+                        "message": {"id": "m2", "content": "status", "channel": "c1"},
+                        "agent": {"id": "agent-a"},
+                        "runtime": {"hermes_home": str(hermes_a), "agent_count": 1},
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            status, stdout, stderr = run_cli(base + ["chat", "interact", "--source", "discord", "--event-json", str(event_a_single)])
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            back_to_one = json.loads(stdout)
+            self.assertEqual(back_to_one["target_topology"]["transition"], "multi_to_single")
+            self.assertEqual(back_to_one["target_topology"]["active_agent_count"], 1)
+
     def test_setup_profile_can_set_prompt_only_runtime_default(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -23,6 +23,8 @@ class ProbeCliTests(unittest.TestCase):
             self.assertEqual(caps["native_hooks"]["status"], "unknown")
             self.assertEqual(caps["omh_plugin_bundle"]["status"], "missing")
             self.assertEqual(caps["plugin_import_smoke"]["status"], "unknown")
+            self.assertEqual(caps["target_registry"]["status"], "missing")
+            self.assertEqual(payload["target_topology"]["mode"], "unknown")
             self.assertFalse(payload["plugin_distribution_ready"])
             self.assertFalse(payload["native_integration_claim_ready"])
 
@@ -59,7 +61,17 @@ class ProbeCliTests(unittest.TestCase):
             self.assertEqual(caps["managed_skills"]["status"], "available")
             self.assertEqual(caps["wrapper_metadata"]["status"], "available")
             self.assertEqual(caps["omh_plugin_bundle"]["status"], "missing")
+            self.assertEqual(caps["target_registry"]["status"], "missing")
             self.assertFalse(json.loads(stdout)["plugin_distribution_ready"])
+
+            self.assertEqual(run_cli(["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "setup"])[0], 0)
+            status, stdout, stderr = run_cli(["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "probe"])
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            payload = json.loads(stdout)
+            caps = {capability["name"]: capability for capability in payload["capabilities"]}
+            self.assertEqual(caps["target_registry"]["status"], "available")
+            self.assertEqual(payload["target_topology"]["mode"], "single_agent_target")
 
     def test_probe_reports_plugin_distribution_without_native_runtime_claim(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -41,6 +41,9 @@ class RouterContentTests(unittest.TestCase):
         self.assertIn("Hermes should retain routing, web/source research, deep interview, planning, status, and evidence narration", router.content)
         self.assertIn("selected executor profile", router.content)
         self.assertIn("prepared_not_observed", router.content)
+        self.assertIn("Multi-Agent Target Awareness", router.content)
+        self.assertIn("omh_target_topology/v1", router.content)
+        self.assertIn("single_to_multi", router.content)
         self.assertIn("skills_list", router.content)
         self.assertIn("skill_view", router.content)
         self.assertIn("name collides", router.content)
@@ -227,6 +230,8 @@ class RouterContentTests(unittest.TestCase):
         self.assertIn("Hermes role: `codex-handoff-guidance`", skills["ultragoal"].content)
         self.assertIn("Handoff policy:", skills["ultragoal"].content)
         self.assertIn("Runtime Evidence", skills["ultragoal"].content)
+        self.assertIn("omh_target_topology/v1", skills["ultragoal"].content)
+        self.assertIn("active_agent_count", skills["ultragoal"].content)
         self.assertIn("omh runtime record --skill ultragoal --harness goal-execution --status started", skills["ultragoal"].content)
         self.assertIn("Prefer richer evidence and clearer stop conditions", skills["code-review"].content)
 
@@ -280,6 +285,7 @@ class RouterContentTests(unittest.TestCase):
 
         self.assertEqual(reference, workflow_reference_markdown())
         self.assertIn("This file is generated from `src/skills/catalog.py`", reference)
+        self.assertIn("omh_target_topology/v1", reference)
         for definition in builtin_definitions():
             self.assertIn(f"### {definition.name}", reference)
             self.assertIn(f"- Category: `{definition.category}`", reference)

--- a/tests/test_targets.py
+++ b/tests/test_targets.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import unittest
+from tempfile import TemporaryDirectory
+from pathlib import Path
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.paths import resolve_paths
+from omh.targets import (
+    build_target_change_notice,
+    inspect_target_observation,
+    record_target_observation,
+    summarize_target_registry,
+)
+
+
+class TargetRegistryTests(unittest.TestCase):
+    def test_records_single_to_multi_and_multi_to_single_without_forgetting_history(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = resolve_paths(root / ".omh", root / ".hermes-a")
+
+            first = record_target_observation(paths, source="setup")
+            self.assertTrue(first["persisted"])
+            self.assertEqual(first["topology"]["mode"], "single_agent_target")
+            self.assertFalse(first["topology"]["changed"])
+
+            second = record_target_observation(
+                paths,
+                source="chat:discord",
+                source_metadata={
+                    "agent_ref": "agent-b",
+                    "hermes_home": str(root / ".hermes-b"),
+                },
+            )
+            self.assertEqual(second["topology"]["transition"], "single_to_multi")
+            self.assertEqual(second["topology"]["mode"], "multi_agent_targets")
+            self.assertTrue(second["topology"]["requires_skill_scope_awareness"])
+
+            back_to_one = inspect_target_observation(
+                paths,
+                source="chat:discord",
+                source_metadata={
+                    "agent_ref": "agent-a",
+                    "hermes_home": str(root / ".hermes-a"),
+                    "agent_count": "1",
+                },
+            )
+            self.assertFalse(back_to_one["persisted"])
+            self.assertEqual(back_to_one["topology"]["transition"], "multi_to_single")
+            self.assertEqual(back_to_one["topology"]["mode"], "single_agent_target")
+            self.assertGreaterEqual(back_to_one["topology"]["known_target_count"], 2)
+            self.assertEqual(back_to_one["topology"]["active_agent_count"], 1)
+
+    def test_change_notice_distinguishes_pending_and_applied_persistence(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = resolve_paths(root / ".omh", root / ".hermes-a")
+
+            record_target_observation(paths, source="setup")
+            pending = inspect_target_observation(
+                paths,
+                source="chat:slack",
+                source_metadata={
+                    "agent_ref": "agent-b",
+                    "hermes_home": str(root / ".hermes-b"),
+                    "agent_count": "2",
+                },
+            )
+            pending_notice = build_target_change_notice(pending)
+
+            self.assertIsNotNone(pending_notice)
+            assert pending_notice is not None
+            self.assertEqual(pending_notice["action"], "ask_to_apply_target_change")
+            self.assertEqual(pending_notice["persistence"], "pending_user_confirmation")
+            self.assertIn("multiple Hermes agent targets", pending_notice["body"])
+            self.assertEqual(pending_notice["apply_payload"]["source"], "chat:slack")
+            self.assertEqual(pending_notice["apply_payload"]["source_metadata"]["agent_ref"], "agent-b")
+            self.assertEqual(pending_notice["apply_payload"]["source_metadata"]["agent_count"], "2")
+
+            applied = record_target_observation(
+                paths,
+                source="chat:slack",
+                source_metadata={
+                    "agent_ref": "agent-b",
+                    "hermes_home": str(root / ".hermes-b"),
+                    "agent_count": "2",
+                },
+            )
+            applied_notice = build_target_change_notice(applied, auto_applied=True)
+
+            self.assertIsNotNone(applied_notice)
+            assert applied_notice is not None
+            self.assertEqual(applied_notice["action"], "target_change_applied")
+            self.assertEqual(applied_notice["persistence"], "persisted")
+            self.assertEqual(summarize_target_registry(paths)["mode"], "multi_agent_targets")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wrapper_contract.py
+++ b/tests/test_wrapper_contract.py
@@ -54,6 +54,47 @@ class WrapperContractTests(unittest.TestCase):
         self.assertNotIn("raw", payload["source_metadata"])
         self.assertEqual(payload["thread_key"], "slack:c1:m1")
 
+    def test_chat_interaction_surfaces_target_change_notice_without_overclaiming(self) -> None:
+        notice = {
+            "schema_version": "omh_target_change_notice/v1",
+            "action": "ask_to_apply_target_change",
+            "headline": "Hermes target setup changed.",
+            "body": "I now see multiple Hermes agent targets for this workspace. Please confirm before I persist the target registry update.",
+            "target_id": "hermes-123",
+            "topology": {
+                "schema_version": "omh_target_topology/v1",
+                "mode": "multi_agent_targets",
+                "transition": "single_to_multi",
+                "active_agent_count": 2,
+                "requires_skill_scope_awareness": True,
+            },
+            "apply_payload": {
+                "schema_version": "omh_target_apply_payload/v1",
+                "source": "chat:discord",
+                "source_metadata": {
+                    "agent_ref": "agent-b",
+                    "hermes_home": "/tmp/hermes-b",
+                    "agent_count": "2",
+                },
+                "persistence_contract": "Pass this source_metadata back to the OMH wrapper backend with target-change apply enabled; no raw chat prompt is required.",
+            },
+            "persistence": "pending_user_confirmation",
+            "claim_boundary": "Target topology is setup evidence only; it does not prove another Hermes agent executed this workflow.",
+        }
+
+        payload = build_chat_interaction_payload("risky refactor", source="discord", target_notice=notice)
+
+        actions = {action["id"] for action in payload["chat_response"]["actions"]}
+        self.assertEqual(payload["target_notice"]["action"], "ask_to_apply_target_change")
+        self.assertEqual(payload["target_topology"]["transition"], "single_to_multi")
+        self.assertEqual(payload["chat_response"]["state"]["target_topology"]["active_agent_count"], 2)
+        self.assertIn("show_target_status", actions)
+        self.assertIn("apply_target_change", actions)
+        apply_action = next(action for action in payload["chat_response"]["actions"] if action["id"] == "apply_target_change")
+        self.assertEqual(apply_action["payload"]["target_observation"]["source_metadata"]["agent_ref"], "agent-b")
+        self.assertNotIn("message", json.dumps(apply_action["payload"]))
+        self.assertIn("Target topology is setup evidence only", payload["chat_response"]["claim_boundary"])
+
     def test_clarify_mode_has_no_handoff_actions(self) -> None:
         payload = build_chat_interaction_payload("fix maybe", mode="delegate")
 

--- a/tests/test_wrapper_sessions.py
+++ b/tests/test_wrapper_sessions.py
@@ -57,6 +57,55 @@ class WrapperSessionTests(unittest.TestCase):
             self.assertNotIn(message, json.dumps(first))
             self.assertEqual(validate_wrapper_session_record(session), [])
 
+    def test_session_start_is_scoped_by_hermes_target_metadata(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = resolve_paths(root / ".omh", root / ".hermes-a")
+            message = "risky refactor"
+            shared_event = {"source_event_id": "m1", "channel_ref": "c1"}
+
+            first = create_or_resume_wrapper_session(
+                paths,
+                message,
+                source="discord",
+                source_metadata={
+                    **shared_event,
+                    "agent_ref": "agent-a",
+                    "hermes_home": str(root / ".hermes-a"),
+                },
+            )
+            second = create_or_resume_wrapper_session(
+                paths,
+                message,
+                source="discord",
+                source_metadata={
+                    **shared_event,
+                    "agent_ref": "agent-b",
+                    "hermes_home": str(root / ".hermes-b"),
+                },
+            )
+            third = create_or_resume_wrapper_session(
+                paths,
+                message,
+                source="discord",
+                source_metadata={
+                    **shared_event,
+                    "agent_ref": "agent-b",
+                    "hermes_home": str(root / ".hermes-b"),
+                },
+            )
+
+            self.assertFalse(first["resumed"])
+            self.assertFalse(second["resumed"])
+            self.assertTrue(third["resumed"])
+            self.assertNotEqual(first["session"]["session_id"], second["session"]["session_id"])
+            self.assertEqual(second["session"]["session_id"], third["session"]["session_id"])
+            self.assertIn("target-", first["session"]["thread_key"])
+            self.assertEqual(first["session"]["source_metadata"]["agent_ref"], "agent-a")
+            self.assertEqual(second["session"]["source_metadata"]["agent_ref"], "agent-b")
+            self.assertEqual(validate_wrapper_session_record(first["session"]), [])
+            self.assertEqual(validate_wrapper_session_record(second["session"]), [])
+
     def test_session_start_treats_policy_route_actions_as_routed(self) -> None:
         with TemporaryDirectory() as tmp:
             paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")


### PR DESCRIPTION
## Summary
- Add deterministic OMH target registry support for Hermes agent topology observations under `~/.omh/targets.json`.
- Surface single-to-multi and multi-to-single target drift through setup, chat wrapper responses, doctor, probe, and generated skill guidance.
- Scope wrapper sessions by target identity when agent/runtime metadata is present, and include sanitized apply payloads for `apply_target_change` actions.
- Preserve prepared-vs-observed boundaries: target topology is setup/wrapper metadata, not execution evidence.

## Review Fixes
- Fixed independent review finding where two Hermes agents in the same channel/event could resume the same wrapper session.
- Fixed `apply_target_change` so wrapper action payloads include `omh_target_apply_payload/v1` source metadata without raw prompt content.

## Verification
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — 223 tests OK
- `uv run python -m compileall -q src tests` — passed
- `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check` — passed, 28/28 tap skills current
- `git diff --check` — passed
- `uv build` — passed, with existing setuptools license deprecation warnings
- Independent code-reviewer: APPROVE
- Independent architect: CLEAR

## Notes
- No Hermes core patching, transport SDKs, network calls, LLM calls, or hidden executor behavior added.
- Unrelated untracked local files were left untouched: `assets/agent-era-dev-checklist.*`, `uv.lock`.
