### PR TITLE
Use full Hermes skill identifier for 1.0.0 install smoke

### DIFF
--- a/INSTALL_FOR_AGENTS.md
+++ b/INSTALL_FOR_AGENTS.md
@@ -79,7 +79,7 @@ door:
 
 ```sh
 hermes skills tap add rlaope/oh-my-hermes-agent
-hermes skills install oh-my-hermes
+hermes skills install rlaope/oh-my-hermes-agent/skills/oh-my-hermes --yes
 ```
 
 Install direct workflow skills only when the user wants them exposed as explicit

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 <p align="center">
   <img alt="Python" src="https://img.shields.io/badge/python-3.11%2B-blue">
   <img alt="License" src="https://img.shields.io/badge/license-MIT-green">
-  <img alt="Status" src="https://img.shields.io/badge/status-quality--gated%20preview-blue">
+  <img alt="Status" src="https://img.shields.io/badge/status-1.0.0%20stable-blue">
 </p>
 
 **oh-my-hermes-agent** makes Hermes Agent feel more capable after install. OMH
@@ -96,8 +96,12 @@ Hermes-native front door:
 
 ```sh
 hermes skills tap add rlaope/oh-my-hermes-agent
-hermes skills install oh-my-hermes
+hermes skills install rlaope/oh-my-hermes-agent/skills/oh-my-hermes --yes
 ```
+
+Use the full identifier above for the first install. It avoids short-name
+resolver ambiguity in current Hermes CLI releases and still installs the
+`oh-my-hermes` skill.
 
 For pinned releases after a matching `v<version>` tag exists:
 
@@ -240,12 +244,12 @@ python3 -m omh.cli --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke set
 ```
 
 Before a release candidate, run the live Hermes profile smoke from the target
-operator profile:
+operator profile. The tap smoke uses the same full identifier install path:
 
 ```sh
 omh release hermes-smoke --live --install-path tap --target-confirmed
 ```
 
-OMH is a quality-gated preview. Stable release, richer profile activation
-probes, and more artifact-backed wrapper examples are tracked in the roadmap
-and release docs.
+OMH 1.0.0 is a quality-gated stable baseline. Richer profile activation probes
+and more artifact-backed wrapper examples are tracked in the roadmap and
+release docs.

--- a/docs/APPLICATION_CASES.md
+++ b/docs/APPLICATION_CASES.md
@@ -12,7 +12,7 @@ Install the Hermes skill pack through Hermes' native skill surface:
 
 ```sh
 hermes skills tap add rlaope/oh-my-hermes-agent
-hermes skills install oh-my-hermes
+hermes skills install rlaope/oh-my-hermes-agent/skills/oh-my-hermes --yes
 ```
 
 If the deployment needs the managed bootstrap path, install and verify the same
@@ -164,7 +164,7 @@ config that `omh apply` updated when using the bootstrap path:
 
 ```sh
 hermes skills tap add rlaope/oh-my-hermes-agent
-hermes skills install oh-my-hermes
+hermes skills install rlaope/oh-my-hermes-agent/skills/oh-my-hermes --yes
 omh setup
 omh doctor
 ```
@@ -415,8 +415,8 @@ Before using these cases as public release evidence, verify:
 
 - The one-command installer still works.
 - `hermes skills tap add rlaope/oh-my-hermes-agent` and
-  `hermes skills install oh-my-hermes` are documented as the primary install
-  path when Hermes taps are available.
+  `hermes skills install rlaope/oh-my-hermes-agent/skills/oh-my-hermes --yes`
+  are documented as the primary install path when Hermes taps are available.
 - `omh setup` reports the managed skill directory, equivalent Hermes install
   intent, and Hermes config registration clearly.
 - `omh doctor` reports the managed skill directory as healthy after setup.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -48,8 +48,12 @@ Use this path when the target Hermes environment supports skill taps:
 
 ```sh
 hermes skills tap add rlaope/oh-my-hermes-agent
-hermes skills install oh-my-hermes
+hermes skills install rlaope/oh-my-hermes-agent/skills/oh-my-hermes --yes
 ```
+
+Use the full identifier for first install. It avoids short-name resolver
+ambiguity in current Hermes CLI releases while installing the same
+`oh-my-hermes` skill.
 
 Install additional workflow skills when you want direct Hermes skill surfaces:
 
@@ -96,12 +100,15 @@ The live smoke runs the selected install path and then verifies:
 hermes skills tap list
 hermes skills list --enabled-only
 hermes skills check oh-my-hermes
-hermes skills inspect oh-my-hermes
+hermes skills inspect rlaope/oh-my-hermes-agent/skills/oh-my-hermes
 ```
 
-This proves Hermes CLI install/list/check/inspect for the target profile. It
-does not prove that a later Hermes chat session selected OMH unless that chat
-response is observed separately.
+The tap path proves Hermes CLI install/list/check/inspect for the target
+profile. The setup path proves `skills.external_dirs` discovery with
+list/check plus `omh doctor`, because current Hermes CLI releases do not
+reliably inspect local external-dir skills by short name. Neither path proves
+that a later Hermes chat session selected OMH unless that chat response is
+observed separately.
 
 ## Install Path B: OMH Bootstrap Setup
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -16,7 +16,7 @@ Hermes-native skill install:
 
 ```sh
 hermes skills tap add rlaope/oh-my-hermes-agent
-hermes skills install oh-my-hermes
+hermes skills install rlaope/oh-my-hermes-agent/skills/oh-my-hermes --yes
 ```
 
 Pinned stable install:
@@ -103,12 +103,14 @@ The live smoke runs install/setup plus:
 hermes skills tap list
 hermes skills list --enabled-only
 hermes skills check oh-my-hermes
-hermes skills inspect oh-my-hermes
+hermes skills inspect rlaope/oh-my-hermes-agent/skills/oh-my-hermes
 ```
 
-Passing this smoke means Hermes CLI install/list/check/inspect commands
-succeeded for the target profile. It still does not prove a later Hermes chat
-session selected OMH unless that chat response is observed separately.
+Passing the tap smoke means Hermes CLI install/list/check/inspect commands
+succeeded for the target profile. Passing the setup smoke means OMH managed
+skill setup, Hermes list/check visibility, and `omh doctor` succeeded for the
+target profile. It still does not prove a later Hermes chat session selected
+OMH unless that chat response is observed separately.
 
 Runtime evidence smoke:
 

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -184,7 +184,7 @@ omh doctor</code>
           </p>
           <div class="command" role="region" aria-label="Hermes skill install commands" tabindex="0">
             <code>hermes skills tap add rlaope/oh-my-hermes-agent
-hermes skills install oh-my-hermes</code>
+hermes skills install rlaope/oh-my-hermes-agent/skills/oh-my-hermes --yes</code>
           </div>
           <p>
             Stable installs are pinned explicitly with a released tag.

--- a/skills/oh-my-hermes/SKILL.md
+++ b/skills/oh-my-hermes/SKILL.md
@@ -22,7 +22,7 @@ Normal users should talk to Hermes Agent or invoke installed Hermes skills throu
 
 Hermes-native install paths should converge on the same skill-visible state:
 
-- `hermes skills tap add rlaope/oh-my-hermes-agent`, then `hermes skills install oh-my-hermes` installs this tap-compatible skill pack directly when Hermes supports taps.
+- `hermes skills tap add rlaope/oh-my-hermes-agent`, then `hermes skills install rlaope/oh-my-hermes-agent/skills/oh-my-hermes --yes` installs this tap-compatible skill pack directly when Hermes supports taps.
 - `omh setup` installs generated managed skills and registers their directory through `skills.external_dirs` when a local bootstrap or repair path is preferred.
 
 Priority:

--- a/src/commands/setup.py
+++ b/src/commands/setup.py
@@ -199,7 +199,7 @@ def cmd_setup(args: argparse.Namespace) -> int:
         "normal_user_surface": "Hermes Agent chat and installed Hermes skills",
         "equivalent_hermes_commands": [
             "hermes skills tap add rlaope/oh-my-hermes-agent",
-            "hermes skills install oh-my-hermes",
+            "hermes skills install rlaope/oh-my-hermes-agent/skills/oh-my-hermes --yes",
         ],
         "bootstrap_final_state": bootstrap_final_state,
         "skills_dir": str(paths.skills_dir),

--- a/src/release.py
+++ b/src/release.py
@@ -84,7 +84,20 @@ def hermes_release_smoke_steps(
         raise ValueError("Hermes smoke skill must not be empty")
     if install_path == "tap" and not tap:
         raise ValueError("Hermes smoke tap must not be empty for tap installs")
-    setup_command = _omh_setup_command(omh_command, omh_home=omh_home, hermes_home=hermes_home)
+    skill_name = _skill_name_for_hermes(skill)
+    tap_identifier = _tap_skill_identifier(tap=tap, skill=skill)
+    setup_command = _omh_scoped_command(
+        omh_command,
+        "setup",
+        omh_home=omh_home,
+        hermes_home=hermes_home,
+    )
+    doctor_command = _omh_scoped_command(
+        omh_command,
+        "doctor",
+        omh_home=omh_home,
+        hermes_home=hermes_home,
+    )
     install_steps = (
         [
             HermesSmokeStep(
@@ -96,10 +109,13 @@ def hermes_release_smoke_steps(
             ),
             HermesSmokeStep(
                 "skill_install",
-                ("hermes", "skills", "install", skill, "--yes"),
+                ("hermes", "skills", "install", tap_identifier, "--yes"),
                 "install",
                 True,
-                proof_boundary="Installs the router skill in the current Hermes profile; this does not prove chat usage.",
+                proof_boundary=(
+                    "Installs the router skill by full GitHub identifier in the current Hermes profile; "
+                    "this does not prove chat usage."
+                ),
             ),
         ]
         if install_path == "tap"
@@ -130,20 +146,46 @@ def hermes_release_smoke_steps(
         ),
         HermesSmokeStep(
             "skill_check",
-            ("hermes", "skills", "check", skill),
+            ("hermes", "skills", "check", skill_name),
             "verify",
             False,
             proof_boundary="Runs Hermes skill validation for the OMH router skill.",
         ),
-        HermesSmokeStep(
-            "skill_inspect",
-            ("hermes", "skills", "inspect", skill),
-            "verify",
-            False,
-            proof_boundary="Prints Hermes-visible skill metadata/content for operator confirmation.",
-        ),
     ]
+    if install_path == "tap":
+        check_steps.append(
+            HermesSmokeStep(
+                "skill_inspect",
+                ("hermes", "skills", "inspect", tap_identifier),
+                "verify",
+                False,
+                proof_boundary="Prints Hermes-visible skill metadata/content for operator confirmation.",
+            )
+        )
+    else:
+        check_steps.append(
+            HermesSmokeStep(
+                "setup_doctor",
+                doctor_command,
+                "verify",
+                False,
+                proof_boundary=(
+                    "Checks OMH-managed local skill registration. Hermes v0.15.1 does not reliably inspect "
+                    "skills.external_dirs local skills by short name, so setup-path smoke uses list/check plus OMH doctor."
+                ),
+            )
+        )
     return install_steps + check_steps
+
+
+def _skill_name_for_hermes(skill: str) -> str:
+    return skill.rstrip("/").split("/")[-1]
+
+
+def _tap_skill_identifier(*, tap: str, skill: str) -> str:
+    if "/" in skill:
+        return skill
+    return f"{tap.rstrip('/')}/skills/{skill}"
 
 
 def hermes_release_smoke_plan(
@@ -319,8 +361,9 @@ def _expand_home(value: str | Path | None, env_key: str, default: str) -> Path:
     return Path(os.path.expandvars(source)).expanduser().resolve()
 
 
-def _omh_setup_command(
+def _omh_scoped_command(
     omh_command: str,
+    command_name: str,
     *,
     omh_home: str | Path | None = None,
     hermes_home: str | Path | None = None,
@@ -330,7 +373,7 @@ def _omh_setup_command(
         command.extend(["--omh-home", str(omh_home)])
     if hermes_home is not None:
         command.extend(["--hermes-home", str(hermes_home)])
-    command.append("setup")
+    command.append(command_name)
     return tuple(command)
 
 
@@ -352,9 +395,14 @@ def _hermes_smoke_next_action(ok: bool, failed_step: str) -> str:
     if failed_step == "tap_add":
         return "Check Hermes tap support, network access, and whether the tap is already configured; rerun the smoke after repair."
     if failed_step == "skill_install":
-        return "Check tap visibility and Hermes skill scan output, then rerun `hermes skills install oh-my-hermes --yes`."
+        return (
+            "Check tap visibility and Hermes skill scan output, then rerun "
+            "`hermes skills install rlaope/oh-my-hermes-agent/skills/oh-my-hermes --yes`."
+        )
     if failed_step == "omh_setup":
         return "Run `omh setup` manually and inspect `omh doctor` for blocking setup checks."
+    if failed_step == "setup_doctor":
+        return "Run `omh doctor` manually and repair the OMH-managed skill registration reported there."
     if failed_step in {"tap_list", "skills_list", "skill_check", "skill_inspect"}:
         return "Inspect the failing Hermes skills command output and confirm the target Hermes profile is the one OMH was installed into."
     return "Inspect the failed Hermes release smoke step and rerun after repair."

--- a/src/skills/render.py
+++ b/src/skills/render.py
@@ -211,7 +211,7 @@ Normal users should talk to Hermes Agent or invoke installed Hermes skills throu
 
 Hermes-native install paths should converge on the same skill-visible state:
 
-- `hermes skills tap add rlaope/oh-my-hermes-agent`, then `hermes skills install oh-my-hermes` installs this tap-compatible skill pack directly when Hermes supports taps.
+- `hermes skills tap add rlaope/oh-my-hermes-agent`, then `hermes skills install rlaope/oh-my-hermes-agent/skills/oh-my-hermes --yes` installs this tap-compatible skill pack directly when Hermes supports taps.
 - `omh setup` installs generated managed skills and registers their directory through `skills.external_dirs` when a local bootstrap or repair path is preferred.
 
 Priority:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -126,7 +126,8 @@ class CliTests(unittest.TestCase):
         self.assertEqual(commands[0], ["omh-dev", "--omh-home", str(omh_home.resolve()), "--hermes-home", str(hermes_home.resolve()), "setup"])
         self.assertIn(["hermes", "skills", "list", "--enabled-only"], commands)
         self.assertIn(["hermes", "skills", "check", "oh-my-hermes"], commands)
-        self.assertIn(["hermes", "skills", "inspect", "oh-my-hermes"], commands)
+        self.assertIn(["omh-dev", "--omh-home", str(omh_home.resolve()), "--hermes-home", str(hermes_home.resolve()), "doctor"], commands)
+        self.assertNotIn(["hermes", "skills", "inspect", "oh-my-hermes"], commands)
 
     def test_release_hermes_smoke_live_requires_target_confirmation(self) -> None:
         status, _stdout, stderr = run_cli(["release", "hermes-smoke", "--live"])
@@ -1946,7 +1947,10 @@ class CliTests(unittest.TestCase):
             self.assertTrue(payload["hermes_native"]["requires_hermes_reload"])
             self.assertIn("Hermes Agent chat", payload["hermes_native"]["normal_user_surface"])
             self.assertIn("hermes skills tap add rlaope/oh-my-hermes-agent", payload["hermes_native"]["equivalent_hermes_commands"])
-            self.assertIn("hermes skills install oh-my-hermes", payload["hermes_native"]["equivalent_hermes_commands"])
+            self.assertIn(
+                "hermes skills install rlaope/oh-my-hermes-agent/skills/oh-my-hermes --yes",
+                payload["hermes_native"]["equivalent_hermes_commands"],
+            )
             self.assertEqual(payload["hermes_native"]["hermes_config_key"], "skills.external_dirs")
             self.assertIn("not the normal chat UX", payload["hermes_native"]["wrapper_backend_surface"])
             self.assertIn(str(omh_home / "skills"), (hermes_home / "config.yaml").read_text(encoding="utf-8"))

--- a/tests/test_release_smoke.py
+++ b/tests/test_release_smoke.py
@@ -20,10 +20,13 @@ class ReleaseSmokeTests(unittest.TestCase):
         self.assertIn("--live", payload["live_command"])
         commands = [step["command"] for step in payload["steps"]]
         self.assertEqual(commands[0], ["hermes", "skills", "tap", "add", "rlaope/oh-my-hermes-agent"])
-        self.assertEqual(commands[1], ["hermes", "skills", "install", "oh-my-hermes", "--yes"])
+        self.assertEqual(
+            commands[1],
+            ["hermes", "skills", "install", "rlaope/oh-my-hermes-agent/skills/oh-my-hermes", "--yes"],
+        )
         self.assertIn(["hermes", "skills", "list", "--enabled-only"], commands)
         self.assertIn(["hermes", "skills", "check", "oh-my-hermes"], commands)
-        self.assertIn(["hermes", "skills", "inspect", "oh-my-hermes"], commands)
+        self.assertIn(["hermes", "skills", "inspect", "rlaope/oh-my-hermes-agent/skills/oh-my-hermes"], commands)
         self.assertIn("does not touch", payload["proof_boundary"])
         self.assertEqual(payload["target_binding"]["hermes_home"], hermes_home)
         self.assertIn("--hermes-home", payload["live_command"])
@@ -41,6 +44,8 @@ class ReleaseSmokeTests(unittest.TestCase):
         commands = [step["command"] for step in payload["steps"]]
         self.assertEqual(commands[0], ["omh-dev", "--omh-home", omh_home, "--hermes-home", hermes_home, "setup"])
         self.assertIn(["hermes", "skills", "check", "oh-my-hermes"], commands)
+        self.assertIn(["omh-dev", "--omh-home", omh_home, "--hermes-home", hermes_home, "doctor"], commands)
+        self.assertNotIn(["hermes", "skills", "inspect", "oh-my-hermes"], commands)
 
     def test_live_smoke_records_successful_command_results(self) -> None:
         seen: list[list[str]] = []
@@ -58,7 +63,7 @@ class ReleaseSmokeTests(unittest.TestCase):
         self.assertTrue(payload["observed"])
         self.assertEqual(payload["hermes_cli"]["path"], "/usr/local/bin/hermes")
         self.assertEqual(seen[0], ["hermes", "skills", "tap", "add", "rlaope/oh-my-hermes-agent"])
-        self.assertEqual(seen[-1], ["hermes", "skills", "inspect", "oh-my-hermes"])
+        self.assertEqual(seen[-1], ["hermes", "skills", "inspect", "rlaope/oh-my-hermes-agent/skills/oh-my-hermes"])
         self.assertTrue(all(env["HERMES_HOME"] == str(Path("/tmp/hermes-smoke").resolve()) for env in seen_env))
         self.assertTrue(all(result["environment"]["HERMES_HOME"] == str(Path("/tmp/hermes-smoke").resolve()) for result in payload["results"]))
         self.assertTrue(all(result["ok"] for result in payload["results"]))

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -393,7 +393,7 @@ class RouterContentTests(unittest.TestCase):
         site_css = Path("site/styles.css").read_text(encoding="utf-8")
 
         self.assertIn("hermes skills tap add rlaope/oh-my-hermes-agent", readme)
-        self.assertIn("hermes skills install oh-my-hermes", readme)
+        self.assertIn("hermes skills install rlaope/oh-my-hermes-agent/skills/oh-my-hermes --yes", readme)
         self.assertIn("curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes-agent/main/install.sh | sh", readme)
         self.assertIn("https://rlaope.github.io/oh-my-hermes-agent/", readme)
         self.assertIn("[Documentation](docs/README.md)", readme)


### PR DESCRIPTION
## Summary
- Use the full Hermes skill identifier for tap-based install/inspect flows because Hermes v0.15.1 can hang while resolving the short `oh-my-hermes` name.
- Keep setup-path release smoke on local setup/list/check plus `omh doctor` instead of claiming short-name inspect works for `skills.external_dirs` skills.
- Update release/install/docs/site copy and tests so first-time install commands are copy-pasteable from live smoke evidence.

## Verification
- `PYTHONPATH=tests uv run python -m unittest discover -s tests` -> 260 tests OK
- `uv run python -m compileall -q src tests` -> OK
- `uv run python -m omh.cli docs workflows --check` -> OK, 28 tap skills checked
- `uv run python -m omh.cli harness validate` -> OK, 15 harnesses / 28 skills
- `git diff --check` -> OK
- `uv build` -> built `dist/oh_my_hermes_agent-1.0.0.tar.gz` and wheel
- fresh wheel install smoke -> `omh --help`, `omh setup --dry-run`, `omh.__version__ == 1.0.0` OK
- `install.sh` wheel smoke -> prints installed `omh` path and PATH guidance
- live Hermes tap smoke -> add/install/list/check/inspect OK with full identifier
- live Hermes setup smoke -> setup/list/check/doctor OK

## Boundary
Live release smoke observes Hermes CLI install/list/check/inspect or setup/list/check/doctor results only. It does not prove a later Hermes chat session selected OMH until that session is observed.
