### PR TITLE
Add OMH parity probe matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ so OMH can display and record `main@old -> main@new` instead of only `main`.
 | Hermes chat contracts | `chat_interaction/v1`, status cards, action ids, and local runtime artifacts for Hermes Agent chat surfaces. |
 | Hermes plugin bridge | `omh setup` installs `~/.hermes/plugins/omh` with metadata-only `omh_hud` and `omh_status` support. |
 | Optional MCP bridge preference | `omh setup --with-mcp` records MCP bridge intent without claiming a host loaded or called it; `omh probe` separates `mcp_preference` from `mcp_host_config`. |
+| Parity verifier | `omh probe --parity` maps common oh-my runtime capability axes to OMH surfaces, gaps, and evidence boundaries. |
 | Operating models | `omh setup --operating-model <id>` records the default Hermes collaboration posture: solo operator, small team, research ops, or coding runtime team. |
 | Optional team profile packs | CTO/PM-style or delivery/research role files can be installed only when selected. |
 
@@ -317,6 +318,7 @@ curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes/main/install.sh
 | AI-agent pasteable install protocol | [Agent Install](INSTALL_FOR_AGENTS.md) |
 | Product direction and boundaries | [Direction](docs/DIRECTION.md) |
 | Architecture and module ownership | [Architecture](docs/ARCHITECTURE.md) |
+| Common oh-my runtime parity and gaps | [Parity Matrix](docs/PARITY.md) |
 | Situation playbooks | [Playbooks](docs/PLAYBOOKS.md) |
 | Role surfaces and profile packs | [Roles](docs/ROLES.md) |
 | Memory/context review and handoff packs | [Memory Context Review](docs/MEMORY_CONTEXT.md) |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -403,6 +403,16 @@ For terminal operators, `omh probe` prints a compact status summary by default.
 Wrappers and automation should request the full capability payload with
 `omh probe --json` or `OMH_OUTPUT=json`.
 
+`omh probe --parity` adds `omh_parity_matrix/v1`. That matrix compares common
+oh-my runtime capability axes with OMH's actual surfaces: skill/plugin
+distribution, specialist roles, team/swarm workers, worktree isolation, HUD and
+session observability, MCP/tool bridge preference, loop/autopilot workflow, and
+release maintenance. It is a product and operator contract, not a hidden runtime
+claim. A `partial` row means OMH has deterministic guidance, handoff metadata,
+or observation records for that axis, while the live worker, worktree, MCP tool,
+or plugin runtime event still belongs to Hermes, the selected executor, or a
+future observed integration.
+
 ## Harness Contract
 
 Representative harnesses are preview metadata for generated prompt guidance.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -213,6 +213,7 @@ omh doctor
 omh list
 omh runtime status
 omh probe
+omh probe --parity
 ```
 
 `omh setup` should report a human-readable setup summary by default, including
@@ -256,6 +257,12 @@ plus local import/register smoke. `omh probe` reports
 `plugin_distribution_ready` separately from `native_integration_claim_ready` so
 operators do not mistake local install readiness for observed Hermes runtime
 use.
+Use `omh probe --parity` when an operator wants the broader comparison against
+common oh-my runtime capability axes. It returns `omh_parity_matrix/v1` with
+available and partial rows for skills/plugins, roles, team/swarm workers,
+worktree isolation, HUD/session status, MCP/tool bridge preference, loop
+autopilot, and release maintenance. Partial rows are intentional evidence
+boundaries, not failures.
 
 For concrete examples that show how the installed skills should affect coding,
 planning, and specialist review flows, see

--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -1,0 +1,85 @@
+# OMH Parity Matrix
+
+This document tracks the gap between common oh-my agent runtime capability
+patterns and OMH's Hermes-native implementation. It is intentionally not a
+clone list. The goal is to keep OMH competitive while preserving its core
+boundary: Hermes owns conversation and workflow narration, selected executors
+own observed execution, and OMH owns deterministic local contracts.
+
+Use the live verifier for the current local install:
+
+```sh
+omh probe --parity
+omh probe --parity --json
+```
+
+The JSON payload includes `omh_parity_matrix/v1`.
+
+## Search Basis
+
+The comparison is based on public oh-my agent runtime patterns across:
+
+- skill and plugin installation surfaces
+- native plugin/HUD/status context
+- specialist role or profile systems
+- team, swarm, worker, and worktree orchestration
+- MCP/tool bridge setup
+- loop/autopilot delivery flows
+- doctor, update, uninstall, and release smoke commands
+
+OMH should absorb the useful capability shape, not copy another project's
+implementation or claim runtime behavior it did not observe.
+
+## Current Matrix
+
+| Capability axis | OMH status | OMH surface | Missing or intentionally delegated |
+| --- | --- | --- | --- |
+| Skill and plugin distribution | Available | Tap-compatible `skills/*/SKILL.md`, `omh setup`, and optional `~/.hermes/plugins/omh` bridge. | Observed Hermes plugin load still needs host runtime evidence. |
+| Specialist role/profile system | Partial | Skill catalog metadata, operating models, optional visible profile packs, and wrapper role narration. | No hidden live specialist agents are claimed without wrapper or runtime evidence. |
+| Team, swarm, and worker protocol | Partial | `team`, `ultrawork`, runtime handoff payloads, worker-protocol guidance, wrapper sessions, and runtime observations. | OMH does not launch hidden tmux teams, spawn workers, or manage panes by itself. |
+| Worktree and project-session isolation | Partial | Coding runtime handoff contracts, loop queue metadata, and runtime observations for worktree creation. | OMH records and requests isolation but does not create Git worktrees in v1. |
+| HUD, status, and session observability | Available | `omh hud`, plugin `omh_hud`/`omh_status`, wrapper sessions, runtime runs, and status cards. | Live host HUD rendering depends on Hermes/plugin support. |
+| MCP and tool bridge preference | Partial | `omh setup --with-mcp`, setup state, and `omh probe` host-config separation. | OMH does not ship or auto-enable a real MCP server/tool bridge in v1. |
+| Loop and autopilot workflow | Available | `loop`, `ultraprocess`, `ralplan`, `ultragoal`, loop queue ticks, verification tiers, and failure-mode cards. | Scheduling, connector I/O, worktree creation, and subagent execution remain prepared or delegated until observed. |
+| Doctor, update, uninstall, and release smoke | Available | `omh setup`, `omh doctor`, `omh update`, `omh uninstall`, `omh release checklist`, and `omh release hermes-smoke`. | Live release smoke still needs an explicit target Hermes profile or operator confirmation before mutation. |
+
+## Implementation Plan
+
+This PR implements the first vertical slice:
+
+- Add a deterministic parity catalog in `src/parity.py`.
+- Add `omh probe --parity` so operators and wrappers can inspect the matrix
+  beside the current local capability probe.
+- Keep the default `omh probe` output unchanged unless `--parity` is passed.
+- Document the comparison, non-goals, and next implementation slices.
+- Add unit tests that lock the JSON schema, human summary, and conservative
+  claim boundaries.
+
+Next PR candidates:
+
+| Next PR | Why it matters |
+| --- | --- |
+| Wrapper-observed role lane results | Closes more of the specialist role gap without inventing hidden Hermes agents. |
+| Worktree/session isolation runbooks and smoke fixtures | Makes executor-neutral worktree guidance operational before any creator command exists. |
+| Real OMH MCP bridge contract | Turns MCP preference into an installable, testable bridge when Hermes support is stable enough. |
+
+## Acceptance Criteria
+
+- `omh probe` remains a compact capability summary by default.
+- `omh probe --parity` prints a human-readable parity section.
+- `omh probe --parity --json` includes `parity_matrix.schema_version` equal to
+  `omh_parity_matrix/v1`.
+- Team/swarm, worktree, and MCP axes are marked `partial`, not `available`,
+  until observed runtime support exists.
+- The matrix never claims hidden worker launch, worktree creation, MCP tool
+  calls, plugin runtime load, executor execution, review, CI, or merge
+  evidence.
+
+## Non-Goals
+
+- No hidden tmux team launcher.
+- No Git worktree creator.
+- No MCP server or tool host.
+- No Discord/Slack transport implementation.
+- No Hermes core patch.
+- No network calls, LLM calls, or executor dispatch from the parity verifier.

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ repo-local contract for Codex agents working here.
 | --- | --- |
 | Understand what OMH is and is not | [Direction](DIRECTION.md) |
 | Understand module boundaries and local artifacts | [Architecture](ARCHITECTURE.md) |
+| Compare common oh-my runtime axes and OMH gaps | [Parity Matrix](PARITY.md) |
 | Understand chat wrapper UX, sessions, and handoffs | [Delegation-First Completeness](DELEGATION_FIRST_COMPLETENESS.md) |
 | Review stale local context and executor handoff packs | [Memory Context Review](MEMORY_CONTEXT.md) |
 | Operate a Hermes-agent wrapper safely | [Hermes Agent Integration Runbook](HERMES_AGENT_INTEGRATION_RUNBOOK.md) |
@@ -109,6 +110,9 @@ selected.
   install evidence.
 - Runtime and wrapper docs should preserve the separation between wrapper
   session state and run-level evidence.
+- Parity docs should map common oh-my runtime capability axes to OMH's
+  Hermes-native evidence model instead of promising hidden workers, worktrees,
+  MCP tools, or plugin runtime load without observation.
 - Goal execution docs should describe `.omh/goals` metadata-only ledgers,
   `goal_completion_gate/v1`, `goal_status_card/v1`, and
   `goal_continuation/v1` as wrapper contracts that name the next action before
@@ -130,6 +134,7 @@ When changing docs, check whether the same claim needs to be updated in:
 - [README](../README.md)
 - [Direction](DIRECTION.md)
 - [Architecture](ARCHITECTURE.md)
+- [Parity Matrix](PARITY.md)
 - [Delegation-First Completeness](DELEGATION_FIRST_COMPLETENESS.md)
 - [Memory Context Review](MEMORY_CONTEXT.md)
 - [Hermes Agent Integration Runbook](HERMES_AGENT_INTEGRATION_RUNBOOK.md)

--- a/src/commands/setup.py
+++ b/src/commands/setup.py
@@ -1723,7 +1723,40 @@ def _print_probe_summary(payload: dict[str, object]) -> None:
     if boundary:
         print(_color("Boundary", "1;32", use_color))
         print(f"  {boundary}")
+    parity = payload.get("parity_matrix")
+    if isinstance(parity, dict):
+        _print_probe_parity_summary(parity, use_color=use_color)
     print(f"  {tr('en', 'machine_readable')}")
+
+
+def _print_probe_parity_summary(payload: dict[str, object], *, use_color: bool) -> None:
+    summary = payload.get("summary", {})
+    if not isinstance(summary, dict):
+        summary = {}
+    print(_color("Parity matrix", "1;32", use_color))
+    print(
+        "  Common oh-my runtime axes: "
+        f"{summary.get('available', 0)} available, "
+        f"{summary.get('partial', 0)} partial, "
+        f"{summary.get('planned', 0)} planned, "
+        f"{summary.get('deferred', 0)} deferred"
+    )
+    capabilities = payload.get("capabilities", [])
+    if not isinstance(capabilities, list):
+        capabilities = []
+    for capability in capabilities:
+        if not isinstance(capability, dict):
+            continue
+        title = str(capability.get("title", "unknown"))
+        status = str(capability.get("status", "unknown"))
+        missing = _short_summary(str(capability.get("missing_piece", "")), limit=108)
+        print(f"  - {title}: {status}")
+        if missing:
+            print(f"    Gap: {missing}")
+    boundary = str(payload.get("claim_boundary", "")).strip()
+    if boundary:
+        print(_color("Parity boundary", "1;32", use_color))
+        print(f"  {_short_summary(boundary, limit=132)}")
 
 
 def _short_summary(value: str, *, limit: int) -> str:
@@ -1882,7 +1915,7 @@ def cmd_snippet(args: argparse.Namespace) -> int:
 
 
 def cmd_probe(args: argparse.Namespace) -> int:
-    payload = probe_capabilities(_paths(args))
+    payload = probe_capabilities(_paths(args), include_parity=bool(getattr(args, "parity", False)))
     if _wants_json(args):
         _print_json(payload)
     else:
@@ -2009,6 +2042,11 @@ def _add_top_level_commands(sub) -> None:
     snippet.set_defaults(func=cmd_snippet)
 
     probe = sub.add_parser("probe", help="Inspect observable OMH/Hermes capability surfaces.")
+    probe.add_argument(
+        "--parity",
+        action="store_true",
+        help="Include the OMH parity matrix for common oh-my agent runtime capability axes.",
+    )
     probe.add_argument("--json", action="store_true", help="Print the full machine-readable capability payload.")
     probe.set_defaults(func=cmd_probe)
 

--- a/src/parity.py
+++ b/src/parity.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+PARITY_MATRIX_SCHEMA_VERSION = "omh_parity_matrix/v1"
+
+
+@dataclass(frozen=True)
+class ParityCapability:
+    id: str
+    title: str
+    common_pattern: str
+    omh_surface: str
+    status: str
+    evidence: tuple[str, ...]
+    missing_piece: str
+    v1_decision: str
+    user_value: str
+    claim_boundary: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "id": self.id,
+            "title": self.title,
+            "common_pattern": self.common_pattern,
+            "omh_surface": self.omh_surface,
+            "status": self.status,
+            "evidence": list(self.evidence),
+            "missing_piece": self.missing_piece,
+            "v1_decision": self.v1_decision,
+            "user_value": self.user_value,
+            "claim_boundary": self.claim_boundary,
+        }
+
+
+PARITY_CAPABILITIES: tuple[ParityCapability, ...] = (
+    ParityCapability(
+        id="skill_plugin_distribution",
+        title="Skill and plugin distribution",
+        common_pattern="Install a native skill/plugin payload, then let the host agent surface workflows without making users memorize backend commands.",
+        omh_surface="`hermes skills ...` compatible skill pack, `omh setup`, and the optional `~/.hermes/plugins/omh` bridge.",
+        status="available",
+        evidence=("skills/*/SKILL.md", "src/plugin_bundle/omh/plugin.yaml", "src/plugin_pack.py", "src/commands/setup.py"),
+        missing_piece="Observed Hermes plugin load/use still requires runtime evidence from the host.",
+        v1_decision="Keep skills as the default surface and plugin as a thin metadata bridge.",
+        user_value="Users install OMH once and then talk to Hermes; operators can still verify the local payload.",
+        claim_boundary="Plugin install/import/register smoke is not proof that Hermes loaded or used the plugin.",
+    ),
+    ParityCapability(
+        id="specialist_roles",
+        title="Specialist role/profile system",
+        common_pattern="Expose reusable specialist roles so the agent can route planning, implementation, review, research, and operations work consistently.",
+        omh_surface="Skill catalog role metadata, operating models, optional OMH-prefixed visible profile packs, and wrapper role narration.",
+        status="partial",
+        evidence=("src/skills/catalog.py", "src/profiles/team.py", "src/team_profiles.py", "skills/oh-my-hermes/SKILL.md"),
+        missing_piece="OMH does not claim hidden live specialist agents unless Hermes or a wrapper records target-specific role evidence.",
+        v1_decision="Keep role profiles optional and Hermes-facing instead of forcing a CTO/PM/Dev/QA organization model at setup.",
+        user_value="Hermes can explain who owns the next step without pretending a separate runtime role acted.",
+        claim_boundary="Role metadata is routing guidance, not observed delegation evidence.",
+    ),
+    ParityCapability(
+        id="team_swarm_workers",
+        title="Team, swarm, and worker protocol",
+        common_pattern="Coordinate multiple lanes with explicit worker ownership, status, handoff, and review boundaries.",
+        omh_surface="`team`, `ultrawork`, runtime handoff payloads, worker-protocol guidance, wrapper sessions, and runtime observations.",
+        status="partial",
+        evidence=("skills/team/SKILL.md", "skills/ultrawork/SKILL.md", "src/coding_delegation.py", "src/runtime/records.py"),
+        missing_piece="OMH does not launch a hidden tmux team, spawn workers, or manage real worker panes itself.",
+        v1_decision="Support executor-neutral team handoff and observation first; real worker launch stays with Hermes, Codex, Claude Code, OMX, OMO, OMC, or another selected runtime.",
+        user_value="A chat wrapper can show Start team, Attach session, Record worker result, and Review status without asking the user to type raw backend commands.",
+        claim_boundary="Prepared worker lanes are not worker dispatch, result, review, CI, or merge evidence.",
+    ),
+    ParityCapability(
+        id="worktree_isolation",
+        title="Worktree and project-session isolation",
+        common_pattern="Use isolated workspaces so parallel agents can work without stepping on each other's files.",
+        omh_surface="Coding runtime handoff contracts, loop queue metadata, and runtime observations for worktree creation.",
+        status="partial",
+        evidence=("src/coding_contracts.py", "src/goal_loop.py", "src/runtime/records.py", "docs/DELEGATION_FIRST_COMPLETENESS.md"),
+        missing_piece="OMH records and requests worktree isolation but does not create Git worktrees or bind host agent sessions directly.",
+        v1_decision="Keep worktree operations explicit and observed; add richer runbook/checklist support before any creator command.",
+        user_value="Teams get the safety language and status boundary now, while actual workspace creation remains in the chosen executor/runtime.",
+        claim_boundary="A worktree plan is not a created worktree; only runtime observation can mark it observed.",
+    ),
+    ParityCapability(
+        id="hud_session_observability",
+        title="HUD, status, and session observability",
+        common_pattern="Show compact live state plus post-session artifacts so operators can inspect what happened.",
+        omh_surface="`omh hud`, plugin `omh_hud`/`omh_status` tools, wrapper sessions, runtime runs, memory inspect, and status cards.",
+        status="available",
+        evidence=("src/hud.py", "src/plugin_bundle/omh/tools/hud_tool.py", "src/wrapper/sessions.py", "src/runtime/artifacts.py"),
+        missing_piece="Live host HUD rendering depends on Hermes/plugin runtime support and is not inferred from local files alone.",
+        v1_decision="Keep the HUD compact: version, plugin readiness, target topology, coding-agent state, and evidence boundary.",
+        user_value="Hermes can answer status questions without mixing prepared handoff with observed execution.",
+        claim_boundary="A HUD line summarizes local state; it is not execution proof.",
+    ),
+    ParityCapability(
+        id="mcp_tool_bridge",
+        title="MCP and tool bridge preference",
+        common_pattern="Offer tool/MCP bridge configuration so the host agent can reach external capabilities through a controlled surface.",
+        omh_surface="`omh setup --with-mcp`, `omh probe`, and MCP preference/host-config separation.",
+        status="partial",
+        evidence=("src/commands/setup.py", "src/probe.py", "docs/INSTALLATION.md"),
+        missing_piece="OMH does not ship or auto-enable a real MCP server/tool bridge in v1.",
+        v1_decision="Record MCP intent and host-file evidence separately until a stable Hermes MCP bridge contract exists.",
+        user_value="Operators can prepare for MCP without accidentally claiming a tool host loaded or ran OMH.",
+        claim_boundary="MCP preference and MCP host config are not MCP tool-call evidence.",
+    ),
+    ParityCapability(
+        id="loop_autopilot",
+        title="Loop and autopilot workflow",
+        common_pattern="Turn large goals into repeated research, plan, execute, verify, feedback, and continuation cycles.",
+        omh_surface="`loop`, `ultraprocess`, `ralplan`, `ultragoal`, loop queue ticks, verification tiers, and failure-mode status cards.",
+        status="available",
+        evidence=("src/goal_loop.py", "src/commands/loop.py", "skills/loop/SKILL.md", "skills/ultraprocess/SKILL.md"),
+        missing_piece="Scheduling, connector I/O, worktree creation, and subagent execution remain prepared or delegated until observed.",
+        v1_decision="Make loop engineering safe and inspectable before adding unattended execution.",
+        user_value="Hermes can keep ambitious goals moving while preserving verification gaps and human judgment points.",
+        claim_boundary="A loop tick prepares orchestration; it is not proof that external work ran.",
+    ),
+    ParityCapability(
+        id="release_doctor_update",
+        title="Doctor, update, uninstall, and release smoke",
+        common_pattern="Give operators maintenance commands that verify installation health, update state, and release readiness.",
+        omh_surface="`omh setup`, `omh doctor`, `omh update`, `omh uninstall`, `omh release checklist`, and `omh release hermes-smoke`.",
+        status="available",
+        evidence=("src/commands/setup.py", "src/doctor.py", "src/release.py", "install.sh"),
+        missing_piece="Live release smoke still needs an explicit target Hermes profile or operator confirmation before mutation.",
+        v1_decision="Keep maintenance local by default and make live Hermes mutation opt-in.",
+        user_value="A company can install, repair, update, uninstall, and prepare releases without guessing what happened.",
+        claim_boundary="Release checklists are plans until their commands are run and evidence is attached.",
+    ),
+)
+
+
+def build_parity_matrix(probe_payload: dict[str, object] | None = None) -> dict[str, object]:
+    capabilities = [capability.to_dict() for capability in PARITY_CAPABILITIES]
+    counts: dict[str, int] = {}
+    for capability in capabilities:
+        status = str(capability.get("status", "unknown"))
+        counts[status] = counts.get(status, 0) + 1
+    return {
+        "schema_version": PARITY_MATRIX_SCHEMA_VERSION,
+        "basis": "OMX/OMC/OMO common public capability patterns, translated into OMH's Hermes-native evidence model.",
+        "summary": {
+            "capability_count": len(capabilities),
+            "available": counts.get("available", 0),
+            "partial": counts.get("partial", 0),
+            "planned": counts.get("planned", 0),
+            "deferred": counts.get("deferred", 0),
+        },
+        "capabilities": capabilities,
+        "probe_alignment": _probe_alignment(probe_payload or {}),
+        "recommended_next_prs": [
+            {
+                "id": "native-role-evidence",
+                "title": "Record wrapper-observed role lane results",
+                "why": "Closes the specialist role gap without claiming hidden Hermes agents.",
+            },
+            {
+                "id": "worktree-runbook",
+                "title": "Add worktree/session isolation runbooks and smoke fixtures",
+                "why": "Makes executor-neutral worktree guidance more operational before any creator command exists.",
+            },
+            {
+                "id": "mcp-bridge-contract",
+                "title": "Define a real OMH MCP bridge contract",
+                "why": "Turns MCP preference into an installable, testable bridge when Hermes support is stable enough.",
+            },
+        ],
+        "claim_boundary": (
+            "The parity matrix is a product and operator contract. It does not claim hidden worker launch, "
+            "worktree creation, MCP tool calls, plugin runtime load, executor execution, review, CI, or merge evidence."
+        ),
+    }
+
+
+def _probe_alignment(probe_payload: dict[str, object]) -> dict[str, object]:
+    capabilities = probe_payload.get("capabilities", [])
+    by_name = {
+        str(capability.get("name", "")): str(capability.get("status", "unknown"))
+        for capability in capabilities
+        if isinstance(capability, dict)
+    }
+    return {
+        "managed_skills": by_name.get("managed_skills", "unknown"),
+        "external_skill_dirs": by_name.get("external_skill_dirs", "unknown"),
+        "omh_plugin_bundle": by_name.get("omh_plugin_bundle", "unknown"),
+        "plugin_register_smoke": by_name.get("plugin_register_smoke", "unknown"),
+        "mcp_preference": by_name.get("mcp_preference", "unknown"),
+        "mcp_host_config": by_name.get("mcp_host_config", "unknown"),
+        "target_topology": by_name.get("target_topology", "unknown"),
+        "wrapper_metadata": by_name.get("wrapper_metadata", "unknown"),
+    }

--- a/src/probe.py
+++ b/src/probe.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from .config_adapter import external_dirs, read_config
+from .parity import build_parity_matrix
 from .paths import OmhPaths
 from .plugin_pack import inspect_plugin_bundle
 from .runtime.artifacts import read_state_result
@@ -118,7 +119,7 @@ def _dir_capability(name: str, path: Path, found_message: str, missing_message: 
     )
 
 
-def probe_capabilities(paths: OmhPaths) -> dict:
+def probe_capabilities(paths: OmhPaths, *, include_parity: bool = False) -> dict:
     config_text = read_config(paths.hermes_config_path)
     configured_dirs = external_dirs(config_text)
     skills_registered = str(paths.skills_dir) in configured_dirs
@@ -255,7 +256,7 @@ def probe_capabilities(paths: OmhPaths) -> dict:
         ]
     )
 
-    return {
+    payload = {
         "schema_version": 1,
         "omh_home": str(paths.omh_home),
         "hermes_home": str(paths.hermes_home),
@@ -265,3 +266,6 @@ def probe_capabilities(paths: OmhPaths) -> dict:
         "native_integration_claim_ready": False,
         "claim_boundary": "Prompt-level routing is the default unless a future stable Hermes extension surface and runtime evidence prove deeper integration.",
     }
+    if include_parity:
+        payload["parity_matrix"] = build_parity_matrix(payload)
+    return payload

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -197,6 +197,46 @@ class CliTests(unittest.TestCase):
             self.assertEqual(status, 0)
             self.assertEqual(json.loads(stdout)["written"], str(output.resolve()))
 
+    def test_probe_parity_matrix_maps_common_agent_runtime_gaps(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+
+            status, _, stderr = run_cli(base + ["setup", "--with-plugin"], output_json=False)
+            self.assertEqual(status, 0, stderr)
+
+            status, stdout, stderr = run_cli(base + ["probe", "--parity", "--json"], output_json=False)
+
+            self.assertEqual(status, 0, stderr)
+            self.assertEqual(stderr, "")
+            payload = json.loads(stdout)
+            matrix = payload["parity_matrix"]
+            self.assertEqual(matrix["schema_version"], "omh_parity_matrix/v1")
+            self.assertGreaterEqual(matrix["summary"]["available"], 3)
+            self.assertGreaterEqual(matrix["summary"]["partial"], 3)
+            capabilities = {item["id"]: item for item in matrix["capabilities"]}
+            self.assertEqual(capabilities["skill_plugin_distribution"]["status"], "available")
+            self.assertEqual(capabilities["team_swarm_workers"]["status"], "partial")
+            self.assertEqual(capabilities["worktree_isolation"]["status"], "partial")
+            self.assertEqual(capabilities["mcp_tool_bridge"]["status"], "partial")
+            self.assertIn("not worker dispatch", capabilities["team_swarm_workers"]["claim_boundary"])
+            self.assertIn("not a created worktree", capabilities["worktree_isolation"]["claim_boundary"])
+            self.assertEqual(matrix["probe_alignment"]["managed_skills"], "available")
+            self.assertEqual(matrix["probe_alignment"]["omh_plugin_bundle"], "available")
+            self.assertIn("does not claim hidden worker launch", matrix["claim_boundary"])
+
+            status, stdout, stderr = run_cli(base + ["probe", "--parity"], output_json=False)
+
+            self.assertEqual(status, 0, stderr)
+            self.assertEqual(stderr, "")
+            self.assertIn("OMH capability probe", stdout)
+            self.assertIn("Parity matrix", stdout)
+            self.assertIn("Team, swarm, and worker protocol: partial", stdout)
+            self.assertIn("Worktree and project-session isolation: partial", stdout)
+            self.assertIn("For machine-readable output, rerun with `--json`.", stdout)
+            with self.assertRaises(json.JSONDecodeError):
+                json.loads(stdout)
+
     def test_setup_interactive_wizard_records_user_choices(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## Feature Report

### What Changed

- Added a deterministic `omh_parity_matrix/v1` catalog for common oh-my runtime capability axes.
- Added `omh probe --parity` to include the parity matrix in both human summaries and JSON output.
- Documented OMH's available and partial surfaces in `docs/PARITY.md`, README, Installation, Architecture, and the docs index.
- Added CLI coverage that locks conservative support boundaries for team/swarm workers, worktree isolation, MCP bridge preference, and skill/plugin distribution.

### Why This Exists

OMH now has many Hermes-native surfaces, but the gap against common oh-my runtimes was scattered across chat history and docs. This PR makes that comparison durable and testable without pretending OMH launches hidden workers, creates worktrees, runs MCP tools, or observes plugin runtime load.

Public search basis used for the capability axes:

- https://github.com/Yeachan-Heo/oh-my-codex
- https://github.com/Yeachan-Heo/oh-my-claudecode
- https://github.com/code-yeongyu/oh-my-openagent

### User / Operator Impact

- Operators can run `omh probe --parity` to see which common runtime axes are available, partial, or deferred.
- Wrapper/backend users can request `omh probe --parity --json` and consume a stable `omh_parity_matrix/v1` payload.
- Normal `omh probe` remains unchanged unless `--parity` is passed.
- The project has a clear next-PR map for role evidence, worktree/session runbooks, and MCP bridge contracts.

### How It Works

- `src/parity.py` defines the parity catalog and builds a schema-versioned matrix.
- `src/probe.py` accepts `include_parity=True` and attaches the matrix to the existing probe payload.
- `src/commands/setup.py` adds the `--parity` flag and renders a concise human summary.
- `tests/test_cli.py` verifies the JSON schema, human output, and evidence-boundary wording.

### Files And Contracts Touched

- `src/parity.py`: new deterministic parity catalog and `build_parity_matrix` helper.
- `src/probe.py`: optional parity matrix inclusion.
- `src/commands/setup.py`: `omh probe --parity` CLI and human summary.
- `docs/PARITY.md`: implementation plan and current parity table.
- `README.md`, `docs/README.md`, `docs/ARCHITECTURE.md`, `docs/INSTALLATION.md`: operator discovery and architecture references.
- `tests/test_cli.py`: parity CLI contract coverage.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_cli.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `PYTHONPATH=tests uv run python -m src.cli docs workflows --check`
- [x] `PYTHONPATH=tests uv run python -m src.cli harness validate`
- [ ] `python3 -m omh.cli release checklist --json` (not in this slice)
- [ ] `python3 -m omh.cli release hermes-smoke` (not in this slice)
- [ ] `omh --help` (not in this slice)
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` (not in this slice)
- [x] Relevant dry-run or smoke command: temp-home `setup --with-plugin --yes`, then `probe --parity`
- [x] Manual Hermes/TUI check, or explicit reason it was not run: not run; this PR adds a local deterministic probe surface only and does not claim live Hermes runtime load.
- [x] `git diff --check`

## Risk

- Low runtime risk: `omh probe` behavior is unchanged unless `--parity` is requested.
- Moderate product-claim risk: the matrix references runtime axes like team/swarm, worktrees, and MCP. The implementation keeps those rows `partial` and ties them to explicit claim boundaries.

## Compatibility / Rollout

- Additive CLI flag only.
- Additive JSON field only when `--parity` is passed.
- No release-channel behavior change.
- No LLM/API/network calls added to OMH runtime code.

## Release / Claims

- [x] Release-channel impact considered (`preview` docs/CLI additive only)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- Record wrapper-observed role lane results.
- Add worktree/session isolation runbooks and smoke fixtures.
- Define a real OMH MCP bridge contract once Hermes support is stable enough.