### PR TITLE
perf: cache generated workflow catalog views

### DIFF
--- a/src/skills/catalog.py
+++ b/src/skills/catalog.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from functools import lru_cache
 
 from ..harness_quality import build_harness_quality_contract, unknown_harness_quality_contract
 
@@ -2248,18 +2249,30 @@ _PRIMARY_HARNESSES = {
 
 
 def builtin_definitions() -> list[SkillDefinition]:
-    return list(_DEFINITIONS)
+    return list(_builtin_definitions_cached())
 
 
 def builtin_harnesses() -> list[HarnessDefinition]:
-    return list(_HARNESSES)
+    return list(_builtin_harnesses_cached())
+
+
+@lru_cache(maxsize=1)
+def _builtin_definitions_cached() -> tuple[SkillDefinition, ...]:
+    return tuple(_DEFINITIONS)
+
+
+@lru_cache(maxsize=1)
+def _builtin_harnesses_cached() -> tuple[HarnessDefinition, ...]:
+    return tuple(_HARNESSES)
+
+
+@lru_cache(maxsize=1)
+def _harnesses_by_name() -> dict[str, HarnessDefinition]:
+    return {harness.name: harness for harness in _builtin_harnesses_cached()}
 
 
 def harness_definition(name: str) -> HarnessDefinition:
-    for harness in _HARNESSES:
-        if harness.name == name:
-            return harness
-    raise KeyError(name)
+    return _harnesses_by_name()[name]
 
 
 def harness_quality_contract(name: str) -> dict[str, object]:
@@ -2286,7 +2299,19 @@ def coding_intent_for_skill(name: str) -> str:
 
 
 def coding_skills_for_intent(intent: str) -> tuple[str, ...]:
-    return tuple(name for name, mapped_intent in _CODING_INTENT_BY_SKILL.items() if mapped_intent == intent)
+    return _coding_skills_by_intent().get(intent, ())
+
+
+@lru_cache(maxsize=1)
+def _coding_skills_by_intent() -> dict[str, tuple[str, ...]]:
+    return {
+        intent: tuple(
+            name
+            for name, mapped_intent in _CODING_INTENT_BY_SKILL.items()
+            if mapped_intent == intent
+        )
+        for intent in CODING_INTENTS
+    }
 
 
 def coding_terms_for_intent(intent: str) -> tuple[str, ...]:
@@ -2294,17 +2319,27 @@ def coding_terms_for_intent(intent: str) -> tuple[str, ...]:
 
 
 def retained_delegation_skill_names() -> tuple[str, ...]:
+    return _retained_delegation_skill_names_cached()
+
+
+@lru_cache(maxsize=1)
+def _retained_delegation_skill_names_cached() -> tuple[str, ...]:
     return tuple(
         definition.name
-        for definition in _DEFINITIONS
+        for definition in _builtin_definitions_cached()
         if definition.delegation_boundary in {"retained", "retained-catalog-intent"}
     )
 
 
 def catalog_intent_delegation_skill_names() -> tuple[str, ...]:
+    return _catalog_intent_delegation_skill_names_cached()
+
+
+@lru_cache(maxsize=1)
+def _catalog_intent_delegation_skill_names_cached() -> tuple[str, ...]:
     return tuple(
         definition.name
-        for definition in _DEFINITIONS
+        for definition in _builtin_definitions_cached()
         if definition.delegation_boundary == "retained-catalog-intent"
     )
 

--- a/src/skills/render.py
+++ b/src/skills/render.py
@@ -431,6 +431,11 @@ def builtin_skill_templates() -> list[SkillTemplate]:
 
 
 def workflow_reference_markdown() -> str:
+    return _workflow_reference_markdown_cached()
+
+
+@lru_cache(maxsize=1)
+def _workflow_reference_markdown_cached() -> str:
     definitions = builtin_definitions()
     harnesses = builtin_harnesses()
     lines = [
@@ -526,6 +531,11 @@ def workflow_reference_markdown() -> str:
 
 
 def workflow_reference_payload() -> dict[str, object]:
+    return _copy_workflow_reference_payload(_workflow_reference_payload_cached())
+
+
+@lru_cache(maxsize=1)
+def _workflow_reference_payload_cached() -> dict[str, object]:
     return {
         "schema_version": "workflow_catalog/v1",
         "description": (
@@ -535,6 +545,57 @@ def workflow_reference_payload() -> dict[str, object]:
         "skills": [_skill_payload(definition) for definition in builtin_definitions()],
         "harnesses": [_harness_payload(harness) for harness in builtin_harnesses()],
     }
+
+
+def _copy_workflow_reference_payload(payload: dict[str, object]) -> dict[str, object]:
+    return {
+        "schema_version": payload["schema_version"],
+        "description": payload["description"],
+        "skills": [_copy_skill_payload(skill) for skill in payload["skills"]],
+        "harnesses": [_copy_harness_payload(harness) for harness in payload["harnesses"]],
+    }
+
+
+def _copy_skill_payload(payload: dict[str, object]) -> dict[str, object]:
+    copied = dict(payload)
+    for key in (
+        "triggers",
+        "do_not_use_when",
+        "quality_bar",
+        "required_inputs",
+        "expected_outputs",
+        "artifact_expectations",
+        "safety_rules",
+    ):
+        copied[key] = list(payload[key])
+    copied["good_example"] = dict(payload["good_example"])
+    copied["bad_example"] = dict(payload["bad_example"])
+    return copied
+
+
+def _copy_harness_payload(payload: dict[str, object]) -> dict[str, object]:
+    copied = dict(payload)
+    for key in (
+        "quality_bar",
+        "required_inputs",
+        "expected_outputs",
+        "stop_conditions",
+        "verification",
+        "evidence_ladder",
+        "wrapper_actions",
+        "artifact_events",
+        "overclaim_guards",
+    ):
+        copied[key] = list(payload[key])
+    copied["harness_quality"] = _copy_harness_quality_payload(payload["harness_quality"])
+    return copied
+
+
+def _copy_harness_quality_payload(payload: dict[str, object]) -> dict[str, object]:
+    copied = dict(payload)
+    for key in ("quality_bar", "evidence_ladder", "wrapper_actions", "overclaim_guards"):
+        copied[key] = list(payload[key])
+    return copied
 
 
 def _skill_payload(definition: SkillDefinition) -> dict[str, object]:

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -7,7 +7,15 @@ from _local_package import load_local_package
 
 load_local_package()
 from omh.skill_pack import builtin_definitions, builtin_skill_templates
-from omh.skills.catalog import explicit_memory_context_skill_names, memory_context_policy_for_skill
+from omh.skills import render as render_module
+from omh.skills.catalog import (
+    builtin_harnesses,
+    catalog_intent_delegation_skill_names,
+    coding_skills_for_intent,
+    explicit_memory_context_skill_names,
+    memory_context_policy_for_skill,
+    retained_delegation_skill_names,
+)
 
 
 class EfficiencyContractTests(unittest.TestCase):
@@ -54,6 +62,46 @@ class EfficiencyContractTests(unittest.TestCase):
         self.assertLessEqual(combined.count("memory_review_card/v1"), explicit_budget)
         self.assertLessEqual(combined.count("handoff_context_pack/v1"), explicit_budget)
         self.assertLessEqual(combined.count("advisory local context"), compact_budget)
+
+    def test_workflow_reference_markdown_reuses_cached_render(self) -> None:
+        render_module._workflow_reference_markdown_cached.cache_clear()
+
+        first = render_module.workflow_reference_markdown()
+        second = render_module.workflow_reference_markdown()
+        cache_info = render_module._workflow_reference_markdown_cached.cache_info()
+
+        self.assertIs(first, second)
+        self.assertEqual(cache_info.misses, 1)
+        self.assertGreaterEqual(cache_info.hits, 1)
+        self.assertIn("# Workflow Reference", first)
+        self.assertIn("## Representative Harnesses", first)
+
+    def test_workflow_reference_payload_cache_is_mutation_safe(self) -> None:
+        render_module._workflow_reference_payload_cached.cache_clear()
+
+        first = render_module.workflow_reference_payload()
+        first["skills"][0]["name"] = "mutated"
+
+        second = render_module.workflow_reference_payload()
+        cache_info = render_module._workflow_reference_payload_cached.cache_info()
+
+        self.assertIsNot(first, second)
+        self.assertNotEqual(second["skills"][0]["name"], "mutated")
+        self.assertEqual(cache_info.misses, 1)
+        self.assertGreaterEqual(cache_info.hits, 1)
+
+    def test_catalog_derived_views_are_reusable_without_list_poisoning(self) -> None:
+        definitions = builtin_definitions()
+        harnesses = builtin_harnesses()
+
+        definitions.clear()
+        harnesses.clear()
+
+        self.assertTrue(builtin_definitions())
+        self.assertTrue(builtin_harnesses())
+        self.assertIn("feedback-triage", catalog_intent_delegation_skill_names())
+        self.assertIn("code-review", coding_skills_for_intent("review"))
+        self.assertIn("research-brief", retained_delegation_skill_names())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Feature Report

### What Changed

- Cached immutable generated catalog views for built-in skill definitions, harness definitions, harness name lookup, coding-intent skill lookup, and retained/catalog-intent skill lists.
- Cached generated workflow reference Markdown and workflow catalog payload source data so repeated docs/CLI/harness paths stop rebuilding the same skill and harness metadata.
- Kept `workflow_reference_payload()` mutation-safe by returning a fresh structured copy of the cached payload, instead of exposing the cached dict/list objects directly.
- Added efficiency regression coverage for cache reuse, payload mutation safety, and catalog list poisoning.

### Why This Exists

OMH now has a large Hermes-facing skill and harness catalog. Several local commands and tests repeatedly render workflow references and payloads from the same deterministic catalog metadata. That creates avoidable AI/compute overhead because the generated guidance is rebuilt even when the source catalog is unchanged within the process.

This PR reduces that repeated computation without changing OMH's public contracts, Hermes-facing wording, prepared-vs-observed boundaries, or generated skill output.

### User / Operator Impact

- Operators running docs checks, harness validation, wrapper/backend checks, or generated catalog JSON in the same process get less repeated catalog/rendering work.
- The generated workflow reference and JSON payload remain stable and safe for callers to mutate locally without corrupting later calls.
- No user-facing command syntax changes.

### How It Works

- `src/skills/catalog.py` now wraps immutable catalog collections and derived views with `lru_cache(maxsize=1)` while preserving the existing public `list(...)` return behavior for `builtin_definitions()` and `builtin_harnesses()`.
- `src/skills/render.py` now caches the expensive workflow reference Markdown string and cached payload source data.
- `workflow_reference_payload()` still returns caller-owned objects through explicit structured copy helpers, avoiding the earlier rejected approach of sharing mutable cached payloads.
- `tests/test_efficiency.py` locks the cache behavior and verifies callers cannot poison later payload/catalog responses.

### Files And Contracts Touched

- `src/skills/catalog.py`: internal catalog/lookup caching only; public function shapes preserved.
- `src/skills/render.py`: internal workflow reference/payload caching plus mutation-safe copy helpers.
- `tests/test_efficiency.py`: new regression tests for AI/compute efficiency contracts.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_efficiency.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_cli.py tests/test_router_content.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — 360 tests OK
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m src.cli docs workflows --check`
- [x] `uv run python -m src.cli harness validate`
- [x] `uv run python -m src.cli release checklist --json`
- [x] `uv run python -m src.cli --help`
- [x] `uv run python -m src.cli release hermes-smoke` — plan mode only
- [x] `git diff --check`
- [x] Relevant performance smoke: 50 repeated calls to `builtin_skill_templates()`, `workflow_reference_payload()`, and `workflow_reference_markdown()` moved from baseline `0.037s / 41,923 calls` to `0.022s / 7,455 calls` in the local profile loop.
- [ ] `omh --help` installed-command smoke: not observed in this shell because `omh` is not on PATH (`zsh: command not found: omh`). Local module help passed instead.
- [ ] Manual Hermes/TUI check: not run; this change is internal deterministic catalog/render caching and does not alter live Hermes profile behavior.

## Risk

Low. The main risk is cache poisoning from mutable payloads. The implementation avoids that by returning fresh structured payload copies, and tests mutate a returned payload to prove the cached source remains clean.

## Compatibility / Rollout

No migration required. Existing callers keep receiving lists/dicts in the same public shapes. Cache lifetime is process-local and deterministic because the catalog is static module data.

## Release / Claims

- [x] Release-channel impact considered: local/internal performance optimization only.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] Known manual Hermes checks are listed, including the skipped live Hermes/TUI check.

## Follow-Up

- Consider a future dedicated JSON serialization fast path only if profiling shows `_print_json(workflow_reference_payload())` is a real bottleneck in a long-lived wrapper process.
