### PR TITLE
Promote Loop as a flagship site workflow

### DIFF
--- a/site/docs/executor-handoff/index.html
+++ b/site/docs/executor-handoff/index.html
@@ -1,0 +1,90 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>OMH Executor-Ready Handoff</title>
+    <meta name="description" content="OMH executor-ready handoff docs for Codex, Claude Code, Hermes-retained work, and executor-neutral implementation plans.">
+    <link rel="stylesheet" href="../../styles.css">
+  </head>
+  <body class="docs-page feature-page">
+    <header class="topbar topbar--solid" aria-label="Primary">
+      <a class="brand brand--link" href="../../">OMH</a>
+      <nav class="nav" aria-label="Primary navigation">
+        <a href="../">Docs</a>
+        <a class="nav__icon" href="https://github.com/rlaope/oh-my-hermes-agent" aria-label="Open OMH repository on GitHub" title="GitHub repository">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2C6.48 2 2 6.58 2 12.22c0 4.52 2.87 8.35 6.85 9.7.5.09.68-.22.68-.49v-1.73c-2.78.62-3.37-1.37-3.37-1.37-.45-1.18-1.11-1.5-1.11-1.5-.91-.64.07-.63.07-.63 1 .07 1.53 1.06 1.53 1.06.9 1.56 2.35 1.11 2.92.85.09-.66.35-1.11.63-1.37-2.22-.26-4.55-1.14-4.55-5.06 0-1.12.39-2.03 1.03-2.75-.1-.26-.45-1.31.1-2.71 0 0 .84-.28 2.75 1.05A9.37 9.37 0 0 1 12 6.92c.85 0 1.7.12 2.5.35 1.9-1.33 2.74-1.05 2.74-1.05.55 1.4.2 2.45.1 2.71.64.72 1.03 1.63 1.03 2.75 0 3.93-2.34 4.79-4.57 5.05.36.32.68.94.68 1.9v2.8c0 .27.18.58.69.48A10.06 10.06 0 0 0 22 12.22C22 6.58 17.52 2 12 2Z"></path></svg>
+        </a>
+      </nav>
+    </header>
+
+    <main class="feature-shell">
+      <header class="feature-hero">
+        <p class="eyebrow">Flagship lane</p>
+        <h1>Executor-ready handoff</h1>
+        <p>
+          Use this lane when coding or implementation may be needed, but Hermes
+          should first prepare a reviewable handoff. The user can choose Codex,
+          Claude Code, another executor, or Hermes-retained work.
+        </p>
+        <div class="feature-actions">
+          <a class="button button--primary" href="../">Back to docs</a>
+          <a class="button" href="../intent-to-plan/">See planning lane</a>
+        </div>
+      </header>
+
+      <section class="feature-section feature-section--split">
+        <div class="feature-copy">
+          <h2>Handoff lifecycle</h2>
+          <p>
+            "Turn this issue into a PR" should become scope, non-goals,
+            acceptance criteria, verification commands, review expectations, and
+            executor choice before anyone claims code changed.
+          </p>
+          <div class="feature-flow feature-flow--handoff" aria-label="Executor handoff flow">
+            <span>request</span>
+            <span>plan accepted</span>
+            <span>executor choice</span>
+            <span>dispatch</span>
+            <span>observed evidence</span>
+          </div>
+        </div>
+        <aside class="feature-contract">
+          <h2>Evidence boundary</h2>
+          <ul class="docs-list">
+            <li>Prepared handoff is not implementation evidence.</li>
+            <li>Executor dispatch must be observed separately.</li>
+            <li>Review, CI, and merge readiness need their own records.</li>
+            <li>Prompt-only executors stay prompt-only until a tested lifecycle exists.</li>
+          </ul>
+        </aside>
+      </section>
+
+      <section class="feature-section">
+        <h2>Use cases</h2>
+        <div class="usecase-grid">
+          <article class="case-card">
+            <span>Open source issue</span>
+            <h3>Make this GitHub issue PR-ready.</h3>
+            <p>Hermes prepares the smallest reviewable unit and hands it to the selected executor after acceptance.</p>
+          </article>
+          <article class="case-card">
+            <span>Multi-executor team</span>
+            <h3>Some people use Codex, others use Claude Code.</h3>
+            <p>OMH keeps the handoff executor-neutral and lets the wrapper ask for selection when needed.</p>
+          </article>
+          <article class="case-card">
+            <span>Safety adoption</span>
+            <h3>We want AI coding but need proof of what happened.</h3>
+            <p>Status stays split across prepared, dispatched, executed, verified, reviewed, CI, and merge-ready states.</p>
+          </article>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <span>Executor-handoff docs are part of the OMH public site.</span>
+      <span>Developed by <a href="https://github.com/rlaope">rlaope</a>.</span>
+    </footer>
+  </body>
+</html>

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -32,6 +32,10 @@
       <aside class="docs-toc" aria-label="Documentation sections">
         <a href="#overview">Overview</a>
         <a href="#flagship">Flagship workflows</a>
+        <a href="loop/">Loop</a>
+        <a href="intent-to-plan/">Intent to plan</a>
+        <a href="product-ops/">Product ops</a>
+        <a href="executor-handoff/">Executor handoff</a>
         <a href="#install">Install</a>
         <a href="#chat">Chat wrappers</a>
         <a href="#runbook">Runbook</a>
@@ -123,10 +127,34 @@
         <section class="docs-section docs-section--feature" id="flagship">
           <h2>Flagship command-set families</h2>
           <p>
-            These are the representative OMH lanes to show first when introducing
-            the product: intent shaping, non-coding product operations, and
-            executor-ready implementation handoff.
+            These are the representative OMH lanes to show first when
+            introducing the product: the new Loop flagship, intent shaping,
+            non-coding product operations, and executor-ready implementation
+            handoff.
           </p>
+          <article class="loop-spotlight loop-spotlight--docs" aria-label="Loop flagship documentation entry">
+            <div class="loop-spotlight__copy">
+              <span class="new-badge">New</span>
+              <h3>Loop!</h3>
+              <p>
+                Loop turns a large goal into a repeating Hermes-native cycle:
+                interview, research, plan, runtime tick queue, handoff,
+                feedback, wait, and resume. It gives wrappers a visible control
+                plane without pretending background work already happened.
+              </p>
+              <a class="button button--primary" href="loop/">Open Loop docs</a>
+            </div>
+            <div class="loop-visual" aria-label="Loop workflow visualization">
+              <span>goal</span>
+              <span>interview</span>
+              <span>research</span>
+              <span>plan</span>
+              <span>tick</span>
+              <span>handoff</span>
+              <span>feedback</span>
+              <span>again</span>
+            </div>
+          </article>
           <figure class="poster-frame poster-frame--docs">
             <img
               src="../assets/omh-flagship-workflows-poster.png"
@@ -134,30 +162,30 @@
             >
           </figure>
           <div class="docs-feature-grid" aria-label="Flagship OMH workflow families">
-            <article class="flagship-item flagship-item--docs">
+            <a class="flagship-item flagship-item--docs" href="intent-to-plan/">
               <span>Intent to plan</span>
               <h3><code>deep-interview</code> / <code>ralplan</code> / <code>ultragoal</code> / <code>loop</code></h3>
               <p>
                 Convert "Make onboarding feel smoother" into a concrete goal,
                 plan, execution-ready path, or direct ambitious goal loop.
               </p>
-            </article>
-            <article class="flagship-item flagship-item--docs">
+            </a>
+            <a class="flagship-item flagship-item--docs" href="product-ops/">
               <span>Company and product ops</span>
               <h3><code>feedback-triage</code> / <code>research-brief</code> / <code>strategy-brief</code></h3>
               <p>
                 Triage customer signals, brief research, set meeting topics, and
                 frame strategic options without defaulting to coding.
               </p>
-            </article>
-            <article class="flagship-item flagship-item--docs">
+            </a>
+            <a class="flagship-item flagship-item--docs" href="executor-handoff/">
               <span>Executor-ready handoff</span>
               <h3><code>idea-to-deploy</code> / coding handoff / executor selection</h3>
               <p>
                 Prepare work for Codex, Claude Code, or another selected executor
                 while keeping evidence boundaries explicit.
               </p>
-            </article>
+            </a>
           </div>
         </section>
 

--- a/site/docs/intent-to-plan/index.html
+++ b/site/docs/intent-to-plan/index.html
@@ -1,0 +1,91 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>OMH Intent to Plan</title>
+    <meta name="description" content="OMH intent-to-plan docs for deep-interview, ralplan, ultragoal, and loop workflows.">
+    <link rel="stylesheet" href="../../styles.css">
+  </head>
+  <body class="docs-page feature-page">
+    <header class="topbar topbar--solid" aria-label="Primary">
+      <a class="brand brand--link" href="../../">OMH</a>
+      <nav class="nav" aria-label="Primary navigation">
+        <a href="../">Docs</a>
+        <a class="nav__icon" href="https://github.com/rlaope/oh-my-hermes-agent" aria-label="Open OMH repository on GitHub" title="GitHub repository">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2C6.48 2 2 6.58 2 12.22c0 4.52 2.87 8.35 6.85 9.7.5.09.68-.22.68-.49v-1.73c-2.78.62-3.37-1.37-3.37-1.37-.45-1.18-1.11-1.5-1.11-1.5-.91-.64.07-.63.07-.63 1 .07 1.53 1.06 1.53 1.06.9 1.56 2.35 1.11 2.92.85.09-.66.35-1.11.63-1.37-2.22-.26-4.55-1.14-4.55-5.06 0-1.12.39-2.03 1.03-2.75-.1-.26-.45-1.31.1-2.71 0 0 .84-.28 2.75 1.05A9.37 9.37 0 0 1 12 6.92c.85 0 1.7.12 2.5.35 1.9-1.33 2.74-1.05 2.74-1.05.55 1.4.2 2.45.1 2.71.64.72 1.03 1.63 1.03 2.75 0 3.93-2.34 4.79-4.57 5.05.36.32.68.94.68 1.9v2.8c0 .27.18.58.69.48A10.06 10.06 0 0 0 22 12.22C22 6.58 17.52 2 12 2Z"></path></svg>
+        </a>
+      </nav>
+    </header>
+
+    <main class="feature-shell">
+      <header class="feature-hero">
+        <p class="eyebrow">Flagship lane</p>
+        <h1>Intent to plan</h1>
+        <p>
+          Use this lane when a user gives Hermes a fuzzy product, technical, or
+          goal-shaped request. Hermes should not jump straight to coding. It
+          should clarify, plan, lock acceptance criteria, and then create a
+          durable goal or handoff only when the shape is ready.
+        </p>
+        <div class="feature-actions">
+          <a class="button button--primary" href="../">Back to docs</a>
+          <a class="button" href="../loop/">Compare with Loop</a>
+        </div>
+      </header>
+
+      <section class="feature-section feature-section--split">
+        <div class="feature-copy">
+          <h2>Plain request</h2>
+          <p>
+            "Make onboarding feel smoother" is not yet a coding task. It needs
+            intent, non-goals, user value, acceptance criteria, and a plan that
+            can survive review.
+          </p>
+          <div class="feature-flow" aria-label="Intent to plan flow">
+            <span>vague request</span>
+            <span>deep-interview</span>
+            <span>ralplan</span>
+            <span>ultragoal</span>
+            <span>status</span>
+          </div>
+        </div>
+        <aside class="feature-contract">
+          <h2>Use these skills</h2>
+          <ul class="docs-list">
+            <li><code>deep-interview</code> asks the smallest blocking question first.</li>
+            <li><code>ralplan</code> turns the clarified intent into a reviewed plan.</li>
+            <li><code>ultragoal</code> records durable progress and completion gates.</li>
+            <li><code>loop</code> takes over when the goal should keep cycling.</li>
+          </ul>
+        </aside>
+      </section>
+
+      <section class="feature-section">
+        <h2>Use cases</h2>
+        <div class="usecase-grid">
+          <article class="case-card">
+            <span>Product shaping</span>
+            <h3>Onboarding should feel smoother.</h3>
+            <p>Hermes clarifies the target user, pain, success signal, and non-goals before planning.</p>
+          </article>
+          <article class="case-card">
+            <span>Architecture change</span>
+            <h3>This refactor feels risky.</h3>
+            <p>Hermes names scope, rollback, tests, and review gates before an executor sees the work.</p>
+          </article>
+          <article class="case-card">
+            <span>Long goal</span>
+            <h3>Improve the whole repo quality.</h3>
+            <p>Hermes turns ambition into checkpoints, acceptance criteria, and observed evidence requirements.</p>
+          </article>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <span>Intent-to-plan docs are part of the OMH public site.</span>
+      <span>Developed by <a href="https://github.com/rlaope">rlaope</a>.</span>
+    </footer>
+  </body>
+</html>

--- a/site/docs/loop/index.html
+++ b/site/docs/loop/index.html
@@ -1,0 +1,159 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>OMH Loop - Loop Engineering for Hermes</title>
+    <meta
+      name="description"
+      content="Loop Engineering docs for OMH: direct ambitious goal loops for Hermes Agent with interview, research, plan, runtime tick queue, handoff, feedback, and evidence boundaries."
+    >
+    <link rel="stylesheet" href="../../styles.css">
+  </head>
+  <body class="docs-page feature-page">
+    <header class="topbar topbar--solid" aria-label="Primary">
+      <a class="brand brand--link" href="../../">OMH</a>
+      <nav class="nav" aria-label="Primary navigation">
+        <a href="../">Docs</a>
+        <a
+          class="nav__icon"
+          href="https://github.com/rlaope/oh-my-hermes-agent"
+          aria-label="Open OMH repository on GitHub"
+          title="GitHub repository"
+        >
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M12 2C6.48 2 2 6.58 2 12.22c0 4.52 2.87 8.35 6.85 9.7.5.09.68-.22.68-.49v-1.73c-2.78.62-3.37-1.37-3.37-1.37-.45-1.18-1.11-1.5-1.11-1.5-.91-.64.07-.63.07-.63 1 .07 1.53 1.06 1.53 1.06.9 1.56 2.35 1.11 2.92.85.09-.66.35-1.11.63-1.37-2.22-.26-4.55-1.14-4.55-5.06 0-1.12.39-2.03 1.03-2.75-.1-.26-.45-1.31.1-2.71 0 0 .84-.28 2.75 1.05A9.37 9.37 0 0 1 12 6.92c.85 0 1.7.12 2.5.35 1.9-1.33 2.74-1.05 2.74-1.05.55 1.4.2 2.45.1 2.71.64.72 1.03 1.63 1.03 2.75 0 3.93-2.34 4.79-4.57 5.05.36.32.68.94.68 1.9v2.8c0 .27.18.58.69.48A10.06 10.06 0 0 0 22 12.22C22 6.58 17.52 2 12 2Z"></path>
+          </svg>
+        </a>
+      </nav>
+    </header>
+
+    <main class="feature-shell">
+      <header class="feature-hero feature-hero--loop">
+        <p class="eyebrow">New flagship workflow</p>
+        <span class="new-badge">New</span>
+        <h1>Loop!</h1>
+        <p>
+          OMH Loop lets Hermes Agent treat a high-level goal as a repeating
+          system: clarify the goal, research the gap, plan the next move, queue
+          a runtime tick, prepare handoff when allowed, evaluate feedback, and
+          continue until evidence, authority, context, or external waiting says
+          to stop.
+        </p>
+        <div class="feature-actions">
+          <a class="button button--primary" href="../">Back to docs</a>
+          <a class="button" href="https://github.com/rlaope/oh-my-hermes-agent">GitHub</a>
+        </div>
+      </header>
+
+      <section class="feature-section">
+        <div class="feature-copy">
+          <h2>Loop Engineering</h2>
+          <p>
+            In the AI ecosystem, after harness engineering, Loop Engineering is
+            emerging as the next practical layer. The point is no longer just
+            prompting. The point is giving a clear goal and designing the system
+            that decides what to find, how to process it, when to hand off work,
+            when to wait, and when to stop.
+          </p>
+          <blockquote class="loop-post">
+            <p>AI 생태계에서 하네스 엔지니어링이라는 개념에 이어서 루프 엔지니어링이 새로 태어났습니다.</p>
+            <p>이젠 프롬프팅이 아니라 확실한 Goal을 주고, 구축된 시스템이 계속해 목표를 세우고 문제를 스스로 정의하고 개발하는 자동화된 파이프라인 루프가 필요하게 됩니다.</p>
+            <p>즉, 사람이 매번 지시하는 대신 무엇을 찾고, 어떻게 처리하고, 언제 멈출지를 시스템으로 설계합니다.</p>
+            <p>OMH에서는 이 개념을 Hermes Agent 위에서 딸깍으로 정의하고, 스킬, 플러그인, 커넥터, 서브에이전트, 워크트리, 외부 메모리 같은 요소가 안전하게 만나는 루프 계약으로 제공합니다.</p>
+          </blockquote>
+        </div>
+        <div class="loop-visual loop-visual--large" aria-label="Loop engineering cycle">
+          <span>goal</span>
+          <span>interview</span>
+          <span>research</span>
+          <span>plan</span>
+          <span>tick</span>
+          <span>handoff</span>
+          <span>feedback</span>
+          <span>again</span>
+        </div>
+      </section>
+
+      <section class="feature-section feature-section--split">
+        <div>
+          <h2>When to use it</h2>
+          <div class="usecase-grid">
+            <article class="case-card">
+              <span>Open source ambition</span>
+              <h3>Make this a 10k-star quality OSS.</h3>
+              <p>Hermes reframes the large goal into research, product, docs, QA, release, and distribution loops without pretending market response was observed.</p>
+            </article>
+            <article class="case-card">
+              <span>Long refactor</span>
+              <h3>Finish all major refactoring safely.</h3>
+              <p>The loop records each risk, plan, handoff, feedback gate, and checkpoint so the work can continue across context limits.</p>
+            </article>
+            <article class="case-card">
+              <span>Product development</span>
+              <h3>Keep improving onboarding until it feels polished.</h3>
+              <p>Hermes cycles discovery, plan, executor handoff, QA feedback, and user-facing status while preserving evidence boundaries.</p>
+            </article>
+          </div>
+        </div>
+        <aside class="feature-contract">
+          <h2>What the tick means</h2>
+          <p>
+            <code>loop_runtime/v1</code> is a prepared queue, not execution
+            evidence. It can name a worktree plan, subagent plan, connector
+            intent, or executor handoff, but observed work must be recorded
+            separately.
+          </p>
+          <ul class="docs-list">
+            <li>Prepared queue item is not worktree creation.</li>
+            <li>Prepared subagent plan is not subagent dispatch.</li>
+            <li>Prepared connector plan is not connector I/O.</li>
+            <li>External outcomes stay waiting until observed.</li>
+          </ul>
+        </aside>
+      </section>
+
+      <section class="feature-section">
+        <h2>How Hermes can present it</h2>
+        <div class="discord-frame" aria-label="Hermes Loop chat example">
+          <div class="discord-channel"># founder-loop</div>
+          <div class="discord-message">
+            <div class="avatar avatar--user">U</div>
+            <div class="message-body">
+              <div class="message-meta"><strong>user</strong></div>
+              <p>./loop Make OMH a 10k-star quality Hermes-native project.</p>
+            </div>
+          </div>
+          <div class="discord-message">
+            <div class="avatar avatar--bot">H</div>
+            <div class="message-body bot-response">
+              <div class="message-meta"><strong>Hermes Agent</strong> <span>BOT</span></div>
+              <div class="route-lens">
+                <span>workflow: loop</span>
+                <span>phase: interview</span>
+                <span>next: choose permission profile</span>
+              </div>
+              <h3>I can start this as a Loop.</h3>
+              <p>
+                I will keep the ambition large, separate implementable work from
+                external adoption waiting, and queue the next runtime step only
+                inside the permission profile you choose.
+              </p>
+              <div class="button-row">
+                <button type="button">Observe only</button>
+                <button type="button">Handoff only</button>
+                <button type="button">Execute with gates</button>
+              </div>
+              <p class="claim-boundary">A loop tick is not execution, review, CI, merge, publication, or market response evidence.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <span>Loop docs are part of the OMH public site.</span>
+      <span>Developed by <a href="https://github.com/rlaope">rlaope</a>.</span>
+    </footer>
+  </body>
+</html>

--- a/site/docs/product-ops/index.html
+++ b/site/docs/product-ops/index.html
@@ -1,0 +1,91 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>OMH Company and Product Ops</title>
+    <meta name="description" content="OMH company and product operations docs for feedback triage, research briefs, meeting briefs, and strategy briefs.">
+    <link rel="stylesheet" href="../../styles.css">
+  </head>
+  <body class="docs-page feature-page">
+    <header class="topbar topbar--solid" aria-label="Primary">
+      <a class="brand brand--link" href="../../">OMH</a>
+      <nav class="nav" aria-label="Primary navigation">
+        <a href="../">Docs</a>
+        <a class="nav__icon" href="https://github.com/rlaope/oh-my-hermes-agent" aria-label="Open OMH repository on GitHub" title="GitHub repository">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2C6.48 2 2 6.58 2 12.22c0 4.52 2.87 8.35 6.85 9.7.5.09.68-.22.68-.49v-1.73c-2.78.62-3.37-1.37-3.37-1.37-.45-1.18-1.11-1.5-1.11-1.5-.91-.64.07-.63.07-.63 1 .07 1.53 1.06 1.53 1.06.9 1.56 2.35 1.11 2.92.85.09-.66.35-1.11.63-1.37-2.22-.26-4.55-1.14-4.55-5.06 0-1.12.39-2.03 1.03-2.75-.1-.26-.45-1.31.1-2.71 0 0 .84-.28 2.75 1.05A9.37 9.37 0 0 1 12 6.92c.85 0 1.7.12 2.5.35 1.9-1.33 2.74-1.05 2.74-1.05.55 1.4.2 2.45.1 2.71.64.72 1.03 1.63 1.03 2.75 0 3.93-2.34 4.79-4.57 5.05.36.32.68.94.68 1.9v2.8c0 .27.18.58.69.48A10.06 10.06 0 0 0 22 12.22C22 6.58 17.52 2 12 2Z"></path></svg>
+        </a>
+      </nav>
+    </header>
+
+    <main class="feature-shell">
+      <header class="feature-hero">
+        <p class="eyebrow">Flagship lane</p>
+        <h1>Company and product ops</h1>
+        <p>
+          Use this lane when Hermes should help a team work through customer
+          signals, research, meetings, strategy, and operating reviews without
+          defaulting to coding.
+        </p>
+        <div class="feature-actions">
+          <a class="button button--primary" href="../">Back to docs</a>
+          <a class="button" href="../executor-handoff/">See handoff lane</a>
+        </div>
+      </header>
+
+      <section class="feature-section feature-section--split">
+        <div class="feature-copy">
+          <h2>Operating pipeline</h2>
+          <p>
+            A small SaaS team can send "Payment failures keep coming up" in
+            Discord. Hermes can triage the signal, name missing evidence, create
+            a meeting topic, propose strategy options, and record what still has
+            not been observed.
+          </p>
+          <div class="feature-flow feature-flow--ops" aria-label="Company operation flow">
+            <span>data search</span>
+            <span>feedback triage</span>
+            <span>meeting topic</span>
+            <span>strategy</span>
+            <span>record</span>
+          </div>
+        </div>
+        <aside class="feature-contract">
+          <h2>Use these skills</h2>
+          <ul class="docs-list">
+            <li><code>feedback-triage</code> clusters customer signals.</li>
+            <li><code>research-brief</code> separates sources from inference.</li>
+            <li><code>meeting-brief</code> turns signals into agenda items.</li>
+            <li><code>strategy-brief</code> names options, tradeoffs, and next decisions.</li>
+          </ul>
+        </aside>
+      </section>
+
+      <section class="feature-section">
+        <h2>Use cases</h2>
+        <div class="usecase-grid">
+          <article class="case-card">
+            <span>Startup triage</span>
+            <h3>Customers keep reporting payment failures.</h3>
+            <p>Hermes separates feedback clusters, reproduction needs, and product decisions.</p>
+          </article>
+          <article class="case-card">
+            <span>Weekly meeting</span>
+            <h3>Prepare next week's strategy meeting.</h3>
+            <p>Hermes turns support themes, release risk, and research gaps into a focused agenda.</p>
+          </article>
+          <article class="case-card">
+            <span>Agency operations</span>
+            <h3>Repeat the same client workflow without prompt drift.</h3>
+            <p>Hermes follows the same requirement, research, strategy, QA, and record pattern per project.</p>
+          </article>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <span>Product-ops docs are part of the OMH public site.</span>
+      <span>Developed by <a href="https://github.com/rlaope">rlaope</a>.</span>
+    </footer>
+  </body>
+</html>

--- a/site/index.html
+++ b/site/index.html
@@ -183,13 +183,43 @@ omh setup</code>
       <section class="section section--poster" id="flagship-workflows">
         <div class="section__header section__header--poster">
           <p class="eyebrow">Representative workflows</p>
-          <h2>Three command-set lanes for the public story.</h2>
+          <h2>Loop is now a flagship OMH lane.</h2>
           <p>
-            OMH helps Hermes shape fuzzy intent, operate non-coding product work,
-            and prepare executor-ready coding handoffs without blurring who owns
-            observed evidence.
+            OMH helps Hermes run ambitious goal loops, shape fuzzy intent,
+            operate non-coding product work, and prepare executor-ready coding
+            handoffs without blurring who owns observed evidence.
           </p>
         </div>
+        <article class="loop-spotlight" aria-label="New Loop flagship workflow">
+          <div class="loop-spotlight__copy">
+            <span class="new-badge">New</span>
+            <h3>Loop!</h3>
+            <p>
+              After harness engineering, loop engineering becomes the next
+              product surface: give Hermes a clear goal, then let the system
+              decide what to find, how to process it, when to hand off, and
+              when to stop or wait for external evidence.
+            </p>
+            <p>
+              OMH keeps that loop visible through interview, research, plan,
+              runtime tick queue, handoff, feedback, and resume states.
+            </p>
+            <div class="loop-actions">
+              <a class="button button--primary" href="docs/loop/">Explore Loop</a>
+              <a class="button" href="docs/#flagship">All flagship lanes</a>
+            </div>
+          </div>
+          <div class="loop-visual" aria-label="Loop workflow visualization">
+            <span>goal</span>
+            <span>interview</span>
+            <span>research</span>
+            <span>plan</span>
+            <span>tick</span>
+            <span>handoff</span>
+            <span>feedback</span>
+            <span>again</span>
+          </div>
+        </article>
         <div class="flagship-showcase">
           <figure class="poster-frame">
             <img
@@ -206,6 +236,7 @@ omh setup</code>
                 smoother" into a concrete goal, plan, execution-ready path, or
                 direct ambitious goal loop.
               </p>
+              <a class="text-link" href="docs/intent-to-plan/">Open docs</a>
             </article>
             <article class="flagship-item">
               <span>Company and product ops</span>
@@ -214,6 +245,7 @@ omh setup</code>
                 Hermes keeps customer signals, evidence gathering, meeting topics,
                 and strategic options in non-coding operating workflows.
               </p>
+              <a class="text-link" href="docs/product-ops/">Open docs</a>
             </article>
             <article class="flagship-item">
               <span>Executor-ready handoff</span>
@@ -222,6 +254,7 @@ omh setup</code>
                 Hermes prepares scoped work for Codex, Claude Code, or another
                 selected executor instead of hiding coding inside Hermes.
               </p>
+              <a class="text-link" href="docs/executor-handoff/">Open docs</a>
             </article>
           </div>
         </div>

--- a/site/styles.css
+++ b/site/styles.css
@@ -63,6 +63,10 @@ a {
 .card,
 .case-card,
 .flagship-item,
+.loop-spotlight,
+.loop-visual,
+.feature-hero,
+.feature-contract,
 .playbook-row,
 .lifecycle-step,
 .role-card,
@@ -814,6 +818,152 @@ h1 {
   color: #7ed7c2;
 }
 
+.loop-spotlight {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 0.92fr) minmax(320px, 1.08fr);
+  gap: 28px;
+  align-items: center;
+  overflow: hidden;
+  margin-bottom: 24px;
+  padding: 28px;
+  border: 1px solid rgba(126, 215, 194, 0.28);
+  border-radius: 8px;
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.12), rgba(126, 215, 194, 0.1)),
+    radial-gradient(circle at 82% 24%, rgba(126, 215, 194, 0.22), transparent 34%);
+  box-shadow: 0 26px 74px rgba(0, 0, 0, 0.24);
+}
+
+.loop-spotlight::before {
+  content: "";
+  position: absolute;
+  inset: -45% auto -35% 58%;
+  width: 260px;
+  border: 1px solid rgba(126, 215, 194, 0.16);
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(126, 215, 194, 0.1) 0 1px,
+      transparent 1px 28px
+    );
+  transform: rotate(-13deg);
+  opacity: 0.7;
+}
+
+.loop-spotlight--docs {
+  margin: 22px 0;
+  border-color: rgba(25, 116, 102, 0.22);
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.94), rgba(238, 250, 245, 0.84)),
+    radial-gradient(circle at 82% 24%, rgba(126, 215, 194, 0.2), transparent 34%);
+  box-shadow: 0 26px 74px rgba(16, 28, 40, 0.13);
+  color: var(--ink);
+}
+
+.loop-spotlight--docs p {
+  color: var(--muted);
+}
+
+.loop-spotlight__copy {
+  position: relative;
+  z-index: 1;
+}
+
+.new-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 28px;
+  padding: 5px 10px;
+  border: 1px solid rgba(240, 184, 110, 0.3);
+  border-radius: 999px;
+  background: rgba(255, 248, 234, 0.96);
+  color: var(--gold);
+  font-size: 12px;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+.loop-spotlight h3 {
+  margin: 12px 0 10px;
+  font-size: clamp(42px, 7vw, 76px);
+  line-height: 0.95;
+}
+
+.loop-spotlight p {
+  max-width: 690px;
+  color: rgba(224, 239, 245, 0.82);
+  font-size: 17px;
+}
+
+.loop-actions,
+.feature-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 20px;
+}
+
+.loop-visual {
+  position: relative;
+  z-index: 1;
+  min-height: 270px;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+  padding: 20px;
+  border: 1px solid rgba(126, 215, 194, 0.22);
+  border-radius: 8px;
+  background:
+    linear-gradient(145deg, rgba(15, 24, 34, 0.96), rgba(20, 70, 68, 0.86));
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.08),
+    0 26px 70px rgba(16, 28, 40, 0.22);
+  color: #ffffff;
+  perspective: 900px;
+}
+
+.loop-visual::before {
+  content: "";
+  position: absolute;
+  inset: 50% 34px auto;
+  height: 2px;
+  background: linear-gradient(90deg, #7ed7c2, #f0b86e, #7ed7c2);
+  box-shadow: 0 0 22px rgba(126, 215, 194, 0.36);
+}
+
+.loop-visual span {
+  position: relative;
+  display: grid;
+  place-items: center;
+  min-height: 68px;
+  padding: 10px;
+  border: 1px solid rgba(126, 215, 194, 0.28);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.1);
+  color: #eefaf5;
+  font-weight: 900;
+  text-align: center;
+  text-transform: uppercase;
+  transform: translateZ(0);
+  transition:
+    background 170ms ease,
+    border-color 170ms ease,
+    transform 170ms ease;
+}
+
+.loop-visual span:hover {
+  transform: translateY(-5px) translateZ(24px);
+  border-color: rgba(240, 184, 110, 0.54);
+  background: rgba(126, 215, 194, 0.18);
+}
+
+.loop-visual span:nth-child(1),
+.loop-visual span:nth-child(8) {
+  background: rgba(240, 184, 110, 0.18);
+}
+
 .flagship-showcase {
   display: grid;
   grid-template-columns: minmax(0, 1.15fr) minmax(320px, 0.85fr);
@@ -841,6 +991,7 @@ h1 {
 }
 
 .flagship-item {
+  display: block;
   min-height: 164px;
   padding: 22px;
   border: 1px solid rgba(126, 215, 194, 0.24);
@@ -848,6 +999,8 @@ h1 {
   background:
     linear-gradient(180deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.03));
   box-shadow: 0 20px 54px rgba(0, 0, 0, 0.22);
+  color: inherit;
+  text-decoration: none;
   transition:
     border-color 180ms ease,
     box-shadow 180ms ease,
@@ -884,6 +1037,16 @@ h1 {
 
 .flagship-item code {
   color: #9cf0e5;
+}
+
+.text-link {
+  display: inline-flex;
+  margin-top: 12px;
+  color: #9cf0e5;
+  font-size: 14px;
+  font-weight: 900;
+  text-decoration-color: rgba(126, 215, 194, 0.34);
+  text-underline-offset: 3px;
 }
 
 .role-grid {
@@ -2011,6 +2174,202 @@ h1 {
   background: #6b7280;
 }
 
+.feature-page {
+  background:
+    linear-gradient(180deg, #ffffff 0, #f5fbf8 420px, #ffffff 920px);
+}
+
+.feature-shell {
+  max-width: 1160px;
+  margin: 0 auto;
+  padding: 44px clamp(20px, 5vw, 72px) 84px;
+}
+
+.feature-hero {
+  position: relative;
+  overflow: hidden;
+  padding: clamp(30px, 5vw, 58px);
+  border: 1px solid rgba(215, 220, 216, 0.78);
+  border-radius: 8px;
+  background:
+    linear-gradient(145deg, rgba(255, 255, 255, 0.92), rgba(238, 250, 245, 0.7)),
+    radial-gradient(circle at 84% 18%, rgba(126, 215, 194, 0.24), transparent 32%);
+  box-shadow: 0 28px 84px rgba(16, 28, 40, 0.12);
+}
+
+.feature-hero--loop {
+  background:
+    linear-gradient(145deg, rgba(255, 255, 255, 0.9), rgba(238, 250, 245, 0.72)),
+    radial-gradient(circle at 82% 20%, rgba(240, 184, 110, 0.2), transparent 30%),
+    radial-gradient(circle at 12% 80%, rgba(126, 215, 194, 0.22), transparent 28%);
+}
+
+.feature-hero::after {
+  content: "";
+  position: absolute;
+  right: -12%;
+  bottom: -42%;
+  width: 460px;
+  height: 260px;
+  border: 1px solid rgba(25, 116, 102, 0.14);
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(25, 116, 102, 0.1) 0 1px,
+      transparent 1px 34px
+    );
+  transform: rotate(-10deg);
+}
+
+.feature-hero > * {
+  position: relative;
+  z-index: 1;
+}
+
+.feature-hero h1 {
+  max-width: 780px;
+  margin: 10px 0 18px;
+  font-size: clamp(48px, 8vw, 88px);
+  line-height: 0.96;
+}
+
+.feature-hero p {
+  max-width: 820px;
+  color: var(--muted);
+  font-size: 19px;
+}
+
+.feature-section {
+  padding: 50px 0;
+  border-bottom: 1px solid var(--line);
+}
+
+.feature-section h2 {
+  margin: 0 0 14px;
+  font-size: clamp(30px, 4vw, 46px);
+  line-height: 1.08;
+}
+
+.feature-section p {
+  color: var(--muted);
+  font-size: 17px;
+}
+
+.feature-section--split {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(300px, 0.72fr);
+  gap: 24px;
+  align-items: start;
+}
+
+.feature-copy {
+  min-width: 0;
+}
+
+.loop-post {
+  display: grid;
+  gap: 12px;
+  margin: 24px 0 0;
+  padding: 24px;
+  border-left: 4px solid var(--accent);
+  border-radius: 8px;
+  background: #f8fcf9;
+  box-shadow: 0 14px 36px rgba(16, 28, 40, 0.08);
+}
+
+.loop-post p {
+  margin: 0;
+  color: var(--ink);
+  font-size: 17px;
+}
+
+.loop-visual--large {
+  min-height: 390px;
+}
+
+.feature-contract {
+  padding: 24px;
+  border: 1px solid rgba(25, 116, 102, 0.18);
+  border-radius: 8px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(238, 250, 245, 0.76));
+  box-shadow: var(--shadow);
+}
+
+.feature-contract h2 {
+  font-size: 26px;
+}
+
+.feature-flow {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 10px;
+  margin-top: 22px;
+  padding: 18px;
+  border: 1px solid rgba(25, 116, 102, 0.16);
+  border-radius: 8px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(247, 251, 248, 0.86));
+  box-shadow: 0 18px 44px rgba(16, 28, 40, 0.1);
+}
+
+.feature-flow span {
+  position: relative;
+  min-height: 86px;
+  display: grid;
+  place-items: center;
+  padding: 12px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #ffffff;
+  color: var(--ink);
+  font-size: 14px;
+  font-weight: 900;
+  text-align: center;
+  text-transform: uppercase;
+  transition:
+    border-color 170ms ease,
+    box-shadow 170ms ease,
+    transform 170ms ease;
+}
+
+.feature-flow span::after {
+  content: "";
+  position: absolute;
+  right: -11px;
+  top: 50%;
+  width: 12px;
+  height: 2px;
+  background: rgba(25, 116, 102, 0.36);
+}
+
+.feature-flow span:last-child::after {
+  display: none;
+}
+
+.feature-flow span:hover {
+  transform: translateY(-4px);
+  border-color: rgba(25, 116, 102, 0.28);
+  box-shadow: 0 18px 40px rgba(16, 28, 40, 0.12);
+}
+
+.feature-flow--ops span:nth-child(4) {
+  border-color: rgba(179, 107, 22, 0.28);
+  background: #fff8ea;
+}
+
+.feature-flow--handoff span:nth-child(n + 4) {
+  border-color: rgba(179, 107, 22, 0.28);
+  background: #fff8ea;
+}
+
+.usecase-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+  margin-top: 20px;
+}
+
 @keyframes heroSheen {
   from {
     background-position: 0 0, 0 0;
@@ -2141,6 +2500,10 @@ h1 {
   .case-grid,
   .case-grid--docs,
   .flagship-showcase,
+  .loop-spotlight,
+  .feature-section--split,
+  .feature-flow,
+  .usecase-grid,
   .role-grid,
   .site-example,
   .docs-shell,
@@ -2183,6 +2546,34 @@ h1 {
 
   .docs-hero {
     padding: 28px 22px;
+  }
+
+  .feature-shell {
+    padding-top: 28px;
+  }
+
+  .feature-hero {
+    padding: 30px 22px;
+  }
+
+  .loop-visual {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    min-height: 0;
+  }
+
+  .loop-visual::before {
+    inset: 24px 50% 24px auto;
+    width: 2px;
+    height: auto;
+  }
+
+  .feature-flow span::after {
+    right: auto;
+    top: auto;
+    bottom: -11px;
+    left: 50%;
+    width: 2px;
+    height: 12px;
   }
 
   .status-preview {

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -381,6 +381,10 @@ class RouterContentTests(unittest.TestCase):
             Path(".github/ISSUE_TEMPLATE/config.yml"),
             Path("site/index.html"),
             Path("site/docs/index.html"),
+            Path("site/docs/loop/index.html"),
+            Path("site/docs/intent-to-plan/index.html"),
+            Path("site/docs/product-ops/index.html"),
+            Path("site/docs/executor-handoff/index.html"),
             Path("site/styles.css"),
             Path("site/assets/hermes-agent-hero.png"),
         ]
@@ -400,6 +404,10 @@ class RouterContentTests(unittest.TestCase):
         install_sh = Path("install.sh").read_text(encoding="utf-8")
         site = Path("site/index.html").read_text(encoding="utf-8")
         site_docs = Path("site/docs/index.html").read_text(encoding="utf-8")
+        site_loop = Path("site/docs/loop/index.html").read_text(encoding="utf-8")
+        site_intent = Path("site/docs/intent-to-plan/index.html").read_text(encoding="utf-8")
+        site_product_ops = Path("site/docs/product-ops/index.html").read_text(encoding="utf-8")
+        site_handoff = Path("site/docs/executor-handoff/index.html").read_text(encoding="utf-8")
         site_css = Path("site/styles.css").read_text(encoding="utf-8")
 
         self.assertIn("hermes skills tap add rlaope/oh-my-hermes-agent", readme)
@@ -535,6 +543,12 @@ class RouterContentTests(unittest.TestCase):
         self.assertIn("planning-lead", site)
         self.assertIn("Prepared is not observed", site)
         self.assertIn("Routing is not plan acceptance, dispatch, or execution evidence.", site)
+        self.assertIn("Loop is now a flagship OMH lane.", site)
+        self.assertIn("<h3>Loop!</h3>", site)
+        self.assertIn('href="docs/loop/"', site)
+        self.assertIn('href="docs/intent-to-plan/"', site)
+        self.assertIn('href="docs/product-ops/"', site)
+        self.assertIn('href="docs/executor-handoff/"', site)
         self.assertIn("Hermes Agent Integration Runbook", site_docs)
         self.assertIn("examples/wrapper-golden/hermes-agent-integration.json", site_docs)
         self.assertIn("Role surface", site_docs)
@@ -543,6 +557,20 @@ class RouterContentTests(unittest.TestCase):
         self.assertIn("request-to-handoff", site_docs)
         self.assertIn("planning-lead", site_docs)
         self.assertIn("Routing is not plan acceptance, dispatch, or execution evidence.", site_docs)
+        self.assertIn('href="loop/">Open Loop docs</a>', site_docs)
+        self.assertIn('href="intent-to-plan/"', site_docs)
+        self.assertIn('href="product-ops/"', site_docs)
+        self.assertIn('href="executor-handoff/"', site_docs)
+        self.assertIn("Loop Engineering", site_loop)
+        self.assertIn("하네스 엔지니어링", site_loop)
+        self.assertIn("loop_runtime/v1", site_loop)
+        self.assertIn("A loop tick is not execution", site_loop)
+        self.assertIn("Intent to plan", site_intent)
+        self.assertIn("deep-interview", site_intent)
+        self.assertIn("Company and product ops", site_product_ops)
+        self.assertIn("feedback-triage", site_product_ops)
+        self.assertIn("Executor-ready handoff", site_handoff)
+        self.assertIn("Codex, Claude Code", site_handoff)
         topbar = site.split('<header class="topbar"', 1)[1].split("</header>", 1)[0]
         self.assertIn('href="docs/"', topbar)
         self.assertNotIn('href="#architecture"', topbar)
@@ -568,6 +596,8 @@ class RouterContentTests(unittest.TestCase):
         self.assertIn("omh harness validate", site_docs)
         self.assertIn("harness_progress/v1", site)
         self.assertIn("assets/hermes-agent-hero.png", site_css)
+        self.assertIn(".loop-spotlight", site_css)
+        self.assertIn(".feature-flow", site_css)
 
     def test_direction_and_agent_contract_lock_product_boundary(self) -> None:
         direction = Path("docs/DIRECTION.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- promote Loop as a new flagship workflow above the existing three representative site lanes
- add dedicated site docs pages for Loop, intent-to-plan, company/product ops, and executor-ready handoff
- include Loop Engineering copy, use-case visualizations, chat examples, and prepared-vs-observed evidence boundaries
- lock the new public site surfaces in router content tests

## Verification
- `PYTHONPATH=tests uv run python -m unittest tests/test_router_content.py -v` -> 22 tests OK
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` -> 273 tests OK
- `uv run python -m compileall -q src tests` -> OK
- `uv run python -m src.cli docs workflows --check` -> OK, tap skills 29/29, stale []
- static HTTP smoke: `/`, `/docs/`, `/docs/loop/`, `/docs/intent-to-plan/`, `/docs/product-ops/`, `/docs/executor-handoff/` -> HTTP 200
- static site link check -> OK
- `git diff --check` -> OK

## Notes
- Browser screenshot review was not run because this session did not expose a callable Browser tool and Playwright was not installed.
- The Loop page keeps the runtime claim bounded: `loop_runtime/v1` tick queues are prepared state, not execution evidence.