### PR TITLE
Split MCP probe preference from host config

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ so OMH can display and record `main@old -> main@new` instead of only `main`.
 | Strict goal progress | `.omh/goals` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, and `goal_continuation/v1` keep long-running goals from being treated as done before evidence is ready. |
 | Hermes chat contracts | `chat_interaction/v1`, status cards, action ids, and local runtime artifacts for Hermes Agent chat surfaces. |
 | Hermes plugin bridge | `omh setup` installs `~/.hermes/plugins/omh` with metadata-only `omh_hud` and `omh_status` support. |
-| Optional MCP bridge preference | `omh setup --with-mcp` records MCP bridge intent without claiming a host loaded or called it. |
+| Optional MCP bridge preference | `omh setup --with-mcp` records MCP bridge intent without claiming a host loaded or called it; `omh probe` separates `mcp_preference` from `mcp_host_config`. |
 | Operating models | `omh setup --operating-model <id>` records the default Hermes collaboration posture: solo operator, small team, research ops, or coding runtime team. |
 | Optional team profile packs | CTO/PM-style or delivery/research role files can be installed only when selected. |
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -386,7 +386,8 @@ observable local evidence for:
 - external skill directory registration
 - managed skill installation
 - hook-like files
-- plugin, app, and MCP-like paths
+- plugin and app paths
+- MCP setup preference and MCP host config paths as separate capabilities
 - wrapper observation artifacts
 - native skill metadata readiness
 
@@ -394,6 +395,9 @@ Probe results use `available`, `missing`, `unknown`, or `unverified`. A file or
 directory probe marked `unverified` is not a native integration claim. Deeper
 Hermes integration requires both a stable Hermes extension contract and runtime
 evidence that the extension ran.
+`mcp_preference` is OMH setup state only; `mcp_host_config` is a host-file probe
+only. Keeping them separate prevents a requested bridge preference from being
+mistaken for observed MCP host load or tool execution.
 
 For terminal operators, `omh probe` prints a compact status summary by default.
 Wrappers and automation should request the full capability payload with

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -244,6 +244,11 @@ surface.
 `omh runtime status` should show the local runtime artifact directory and the
 latest install/apply/doctor state when those commands have run. `omh probe`
 reports observable Hermes capability surfaces without mutating Hermes internals.
+For MCP, `omh probe` reports the setup preference and host config separately:
+`mcp_preference` means `omh setup --with-mcp` was requested in OMH local state,
+while `mcp_host_config` only means a Hermes MCP config file such as `.mcp.json`
+or `mcp.json` exists. Neither field proves an MCP host loaded OMH or called a
+tool unless separate runtime evidence records that event.
 After `omh setup` has run, `omh doctor` also checks the managed plugin manifest
 plus local import/register smoke. `omh probe` reports
 `plugin_distribution_ready` separately from `native_integration_claim_ready` so

--- a/src/probe.py
+++ b/src/probe.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from .config_adapter import external_dirs, read_config
 from .paths import OmhPaths
 from .plugin_pack import inspect_plugin_bundle
+from .runtime.artifacts import read_state_result
 from .targets import summarize_target_registry
 
 PROBE_STATUSES = ("available", "missing", "unknown", "unverified")
@@ -52,6 +53,58 @@ def _marker_capability(name: str, markers: list[Path], found_message: str, missi
         "unverified" if found else "unknown",
         ", ".join(str(path) for path in markers),
         found_message if found else missing_message,
+    )
+
+
+def _mcp_preference_capability(paths: OmhPaths) -> Capability:
+    state, error = read_state_result(paths)
+    evidence = str(paths.runtime_state_path)
+    if error:
+        return Capability(
+            "mcp_preference",
+            "unknown",
+            evidence,
+            f"Could not read OMH setup state for MCP preference: {error}",
+        )
+    if not isinstance(state, dict):
+        return Capability(
+            "mcp_preference",
+            "unknown",
+            evidence,
+            "No OMH setup state has recorded an MCP bridge preference",
+        )
+    last_setup = state.get("last_setup")
+    mcp_setup = last_setup.get("mcp_setup") if isinstance(last_setup, dict) else None
+    if not isinstance(mcp_setup, dict):
+        return Capability(
+            "mcp_preference",
+            "unknown",
+            evidence,
+            "No OMH setup state has recorded an MCP bridge preference",
+        )
+
+    mode = str(mcp_setup.get("mode", "none"))
+    requested = bool(mcp_setup.get("requested", False))
+    observed = bool(mcp_setup.get("observed", False))
+    if not requested or mode == "none":
+        return Capability(
+            "mcp_preference",
+            "unknown",
+            evidence,
+            "OMH setup state says no optional MCP bridge preference was requested",
+        )
+    if observed:
+        return Capability(
+            "mcp_preference",
+            "available",
+            evidence,
+            f"OMH MCP bridge preference was requested and observed by setup state (mode={mode})",
+        )
+    return Capability(
+        "mcp_preference",
+        "unverified",
+        evidence,
+        f"OMH MCP bridge preference was requested (mode={mode}), but no MCP host load or tool-call evidence is recorded",
     )
 
 
@@ -114,12 +167,13 @@ def probe_capabilities(paths: OmhPaths) -> dict:
         )
     )
     mcp_markers = [paths.hermes_home / ".mcp.json", paths.hermes_home / "mcp.json"]
+    capabilities.append(_mcp_preference_capability(paths))
     capabilities.append(
         _marker_capability(
-            "mcp",
+            "mcp_host_config",
             mcp_markers,
-            "MCP-like config exists, but omh has not verified a Hermes MCP extension contract",
-            "No Hermes MCP config detected by file probe",
+            "MCP host config exists, but OMH has not verified a Hermes MCP extension contract or host load event",
+            "No Hermes MCP host config detected by file probe",
         )
     )
     capabilities.append(

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -21,6 +21,8 @@ class ProbeCliTests(unittest.TestCase):
             self.assertEqual(caps["external_skill_dirs"]["status"], "unknown")
             self.assertEqual(caps["managed_skills"]["status"], "missing")
             self.assertEqual(caps["native_hooks"]["status"], "unknown")
+            self.assertEqual(caps["mcp_preference"]["status"], "unknown")
+            self.assertEqual(caps["mcp_host_config"]["status"], "unknown")
             self.assertEqual(caps["omh_plugin_bundle"]["status"], "missing")
             self.assertEqual(caps["plugin_import_smoke"]["status"], "unknown")
             self.assertEqual(caps["target_registry"]["status"], "missing")
@@ -72,6 +74,38 @@ class ProbeCliTests(unittest.TestCase):
             caps = {capability["name"]: capability for capability in payload["capabilities"]}
             self.assertEqual(caps["target_registry"]["status"], "available")
             self.assertEqual(payload["target_topology"]["mode"], "single_agent_target")
+
+    def test_probe_separates_mcp_preference_from_host_config(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / ".omh"
+            hermes_home = root / ".hermes"
+
+            self.assertEqual(run_cli(["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "setup", "--with-mcp"])[0], 0)
+
+            status, stdout, stderr = run_cli(["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "probe"])
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            payload = json.loads(stdout)
+            caps = {capability["name"]: capability for capability in payload["capabilities"]}
+            self.assertEqual(caps["mcp_preference"]["status"], "unverified")
+            self.assertIn("bridge preference was requested", caps["mcp_preference"]["message"])
+            self.assertIn("runtime/state.json", caps["mcp_preference"]["evidence"])
+            self.assertEqual(caps["mcp_host_config"]["status"], "unknown")
+            self.assertIn("No Hermes MCP host config", caps["mcp_host_config"]["message"])
+            self.assertFalse(payload["native_integration_claim_ready"])
+
+            (hermes_home / ".mcp.json").write_text("{}", encoding="utf-8")
+            status, stdout, stderr = run_cli(["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "probe"])
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            caps = {capability["name"]: capability for capability in json.loads(stdout)["capabilities"]}
+            self.assertEqual(caps["mcp_preference"]["status"], "unverified")
+            self.assertEqual(caps["mcp_host_config"]["status"], "unverified")
+            self.assertIn("MCP host config exists", caps["mcp_host_config"]["message"])
+            self.assertNotIn("mcp", {capability["name"] for capability in json.loads(stdout)["capabilities"]})
 
     def test_probe_reports_plugin_distribution_without_native_runtime_claim(self) -> None:
         with TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Feature Report

### What Changed

- Split `omh probe` MCP reporting into two explicit capabilities:
  - `mcp_preference`: reads OMH setup state and reports whether `omh setup --with-mcp` recorded an optional bridge preference.
  - `mcp_host_config`: checks Hermes home for `.mcp.json` or `mcp.json` host config markers.
- Updated probe tests so the payload no longer exposes the ambiguous old `mcp` capability name.
- Updated README and installation/architecture docs to explain the setup-preference versus host-config evidence boundary.

### Why This Exists

- Operators could request MCP support during setup and then see `omh probe` still report a generic `mcp: unknown` capability, which made it unclear whether OMH had forgotten the setup preference or was refusing to claim runtime evidence.
- OMH needs to preserve the distinction between requested configuration, detected host files, and observed host runtime/tool-call evidence.

### User / Operator Impact

- After `omh setup --with-mcp`, operators can run `omh probe` and see that OMH remembers the MCP bridge preference as `mcp_preference: unverified` even if Hermes host config is not present.
- If a Hermes MCP host config file exists, operators see `mcp_host_config: unverified` separately.
- OMH still does not claim Hermes loaded an MCP bridge or called a tool unless separate runtime evidence exists.

### How It Works

- `src/probe.py` now reads `runtime/state.json` through `read_state_result()` and extracts `last_setup.mcp_setup` into a metadata-only probe capability.
- Host config markers remain a file probe, but under the clearer `mcp_host_config` capability name.
- The probe payload keeps `native_integration_claim_ready: false`; both MCP fields are evidence hints, not runtime-ready claims.

### Files And Contracts Touched

- `src/probe.py`: adds the `mcp_preference` capability and renames the host-file capability to `mcp_host_config`.
- `tests/test_probe.py`: covers no-install, setup preference, host config marker, and removal of the ambiguous old `mcp` capability.
- `README.md`, `docs/ARCHITECTURE.md`, `docs/INSTALLATION.md`: document the split and claim boundary.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m src.cli docs workflows --check`
- [x] `uv run python -m src.cli harness validate`
- [ ] `python3 -m omh.cli release checklist --json` (not run; release surface not touched)
- [ ] `python3 -m omh.cli release hermes-smoke` (not run; live Hermes smoke not needed for metadata-only probe split)
- [ ] `omh --help` (not run; command parser surface not changed)
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` (not run; release smoke not touched)
- [x] Relevant dry-run or smoke command: temporary-home `setup --with-mcp` followed by `probe --json` with and without `.hermes/.mcp.json` showed `no_host unverified unknown` and `host unverified unverified`.
- [x] Manual Hermes/TUI check, or explicit reason it was not run: not run; this PR intentionally does not claim Hermes MCP runtime load or tool-call observation.

## Risk

- The machine-readable probe capability formerly named `mcp` is intentionally replaced by `mcp_host_config`. Consumers should read the more specific names instead of relying on the ambiguous old field.

## Compatibility / Rollout

- Existing setup behavior is unchanged.
- Existing MCP bridge preference state remains readable because the new probe uses `last_setup.mcp_setup` already written by setup.
- Rollout is safe for local operators; wrappers consuming probe JSON should update to `mcp_preference` and `mcp_host_config`.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- Add runtime-observed MCP evidence only after OMH has a stable Hermes-side host/tool-call observation contract.
