### PR TITLE
Make OMH update refresh same-version installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ omh doctor
 
 `omh doctor` prints a short health summary by default. Use `omh doctor --json`
 for the full check payload.
+`omh install` and `omh update` follow the same rule: human-readable summaries
+for terminal use, `--json` for wrappers and automation.
 
 The installer creates an isolated OMH virtual environment, links the `omh`
 command into `~/.local/bin` when possible, and prints the installed command

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -178,6 +178,9 @@ Hermes before claiming the skill is visible in chat.
 `omh doctor` should report a healthy summary by default; `omh doctor --json`
 returns the full check payload. `omh list` should show the managed skills
 available to Hermes.
+`omh install` and `omh update` also print concise summaries by default; use
+`--json` or `OMH_OUTPUT=json` when a wrapper or automation needs the complete
+manifest payload.
 `omh runtime status` should show the local runtime artifact directory and the
 latest install/apply/doctor state when those commands have run. `omh probe`
 reports observable Hermes capability surfaces without mutating Hermes internals.

--- a/install.sh
+++ b/install.sh
@@ -148,7 +148,7 @@ install_into_venv() {
   say "Installing OMH package..."
   # Intentional shell splitting: OMH_PIP_ARGS is an advanced operator escape hatch.
   # shellcheck disable=SC2086
-  PIP_DISABLE_PIP_VERSION_CHECK=1 "$OMH_RUNTIME_PYTHON" -m pip install --disable-pip-version-check -q $OMH_PIP_ARGS --upgrade "$OMH_PACKAGE_URL"
+  PIP_DISABLE_PIP_VERSION_CHECK=1 "$OMH_RUNTIME_PYTHON" -m pip install --disable-pip-version-check -q --force-reinstall $OMH_PIP_ARGS --upgrade "$OMH_PACKAGE_URL"
   OMH_COMMAND_HINT="$OMH_VENV_DIR/bin/omh"
   link_omh_command
 }
@@ -161,7 +161,7 @@ install_into_python() {
   say "Installing OMH package..."
   # Intentional shell splitting: OMH_DIRECT_PIP_ARGS is an advanced operator escape hatch.
   # shellcheck disable=SC2086
-  PIP_DISABLE_PIP_VERSION_CHECK=1 "$OMH_PYTHON" -m pip install --disable-pip-version-check -q $OMH_DIRECT_PIP_ARGS --upgrade "$OMH_PACKAGE_URL"
+  PIP_DISABLE_PIP_VERSION_CHECK=1 "$OMH_PYTHON" -m pip install --disable-pip-version-check -q --force-reinstall $OMH_DIRECT_PIP_ARGS --upgrade "$OMH_PACKAGE_URL"
   OMH_RUNTIME_PYTHON="$OMH_PYTHON"
 }
 

--- a/src/commands/setup.py
+++ b/src/commands/setup.py
@@ -25,7 +25,11 @@ from .common import _paths, _print_json, _wants_json
 
 
 def cmd_install(args: argparse.Namespace) -> int:
-    _print_json(_install_result(args))
+    payload = _install_result(args)
+    if _wants_json(args):
+        _print_json(payload)
+    else:
+        _print_install_summary(payload, command=str(getattr(args, "command", "install")))
     return 0
 
 
@@ -451,6 +455,29 @@ def _print_doctor_summary(payload: dict[str, object]) -> None:
     print("For machine-readable output, rerun with `--json`.")
 
 
+def _print_install_summary(payload: dict[str, object], *, command: str) -> None:
+    skills = payload.get("skills", [])
+    if not isinstance(skills, list):
+        skills = []
+    dry_run = bool(payload.get("dry_run", False))
+    label = "update" if command == "update" else "install"
+    title = f"OMH {label} preview complete." if dry_run else f"OMH {label} complete."
+    print(title)
+    print(f"Skills: {len(skills)} managed skill(s) at {payload.get('skills_dir', '')}")
+    print(f"Source: {payload.get('source', 'builtin')}")
+    channel = str(payload.get("release_channel", "")).strip()
+    package_url = str(payload.get("release_package_url", "")).strip()
+    if channel:
+        print(f"Release channel: {channel}")
+    if package_url and package_url != "local":
+        print(f"Package URL: {package_url}")
+    if dry_run:
+        print("Next: rerun without `--dry-run` to refresh the managed skills.")
+    else:
+        print("Next: run `omh setup` to repair Hermes registration, or `omh doctor` to verify health.")
+    print("For machine-readable output, rerun with `--json`.")
+
+
 def _plugin_setup_result(args: argparse.Namespace, paths) -> dict[str, object]:
     try:
         result = install_plugin_bundle(paths, force=args.force, dry_run=args.dry_run)
@@ -559,10 +586,12 @@ def _add_top_level_commands(sub) -> None:
 
     install = sub.add_parser("install")
     _add_common_install_options(install)
+    install.add_argument("--json", action="store_true", help="Print the full machine-readable install payload.")
     install.set_defaults(func=cmd_install)
 
     update = sub.add_parser("update")
     _add_common_install_options(update)
+    update.add_argument("--json", action="store_true", help="Print the full machine-readable update payload.")
     update.set_defaults(func=cmd_update)
 
     convert = sub.add_parser("convert")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -123,6 +123,34 @@ class CliTests(unittest.TestCase):
             self.assertEqual(profile["default_executor"], "choose")
             self.assertFalse((hermes_home / "plugins" / "omh" / "plugin.yaml").exists())
 
+    def test_install_and_update_default_to_human_summary_with_json_escape_hatch(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = ["--omh-home", str(root / ".omh")]
+
+            status, stdout, stderr = run_cli(base + ["install"], output_json=False)
+
+            self.assertEqual(status, 0, stderr)
+            self.assertEqual(stderr, "")
+            self.assertIn("OMH install complete.", stdout)
+            self.assertIn("Skills: 29 managed skill(s)", stdout)
+            self.assertIn("Next: run `omh setup`", stdout)
+            with self.assertRaises(json.JSONDecodeError):
+                json.loads(stdout)
+
+            status, stdout, stderr = run_cli(base + ["update", "--dry-run"], output_json=False)
+
+            self.assertEqual(status, 0, stderr)
+            self.assertEqual(stderr, "")
+            self.assertIn("OMH update preview complete.", stdout)
+            self.assertIn("Next: rerun without `--dry-run`", stdout)
+
+            status, stdout, stderr = run_cli(base + ["update", "--json"], output_json=False)
+
+            self.assertEqual(status, 0, stderr)
+            self.assertEqual(stderr, "")
+            self.assertEqual(json.loads(stdout)["package"], "oh-my-hermes-agent")
+
     def test_goal_cli_records_checkpoints_and_completion_gate(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -495,6 +495,7 @@ class RouterContentTests(unittest.TestCase):
         self.assertIn('set -- "$@" --source "$OMH_PACKAGE_URL"', install_sh)
         self.assertIn("Installing OMH package...", install_sh)
         self.assertIn("--disable-pip-version-check -q", install_sh)
+        self.assertIn("--force-reinstall", install_sh)
         self.assertIn("wrapper_actions", harness_quality)
         self.assertIn("overclaim_guards", harness_quality)
         self.assertIn("harness_progress/v1", harness_quality)


### PR DESCRIPTION
## Summary
- force reinstall package archives in install.sh so preview/local updates replace stale same-version entrypoints
- make `omh install` and `omh update` human-readable by default
- keep `omh install --json`, `omh update --json`, and `OMH_OUTPUT=json` as machine-readable escape hatches

## Why
After PR #66 merged, `install.sh` ran new setup output from the checkout, but the installed `/Users/rlaope/.local/bin/omh` entrypoint still imported stale site-packages code because the package version remained `1.0.0`. Preview/main installs need to refresh even without a version bump.

## Verification
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- `uv run python -m compileall -q src tests`
- `uv run python -m src.cli docs workflows --check`
- `git diff --check`
- local `install.sh` force-reinstall smoke against `/Users/rlaope/.local/bin/omh`
- real `omh update` and `omh update --json` smoke

## Notes
- network curl preview install is not claimed until this commit lands on main
- unrelated untracked files remain untouched: `assets/agent-era-dev-checklist.*`, `uv.lock`
