### PR TITLE
Add OMH HUD bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ so OMH can display and record `main@old -> main@new` instead of only `main`.
 | Memory context review | Review OMH-local and wrapper-supplied context, flag stale assumptions, and attach conflict-free summaries to executor handoffs. |
 | Strict goal progress | `.omh/goals` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, and `goal_continuation/v1` keep long-running goals from being treated as done before evidence is ready. |
 | Hermes chat contracts | `chat_interaction/v1`, status cards, action ids, and local runtime artifacts for Hermes Agent chat surfaces. |
-| Hermes plugin bridge | `omh setup` installs `~/.hermes/plugins/omh` with metadata-only `omh_status` support. |
+| Hermes plugin bridge | `omh setup` installs `~/.hermes/plugins/omh` with metadata-only `omh_hud` and `omh_status` support. |
 | Optional MCP bridge preference | `omh setup --with-mcp` records MCP bridge intent without claiming a host loaded or called it. |
 | Optional team profile packs | CTO/PM-style or delivery/research role files can be installed only when selected. |
 
@@ -248,8 +248,11 @@ Profile packs write OMH-prefixed role files under `~/.hermes/agents`. The
 is not installed by default.
 
 The plugin bridge installs `~/.hermes/plugins/omh` and registers metadata-only
-status support. Local plugin install or import/register smoke is not proof that
-Hermes loaded the plugin, executed code, reviewed a PR, passed CI, or merged.
+HUD/status support. `omh hud` prints the same compact line a Hermes TUI or
+status surface can render, for example `[omh] v1.0.0 | tokens:unobserved | ...`.
+Token usage is shown only when the host supplies token metadata. Local plugin
+install or import/register smoke is not proof that Hermes loaded the plugin,
+executed code, reviewed a PR, passed CI, or merged.
 
 The installer can also pass these advanced setup choices directly:
 

--- a/README.md
+++ b/README.md
@@ -249,10 +249,17 @@ is not installed by default.
 
 The plugin bridge installs `~/.hermes/plugins/omh` and registers metadata-only
 HUD/status support. `omh hud` prints the same compact line a Hermes TUI or
-status surface can render, for example `[omh] v1.0.0 | tokens:unobserved | ...`.
-Token usage is shown only when the host supplies token metadata. Local plugin
-install or import/register smoke is not proof that Hermes loaded the plugin,
-executed code, reviewed a PR, passed CI, or merged.
+status surface can render, for example
+`[omh] v1.0.0 | plugin:ready | target:single | coding-agent:idle(ask)`.
+When host token metadata or runtime evidence exists, the line can add segments
+such as `tokens:1200/4000`, `coding-agent:<workflow>:<phase>(codex)#<id>`,
+and `evidence:prepared_not_observed`. HUD is intentionally small: version,
+host-supplied token metadata, plugin status, target topology, current or
+default coding agent, latest run, and evidence state. Skill inventory and deep
+diagnostics belong in `omh doctor`,
+`omh_status`, or machine-readable setup output, not the status line. Local
+plugin install or import/register smoke is not proof that Hermes loaded the
+plugin, executed code, reviewed a PR, passed CI, or merged.
 
 The installer can also pass these advanced setup choices directly:
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -11,7 +11,7 @@ of copied prompt files.
 The architecture favors:
 
 - Hermes-native skill installation as the primary user-facing entry point
-- a thin Hermes plugin bridge for metadata-only status context
+- a thin Hermes plugin bridge for metadata-only HUD/status context
 - a small support command interface for bootstrap, verification, and wrappers
 - reversible local bootstrap installation
 - generated skill text from testable catalog data
@@ -41,7 +41,7 @@ flowchart LR
 
   user --> hermes
   skills --> hermes
-  plugin -->|"omh_status, pre_llm_call"| hermes
+  plugin -->|"omh_hud, omh_status, pre_llm_call"| hermes
   user --> wrapper
   wrapper -->|"chat_interaction/v1"| omh
   omh -->|"answer, clarify, plan, or status"| wrapper
@@ -142,10 +142,12 @@ skill templates so `hermes skills tap add rlaope/oh-my-hermes` can expose
 OMH directly when Hermes taps are available.
 
 `plugin_bundle/omh/` is the Hermes plugin payload installed by `omh setup` to
-`~/.hermes/plugins/omh`. The v1 plugin registers
-only a metadata-only `omh_status` tool and a passive `pre_llm_call` hook. It
-does not run verification commands, patch Hermes core, or
-claim execution evidence from prepared handoffs.
+`~/.hermes/plugins/omh`. The v1 plugin registers a compact metadata-only
+`omh_hud` tool, a detailed metadata-only `omh_status` tool, and a passive
+`pre_llm_call` hook. `omh hud` exposes the same status-line payload for local
+operator smoke tests. The HUD line reports host-supplied token metadata only
+when it is actually provided. It does not run verification commands, patch
+Hermes core, or claim execution evidence from prepared handoffs.
 
 `cli.py` is a compatibility adapter. `commands/main.py` owns parser assembly,
 top-level error handling, and the public command handler re-export surface.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -146,8 +146,12 @@ OMH directly when Hermes taps are available.
 `omh_hud` tool, a detailed metadata-only `omh_status` tool, and a passive
 `pre_llm_call` hook. `omh hud` exposes the same status-line payload for local
 operator smoke tests. The HUD line reports host-supplied token metadata only
-when it is actually provided. It does not run verification commands, patch
-Hermes core, or claim execution evidence from prepared handoffs.
+when it is actually provided and stays limited to version, plugin bridge
+readiness, target topology, current or default coding agent, latest run, and
+evidence state.
+It intentionally omits install inventory such as managed skill counts. It does
+not run verification commands, patch Hermes core, or claim execution evidence
+from prepared handoffs.
 
 `cli.py` is a compatibility adapter. `commands/main.py` owns parser assembly,
 top-level error handling, and the public command handler re-export surface.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -50,10 +50,12 @@ when possible. If that directory is not on `PATH`, add the printed directory to
 Plugin support is installed by `omh setup` by default. It provides a thin
 Hermes plugin bridge in addition to the skill pack:
 
-That installs `~/.hermes/plugins/omh` with metadata-only status support. It
-does not execute code, patch Hermes core, or prove Hermes has loaded the
-plugin. If the target Hermes runtime requires a separate plugin enable command,
-follow that runtime's plugin enable/reload step.
+That installs `~/.hermes/plugins/omh` with metadata-only HUD/status support.
+`omh hud` prints the same compact status line a Hermes TUI or plugin surface can
+render. Token usage appears only when the host supplies token metadata. The
+plugin does not execute code, patch Hermes core, or prove Hermes has loaded it.
+If the target Hermes runtime requires a separate plugin enable command, follow
+that runtime's plugin enable/reload step.
 
 MCP bridge setup is also optional and intentionally conservative:
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -52,8 +52,13 @@ Hermes plugin bridge in addition to the skill pack:
 
 That installs `~/.hermes/plugins/omh` with metadata-only HUD/status support.
 `omh hud` prints the same compact status line a Hermes TUI or plugin surface can
-render. Token usage appears only when the host supplies token metadata. The
-plugin does not execute code, patch Hermes core, or prove Hermes has loaded it.
+render. It shows only operationally useful status: OMH version, host-supplied
+token metadata, plugin readiness, target topology, current or default coding
+agent, latest run, and evidence state. Skill counts and setup inventory are
+left to `omh doctor` and `omh_status`. A quiet idle line looks like
+`[omh] v1.0.0 | plugin:ready | target:single | coding-agent:idle(ask)`.
+Token usage appears only when the host supplies token metadata. The plugin does
+not execute code, patch Hermes core, or prove Hermes has loaded it.
 If the target Hermes runtime requires a separate plugin enable command, follow
 that runtime's plugin enable/reload step.
 

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -321,7 +321,7 @@ uv run python examples/slack-adapter-shim.py</code>
             </div>
             <div class="arch-node arch-node--hermes">
               <span>Optional OMH plugin</span>
-              <strong>omh_status, passive context</strong>
+              <strong>omh_hud, omh_status, passive context</strong>
             </div>
             <div class="arch-node arch-node--executor">
               <span>Selected coding executor</span>

--- a/src/commands/hud.py
+++ b/src/commands/hud.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import argparse
+import time
+from typing import Any
+
+from ..hud import build_hud_payload
+from .common import _paths, _print_json, _wants_json
+
+
+def cmd_hud(args: argparse.Namespace) -> int:
+    payload = _hud_payload(args)
+    if _wants_json(args):
+        _print_json(payload)
+    else:
+        print(payload["display"]["line"])
+    if not getattr(args, "watch", False):
+        return 0
+    while True:
+        time.sleep(max(0.2, float(args.interval)))
+        payload = _hud_payload(args)
+        if _wants_json(args):
+            _print_json(payload)
+        else:
+            print(payload["display"]["line"], flush=True)
+
+
+def _hud_payload(args: argparse.Namespace) -> dict[str, Any]:
+    return build_hud_payload(
+        _paths(args),
+        preset=args.preset,
+        limit=args.limit,
+        token_metadata=_token_metadata(args),
+    )
+
+
+def _token_metadata(args: argparse.Namespace) -> dict[str, Any]:
+    return {
+        key: value
+        for key, value in {
+            "tokens_remaining": args.tokens_remaining,
+            "token_budget": args.token_budget,
+            "input_tokens": args.input_tokens,
+            "output_tokens": args.output_tokens,
+            "context_remaining_percent": args.context_remaining_percent,
+        }.items()
+        if value is not None
+    }
+
+
+def _add_hud_commands(sub) -> None:
+    hud = sub.add_parser("hud", help="Print the compact OMH status line that Hermes TUI/plugin surfaces can render.")
+    hud.add_argument("--preset", choices=("minimal", "focused", "full"), default="focused")
+    hud.add_argument("--limit", type=int, default=3, help="Maximum recent runtime runs to inspect.")
+    hud.add_argument("--tokens-remaining", type=float, default=None, help="Optional host-provided token metadata.")
+    hud.add_argument("--token-budget", type=float, default=None, help="Optional host-provided token budget metadata.")
+    hud.add_argument("--input-tokens", type=float, default=None, help="Optional host-provided input token metadata.")
+    hud.add_argument("--output-tokens", type=float, default=None, help="Optional host-provided output token metadata.")
+    hud.add_argument("--context-remaining-percent", type=float, default=None, help="Optional host-provided context remaining percentage.")
+    hud.add_argument("--watch", action="store_true", help="Keep printing the HUD line until interrupted.")
+    hud.add_argument("--interval", type=float, default=2.0, help="Seconds between --watch refreshes.")
+    hud.add_argument("--json", action="store_true", help="Print the full machine-readable HUD payload.")
+    hud.set_defaults(func=cmd_hud)

--- a/src/commands/main.py
+++ b/src/commands/main.py
@@ -44,6 +44,7 @@ from .goal import (
     cmd_goal_status,
 )
 from .hermes import _add_hermes_commands, cmd_hermes_plan
+from .hud import _add_hud_commands, cmd_hud
 from .loop import _add_loop_commands, cmd_loop_feedback, cmd_loop_permit, cmd_loop_start, cmd_loop_status
 from .memory import _add_memory_commands, cmd_memory_apply, cmd_memory_inspect, cmd_memory_pack
 from .playbook import _add_playbook_commands, cmd_playbook_inspect, cmd_playbook_list, cmd_playbook_recommend
@@ -100,6 +101,7 @@ def build_parser() -> argparse.ArgumentParser:
             "  omh recommend \"risky refactor\"\n"
             "  omh playbook recommend \"turn this issue into a PR\"\n"
             "  omh chat interact \"turn this issue into a PR-ready plan\"\n"
+            "  omh hud\n"
             "  omh loop status\n"
             "  omh runtime status\n\n"
             "Human-facing maintenance and catalog commands print summaries by default;\n"
@@ -128,6 +130,7 @@ def build_parser() -> argparse.ArgumentParser:
     _add_chat_commands(sub)
     _add_coding_commands(sub)
     _add_hermes_commands(sub)
+    _add_hud_commands(sub)
     _add_loop_commands(sub)
     _add_memory_commands(sub)
     _add_runtime_commands(sub)
@@ -156,6 +159,7 @@ Useful operator commands:
   omh recommend "risky refactor"
   omh playbook recommend "turn this issue into a PR"
   omh chat interact "turn this issue into a PR-ready plan"
+  omh hud                Show the compact OMH status line
   omh loop status        Show ambitious goal loop state
   omh runtime status     Show local evidence artifacts
 

--- a/src/hud.py
+++ b/src/hud.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import Any
+
+from . import __version__
+from .paths import OmhPaths
+from .plugin_bundle.omh.runtime_reader import read_omh_hud
+
+
+def build_hud_payload(
+    paths: OmhPaths,
+    *,
+    preset: str = "focused",
+    limit: int = 3,
+    token_metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return read_omh_hud(
+        omh_home=paths.omh_home,
+        hermes_home=paths.hermes_home,
+        preset=preset,
+        limit=limit,
+        token_metadata=token_metadata or {},
+        package_version=__version__,
+    )

--- a/src/plugin_bundle/omh/__init__.py
+++ b/src/plugin_bundle/omh/__init__.py
@@ -6,8 +6,16 @@ _TOOLSET = "omh"
 def register(ctx):
     """Register the OMH thin native bridge with Hermes."""
     from .hooks.llm_hooks import pre_llm_call
+    from .tools.hud_tool import OMH_HUD_SCHEMA, omh_hud_handler
     from .tools.status_tool import OMH_STATUS_SCHEMA, omh_status_handler
 
+    ctx.register_tool(
+        "omh_hud",
+        _TOOLSET,
+        OMH_HUD_SCHEMA,
+        omh_hud_handler,
+        description=OMH_HUD_SCHEMA["description"],
+    )
     ctx.register_tool(
         "omh_status",
         _TOOLSET,

--- a/src/plugin_bundle/omh/config.yaml
+++ b/src/plugin_bundle/omh/config.yaml
@@ -1,5 +1,6 @@
 omh_home: "~/.omh"
 status_limit: 3
+hud_preset: focused
 inject_context: true
 privacy: metadata_only
 claim_boundary: "Prepared handoffs are not execution, review, CI, merge-readiness, or merge evidence."

--- a/src/plugin_bundle/omh/hooks/llm_hooks.py
+++ b/src/plugin_bundle/omh/hooks/llm_hooks.py
@@ -1,13 +1,32 @@
 from __future__ import annotations
 
-from ..runtime_reader import read_omh_status
+from ..runtime_reader import read_omh_hud, read_omh_status
+
+
+def _token_metadata_from_kwargs(kwargs: dict) -> dict[str, object]:
+    keys = (
+        "tokens_remaining",
+        "token_budget",
+        "input_tokens",
+        "output_tokens",
+        "context_remaining_percent",
+    )
+    return {key: kwargs[key] for key in keys if kwargs.get(key) is not None}
 
 
 def pre_llm_call(**kwargs) -> dict[str, str] | None:
     """Inject bounded OMH status context without reading or storing prompts."""
     try:
         omh_home = str(kwargs.get("omh_home", "") or "") or None
+        hermes_home = str(kwargs.get("hermes_home", "") or "") or None
         status = read_omh_status(omh_home=omh_home, limit=3)
+        hud = read_omh_hud(
+            omh_home=omh_home,
+            hermes_home=hermes_home,
+            preset="focused",
+            limit=3,
+            token_metadata=_token_metadata_from_kwargs(kwargs),
+        )
     except Exception:
         return None
 
@@ -15,6 +34,7 @@ def pre_llm_call(**kwargs) -> dict[str, str] | None:
         return None
 
     lines = [
+        str(hud.get("display", {}).get("line", "[omh] status unavailable")),
         "[OMH] Native bridge status context.",
         "Evidence boundary: prepared handoffs are not execution, review, CI, merge-readiness, or merge evidence.",
     ]
@@ -34,5 +54,5 @@ def pre_llm_call(**kwargs) -> dict[str, str] | None:
             f"- {run_id}: workflow={workflow}, phase={phase}, observation={observation}, "
             f"execution_observed={execution}, review_observed={review}, ci_observed={ci}, merge_observed={merge}."
         )
-    lines.append("Use omh_status for the full metadata-only status payload.")
+    lines.append("Use omh_hud for the compact status line or omh_status for the full metadata-only status payload.")
     return {"context": "\n".join(lines)}

--- a/src/plugin_bundle/omh/plugin.yaml
+++ b/src/plugin_bundle/omh/plugin.yaml
@@ -1,8 +1,9 @@
 name: omh
 version: "1.0.0"
-description: "Oh My Hermes native bridge for metadata-only runtime status and evidence-boundary context."
+description: "Oh My Hermes native bridge for metadata-only runtime status, HUD, and evidence-boundary context."
 author: oh-my-hermes maintainers
 provides_tools:
+  - omh_hud
   - omh_status
 provides_hooks:
   - pre_llm_call

--- a/src/plugin_bundle/omh/runtime_reader.py
+++ b/src/plugin_bundle/omh/runtime_reader.py
@@ -6,6 +6,8 @@ from pathlib import Path
 from typing import Any
 
 STATUS_SCHEMA_VERSION = "omh_status/v1"
+HUD_SCHEMA_VERSION = "omh_hud/v1"
+HUD_PRESETS = {"minimal", "focused", "full"}
 
 
 def _expand_path(value: str | Path) -> Path:
@@ -14,6 +16,10 @@ def _expand_path(value: str | Path) -> Path:
 
 def _default_omh_home() -> Path:
     return _expand_path(os.environ.get("OMH_HOME", "~/.omh"))
+
+
+def _default_hermes_home() -> Path:
+    return _expand_path(os.environ.get("HERMES_HOME", "~/.hermes"))
 
 
 def _read_json(path: Path) -> dict[str, Any]:
@@ -54,6 +60,281 @@ def _summarize_run(run_dir: Path) -> dict[str, Any]:
         "merge_observed": _bool_from_record(merge),
         "merge_status": str(merge.get("status", "not_observed" if merge else "unknown")),
     }
+
+
+def read_omh_hud(
+    omh_home: str | Path | None = None,
+    hermes_home: str | Path | None = None,
+    *,
+    preset: str = "focused",
+    limit: int = 3,
+    token_metadata: dict[str, Any] | None = None,
+    package_version: str = "",
+) -> dict[str, Any]:
+    safe_preset = preset if preset in HUD_PRESETS else "focused"
+    home = _expand_path(omh_home) if omh_home else _default_omh_home()
+    hermes = _expand_path(hermes_home) if hermes_home else _default_hermes_home()
+    status = read_omh_status(home, limit=limit)
+    state = _read_json(home / "runtime" / "state.json")
+    manifest = _read_json(home / "manifest.json")
+    profile = _read_json(home / "setup-profile.json")
+    target_registry = _read_json(home / "targets.json")
+    runs = status.get("runs", [])
+    latest_run = runs[0] if runs else {}
+    payload: dict[str, Any] = {
+        "schema_version": HUD_SCHEMA_VERSION,
+        "preset": safe_preset,
+        "package": "oh-my-hermes",
+        "version": _package_version(state, package_version),
+        "omh_home": str(home),
+        "hermes_home": str(hermes),
+        "skills": _skills_summary(manifest, state),
+        "plugin": _plugin_summary(hermes, state),
+        "target_topology": _target_topology_summary(target_registry),
+        "executor": _executor_summary(profile),
+        "runtime": _hud_runtime_summary(status, latest_run),
+        "tokens": _token_summary(token_metadata or {}),
+        "evidence_boundary": (
+            "HUD is metadata-only. Prepared handoffs are not execution, review, CI, merge, or token-usage evidence."
+        ),
+        "privacy": "metadata_only",
+    }
+    payload["display"] = {
+        "line": format_omh_hud_line(payload, preset=safe_preset),
+        "segments": _hud_segments(payload, preset=safe_preset),
+    }
+    return payload
+
+
+def format_omh_hud_line(payload: dict[str, Any], *, preset: str = "focused") -> str:
+    return " | ".join(_hud_segments(payload, preset=preset))
+
+
+def _package_version(state: dict[str, Any], fallback: str) -> str:
+    value = str(state.get("version", "") or fallback or "").strip()
+    if value:
+        return value
+    last_install = state.get("last_install", {})
+    if isinstance(last_install, dict):
+        release_update = last_install.get("release_update", {})
+        current = release_update.get("current", {}) if isinstance(release_update, dict) else {}
+        value = str(current.get("package_version", "") if isinstance(current, dict) else "").strip()
+    return value or "unknown"
+
+
+def _skills_summary(manifest: dict[str, Any], state: dict[str, Any]) -> dict[str, Any]:
+    skills = manifest.get("skills", [])
+    count = len(skills) if isinstance(skills, list) else _safe_int(state.get("installed_skills"), 0)
+    return {
+        "count": count,
+        "status": "installed" if count else "missing",
+    }
+
+
+def _plugin_summary(hermes_home: Path, state: dict[str, Any]) -> dict[str, Any]:
+    plugin_dir = hermes_home / "plugins" / "omh"
+    installed = plugin_dir.is_dir()
+    ready = installed and (plugin_dir / "plugin.yaml").is_file() and (plugin_dir / "__init__.py").is_file()
+    last_distribution = state.get("last_plugin_distribution", {})
+    observed = bool(last_distribution.get("observed", False)) if isinstance(last_distribution, dict) else False
+    if ready:
+        status = "ready"
+    elif installed or observed:
+        status = "installed"
+    else:
+        status = "missing"
+    return {
+        "status": status,
+        "plugin_dir": str(plugin_dir),
+        "distribution_observed": observed,
+        "runtime_observed": False,
+    }
+
+
+def _target_topology_summary(registry: dict[str, Any]) -> dict[str, Any]:
+    topology = registry.get("topology", {}) if isinstance(registry, dict) else {}
+    if not isinstance(topology, dict):
+        topology = {}
+    targets = registry.get("targets", {}) if isinstance(registry, dict) else {}
+    known_count = _safe_int(topology.get("known_target_count"), len(targets) if isinstance(targets, dict) else 0)
+    active_count = _safe_int(topology.get("active_agent_count"), known_count)
+    mode = str(topology.get("mode", "") or "").strip()
+    if not mode:
+        mode = "multi_agent_targets" if active_count > 1 else "single_agent_target" if active_count == 1 else "unknown"
+    return {
+        "mode": mode,
+        "known_target_count": known_count,
+        "active_agent_count": active_count,
+        "transition": str(topology.get("transition", "unknown") or "unknown"),
+    }
+
+
+def _executor_summary(profile: dict[str, Any]) -> dict[str, Any]:
+    executor = str(profile.get("default_executor", "") or "").strip() if isinstance(profile, dict) else ""
+    if not executor:
+        executor = "choose"
+    return {
+        "default": executor,
+        "dispatch_policy": str(profile.get("dispatch_policy", "ask_before_dispatch") if isinstance(profile, dict) else "ask_before_dispatch"),
+    }
+
+
+def _hud_runtime_summary(status: dict[str, Any], latest_run: dict[str, Any]) -> dict[str, Any]:
+    runs = status.get("runs", [])
+    run_count = len(runs) if isinstance(runs, list) else 0
+    if not latest_run:
+        return {
+            "state_present": bool(status.get("runtime_state_present", False)),
+            "recent_run_count": run_count,
+            "latest_run_id": "",
+            "workflow": "idle",
+            "phase": "idle",
+            "observation_status": "idle",
+            "evidence_state": "idle",
+        }
+    return {
+        "state_present": bool(status.get("runtime_state_present", False)),
+        "recent_run_count": run_count,
+        "latest_run_id": str(latest_run.get("run_id", "")),
+        "workflow": str(latest_run.get("workflow", "unknown")),
+        "phase": str(latest_run.get("phase", "unknown")),
+        "observation_status": str(latest_run.get("observation_status", "unknown")),
+        "evidence_state": _evidence_state(latest_run),
+    }
+
+
+def _evidence_state(run: dict[str, Any]) -> str:
+    if run.get("merge_observed"):
+        return "merge_observed"
+    if run.get("ci_observed"):
+        return "ci_observed"
+    if run.get("review_observed"):
+        return "review_observed"
+    if run.get("verification_observed"):
+        return "verification_observed"
+    if run.get("execution_observed"):
+        return "execution_observed"
+    if run.get("prompt_dispatched"):
+        return "dispatch_observed"
+    if run.get("prepared_handoff"):
+        return "prepared_not_observed"
+    return str(run.get("observation_status", "unknown") or "unknown")
+
+
+def _token_summary(metadata: dict[str, Any]) -> dict[str, Any]:
+    values = {
+        key: value
+        for key, value in (
+            ("tokens_remaining", _optional_number(metadata.get("tokens_remaining"))),
+            ("token_budget", _optional_number(metadata.get("token_budget"))),
+            ("input_tokens", _optional_number(metadata.get("input_tokens"))),
+            ("output_tokens", _optional_number(metadata.get("output_tokens"))),
+            ("context_remaining_percent", _optional_number(metadata.get("context_remaining_percent"))),
+        )
+        if value is not None
+    }
+    if not values:
+        return {
+            "status": "unobserved",
+            "summary": "unobserved",
+            "values": {},
+        }
+    summary = _token_display(values)
+    return {
+        "status": "observed_from_host_metadata",
+        "summary": summary,
+        "values": values,
+    }
+
+
+def _token_display(values: dict[str, int | float]) -> str:
+    remaining = values.get("tokens_remaining")
+    budget = values.get("token_budget")
+    percent = values.get("context_remaining_percent")
+    if remaining is not None and budget is not None:
+        return f"{remaining}/{budget}"
+    if remaining is not None:
+        return f"remaining={remaining}"
+    if percent is not None:
+        return f"context={percent}%"
+    parts = []
+    if values.get("input_tokens") is not None:
+        parts.append(f"in={values['input_tokens']}")
+    if values.get("output_tokens") is not None:
+        parts.append(f"out={values['output_tokens']}")
+    return ",".join(parts) if parts else "observed"
+
+
+def _hud_segments(payload: dict[str, Any], *, preset: str) -> list[str]:
+    version = str(payload.get("version", "unknown"))
+    tokens = payload.get("tokens", {})
+    plugin = payload.get("plugin", {})
+    skills = payload.get("skills", {})
+    topology = payload.get("target_topology", {})
+    executor = payload.get("executor", {})
+    runtime = payload.get("runtime", {})
+    base = [f"[omh] v{version}", f"tokens:{tokens.get('summary', 'unobserved')}"]
+    if preset == "minimal":
+        return [*base, _activity_label(runtime)]
+    focused = [
+        *base,
+        f"plugin:{plugin.get('status', 'unknown')}",
+        f"skills:{skills.get('count', 0)}",
+        f"target:{_topology_label(topology)}",
+        f"executor:{executor.get('default', 'choose')}",
+        f"run:{_run_label(runtime)}",
+    ]
+    if preset == "full":
+        focused.append(f"evidence:{runtime.get('evidence_state', 'unknown')}")
+    return focused
+
+
+def _activity_label(runtime: dict[str, Any]) -> str:
+    workflow = str(runtime.get("workflow", "idle"))
+    phase = str(runtime.get("phase", "idle"))
+    return "idle" if workflow == "idle" else f"{workflow}:{phase}"
+
+
+def _run_label(runtime: dict[str, Any]) -> str:
+    run_id = str(runtime.get("latest_run_id", ""))
+    if not run_id:
+        return "none"
+    return f"{_activity_label(runtime)}#{run_id[:8]}"
+
+
+def _topology_label(topology: dict[str, Any]) -> str:
+    mode = str(topology.get("mode", "unknown"))
+    active = _safe_int(topology.get("active_agent_count"), 0)
+    if mode == "single_agent_target":
+        return "single"
+    if mode == "multi_agent_targets":
+        return f"multi:{active}"
+    return "unknown"
+
+
+def _optional_number(value: Any) -> int | float | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value) if value.is_integer() else value
+    try:
+        parsed = float(str(value).strip())
+    except (TypeError, ValueError):
+        return None
+    if parsed.is_integer():
+        return int(parsed)
+    return parsed
+
+
+def _safe_int(value: Any, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
 
 
 def read_omh_status(omh_home: str | Path | None = None, limit: int = 5) -> dict[str, Any]:

--- a/src/plugin_bundle/omh/runtime_reader.py
+++ b/src/plugin_bundle/omh/runtime_reader.py
@@ -8,6 +8,8 @@ from typing import Any
 STATUS_SCHEMA_VERSION = "omh_status/v1"
 HUD_SCHEMA_VERSION = "omh_hud/v1"
 HUD_PRESETS = {"minimal", "focused", "full"}
+HUD_REQUIRED_TOOLS = ("omh_hud", "omh_status")
+HUD_REQUIRED_HOOKS = ("pre_llm_call",)
 
 
 def _expand_path(value: str | Path) -> Path:
@@ -46,6 +48,7 @@ def _summarize_run(run_dir: Path) -> dict[str, Any]:
         "run_id": str(run.get("run_id", run_dir.name)),
         "workflow": str(coding.get("recommended_workflow") or run.get("skill", "unknown")),
         "harness": str(coding.get("recommended_harness") or run.get("harness", "unknown")),
+        "executor_target": _executor_target_from_coding(coding),
         "phase": str(run.get("phase", run.get("status", "unknown"))),
         "artifact_kind": str(run.get("artifact_kind", "")),
         "observation_status": str(run.get("observation_status", coding.get("status", "unknown"))),
@@ -62,6 +65,23 @@ def _summarize_run(run_dir: Path) -> dict[str, Any]:
     }
 
 
+def _executor_target_from_coding(coding: dict[str, Any]) -> str:
+    if not isinstance(coding, dict):
+        return ""
+    handoff = coding.get("executor_handoff")
+    if isinstance(handoff, dict):
+        value = str(handoff.get("executor_target") or handoff.get("selected_executor_profile") or "").strip()
+        if value:
+            return value
+    prompt_handoff = coding.get("prompt_handoff")
+    if isinstance(prompt_handoff, dict):
+        value = str(prompt_handoff.get("selected_executor_profile") or "").strip()
+        if value:
+            return value
+    value = str(coding.get("selected_executor_profile") or coding.get("executor_profile") or "").strip()
+    return value
+
+
 def read_omh_hud(
     omh_home: str | Path | None = None,
     hermes_home: str | Path | None = None,
@@ -74,9 +94,9 @@ def read_omh_hud(
     safe_preset = preset if preset in HUD_PRESETS else "focused"
     home = _expand_path(omh_home) if omh_home else _default_omh_home()
     hermes = _expand_path(hermes_home) if hermes_home else _default_hermes_home()
-    status = read_omh_status(home, limit=limit)
+    safe_limit = _safe_limit(limit, default=3)
+    status = read_omh_status(home, limit=safe_limit)
     state = _read_json(home / "runtime" / "state.json")
-    manifest = _read_json(home / "manifest.json")
     profile = _read_json(home / "setup-profile.json")
     target_registry = _read_json(home / "targets.json")
     runs = status.get("runs", [])
@@ -88,7 +108,6 @@ def read_omh_hud(
         "version": _package_version(state, package_version),
         "omh_home": str(home),
         "hermes_home": str(hermes),
-        "skills": _skills_summary(manifest, state),
         "plugin": _plugin_summary(hermes, state),
         "target_topology": _target_topology_summary(target_registry),
         "executor": _executor_summary(profile),
@@ -122,24 +141,20 @@ def _package_version(state: dict[str, Any], fallback: str) -> str:
     return value or "unknown"
 
 
-def _skills_summary(manifest: dict[str, Any], state: dict[str, Any]) -> dict[str, Any]:
-    skills = manifest.get("skills", [])
-    count = len(skills) if isinstance(skills, list) else _safe_int(state.get("installed_skills"), 0)
-    return {
-        "count": count,
-        "status": "installed" if count else "missing",
-    }
-
-
 def _plugin_summary(hermes_home: Path, state: dict[str, Any]) -> dict[str, Any]:
     plugin_dir = hermes_home / "plugins" / "omh"
     installed = plugin_dir.is_dir()
-    ready = installed and (plugin_dir / "plugin.yaml").is_file() and (plugin_dir / "__init__.py").is_file()
     last_distribution = state.get("last_plugin_distribution", {})
     observed = bool(last_distribution.get("observed", False)) if isinstance(last_distribution, dict) else False
-    if ready:
+    capabilities = _plugin_capabilities(plugin_dir, last_distribution if isinstance(last_distribution, dict) else {})
+    complete_files = bool(capabilities["files"]["plugin_yaml"] and capabilities["files"]["init_py"])
+    required_tools_ready = all(capabilities["tools"].values())
+    required_hooks_ready = all(capabilities["hooks"].values())
+    if installed and complete_files and required_tools_ready and required_hooks_ready:
         status = "ready"
-    elif installed or observed:
+    elif installed and complete_files:
+        status = "stale"
+    elif installed:
         status = "installed"
     else:
         status = "missing"
@@ -148,7 +163,84 @@ def _plugin_summary(hermes_home: Path, state: dict[str, Any]) -> dict[str, Any]:
         "plugin_dir": str(plugin_dir),
         "distribution_observed": observed,
         "runtime_observed": False,
+        "required_tools": list(HUD_REQUIRED_TOOLS),
+        "required_hooks": list(HUD_REQUIRED_HOOKS),
+        "capabilities": capabilities,
+        "stale": status == "stale",
     }
+
+
+def _plugin_capabilities(plugin_dir: Path, last_distribution: dict[str, Any]) -> dict[str, Any]:
+    files = {
+        "plugin_yaml": (plugin_dir / "plugin.yaml").is_file(),
+        "init_py": (plugin_dir / "__init__.py").is_file(),
+        "hud_tool": (plugin_dir / "tools" / "hud_tool.py").is_file(),
+        "status_tool": (plugin_dir / "tools" / "status_tool.py").is_file(),
+        "managed_manifest": (plugin_dir / ".omh-plugin-manifest.json").is_file(),
+    }
+    yaml_text = _read_text(plugin_dir / "plugin.yaml")
+    advertised_tools = set(_yaml_list_values(yaml_text, "provides_tools"))
+    advertised_hooks = set(_yaml_list_values(yaml_text, "provides_hooks"))
+    registered_tools = set(_string_list(last_distribution.get("registered_tools", [])))
+    registered_hooks = set(_string_list(last_distribution.get("registered_hooks", [])))
+    tool_sources = advertised_tools | registered_tools
+    hook_sources = advertised_hooks | registered_hooks
+    return {
+        "files": files,
+        "tools": {
+            "omh_hud": files["hud_tool"] and "omh_hud" in tool_sources,
+            "omh_status": files["status_tool"] and "omh_status" in tool_sources,
+        },
+        "hooks": {
+            "pre_llm_call": "pre_llm_call" in hook_sources,
+        },
+        "advertised_tools": sorted(advertised_tools),
+        "advertised_hooks": sorted(advertised_hooks),
+    }
+
+
+def _read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
+
+def _yaml_list_values(text: str, key: str) -> list[str]:
+    values: list[str] = []
+    in_list = False
+    for raw_line in text.splitlines():
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if in_list:
+            if stripped.startswith("- "):
+                values.append(_unquote_yaml_scalar(stripped[2:].strip()))
+                continue
+            if not raw_line.startswith((" ", "\t")):
+                in_list = False
+        if stripped.startswith(f"{key}:"):
+            remainder = stripped.split(":", 1)[1].strip()
+            if not remainder:
+                in_list = True
+            elif remainder.startswith("[") and remainder.endswith("]"):
+                values.extend(_unquote_yaml_scalar(item.strip()) for item in remainder[1:-1].split(",") if item.strip())
+            else:
+                values.append(_unquote_yaml_scalar(remainder))
+    return values
+
+
+def _unquote_yaml_scalar(value: str) -> str:
+    cleaned = value.split("#", 1)[0].strip()
+    if len(cleaned) >= 2 and cleaned[0] == cleaned[-1] and cleaned[0] in {"'", '"'}:
+        return cleaned[1:-1]
+    return cleaned
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value if str(item)]
 
 
 def _target_topology_summary(registry: dict[str, Any]) -> dict[str, Any]:
@@ -175,6 +267,7 @@ def _executor_summary(profile: dict[str, Any]) -> dict[str, Any]:
         executor = "choose"
     return {
         "default": executor,
+        "configured": bool(profile),
         "dispatch_policy": str(profile.get("dispatch_policy", "ask_before_dispatch") if isinstance(profile, dict) else "ask_before_dispatch"),
     }
 
@@ -187,6 +280,7 @@ def _hud_runtime_summary(status: dict[str, Any], latest_run: dict[str, Any]) -> 
             "state_present": bool(status.get("runtime_state_present", False)),
             "recent_run_count": run_count,
             "latest_run_id": "",
+            "executor_target": "",
             "workflow": "idle",
             "phase": "idle",
             "observation_status": "idle",
@@ -196,6 +290,7 @@ def _hud_runtime_summary(status: dict[str, Any], latest_run: dict[str, Any]) -> 
         "state_present": bool(status.get("runtime_state_present", False)),
         "recent_run_count": run_count,
         "latest_run_id": str(latest_run.get("run_id", "")),
+        "executor_target": str(latest_run.get("executor_target", "")),
         "workflow": str(latest_run.get("workflow", "unknown")),
         "phase": str(latest_run.get("phase", "unknown")),
         "observation_status": str(latest_run.get("observation_status", "unknown")),
@@ -269,24 +364,60 @@ def _hud_segments(payload: dict[str, Any], *, preset: str) -> list[str]:
     version = str(payload.get("version", "unknown"))
     tokens = payload.get("tokens", {})
     plugin = payload.get("plugin", {})
-    skills = payload.get("skills", {})
     topology = payload.get("target_topology", {})
     executor = payload.get("executor", {})
     runtime = payload.get("runtime", {})
-    base = [f"[omh] v{version}", f"tokens:{tokens.get('summary', 'unobserved')}"]
+    base = [f"[omh] v{version}"]
+    if _has_observed_tokens(tokens):
+        base.append(f"tokens:{tokens.get('summary', 'observed')}")
     if preset == "minimal":
         return [*base, _activity_label(runtime)]
-    focused = [
-        *base,
-        f"plugin:{plugin.get('status', 'unknown')}",
-        f"skills:{skills.get('count', 0)}",
-        f"target:{_topology_label(topology)}",
-        f"executor:{executor.get('default', 'choose')}",
-        f"run:{_run_label(runtime)}",
-    ]
-    if preset == "full":
-        focused.append(f"evidence:{runtime.get('evidence_state', 'unknown')}")
+    focused = [*base, f"plugin:{_plugin_display_status(plugin)}"]
+    topology_label = _topology_label(topology)
+    if topology_label != "unknown":
+        focused.append(f"target:{topology_label}")
+    focused.append(_coding_agent_segment(runtime, executor))
+    evidence_state = str(runtime.get("evidence_state", "unknown") or "unknown")
+    if preset == "full" and evidence_state not in {"idle", "unknown"}:
+        focused.append(f"evidence:{evidence_state}")
     return focused
+
+
+def _has_observed_tokens(tokens: dict[str, Any]) -> bool:
+    return bool(tokens.get("values")) or str(tokens.get("status", "")) == "observed_from_host_metadata"
+
+
+def _plugin_display_status(plugin: dict[str, Any]) -> str:
+    status = str(plugin.get("status", "unknown") or "unknown")
+    labels = {
+        "missing": "not-installed",
+        "stale": "update-needed",
+    }
+    return labels.get(status, status)
+
+
+def _coding_agent_segment(runtime: dict[str, Any], executor: dict[str, Any]) -> str:
+    run_id = str(runtime.get("latest_run_id", ""))
+    agent = _coding_agent_label(runtime.get("executor_target") or executor.get("default"))
+    activity = _activity_label(runtime)
+    if run_id:
+        return f"coding-agent:{activity}({agent})#{_short_run_id(run_id)}"
+    return f"coding-agent:idle({agent})"
+
+
+def _coding_agent_label(value: Any) -> str:
+    default = str(value or "choose").strip() or "choose"
+    labels = {
+        "choose": "ask",
+        "generic": "prompt",
+        "hermes": "hermes",
+        "codex": "codex",
+        "claude-code": "claude-code",
+        "omx-runtime": "omx-runtime",
+        "omo-runtime": "omo-runtime",
+        "omc-runtime": "omc-runtime",
+    }
+    return labels.get(default, default)
 
 
 def _activity_label(runtime: dict[str, Any]) -> str:
@@ -295,11 +426,9 @@ def _activity_label(runtime: dict[str, Any]) -> str:
     return "idle" if workflow == "idle" else f"{workflow}:{phase}"
 
 
-def _run_label(runtime: dict[str, Any]) -> str:
-    run_id = str(runtime.get("latest_run_id", ""))
-    if not run_id:
-        return "none"
-    return f"{_activity_label(runtime)}#{run_id[:8]}"
+def _short_run_id(run_id: str) -> str:
+    suffix = run_id.rsplit("-", 1)[-1].strip()
+    return suffix[:8] if suffix else run_id[:8]
 
 
 def _topology_label(topology: dict[str, Any]) -> str:
@@ -337,8 +466,12 @@ def _safe_int(value: Any, default: int) -> int:
         return default
 
 
+def _safe_limit(value: Any, *, default: int, maximum: int = 20) -> int:
+    return max(0, min(_safe_int(value, default), maximum))
+
+
 def read_omh_status(omh_home: str | Path | None = None, limit: int = 5) -> dict[str, Any]:
-    safe_limit = max(0, min(int(limit), 20))
+    safe_limit = _safe_limit(limit, default=5)
     home = _expand_path(omh_home) if omh_home else _default_omh_home()
     runtime_dir = home / "runtime"
     runs_dir = runtime_dir / "runs"

--- a/src/plugin_bundle/omh/tools/hud_tool.py
+++ b/src/plugin_bundle/omh/tools/hud_tool.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from ..runtime_reader import read_omh_hud
+
+OMH_HUD_SCHEMA = {
+    "name": "omh_hud",
+    "description": (
+        "Read the compact OMH metadata-only HUD payload for Hermes TUI/status surfaces. "
+        "Token fields are shown only when supplied by the host metadata."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "omh_home": {
+                "type": "string",
+                "description": "Optional OMH_HOME override. Defaults to $OMH_HOME or ~/.omh.",
+            },
+            "hermes_home": {
+                "type": "string",
+                "description": "Optional HERMES_HOME override. Defaults to $HERMES_HOME or ~/.hermes.",
+            },
+            "preset": {
+                "type": "string",
+                "enum": ["minimal", "focused", "full"],
+                "description": "HUD display density.",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum recent runtime runs to summarize.",
+            },
+            "tokens_remaining": {
+                "type": "number",
+                "description": "Optional host-provided token count.",
+            },
+            "token_budget": {
+                "type": "number",
+                "description": "Optional host-provided token budget.",
+            },
+            "input_tokens": {
+                "type": "number",
+                "description": "Optional host-provided input token count.",
+            },
+            "output_tokens": {
+                "type": "number",
+                "description": "Optional host-provided output token count.",
+            },
+            "context_remaining_percent": {
+                "type": "number",
+                "description": "Optional host-provided context remaining percentage.",
+            },
+        },
+    },
+}
+
+
+def omh_hud_handler(args: dict[str, Any], **kwargs) -> str:
+    token_metadata = {
+        key: args.get(key)
+        for key in (
+            "tokens_remaining",
+            "token_budget",
+            "input_tokens",
+            "output_tokens",
+            "context_remaining_percent",
+        )
+        if args.get(key) is not None
+    }
+    payload = read_omh_hud(
+        omh_home=str(args.get("omh_home", "") or "") or None,
+        hermes_home=str(args.get("hermes_home", "") or "") or None,
+        preset=str(args.get("preset", "focused") or "focused"),
+        limit=int(args.get("limit") or 3),
+        token_metadata=token_metadata,
+    )
+    return json.dumps(payload, sort_keys=True)

--- a/src/plugin_bundle/omh/tools/hud_tool.py
+++ b/src/plugin_bundle/omh/tools/hud_tool.py
@@ -72,7 +72,7 @@ def omh_hud_handler(args: dict[str, Any], **kwargs) -> str:
         omh_home=str(args.get("omh_home", "") or "") or None,
         hermes_home=str(args.get("hermes_home", "") or "") or None,
         preset=str(args.get("preset", "focused") or "focused"),
-        limit=int(args.get("limit") or 3),
+        limit=args.get("limit") or 3,
         token_metadata=token_metadata,
     )
     return json.dumps(payload, sort_keys=True)

--- a/src/plugin_pack.py
+++ b/src/plugin_pack.py
@@ -264,9 +264,10 @@ def _register_smoke(plugin_dir: Path) -> dict[str, Any]:
         if not callable(register):
             return {"import_smoke": True, "register_smoke": False, "error": "register(ctx) is missing"}
         register(ctx)
+        required_tools = {"omh_hud", "omh_status"}
         return {
             "import_smoke": True,
-            "register_smoke": "omh_status" in ctx.tools and "pre_llm_call" in ctx.hooks,
+            "register_smoke": required_tools.issubset(set(ctx.tools)) and "pre_llm_call" in ctx.hooks,
             "registered_tools": sorted(ctx.tools),
             "registered_hooks": sorted(ctx.hooks),
         }

--- a/tests/test_hud.py
+++ b/tests/test_hud.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from _cli_harness import run_cli
+
+
+class HudCliTests(unittest.TestCase):
+    def test_hud_prints_compact_line_without_runtime_state(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            status, stdout, stderr = run_cli(
+                ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes"), "hud"],
+                output_json=False,
+            )
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            self.assertIn("[omh] v1.0.0", stdout)
+            self.assertIn("tokens:unobserved", stdout)
+            self.assertIn("plugin:missing", stdout)
+
+    def test_hud_reports_setup_plugin_target_and_prepared_runtime_boundary(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / ".omh"
+            hermes_home = root / ".hermes"
+            self.assertEqual(run_cli(["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "setup"])[0], 0)
+            status, stdout, stderr = run_cli(
+                [
+                    "--omh-home",
+                    str(omh_home),
+                    "--hermes-home",
+                    str(hermes_home),
+                    "coding",
+                    "delegate",
+                    "--record",
+                    "--executor",
+                    "codex",
+                    "Safely add feature without overclaiming.",
+                ]
+            )
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            run_id = json.loads(stdout)["runtime"]["run"]["run_id"]
+
+            status, stdout, stderr = run_cli(
+                [
+                    "--omh-home",
+                    str(omh_home),
+                    "--hermes-home",
+                    str(hermes_home),
+                    "hud",
+                    "--json",
+                    "--preset",
+                    "full",
+                    "--tokens-remaining",
+                    "1200",
+                    "--token-budget",
+                    "4000",
+                ]
+            )
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            payload = json.loads(stdout)
+            self.assertEqual(payload["schema_version"], "omh_hud/v1")
+            self.assertEqual(payload["version"], "1.0.0")
+            self.assertEqual(payload["plugin"]["status"], "ready")
+            self.assertEqual(payload["target_topology"]["mode"], "single_agent_target")
+            self.assertEqual(payload["runtime"]["latest_run_id"], run_id)
+            self.assertEqual(payload["runtime"]["evidence_state"], "prepared_not_observed")
+            self.assertEqual(payload["tokens"]["status"], "observed_from_host_metadata")
+            self.assertIn("tokens:1200/4000", payload["display"]["line"])
+            self.assertIn("evidence:prepared_not_observed", payload["display"]["line"])
+            self.assertIn("Prepared handoffs are not execution", payload["evidence_boundary"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_hud.py
+++ b/tests/test_hud.py
@@ -20,8 +20,11 @@ class HudCliTests(unittest.TestCase):
             self.assertEqual(stderr, "")
             self.assertEqual(status, 0)
             self.assertIn("[omh] v1.0.0", stdout)
-            self.assertIn("tokens:unobserved", stdout)
-            self.assertIn("plugin:missing", stdout)
+            self.assertIn("plugin:not-installed", stdout)
+            self.assertIn("coding-agent:idle(ask)", stdout)
+            self.assertNotIn("tokens:unobserved", stdout)
+            self.assertNotIn("executor:", stdout)
+            self.assertNotIn("handoff:", stdout)
 
     def test_hud_reports_setup_plugin_target_and_prepared_runtime_boundary(self) -> None:
         with TemporaryDirectory() as tmp:
@@ -70,13 +73,76 @@ class HudCliTests(unittest.TestCase):
             self.assertEqual(payload["schema_version"], "omh_hud/v1")
             self.assertEqual(payload["version"], "1.0.0")
             self.assertEqual(payload["plugin"]["status"], "ready")
+            self.assertNotIn("skills", payload)
             self.assertEqual(payload["target_topology"]["mode"], "single_agent_target")
             self.assertEqual(payload["runtime"]["latest_run_id"], run_id)
             self.assertEqual(payload["runtime"]["evidence_state"], "prepared_not_observed")
             self.assertEqual(payload["tokens"]["status"], "observed_from_host_metadata")
             self.assertIn("tokens:1200/4000", payload["display"]["line"])
+            self.assertIn("plugin:ready", payload["display"]["line"])
+            self.assertIn("coding-agent:", payload["display"]["line"])
+            self.assertIn("(codex)", payload["display"]["line"])
+            self.assertRegex(payload["display"]["line"], r"coding-agent:plan:prepared\(codex\)#[0-9a-f]{6}")
+            self.assertNotIn("skills:", payload["display"]["line"])
+            self.assertNotIn("executor:", payload["display"]["line"])
+            self.assertNotIn("handoff:", payload["display"]["line"])
             self.assertIn("evidence:prepared_not_observed", payload["display"]["line"])
             self.assertIn("Prepared handoffs are not execution", payload["evidence_boundary"])
+
+    def test_hud_marks_older_plugin_bundle_as_stale(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / ".omh"
+            hermes_home = root / ".hermes"
+            plugin_dir = hermes_home / "plugins" / "omh"
+            tools_dir = plugin_dir / "tools"
+            tools_dir.mkdir(parents=True)
+            (plugin_dir / "__init__.py").write_text("def register(ctx):\n    pass\n", encoding="utf-8")
+            (plugin_dir / "plugin.yaml").write_text(
+                "\n".join(
+                    [
+                        "name: omh",
+                        'version: "0.9.0"',
+                        "provides_tools:",
+                        "  - omh_status",
+                        "provides_hooks:",
+                        "  - pre_llm_call",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            (tools_dir / "status_tool.py").write_text("OMH_STATUS_SCHEMA = {}\n", encoding="utf-8")
+
+            status, stdout, stderr = run_cli(
+                ["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "hud", "--json"]
+            )
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            payload = json.loads(stdout)
+            self.assertEqual(payload["plugin"]["status"], "stale")
+            self.assertTrue(payload["plugin"]["stale"])
+            self.assertFalse(payload["plugin"]["capabilities"]["tools"]["omh_hud"])
+            self.assertTrue(payload["plugin"]["capabilities"]["tools"]["omh_status"])
+            self.assertIn("plugin:update-needed", payload["display"]["line"])
+
+    def test_hud_plugin_tool_tolerates_untrusted_limit_argument(self) -> None:
+        from omh.plugin_bundle.omh.tools.hud_tool import omh_hud_handler
+
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            payload = json.loads(
+                omh_hud_handler(
+                    {
+                        "omh_home": str(root / ".omh"),
+                        "hermes_home": str(root / ".hermes"),
+                        "limit": "not-a-number",
+                    }
+                )
+            )
+
+            self.assertEqual(payload["schema_version"], "omh_hud/v1")
+            self.assertEqual(payload["runtime"]["recent_run_count"], 0)
 
 
 if __name__ == "__main__":

--- a/tests/test_plugin_distribution.py
+++ b/tests/test_plugin_distribution.py
@@ -92,7 +92,7 @@ class PluginDistributionTests(unittest.TestCase):
             self.assertTrue(plugin["requires_hermes_plugin_enable"])
             self.assertTrue((plugin_dir / "plugin.yaml").exists())
             self.assertTrue((plugin_dir / ".omh-plugin-manifest.json").exists())
-            self.assertEqual(plugin["registered_tools"], ["omh_status"])
+            self.assertEqual(plugin["registered_tools"], ["omh_hud", "omh_status"])
             self.assertEqual(plugin["registered_hooks"], ["pre_llm_call"])
 
             inspection = inspect_plugin_bundle(resolve_paths(omh_home, hermes_home))
@@ -179,8 +179,16 @@ class PluginDistributionTests(unittest.TestCase):
             module = load_installed_plugin(hermes_home / "plugins" / "omh")
             ctx = FakeHermesContext()
             module.register(ctx)
+            self.assertIn("omh_hud", ctx.tools)
             self.assertIn("omh_status", ctx.tools)
             self.assertIn("pre_llm_call", ctx.hooks)
+
+            hud_handler = ctx.tools["omh_hud"]["args"][2]
+            hud_payload = json.loads(hud_handler({"omh_home": str(omh_home), "hermes_home": str(hermes_home), "limit": 1}))
+            self.assertEqual(hud_payload["schema_version"], "omh_hud/v1")
+            self.assertIn("[omh]", hud_payload["display"]["line"])
+            self.assertEqual(hud_payload["runtime"]["evidence_state"], "prepared_not_observed")
+            self.assertEqual(hud_payload["tokens"]["status"], "unobserved")
 
             handler = ctx.tools["omh_status"]["args"][2]
             payload = json.loads(handler({"omh_home": str(omh_home), "limit": 1}))
@@ -197,6 +205,7 @@ class PluginDistributionTests(unittest.TestCase):
             )
             self.assertIsNotNone(hook_payload)
             context = hook_payload["context"]
+            self.assertIn("[omh]", context)
             self.assertIn("prepared handoffs are not execution", context)
             self.assertNotIn("this raw prompt should not leak", context)
 


### PR DESCRIPTION
## Summary
- Add a metadata-only `omh hud` command that prints a compact `[omh]` status line for Hermes TUI/status surfaces.
- Register an `omh_hud` plugin tool alongside `omh_status`, and include the compact line in passive `pre_llm_call` context.
- Keep token usage conservative: token fields render as `unobserved` unless host metadata is explicitly supplied.
- Update README, installation, architecture, site docs, and plugin distribution tests.

## Verification
- `PYTHONPATH=tests python3 -m unittest tests/test_hud.py -v`
- `PYTHONPATH=tests python3 -m unittest tests/test_plugin_distribution.py -v`
- `PYTHONPATH=tests python3 -m unittest tests/test_cli.py -v`
- `PYTHONPATH=tests python3 -m unittest tests/test_router_content.py -v`
- `PYTHONPATH=tests python3 -m unittest tests/test_probe.py -v`
- `PYTHONPATH=tests python3 -m unittest discover -s tests -v`
- `python3 -m compileall -q src tests`
- `python3 -m src.cli docs workflows --check`
- `git diff --check`
- Local setup-to-hud smoke with temporary OMH/Hermes homes.

## Boundary
Actual Hermes TUI rendering is not claimed here. This PR provides the deterministic OMH CLI/plugin payload that a Hermes TUI/plugin surface can render without patching Hermes core.
