### PR TITLE
Add memory context review and handoff packs

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes-agent/main/inst
 | App operation loops | `idea-to-deploy`, `cto-loop`, and `deploy-and-monitor` make Hermes feel like an app delivery operator while keeping evidence boundaries strict. |
 | Business workflows | Research briefs, strategy briefs, meeting briefs, feedback triage, and ops review for non-coding company work. |
 | Coding handoffs | Executor-neutral handoff payloads with acceptance, review, and verification expectations. |
+| Memory context review | Review OMH-local and wrapper-supplied context, flag stale assumptions, and attach conflict-free summaries to executor handoffs. |
 | Wrapper contracts | `chat_interaction/v1`, status cards, action ids, and local runtime artifacts for Discord, Slack, or hosted adapters. |
 | Optional plugin bridge | `omh setup --with-plugin` installs `~/.hermes/plugins/omh` with metadata-only `omh_status` support. |
 | Optional team profile packs | CTO/PM-style or delivery/research role files can be installed only when selected. |
@@ -179,6 +180,7 @@ curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes-agent/main/inst
 | Architecture and module ownership | [Architecture](docs/ARCHITECTURE.md) |
 | Situation playbooks | [Playbooks](docs/PLAYBOOKS.md) |
 | Role surfaces and profile packs | [Roles](docs/ROLES.md) |
+| Memory/context review and handoff packs | [Memory Context Review](docs/MEMORY_CONTEXT.md) |
 | Discord-style wrapper examples | [Chat Wrapper Examples](docs/CHAT_WRAPPER_EXAMPLES.md) |
 | Harness quality contracts | [Harness Quality Contract](docs/HARNESS_QUALITY.md) |
 | Representative workflows | [Application Cases](docs/APPLICATION_CASES.md) |

--- a/docs/DELEGATION_FIRST_COMPLETENESS.md
+++ b/docs/DELEGATION_FIRST_COMPLETENESS.md
@@ -33,6 +33,7 @@ evidence exists.
 | `omh hermes plan` | Produces Hermes-facing plan scaffolds and wrapper contracts under `.hermes/plans`. | `src/hermes_planning.py`, `docs/ARCHITECTURE.md` |
 | `omh coding delegate` | Prepares metadata-only coding handoffs, executor-choice contracts, and prompt-only payloads without overclaiming execution. | `src/coding_delegation.py`, `src/runtime/artifacts.py` |
 | `omh coding lifecycle` | Tracks Codex-selected handoff dispatch, executor result, verification, and reportable status from existing runtime evidence. | `src/wrapper/lifecycle.py`, `tests/test_coding_lifecycle.py`, `tests/test_cli.py` |
+| `omh memory inspect/pack/apply` | Reviews OMH-local and wrapper-supplied context, creates `memory_review_card/v1`, and attaches only conflict-free `handoff_context_pack/v1` summaries to executor handoffs. | `src/memory.py`, `tests/test_memory.py` |
 | `omh runtime wrapper` | Lets wrappers record what they actually observed after dispatch. | `src/runtime/artifacts.py`, `README.md` |
 | `omh runtime review`, `omh runtime ci`, `omh runtime merge` | Records observed review, CI, merge-readiness, and merge evidence under the run ledger. | `src/runtime/artifacts.py`, `src/runtime/records.py`, `tests/test_cli.py` |
 | `omh runtime validate/export` | Validates and exports local evidence without storing prompt bodies by default. | `src/runtime/artifacts.py`, `tests/test_runtime_artifacts.py` |
@@ -132,8 +133,12 @@ source, source metadata, message hash and length, `thread_key`, mode,
 visibility, headline, body, state, platform-neutral actions, and claim boundary.
 Allowed actions include `answer:*`, `accept_plan`, `revise_plan`,
 `prepare_handoff`, `choose_executor`, `show_prompt_handoff`,
-`copy_prompt_handoff`, `send_to_executor`, `show_status`, and `cancel`.
-`send_to_codex` remains a compatibility alias only for Codex-selected flows.
+`copy_prompt_handoff`, `send_to_executor`, `show_status`,
+`show_memory_status`, `apply_memory_updates`, and `cancel`. Memory review
+actions such as `keep_memory`, `forget_memory`, `update_memory`, and
+`change_memory_scope` belong to `memory_review_card/v1`, not
+`status_card/v1`. `send_to_codex` remains a compatibility alias only for
+Codex-selected flows.
 Action labels remain product-level labels; they do not expose CLI commands,
 argv arrays, or shell text.
 

--- a/docs/DIRECTION.md
+++ b/docs/DIRECTION.md
@@ -111,6 +111,11 @@ Selected coding executors own:
    schema-versioned, redacted by default, and local-only unless a wrapper
    outside this repository performs transport work.
 
+   Memory/context review follows the same rule. OMH may inspect OMH-local
+   memory files, wrapper sessions, target topology, setup profiles, and
+   wrapper-supplied snapshots; it must not claim it read or changed opaque
+   Hermes internal memory.
+
 6. Do not widen into platform transports prematurely.
    Transport adapters, auth, retries, message edits, and posting belong outside
    this repository until their dependency and packaging story is explicitly

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -176,9 +176,13 @@ The backend flow is:
    multi-to-single target changes as persistent setup state. When target
    identity metadata is present, `thread_key` is scoped by that target so two
    Hermes agents in the same channel do not share wrapper session state.
-9. Status updates use `omh coding lifecycle report` or
+9. If the wrapper has local memory-like context candidates, it can run
+   `omh memory inspect` and attach a conflict-free `handoff_context_pack/v1` to
+   the later handoff. Conflicting or stale assumptions must be shown as memory
+   review, not silently reused.
+10. Status updates use `omh coding lifecycle report` or
    `omh chat interact --run <run-id>` and stay in the same thread.
-10. Hermes still starts with its normal config and reads `skills.external_dirs`;
+11. Hermes still starts with its normal config and reads `skills.external_dirs`;
    `omh apply` makes sure `~/.omh/skills` is included in that discovery list.
 
 `omh` does not replace the Discord bot, modify Slack commands, open network
@@ -230,6 +234,20 @@ omh chat session select-executor "$session_id" codex
 omh chat session select-executor "$session_id" claude-code
 omh chat session select-executor "$session_id" generic
 ```
+
+Review stale local context before a handoff:
+
+```sh
+omh memory inspect --fixture wrapper-memory.json
+omh memory pack --fixture wrapper-memory.json --executor codex --session-id "$session_id" > handoff-context.json
+omh chat session prepare-handoff "$session_id" --context-pack handoff-context.json "risky refactor"
+```
+
+`memory_review_card/v1` is separate from `status_card/v1`. It can drive
+`keep_memory`, `forget_memory`, `update_memory`, `change_memory_scope`,
+`apply_memory_updates`, and `show_memory_status` buttons. Approved changes are
+written only to `.omh/memory/`; OMH does not read or mutate opaque Hermes
+internal memory.
 
 Codex lifecycle calls after the wrapper has an accepted Codex coding handoff:
 
@@ -355,6 +373,10 @@ Before calling the bot integration ready, verify these points:
   `codex_invocation.dispatch_text_template`, for example
   `$ai-slop-cleaner {message}`. The wrapper replaces `{message}` only when it
   dispatches to Codex.
+- `omh memory pack` attaches `context_pack` only when no unresolved memory
+  conflict remains; otherwise the handoff contains `context_pack_blocked`.
+- `omh memory apply --batch <file> --dry-run` previews approved memory updates
+  without writing, and the real apply writes only under `.omh/memory/`.
 - `omh coding lifecycle result --run <run-id> --result completed` is rejected
   until `omh coding lifecycle dispatch --run <run-id>` records dispatch
   observation.

--- a/docs/MEMORY_CONTEXT.md
+++ b/docs/MEMORY_CONTEXT.md
@@ -1,0 +1,82 @@
+# Memory Context Review
+
+OMH memory context review helps Hermes and wrappers stop reusing stale
+assumptions. It is a local, deterministic review surface for OMH-managed state
+and wrapper-supplied context candidates.
+
+It does not read, scrape, or mutate opaque Hermes internal memory.
+
+## What It Gives Users
+
+When a user says "check what Hermes remembers about this work", a wrapper can
+show a review card instead of asking the user to manually inspect files.
+
+The card can say:
+
+- what context OMH found locally
+- which assumptions conflict with fresher setup, target, runtime-state, or
+  wrapper evidence
+- which items can be kept, updated, forgotten, rescoped, or dismissed
+- whether a context pack is safe to attach to an executor handoff
+
+The important boundary is that a remembered note is not proof that execution,
+review, CI, or merge happened.
+
+## Schemas
+
+| Schema | Purpose |
+| --- | --- |
+| `memory_snapshot/v1` | A wrapper-supplied or OMH-local context source. |
+| `memory_inspection/v1` | Source inventory, conflict detection, review items, and preview data. |
+| `memory_review_card/v1` | Wrapper-renderable review UX separate from `status_card/v1`. |
+| `memory_update_batch/v1` | User-approved keep/forget/update/scope/conflict decisions. |
+| `handoff_context_pack/v1` | Conflict-free metadata-only context attached to executor handoffs. |
+
+## Wrapper Flow
+
+```sh
+omh memory inspect --fixture wrapper-memory.json
+omh memory pack --fixture wrapper-memory.json --executor codex --session-id "$session_id"
+omh chat session prepare-handoff "$session_id" --context-pack handoff-context.json "risky refactor"
+```
+
+The fixture is optional. Without it, OMH inspects local setup profile, target
+topology, runtime state, wrapper sessions, approved `.omh/memory` context, and
+catalog hints.
+
+Apply user-approved changes:
+
+```sh
+omh memory apply --batch memory-update-batch.json --dry-run
+omh memory apply --batch memory-update-batch.json
+```
+
+Approved writes stay under `.omh/memory/`. Unsafe scope refs, path traversal,
+and symlink escapes are rejected.
+
+## Handoff Behavior
+
+Executor handoffs can include `context_pack` only when
+`blocked_by_conflicts` is empty.
+
+If conflicts remain, OMH writes `context_pack_blocked` with the conflict list
+instead of attaching stale context to the executor prompt. This keeps
+`prepared_not_observed` handoffs from becoming accidental memory dumps or false
+evidence.
+
+## Source Priority
+
+OMH treats sources conservatively:
+
+1. runtime evidence from run-ledger artifacts
+2. wrapper session state
+3. runtime state index
+4. target topology
+5. setup profile
+6. approved OMH memory
+7. wiki or notes
+8. catalog hints
+9. wrapper snapshot candidates
+
+Higher-priority sources can block stale lower-priority assumptions from being
+reused in handoffs.

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ repo-local contract for Codex agents working here.
 | Understand what OMH is and is not | [Direction](DIRECTION.md) |
 | Understand module boundaries and local artifacts | [Architecture](ARCHITECTURE.md) |
 | Understand chat wrapper UX, sessions, and handoffs | [Delegation-First Completeness](DELEGATION_FIRST_COMPLETENESS.md) |
+| Review stale local context and executor handoff packs | [Memory Context Review](MEMORY_CONTEXT.md) |
 | Operate a Hermes-agent wrapper safely | [Hermes Agent Integration Runbook](HERMES_AGENT_INTEGRATION_RUNBOOK.md) |
 | Install from an AI-agent protocol | [Agent Install Protocol](../INSTALL_FOR_AGENTS.md) |
 | Understand responsibility roles | [Role Surface](ROLES.md) |
@@ -76,6 +77,8 @@ merge.
   harness examples should stay backed by conformance tests.
 - Runtime and wrapper docs should preserve the separation between wrapper
   session state and run-level evidence.
+- Memory/context docs should state that OMH reviews local or wrapper-supplied
+  context only; it does not read or mutate opaque Hermes internal memory.
 - The GitHub Pages site should stay a short public entry point that links back
   to this docs set instead of becoming a second source of truth.
 
@@ -87,6 +90,7 @@ When changing docs, check whether the same claim needs to be updated in:
 - [Direction](DIRECTION.md)
 - [Architecture](ARCHITECTURE.md)
 - [Delegation-First Completeness](DELEGATION_FIRST_COMPLETENESS.md)
+- [Memory Context Review](MEMORY_CONTEXT.md)
 - [Hermes Agent Integration Runbook](HERMES_AGENT_INTEGRATION_RUNBOOK.md)
 - [Role Surface](ROLES.md)
 - [Agent Install Protocol](../INSTALL_FOR_AGENTS.md)

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -7,6 +7,7 @@ The reference describes prompt-level Hermes workflow guidance and local evidence
 Workflow names are kept for compatibility, but each skill declares advisory wrapper guidance for whether Hermes should retain the work directly, ask the user to choose an executor, or prepare a coding handoff for coding-heavy execution.
 
 When wrapper metadata reports `omh_target_topology/v1`, skills bind workflow state to the current Hermes target/thread, adapt only the steps that benefit from multiple targets, and fall back to single-target behavior when the active agent count is one.
+`memory_review_card/v1` is separate from `status_card/v1`; `handoff_context_pack/v1` may be attached to executor handoffs only when unresolved conflicts are absent.
 
 ## Skills
 

--- a/skills/ai-slop-cleaner/SKILL.md
+++ b/skills/ai-slop-cleaner/SKILL.md
@@ -85,6 +85,7 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
 - Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
 - When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers or explicit checklists,
   - question renderers -> one concise question in the current Hermes interface,

--- a/skills/ask/SKILL.md
+++ b/skills/ask/SKILL.md
@@ -84,6 +84,7 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
 - Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
 - When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers or explicit checklists,
   - question renderers -> one concise question in the current Hermes interface,

--- a/skills/autoresearch-goal/SKILL.md
+++ b/skills/autoresearch-goal/SKILL.md
@@ -84,6 +84,7 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
 - Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
 - When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers or explicit checklists,
   - question renderers -> one concise question in the current Hermes interface,

--- a/skills/best-practice-research/SKILL.md
+++ b/skills/best-practice-research/SKILL.md
@@ -84,6 +84,7 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
 - Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
 - When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers or explicit checklists,
   - question renderers -> one concise question in the current Hermes interface,

--- a/skills/cancel/SKILL.md
+++ b/skills/cancel/SKILL.md
@@ -81,6 +81,7 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
 - Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
 - When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers or explicit checklists,
   - question renderers -> one concise question in the current Hermes interface,

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -85,6 +85,7 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
 - Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
 - When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers or explicit checklists,
   - question renderers -> one concise question in the current Hermes interface,

--- a/skills/cto-loop/SKILL.md
+++ b/skills/cto-loop/SKILL.md
@@ -89,6 +89,7 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
 - Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
 - When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers or explicit checklists,
   - question renderers -> one concise question in the current Hermes interface,

--- a/skills/deep-interview/SKILL.md
+++ b/skills/deep-interview/SKILL.md
@@ -85,6 +85,7 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
 - Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
 - When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers or explicit checklists,
   - question renderers -> one concise question in the current Hermes interface,

--- a/skills/deploy-and-monitor/SKILL.md
+++ b/skills/deploy-and-monitor/SKILL.md
@@ -89,6 +89,7 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
 - Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
 - When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers or explicit checklists,
   - question renderers -> one concise question in the current Hermes interface,

--- a/skills/doctor/SKILL.md
+++ b/skills/doctor/SKILL.md
@@ -83,6 +83,7 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
 - Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
 - When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers or explicit checklists,
   - question renderers -> one concise question in the current Hermes interface,

--- a/skills/feedback-triage/SKILL.md
+++ b/skills/feedback-triage/SKILL.md
@@ -85,6 +85,7 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
 - Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
 - When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers or explicit checklists,
   - question renderers -> one concise question in the current Hermes interface,

--- a/skills/idea-to-deploy/SKILL.md
+++ b/skills/idea-to-deploy/SKILL.md
@@ -88,6 +88,7 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
 - Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
 - When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers or explicit checklists,
   - question renderers -> one concise question in the current Hermes interface,

--- a/skills/meeting-brief/SKILL.md
+++ b/skills/meeting-brief/SKILL.md
@@ -87,6 +87,7 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
 - Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
 - When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers or explicit checklists,
   - question renderers -> one concise question in the current Hermes interface,

--- a/skills/oh-my-hermes/SKILL.md
+++ b/skills/oh-my-hermes/SKILL.md
@@ -115,6 +115,10 @@ The command returns a `coding_delegation/v1` payload with a recommended workflow
 
 With `--record`, `omh` creates a `.omh/runtime/runs/<run-id>/` prepared runtime run only for a Codex-selected delegate payload that contains a real `executor_handoff`. Executor-choice, prompt-only, retained-Hermes, clarify, and fallback responses return `runtime.recorded=false` and must stay wrapper/session state rather than prepared run evidence. For Codex runs, `coding_delegation.json` is paired with `run.json` marked `status: prepared`, `artifact_kind: prepared_coding_delegation`, `phase: prepared`, and `observation_status: prepared_not_observed`. These artifacts store only allowlisted metadata, acceptance criteria, verification expectations, recommendation evidence, source references, `message_sha256`, and `message_length`. They mean a coding handoff was prepared; they do not mean Hermes executed the work or that a specialist lane was observed.
 
+## Wrapper Backend Memory Context
+
+Wrappers can run `omh memory inspect`, `omh memory pack`, and `omh memory apply` to review OMH-local or wrapper-supplied context before preparing a handoff. This emits `memory_review_card/v1` and `handoff_context_pack/v1` artifacts only; it does not read or mutate opaque Hermes internal memory. A context pack may be attached to an executor handoff only when unresolved conflicts are absent.
+
 ## Hermes-Facing Planning
 
 For planning-shaped requests, wrappers or operators can run `omh hermes plan` to create a deterministic `hermes_plan/v1` planning scaffold. In normal chat, Hermes can express this plan directly through the installed skill guidance:

--- a/skills/ops-review/SKILL.md
+++ b/skills/ops-review/SKILL.md
@@ -88,6 +88,7 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
 - Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
 - When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers or explicit checklists,
   - question renderers -> one concise question in the current Hermes interface,

--- a/skills/performance-goal/SKILL.md
+++ b/skills/performance-goal/SKILL.md
@@ -85,6 +85,7 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
 - Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
 - When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers or explicit checklists,
   - question renderers -> one concise question in the current Hermes interface,

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -85,6 +85,7 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
 - Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
 - When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers or explicit checklists,
   - question renderers -> one concise question in the current Hermes interface,

--- a/skills/ralph/SKILL.md
+++ b/skills/ralph/SKILL.md
@@ -85,6 +85,7 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
 - Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
 - When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers or explicit checklists,
   - question renderers -> one concise question in the current Hermes interface,

--- a/skills/ralplan/SKILL.md
+++ b/skills/ralplan/SKILL.md
@@ -86,6 +86,7 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
 - Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
 - When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers or explicit checklists,
   - question renderers -> one concise question in the current Hermes interface,

--- a/skills/research-brief/SKILL.md
+++ b/skills/research-brief/SKILL.md
@@ -85,6 +85,7 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
 - Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
 - When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers or explicit checklists,
   - question renderers -> one concise question in the current Hermes interface,

--- a/skills/skill/SKILL.md
+++ b/skills/skill/SKILL.md
@@ -81,6 +81,7 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
 - Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
 - When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers or explicit checklists,
   - question renderers -> one concise question in the current Hermes interface,

--- a/skills/strategy-brief/SKILL.md
+++ b/skills/strategy-brief/SKILL.md
@@ -87,6 +87,7 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
 - Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
 - When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers or explicit checklists,
   - question renderers -> one concise question in the current Hermes interface,

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -85,6 +85,7 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
 - Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
 - When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers or explicit checklists,
   - question renderers -> one concise question in the current Hermes interface,

--- a/skills/ultragoal/SKILL.md
+++ b/skills/ultragoal/SKILL.md
@@ -85,6 +85,7 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
 - Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
 - When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers or explicit checklists,
   - question renderers -> one concise question in the current Hermes interface,

--- a/skills/ultraqa/SKILL.md
+++ b/skills/ultraqa/SKILL.md
@@ -85,6 +85,7 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
 - Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
 - When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers or explicit checklists,
   - question renderers -> one concise question in the current Hermes interface,

--- a/skills/ultrawork/SKILL.md
+++ b/skills/ultrawork/SKILL.md
@@ -86,6 +86,7 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
 - Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
 - When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers or explicit checklists,
   - question renderers -> one concise question in the current Hermes interface,

--- a/skills/web-research/SKILL.md
+++ b/skills/web-research/SKILL.md
@@ -85,6 +85,7 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
 - Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
 - When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers or explicit checklists,
   - question renderers -> one concise question in the current Hermes interface,

--- a/skills/wiki/SKILL.md
+++ b/skills/wiki/SKILL.md
@@ -84,6 +84,7 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
 - Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
 - When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers or explicit checklists,
   - question renderers -> one concise question in the current Hermes interface,

--- a/src/coding_delegation.py
+++ b/src/coding_delegation.py
@@ -13,6 +13,7 @@ from .executors import (
 )
 from .harness_quality import with_wrapper_actions
 from .ingress import CHAT_SOURCES, extract_message_text, extract_source_metadata
+from .memory import validate_handoff_context_blocked, validate_handoff_context_pack
 from .routing.recommend import recommend_skills
 from .skills.catalog import (
     CODING_INTENT_PRIORITY,
@@ -61,6 +62,7 @@ def build_coding_delegation_payload(
     include_message: bool = False,
     source_metadata: dict[str, str] | None = None,
     executor_target: str = "generic",
+    context_pack: dict[str, object] | None = None,
 ) -> dict[str, object]:
     message = message.strip()
     if not message:
@@ -119,8 +121,10 @@ def build_coding_delegation_payload(
     )
     if selection.selected_executor_profile == "codex" and delegation.action == "delegate":
         payload["executor_handoff"] = _executor_handoff(executor_target, delegation)
+        _attach_context_pack(payload["executor_handoff"], context_pack)
     elif selection.work_owner_mode == "prompt_only_handoff" and selection.selected_executor_profile and delegation.action == "delegate":
         payload["prompt_handoff"] = _prompt_handoff(selection.selected_executor_profile, delegation)
+        _attach_context_pack(payload["prompt_handoff"], context_pack)
     payload["harness_quality"] = _public_harness_quality(
         harness,
         action=delegation.action,
@@ -159,6 +163,28 @@ def build_coding_delegation_event_payload(
         include_message=include_message,
         source_metadata=extract_source_metadata(event),
     )
+
+
+def _attach_context_pack(handoff: object, context_pack: dict[str, object] | None) -> None:
+    if not isinstance(handoff, dict) or not context_pack:
+        return
+    blocked = context_pack.get("blocked_by_conflicts", [])
+    if isinstance(blocked, list) and blocked:
+        blocked_marker = {
+            "schema_version": "handoff_context_blocked/v1",
+            "blocked_by_conflicts": blocked,
+            "claim_boundary": "Unresolved memory conflicts block this context pack from executor handoff attachment.",
+        }
+        errors = validate_handoff_context_pack(context_pack, require_conflict_free=False, label="context_pack")
+        errors.extend(validate_handoff_context_blocked(blocked_marker, label="context_pack_blocked"))
+        if errors:
+            raise ValueError("; ".join(errors))
+        handoff["context_pack_blocked"] = blocked_marker
+        return
+    errors = validate_handoff_context_pack(context_pack, require_conflict_free=True, label="context_pack")
+    if errors:
+        raise ValueError("; ".join(errors))
+    handoff["context_pack"] = context_pack
 
 
 def coding_delegation_record_payload(

--- a/src/commands/chat.py
+++ b/src/commands/chat.py
@@ -6,6 +6,7 @@ import json
 from ..coding_delegation import CODING_EXECUTOR_TARGETS
 from ..ingress import CHAT_SOURCES
 from ..installer import OmhError
+from ..memory import read_handoff_context_pack_file
 from ..routing.chat import CONFIDENCE_LEVELS, public_route_payload, route_chat_message, routing_record_payload
 from ..runtime.artifacts import create_run, summarize_delegated_coding_status, write_routing_decision
 from ..targets import TARGET_METADATA_KEYS, build_target_change_notice, inspect_target_observation, record_target_observation
@@ -134,6 +135,7 @@ def cmd_chat_session_prepare_handoff(args: argparse.Namespace) -> int:
             include_message=args.include_message,
             source_metadata=source_metadata,
             executor_target=args.executor,
+            context_pack=_context_pack(args),
         )
     except FileNotFoundError as exc:
         raise OmhError(f"wrapper session not found: {args.session_id}") from exc
@@ -158,6 +160,13 @@ def _target_notice(args: argparse.Namespace, source_metadata: dict[str, str]) ->
     else:
         observation = inspect_target_observation(paths, source=f"chat:{args.source}", source_metadata=source_metadata)
     return build_target_change_notice(observation, auto_applied=auto_apply)
+
+
+def _context_pack(args: argparse.Namespace) -> dict[str, object] | None:
+    path = getattr(args, "context_pack", None)
+    if not path:
+        return None
+    return read_handoff_context_pack_file(path)
 
 
 def _has_target_metadata(source_metadata: dict[str, str]) -> bool:
@@ -329,6 +338,11 @@ def _add_chat_commands(sub) -> None:
     session_prepare.add_argument("--channel-ref", default="")
     session_prepare.add_argument("--user-ref", default="")
     session_prepare.add_argument("--executor", choices=tuple(value for value in CODING_EXECUTOR_TARGETS if value != "choose"), default=None)
+    session_prepare.add_argument(
+        "--context-pack",
+        default=None,
+        help="Optional handoff_context_pack/v1 JSON to attach to the prepared executor prompt when conflict-free.",
+    )
     session_prepare.set_defaults(func=cmd_chat_session_prepare_handoff)
 
     session_status = session_sub.add_parser("status")

--- a/src/commands/coding.py
+++ b/src/commands/coding.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from ..coding_delegation import CODING_EXECUTOR_TARGETS, build_coding_delegation_payload, coding_delegation_record_payload
 from ..ingress import CHAT_SOURCES, extract_message_text, extract_source_metadata
 from ..installer import OmhError
+from ..memory import read_handoff_context_pack_file
 from ..runtime.artifacts import create_prepared_coding_delegation_run, write_coding_delegation
 from ..wrapper.lifecycle import (
     CodingLifecycleError,
@@ -44,6 +45,7 @@ def cmd_coding_delegate(args: argparse.Namespace) -> int:
             include_message=args.include_message,
             source_metadata=source_metadata,
             executor_target=_resolved_executor(args, default="generic"),
+            context_pack=_context_pack(args),
         )
         runtime_skip_reason = _coding_delegate_runtime_skip_reason(payload) if args.record else ""
         if runtime_skip_reason:
@@ -93,6 +95,13 @@ def _coding_delegate_runtime_skip_reason(payload: dict[str, object]) -> str:
     return ""
 
 
+def _context_pack(args: argparse.Namespace) -> dict[str, object] | None:
+    path = getattr(args, "context_pack", None)
+    if not path:
+        return None
+    return read_handoff_context_pack_file(path)
+
+
 def cmd_coding_lifecycle_start(args: argparse.Namespace) -> int:
     if not args.record:
         raise OmhError("coding lifecycle start requires --record")
@@ -108,6 +117,7 @@ def cmd_coding_lifecycle_start(args: argparse.Namespace) -> int:
             source_metadata=source_metadata,
             limit=args.limit,
             include_message=args.include_message,
+            context_pack=_context_pack(args),
         )
     except (OSError, json.JSONDecodeError, ValueError) as exc:
         raise OmhError(str(exc)) from exc
@@ -200,6 +210,11 @@ def _add_coding_commands(sub) -> None:
         help="Include raw message and expanded delegation prompt in stdout for non-logging wrappers.",
     )
     delegate.add_argument("--record", action="store_true", help="Record a metadata-only coding delegation artifact under .omh/runtime.")
+    delegate.add_argument(
+        "--context-pack",
+        default=None,
+        help="Optional handoff_context_pack/v1 JSON to attach to the prepared executor prompt when conflict-free.",
+    )
     delegate.add_argument("--source-event-id", default="", help="Optional source message/event id to store as metadata.")
     delegate.add_argument("--channel-ref", default="", help="Optional channel reference to store as metadata.")
     delegate.add_argument("--user-ref", default="", help="Optional user reference to store as metadata.")
@@ -229,6 +244,11 @@ def _add_coding_commands(sub) -> None:
         "--include-message",
         action="store_true",
         help="Include raw message and expanded executor prompt in stdout for immediate wrapper dispatch.",
+    )
+    lifecycle_start.add_argument(
+        "--context-pack",
+        default=None,
+        help="Optional handoff_context_pack/v1 JSON to attach to the prepared Codex lifecycle handoff when conflict-free.",
     )
     lifecycle_start.add_argument("--source-event-id", default="", help="Optional source message/event id to store as metadata.")
     lifecycle_start.add_argument("--channel-ref", default="", help="Optional channel reference to store as metadata.")

--- a/src/commands/main.py
+++ b/src/commands/main.py
@@ -35,6 +35,7 @@ from .docs import (
     cmd_harness_validate,
 )
 from .hermes import _add_hermes_commands, cmd_hermes_plan
+from .memory import _add_memory_commands, cmd_memory_apply, cmd_memory_inspect, cmd_memory_pack
 from .playbook import _add_playbook_commands, cmd_playbook_inspect, cmd_playbook_list, cmd_playbook_recommend
 from .runtime import (
     _add_runtime_commands,
@@ -87,6 +88,7 @@ def build_parser() -> argparse.ArgumentParser:
     _add_chat_commands(sub)
     _add_coding_commands(sub)
     _add_hermes_commands(sub)
+    _add_memory_commands(sub)
     _add_runtime_commands(sub)
     _add_state_commands(sub)
     return parser

--- a/src/commands/memory.py
+++ b/src/commands/memory.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from ..installer import OmhError
+from ..memory import (
+    apply_memory_update_batch,
+    build_handoff_context_pack,
+    build_memory_inspection,
+    read_memory_snapshot_file,
+)
+from .common import _paths, _print_json
+
+
+def cmd_memory_inspect(args: argparse.Namespace) -> int:
+    try:
+        inspection = build_memory_inspection(_paths(args), wrapper_snapshot=_read_optional_json(args.fixture))
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        raise OmhError(str(exc)) from exc
+    _print_json(inspection)
+    return 0
+
+
+def cmd_memory_pack(args: argparse.Namespace) -> int:
+    try:
+        paths = _paths(args)
+        inspection = build_memory_inspection(paths, wrapper_snapshot=_read_optional_json(args.fixture))
+        pack = build_handoff_context_pack(
+            paths,
+            inspection=inspection,
+            executor_target=args.executor,
+            session_id=args.session_id,
+        )
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        raise OmhError(str(exc)) from exc
+    _print_json(pack)
+    return 0
+
+
+def cmd_memory_apply(args: argparse.Namespace) -> int:
+    try:
+        batch = _read_required_json(args.batch)
+        result = apply_memory_update_batch(_paths(args), batch, dry_run=args.dry_run)
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        raise OmhError(str(exc)) from exc
+    _print_json(result)
+    return 0
+
+
+def _read_optional_json(path: str | None) -> dict[str, object] | None:
+    if not path:
+        return None
+    return read_memory_snapshot_file(path)
+
+
+def _read_required_json(path: str) -> dict[str, object]:
+    raw = sys.stdin.read() if path == "-" else Path(path).expanduser().read_text(encoding="utf-8")
+    data = json.loads(raw)
+    if not isinstance(data, dict):
+        raise ValueError("memory JSON input must be an object")
+    return data
+
+
+def _add_memory_commands(sub) -> None:
+    memory = sub.add_parser("memory")
+    memory_sub = memory.add_subparsers(dest="memory_command", required=True)
+
+    inspect = memory_sub.add_parser("inspect")
+    inspect.add_argument(
+        "--fixture",
+        default=None,
+        help="Optional memory_snapshot/v1 JSON fixture supplied by a wrapper for deterministic inspection.",
+    )
+    inspect.set_defaults(func=cmd_memory_inspect)
+
+    pack = memory_sub.add_parser("pack")
+    pack.add_argument(
+        "--fixture",
+        default=None,
+        help="Optional memory_snapshot/v1 JSON fixture supplied by a wrapper before packing handoff context.",
+    )
+    pack.add_argument("--executor", default="generic", help="Executor target label to record in the context pack.")
+    pack.add_argument("--session-id", default="", help="Optional wrapper session id to bind to the context pack.")
+    pack.set_defaults(func=cmd_memory_pack)
+
+    apply = memory_sub.add_parser("apply")
+    apply.add_argument(
+        "--batch",
+        required=True,
+        help="Path to memory_update_batch/v1 JSON, or '-' to read from stdin.",
+    )
+    apply.add_argument("--dry-run", action="store_true", help="Validate and preview the batch without writing .omh/memory.")
+    apply.set_defaults(func=cmd_memory_apply)

--- a/src/memory.py
+++ b/src/memory.py
@@ -1,0 +1,896 @@
+from __future__ import annotations
+
+import hashlib
+import re
+from pathlib import Path
+from typing import Any
+
+from .local_store import atomic_write_json, ensure_dir, read_json_object, read_json_object_result, utc_now
+from .paths import OmhPaths
+from .profiles.setup import read_setup_profile
+from .targets import summarize_target_registry
+
+
+MEMORY_SNAPSHOT_SCHEMA_VERSION = "memory_snapshot/v1"
+MEMORY_INSPECTION_SCHEMA_VERSION = "memory_inspection/v1"
+MEMORY_REVIEW_CARD_SCHEMA_VERSION = "memory_review_card/v1"
+HANDOFF_CONTEXT_PACK_SCHEMA_VERSION = "handoff_context_pack/v1"
+MEMORY_UPDATE_BATCH_SCHEMA_VERSION = "memory_update_batch/v1"
+MEMORY_SCOPE_SCHEMA_VERSION = "omh_memory_scope/v1"
+MEMORY_INDEX_SCHEMA_VERSION = "omh_memory_index/v1"
+
+SOURCE_TRUTH_LEVELS = {
+    "runtime_evidence": "observed_evidence",
+    "runtime_state": "runtime_index_state",
+    "wrapper_session": "chat_decision_state",
+    "target_topology": "setup_evidence",
+    "setup_profile": "preference_default",
+    "omh_memory": "approved_context",
+    "wiki_notes": "durable_knowledge",
+    "catalog_hint": "capability_hint",
+    "wrapper_snapshot": "supplied_hint",
+}
+SOURCE_PRECEDENCE = {
+    "runtime_evidence": 100,
+    "wrapper_session": 90,
+    "runtime_state": 85,
+    "target_topology": 80,
+    "setup_profile": 70,
+    "omh_memory": 60,
+    "wiki_notes": 50,
+    "catalog_hint": 40,
+    "wrapper_snapshot": 30,
+}
+ALLOWED_UPDATE_OPS = {"keep", "forget", "update", "change_scope", "dismiss_conflict"}
+ALLOWED_SCOPE_KINDS = {"project", "target", "thread", "run"}
+MEMORY_ACTION_IDS = (
+    "keep_memory",
+    "forget_memory",
+    "update_memory",
+    "change_memory_scope",
+    "apply_memory_updates",
+    "show_memory_status",
+    "cancel",
+)
+_SAFE_REF = re.compile(r"^[A-Za-z0-9_.:-]{1,120}$")
+_PROMPTISH_KEYS = {"message", "prompt", "raw", "text", "body", "content", "prompt_template"}
+_HANDOFF_CONTEXT_PACK_KEYS = {
+    "schema_version",
+    "executor_target",
+    "session_id",
+    "scope",
+    "source_refs",
+    "included_context",
+    "excluded_context",
+    "blocked_by_conflicts",
+    "redaction_policy",
+    "claim_boundary",
+}
+_HANDOFF_CONTEXT_SCOPE_KEYS = {"kind", "ref"}
+_HANDOFF_CONTEXT_SOURCE_REF_KEYS = {"source", "truth_level", "precedence", "item_count"}
+_HANDOFF_CONTEXT_INCLUDED_KEYS = {"item_id", "key", "summary", "source", "truth_level", "scope"}
+_HANDOFF_CONTEXT_EXCLUDED_KEYS = {"item_id", "source", "reason"}
+_HANDOFF_CONTEXT_CONFLICT_KEYS = {
+    "item_id",
+    "key",
+    "severity",
+    "current_value",
+    "preferred_value",
+    "current_source",
+    "preferred_source",
+    "reason",
+    "claim_boundary",
+}
+_HANDOFF_CONTEXT_BLOCKED_KEYS = {"schema_version", "blocked_by_conflicts", "claim_boundary"}
+
+
+def build_memory_inspection(
+    paths: OmhPaths,
+    *,
+    wrapper_snapshot: dict[str, Any] | None = None,
+) -> dict[str, object]:
+    snapshots = _local_snapshots(paths)
+    if wrapper_snapshot:
+        snapshots.append(_normalize_wrapper_snapshot(wrapper_snapshot))
+    conflicts = _detect_conflicts(snapshots)
+    stale_candidates = [conflict for conflict in conflicts if conflict["severity"] in {"warning", "blocker"}]
+    review_items = _review_items(snapshots, conflicts)
+    payload: dict[str, object] = {
+        "schema_version": MEMORY_INSPECTION_SCHEMA_VERSION,
+        "created_at": utc_now(),
+        "snapshots": snapshots,
+        "review_items": review_items,
+        "conflicts": conflicts,
+        "stale_candidates": stale_candidates,
+        "recommended_actions": _recommended_actions(conflicts),
+        "handoff_context_preview": _handoff_preview(snapshots, conflicts),
+        "redaction_policy": "metadata_only",
+        "claim_boundary": (
+            "Memory inspection reviews OMH-local or wrapper-supplied context only; it is not proof that Hermes internal memory was read or changed."
+        ),
+    }
+    payload["review_card"] = build_memory_review_card(payload)
+    return payload
+
+
+def build_memory_review_card(inspection: dict[str, Any]) -> dict[str, object]:
+    review_items = list(inspection.get("review_items", []) if isinstance(inspection.get("review_items"), list) else [])
+    conflicts = list(inspection.get("conflicts", []) if isinstance(inspection.get("conflicts"), list) else [])
+    blocker_count = sum(1 for conflict in conflicts if isinstance(conflict, dict) and conflict.get("severity") == "blocker")
+    headline = "Review Hermes memory assumptions."
+    if blocker_count:
+        headline = f"Review {blocker_count} stale or conflicting memory assumption(s)."
+    return {
+        "schema_version": MEMORY_REVIEW_CARD_SCHEMA_VERSION,
+        "headline": headline,
+        "summary": f"{len(review_items)} memory/context item(s) are available for review; {len(conflicts)} conflict(s) are flagged.",
+        "primary_action": "apply_memory_updates" if review_items else "show_memory_status",
+        "actions": [_memory_action(action_id) for action_id in MEMORY_ACTION_IDS],
+        "review_items": review_items,
+        "conflicts": conflicts,
+        "redaction_policy": "metadata_only",
+        "claim_boundary": "Memory review is not runtime execution evidence and does not mutate opaque Hermes memory.",
+    }
+
+
+def build_handoff_context_pack(
+    paths: OmhPaths,
+    *,
+    inspection: dict[str, Any] | None = None,
+    executor_target: str = "generic",
+    session_id: str = "",
+) -> dict[str, object]:
+    inspection = inspection or build_memory_inspection(paths)
+    conflicts = [conflict for conflict in inspection.get("conflicts", []) if isinstance(conflict, dict)]
+    blocking_conflicts = [conflict for conflict in conflicts if conflict.get("severity") == "blocker"]
+    included: list[dict[str, object]] = []
+    excluded: list[dict[str, object]] = []
+    for snapshot in inspection.get("snapshots", []):
+        if not isinstance(snapshot, dict):
+            continue
+        for item in snapshot.get("items", []) if isinstance(snapshot.get("items"), list) else []:
+            if not isinstance(item, dict):
+                continue
+            if _item_conflicts(item, blocking_conflicts):
+                excluded.append(
+                    {
+                        "item_id": str(item.get("item_id", "")),
+                        "source": str(snapshot.get("source", "")),
+                        "reason": "blocked_by_unresolved_conflict",
+                    }
+                )
+                continue
+            if _is_packable(item, snapshot):
+                included.append(
+                    {
+                        "item_id": str(item.get("item_id", "")),
+                        "key": str(item.get("key", "")),
+                        "summary": str(item.get("summary", "")),
+                        "source": str(snapshot.get("source", "")),
+                        "truth_level": str(snapshot.get("truth_level", "")),
+                        "scope": item.get("scope", snapshot.get("scope", _scope("project", "default"))),
+                    }
+                )
+    return {
+        "schema_version": HANDOFF_CONTEXT_PACK_SCHEMA_VERSION,
+        "executor_target": executor_target,
+        "session_id": session_id,
+        "scope": _scope("project", "default"),
+        "source_refs": _source_refs(inspection),
+        "included_context": included[:12],
+        "excluded_context": excluded,
+        "blocked_by_conflicts": blocking_conflicts,
+        "redaction_policy": "metadata_only",
+        "claim_boundary": "Context packs contain approved summaries only; they are not raw memory dumps or execution evidence.",
+    }
+
+
+def apply_memory_update_batch(paths: OmhPaths, batch: dict[str, Any], *, dry_run: bool = False) -> dict[str, object]:
+    if batch.get("schema_version") != MEMORY_UPDATE_BATCH_SCHEMA_VERSION:
+        raise ValueError("unsupported memory update batch schema")
+    updates = batch.get("updates")
+    if not isinstance(updates, list):
+        raise ValueError("memory update batch requires updates list")
+    result_updates: list[dict[str, object]] = []
+    written_paths: list[str] = []
+    not_applied: list[dict[str, object]] = []
+    touched: dict[Path, dict[str, Any]] = {}
+    base = _memory_root(paths)
+    for update in updates:
+        try:
+            result = _prepare_update(paths, update, touched)
+            result_updates.append(result)
+        except OSError as exc:
+            item_id = str(update.get("item_id", "")) if isinstance(update, dict) else ""
+            not_applied.append({"item_id": item_id, "reason": str(exc)})
+    if not dry_run and not not_applied:
+        ensure_dir(base, private=True)
+        for path, data in touched.items():
+            _assert_under_memory_root(paths, path)
+            atomic_write_json(path, data, private=True)
+            written_paths.append(str(path))
+        _write_memory_index(paths)
+    return {
+        "schema_version": MEMORY_UPDATE_BATCH_SCHEMA_VERSION,
+        "approved_by": str(batch.get("approved_by", "")),
+        "source_surface": str(batch.get("source_surface", "")),
+        "dry_run": dry_run,
+        "applied": bool(updates) and not dry_run and not not_applied,
+        "updates": result_updates,
+        "written_paths": written_paths,
+        "not_applied": not_applied,
+        "claim_boundary": "Approved updates write OMH-local memory only; Hermes internal memory is not mutated.",
+    }
+
+
+def read_memory_snapshot_file(path: str | Path) -> dict[str, Any]:
+    data = read_json_object(Path(path).expanduser().resolve())
+    if not isinstance(data, dict):
+        raise ValueError("memory snapshot fixture must be a JSON object")
+    return data
+
+
+def read_handoff_context_pack_file(path: str | Path) -> dict[str, Any]:
+    data = read_json_object(Path(path).expanduser().resolve())
+    if not isinstance(data, dict):
+        raise ValueError("context pack must be a JSON object")
+    errors = validate_handoff_context_pack(data, require_conflict_free=False, label="context pack")
+    if errors:
+        raise ValueError("; ".join(errors))
+    return data
+
+
+def validate_handoff_context_pack(value: Any, *, require_conflict_free: bool, label: str = "context_pack") -> list[str]:
+    errors: list[str] = []
+    if not isinstance(value, dict):
+        return [f"{label} must be an object"]
+    _validate_allowed_keys(value, _HANDOFF_CONTEXT_PACK_KEYS, errors, label)
+    if value.get("schema_version") != HANDOFF_CONTEXT_PACK_SCHEMA_VERSION:
+        errors.append(f"{label} schema_version must be {HANDOFF_CONTEXT_PACK_SCHEMA_VERSION}")
+    if value.get("redaction_policy") != "metadata_only":
+        errors.append(f"{label} redaction_policy must be metadata_only")
+    if not isinstance(value.get("claim_boundary"), str):
+        errors.append(f"{label} claim_boundary must be a string")
+    if not isinstance(value.get("executor_target"), str):
+        errors.append(f"{label} executor_target must be a string")
+    if not isinstance(value.get("session_id"), str):
+        errors.append(f"{label} session_id must be a string")
+    _validate_context_scope(value.get("scope"), errors, f"{label}.scope")
+    _validate_context_list(value.get("source_refs"), _HANDOFF_CONTEXT_SOURCE_REF_KEYS, errors, f"{label}.source_refs")
+    _validate_context_list(value.get("included_context"), _HANDOFF_CONTEXT_INCLUDED_KEYS, errors, f"{label}.included_context", scope_key="scope")
+    _validate_context_list(value.get("excluded_context"), _HANDOFF_CONTEXT_EXCLUDED_KEYS, errors, f"{label}.excluded_context")
+    _validate_context_list(value.get("blocked_by_conflicts"), _HANDOFF_CONTEXT_CONFLICT_KEYS, errors, f"{label}.blocked_by_conflicts")
+    if require_conflict_free and value.get("blocked_by_conflicts") != []:
+        errors.append(f"{label} must be conflict-free when attached")
+    if _contains_sensitive_text(value):
+        errors.append(f"{label} contains sensitive-looking text and cannot be attached")
+    return errors
+
+
+def validate_handoff_context_blocked(value: Any, *, label: str = "context_pack_blocked") -> list[str]:
+    errors: list[str] = []
+    if not isinstance(value, dict):
+        return [f"{label} must be an object"]
+    _validate_allowed_keys(value, _HANDOFF_CONTEXT_BLOCKED_KEYS, errors, label)
+    if value.get("schema_version") != "handoff_context_blocked/v1":
+        errors.append(f"{label} schema_version must be handoff_context_blocked/v1")
+    _validate_context_list(value.get("blocked_by_conflicts"), _HANDOFF_CONTEXT_CONFLICT_KEYS, errors, f"{label}.blocked_by_conflicts")
+    if not value.get("blocked_by_conflicts"):
+        errors.append(f"{label} requires at least one conflict")
+    if not isinstance(value.get("claim_boundary"), str):
+        errors.append(f"{label} claim_boundary must be a string")
+    if _contains_sensitive_text(value):
+        errors.append(f"{label} contains sensitive-looking text and cannot be attached")
+    return errors
+
+
+def _local_snapshots(paths: OmhPaths) -> list[dict[str, object]]:
+    snapshots: list[dict[str, object]] = []
+    setup = read_setup_profile(paths)
+    if setup:
+        snapshots.append(_setup_snapshot(setup))
+    topology = summarize_target_registry(paths)
+    if topology.get("status") == "available":
+        snapshots.append(_target_snapshot(topology))
+    runtime_state, runtime_error = read_json_object_result(paths.runtime_state_path)
+    if runtime_state:
+        snapshots.append(_runtime_state_snapshot(runtime_state))
+    elif runtime_error:
+        snapshots.append(_snapshot("runtime_state", _scope("project", "default"), [{"item_id": "runtime-state-error", "key": "runtime_state", "summary": runtime_error}]))
+    memory_snapshots = _memory_snapshots(paths)
+    snapshots.extend(memory_snapshots)
+    snapshots.extend(_wrapper_session_snapshots(paths))
+    snapshots.append(_catalog_hint_snapshot())
+    return snapshots
+
+
+def _setup_snapshot(setup: dict[str, Any]) -> dict[str, object]:
+    return _snapshot(
+        "setup_profile",
+        _scope("project", "default"),
+        [
+            {
+                "item_id": "setup-default-executor",
+                "key": "default_executor",
+                "value": str(setup.get("default_executor", "")),
+                "summary": f"default executor: {setup.get('default_executor', '')}",
+            },
+            {
+                "item_id": "setup-dispatch-policy",
+                "key": "dispatch_policy",
+                "value": str(setup.get("dispatch_policy", "")),
+                "summary": f"dispatch policy: {setup.get('dispatch_policy', '')}",
+            },
+        ],
+    )
+
+
+def _target_snapshot(topology: dict[str, Any]) -> dict[str, object]:
+    return _snapshot(
+        "target_topology",
+        _scope("target", str(topology.get("current_target_id") or "default")),
+        [
+            {
+                "item_id": "target-mode",
+                "key": "target_mode",
+                "value": str(topology.get("mode", "")),
+                "summary": f"target mode: {topology.get('mode', '')}; active agents: {topology.get('active_agent_count', 0)}",
+            },
+            {
+                "item_id": "target-active-agent-count",
+                "key": "active_agent_count",
+                "value": str(topology.get("active_agent_count", 0)),
+                "summary": f"active Hermes agents: {topology.get('active_agent_count', 0)}",
+            },
+        ],
+    )
+
+
+def _runtime_state_snapshot(state: dict[str, Any]) -> dict[str, object]:
+    items: list[dict[str, object]] = []
+    last_run = str(state.get("last_run_id", ""))
+    if last_run:
+        items.append({"item_id": "runtime-last-run", "key": "last_run_id", "value": last_run, "summary": f"last runtime run: {last_run}"})
+    last_setup = state.get("last_setup")
+    if isinstance(last_setup, dict):
+        items.append({"item_id": "runtime-last-setup", "key": "last_setup", "summary": f"last setup ok: {bool(last_setup.get('ok', False))}"})
+    return _snapshot("runtime_state", _scope("project", "default"), items)
+
+
+def _memory_snapshots(paths: OmhPaths) -> list[dict[str, object]]:
+    snapshots: list[dict[str, object]] = []
+    for path in _memory_scope_paths(paths):
+        data = read_json_object(path)
+        if not isinstance(data, dict):
+            continue
+        items = []
+        for item_id, item in (data.get("items", {}) if isinstance(data.get("items"), dict) else {}).items():
+            if isinstance(item, dict):
+                items.append(
+                    {
+                        "item_id": str(item_id),
+                        "key": str(item.get("key", item_id)),
+                        "value": str(item.get("value", "")),
+                        "summary": _safe_summary(item),
+                        "scope": data.get("scope", _scope("project", "default")),
+                    }
+                )
+        snapshots.append(_snapshot("omh_memory", data.get("scope", _scope("project", "default")), items))
+    return snapshots
+
+
+def _wrapper_session_snapshots(paths: OmhPaths) -> list[dict[str, object]]:
+    if not paths.runtime_wrapper_sessions_dir.exists():
+        return []
+    snapshots: list[dict[str, object]] = []
+    for session_json in sorted(paths.runtime_wrapper_sessions_dir.glob("*/session.json")):
+        session = read_json_object(session_json)
+        if not isinstance(session, dict):
+            continue
+        session_id = str(session.get("session_id", session_json.parent.name))
+        items = [
+            {
+                "item_id": f"wrapper-session-{session_id}",
+                "key": "wrapper_session_status",
+                "value": str(session.get("status", "")),
+                "summary": f"wrapper session {session_id}: {session.get('status', '')}",
+            }
+        ]
+        selected_executor = str(session.get("selected_executor_profile") or "")
+        if selected_executor:
+            items.append(
+                {
+                    "item_id": f"wrapper-session-{session_id}-executor",
+                    "key": "default_executor",
+                    "value": selected_executor,
+                    "summary": f"session executor: {selected_executor}",
+                }
+            )
+        snapshots.append(_snapshot("wrapper_session", _scope("thread", _stable_ref(session.get("thread_key", session_id))), items))
+    return snapshots
+
+
+def _catalog_hint_snapshot() -> dict[str, object]:
+    return _snapshot(
+        "catalog_hint",
+        _scope("project", "default"),
+        [
+            {
+                "item_id": "catalog-memory-boundary",
+                "key": "memory_boundary",
+                "summary": "OMH can inspect local state and wrapper snapshots; opaque Hermes memory requires explicit source evidence.",
+            }
+        ],
+    )
+
+
+def _normalize_wrapper_snapshot(snapshot: dict[str, Any]) -> dict[str, object]:
+    if snapshot.get("schema_version") != MEMORY_SNAPSHOT_SCHEMA_VERSION:
+        raise ValueError("wrapper memory snapshot schema_version must be memory_snapshot/v1")
+    source = "wrapper_snapshot"
+    scope = _normalize_scope(snapshot.get("scope", _scope("project", "default")))
+    items = [_sanitize_item(item, default_scope=scope) for item in snapshot.get("items", []) if isinstance(item, dict)]
+    return _snapshot(source, scope, items, claim_boundary=str(snapshot.get("claim_boundary", "Wrapper supplied memory candidates are not trusted until reviewed.")))
+
+
+def _snapshot(source: str, scope: Any, items: list[dict[str, object]], *, claim_boundary: str = "") -> dict[str, object]:
+    normalized_scope = _normalize_scope(scope)
+    return {
+        "schema_version": MEMORY_SNAPSHOT_SCHEMA_VERSION,
+        "source": source,
+        "truth_level": SOURCE_TRUTH_LEVELS[source],
+        "precedence": SOURCE_PRECEDENCE[source],
+        "scope": normalized_scope,
+        "items": [_sanitize_item(item, default_scope=normalized_scope) for item in items],
+        "observed_at": utc_now(),
+        "redaction_policy": "metadata_only",
+        "claim_boundary": claim_boundary or _claim_boundary_for_source(source),
+    }
+
+
+def _sanitize_item(item: dict[str, Any], *, default_scope: dict[str, str]) -> dict[str, object]:
+    item_id = str(item.get("item_id") or _stable_ref(item.get("key", "item")))
+    key = str(item.get("key", item_id))
+    summary = _safe_summary(item)
+    sanitized: dict[str, object] = {
+        "item_id": item_id,
+        "key": key,
+        "summary": summary,
+        "scope": _normalize_scope(item.get("scope", default_scope)),
+        "sensitive": bool(item.get("sensitive", False)),
+    }
+    value = item.get("value")
+    if _safe_to_expose_value(key, value, item):
+        sanitized["value"] = str(value)
+    return sanitized
+
+
+def _safe_summary(item: dict[str, Any]) -> str:
+    summary = str(item.get("summary", ""))
+    if summary:
+        return _redact(summary)
+    key = str(item.get("key", item.get("item_id", "item")))
+    value = str(item.get("value", ""))
+    if key in _PROMPTISH_KEYS or item.get("sensitive"):
+        return f"{key}: redacted"
+    return _redact(f"{key}: {value}")[:240]
+
+
+def _safe_to_expose_value(key: str, value: Any, item: dict[str, Any]) -> bool:
+    if value is None or item.get("sensitive"):
+        return False
+    text = str(value)
+    if key in _PROMPTISH_KEYS:
+        return False
+    if _looks_sensitive(text):
+        return False
+    return len(text) <= 240
+
+
+def _redact(value: str) -> str:
+    if _looks_sensitive(value):
+        return "[redacted]"
+    return value[:240]
+
+
+def _looks_sensitive(value: str) -> bool:
+    lowered = value.lower()
+    return any(marker in lowered for marker in ("secret", "token", "password", "private-key", "api_key", "apikey"))
+
+
+def _validate_allowed_keys(value: dict[str, Any], allowed: set[str], errors: list[str], label: str) -> None:
+    extra_keys = sorted(set(value) - allowed)
+    if extra_keys:
+        errors.append(f"{label} has unsupported keys: {extra_keys}")
+
+
+def _validate_context_scope(value: Any, errors: list[str], label: str) -> None:
+    if not isinstance(value, dict):
+        errors.append(f"{label} must be an object")
+        return
+    _validate_allowed_keys(value, _HANDOFF_CONTEXT_SCOPE_KEYS, errors, label)
+    kind = value.get("kind")
+    ref = value.get("ref")
+    if not isinstance(kind, str) or not kind:
+        errors.append(f"{label}.kind must be a non-empty string")
+    if not isinstance(ref, str) or not ref:
+        errors.append(f"{label}.ref must be a non-empty string")
+
+
+def _validate_context_list(
+    value: Any,
+    allowed: set[str],
+    errors: list[str],
+    label: str,
+    *,
+    scope_key: str | None = None,
+) -> None:
+    if not isinstance(value, list):
+        errors.append(f"{label} must be a list")
+        return
+    for index, item in enumerate(value):
+        item_label = f"{label}[{index}]"
+        if not isinstance(item, dict):
+            errors.append(f"{item_label} must be an object")
+            continue
+        _validate_allowed_keys(item, allowed, errors, item_label)
+        for key, nested in item.items():
+            nested_label = f"{item_label}.{key}"
+            if scope_key and key == scope_key:
+                _validate_context_scope(nested, errors, nested_label)
+            elif isinstance(nested, (str, int, bool)) or nested is None:
+                continue
+            else:
+                errors.append(f"{nested_label} must be scalar metadata")
+
+
+def _contains_sensitive_text(value: Any) -> bool:
+    if isinstance(value, dict):
+        return any(_contains_sensitive_text(item) for item in value.values())
+    if isinstance(value, list):
+        return any(_contains_sensitive_text(item) for item in value)
+    if isinstance(value, str):
+        return _looks_sensitive(value)
+    return False
+
+
+def _detect_conflicts(snapshots: list[dict[str, object]]) -> list[dict[str, object]]:
+    conflicts: list[dict[str, object]] = []
+    values = _values_by_key(snapshots)
+    conflicts.extend(_pairwise_conflict(values, "default_executor", preferred_source="setup_profile"))
+    conflicts.extend(_pairwise_conflict(values, "target_mode", preferred_source="target_topology"))
+    if any(value["key"] == "verification_status" and str(value.get("value", "")).lower() in {"verified", "passed"} for value in values):
+        has_runtime_verification = any(value["source"] == "runtime_evidence" and value["key"] in {"verification_status", "verification_observed"} for value in values)
+        if not has_runtime_verification:
+            conflicts.append(
+                {
+                    "item_id": "verification-status-conflict",
+                    "key": "verification_status",
+                    "severity": "blocker",
+                    "preferred_source": "runtime_evidence",
+                    "reason": "Remembered verification cannot be used as runtime evidence without a run-ledger verification record.",
+                    "claim_boundary": "Remembered verification is not observed verification evidence.",
+                }
+            )
+    return conflicts
+
+
+def _pairwise_conflict(values: list[dict[str, Any]], key: str, *, preferred_source: str) -> list[dict[str, object]]:
+    keyed = [value for value in values if value["key"] == key and value.get("value") not in {None, ""}]
+    preferred = [value for value in keyed if value["source"] == preferred_source]
+    if not preferred:
+        return []
+    preferred_value = str(preferred[0].get("value", ""))
+    conflicts = []
+    for value in keyed:
+        if value["source"] == preferred_source:
+            continue
+        if str(value.get("value", "")) and str(value.get("value", "")) != preferred_value:
+            conflicts.append(
+                {
+                    "item_id": str(value.get("item_id", "")),
+                    "key": key,
+                    "severity": "blocker",
+                    "current_value": str(value.get("value", "")),
+                    "preferred_value": preferred_value,
+                    "current_source": value["source"],
+                    "preferred_source": preferred_source,
+                    "reason": f"{key} from {value['source']} conflicts with {preferred_source}.",
+                    "claim_boundary": "Conflicting memory-like context must be reviewed before it is reused in a handoff.",
+                }
+            )
+    return conflicts
+
+
+def _values_by_key(snapshots: list[dict[str, object]]) -> list[dict[str, Any]]:
+    values: list[dict[str, Any]] = []
+    for snapshot in snapshots:
+        source = str(snapshot.get("source", ""))
+        for item in snapshot.get("items", []) if isinstance(snapshot.get("items"), list) else []:
+            if not isinstance(item, dict):
+                continue
+            values.append({**item, "source": source, "precedence": snapshot.get("precedence", 0)})
+    return values
+
+
+def _review_items(snapshots: list[dict[str, object]], conflicts: list[dict[str, object]]) -> list[dict[str, object]]:
+    conflict_ids = {str(conflict.get("item_id", "")) for conflict in conflicts}
+    synthetic_conflict_keys = {
+        str(conflict.get("key", ""))
+        for conflict in conflicts
+        if str(conflict.get("item_id", "")).endswith("-conflict") and str(conflict.get("key", ""))
+    }
+    items: list[dict[str, object]] = []
+    for snapshot in snapshots:
+        for item in snapshot.get("items", []) if isinstance(snapshot.get("items"), list) else []:
+            if not isinstance(item, dict):
+                continue
+            item_id = str(item.get("item_id", ""))
+            blocked = item_id in conflict_ids or str(item.get("key", "")) in synthetic_conflict_keys
+            items.append(
+                {
+                    "item_id": item_id,
+                    "source": snapshot.get("source", ""),
+                    "truth_level": snapshot.get("truth_level", ""),
+                    "key": item.get("key", ""),
+                    "summary": item.get("summary", ""),
+                    "scope": item.get("scope", snapshot.get("scope", _scope("project", "default"))),
+                    "suggested_action": "update_memory" if blocked else "keep_memory",
+                    "blocked": blocked,
+                }
+            )
+    return items
+
+
+def _recommended_actions(conflicts: list[dict[str, object]]) -> list[str]:
+    if conflicts:
+        return ["update_memory", "change_memory_scope", "dismiss_conflict", "apply_memory_updates"]
+    return ["keep_memory", "show_memory_status"]
+
+
+def _handoff_preview(snapshots: list[dict[str, object]], conflicts: list[dict[str, object]]) -> dict[str, object]:
+    return {
+        "schema_version": HANDOFF_CONTEXT_PACK_SCHEMA_VERSION,
+        "included_candidate_count": sum(len(snapshot.get("items", [])) for snapshot in snapshots if isinstance(snapshot.get("items"), list)),
+        "blocked_by_conflict_count": len(conflicts),
+        "claim_boundary": "Preview only; use handoff_context_pack/v1 before embedding context in a handoff.",
+    }
+
+
+def _prepare_update(paths: OmhPaths, update: Any, touched: dict[Path, dict[str, Any]]) -> dict[str, object]:
+    if not isinstance(update, dict):
+        raise ValueError("memory update must be an object")
+    op = str(update.get("op", ""))
+    if op not in ALLOWED_UPDATE_OPS:
+        raise ValueError(f"unsupported memory update op: {op}")
+    item_id = str(update.get("item_id", ""))
+    if not _SAFE_REF.match(item_id):
+        raise ValueError(f"unsafe memory item id: {item_id!r}")
+    scope = _scope_for_update(update, "scope")
+    path = _scope_path(paths, scope)
+    data = touched.setdefault(path, _read_scope_file(path, scope))
+    status = "prepared"
+    if op in {"keep", "update", "dismiss_conflict"}:
+        status = _upsert_item(data, item_id, update, op=op)
+    elif op == "forget":
+        status = _forget_item(data, item_id, update)
+    elif op == "change_scope":
+        from_scope = _scope_for_update(update, "from_scope")
+        to_scope = _scope_for_update(update, "to_scope")
+        from_path = _scope_path(paths, from_scope)
+        to_path = _scope_path(paths, to_scope)
+        from_data = touched.setdefault(from_path, _read_scope_file(from_path, from_scope))
+        to_data = touched.setdefault(to_path, _read_scope_file(to_path, to_scope))
+        status = _move_item(from_data, to_data, item_id, update)
+        path = to_path
+    return {"item_id": item_id, "op": op, "scope": scope, "status": status, "path": str(path)}
+
+
+def _upsert_item(data: dict[str, Any], item_id: str, update: dict[str, Any], *, op: str) -> str:
+    items = data.setdefault("items", {})
+    existing = items.get(item_id)
+    value = str(update.get("value", existing.get("value", "") if isinstance(existing, dict) else ""))
+    key = str(update.get("key", item_id))
+    item = {
+        "item_id": item_id,
+        "key": key,
+        "summary": _safe_summary(update),
+        "reason": str(update.get("reason", "")),
+        "operation": op,
+        "updated_at": utc_now(),
+    }
+    if _safe_to_expose_value(key, value, update):
+        item["value"] = value
+    if op == "keep":
+        item["confirmed_at"] = item["updated_at"]
+    if op == "dismiss_conflict":
+        item["dismissed_at"] = item["updated_at"]
+    if isinstance(existing, dict) and existing.get("value", "") == item.get("value", "") and existing.get("summary") == item["summary"]:
+        items[item_id] = {**existing, **item}
+        return "noop"
+    items[item_id] = item
+    return "prepared"
+
+
+def _forget_item(data: dict[str, Any], item_id: str, update: dict[str, Any]) -> str:
+    items = data.setdefault("items", {})
+    tombstones = data.setdefault("tombstones", {})
+    existed = item_id in items
+    if existed:
+        items.pop(item_id)
+    tombstones[item_id] = {
+        "item_id": item_id,
+        "reason": str(update.get("reason", "")),
+        "tombstoned_at": utc_now(),
+    }
+    return "prepared" if existed else "noop"
+
+
+def _move_item(from_data: dict[str, Any], to_data: dict[str, Any], item_id: str, update: dict[str, Any]) -> str:
+    from_items = from_data.setdefault("items", {})
+    to_items = to_data.setdefault("items", {})
+    item = from_items.pop(item_id, None)
+    if not isinstance(item, dict):
+        value = str(update.get("value", ""))
+        key = str(update.get("key", item_id))
+        item = {
+            "item_id": item_id,
+            "key": key,
+            "summary": _safe_summary(update),
+        }
+        if _safe_to_expose_value(key, value, update):
+            item["value"] = value
+    if to_items.get(item_id) == item:
+        return "noop"
+    to_items[item_id] = {**item, "moved_at": utc_now(), "reason": str(update.get("reason", ""))}
+    return "prepared"
+
+
+def _scope_for_update(update: dict[str, Any], key: str) -> dict[str, str]:
+    scope = _normalize_scope(update.get(key, update.get("scope", _scope("project", "default"))))
+    if scope["kind"] not in ALLOWED_SCOPE_KINDS:
+        raise ValueError(f"unsupported memory scope kind: {scope['kind']}")
+    if not _SAFE_REF.match(scope["ref"]):
+        raise ValueError(f"unsafe memory scope ref: {scope['ref']!r}")
+    return scope
+
+
+def _read_scope_file(path: Path, scope: dict[str, str]) -> dict[str, Any]:
+    data = read_json_object(path)
+    if isinstance(data, dict):
+        return data
+    return {
+        "schema_version": MEMORY_SCOPE_SCHEMA_VERSION,
+        "scope": scope,
+        "items": {},
+        "tombstones": {},
+        "updated_at": utc_now(),
+    }
+
+
+def _write_memory_index(paths: OmhPaths) -> None:
+    ensure_dir(paths.memory_dir, private=True)
+    scopes = [str(path.relative_to(paths.memory_dir)) for path in _memory_scope_paths(paths)]
+    atomic_write_json(
+        paths.memory_index_path,
+        {
+            "schema_version": MEMORY_INDEX_SCHEMA_VERSION,
+            "updated_at": utc_now(),
+            "scope_files": sorted(scopes),
+            "claim_boundary": "OMH local memory only; this index is not Hermes internal memory.",
+        },
+        private=True,
+    )
+
+
+def _memory_scope_paths(paths: OmhPaths) -> list[Path]:
+    scopes_dir = paths.memory_dir / "scopes"
+    if not scopes_dir.exists():
+        return []
+    safe_paths: list[Path] = []
+    for path in scopes_dir.rglob("*.json"):
+        if path.is_symlink() or not path.is_file():
+            continue
+        _assert_under_memory_root(paths, path)
+        safe_paths.append(path)
+    return sorted(safe_paths)
+
+
+def _scope_path(paths: OmhPaths, scope: dict[str, str]) -> Path:
+    kind = scope["kind"]
+    ref = scope["ref"]
+    if kind == "project":
+        relative = Path("scopes/project.json")
+    else:
+        relative = Path("scopes") / f"{kind}s" / f"{ref}.json"
+    path = paths.memory_dir / relative
+    _assert_under_memory_root(paths, path)
+    return path
+
+
+def _assert_under_memory_root(paths: OmhPaths, path: Path) -> None:
+    root = _memory_root(paths)
+    candidate = path.resolve(strict=False)
+    if root != candidate and root not in candidate.parents:
+        raise ValueError(f"memory write path escapes .omh/memory: {path}")
+
+
+def _memory_root(paths: OmhPaths) -> Path:
+    return paths.memory_dir.resolve(strict=False)
+
+
+def _normalize_scope(value: Any) -> dict[str, str]:
+    if isinstance(value, dict):
+        kind = str(value.get("kind", "project") or "project")
+        ref = str(value.get("ref", "default") or "default")
+        return _scope(kind, ref)
+    if isinstance(value, str) and value:
+        return _scope("project", value)
+    return _scope("project", "default")
+
+
+def _scope(kind: str, ref: str) -> dict[str, str]:
+    return {"kind": kind, "ref": ref}
+
+
+def _source_refs(inspection: dict[str, Any]) -> list[dict[str, object]]:
+    refs = []
+    for snapshot in inspection.get("snapshots", []) if isinstance(inspection.get("snapshots"), list) else []:
+        if isinstance(snapshot, dict):
+            refs.append(
+                {
+                    "source": str(snapshot.get("source", "")),
+                    "truth_level": str(snapshot.get("truth_level", "")),
+                    "precedence": int(snapshot.get("precedence", 0) or 0),
+                    "item_count": len(snapshot.get("items", [])) if isinstance(snapshot.get("items"), list) else 0,
+                }
+            )
+    return refs
+
+
+def _item_conflicts(item: dict[str, Any], conflicts: list[dict[str, object]]) -> bool:
+    item_id = str(item.get("item_id", ""))
+    key = str(item.get("key", ""))
+    return any(conflict.get("item_id") == item_id or conflict.get("key") == key for conflict in conflicts)
+
+
+def _is_packable(item: dict[str, Any], snapshot: dict[str, Any]) -> bool:
+    source = str(snapshot.get("source", ""))
+    if source == "wrapper_snapshot":
+        return False
+    key = str(item.get("key", ""))
+    return key not in {"verification_status"} and bool(item.get("summary"))
+
+
+def _memory_action(action_id: str) -> dict[str, object]:
+    labels = {
+        "keep_memory": "Keep",
+        "forget_memory": "Forget",
+        "update_memory": "Update",
+        "change_memory_scope": "Change scope",
+        "apply_memory_updates": "Apply updates",
+        "show_memory_status": "Show memory status",
+        "cancel": "Cancel",
+    }
+    return {"id": action_id, "label": labels[action_id], "enabled": True}
+
+
+def _claim_boundary_for_source(source: str) -> str:
+    return {
+        "runtime_evidence": "Runtime ledger evidence is the source of execution/review/CI/merge claims.",
+        "runtime_state": "Runtime state is an index of local OMH activity, not execution/review/CI/merge evidence.",
+        "wrapper_session": "Wrapper sessions own chat continuity and plan decisions only.",
+        "target_topology": "Target topology is setup evidence only.",
+        "setup_profile": "Setup profile records defaults and preferences only.",
+        "omh_memory": "OMH memory is user-approved local context only.",
+        "wiki_notes": "Wiki/notes are durable knowledge and can become stale.",
+        "catalog_hint": "Catalog hints describe capabilities, not observed runtime behavior.",
+        "wrapper_snapshot": "Wrapper snapshots are supplied hints until reviewed.",
+    }[source]
+
+
+def _stable_ref(value: Any) -> str:
+    text = str(value or "default")
+    if _SAFE_REF.match(text):
+        return text
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]

--- a/src/paths.py
+++ b/src/paths.py
@@ -35,6 +35,14 @@ class OmhPaths:
         return self.runtime_dir / "wrapper_sessions"
 
     @property
+    def memory_dir(self) -> Path:
+        return self.omh_home / "memory"
+
+    @property
+    def memory_index_path(self) -> Path:
+        return self.memory_dir / "index.json"
+
+    @property
     def setup_profile_path(self) -> Path:
         return self.omh_home / "setup-profile.json"
 

--- a/src/runtime/records.py
+++ b/src/runtime/records.py
@@ -7,6 +7,7 @@ from ..coding_contracts import CODING_EXECUTOR_HANDOFF_TARGETS, EXECUTOR_HANDOFF
 from ..executors import DISPATCH_POLICIES, EXECUTOR_PROFILES, WORK_OWNER_MODES
 from ..harness_quality import HARNESS_QUALITY_KEYS, HARNESS_QUALITY_SCHEMA_VERSION
 from ..local_store import utc_now
+from ..memory import validate_handoff_context_blocked, validate_handoff_context_pack
 
 
 SCHEMA_VERSION = 1
@@ -107,6 +108,8 @@ CODING_EXECUTOR_HANDOFF_KEYS = (
     "report_contract",
     "evidence_contract",
     "harness_quality",
+    "context_pack",
+    "context_pack_blocked",
 )
 CODING_PROMPT_HANDOFF_KEYS = (
     "schema_version",
@@ -125,6 +128,8 @@ CODING_PROMPT_HANDOFF_KEYS = (
     "review",
     "evidence_contract",
     "harness_quality",
+    "context_pack",
+    "context_pack_blocked",
 )
 CODING_PROMPT_HANDOFF_INVOCATION_KEYS = (
     "mode",
@@ -652,6 +657,12 @@ def _compact_executor_handoff(value: Any) -> dict[str, Any]:
             "workflow": _optional_string(review.get("workflow")),
             "evidence_required": str(review.get("evidence_required", "")),
         }
+    context_pack = _compact_context_pack(value.get("context_pack"))
+    if context_pack:
+        compact["context_pack"] = context_pack
+    context_pack_blocked = _compact_context_pack_blocked(value.get("context_pack_blocked"))
+    if context_pack_blocked:
+        compact["context_pack_blocked"] = context_pack_blocked
     return compact
 
 
@@ -684,6 +695,12 @@ def _compact_prompt_handoff(value: Any) -> dict[str, Any]:
             "workflow": _optional_string(review.get("workflow")),
             "evidence_required": str(review.get("evidence_required", "")),
         }
+    context_pack = _compact_context_pack(value.get("context_pack"))
+    if context_pack:
+        compact["context_pack"] = context_pack
+    context_pack_blocked = _compact_context_pack_blocked(value.get("context_pack_blocked"))
+    if context_pack_blocked:
+        compact["context_pack_blocked"] = context_pack_blocked
     return compact
 
 
@@ -741,6 +758,68 @@ def _compact_evidence_contract(value: Any) -> dict[str, list[str]]:
         "prepared_is_not": _compact_string_list(value.get("prepared_is_not", [])),
         "observed_required_for": _compact_string_list(value.get("observed_required_for", [])),
     }
+
+
+def _compact_context_pack(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    return {
+        "schema_version": str(value.get("schema_version", "")),
+        "executor_target": str(value.get("executor_target", "")),
+        "session_id": str(value.get("session_id", "")),
+        "scope": _compact_context_scope(value.get("scope", {})),
+        "source_refs": _compact_context_dict_list(value.get("source_refs", [])),
+        "included_context": _compact_context_dict_list(value.get("included_context", [])),
+        "excluded_context": _compact_context_dict_list(value.get("excluded_context", [])),
+        "blocked_by_conflicts": _compact_context_dict_list(value.get("blocked_by_conflicts", [])),
+        "redaction_policy": str(value.get("redaction_policy", "")),
+        "claim_boundary": str(value.get("claim_boundary", "")),
+    }
+
+
+def _compact_context_pack_blocked(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    return {
+        "schema_version": str(value.get("schema_version", "")),
+        "blocked_by_conflicts": _compact_context_dict_list(value.get("blocked_by_conflicts", [])),
+        "claim_boundary": str(value.get("claim_boundary", "")),
+    }
+
+
+def _compact_context_scope(value: Any) -> dict[str, str]:
+    if not isinstance(value, dict):
+        return {}
+    return {"kind": str(value.get("kind", "")), "ref": str(value.get("ref", ""))}
+
+
+def _compact_context_dict_list(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    compact: list[dict[str, Any]] = []
+    for item in value:
+        if not isinstance(item, dict):
+            continue
+        compact.append(_stringify_context_dict(item))
+    return compact
+
+
+def _stringify_context_dict(value: dict[str, Any]) -> dict[str, Any]:
+    compact: dict[str, Any] = {}
+    for key, item in value.items():
+        if isinstance(item, dict):
+            compact[str(key)] = _stringify_context_dict(item)
+        elif isinstance(item, list):
+            compact[str(key)] = _compact_string_list(item)
+        elif isinstance(item, bool):
+            compact[str(key)] = item
+        elif isinstance(item, int):
+            compact[str(key)] = item
+        elif item is None:
+            compact[str(key)] = ""
+        else:
+            compact[str(key)] = str(item)
+    return compact
 
 
 def _require(condition: bool, errors: list[str], message: str) -> None:
@@ -1246,6 +1325,7 @@ def validate_coding_executor_handoff(handoff: Any) -> list[str]:
                         _require(isinstance(item, str), errors, f"coding_delegation executor_handoff {key}.{nested_key}[{index}] must be a string")
     if "harness_quality" in handoff:
         errors.extend(validate_harness_quality(handoff["harness_quality"], "coding_delegation executor_handoff harness_quality"))
+    errors.extend(validate_handoff_context_pack_fields(handoff, "coding_delegation executor_handoff"))
     return errors
 
 
@@ -1326,6 +1406,19 @@ def validate_coding_prompt_handoff(handoff: Any) -> list[str]:
                     _require(isinstance(item, str), errors, f"coding_delegation prompt_handoff evidence_contract.{nested_key}[{index}] must be a string")
     if "harness_quality" in handoff:
         errors.extend(validate_harness_quality(handoff["harness_quality"], "coding_delegation prompt_handoff harness_quality"))
+    errors.extend(validate_handoff_context_pack_fields(handoff, "coding_delegation prompt_handoff"))
+    return errors
+
+
+def validate_handoff_context_pack_fields(handoff: dict[str, Any], label: str) -> list[str]:
+    errors: list[str] = []
+    has_pack = "context_pack" in handoff
+    has_blocked = "context_pack_blocked" in handoff
+    _require(not (has_pack and has_blocked), errors, f"{label} must not contain both context_pack and context_pack_blocked")
+    if has_pack:
+        errors.extend(validate_handoff_context_pack(handoff.get("context_pack"), require_conflict_free=True, label=f"{label} context_pack"))
+    if has_blocked:
+        errors.extend(validate_handoff_context_blocked(handoff.get("context_pack_blocked"), label=f"{label} context_pack_blocked"))
     return errors
 
 

--- a/src/skills/render.py
+++ b/src/skills/render.py
@@ -49,6 +49,18 @@ TARGET_TOPOLOGY_REFERENCE_CONTEXT = (
     "current Hermes target/thread, adapt only the steps that benefit from multiple targets, and fall "
     "back to single-target behavior when the active agent count is one."
 )
+MEMORY_REVIEW_SCHEMA = "memory_review_card/v1"
+HANDOFF_CONTEXT_PACK_SCHEMA = "handoff_context_pack/v1"
+MEMORY_CONTEXT_SKILL_CONTRACT = (
+    f"When wrapper metadata includes `{MEMORY_REVIEW_SCHEMA}` or `{HANDOFF_CONTEXT_PACK_SCHEMA}`, "
+    "treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context "
+    "summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or "
+    "changed."
+)
+MEMORY_CONTEXT_REFERENCE_CONTEXT = (
+    f"`{MEMORY_REVIEW_SCHEMA}` is separate from `status_card/v1`; `{HANDOFF_CONTEXT_PACK_SCHEMA}` "
+    "may be attached to executor handoffs only when unresolved conflicts are absent."
+)
 
 
 def _target_topology_router_section() -> str:
@@ -68,6 +80,10 @@ def _target_topology_skill_contract_bullets() -> str:
             f"- {TARGET_TOPOLOGY_SKILL_CHANGE_CONTRACT}",
         ]
     )
+
+
+def _memory_context_skill_contract_bullets() -> str:
+    return f"- {MEMORY_CONTEXT_SKILL_CONTRACT}"
 
 
 def _frontmatter(name: str, description: str) -> str:
@@ -230,6 +246,10 @@ The command returns a `coding_delegation/v1` payload with a recommended workflow
 
 With `--record`, `omh` creates a `.omh/runtime/runs/<run-id>/` prepared runtime run only for a Codex-selected delegate payload that contains a real `executor_handoff`. Executor-choice, prompt-only, retained-Hermes, clarify, and fallback responses return `runtime.recorded=false` and must stay wrapper/session state rather than prepared run evidence. For Codex runs, `coding_delegation.json` is paired with `run.json` marked `status: prepared`, `artifact_kind: prepared_coding_delegation`, `phase: prepared`, and `observation_status: prepared_not_observed`. These artifacts store only allowlisted metadata, acceptance criteria, verification expectations, recommendation evidence, source references, `message_sha256`, and `message_length`. They mean a coding handoff was prepared; they do not mean Hermes executed the work or that a specialist lane was observed.
 
+## Wrapper Backend Memory Context
+
+Wrappers can run `omh memory inspect`, `omh memory pack`, and `omh memory apply` to review OMH-local or wrapper-supplied context before preparing a handoff. This emits `{MEMORY_REVIEW_SCHEMA}` and `{HANDOFF_CONTEXT_PACK_SCHEMA}` artifacts only; it does not read or mutate opaque Hermes internal memory. A context pack may be attached to an executor handoff only when unresolved conflicts are absent.
+
 ## Hermes-Facing Planning
 
 For planning-shaped requests, wrappers or operators can run `omh hermes plan` to create a deterministic `hermes_plan/v1` planning scaffold. In normal chat, Hermes can express this plan directly through the installed skill guidance:
@@ -340,6 +360,7 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Use Hermes-native tools, file operations, and subagent/delegation features when available.
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
 {_target_topology_skill_contract_bullets()}
+{_memory_context_skill_contract_bullets()}
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers or explicit checklists,
   - question renderers -> one concise question in the current Hermes interface,
@@ -376,6 +397,7 @@ def workflow_reference_markdown() -> str:
         "Workflow names are kept for compatibility, but each skill declares advisory wrapper guidance for whether Hermes should retain the work directly, ask the user to choose an executor, or prepare a coding handoff for coding-heavy execution.",
         "",
         TARGET_TOPOLOGY_REFERENCE_CONTEXT,
+        MEMORY_CONTEXT_REFERENCE_CONTEXT,
         "",
         "## Skills",
         "",

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -28,6 +28,12 @@ VISIBLE_ACTIONS = (
     "show_status",
     "show_target_status",
     "apply_target_change",
+    "keep_memory",
+    "forget_memory",
+    "update_memory",
+    "change_memory_scope",
+    "apply_memory_updates",
+    "show_memory_status",
     "cancel",
 )
 _ROUTE_TO_MODE = {"dispatch": "plan", "clarify": "clarify", "fallback": "clarify"}

--- a/src/wrapper/lifecycle.py
+++ b/src/wrapper/lifecycle.py
@@ -31,6 +31,7 @@ def start_codex_delegation_lifecycle(
     source_metadata: dict[str, str] | None = None,
     limit: int = 3,
     include_message: bool = False,
+    context_pack: dict[str, object] | None = None,
 ) -> dict[str, object]:
     payload = build_coding_delegation_payload(
         message,
@@ -39,6 +40,7 @@ def start_codex_delegation_lifecycle(
         include_message=include_message,
         source_metadata=source_metadata,
         executor_target="codex",
+        context_pack=context_pack,
     )
     delegation = payload.get("delegation")
     if not isinstance(delegation, dict):

--- a/src/wrapper/sessions.py
+++ b/src/wrapper/sessions.py
@@ -188,6 +188,7 @@ def prepare_wrapper_session_handoff(
     include_message: bool = False,
     source_metadata: dict[str, str] | None = None,
     executor_target: str | None = None,
+    context_pack: dict[str, object] | None = None,
 ) -> dict[str, object]:
     session = _existing_session(paths, session_id)
     if session["status"] == "cancelled":
@@ -231,6 +232,7 @@ def prepare_wrapper_session_handoff(
             include_message=include_message,
             source_metadata=source_metadata,
             executor_target=selected_executor,
+            context_pack=context_pack,
         )
     message = extract_message_text(event_or_message)
     metadata = _source_metadata(event_or_message)
@@ -256,6 +258,7 @@ def prepare_wrapper_session_handoff(
         source_metadata=metadata,
         limit=limit,
         include_message=include_message,
+        context_pack=context_pack,
     )
     run_id = str(lifecycle["run"]["run_id"])
     linked = _link_prepared_handoff_run(paths, session, run_id, recovered=False)
@@ -273,6 +276,7 @@ def _prepare_prompt_only_session_handoff(
     include_message: bool,
     source_metadata: dict[str, str] | None,
     executor_target: str,
+    context_pack: dict[str, object] | None,
 ) -> dict[str, object]:
     message = extract_message_text(event_or_message)
     metadata = _source_metadata(event_or_message)
@@ -286,6 +290,7 @@ def _prepare_prompt_only_session_handoff(
         include_message=include_message,
         source_metadata=metadata,
         executor_target=executor_target,
+        context_pack=context_pack,
     )
     prompt_handoff = payload.get("prompt_handoff")
     if not isinstance(prompt_handoff, dict):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -29,6 +29,103 @@ class CliTests(unittest.TestCase):
         payload = json.loads(result.stdout)
         self.assertEqual(payload["query"], "risky refactor")
 
+    def test_memory_cli_inspects_packs_and_applies_review_updates(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / ".omh"
+            hermes_home = root / ".hermes"
+            fixture = root / "memory-snapshot.json"
+            fixture.write_text(
+                json.dumps(
+                    {
+                        "schema_version": "memory_snapshot/v1",
+                        "source": "wrapper_snapshot",
+                        "scope": {"kind": "project", "ref": "default"},
+                        "items": [
+                            {
+                                "item_id": "executor-pref",
+                                "key": "default_executor",
+                                "value": "codex",
+                                "summary": "Use Codex by default",
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            status, stdout, stderr = run_cli(["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "memory", "inspect", "--fixture", str(fixture)])
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            inspection = json.loads(stdout)
+            self.assertEqual(inspection["schema_version"], "memory_inspection/v1")
+            self.assertEqual(inspection["review_card"]["schema_version"], "memory_review_card/v1")
+
+            batch_path = root / "memory-batch.json"
+            batch_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": "memory_update_batch/v1",
+                        "updates": [
+                            {
+                                "op": "update",
+                                "item_id": "executor-pref",
+                                "scope": {"kind": "project", "ref": "default"},
+                                "key": "default_executor",
+                                "value": "codex",
+                                "summary": "Use Codex by default",
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            status, stdout, stderr = run_cli(["--omh-home", str(omh_home), "memory", "apply", "--batch", str(batch_path), "--dry-run"])
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            dry_run = json.loads(stdout)
+            self.assertEqual(dry_run["schema_version"], "memory_update_batch/v1")
+            self.assertFalse(dry_run["applied"])
+            self.assertFalse((omh_home / "memory").exists())
+
+            self.assertEqual(run_cli(["--omh-home", str(omh_home), "memory", "apply", "--batch", str(batch_path)])[0], 0)
+
+            status, stdout, stderr = run_cli(["--omh-home", str(omh_home), "memory", "pack", "--executor", "codex"])
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            context_pack = json.loads(stdout)
+            self.assertEqual(context_pack["schema_version"], "handoff_context_pack/v1")
+            self.assertEqual(context_pack["blocked_by_conflicts"], [])
+            self.assertTrue(context_pack["included_context"])
+
+            pack_path = root / "handoff-context.json"
+            pack_path.write_text(json.dumps(context_pack), encoding="utf-8")
+            status, stdout, stderr = run_cli(
+                [
+                    "--omh-home",
+                    str(omh_home),
+                    "coding",
+                    "delegate",
+                    "--source",
+                    "discord",
+                    "--executor",
+                    "codex",
+                    "--context-pack",
+                    str(pack_path),
+                    "risky",
+                    "refactor",
+                ]
+            )
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            delegation = json.loads(stdout)
+            self.assertEqual(delegation["executor_handoff"]["context_pack"]["schema_version"], "handoff_context_pack/v1")
+
     def test_recommend_risky_refactor_includes_cleanup_workflow(self) -> None:
         status, stdout, stderr = run_cli(["recommend", "risky", "refactor"])
 

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,0 +1,305 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.coding_delegation import build_coding_delegation_payload
+from omh.memory import (
+    apply_memory_update_batch,
+    build_handoff_context_pack,
+    build_memory_inspection,
+    build_memory_review_card,
+    read_handoff_context_pack_file,
+)
+from omh.paths import resolve_paths
+from omh.profiles.setup import write_setup_profile
+from omh.targets import record_target_observation
+
+
+class MemoryContractTests(unittest.TestCase):
+    def test_inspection_separates_sources_and_detects_stale_conflicts(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            write_setup_profile(paths, ["prompt-only-coding"])
+            record_target_observation(
+                paths,
+                source="discord",
+                source_metadata={"target_ref": "team-thread", "agent_count": "3"},
+            )
+            wrapper_snapshot = _wrapper_snapshot(
+                [
+                    {
+                        "item_id": "executor-pref",
+                        "key": "default_executor",
+                        "value": "codex",
+                        "summary": "Use Codex by default",
+                        "scope": {"kind": "project", "ref": "default"},
+                    },
+                    {
+                        "item_id": "target-mode",
+                        "key": "target_mode",
+                        "value": "single_agent_target",
+                        "summary": "Assume one Hermes agent",
+                        "scope": {"kind": "project", "ref": "default"},
+                    },
+                    {
+                        "item_id": "release-verified",
+                        "key": "verification_status",
+                        "value": "verified",
+                        "summary": "Release is verified",
+                        "scope": {"kind": "project", "ref": "default"},
+                    },
+                    {
+                        "item_id": "private-note",
+                        "key": "note",
+                        "value": "raw-secret-token-123",
+                        "summary": "Private note",
+                        "scope": {"kind": "project", "ref": "default"},
+                    },
+                ]
+            )
+
+            inspection = build_memory_inspection(paths, wrapper_snapshot=wrapper_snapshot)
+
+            self.assertEqual(inspection["schema_version"], "memory_inspection/v1")
+            source_levels = {snapshot["source"]: snapshot["truth_level"] for snapshot in inspection["snapshots"]}
+            self.assertEqual(source_levels["setup_profile"], "preference_default")
+            self.assertEqual(source_levels["target_topology"], "setup_evidence")
+            self.assertEqual(source_levels["wrapper_snapshot"], "supplied_hint")
+            conflict_keys = {conflict["key"] for conflict in inspection["conflicts"]}
+            self.assertIn("default_executor", conflict_keys)
+            self.assertIn("target_mode", conflict_keys)
+            self.assertIn("verification_status", conflict_keys)
+            self.assertNotIn("raw-secret-token-123", json.dumps(inspection))
+
+    def test_wrapper_snapshot_cannot_claim_runtime_evidence(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            wrapper_snapshot = _wrapper_snapshot(
+                [
+                    {
+                        "item_id": "release-verified",
+                        "key": "verification_status",
+                        "value": "verified",
+                        "summary": "Release is verified",
+                        "scope": {"kind": "project", "ref": "default"},
+                    }
+                ]
+            )
+            wrapper_snapshot["source"] = "runtime_evidence"
+
+            inspection = build_memory_inspection(paths, wrapper_snapshot=wrapper_snapshot)
+
+            wrapper_sources = [snapshot for snapshot in inspection["snapshots"] if snapshot["source"] == "wrapper_snapshot"]
+            self.assertEqual(len(wrapper_sources), 1)
+            self.assertEqual(wrapper_sources[0]["truth_level"], "supplied_hint")
+            self.assertIn("verification_status", {conflict["key"] for conflict in inspection["conflicts"]})
+            review_items = {item["item_id"]: item for item in inspection["review_items"]}
+            self.assertTrue(review_items["release-verified"]["blocked"])
+
+    def test_review_card_is_distinct_from_runtime_status_card(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            inspection = build_memory_inspection(paths, wrapper_snapshot=_wrapper_snapshot([]))
+
+            card = build_memory_review_card(inspection)
+
+            self.assertEqual(card["schema_version"], "memory_review_card/v1")
+            self.assertNotEqual(card["schema_version"], "status_card/v1")
+            action_ids = {action["id"] for action in card["actions"]}
+            self.assertIn("keep_memory", action_ids)
+            self.assertIn("forget_memory", action_ids)
+            self.assertIn("update_memory", action_ids)
+            self.assertIn("change_memory_scope", action_ids)
+            self.assertIn("apply_memory_updates", action_ids)
+            self.assertIn("Memory review is not runtime execution evidence", card["claim_boundary"])
+
+    def test_apply_batch_is_dry_run_idempotent_and_path_safe(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            batch = {
+                "schema_version": "memory_update_batch/v1",
+                "approved_by": "user",
+                "source_surface": "discord",
+                "updates": [
+                    {
+                        "op": "update",
+                        "item_id": "executor-pref",
+                        "scope": {"kind": "project", "ref": "default"},
+                        "value": "claude-code",
+                        "summary": "Prefer Claude Code prompt-only handoffs",
+                        "reason": "User changed default coding preference",
+                    }
+                ],
+            }
+
+            dry_run = apply_memory_update_batch(paths, batch, dry_run=True)
+
+            self.assertFalse(dry_run["applied"])
+            self.assertFalse((paths.omh_home / "memory").exists())
+
+            applied = apply_memory_update_batch(paths, batch)
+            second = apply_memory_update_batch(paths, batch)
+
+            self.assertTrue(applied["applied"])
+            self.assertEqual(second["updates"][0]["status"], "noop")
+            memory_file = paths.omh_home / "memory" / "scopes" / "project.json"
+            self.assertTrue(memory_file.exists())
+            stored = json.loads(memory_file.read_text(encoding="utf-8"))
+            self.assertEqual(stored["items"]["executor-pref"]["value"], "claude-code")
+
+            secret_batch = {
+                "schema_version": "memory_update_batch/v1",
+                "updates": [
+                    {
+                        "op": "update",
+                        "item_id": "private-note",
+                        "scope": {"kind": "project", "ref": "default"},
+                        "key": "note",
+                        "value": "raw-secret-token-123",
+                        "summary": "Private note",
+                    }
+                ],
+            }
+            apply_memory_update_batch(paths, secret_batch)
+            stored_after_secret = memory_file.read_text(encoding="utf-8")
+            self.assertNotIn("raw-secret-token-123", stored_after_secret)
+            private_note = json.loads(stored_after_secret)["items"]["private-note"]
+            self.assertNotIn("value", private_note)
+
+            unsafe = {
+                "schema_version": "memory_update_batch/v1",
+                "updates": [
+                    {
+                        "op": "update",
+                        "item_id": "bad",
+                        "scope": {"kind": "thread", "ref": "../../escape"},
+                        "value": "bad",
+                    }
+                ],
+            }
+            with self.assertRaises(ValueError):
+                apply_memory_update_batch(paths, unsafe)
+
+    def test_memory_inspection_ignores_symlink_scope_escapes(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            outside = root / "outside.json"
+            outside.write_text(
+                json.dumps(
+                    {
+                        "schema_version": "omh_memory_scope/v1",
+                        "scope": {"kind": "project", "ref": "default"},
+                        "items": {"outside": {"item_id": "outside", "key": "note", "value": "outside-secret-token"}},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            scopes = paths.memory_dir / "scopes"
+            scopes.mkdir(parents=True)
+            (scopes / "escape.json").symlink_to(outside)
+
+            inspection = build_memory_inspection(paths)
+
+            self.assertNotIn("outside-secret-token", json.dumps(inspection))
+            self.assertNotIn("outside", {item["item_id"] for item in inspection["review_items"]})
+
+    def test_handoff_context_pack_attaches_only_when_conflict_free(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            apply_memory_update_batch(
+                paths,
+                {
+                    "schema_version": "memory_update_batch/v1",
+                    "updates": [
+                        {
+                            "op": "update",
+                            "item_id": "repo-verification",
+                            "scope": {"kind": "project", "ref": "default"},
+                            "key": "verification_command",
+                            "value": "uv run python -m unittest discover -s tests -v",
+                            "summary": "Run the unittest suite",
+                            "reason": "Project verification default",
+                        }
+                    ],
+                },
+            )
+
+            pack = build_handoff_context_pack(paths, executor_target="codex")
+            payload = build_coding_delegation_payload(
+                "risky refactor with token-secret-123",
+                source="discord",
+                executor_target="codex",
+                include_message=True,
+                context_pack=pack,
+            )
+
+            self.assertEqual(pack["schema_version"], "handoff_context_pack/v1")
+            self.assertEqual(pack["blocked_by_conflicts"], [])
+            self.assertIn("context_pack", payload["executor_handoff"])
+            self.assertEqual(payload["executor_handoff"]["context_pack"]["schema_version"], "handoff_context_pack/v1")
+            self.assertNotIn("token-secret-123", json.dumps(payload["executor_handoff"]["context_pack"]))
+
+    def test_conflicting_context_pack_is_blocked_instead_of_attached(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            write_setup_profile(paths, ["prompt-only-coding"])
+            inspection = build_memory_inspection(
+                paths,
+                wrapper_snapshot=_wrapper_snapshot(
+                    [
+                        {
+                            "item_id": "executor-pref",
+                            "key": "default_executor",
+                            "value": "codex",
+                            "summary": "Use Codex by default",
+                            "scope": {"kind": "project", "ref": "default"},
+                        }
+                    ]
+                ),
+            )
+            pack = build_handoff_context_pack(paths, inspection=inspection, executor_target="codex")
+
+            payload = build_coding_delegation_payload("risky refactor", source="discord", executor_target="codex", context_pack=pack)
+
+            self.assertTrue(pack["blocked_by_conflicts"])
+            self.assertNotIn("context_pack", payload["executor_handoff"])
+            self.assertIn("context_pack_blocked", payload["executor_handoff"])
+
+    def test_malformed_context_pack_is_rejected_before_attachment(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            malformed = build_handoff_context_pack(paths, executor_target="codex")
+            malformed["blocked_by_conflicts"] = "none"
+            malformed["redaction_policy"] = "raw"
+            malformed["included_context"] = [{"item_id": "bad", "key": "note", "value": "raw-secret-token"}]
+            pack_path = root / "pack.json"
+            pack_path.write_text(json.dumps(malformed), encoding="utf-8")
+
+            with self.assertRaises(ValueError):
+                read_handoff_context_pack_file(pack_path)
+            with self.assertRaises(ValueError):
+                build_coding_delegation_payload("risky refactor", source="discord", executor_target="codex", context_pack=malformed)
+
+
+def _wrapper_snapshot(items: list[dict[str, object]]) -> dict[str, object]:
+    return {
+        "schema_version": "memory_snapshot/v1",
+        "source": "wrapper_snapshot",
+        "scope": {"kind": "project", "ref": "default"},
+        "items": items,
+        "redaction_policy": "metadata_only",
+        "claim_boundary": "Wrapper supplied memory candidates are not trusted until reviewed.",
+    }
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add deterministic `omh memory inspect`, `omh memory pack`, and `omh memory apply` contracts for OMH-local/wrapper-supplied context review
- add `memory_review_card/v1` and conflict-gated `handoff_context_pack/v1` attachment for coding delegation and wrapper session handoffs
- document the memory boundary, regenerate skill guidance, and add regression coverage for spoofed sources, malformed packs, symlink escapes, sensitive persistence, and stale verification claims

## Verification
- `PYTHONPATH=tests uv run python -m unittest tests/test_memory.py -v`
- `PYTHONPATH=tests uv run python -m unittest tests/test_memory.py tests/test_cli.py tests/test_wrapper_sessions.py tests/test_coding_lifecycle.py tests/test_runtime_artifacts.py tests/test_router_content.py -v`
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- `uv run python -m compileall -q src tests`
- `uv run python -m src.cli docs workflows --check`
- `uv run python -m src.cli harness validate`
- `git diff --check`

## Review
- Code review: APPROVE after fixing 2 high and 3 medium findings
- Architecture review: CLEAR

## Boundaries
- no Hermes core patching
- no LLM/API/network calls
- no opaque Hermes memory reads or mutations
- memory context remains metadata-only and separate from runtime execution evidence
