### PR TITLE
Remove transport-gap framing from Hermes docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,9 +136,9 @@ curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes-agent/main/inst
 
 - **Natural-language first** - users in chat do not need to know `omh` commands.
 - **Install-first, not dashboard-first** - get Hermes-visible skills without
-  adopting a hosted service, bot SDK, or separate app.
-- **Hermes-native boundary** - no Hermes core patching, hidden transport bot, or
-  network service inside this package.
+  adopting a separate dashboard or app.
+- **Hermes-native boundary** - OMH extends Hermes Agent with skills,
+  workflows, plugin context, and local evidence contracts.
 - **Delegation-first coding** - coding-heavy requests become prepared handoffs
   for the selected executor: Codex when supported, or prompt-only handoff for
   Claude Code, generic agents, OMH-style runtimes, or Hermes-retained work.
@@ -174,7 +174,7 @@ curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes-agent/main/inst
 | Coding handoffs | Executor-neutral handoff payloads with acceptance, review, and verification expectations. |
 | Memory context review | Review OMH-local and wrapper-supplied context, flag stale assumptions, and attach conflict-free summaries to executor handoffs. |
 | Strict goal progress | `.omh/goals` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, and `goal_continuation/v1` keep long-running goals from being treated as done before evidence is ready. |
-| Wrapper contracts | `chat_interaction/v1`, status cards, action ids, and local runtime artifacts for Discord, Slack, or hosted adapters. |
+| Hermes chat contracts | `chat_interaction/v1`, status cards, action ids, and local runtime artifacts for Hermes Agent chat surfaces. |
 | Optional plugin bridge | `omh setup --with-plugin` installs `~/.hermes/plugins/omh` with metadata-only `omh_status` support. |
 | Optional team profile packs | CTO/PM-style or delivery/research role files can be installed only when selected. |
 

--- a/docs/APPLICATION_CASES.md
+++ b/docs/APPLICATION_CASES.md
@@ -363,11 +363,13 @@ Expected behavior:
   `strategy-synthesis`, `meeting-facilitation`, or `business-research` rather
   than `coding-handling`
 
-### Current Limit
+### Transport Boundary
 
-OMH does not fetch company data, read private feedback systems, or post to
-Discord/Slack by itself. A wrapper or Hermes environment must supply observed
-source evidence before Hermes can claim data was actually reviewed.
+OMH assumes Hermes Agent or the hosted chat surface receives messages, renders
+replies, and owns platform-specific transport. OMH does not duplicate that
+layer. It supplies deterministic routing, plan, handoff, and status contracts,
+and it requires observed source evidence before Hermes can claim data was
+actually reviewed.
 
 ## Grounded UltraQA Scenario Matrix
 

--- a/docs/APPLICATION_CASES.md
+++ b/docs/APPLICATION_CASES.md
@@ -295,9 +295,9 @@ PYTHONPATH=tests python3 -m unittest tests/test_cli.py -v
 
 ### Current Limit
 
-Playbooks are deterministic local contracts. They do not post messages,
-authenticate transport bots, launch coding executors, or prove that a later
-stage happened. Runtime status must still come from observed evidence records.
+Playbooks are deterministic local contracts. They do not launch coding
+executors or prove that a later stage happened. Runtime status must still come
+from observed evidence records.
 
 ## Case 5: Company Workflows Without CLI Knowledge
 
@@ -363,13 +363,11 @@ Expected behavior:
   `strategy-synthesis`, `meeting-facilitation`, or `business-research` rather
   than `coding-handling`
 
-### Transport Boundary
+### Evidence Boundary
 
-OMH assumes Hermes Agent or the hosted chat surface receives messages, renders
-replies, and owns platform-specific transport. OMH does not duplicate that
-layer. It supplies deterministic routing, plan, handoff, and status contracts,
-and it requires observed source evidence before Hermes can claim data was
-actually reviewed.
+OMH supplies deterministic routing, plan, handoff, and status contracts for
+Hermes Agent. It still requires observed source evidence before Hermes can
+claim data was actually reviewed.
 
 ## Grounded UltraQA Scenario Matrix
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -32,7 +32,7 @@ flowchart LR
   user["User in Hermes, Discord, Slack, or hosted chat"]
   skills["Installed OMH skills\nHermes skill tap or omh setup"]
   plugin["Optional OMH plugin\n~/.hermes/plugins/omh"]
-  wrapper["Wrapper adapter\nbuttons, threads, edits"]
+  wrapper["Hermes chat surface\nbuttons, threads, edits"]
   omh["OMH local contract layer\nplaybooks, routing, plan, handoff, status"]
   hermes["Hermes Agent\nclarify, research, plan, narrate"]
   executor["Selected coding executor\nimplementation, verification"]
@@ -58,7 +58,7 @@ flowchart LR
 Chat user
   -> Hermes Agent owns conversation, planning, and status narration
   -> Installed OMH skills provide workflow and evidence guidance
-  -> Optional wrapper owns transport UX and asks OMH for backend contracts
+  -> Hermes chat surface asks OMH for backend contracts
   -> Executor owns main coding work when dispatched
   -> Runtime artifacts own observed evidence
 ```
@@ -144,7 +144,7 @@ OMH directly when Hermes taps are available.
 `plugin_bundle/omh/` is the optional Hermes plugin payload installed by
 `omh setup --with-plugin` to `~/.hermes/plugins/omh`. The v1 plugin registers
 only a metadata-only `omh_status` tool and a passive `pre_llm_call` hook. It
-does not run verification commands, install transports, patch Hermes core, or
+does not run verification commands, patch Hermes core, or
 claim execution evidence from prepared handoffs.
 
 `cli.py` is a compatibility adapter. `commands/main.py` owns parser assembly,
@@ -259,10 +259,10 @@ Routing, planning, and delegation have eight local surfaces:
    operators create deterministic `hermes_plan/v1` planning scaffolds under
    `.hermes/plans/` without claiming that execution or review already happened.
 
-`omh chat interact` is the primary adapter contract. It composes the lower-level
-surfaces into one response envelope so each transport does not need to invent
-its own orchestration policy. The `chat_response/v1` subobject is safe for the
-adapter to render directly: it names the state, provides concise copy, exposes
+`omh chat interact` is the primary Hermes-facing chat contract. It composes the
+lower-level surfaces into one response envelope so each Hermes Agent surface can
+share the same orchestration policy. The `chat_response/v1` subobject is safe
+to render directly: it names the state, provides concise copy, exposes
 platform-neutral actions, and never asks the end user to run an `omh` command.
 The surrounding envelope preserves source metadata, message hash and length,
 thread key, selected mode, next action, redaction policy, and claim boundary.
@@ -291,8 +291,8 @@ the companion `run.json` is marked as
 and `coding_delegation.json` as a required pair. The run envelope is
 implementation bookkeeping, not proof that Hermes executed the handoff.
 
-Neither the wrapper contract nor the lower-level surfaces include Discord SDKs,
-Slack SDKs, network calls, Codex process launching, or Hermes core patching.
+The wrapper contract and lower-level surfaces are local contracts; execution
+evidence still comes from Hermes Agent and the selected executor.
 
 Hermes planning writes Markdown plans under the configured Hermes home rather
 than runtime JSON under `.omh/runtime/`. The artifact is user-facing: it includes

--- a/docs/CHAT_WRAPPER_EXAMPLES.md
+++ b/docs/CHAT_WRAPPER_EXAMPLES.md
@@ -1,9 +1,8 @@
 # Chat Wrapper Examples
 
-This page shows how a Discord-style wrapper can render OMH output as a normal
-Hermes Agent chat response. The example is generated from local fixtures; it
-does not require a bot SDK, credentials, network access, an LLM call, or Hermes
-core changes.
+This page shows how a Discord-style Hermes Agent surface can render OMH output
+as a normal chat response. The example is generated from local fixtures so the
+contract is easy to inspect.
 
 For the operator runbook that ties these examples to state transitions,
 responsibilities, and evidence boundaries, read
@@ -211,6 +210,5 @@ What gets better for the team:
 | Status rows | `status_card.steps[]` |
 | Primary status action | `status_card.primary_action` |
 
-Wrappers should render these fields natively and keep platform-specific work
-outside OMH: authentication, posting, message edits, retries, buttons, and
-thread lifecycle all remain adapter responsibilities.
+Hermes Agent surfaces should render these fields natively and keep OMH focused
+on the routing, handoff, status, and evidence contract.

--- a/docs/DELEGATION_FIRST_COMPLETENESS.md
+++ b/docs/DELEGATION_FIRST_COMPLETENESS.md
@@ -55,12 +55,12 @@ The strongest existing path is:
 6. Separate wrapper/runtime evidence is required before OMH can say execution,
    review, verification, CI, merge, or merge-readiness was observed.
 
-## Completeness Gaps
+## Integration Boundaries
 
-| Priority | Gap | Why it matters | Target story |
+| Priority | Boundary | Why it matters | Target story |
 | --- | --- | --- | --- |
-| P0 | Actual Discord and Slack adapters are not implemented in this repository. | The core contract is ready, but platform auth, retries, edits, and posting still belong to wrapper projects. | Build example adapter shims only after transport dependencies and packaging are approved. |
-| P1 | Adapter projects still need transport-specific examples. | Golden JSON locks the wrapper contract, but production bots need platform auth, retry, edit, and thread patterns. | Add adapter shims only after transport dependencies are approved. |
+| P0 | Hermes Agent or the hosted chat surface owns transport. | OMH should not duplicate platform auth, retries, edits, or posting when Hermes-hosted chat already supplies that layer. | Keep OMH focused on fixture-backed wrapper contracts and local status artifacts. |
+| P1 | Hosted chat surfaces still need contract-consumption examples. | Golden JSON locks the wrapper contract, but operators still need examples for rendering replies, actions, status cards, and thread keys. | Add fixture-backed examples that do not introduce platform SDK dependencies. |
 | P2 | Run-backed lifecycle reporting is Codex-only in Phase 1. | Other executor targets are supported as prompt-only handoffs until a tested lifecycle contract exists. | Generalize only after another executor contract exists. |
 
 ## First Implementation Contract

--- a/docs/DELEGATION_FIRST_COMPLETENESS.md
+++ b/docs/DELEGATION_FIRST_COMPLETENESS.md
@@ -55,12 +55,12 @@ The strongest existing path is:
 6. Separate wrapper/runtime evidence is required before OMH can say execution,
    review, verification, CI, merge, or merge-readiness was observed.
 
-## Integration Boundaries
+## Hermes Surface Readiness
 
-| Priority | Boundary | Why it matters | Target story |
+| Priority | Focus | Why it matters | Target story |
 | --- | --- | --- | --- |
-| P0 | Hermes Agent or the hosted chat surface owns transport. | OMH should not duplicate platform auth, retries, edits, or posting when Hermes-hosted chat already supplies that layer. | Keep OMH focused on fixture-backed wrapper contracts and local status artifacts. |
-| P1 | Hosted chat surfaces still need contract-consumption examples. | Golden JSON locks the wrapper contract, but operators still need examples for rendering replies, actions, status cards, and thread keys. | Add fixture-backed examples that do not introduce platform SDK dependencies. |
+| P0 | Hermes Agent consumes OMH contracts. | OMH should read as a Hermes-native capability layer, not as a separate bot product. | Keep OMH focused on fixture-backed chat contracts and local status artifacts. |
+| P1 | Hermes-facing examples should stay concrete. | Golden JSON locks the wrapper contract, but operators still need examples for rendering replies, actions, status cards, and thread keys. | Add fixture-backed examples that show chat UX without implying missing platform code. |
 | P2 | Run-backed lifecycle reporting is Codex-only in Phase 1. | Other executor targets are supported as prompt-only handoffs until a tested lifecycle contract exists. | Generalize only after another executor contract exists. |
 
 ## First Implementation Contract

--- a/docs/DIRECTION.md
+++ b/docs/DIRECTION.md
@@ -108,18 +108,17 @@ Selected coding executors own:
 
 5. Prefer local deterministic artifacts over hidden magic.
    Runtime records, wrapper sessions, and plans should be inspectable,
-   schema-versioned, redacted by default, and local-only unless a wrapper
-   outside this repository performs transport work.
+   schema-versioned, redacted by default, and local-first.
 
    Memory/context review follows the same rule. OMH may inspect OMH-local
    memory files, wrapper sessions, target topology, setup profiles, and
    wrapper-supplied snapshots; it must not claim it read or changed opaque
    Hermes internal memory.
 
-6. Do not widen into platform transports prematurely.
-   Transport adapters, auth, retries, message edits, and posting belong outside
-   this repository until their dependency and packaging story is explicitly
-   approved.
+6. Keep Hermes Agent as the chat surface.
+   OMH should not describe missing Discord/Slack bot layers as product gaps.
+   The product story is that Hermes Agent receives natural language and consumes
+   OMH skills, workflows, and local status contracts.
 
 7. Treat compatibility skill names as UX affordances.
    Workflow names may remain installed for familiarity, but their generated
@@ -150,10 +149,9 @@ Split into separate PRs only when:
    Keep this document, architecture docs, README, generated skills, examples,
    and tests aligned around delegation-first wrapper orchestration.
 
-2. Wrapper-native UX depth.
-   Expand golden JSON into adapter pseudocode examples for Discord and Slack
-   actions, threads, buttons, and status updates without adding transport
-   dependencies.
+2. Hermes-native UX depth.
+   Expand golden JSON into Hermes Agent-facing examples for actions, threads,
+   buttons, and status updates without turning them into separate bot products.
 
 3. Evidence completeness.
    Keep review, CI, merge-readiness, and merge observation records strict at
@@ -164,10 +162,10 @@ Split into separate PRs only when:
    non-coding requests feel first-class rather than like coding handoff
    leftovers.
 
-5. Adapter boundary readiness.
-   Only after the local contract is stable, consider example shims or adapter
-   packages that consume `chat_interaction/v1` without moving platform secrets
-   or network behavior into core OMH.
+5. Hermes surface readiness.
+   Keep improving examples that consume `chat_interaction/v1` from the Hermes
+   Agent side so users understand the chat-first flow without learning CLI
+   commands.
 
 6. Skill-first distribution.
    Lead with Hermes skill tap/install when the target Hermes environment
@@ -198,6 +196,6 @@ Before accepting direction-changing work, verify:
 - Does it keep coding execution in a selected executor handoff when code
   changes are required?
 - Does it preserve `prepared_not_observed` until wrapper evidence exists?
-- Does it avoid Hermes core patching, LLM/API calls, and transport networking?
+- Does it avoid Hermes core patching and hidden LLM/API calls?
 - Does it keep chat users free from command knowledge?
 - Does it fit one coherent goal PR unless there is a clear reason to split?

--- a/docs/HERMES_AGENT_INTEGRATION_RUNBOOK.md
+++ b/docs/HERMES_AGENT_INTEGRATION_RUNBOOK.md
@@ -23,9 +23,8 @@ questions:
 
 | Owner | Owns | Does not own |
 | --- | --- | --- |
-| Hermes Agent | Chat continuity, clarification, research, planning, and status narration. | Hidden coding execution, or CI/merge proof. |
-| Hermes-hosted chat surface | Platform auth, hosted-chat events, buttons, threads, edits, notifications, and surface-local event/thread caches. | OMH-owned session or run records, or deciding that prepared artifacts prove execution. |
-| OMH | Deterministic local routing, playbook, planning, handoff, session, status, and fixture contracts. | Hermes core patches, platform SDKs, network calls, LLM calls, or executor launch. |
+| Hermes Agent | Chat continuity, clarification, research, planning, status narration, and user-visible actions. | Hidden coding execution, or CI/merge proof. |
+| OMH | Deterministic local routing, playbook, planning, handoff, session, status, and fixture contracts. | Hermes core patches, hidden LLM calls, or executor launch. |
 | Selected coding executor | Main implementation work, verification output, review fixes, and execution evidence after dispatch or prompt handoff. | Chat UX or OMH contract generation. |
 | Runtime artifacts | Metadata-only observed evidence for dispatch, result, verification, review, CI, merge readiness, and merge. | Raw chat secrets or unobserved assumptions. |
 

--- a/docs/HERMES_AGENT_INTEGRATION_RUNBOOK.md
+++ b/docs/HERMES_AGENT_INTEGRATION_RUNBOOK.md
@@ -23,8 +23,8 @@ questions:
 
 | Owner | Owns | Does not own |
 | --- | --- | --- |
-| Hermes Agent | Chat continuity, clarification, research, planning, and status narration. | Platform auth, SDK posting, hidden coding execution, or CI/merge proof. |
-| Wrapper adapter | Discord/Slack or hosted-chat events, buttons, threads, edits, notifications, and adapter-local event/thread caches. | OMH-owned session or run records, or deciding that prepared artifacts prove execution. |
+| Hermes Agent | Chat continuity, clarification, research, planning, and status narration. | Hidden coding execution, or CI/merge proof. |
+| Hermes-hosted chat surface | Platform auth, hosted-chat events, buttons, threads, edits, notifications, and surface-local event/thread caches. | OMH-owned session or run records, or deciding that prepared artifacts prove execution. |
 | OMH | Deterministic local routing, playbook, planning, handoff, session, status, and fixture contracts. | Hermes core patches, platform SDKs, network calls, LLM calls, or executor launch. |
 | Selected coding executor | Main implementation work, verification output, review fixes, and execution evidence after dispatch or prompt handoff. | Chat UX or OMH contract generation. |
 | Runtime artifacts | Metadata-only observed evidence for dispatch, result, verification, review, CI, merge readiness, and merge. | Raw chat secrets or unobserved assumptions. |

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -47,9 +47,9 @@ omh doctor
 ```
 
 That installs `~/.hermes/plugins/omh` with metadata-only status support. It
-does not execute code, install Discord or Slack transports, patch Hermes core,
-or prove Hermes has loaded the plugin. If the target Hermes runtime requires a
-separate plugin enable command, follow that runtime's plugin enable/reload step.
+does not execute code, patch Hermes core, or prove Hermes has loaded the
+plugin. If the target Hermes runtime requires a separate plugin enable command,
+follow that runtime's plugin enable/reload step.
 
 ## Install Path A: Hermes-Native Skill Tap
 
@@ -476,12 +476,10 @@ Before calling the bot integration ready, verify these points:
 - If skills do not appear, run `omh setup`, then `omh doctor`, then restart the
   bot again.
 
-Current limitation: actual Discord, Slack, Hermes, coding executors, GitHub, CI,
-and merge operations still happen outside OMH. `omh chat interact`,
-`omh chat route`, `omh coding delegate`, and `omh coding lifecycle` choose
-contracts and record local metadata, but the wrapper adapter must render
-messages, dispatch to Hermes or the selected coding executor, and record only
-evidence it actually observed.
+Current limitation: `omh chat interact`, `omh chat route`,
+`omh coding delegate`, and `omh coding lifecycle` choose contracts and record
+local metadata. Hermes Agent and the selected executor still provide the actual
+conversation, execution, GitHub, CI, and merge evidence that OMH later records.
 
 ## Update
 

--- a/docs/PLAYBOOKS.md
+++ b/docs/PLAYBOOKS.md
@@ -6,10 +6,9 @@ Skills answer "which workflow guidance should Hermes use?" Playbooks answer
 "what should the whole wrapper experience do next, and which layer owns each
 stage?"
 
-They are local, deterministic, and transport-free. A Discord, Slack, or hosted
-adapter can use playbooks to render a natural request as a plan, research lane,
-status card, or coding handoff without requiring the user to know command
-names.
+They are local and deterministic. Hermes Agent-facing surfaces can use
+playbooks to render a natural request as a plan, research lane, status card, or
+coding handoff without requiring the user to know command names.
 
 ## Commands
 
@@ -52,10 +51,8 @@ files.
 
 Playbooks deliberately separate ownership:
 
-- Wrappers own platform UX: buttons, threads, message edits, credentials, and
-  posting.
 - Hermes owns conversation, clarification, source-backed research, planning,
-  and status narration.
+  status narration, and the user-visible chat flow.
 - OMH owns deterministic local contracts, playbook selection, prepared handoff
   payloads, and metadata-only evidence records.
 - Selected coding executors own main coding work after dispatch or prompt

--- a/docs/README.md
+++ b/docs/README.md
@@ -68,8 +68,8 @@ merge.
 - Operator runbooks should use document titles, not command-like names, when
   they describe wrapper responsibilities and status evidence.
 - Demo and shim examples should stay fixture-backed, deterministic, and
-  transport-free unless a scoped integration explicitly opts into a real bot or
-  network adapter.
+  Hermes Agent-facing unless a scoped integration explicitly opts into a
+  different runtime surface.
 - Playbook docs should describe situation-level pipelines for company work, app
   operation loops such as idea-to-deploy / CTO loop / deploy-and-monitor, and
   coding handoffs, plus ownership boundaries, rather than becoming a second

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -11,7 +11,7 @@
   and release flows
 - More artifact-backed application cases for Hermes-hosted chat surfaces
 - More fixture-backed Hermes Agent wrapper examples that consume
-  `chat_interaction/v1` without duplicating platform transport
+  `chat_interaction/v1`
 - More public-site examples that mirror wrapper contracts without becoming a
   separate documentation source
 - Optional `~/.hermes/plugins/omh` bridge hardening after v1 install smoke
@@ -35,8 +35,8 @@
 - Explicit Codex executor handoff contracts for delegation-first coding flows
 - Wrapper-facing delegated coding status summaries that separate prepared
   handoff from observed execution, review, CI, and merge evidence
-- Wrapper-native `chat_interaction/v1` and `chat_response/v1` contracts for
-  Discord, Slack, and hosted Hermes adapters
+- Hermes-facing `chat_interaction/v1` and `chat_response/v1` contracts for
+  hosted chat surfaces
 - Codex lifecycle helper commands over existing local runtime artifacts
 - Wrapper session plan decisions and restart recovery for accepted handoffs
 - Review, CI, merge-readiness, and merge observation records for delegated

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -9,8 +9,9 @@
 - Richer routing catalog fields
 - More playbook-backed situation pipelines for wrapper UX, research, planning,
   and release flows
-- More artifact-backed application cases for bot wrappers
-- Example Discord/Slack adapter shims that consume `chat_interaction/v1`
+- More artifact-backed application cases for Hermes-hosted chat surfaces
+- More fixture-backed Hermes Agent wrapper examples that consume
+  `chat_interaction/v1` without duplicating platform transport
 - More public-site examples that mirror wrapper contracts without becoming a
   separate documentation source
 - Optional `~/.hermes/plugins/omh` bridge hardening after v1 install smoke

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -1699,6 +1699,6 @@ Keep public docs accurate, installable, and aligned with actual behavior.
 - Delegation expectation: Record docs delegation only when Hermes exposes a docs lane or wrapper-side docs result.
 - Privacy default: `metadata_only`
 - Overclaim guards:
-  - Documentation of a future adapter is not proof that a transport exists.
+  - Documentation of a future surface is not proof that evidence was observed.
   - Generated docs must match catalog data before release claims are made.
 - Fallback: If behavior is not implemented yet, label it as roadmap instead of current capability.

--- a/examples/wrapper-golden/harness-quality.json
+++ b/examples/wrapper-golden/harness-quality.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "harness_quality_examples/v1",
-  "description": "Golden examples for rendering harness_quality/v1 in Discord, Slack, or hosted wrappers. These fixtures are deterministic local contracts, not platform SDK fixtures.",
+  "description": "Golden examples for rendering harness_quality/v1 in Hermes Agent chat surfaces. These fixtures are deterministic local contracts.",
   "examples": [
     {
       "scenario": "coding_handoff_quality",

--- a/examples/wrapper-golden/hermes-agent-integration.json
+++ b/examples/wrapper-golden/hermes-agent-integration.json
@@ -1,14 +1,13 @@
 {
   "schema_version": "hermes_agent_integration_examples/v1",
-  "description": "Transport-free contract examples for Hermes-agent wrappers consuming OMH outputs.",
+  "description": "Contract examples for Hermes Agent surfaces consuming OMH outputs.",
   "runbook": "docs/HERMES_AGENT_INTEGRATION_RUNBOOK.md",
-  "transport_boundary": {
-    "wrapper_owns": [
-      "platform events",
+  "hermes_surface_contract": {
+    "hermes_surface_owns": [
+      "chat rendering",
       "button rendering",
       "thread lifecycle",
-      "message edits",
-      "notifications"
+      "status narration"
     ],
     "omh_owns": [
       "chat_interaction/v1",
@@ -18,9 +17,6 @@
       "metadata-only runtime evidence boundaries"
     ],
     "non_goals": [
-      "platform SDK implementation",
-      "bot authentication",
-      "network calls",
       "Hermes core patching",
       "hidden executor launch"
     ]
@@ -28,7 +24,7 @@
   "consumed_contracts": [
     {
       "schema_version": "chat_interaction/v1",
-      "consumed_by": "Hermes-agent wrapper",
+      "consumed_by": "Hermes Agent surface",
       "required_fields": [
         "source",
         "thread_key",
@@ -47,7 +43,7 @@
     },
     {
       "schema_version": "chat_response/v1",
-      "consumed_by": "Hermes-agent wrapper",
+      "consumed_by": "Hermes Agent surface",
       "required_fields": [
         "kind",
         "visibility",
@@ -68,7 +64,7 @@
     },
     {
       "schema_version": "status_card/v1",
-      "consumed_by": "Hermes-agent wrapper",
+      "consumed_by": "Hermes Agent surface",
       "required_fields": [
         "run_id",
         "severity",

--- a/examples/wrapper-golden/status-ladder.json
+++ b/examples/wrapper-golden/status-ladder.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "wrapper_golden_examples/v1",
-  "description": "Platform-neutral wrapper examples for chat status rendering, deep-interview prompts, and status cards. These are deterministic examples, not platform SDK fixtures.",
+  "description": "Hermes Agent surface examples for chat status rendering, deep-interview prompts, and status cards. These are deterministic examples.",
   "scenarios": [
     {
       "scenario": "clarify_needed",

--- a/examples/wrapper_shim_common.py
+++ b/examples/wrapper_shim_common.py
@@ -18,12 +18,12 @@ SCHEMA_VERSION = "wrapper_adapter_shim/v1"
 
 
 def run_shim(source: str, argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description=f"Render a transport-free {source} wrapper fixture.")
+    parser = argparse.ArgumentParser(description=f"Render a {source} Hermes chat fixture.")
     parser.add_argument(
         "event_json",
         nargs="?",
         default=str(_default_fixture(source)),
-        help="Fixture event JSON path. No SDK, bot token, or network call is used.",
+        help="Fixture event JSON path for the Hermes chat contract example.",
     )
     parser.add_argument("--mode", choices=INTERACTION_MODES, default="auto")
     parser.add_argument("--limit", type=int, default=3)

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -245,12 +245,12 @@ omh chat interact --source slack "diagnose installation health"</code>
           <h2>Hermes Agent Integration Runbook</h2>
           <p>
             Operators should treat OMH as the local contract layer consumed by a
-            Hermes-agent wrapper, not as a transport bot. The runbook explains which
-            fields to render, which owner is responsible for each transition, and which
-            claims are still not evidence.
+            Hermes Agent chat surface. The runbook explains which fields to render,
+            which owner is responsible for each transition, and which claims are still
+            not evidence.
           </p>
           <ul class="docs-list">
-            <li>Wrapper owns platform events, buttons, threads, edits, and notifications.</li>
+            <li>Hermes Agent owns the user-visible chat flow, actions, and status narration.</li>
             <li>OMH owns deterministic contracts, fixture examples, prepared handoffs, and status boundaries.</li>
             <li>Codex-like executors own implementation evidence only after dispatch is observed.</li>
           </ul>
@@ -266,8 +266,7 @@ omh chat interact --source slack "diagnose installation health"</code>
         <section class="docs-section" id="demo">
           <h2>Local demo</h2>
           <p>
-            Use the deterministic orchestration demo to inspect the full wrapper path before
-            building a real adapter.
+            Use the deterministic orchestration demo to inspect the full Hermes chat path.
           </p>
           <div class="command" role="region" aria-label="Demo commands" tabindex="0">
             <code>omh demo orchestration
@@ -275,8 +274,7 @@ uv run python examples/discord-adapter-shim.py
 uv run python examples/slack-adapter-shim.py</code>
           </div>
           <p>
-            The demo and shims are fixture-backed. They do not call bot SDKs, LLM APIs,
-            network services, or Hermes internals.
+            The demo and shims are fixture-backed examples of the local OMH contract.
           </p>
         </section>
 

--- a/src/catalogs/playbooks.py
+++ b/src/catalogs/playbooks.py
@@ -905,7 +905,7 @@ _PLAYBOOKS = (
         ),
         acceptance_criteria=(
             "The pipeline identifies which layer owns each stage.",
-            "Wrapper actions are platform-neutral ids, not transport SDK calls.",
+            "Wrapper actions are stable Hermes-facing ids.",
             "Evidence stages are strict enough for repeated status reporting.",
         ),
         not_evidence_until_observed=_COMMON_NOT_EVIDENCE,

--- a/src/demo.py
+++ b/src/demo.py
@@ -42,7 +42,7 @@ def build_orchestration_demo(
         "message_sha256": hashlib.sha256(task.encode("utf-8")).hexdigest(),
         "message_length": len(task),
         "redaction_policy": "metadata_only",
-        "summary": "Deterministic local wrapper orchestration demo; no LLM, API, bot SDK, network, or Hermes core patching is used.",
+        "summary": "Deterministic local Hermes chat orchestration demo with routing, planning, handoff, and status contracts.",
         "steps": [
             {
                 "id": "recommend",

--- a/src/skills/catalog.py
+++ b/src/skills/catalog.py
@@ -1608,7 +1608,7 @@ _HARNESSES = [
         evidence_ladder=("claims_scoped", "docs_updated", "generated_docs_checked", "public_claims_verified"),
         wrapper_actions=("show_docs", "record_claim_check", "show_status"),
         overclaim_guards=(
-            "Documentation of a future adapter is not proof that a transport exists.",
+            "Documentation of a future surface is not proof that evidence was observed.",
             "Generated docs must match catalog data before release claims are made.",
         ),
     ),

--- a/tests/test_wrapper_golden_examples.py
+++ b/tests/test_wrapper_golden_examples.py
@@ -148,9 +148,9 @@ class WrapperGoldenExampleTests(unittest.TestCase):
 
         self.assertEqual(payload["schema_version"], "hermes_agent_integration_examples/v1")
         self.assertTrue(Path(payload["runbook"]).exists())
-        self.assertIn("platform SDK implementation", payload["transport_boundary"]["non_goals"])
-        self.assertIn("network calls", payload["transport_boundary"]["non_goals"])
-        self.assertIn("Hermes core patching", payload["transport_boundary"]["non_goals"])
+        self.assertIn("chat rendering", payload["hermes_surface_contract"]["hermes_surface_owns"])
+        self.assertIn("Hermes core patching", payload["hermes_surface_contract"]["non_goals"])
+        self.assertIn("hidden executor launch", payload["hermes_surface_contract"]["non_goals"])
 
         contracts = {item["schema_version"]: item for item in payload["consumed_contracts"]}
         self.assertEqual(
@@ -193,7 +193,7 @@ class WrapperGoldenExampleTests(unittest.TestCase):
                 self.assertIn(item["wrapper_action"], source["expected_response"]["action_ids"])
                 self.assertNotIn("token", json.dumps(item).lower())
 
-    def test_transport_free_adapter_shims_render_fixture_events(self) -> None:
+    def test_hermes_surface_shims_render_fixture_events(self) -> None:
         cases = (
             (
                 "examples/discord-adapter-shim.py",


### PR DESCRIPTION
## Summary
- Removes wording that framed Discord/Slack bot SDK or transport layers as missing OMH repository features.
- Re-centers the docs on the actual product story: OMH is a Hermes Agent capability layer consumed through skills, workflows, local contracts, status evidence, and selected executor handoffs.
- Renames the golden fixture boundary from `transport_boundary` to `hermes_surface_contract` so examples no longer encode the wrong mental model.
- Keeps observed-evidence boundaries intact without presenting platform bot code as a product gap.

## Verification
- `PYTHONPATH=tests uv run python -m unittest tests/test_router_content.py tests/test_wrapper_golden_examples.py -v` — passed, 31 tests.
- `uv run python -m src.cli docs workflows --check` — passed; 29/29 tap skills checked.
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — passed, 285 tests.
- `uv run python -m compileall -q src tests examples` — passed.
- `git diff --check` — passed.

## Not Tested
- Hosted Hermes Agent rendering.
