### PR TITLE
Modernize packaging license metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=68"]
+requires = ["setuptools>=77"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -8,7 +8,7 @@ version = "1.0.0"
 description = "Install a Hermes-native skill workflow pack."
 readme = "README.md"
 requires-python = ">=3.11"
-license = { text = "MIT" }
+license = "MIT"
 authors = [{ name = "oh-my-hermes maintainers" }]
 dependencies = []
 keywords = ["hermes", "agent", "skills", "workflow", "automation"]
@@ -16,7 +16,6 @@ classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Environment :: Console",
   "Intended Audience :: Developers",
-  "License :: OSI Approved :: MIT License",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.11",
   "Topic :: Software Development",

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import tomllib
+import unittest
+from pathlib import Path
+
+
+class PackagingMetadataTests(unittest.TestCase):
+    def test_license_uses_modern_spdx_expression(self) -> None:
+        metadata = tomllib.loads(Path("pyproject.toml").read_text())
+        project = metadata["project"]
+
+        self.assertEqual(project["license"], "MIT")
+        self.assertNotIn("License :: OSI Approved :: MIT License", project["classifiers"])
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- Updated `pyproject.toml` to use the modern SPDX license expression form: `license = "MIT"`.
- Removed the deprecated `License :: OSI Approved :: MIT License` classifier.
- Raised the build backend floor to `setuptools>=77`, which is the setuptools line that supports the modern PEP 639 metadata path used here.
- Added `tests/test_packaging_metadata.py` to prevent the package metadata from drifting back to the deprecated form.

### Why This Exists

The previous release smoke surfaced setuptools deprecation warnings during `uv build`. The package still built successfully, but the warning says the old license table/classifier path will eventually stop being supported. This PR clears that warning before it becomes release noise or a future packaging failure.

### User / Operator Impact

- Release builds are quieter and cleaner.
- The wheel/sdist metadata now exposes the modern license expression path.
- Runtime OMH behavior does not change.

### How It Works

- `pyproject.toml` now declares `license = "MIT"` instead of `license = { text = "MIT" }`.
- The old license classifier is removed because the SPDX expression is now the source of truth.
- The new unittest reads `pyproject.toml` with `tomllib` and asserts the modern license shape.

### Files And Contracts Touched

- `pyproject.toml`: packaging metadata only.
- `tests/test_packaging_metadata.py`: packaging metadata regression coverage.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_packaging_metadata.py -v` - passed
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` - passed, 353 tests
- [x] `uv run python -m compileall -q src tests` - passed
- [x] `uv build` - passed; previous setuptools license deprecation warnings no longer appeared
- [x] `git diff --check` - passed
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; this is packaging metadata only and does not affect Hermes runtime behavior.

## Risk

- Low. The only compatibility tradeoff is that source builds now require `setuptools>=77`; that matches the metadata feature being used and current isolated build tooling resolves it.

## Compatibility / Rollout

- Runtime-compatible with existing OMH users.
- Build tooling must support setuptools 77 or newer when building from source.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- None for this packaging cleanup.
