### PR TITLE
Prefix OMH skill descriptions for TUI discovery

### DIFF
--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -14,7 +14,7 @@ When wrapper metadata reports `omh_target_topology/v1`, skills bind workflow sta
 
 ### oh-my-hermes
 
-Router guidance for using oh-my-hermes workflow skills inside Hermes Agent.
+[omh] Router guidance for using oh-my-hermes workflow skills inside Hermes Agent.
 
 - Category: `router`
 - Phase: `routing`
@@ -44,7 +44,7 @@ Router guidance for using oh-my-hermes workflow skills inside Hermes Agent.
 
 ### ralph
 
-Hermes Ralph workflow: persistent execution with verification and review.
+[omh] Hermes Ralph workflow: persistent execution with verification and review.
 
 - Category: `execution`
 - Phase: `completion`
@@ -74,7 +74,7 @@ Hermes Ralph workflow: persistent execution with verification and review.
 
 ### ultragoal
 
-Hermes Ultragoal workflow: file-backed durable goal ledgers.
+[omh] Hermes Ultragoal workflow: file-backed durable goal ledgers.
 
 - Category: `execution`
 - Phase: `durable-goals`
@@ -108,7 +108,7 @@ Hermes Ultragoal workflow: file-backed durable goal ledgers.
 
 ### loop
 
-Hermes Loop workflow: ambitious goal interview, research, planning, runtime ticks, handoff, feedback, and resume cycles.
+[omh] Hermes Loop workflow: ambitious goal interview, research, planning, runtime ticks, handoff, feedback, and resume cycles.
 
 - Category: `goal-loop`
 - Phase: `continuous-goal-loop`
@@ -159,7 +159,7 @@ Hermes Loop workflow: ambitious goal interview, research, planning, runtime tick
 
 ### ultraprocess
 
-Ultra Process - Research - Ralplan - Ultragoal - Code Review - Sync Circle: one PR-ready delivery cycle.
+[omh] Ultra Process - Research - Ralplan - Ultragoal - Code Review - Sync Circle: one PR-ready delivery cycle.
 
 - Category: `process`
 - Phase: `single-cycle-plan-to-pr`
@@ -199,7 +199,7 @@ Ultra Process - Research - Ralplan - Ultragoal - Code Review - Sync Circle: one 
 
 ### deep-interview
 
-Hermes Deep Interview workflow: one-question-at-a-time clarification.
+[omh] Hermes Deep Interview workflow: one-question-at-a-time clarification.
 
 - Category: `clarification`
 - Phase: `discovery`
@@ -229,7 +229,7 @@ Hermes Deep Interview workflow: one-question-at-a-time clarification.
 
 ### team
 
-Hermes Team workflow: coordinated parallel or sequential work lanes.
+[omh] Hermes Team workflow: coordinated parallel or sequential work lanes.
 
 - Category: `execution`
 - Phase: `coordination`
@@ -259,7 +259,7 @@ Hermes Team workflow: coordinated parallel or sequential work lanes.
 
 ### ultrawork
 
-Hermes Ultrawork compatibility workflow: bounded parallel delivery guidance.
+[omh] Hermes Ultrawork compatibility workflow: bounded parallel delivery guidance.
 
 - Category: `execution`
 - Phase: `parallel-delivery`
@@ -290,7 +290,7 @@ Hermes Ultrawork compatibility workflow: bounded parallel delivery guidance.
 
 ### web-research
 
-Hermes Web Research workflow: source-backed current information gathering.
+[omh] Hermes Web Research workflow: source-backed current information gathering.
 
 - Category: `research`
 - Phase: `current-evidence`
@@ -320,7 +320,7 @@ Hermes Web Research workflow: source-backed current information gathering.
 
 ### research-brief
 
-Hermes Research Brief workflow: source-backed business research without pretending evidence was fetched.
+[omh] Hermes Research Brief workflow: source-backed business research without pretending evidence was fetched.
 
 - Category: `research`
 - Phase: `business-brief`
@@ -350,7 +350,7 @@ Hermes Research Brief workflow: source-backed business research without pretendi
 
 ### strategy-brief
 
-Hermes Strategy Brief workflow: options, tradeoffs, recommendation, and decision notes.
+[omh] Hermes Strategy Brief workflow: options, tradeoffs, recommendation, and decision notes.
 
 - Category: `strategy`
 - Phase: `brief`
@@ -382,7 +382,7 @@ Hermes Strategy Brief workflow: options, tradeoffs, recommendation, and decision
 
 ### meeting-brief
 
-Hermes Meeting Brief workflow: agenda, prompts, decisions, and record template.
+[omh] Hermes Meeting Brief workflow: agenda, prompts, decisions, and record template.
 
 - Category: `meeting`
 - Phase: `preparation`
@@ -414,7 +414,7 @@ Hermes Meeting Brief workflow: agenda, prompts, decisions, and record template.
 
 ### feedback-triage
 
-Hermes Feedback Triage workflow: cluster customer signals and choose the next workflow.
+[omh] Hermes Feedback Triage workflow: cluster customer signals and choose the next workflow.
 
 - Category: `triage`
 - Phase: `feedback`
@@ -444,7 +444,7 @@ Hermes Feedback Triage workflow: cluster customer signals and choose the next wo
 
 ### ops-review
 
-Hermes Ops Review workflow: status, risks, blockers, priorities, and follow-ups.
+[omh] Hermes Ops Review workflow: status, risks, blockers, priorities, and follow-ups.
 
 - Category: `operations`
 - Phase: `status-review`
@@ -477,7 +477,7 @@ Hermes Ops Review workflow: status, risks, blockers, priorities, and follow-ups.
 
 ### idea-to-deploy
 
-Hermes Idea-to-Deploy workflow: shape an app idea into decisions, delivery handoff, verification, release, and monitoring status.
+[omh] Hermes Idea-to-Deploy workflow: shape an app idea into decisions, delivery handoff, verification, release, and monitoring status.
 
 - Category: `delivery`
 - Phase: `app-delivery-loop`
@@ -510,7 +510,7 @@ Hermes Idea-to-Deploy workflow: shape an app idea into decisions, delivery hando
 
 ### cto-loop
 
-Hermes CTO Loop workflow: roadmap, PM, technical tradeoffs, risk, delivery, release, and follow-up operating cadence.
+[omh] Hermes CTO Loop workflow: roadmap, PM, technical tradeoffs, risk, delivery, release, and follow-up operating cadence.
 
 - Category: `leadership`
 - Phase: `operating-loop`
@@ -544,7 +544,7 @@ Hermes CTO Loop workflow: roadmap, PM, technical tradeoffs, risk, delivery, rele
 
 ### deploy-and-monitor
 
-Hermes Deploy-and-Monitor workflow: release checklist, deploy decision, health signals, rollback gate, and post-deploy status.
+[omh] Hermes Deploy-and-Monitor workflow: release checklist, deploy decision, health signals, rollback gate, and post-deploy status.
 
 - Category: `monitoring`
 - Phase: `release-ops`
@@ -578,7 +578,7 @@ Hermes Deploy-and-Monitor workflow: release checklist, deploy decision, health s
 
 ### ultraqa
 
-Hermes UltraQA workflow: adversarial QA and fix loops.
+[omh] Hermes UltraQA workflow: adversarial QA and fix loops.
 
 - Category: `verification`
 - Phase: `qa`
@@ -608,7 +608,7 @@ Hermes UltraQA workflow: adversarial QA and fix loops.
 
 ### plan
 
-Hermes Plan workflow: structured planning before execution.
+[omh] Hermes Plan workflow: structured planning before execution.
 
 - Category: `planning`
 - Phase: `plan`
@@ -638,7 +638,7 @@ Hermes Plan workflow: structured planning before execution.
 
 ### ralplan
 
-Hermes Ralplan workflow: consensus planning with review gates.
+[omh] Hermes Ralplan workflow: consensus planning with review gates.
 
 - Category: `planning`
 - Phase: `reviewed-plan`
@@ -669,7 +669,7 @@ Hermes Ralplan workflow: consensus planning with review gates.
 
 ### code-review
 
-Hermes Code Review workflow: bug-first review with evidence.
+[omh] Hermes Code Review workflow: bug-first review with evidence.
 
 - Category: `review`
 - Phase: `critique`
@@ -699,7 +699,7 @@ Hermes Code Review workflow: bug-first review with evidence.
 
 ### ai-slop-cleaner
 
-Hermes AI slop cleaner workflow: behavior-preserving cleanup.
+[omh] Hermes AI slop cleaner workflow: behavior-preserving cleanup.
 
 - Category: `maintenance`
 - Phase: `cleanup`
@@ -729,7 +729,7 @@ Hermes AI slop cleaner workflow: behavior-preserving cleanup.
 
 ### best-practice-research
 
-Hermes adaptation for bounded official/upstream best-practice research.
+[omh] Hermes adaptation for bounded official/upstream best-practice research.
 
 - Category: `research`
 - Phase: `evidence`
@@ -758,7 +758,7 @@ Hermes adaptation for bounded official/upstream best-practice research.
 
 ### autoresearch-goal
 
-Hermes adaptation for durable research-goal execution.
+[omh] Hermes adaptation for durable research-goal execution.
 
 - Category: `research`
 - Phase: `durable-research`
@@ -787,7 +787,7 @@ Hermes adaptation for durable research-goal execution.
 
 ### performance-goal
 
-Hermes adaptation for measurable performance-goal execution.
+[omh] Hermes adaptation for measurable performance-goal execution.
 
 - Category: `optimization`
 - Phase: `measurement`
@@ -817,7 +817,7 @@ Hermes adaptation for measurable performance-goal execution.
 
 ### wiki
 
-Hermes adaptation for maintaining a project-local markdown wiki.
+[omh] Hermes adaptation for maintaining a project-local markdown wiki.
 
 - Category: `knowledge`
 - Phase: `capture`
@@ -846,7 +846,7 @@ Hermes adaptation for maintaining a project-local markdown wiki.
 
 ### ask
 
-Hermes adaptation for consulting an external advisor when configured.
+[omh] Hermes adaptation for consulting an external advisor when configured.
 
 - Category: `review`
 - Phase: `external-advice`
@@ -875,7 +875,7 @@ Hermes adaptation for consulting an external advisor when configured.
 
 ### cancel
 
-Hermes adaptation for ending active workflow state cleanly.
+[omh] Hermes adaptation for ending active workflow state cleanly.
 
 - Category: `operator`
 - Phase: `state-cleanup`
@@ -901,7 +901,7 @@ Hermes adaptation for ending active workflow state cleanly.
 
 ### skill
 
-Hermes adaptation for managing local skills.
+[omh] Hermes adaptation for managing local skills.
 
 - Category: `operator`
 - Phase: `skill-management`
@@ -927,7 +927,7 @@ Hermes adaptation for managing local skills.
 
 ### doctor
 
-Hermes adaptation for diagnosing oh-my-hermes installation health.
+[omh] Hermes adaptation for diagnosing oh-my-hermes installation health.
 
 - Category: `operator`
 - Phase: `diagnostics`

--- a/skills/ai-slop-cleaner/SKILL.md
+++ b/skills/ai-slop-cleaner/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ai-slop-cleaner
-description: Hermes AI slop cleaner workflow: behavior-preserving cleanup.
+description: [omh] Hermes AI slop cleaner workflow: behavior-preserving cleanup.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, maintenance]

--- a/skills/ask/SKILL.md
+++ b/skills/ask/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ask
-description: Hermes adaptation for consulting an external advisor when configured.
+description: [omh] Hermes adaptation for consulting an external advisor when configured.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, review]

--- a/skills/autoresearch-goal/SKILL.md
+++ b/skills/autoresearch-goal/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: autoresearch-goal
-description: Hermes adaptation for durable research-goal execution.
+description: [omh] Hermes adaptation for durable research-goal execution.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, research]

--- a/skills/best-practice-research/SKILL.md
+++ b/skills/best-practice-research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: best-practice-research
-description: Hermes adaptation for bounded official/upstream best-practice research.
+description: [omh] Hermes adaptation for bounded official/upstream best-practice research.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, research]

--- a/skills/cancel/SKILL.md
+++ b/skills/cancel/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cancel
-description: Hermes adaptation for ending active workflow state cleanly.
+description: [omh] Hermes adaptation for ending active workflow state cleanly.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, operator]

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-review
-description: Hermes Code Review workflow: bug-first review with evidence.
+description: [omh] Hermes Code Review workflow: bug-first review with evidence.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, review]

--- a/skills/cto-loop/SKILL.md
+++ b/skills/cto-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cto-loop
-description: Hermes CTO Loop workflow: roadmap, PM, technical tradeoffs, risk, delivery, release, and follow-up operating cadence.
+description: [omh] Hermes CTO Loop workflow: roadmap, PM, technical tradeoffs, risk, delivery, release, and follow-up operating cadence.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, leadership]

--- a/skills/deep-interview/SKILL.md
+++ b/skills/deep-interview/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deep-interview
-description: Hermes Deep Interview workflow: one-question-at-a-time clarification.
+description: [omh] Hermes Deep Interview workflow: one-question-at-a-time clarification.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, clarification]

--- a/skills/deploy-and-monitor/SKILL.md
+++ b/skills/deploy-and-monitor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deploy-and-monitor
-description: Hermes Deploy-and-Monitor workflow: release checklist, deploy decision, health signals, rollback gate, and post-deploy status.
+description: [omh] Hermes Deploy-and-Monitor workflow: release checklist, deploy decision, health signals, rollback gate, and post-deploy status.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, monitoring]

--- a/skills/doctor/SKILL.md
+++ b/skills/doctor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: doctor
-description: Hermes adaptation for diagnosing oh-my-hermes installation health.
+description: [omh] Hermes adaptation for diagnosing oh-my-hermes installation health.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, operator]

--- a/skills/feedback-triage/SKILL.md
+++ b/skills/feedback-triage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: feedback-triage
-description: Hermes Feedback Triage workflow: cluster customer signals and choose the next workflow.
+description: [omh] Hermes Feedback Triage workflow: cluster customer signals and choose the next workflow.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, triage]

--- a/skills/idea-to-deploy/SKILL.md
+++ b/skills/idea-to-deploy/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: idea-to-deploy
-description: Hermes Idea-to-Deploy workflow: shape an app idea into decisions, delivery handoff, verification, release, and monitoring status.
+description: [omh] Hermes Idea-to-Deploy workflow: shape an app idea into decisions, delivery handoff, verification, release, and monitoring status.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, delivery]

--- a/skills/loop/SKILL.md
+++ b/skills/loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: loop
-description: Hermes Loop workflow: ambitious goal interview, research, planning, runtime ticks, handoff, feedback, and resume cycles.
+description: [omh] Hermes Loop workflow: ambitious goal interview, research, planning, runtime ticks, handoff, feedback, and resume cycles.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, goal-loop]

--- a/skills/meeting-brief/SKILL.md
+++ b/skills/meeting-brief/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: meeting-brief
-description: Hermes Meeting Brief workflow: agenda, prompts, decisions, and record template.
+description: [omh] Hermes Meeting Brief workflow: agenda, prompts, decisions, and record template.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, meeting]

--- a/skills/oh-my-hermes/SKILL.md
+++ b/skills/oh-my-hermes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: oh-my-hermes
-description: Router guidance for using oh-my-hermes workflow skills inside Hermes Agent.
+description: [omh] Router guidance for using oh-my-hermes workflow skills inside Hermes Agent.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, router]

--- a/skills/ops-review/SKILL.md
+++ b/skills/ops-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ops-review
-description: Hermes Ops Review workflow: status, risks, blockers, priorities, and follow-ups.
+description: [omh] Hermes Ops Review workflow: status, risks, blockers, priorities, and follow-ups.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, operations]

--- a/skills/performance-goal/SKILL.md
+++ b/skills/performance-goal/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: performance-goal
-description: Hermes adaptation for measurable performance-goal execution.
+description: [omh] Hermes adaptation for measurable performance-goal execution.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, optimization]

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plan
-description: Hermes Plan workflow: structured planning before execution.
+description: [omh] Hermes Plan workflow: structured planning before execution.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, planning]

--- a/skills/ralph/SKILL.md
+++ b/skills/ralph/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ralph
-description: Hermes Ralph workflow: persistent execution with verification and review.
+description: [omh] Hermes Ralph workflow: persistent execution with verification and review.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, execution]

--- a/skills/ralplan/SKILL.md
+++ b/skills/ralplan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ralplan
-description: Hermes Ralplan workflow: consensus planning with review gates.
+description: [omh] Hermes Ralplan workflow: consensus planning with review gates.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, planning]

--- a/skills/research-brief/SKILL.md
+++ b/skills/research-brief/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: research-brief
-description: Hermes Research Brief workflow: source-backed business research without pretending evidence was fetched.
+description: [omh] Hermes Research Brief workflow: source-backed business research without pretending evidence was fetched.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, research]

--- a/skills/skill/SKILL.md
+++ b/skills/skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill
-description: Hermes adaptation for managing local skills.
+description: [omh] Hermes adaptation for managing local skills.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, operator]

--- a/skills/strategy-brief/SKILL.md
+++ b/skills/strategy-brief/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: strategy-brief
-description: Hermes Strategy Brief workflow: options, tradeoffs, recommendation, and decision notes.
+description: [omh] Hermes Strategy Brief workflow: options, tradeoffs, recommendation, and decision notes.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, strategy]

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: team
-description: Hermes Team workflow: coordinated parallel or sequential work lanes.
+description: [omh] Hermes Team workflow: coordinated parallel or sequential work lanes.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, execution]

--- a/skills/ultragoal/SKILL.md
+++ b/skills/ultragoal/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ultragoal
-description: Hermes Ultragoal workflow: file-backed durable goal ledgers.
+description: [omh] Hermes Ultragoal workflow: file-backed durable goal ledgers.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, execution]

--- a/skills/ultraprocess/SKILL.md
+++ b/skills/ultraprocess/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ultraprocess
-description: Ultra Process - Research - Ralplan - Ultragoal - Code Review - Sync Circle: one PR-ready delivery cycle.
+description: [omh] Ultra Process - Research - Ralplan - Ultragoal - Code Review - Sync Circle: one PR-ready delivery cycle.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, process]

--- a/skills/ultraqa/SKILL.md
+++ b/skills/ultraqa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ultraqa
-description: Hermes UltraQA workflow: adversarial QA and fix loops.
+description: [omh] Hermes UltraQA workflow: adversarial QA and fix loops.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, verification]

--- a/skills/ultrawork/SKILL.md
+++ b/skills/ultrawork/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ultrawork
-description: Hermes Ultrawork compatibility workflow: bounded parallel delivery guidance.
+description: [omh] Hermes Ultrawork compatibility workflow: bounded parallel delivery guidance.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, execution]

--- a/skills/web-research/SKILL.md
+++ b/skills/web-research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: web-research
-description: Hermes Web Research workflow: source-backed current information gathering.
+description: [omh] Hermes Web Research workflow: source-backed current information gathering.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, research]

--- a/skills/wiki/SKILL.md
+++ b/skills/wiki/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wiki
-description: Hermes adaptation for maintaining a project-local markdown wiki.
+description: [omh] Hermes adaptation for maintaining a project-local markdown wiki.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, knowledge]

--- a/src/converter.py
+++ b/src/converter.py
@@ -4,6 +4,7 @@ import re
 from pathlib import Path
 
 from .skill_pack import DESCRIPTIONS, SkillTemplate
+from .skills.catalog import omh_description
 
 FRONTMATTER_RE = re.compile(r"^---\n(?P<meta>.*?)\n---\n(?P<body>.*)$", re.DOTALL)
 
@@ -20,8 +21,8 @@ def extract_name(raw: str, fallback: str) -> str:
 
 def convert_skill(raw: str, fallback_name: str) -> SkillTemplate:
     name = extract_name(raw, fallback_name)
-    description = DESCRIPTIONS.get(name, f"Hermes workflow skill for {name}.")
-    content = raw.rstrip() + f"""
+    description = DESCRIPTIONS.get(name, omh_description(f"Hermes workflow skill for {name}."))
+    content = _replace_frontmatter_description(raw, name=name, description=description).rstrip() + f"""
 
 ## Hermes Compatibility Contract
 
@@ -32,6 +33,30 @@ This skill was imported by `omh` from a local skill source.
 - Use Hermes `skills_list`, `skill_view`, file tools, terminal tools, and Hermes delegation when available.
 """
     return SkillTemplate(name=name, content=content + "\n")
+
+
+def _replace_frontmatter_description(raw: str, *, name: str, description: str) -> str:
+    match = FRONTMATTER_RE.match(raw)
+    if not match:
+        return f"---\nname: {name}\ndescription: {description}\n---\n\n{raw}"
+    lines = match.group("meta").splitlines()
+    output: list[str] = []
+    saw_name = False
+    saw_description = False
+    for line in lines:
+        if line.startswith("name:"):
+            output.append(f"name: {name}")
+            saw_name = True
+        elif line.startswith("description:"):
+            output.append(f"description: {description}")
+            saw_description = True
+        else:
+            output.append(line)
+    if not saw_name:
+        output.insert(0, f"name: {name}")
+    if not saw_description:
+        output.insert(1, f"description: {description}")
+    return "---\n" + "\n".join(output) + "\n---\n" + match.group("body")
 
 
 def discover_skill_files(source_dir: Path) -> list[Path]:

--- a/src/skills/catalog.py
+++ b/src/skills/catalog.py
@@ -5,6 +5,16 @@ from dataclasses import dataclass
 from ..harness_quality import build_harness_quality_contract, unknown_harness_quality_contract
 
 
+OMH_DESCRIPTION_PREFIX = "[omh] "
+
+
+def omh_description(description: str) -> str:
+    text = description.strip()
+    if text.lower().startswith(OMH_DESCRIPTION_PREFIX):
+        return text
+    return f"{OMH_DESCRIPTION_PREFIX}{text}"
+
+
 @dataclass(frozen=True)
 class SkillDefinition:
     name: str
@@ -28,6 +38,9 @@ class SkillDefinition:
         "Name the workflow target, constraints, validation evidence, and stop condition.",
         "Separate Hermes guidance from executor or wrapper behavior unless evidence proves the step happened.",
     )
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "description", omh_description(self.description))
 
 
 @dataclass(frozen=True)

--- a/src/skills/render.py
+++ b/src/skills/render.py
@@ -11,6 +11,7 @@ from .catalog import (
     builtin_harnesses,
     harness_quality_contract,
     memory_context_policy_for_skill,
+    omh_description,
     primary_harness_for_skill,
 )
 
@@ -109,6 +110,7 @@ def _frontmatter(name: str, description: str) -> str:
     definition = _definitions_by_name().get(name)
     category = definition.category if definition else "workflow"
     phase = definition.phase if definition else "general"
+    description = omh_description(description)
     return (
         f"---\nname: {name}\ndescription: {description}\nmetadata:\n"
         f"  hermes:\n    tags: [workflow, oh-my-hermes, {category}]\n"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3039,6 +3039,7 @@ class CliTests(unittest.TestCase):
 
             self.assertEqual(run_cli(["--omh-home", str(omh_home), "convert", "--from-skills-dir", str(root / "local-skills")])[0], 0)
             converted = (omh_home / "skills" / "ralph" / "SKILL.md").read_text(encoding="utf-8")
+            self.assertIn("description: [omh] Hermes Ralph workflow", converted)
             self.assertIn("Hermes Compatibility Contract", converted)
 
     def test_mocked_source_install_update(self) -> None:

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -168,6 +168,7 @@ class RouterContentTests(unittest.TestCase):
 
     def test_catalog_definitions_expose_required_metadata_fields(self) -> None:
         for definition in builtin_definitions():
+            self.assertTrue(definition.description.startswith("[omh] "), definition.name)
             self.assertTrue(definition.category, definition.name)
             self.assertTrue(definition.phase, definition.name)
             self.assertTrue(definition.quality_tier, definition.name)
@@ -179,6 +180,8 @@ class RouterContentTests(unittest.TestCase):
             self.assertTrue(definition.hermes_role, definition.name)
             self.assertIn(definition.delegation_boundary, {"default", "retained", "retained-catalog-intent"}, definition.name)
             self.assertTrue(definition.handoff_policy, definition.name)
+        for template in builtin_skill_templates():
+            self.assertIn("description: [omh] ", template.content.split("---", 2)[1], template.name)
 
     def test_catalog_marks_retained_and_codex_handoff_skills(self) -> None:
         definitions = {definition.name: definition for definition in builtin_definitions()}
@@ -191,7 +194,7 @@ class RouterContentTests(unittest.TestCase):
         self.assertEqual(definitions["ultraprocess"].hermes_role, "retained-cognition")
         self.assertEqual(
             definitions["ultraprocess"].description,
-            "Ultra Process - Research - Ralplan - Ultragoal - Code Review - Sync Circle: one PR-ready delivery cycle.",
+            "[omh] Ultra Process - Research - Ralplan - Ultragoal - Code Review - Sync Circle: one PR-ready delivery cycle.",
         )
         self.assertEqual(definitions["ultrawork"].hermes_role, "codex-handoff-guidance")
         self.assertEqual(definitions["ai-slop-cleaner"].hermes_role, "codex-handoff-guidance")


### PR DESCRIPTION
## Summary
- normalize built-in OMH skill descriptions with a `[omh]` prefix for Hermes TUI/picker identification
- defensively apply the same prefix in generated skill frontmatter and converted local skills
- refresh generated tap skills and workflow reference docs, with regression tests for the prefix contract

## Verification
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- `PYTHONPATH=tests uv run python -m unittest tests/test_router_content.py tests.test_cli.CliTests.test_convert_from_local_skill_fixture -v`
- `uv run python -m src.cli docs workflows --check`
- `uv run python -m compileall -q src tests`
- `git diff --check`

## Notes
- Live Hermes TUI picker rendering was not exercised locally.