### PR TITLE
Harden installed OMH release smoke

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,6 +27,8 @@
 - [ ] `python3 -m omh.cli docs workflows --check`
 - [ ] `python3 -m omh.cli harness validate`
 - [ ] `python3 -m omh.cli release hermes-smoke`
+- [ ] `omh --help`
+- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
 - [ ] Relevant dry-run or smoke command:
 - [ ] Manual Hermes/TUI check, or explicit reason it was not run:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,10 @@ jobs:
         run: python -m omh.cli --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke probe
       - name: Hermes release smoke plan
         run: python -m omh.cli release hermes-smoke
+      - name: Installed OMH command smoke
+        run: |
+          omh --help
+          omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke
       - name: Runtime artifact smoke
         run: |
           run_json="$(python -m omh.cli --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke runtime record --skill oh-my-hermes --harness coding-handling --status started)"

--- a/README.md
+++ b/README.md
@@ -341,6 +341,8 @@ python3 -m compileall src
 python3 -m omh.cli docs workflows --check
 python3 -m omh.cli harness validate
 python3 -m omh.cli release hermes-smoke
+omh --help
+omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke
 ```
 
 Smoke-test setup without touching real home directories:

--- a/docs/HERMES_AGENT_INTEGRATION_RUNBOOK.md
+++ b/docs/HERMES_AGENT_INTEGRATION_RUNBOOK.md
@@ -120,7 +120,9 @@ omh chat session prepare-handoff "$SESSION_ID" "risky refactor"
 omh chat session status "$SESSION_ID"
 ```
 
-After a handoff is prepared, render the returned `chat_response.actions` as
+Before a handoff is prepared, the status card should explain the plan or
+executor-choice state without showing executor open/result buttons. After a
+handoff is prepared, render the returned `chat_response.actions` as
 Hermes-native buttons. A normal user should see actions such as Open in Codex,
 Open in Claude Code, Attach session, Refresh status, Record completed, Record
 blocked, or Ask Hermes to verify. The wrapper process maps those buttons back

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -118,6 +118,18 @@ in CI without touching the current Hermes profile:
 omh release hermes-smoke
 ```
 
+The plan also reports `installed_command_smoke` and
+`first_use_status_smoke`. The first checks that the installed `omh` console
+script can run; the second locks the first Hermes chat/status boundary so
+pre-handoff status does not show executor open/result actions.
+
+After installing OMH into the target runtime, verify the command path too:
+
+```sh
+omh --help
+omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke
+```
+
 When an operator explicitly wants live evidence from the target Hermes profile,
 run one of these:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -103,8 +103,9 @@ selected.
   `harness_quality/v1` instead of being prose-only wrapper behavior.
 - Harness catalog changes should pass `omh harness validate`, and user-facing
   harness examples should stay backed by conformance tests.
-- Release checks should include `omh release hermes-smoke`; use `--live` only
-  from the target Hermes profile when an operator wants real install evidence.
+- Release checks should include `omh release hermes-smoke` plus installed
+  command smoke (`omh --help`); use `--live` only from the target Hermes
+  profile when an operator wants real install evidence.
 - Runtime and wrapper docs should preserve the separation between wrapper
   session state and run-level evidence.
 - Goal execution docs should describe `.omh/goals` metadata-only ledgers,

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -60,13 +60,15 @@ python3 -m omh.cli docs workflows --check
 python3 -m omh.cli harness validate
 python3 -m omh.cli --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke install --dry-run --channel stable --version 1.0.0
 python3 -m omh.cli --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke setup --dry-run --channel stable --version 1.0.0
-python3 -m omh.cli --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke setup --dry-run --channel stable --version 1.0.0
 python3 -m omh.cli --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke probe
 python3 -m omh.cli release hermes-smoke
+omh --help
+omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke
 uv build
 python3 -m venv /tmp/omh-wheel-smoke
 /tmp/omh-wheel-smoke/bin/python -m pip install --upgrade dist/oh_my_hermes-1.0.0-py3-none-any.whl
 /tmp/omh-wheel-smoke/bin/omh --help
+/tmp/omh-wheel-smoke/bin/omh --omh-home /tmp/omh-wheel-home --hermes-home /tmp/hermes-wheel-home release hermes-smoke --install-path setup --omh-command /tmp/omh-wheel-smoke/bin/omh --include-command-smoke
 /tmp/omh-wheel-smoke/bin/omh --omh-home /tmp/omh-wheel-home --hermes-home /tmp/hermes-wheel-home setup --dry-run --channel stable --version 1.0.0
 OMH_PYTHON=/tmp/omh-wheel-smoke/bin/python OMH_PACKAGE_URL=file://$PWD/dist/oh_my_hermes-1.0.0-py3-none-any.whl OMH_VENV_DIR=/tmp/omh-installer-venv OMH_BIN_DIR=/tmp/omh-installer-bin OMH_SETUP_ARGS="--dry-run" OMH_RUN_DOCTOR=0 sh install.sh
 ```
@@ -79,6 +81,21 @@ profile:
 
 ```sh
 python3 -m omh.cli release hermes-smoke
+```
+
+The plan includes two release-contract subchecks:
+
+- `installed_command_smoke`: proves the installed `omh` console script can run
+  `omh --help` and render the setup-path smoke plan.
+- `first_use_status_smoke`: documents the first Hermes chat/status path and
+  locks that pre-handoff status cards do not expose executor open/result
+  actions.
+
+Run the installed command smoke in CI or a release shell after installing OMH:
+
+```sh
+omh --help
+omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke
 ```
 
 For release candidates, run exactly one live smoke against the target Hermes

--- a/src/commands/release.py
+++ b/src/commands/release.py
@@ -3,7 +3,14 @@ from __future__ import annotations
 import argparse
 
 from ..installer import OmhError
-from ..release import DEFAULT_HERMES_SKILL, DEFAULT_HERMES_TAP, INSTALL_PATHS, hermes_release_smoke_plan, run_hermes_release_smoke
+from ..release import (
+    DEFAULT_HERMES_SKILL,
+    DEFAULT_HERMES_TAP,
+    INSTALL_PATHS,
+    hermes_release_smoke_plan,
+    run_hermes_release_smoke,
+    run_installed_command_smoke,
+)
 from .common import _print_json
 
 
@@ -24,20 +31,31 @@ def cmd_release_hermes_smoke(args: argparse.Namespace) -> int:
             omh_home=args.omh_home,
             hermes_home=args.hermes_home,
             timeout_seconds=args.timeout,
+            include_command_smoke=args.include_command_smoke,
         )
         _print_json(payload)
         return 0 if payload["ok"] else 1
-    _print_json(
-        hermes_release_smoke_plan(
-            install_path=args.install_path,
-            skill=args.skill,
-            tap=args.tap,
+    installed_command_smoke = (
+        run_installed_command_smoke(
             omh_command=args.omh_command,
             omh_home=args.omh_home,
             hermes_home=args.hermes_home,
+            timeout_seconds=args.timeout,
         )
+        if args.include_command_smoke
+        else None
     )
-    return 0
+    payload = hermes_release_smoke_plan(
+        install_path=args.install_path,
+        skill=args.skill,
+        tap=args.tap,
+        omh_command=args.omh_command,
+        omh_home=args.omh_home,
+        hermes_home=args.hermes_home,
+        installed_command_smoke=installed_command_smoke,
+    )
+    _print_json(payload)
+    return 0 if payload["ok"] else 1
 
 
 def _add_release_commands(sub) -> None:
@@ -63,5 +81,10 @@ def _add_release_commands(sub) -> None:
     smoke.add_argument("--skill", default=DEFAULT_HERMES_SKILL, help="Hermes skill identifier to install/check.")
     smoke.add_argument("--tap", default=DEFAULT_HERMES_TAP, help="Hermes skill tap repository to add for tap installs.")
     smoke.add_argument("--omh-command", default="omh", help="OMH executable to use for the setup install path.")
-    smoke.add_argument("--timeout", type=int, default=30, help="Per-command timeout in seconds for --live mode.")
+    smoke.add_argument(
+        "--include-command-smoke",
+        action="store_true",
+        help="Also execute installed `omh --help` and installed setup-path plan rendering without mutating Hermes.",
+    )
+    smoke.add_argument("--timeout", type=int, default=30, help="Per-command timeout in seconds for --live or --include-command-smoke.")
     smoke.set_defaults(func=cmd_release_hermes_smoke)

--- a/src/release.py
+++ b/src/release.py
@@ -10,8 +10,11 @@ from typing import Callable, Mapping, Sequence
 REPOSITORY_ARCHIVE_ROOT = "https://github.com/rlaope/oh-my-hermes/archive/refs"
 RELEASE_CHANNELS = ("stable", "preview", "local")
 HERMES_SMOKE_SCHEMA = "hermes_release_smoke/v1"
+INSTALLED_COMMAND_SMOKE_SCHEMA = "installed_omh_command_smoke/v1"
+FIRST_USE_STATUS_SMOKE_SCHEMA = "first_use_status_smoke/v1"
 DEFAULT_HERMES_TAP = "rlaope/oh-my-hermes"
 DEFAULT_HERMES_SKILL = "oh-my-hermes"
+DEFAULT_FIRST_USE_MESSAGE = "I want to safely add a feature to this repo"
 INSTALL_PATHS = ("tap", "setup")
 
 
@@ -196,6 +199,7 @@ def hermes_release_smoke_plan(
     omh_command: str = "omh",
     omh_home: str | Path | None = None,
     hermes_home: str | Path | None = None,
+    installed_command_smoke: Mapping[str, object] | None = None,
 ) -> dict[str, object]:
     target = _target_binding(omh_home=omh_home, hermes_home=hermes_home)
     steps = hermes_release_smoke_steps(
@@ -206,10 +210,20 @@ def hermes_release_smoke_plan(
         omh_home=target["omh_home"],
         hermes_home=target["hermes_home"],
     )
+    command_smoke = (
+        dict(installed_command_smoke)
+        if installed_command_smoke is not None
+        else installed_command_smoke_plan(
+            omh_command=omh_command,
+            omh_home=target["omh_home"],
+            hermes_home=target["hermes_home"],
+        )
+    )
+    ok = not (command_smoke.get("observed") and not command_smoke.get("ok"))
     return {
         "schema_version": HERMES_SMOKE_SCHEMA,
         "mode": "plan",
-        "ok": True,
+        "ok": ok,
         "observed": False,
         "install_path": install_path,
         "skill": skill,
@@ -220,7 +234,206 @@ def hermes_release_smoke_plan(
             "installed, loaded, or used OMH. Run with --live against the target profile for observed smoke evidence."
         ),
         "steps": [step.to_payload() for step in steps],
+        "installed_command_smoke": command_smoke,
+        "first_use_status_smoke": first_use_status_smoke_plan(
+            omh_command=omh_command,
+            omh_home=target["omh_home"],
+            hermes_home=target["hermes_home"],
+        ),
         "live_command": _live_smoke_command(install_path, target),
+    }
+
+
+def installed_command_smoke_plan(
+    *,
+    omh_command: str = "omh",
+    omh_home: str | Path | None = None,
+    hermes_home: str | Path | None = None,
+) -> dict[str, object]:
+    target = _target_binding(omh_home=omh_home, hermes_home=hermes_home)
+    steps = [
+        HermesSmokeStep(
+            "installed_omh_help",
+            (omh_command, "--help"),
+            "verify",
+            False,
+            proof_boundary="Verifies the installed OMH console script is importable and runnable from the current PATH.",
+        ),
+        HermesSmokeStep(
+            "installed_omh_setup_plan",
+            _omh_release_plan_command(
+                omh_command,
+                install_path="setup",
+                omh_home=target["omh_home"],
+                hermes_home=target["hermes_home"],
+            ),
+            "verify",
+            False,
+            proof_boundary=(
+                "Verifies the installed OMH console script can render the setup-path Hermes smoke plan. "
+                "This is still plan evidence, not live Hermes profile mutation."
+            ),
+        ),
+    ]
+    return {
+        "schema_version": INSTALLED_COMMAND_SMOKE_SCHEMA,
+        "mode": "plan",
+        "ok": True,
+        "observed": False,
+        "command_under_test": omh_command,
+        "target_binding": target,
+        "proof_boundary": (
+            "Plan mode lists installed-command checks only. Run release hermes-smoke with "
+            "--include-command-smoke to observe the installed OMH executable."
+        ),
+        "steps": [step.to_payload() for step in steps],
+    }
+
+
+def first_use_status_smoke_plan(
+    *,
+    omh_command: str = "omh",
+    omh_home: str | Path | None = None,
+    hermes_home: str | Path | None = None,
+    message: str = DEFAULT_FIRST_USE_MESSAGE,
+) -> dict[str, object]:
+    target = _target_binding(omh_home=omh_home, hermes_home=hermes_home)
+    session_id = "<session_id>"
+    return {
+        "schema_version": FIRST_USE_STATUS_SMOKE_SCHEMA,
+        "mode": "plan",
+        "ok": True,
+        "observed": False,
+        "example_message": message,
+        "target_binding": target,
+        "proof_boundary": (
+            "This first-use smoke is fixture-backed guidance for wrapper/Hermes status UX. It does not prove "
+            "a live chat selected OMH unless the wrapper records that chat response."
+        ),
+        "steps": [
+            {
+                "name": "chat_session_start",
+                "command": list(
+                    _omh_scoped_command(
+                        omh_command,
+                        "chat",
+                        "session",
+                        "start",
+                        "--source",
+                        "hermes",
+                        "--source-event-id",
+                        "release-smoke-message",
+                        "--channel-ref",
+                        "release-smoke",
+                        message,
+                        omh_home=target["omh_home"],
+                        hermes_home=target["hermes_home"],
+                    )
+                ),
+                "phase": "verify",
+                "mutates_profile": False,
+                "required": True,
+                "expected": "Creates or resumes a metadata-only wrapper session and returns a status card without executor open/result actions.",
+                "proof_boundary": "Starting a wrapper session is routing/status evidence only; it is not execution evidence.",
+            },
+            {
+                "name": "chat_session_accept_plan",
+                "command": list(
+                    _omh_scoped_command(
+                        omh_command,
+                        "chat",
+                        "session",
+                        "accept-plan",
+                        session_id,
+                        omh_home=target["omh_home"],
+                        hermes_home=target["hermes_home"],
+                    )
+                ),
+                "phase": "verify",
+                "mutates_profile": False,
+                "required": True,
+                "expected": "Records explicit plan acceptance before any coding handoff can be prepared.",
+                "proof_boundary": "Plan acceptance is a wrapper decision; it is still not dispatch or execution evidence.",
+            },
+            {
+                "name": "chat_session_select_executor",
+                "command": list(
+                    _omh_scoped_command(
+                        omh_command,
+                        "chat",
+                        "session",
+                        "select-executor",
+                        session_id,
+                        "codex",
+                        omh_home=target["omh_home"],
+                        hermes_home=target["hermes_home"],
+                    )
+                ),
+                "phase": "verify",
+                "mutates_profile": False,
+                "required": True,
+                "expected": "Records the selected coding agent before backend open/attach actions become visible.",
+                "proof_boundary": "Executor selection is not executor dispatch; it only chooses the handoff target.",
+            },
+            {
+                "name": "chat_session_prepare_handoff",
+                "command": list(
+                    _omh_scoped_command(
+                        omh_command,
+                        "chat",
+                        "session",
+                        "prepare-handoff",
+                        session_id,
+                        message,
+                        omh_home=target["omh_home"],
+                        hermes_home=target["hermes_home"],
+                    )
+                ),
+                "phase": "verify",
+                "mutates_profile": False,
+                "required": True,
+                "expected": "Prepares the coding handoff while keeping dispatch/result/verification not observed.",
+                "proof_boundary": "A prepared handoff is not an observed executor open, result, review, CI, or merge.",
+            },
+            {
+                "name": "chat_session_status_after_handoff",
+                "command": list(
+                    _omh_scoped_command(
+                        omh_command,
+                        "chat",
+                        "session",
+                        "status",
+                        session_id,
+                        omh_home=target["omh_home"],
+                        hermes_home=target["hermes_home"],
+                    )
+                ),
+                "phase": "verify",
+                "mutates_profile": False,
+                "required": True,
+                "expected": "After plan acceptance, executor selection, and handoff preparation, status shows prepared handoff without observed dispatch/result.",
+                "proof_boundary": "Prepared handoff status remains prepared_not_observed until dispatch/result evidence is recorded.",
+            },
+        ],
+        "expected_status_boundary": {
+            "before_handoff": {
+                "executor_actions_visible": False,
+                "forbidden_action_ids": [
+                    "open_executor_session",
+                    "attach_executor_session",
+                    "record_executor_completed",
+                    "record_executor_blocked",
+                    "record_executor_failed",
+                    "ask_hermes_verify",
+                ],
+            },
+            "after_handoff": {
+                "handoff": "prepared",
+                "dispatch": "not_observed",
+                "result": "not_observed",
+                "verification": "not_requested",
+            },
+        },
     }
 
 
@@ -234,6 +447,7 @@ def run_hermes_release_smoke(
     hermes_home: str | Path | None = None,
     timeout_seconds: int = 30,
     runner: Runner | None = None,
+    include_command_smoke: bool = False,
 ) -> dict[str, object]:
     if timeout_seconds < 1:
         raise ValueError("Hermes smoke timeout must be at least one second")
@@ -245,6 +459,22 @@ def run_hermes_release_smoke(
         omh_command=omh_command,
         omh_home=target["omh_home"],
         hermes_home=target["hermes_home"],
+    )
+    execute = runner or _subprocess_runner
+    command_smoke = (
+        run_installed_command_smoke(
+            omh_command=omh_command,
+            omh_home=target["omh_home"],
+            hermes_home=target["hermes_home"],
+            timeout_seconds=timeout_seconds,
+            runner=execute,
+        )
+        if include_command_smoke
+        else installed_command_smoke_plan(
+            omh_command=omh_command,
+            omh_home=target["omh_home"],
+            hermes_home=target["hermes_home"],
+        )
     )
     hermes_path = shutil.which("hermes")
     results: list[dict[str, object]] = []
@@ -261,11 +491,16 @@ def run_hermes_release_smoke(
             "target_binding": target,
             "hermes_cli": {"found": False, "path": None},
             "results": [],
+            "installed_command_smoke": command_smoke,
+            "first_use_status_smoke": first_use_status_smoke_plan(
+                omh_command=omh_command,
+                omh_home=target["omh_home"],
+                hermes_home=target["hermes_home"],
+            ),
             "failed_step": "hermes_cli",
             "recommended_next_action": "Install Hermes Agent CLI or run this smoke from the target Hermes profile.",
             "proof_boundary": "No Hermes CLI was observed, so no Hermes install, list, check, or inspect evidence exists.",
         }
-    execute = runner or _subprocess_runner
     ok = True
     failed_step = ""
     for step in steps:
@@ -286,6 +521,10 @@ def run_hermes_release_smoke(
             failed_step = step.name
             if step.required:
                 break
+    if include_command_smoke and not bool(command_smoke.get("ok", False)):
+        ok = False
+        if not failed_step:
+            failed_step = "installed_command_smoke"
     return {
         "schema_version": HERMES_SMOKE_SCHEMA,
         "mode": "live",
@@ -297,11 +536,75 @@ def run_hermes_release_smoke(
         "target_binding": target,
         "hermes_cli": {"found": True, "path": hermes_path},
         "results": results,
+        "installed_command_smoke": command_smoke,
+        "first_use_status_smoke": first_use_status_smoke_plan(
+            omh_command=omh_command,
+            omh_home=target["omh_home"],
+            hermes_home=target["hermes_home"],
+        ),
         "failed_step": failed_step,
         "recommended_next_action": _hermes_smoke_next_action(ok, failed_step),
         "proof_boundary": (
             "Live smoke observes Hermes CLI install/list/check/inspect command results only. "
             "It still does not prove a later chat session selected OMH unless that session is observed separately."
+        ),
+    }
+
+
+def run_installed_command_smoke(
+    *,
+    omh_command: str = "omh",
+    omh_home: str | Path | None = None,
+    hermes_home: str | Path | None = None,
+    timeout_seconds: int = 30,
+    runner: Runner | None = None,
+) -> dict[str, object]:
+    if timeout_seconds < 1:
+        raise ValueError("Installed command smoke timeout must be at least one second")
+    plan = installed_command_smoke_plan(omh_command=omh_command, omh_home=omh_home, hermes_home=hermes_home)
+    target = plan["target_binding"]
+    execute = runner or _subprocess_runner
+    results: list[dict[str, object]] = []
+    ok = True
+    failed_step = ""
+    for raw_step in plan["steps"]:
+        step = HermesSmokeStep(
+            str(raw_step["name"]),
+            tuple(str(part) for part in raw_step["command"]),
+            str(raw_step["phase"]),
+            bool(raw_step["mutates_profile"]),
+            required=bool(raw_step["required"]),
+            proof_boundary=str(raw_step["proof_boundary"]),
+        )
+        result = execute(step.command, timeout_seconds, None)
+        step_ok = result.returncode == 0
+        ok = ok and step_ok
+        results.append(
+            {
+                **step.to_payload(),
+                "returncode": result.returncode,
+                "ok": step_ok,
+                "stdout_excerpt": _bounded_text(result.stdout),
+                "stderr_excerpt": _bounded_text(result.stderr),
+            }
+        )
+        if not step_ok and not failed_step:
+            failed_step = step.name
+            if step.required:
+                break
+    return {
+        "schema_version": INSTALLED_COMMAND_SMOKE_SCHEMA,
+        "mode": "live",
+        "ok": ok,
+        "observed": bool(results),
+        "command_under_test": omh_command,
+        "target_binding": target,
+        "results": results,
+        "failed_step": failed_step,
+        "recommended_next_action": _installed_command_smoke_next_action(ok, failed_step),
+        "proof_boundary": (
+            "Installed command smoke observes the OMH console script and plan rendering only. "
+            "It does not mutate Hermes or prove live chat usage."
         ),
     }
 
@@ -363,7 +666,17 @@ def _expand_home(value: str | Path | None, env_key: str, default: str) -> Path:
 
 def _omh_scoped_command(
     omh_command: str,
-    command_name: str,
+    *command_parts: str,
+    omh_home: str | Path | None = None,
+    hermes_home: str | Path | None = None,
+) -> tuple[str, ...]:
+    command = list(_omh_base_command(omh_command, omh_home=omh_home, hermes_home=hermes_home))
+    command.extend(command_parts)
+    return tuple(command)
+
+
+def _omh_base_command(
+    omh_command: str,
     *,
     omh_home: str | Path | None = None,
     hermes_home: str | Path | None = None,
@@ -373,8 +686,25 @@ def _omh_scoped_command(
         command.extend(["--omh-home", str(omh_home)])
     if hermes_home is not None:
         command.extend(["--hermes-home", str(hermes_home)])
-    command.append(command_name)
     return tuple(command)
+
+
+def _omh_release_plan_command(
+    omh_command: str,
+    *,
+    install_path: str,
+    omh_home: str | Path | None = None,
+    hermes_home: str | Path | None = None,
+) -> tuple[str, ...]:
+    return (
+        *_omh_base_command(omh_command, omh_home=omh_home, hermes_home=hermes_home),
+        "release",
+        "hermes-smoke",
+        "--install-path",
+        install_path,
+        "--omh-command",
+        omh_command,
+    )
 
 
 def _live_smoke_command(install_path: str, target: Mapping[str, object]) -> list[str]:
@@ -403,6 +733,18 @@ def _hermes_smoke_next_action(ok: bool, failed_step: str) -> str:
         return "Run `omh setup` manually and inspect `omh doctor` for blocking setup checks."
     if failed_step == "setup_doctor":
         return "Run `omh doctor` manually and repair the OMH-managed skill registration reported there."
+    if failed_step == "installed_command_smoke":
+        return "Repair the installed `omh` console script path, then rerun the smoke with --include-command-smoke."
     if failed_step in {"tap_list", "skills_list", "skill_check", "skill_inspect"}:
         return "Inspect the failing Hermes skills command output and confirm the target Hermes profile is the one OMH was installed into."
     return "Inspect the failed Hermes release smoke step and rerun after repair."
+
+
+def _installed_command_smoke_next_action(ok: bool, failed_step: str) -> str:
+    if ok:
+        return "Installed `omh` command path is runnable; continue with Hermes profile smoke or release tagging."
+    if failed_step == "installed_omh_help":
+        return "Check PATH, package installation, and console-script importability for `omh`."
+    if failed_step == "installed_omh_setup_plan":
+        return "Run `omh release hermes-smoke --install-path setup` directly and inspect the console-script error."
+    return "Inspect the failed installed command smoke step and rerun after repair."

--- a/src/wrapper/executor_sessions.py
+++ b/src/wrapper/executor_sessions.py
@@ -72,7 +72,7 @@ def build_executor_session_status(
         "schema_version": EXECUTOR_SESSION_STATUS_SCHEMA_VERSION,
         "session_id": session_id,
         "selected_executor_profile": executor,
-        "executor_label": executor_label(executor),
+        "executor_label": _surface_executor_label(executor, handoff_state=_handoff_state(session)),
         "session_kind": _session_kind(session),
         "coding_agent": f"{agent_state}({executor})",
         "executor_session": "attached" if attached else "not_attached",
@@ -147,9 +147,19 @@ def build_executor_session_actions(
         "schema_version": "executor_session_action/v1",
         "session_id": session_id,
         "selected_executor_profile": executor,
-        "executor_label": executor_label(executor),
+        "executor_label": _surface_executor_label(executor, handoff_state=_handoff_state(session)),
         "claim_boundary": "The wrapper must call the backend action after it observes the corresponding user or executor event.",
     }
+    if _handoff_state(session) != "prepared":
+        return [
+            _action(
+                "refresh_executor_status",
+                "Refresh status",
+                "secondary",
+                enabled=True,
+                payload={**base_payload, "backend_action": "status"},
+            )
+        ]
     return [
         _action(
             "open_executor_session",
@@ -379,9 +389,7 @@ def enhance_chat_response_with_executor_session(
     updated["state"] = state
     actions = [action for action in updated.get("actions", []) if isinstance(action, dict)]
     action_ids = {str(action.get("id", "")) for action in actions}
-    for action in executor_status.get("actions", []):
-        if not isinstance(action, dict):
-            continue
+    for action in _executor_surface_actions(executor_status):
         action_id = str(action.get("id", ""))
         if action_id in action_ids:
             continue
@@ -410,7 +418,7 @@ def enhance_status_card_with_executor_session(
     executor_next_action = _next_executor_action(executor_status)
     updated["executor_next_action"] = executor_next_action
     updated["executor_next_action_label"] = _executor_action_label(executor_status, executor_next_action)
-    updated["executor_actions"] = [action for action in executor_status.get("actions", []) if isinstance(action, dict)]
+    updated["executor_actions"] = _executor_surface_actions(executor_status)
     return updated
 
 
@@ -471,6 +479,12 @@ def _default_executor_session(session: dict[str, Any]) -> dict[str, Any]:
         "summary": "",
         "claim_boundary": _claim_boundary(),
     }
+
+
+def _executor_surface_actions(executor_status: dict[str, object]) -> list[dict[str, object]]:
+    if str(executor_status.get("handoff", "")) != "prepared":
+        return []
+    return [action for action in executor_status.get("actions", []) if isinstance(action, dict)]
 
 
 def _merge_executor_session(paths: OmhPaths, session: dict[str, Any], patch: dict[str, Any]) -> dict[str, Any]:
@@ -779,8 +793,13 @@ def _display_status_lines(
     verification_status: str,
     status_blocker: str,
 ) -> list[str]:
+    coding_agent_line = (
+        "Coding agent is not selected yet."
+        if executor == "choose" and handoff_state != "prepared"
+        else f"Coding agent is {agent_state} in {executor_label(executor)}."
+    )
     lines = [
-        f"Coding agent is {agent_state} in {executor_label(executor)}.",
+        coding_agent_line,
         "Executor session is attached." if attached else "Executor session is not attached yet.",
         "Handoff is ready." if handoff_state == "prepared" else "Handoff is not ready yet.",
         "Dispatch/open has been observed." if dispatch_observed else "Dispatch/open has not been observed yet.",
@@ -790,6 +809,12 @@ def _display_status_lines(
     if status_blocker:
         lines.append(f"Action is blocked until OMH can read valid evidence: {status_blocker}")
     return lines
+
+
+def _surface_executor_label(executor: str, *, handoff_state: str) -> str:
+    if executor == "choose" and handoff_state != "prepared":
+        return "Coding agent not selected"
+    return executor_label(executor)
 
 
 def _result_display_line(result_status: str) -> str:
@@ -842,6 +867,8 @@ def _executor_status_summary(executor_status: dict[str, object]) -> dict[str, ob
 
 
 def _next_executor_action(executor_status: dict[str, object]) -> str:
+    if str(executor_status.get("handoff", "")) != "prepared":
+        return "show_status"
     dispatch = str(executor_status.get("dispatch", "not_observed"))
     result = str(executor_status.get("result", "not_observed"))
     verification = str(executor_status.get("verification", "not_requested"))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -516,6 +516,70 @@ class CliTests(unittest.TestCase):
         self.assertIn(["hermes", "skills", "check", "oh-my-hermes"], commands)
         self.assertIn(["omh-dev", "--omh-home", str(omh_home.resolve()), "--hermes-home", str(hermes_home.resolve()), "doctor"], commands)
         self.assertNotIn(["hermes", "skills", "inspect", "oh-my-hermes"], commands)
+        installed_commands = [step["command"] for step in payload["installed_command_smoke"]["steps"]]
+        self.assertEqual(installed_commands[0], ["omh-dev", "--help"])
+        self.assertIn(
+            [
+                "omh-dev",
+                "--omh-home",
+                str(omh_home.resolve()),
+                "--hermes-home",
+                str(hermes_home.resolve()),
+                "release",
+                "hermes-smoke",
+                "--install-path",
+                "setup",
+                "--omh-command",
+                "omh-dev",
+            ],
+            installed_commands,
+        )
+        self.assertEqual(payload["first_use_status_smoke"]["schema_version"], "first_use_status_smoke/v1")
+        self.assertFalse(payload["first_use_status_smoke"]["observed"])
+        self.assertFalse(payload["first_use_status_smoke"]["expected_status_boundary"]["before_handoff"]["executor_actions_visible"])
+
+    def test_release_hermes_smoke_cli_can_observe_installed_command_without_live_profile_mutation(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / ".omh"
+            hermes_home = root / ".hermes"
+            fake_omh = root / "fake-omh"
+            fake_omh.write_text(
+                "#!/usr/bin/env python3\n"
+                "import sys\n"
+                "if '--help' in sys.argv:\n"
+                "    print('fake omh help')\n"
+                "else:\n"
+                "    print('{\"schema_version\":\"fake_release_plan/v1\",\"ok\":true}')\n",
+                encoding="utf-8",
+            )
+            fake_omh.chmod(0o755)
+            status, stdout, stderr = run_cli(
+                [
+                    "--omh-home",
+                    str(omh_home),
+                    "--hermes-home",
+                    str(hermes_home),
+                    "release",
+                    "hermes-smoke",
+                    "--install-path",
+                    "setup",
+                    "--omh-command",
+                    str(fake_omh),
+                    "--include-command-smoke",
+                ]
+            )
+
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        payload = json.loads(stdout)
+        self.assertEqual(payload["mode"], "plan")
+        self.assertFalse(payload["observed"])
+        self.assertTrue(payload["installed_command_smoke"]["observed"])
+        self.assertEqual(payload["installed_command_smoke"]["mode"], "live")
+        self.assertTrue(payload["installed_command_smoke"]["ok"])
+        self.assertEqual(payload["installed_command_smoke"]["results"][0]["command"], [str(fake_omh), "--help"])
+        self.assertFalse(payload["first_use_status_smoke"]["observed"])
 
     def test_release_hermes_smoke_live_requires_target_confirmation(self) -> None:
         status, _stdout, stderr = run_cli(["release", "hermes-smoke", "--live"])

--- a/tests/test_release_smoke.py
+++ b/tests/test_release_smoke.py
@@ -30,6 +30,26 @@ class ReleaseSmokeTests(unittest.TestCase):
         self.assertIn("does not touch", payload["proof_boundary"])
         self.assertEqual(payload["target_binding"]["hermes_home"], hermes_home)
         self.assertIn("--hermes-home", payload["live_command"])
+        self.assertEqual(payload["installed_command_smoke"]["schema_version"], "installed_omh_command_smoke/v1")
+        installed_commands = [step["command"] for step in payload["installed_command_smoke"]["steps"]]
+        self.assertEqual(installed_commands[0], ["omh", "--help"])
+        self.assertIn(
+            ["omh", "--omh-home", omh_home, "--hermes-home", hermes_home, "release", "hermes-smoke", "--install-path", "setup", "--omh-command", "omh"],
+            installed_commands,
+        )
+        self.assertEqual(payload["first_use_status_smoke"]["schema_version"], "first_use_status_smoke/v1")
+        self.assertFalse(payload["first_use_status_smoke"]["observed"])
+        first_use_commands = [step["command"] for step in payload["first_use_status_smoke"]["steps"]]
+        self.assertIn("chat", first_use_commands[0])
+        self.assertIn("session", first_use_commands[0])
+        self.assertIn("accept-plan", first_use_commands[1])
+        self.assertIn("select-executor", first_use_commands[2])
+        self.assertIn("prepare-handoff", first_use_commands[3])
+        self.assertIn("status", first_use_commands[4])
+        self.assertEqual(
+            payload["first_use_status_smoke"]["expected_status_boundary"]["before_handoff"]["executor_actions_visible"],
+            False,
+        )
 
     def test_setup_install_path_uses_omh_setup_before_hermes_checks(self) -> None:
         omh_home = str(Path("/tmp/omh-smoke").resolve())
@@ -46,6 +66,24 @@ class ReleaseSmokeTests(unittest.TestCase):
         self.assertIn(["hermes", "skills", "check", "oh-my-hermes"], commands)
         self.assertIn(["omh-dev", "--omh-home", omh_home, "--hermes-home", hermes_home, "doctor"], commands)
         self.assertNotIn(["hermes", "skills", "inspect", "oh-my-hermes"], commands)
+        installed_commands = [step["command"] for step in payload["installed_command_smoke"]["steps"]]
+        self.assertEqual(installed_commands[0], ["omh-dev", "--help"])
+        self.assertIn(
+            [
+                "omh-dev",
+                "--omh-home",
+                omh_home,
+                "--hermes-home",
+                hermes_home,
+                "release",
+                "hermes-smoke",
+                "--install-path",
+                "setup",
+                "--omh-command",
+                "omh-dev",
+            ],
+            installed_commands,
+        )
 
     def test_live_smoke_records_successful_command_results(self) -> None:
         seen: list[list[str]] = []
@@ -68,6 +106,60 @@ class ReleaseSmokeTests(unittest.TestCase):
         self.assertTrue(all(result["environment"]["HERMES_HOME"] == str(Path("/tmp/hermes-smoke").resolve()) for result in payload["results"]))
         self.assertTrue(all(result["ok"] for result in payload["results"]))
         self.assertIn("does not prove a later chat session", payload["proof_boundary"])
+        self.assertFalse(payload["installed_command_smoke"]["observed"])
+
+    def test_live_smoke_can_include_installed_command_smoke(self) -> None:
+        seen: list[list[str]] = []
+
+        def runner(command, _timeout, _env):
+            seen.append(list(command))
+            return CommandResult(command, 0, "ok", "")
+
+        with patch("omh.release.shutil.which", return_value="/usr/local/bin/hermes"):
+            payload = run_hermes_release_smoke(
+                runner=runner,
+                timeout_seconds=5,
+                hermes_home="/tmp/hermes-smoke",
+                omh_home="/tmp/omh-smoke",
+                omh_command="omh-dev",
+                include_command_smoke=True,
+            )
+
+        omh_home = str(Path("/tmp/omh-smoke").resolve())
+        hermes_home = str(Path("/tmp/hermes-smoke").resolve())
+        self.assertTrue(payload["ok"])
+        self.assertTrue(payload["installed_command_smoke"]["observed"])
+        self.assertIn(["omh-dev", "--help"], seen)
+        self.assertIn(
+            [
+                "omh-dev",
+                "--omh-home",
+                omh_home,
+                "--hermes-home",
+                hermes_home,
+                "release",
+                "hermes-smoke",
+                "--install-path",
+                "setup",
+                "--omh-command",
+                "omh-dev",
+            ],
+            seen,
+        )
+
+    def test_installed_command_smoke_failure_marks_release_smoke_failed(self) -> None:
+        def runner(command, _timeout, _env):
+            if list(command) == ["omh-dev", "--help"]:
+                return CommandResult(command, 127, "", "missing omh")
+            return CommandResult(command, 0, "ok", "")
+
+        with patch("omh.release.shutil.which", return_value="/usr/local/bin/hermes"):
+            payload = run_hermes_release_smoke(runner=runner, omh_command="omh-dev", include_command_smoke=True)
+
+        self.assertFalse(payload["ok"])
+        self.assertEqual(payload["failed_step"], "installed_command_smoke")
+        self.assertEqual(payload["installed_command_smoke"]["failed_step"], "installed_omh_help")
+        self.assertIn("console script", payload["recommended_next_action"])
 
     def test_live_smoke_stops_on_required_failure(self) -> None:
         def runner(command, _timeout, _env):
@@ -93,6 +185,23 @@ class ReleaseSmokeTests(unittest.TestCase):
         self.assertFalse(payload["ok"])
         self.assertFalse(payload["observed"])
         self.assertEqual(payload["failed_step"], "hermes_cli")
+        self.assertEqual(payload["results"], [])
+
+    def test_missing_hermes_cli_can_still_observe_installed_command_smoke(self) -> None:
+        seen: list[list[str]] = []
+
+        def runner(command, _timeout, _env):
+            seen.append(list(command))
+            return CommandResult(command, 0, "ok", "")
+
+        with patch("omh.release.shutil.which", return_value=None):
+            payload = run_hermes_release_smoke(runner=runner, omh_command="omh-dev", include_command_smoke=True)
+
+        self.assertFalse(payload["ok"])
+        self.assertFalse(payload["observed"])
+        self.assertEqual(payload["failed_step"], "hermes_cli")
+        self.assertTrue(payload["installed_command_smoke"]["observed"])
+        self.assertIn(["omh-dev", "--help"], seen)
         self.assertEqual(payload["results"], [])
 
     def test_subprocess_runner_reports_missing_executable_as_command_failure(self) -> None:

--- a/tests/test_wrapper_sessions.py
+++ b/tests/test_wrapper_sessions.py
@@ -447,6 +447,34 @@ class WrapperSessionTests(unittest.TestCase):
             self.assertEqual(len(status["runtime_status"]["runtime_validation"]["wrapper_sessions"]), 1)
             self.assertTrue(status["runtime_status"]["runtime_validation"]["wrapper_sessions"][0]["ok"])
 
+    def test_pre_handoff_status_does_not_surface_executor_buttons(self) -> None:
+        forbidden_action_ids = {
+            "open_executor_session",
+            "attach_executor_session",
+            "record_executor_completed",
+            "record_executor_blocked",
+            "record_executor_failed",
+            "ask_hermes_verify",
+        }
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            started = create_or_resume_wrapper_session(paths, "risky refactor", source="discord")
+            session_id = str(started["session"]["session_id"])
+
+            started_status = build_wrapper_session_status(paths, session_id)
+            accepted = record_plan_decision(paths, session_id, "accept")
+            accepted_status = accepted["status"]
+
+            for status in (started_status, accepted_status):
+                card = status["status_card"]
+                chat_response = status["chat_response"]
+                self.assertEqual(card["executor_next_action"], "show_status")
+                self.assertEqual(card["executor_next_action_label"], "Show status")
+                self.assertEqual(card["executor_actions"], [])
+                self.assertTrue(forbidden_action_ids.isdisjoint({action["id"] for action in chat_response["actions"]}))
+                self.assertTrue(forbidden_action_ids.isdisjoint({action["id"] for action in status["executor_session_status"]["actions"]}))
+                self.assertNotIn("Open Unselected executor", json.dumps(status))
+
     def test_codex_wrapper_session_exposes_open_attach_record_actions(self) -> None:
         with TemporaryDirectory() as tmp:
             paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")


### PR DESCRIPTION
## Feature Report

### What Changed

- Added a dedicated installed-command smoke contract to `omh release hermes-smoke`.
- Added a first-use status smoke contract that documents the Hermes chat path from natural-language request to plan acceptance, executor selection, handoff preparation, and status rendering.
- Updated wrapper executor session status so pre-handoff cards do not show executor open, attach, result, or verify actions.
- Added CI, release docs, installation docs, and PR-template checks for the installed `omh` command path.

### Why This Exists

OMH release checks previously proved that `python -m omh.cli` could render smoke plans, but they did not lock the user-installed `omh` console script path. That left a real release risk: a user could install OMH and still fail on the first terminal command even while CI stayed green.

The first-use Hermes status path also needed a stronger boundary. Before a coding handoff is prepared, the UI should not imply that an executor can be opened, attached, completed, or verified.

### User / Operator Impact

- Release operators now have an explicit smoke command that proves the installed `omh` executable can run.
- CI now exercises `omh --help` and `omh release hermes-smoke --include-command-smoke` through the installed console script.
- Hermes wrappers get safer status cards: before a handoff exists, users see plan/executor-choice state rather than misleading executor action buttons.
- The release docs now distinguish local installed-command evidence from live Hermes profile mutation evidence.

### How It Works

- `src/release.py` now emits `installed_omh_command_smoke/v1` and `first_use_status_smoke/v1` sections from the release smoke plan.
- `omh release hermes-smoke --include-command-smoke` runs only the installed command smoke in non-live mode, keeping the outer Hermes profile smoke as `mode=plan` and `observed=false`.
- The nested installed-command smoke runs `omh --help` and uses the installed command to render the setup-path smoke plan without mutating a Hermes profile.
- `src/wrapper/executor_sessions.py` now filters executor surface actions until `handoff=prepared`.

### Files And Contracts Touched

- `src/release.py`: release smoke contracts and installed command smoke runner.
- `src/commands/release.py`: `--include-command-smoke` CLI behavior.
- `src/wrapper/executor_sessions.py`: pre-handoff executor action filtering.
- `tests/test_release_smoke.py`, `tests/test_cli.py`, `tests/test_wrapper_sessions.py`: regression coverage.
- `.github/workflows/ci.yml`, `.github/pull_request_template.md`, `README.md`, `docs/RELEASE.md`, `docs/INSTALLATION.md`, `docs/README.md`, `docs/HERMES_AGENT_INTEGRATION_RUNBOOK.md`: release and operator guidance.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` - passed, 352 tests
- [x] `uv run python -m compileall -q src tests` - passed
- [x] `uv run python -m src.cli docs workflows --check` - passed
- [x] `uv run python -m src.cli harness validate` - passed
- [x] `uv run omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` - passed; outer smoke remained plan/unobserved while nested installed-command smoke was live/observed
- [x] `uv run omh --help` - passed after repairing local macOS hidden flags on editable `.pth` files in the developer venv
- [x] `uv build` - passed; emitted existing setuptools license deprecation warnings
- [x] Wheel-installed smoke: `/tmp/omh-wheel-smoke/bin/omh --omh-home /tmp/omh-wheel-home --hermes-home /tmp/hermes-wheel-home release hermes-smoke --install-path setup --omh-command /tmp/omh-wheel-smoke/bin/omh --include-command-smoke` - passed
- [x] `git diff --check` - passed
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; this PR avoids live Hermes profile mutation and keeps the live smoke guarded behind `--live --target-confirmed` or an explicit `--hermes-home`.

## Risk

- Moderate schema surface growth in release smoke JSON. The new sections are additive and keep existing fields intact.
- Operators must still run a guarded `--live` smoke when they want proof that Hermes itself installed, listed, checked, and inspected the skill.

## Compatibility / Rollout

- Backward compatible for existing `omh release hermes-smoke` plan usage.
- `--include-command-smoke` adds observed command-path evidence without live Hermes profile mutation.
- CI now fails if the installed `omh` command path is broken.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- Consider a separate packaging cleanup for the setuptools license deprecation warnings before future packaging policy changes become hard failures.
