### PR TITLE
Add bounded plugin evidence probe

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ so OMH can display and record `main@old -> main@new` instead of only `main`.
 | Memory context review | Review OMH-local and wrapper-supplied context, flag stale assumptions, and attach conflict-free summaries to executor handoffs. |
 | Strict goal progress | `.omh/goals` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, and `goal_continuation/v1` keep long-running goals from being treated as done before evidence is ready. |
 | Hermes chat contracts | `chat_interaction/v1`, status cards, action ids, and local runtime artifacts for Hermes Agent chat surfaces. |
-| Hermes plugin bridge | `omh setup` installs `~/.hermes/plugins/omh` with metadata-only `omh_hud`, `omh_role`, `omh_status`, role marker validation, and session checkpoint support. |
+| Hermes plugin bridge | `omh setup` installs `~/.hermes/plugins/omh` with metadata-only `omh_hud`, `omh_role`, `omh_status`, bounded `omh_gather_evidence`, role marker validation, and session checkpoint support. |
 | Optional MCP bridge preference | `omh setup --with-mcp` records MCP bridge intent without claiming a host loaded or called it; `omh probe` separates `mcp_preference` from `mcp_host_config`. |
 | Parity verifier | `omh probe --parity` maps common oh-my runtime capability axes to OMH surfaces, gaps, and evidence boundaries. |
 | Operating models | `omh setup --operating-model <id>` records the default Hermes collaboration posture: solo operator, small team, research ops, or coding runtime team. |
@@ -255,8 +255,8 @@ Profile packs write OMH-prefixed role files under `~/.hermes/agents`. The
 is not installed by default.
 
 The plugin bridge installs `~/.hermes/plugins/omh` and registers metadata-only
-HUD/status support. `omh hud` prints the same compact line a Hermes TUI or
-status surface can render, for example
+HUD/status support plus a bounded local evidence probe. `omh hud` prints the
+same compact line a Hermes TUI or status surface can render, for example
 `[omh] v1.0.0 | plugin:ready | target:single | coding-agent:idle(ask)`.
 
 For coding runtime handoffs, wrappers can record observed steps without claiming
@@ -302,6 +302,10 @@ Skill inventory and deep diagnostics belong in `omh doctor`,
 `omh_status`, or machine-readable setup output, not the status line. Local
 plugin install or import/register smoke is not proof that Hermes loaded the
 plugin, executed code, reviewed a PR, passed CI, or merged.
+`omh_gather_evidence` can run only allowlisted local verification probes and
+returns truncated structured output. It is verification evidence for that
+specific command, not executor dispatch, implementation, review, CI, merge, or
+live Hermes plugin-load evidence.
 
 The installer can also pass these advanced setup choices directly:
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -41,7 +41,7 @@ flowchart LR
 
   user --> hermes
   skills --> hermes
-  plugin -->|"omh_hud, omh_role, omh_status, hooks"| hermes
+  plugin -->|"omh_hud, omh_role, omh_status, omh_gather_evidence, hooks"| hermes
   user --> wrapper
   wrapper -->|"chat_interaction/v1"| omh
   omh -->|"answer, clarify, plan, or status"| wrapper
@@ -144,16 +144,19 @@ OMH directly when Hermes taps are available.
 `plugin_bundle/omh/` is the Hermes plugin payload installed by `omh setup` to
 `~/.hermes/plugins/omh`. The v1 plugin registers a compact metadata-only
 `omh_hud` tool, a detailed metadata-only `omh_status` tool, an `omh_role` role
-context tool, and passive lifecycle hooks for bounded status context, role
-marker validation, and metadata-only session-end checkpointing. `omh hud`
+context tool, a bounded `omh_gather_evidence` local verification probe, and
+passive lifecycle hooks for bounded status context, role marker validation, and
+metadata-only session-end checkpointing. `omh hud`
 exposes the same status-line payload for local operator smoke tests. The HUD
 line stays limited to version, plugin bridge readiness, target topology, current
 or default coding agent, and evidence state. Host-supplied token metadata
 remains available in the machine-readable payload but is not shown in the
 Hermes-facing status line.
-It intentionally omits install inventory such as managed skill counts. It does
-not run verification commands, patch Hermes core, or claim execution evidence
-from prepared handoffs. Role context is prompt guidance only; it is not proof
+It intentionally omits install inventory such as managed skill counts. Its
+evidence probe is allowlisted, shell-free, bounded to a project root, and emits
+truncated structured command output. It does not provide an arbitrary shell,
+patch Hermes core, or claim execution evidence from prepared handoffs. Role
+context is prompt guidance only; it is not proof
 that a separate role, worker, or executor ran.
 
 `cli.py` is a compatibility adapter. `commands/main.py` owns parser assembly,

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -51,7 +51,7 @@ Plugin support is installed by `omh setup` by default. It provides a thin
 Hermes plugin bridge in addition to the skill pack:
 
 That installs `~/.hermes/plugins/omh` with metadata-only HUD/status/role
-support.
+support and a bounded evidence probe.
 `omh hud` prints the same compact status line a Hermes TUI or plugin surface can
 render. It shows only operationally useful status: OMH version, plugin
 readiness, target topology, current or default coding agent, and evidence
@@ -61,8 +61,11 @@ line looks like
 `[omh] v1.0.0 | plugin:ready | target:single | coding-agent:idle(ask)`.
 The plugin also exposes `omh_role`, validates `[omh-role:name]` markers for
 delegated subagent prompts, and records a metadata-only session-end checkpoint
-when OMH runtime state exists. It does not execute code, patch Hermes core, or
-prove Hermes has loaded it.
+when OMH runtime state exists. It also exposes `omh_gather_evidence` for
+explicit allowlisted local verification probes such as OMH doctor, harness
+validation, docs checks, unittest, compileall, and whitespace checks. It does
+not provide an arbitrary shell, patch Hermes core, dispatch executors, or prove
+Hermes has loaded it.
 If the target Hermes runtime requires a separate plugin enable command, follow
 that runtime's plugin enable/reload step.
 

--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -22,6 +22,7 @@ The comparison is based on public oh-my agent runtime patterns across:
 - skill and plugin installation surfaces
 - native plugin/HUD/status context
 - specialist role or profile systems
+- bounded evidence probe tools
 - team, swarm, worker, and worktree orchestration
 - MCP/tool bridge setup
 - loop/autopilot delivery flows
@@ -36,6 +37,7 @@ implementation or claim runtime behavior it did not observe.
 | --- | --- | --- | --- |
 | Skill and plugin distribution | Available | Tap-compatible `skills/*/SKILL.md`, `omh setup`, and optional `~/.hermes/plugins/omh` bridge. | Observed Hermes plugin load still needs host runtime evidence. |
 | Specialist role/profile system | Available | Skill catalog metadata, operating models, optional visible profile packs, wrapper role narration, plugin `omh_role`, and `[omh-role:name]` context injection. | Observed role execution still requires wrapper or runtime evidence; role context is not a hidden live agent. |
+| Bounded evidence probe | Available | Plugin `omh_gather_evidence` runs shell-free allowlisted local probes such as doctor, harness validation, docs checks, unittest, compileall, and whitespace checks. | It is not a general shell, executor dispatch, PR review, CI, merge, or live Hermes plugin-load signal. |
 | Team, swarm, and worker protocol | Partial | `team`, `ultrawork`, runtime handoff payloads, worker-protocol guidance, wrapper sessions, and runtime observations. | OMH does not launch hidden tmux teams, spawn workers, or manage panes by itself. |
 | Worktree and project-session isolation | Partial | Coding runtime handoff contracts, loop queue metadata, and runtime observations for worktree creation. | OMH records and requests isolation but does not create Git worktrees in v1. |
 | HUD, status, and session observability | Available | `omh hud`, plugin `omh_hud`/`omh_status`, wrapper sessions, runtime runs, and status cards. | Live host HUD rendering depends on Hermes/plugin support. |
@@ -52,6 +54,8 @@ This PR implements the first vertical slice:
   beside the current local capability probe.
 - Harden the plugin bridge with native role context lookup, role marker
   injection, delegate marker validation, and session-end checkpoints.
+- Add a bounded `omh_gather_evidence` plugin tool for explicit allowlisted
+  local verification probes.
 - Keep the default `omh probe` output unchanged unless `--parity` is passed.
 - Document the comparison, non-goals, and next implementation slices.
 - Add unit tests that lock the JSON schema, human summary, and conservative
@@ -63,7 +67,7 @@ Next PR candidates:
 | --- | --- |
 | Worktree/session isolation runbooks and smoke fixtures | Makes executor-neutral worktree guidance operational before any creator command exists. |
 | Real OMH MCP bridge contract | Turns MCP preference into an installable, testable bridge when Hermes support is stable enough. |
-| Allowlisted evidence runner design | Evaluates whether a command-running verifier can fit OMH's explicit opt-in and prepared-vs-observed model. |
+| Live Hermes plugin-load smoke evidence | Separates installed/importable plugin payloads from host-observed plugin runtime use. |
 
 ## Acceptance Criteria
 
@@ -75,6 +79,9 @@ Next PR candidates:
   until observed runtime support exists.
 - Specialist roles are `available` only as prompt context, marker validation,
   and profile guidance. They are not hidden runtime agents.
+- Bounded evidence probes are `available` only as explicit allowlisted local
+  command results. They are not executor dispatch, implementation, review, CI,
+  merge, or plugin-load evidence.
 - The matrix never claims hidden worker launch, worktree creation, MCP tool
   calls, plugin runtime load, executor execution, review, CI, or merge
   evidence.
@@ -87,3 +94,4 @@ Next PR candidates:
 - No Discord/Slack transport implementation.
 - No Hermes core patch.
 - No network calls, LLM calls, or executor dispatch from the parity verifier.
+- No arbitrary shell or connector command runner from the plugin bridge.

--- a/src/parity.py
+++ b/src/parity.py
@@ -60,6 +60,18 @@ PARITY_CAPABILITIES: tuple[ParityCapability, ...] = (
         claim_boundary="Role context is prompt guidance, not observed delegation, worker start, execution, review, CI, or merge evidence.",
     ),
     ParityCapability(
+        id="bounded_evidence_probe",
+        title="Bounded evidence probe",
+        common_pattern="Let the host agent run explicitly allowlisted local verification commands and return structured pass/fail output.",
+        omh_surface="Plugin `omh_gather_evidence` runs shell-free allowlisted local probes such as OMH doctor, harness validation, docs checks, unittest, compileall, and git diff whitespace checks.",
+        status="available",
+        evidence=("src/plugin_bundle/omh/tools/evidence_tool.py", "src/plugin_bundle/omh/config.yaml", "tests/test_plugin_distribution.py"),
+        missing_piece="It is not a general command runner and does not observe executor dispatch, PR review, CI, merge, or Hermes plugin runtime load.",
+        v1_decision="Ship a narrow explicit verification probe before any broader evidence runner or connector tool.",
+        user_value="Hermes can gather basic local verification evidence without asking users to paste terminal output or granting arbitrary shell access.",
+        claim_boundary="Evidence probes prove only the allowlisted local command result they ran.",
+    ),
+    ParityCapability(
         id="team_swarm_workers",
         title="Team, swarm, and worker protocol",
         common_pattern="Coordinate multiple lanes with explicit worker ownership, status, handoff, and review boundaries.",
@@ -154,9 +166,9 @@ def build_parity_matrix(probe_payload: dict[str, object] | None = None) -> dict[
         "probe_alignment": _probe_alignment(probe_payload or {}),
         "recommended_next_prs": [
             {
-                "id": "native-role-evidence",
-                "title": "Record wrapper-observed role lane results",
-                "why": "Closes the specialist role gap without claiming hidden Hermes agents.",
+                "id": "observed-plugin-load",
+                "title": "Add live Hermes plugin load smoke evidence",
+                "why": "Separates installed/importable plugin payloads from host-observed plugin runtime use.",
             },
             {
                 "id": "worktree-runbook",

--- a/src/plugin_bundle/omh/__init__.py
+++ b/src/plugin_bundle/omh/__init__.py
@@ -8,10 +8,18 @@ def register(ctx):
     from .hooks.llm_hooks import pre_llm_call
     from .hooks.session_hooks import on_session_end
     from .hooks.tool_hooks import pre_tool_call
+    from .tools.evidence_tool import OMH_EVIDENCE_SCHEMA, omh_evidence_handler
     from .tools.hud_tool import OMH_HUD_SCHEMA, omh_hud_handler
     from .tools.role_tool import OMH_ROLE_SCHEMA, omh_role_handler
     from .tools.status_tool import OMH_STATUS_SCHEMA, omh_status_handler
 
+    ctx.register_tool(
+        "omh_gather_evidence",
+        _TOOLSET,
+        OMH_EVIDENCE_SCHEMA,
+        omh_evidence_handler,
+        description=OMH_EVIDENCE_SCHEMA["description"],
+    )
     ctx.register_tool(
         "omh_hud",
         _TOOLSET,

--- a/src/plugin_bundle/omh/config.yaml
+++ b/src/plugin_bundle/omh/config.yaml
@@ -4,3 +4,22 @@ hud_preset: focused
 inject_context: true
 privacy: metadata_only
 claim_boundary: "Prepared handoffs are not execution, review, CI, merge-readiness, or merge evidence."
+evidence:
+  # Token-prefix allowlist for explicit local verification probes.
+  # These commands are run with shell=False and bounded to the requested project_root.
+  allowlist_prefixes:
+    - "omh --help"
+    - "omh doctor"
+    - "omh probe"
+    - "omh harness validate"
+    - "omh docs workflows --check"
+    - "omh release checklist"
+    - "python -m unittest"
+    - "python3 -m unittest"
+    - "python -m compileall"
+    - "python3 -m compileall"
+    - "uv run python -m unittest"
+    - "uv run python -m compileall"
+    - "uv run python -m src.cli docs workflows --check"
+    - "uv run python -m src.cli harness validate"
+    - "git diff --check"

--- a/src/plugin_bundle/omh/plugin.yaml
+++ b/src/plugin_bundle/omh/plugin.yaml
@@ -1,8 +1,9 @@
 name: omh
 version: "1.0.0"
-description: "Oh My Hermes native bridge for metadata-only runtime status, HUD, role context, and evidence-boundary context."
+description: "Oh My Hermes native bridge for metadata-only runtime status, HUD, role context, bounded evidence probes, and evidence-boundary context."
 author: oh-my-hermes maintainers
 provides_tools:
+  - omh_gather_evidence
   - omh_hud
   - omh_role
   - omh_status

--- a/src/plugin_bundle/omh/runtime_reader.py
+++ b/src/plugin_bundle/omh/runtime_reader.py
@@ -8,7 +8,7 @@ from typing import Any
 STATUS_SCHEMA_VERSION = "omh_status/v1"
 HUD_SCHEMA_VERSION = "omh_hud/v1"
 HUD_PRESETS = {"minimal", "focused", "full"}
-HUD_REQUIRED_TOOLS = ("omh_hud", "omh_role", "omh_status")
+HUD_REQUIRED_TOOLS = ("omh_gather_evidence", "omh_hud", "omh_role", "omh_status")
 HUD_REQUIRED_HOOKS = ("on_session_end", "pre_llm_call", "pre_tool_call")
 
 
@@ -174,6 +174,7 @@ def _plugin_capabilities(plugin_dir: Path, last_distribution: dict[str, Any]) ->
     files = {
         "plugin_yaml": (plugin_dir / "plugin.yaml").is_file(),
         "init_py": (plugin_dir / "__init__.py").is_file(),
+        "evidence_tool": (plugin_dir / "tools" / "evidence_tool.py").is_file(),
         "hud_tool": (plugin_dir / "tools" / "hud_tool.py").is_file(),
         "role_tool": (plugin_dir / "tools" / "role_tool.py").is_file(),
         "status_tool": (plugin_dir / "tools" / "status_tool.py").is_file(),
@@ -190,6 +191,7 @@ def _plugin_capabilities(plugin_dir: Path, last_distribution: dict[str, Any]) ->
     return {
         "files": files,
         "tools": {
+            "omh_gather_evidence": files["evidence_tool"] and "omh_gather_evidence" in tool_sources,
             "omh_hud": files["hud_tool"] and "omh_hud" in tool_sources,
             "omh_role": files["role_tool"] and files["role_catalog"] and "omh_role" in tool_sources,
             "omh_status": files["status_tool"] and "omh_status" in tool_sources,

--- a/src/plugin_bundle/omh/tools/evidence_tool.py
+++ b/src/plugin_bundle/omh/tools/evidence_tool.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+import os
+from pathlib import Path
+import re
+import shlex
+import subprocess
+from typing import Any
+
+OMH_EVIDENCE_SCHEMA = {
+    "name": "omh_gather_evidence",
+    "description": (
+        "Run bounded allowlisted local verification probes and return structured evidence. "
+        "This is explicit verification evidence only, not executor dispatch or coding execution."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "commands": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Commands to run. Each command must match an allowlisted token prefix.",
+            },
+            "project_root": {
+                "type": "string",
+                "description": "Root directory that bounds workdir. Defaults to the current working directory.",
+            },
+            "workdir": {
+                "type": "string",
+                "description": "Working directory for commands. Must stay inside project_root.",
+            },
+            "timeout": {
+                "type": "integer",
+                "description": "Per-command timeout in seconds. Default 60, capped at 180.",
+            },
+            "truncate": {
+                "type": "integer",
+                "description": "Maximum output characters per command. Keeps the tail. Default 4000, capped at 20000.",
+            },
+        },
+        "required": ["commands"],
+    },
+}
+
+SCHEMA_VERSION = "omh_evidence_probe/v1"
+_MAX_COMMANDS = 8
+_MAX_TIMEOUT_SECONDS = 180
+_MAX_TRUNCATE_CHARS = 20_000
+_DEFAULT_TIMEOUT_SECONDS = 60
+_DEFAULT_TRUNCATE_CHARS = 4_000
+_SHELL_METACHAR_RE = re.compile(r"[\n\r;&|`$<>(){}]")
+_DEFAULT_ALLOWLIST = (
+    "omh --help",
+    "omh doctor",
+    "omh probe",
+    "omh harness validate",
+    "omh docs workflows --check",
+    "omh release checklist",
+    "python -m unittest",
+    "python3 -m unittest",
+    "python -m compileall",
+    "python3 -m compileall",
+    "uv run python -m unittest",
+    "uv run python -m compileall",
+    "uv run python -m src.cli docs workflows --check",
+    "uv run python -m src.cli harness validate",
+    "git diff --check",
+)
+
+
+def omh_evidence_handler(args: dict, **kwargs) -> str:
+    commands = args.get("commands", [])
+    if not isinstance(commands, list) or not commands:
+        return _json({"error": "commands must be a non-empty list"})
+    if len(commands) > _MAX_COMMANDS:
+        return _json({"error": f"too many commands: {len(commands)} > {_MAX_COMMANDS}"})
+
+    project_root = _project_root(args, kwargs)
+    if not project_root.is_dir():
+        return _json({"error": "project_root must be an existing directory", "project_root": str(project_root)})
+    workdir = _workdir(args, project_root)
+    if isinstance(workdir, dict):
+        return _json(workdir)
+
+    timeout = min(_positive_int(args.get("timeout"), _DEFAULT_TIMEOUT_SECONDS), _MAX_TIMEOUT_SECONDS)
+    truncate = min(_positive_int(args.get("truncate"), _DEFAULT_TRUNCATE_CHARS), _MAX_TRUNCATE_CHARS)
+    allowlist = _allowlist()
+    parsed: list[tuple[str, list[str]]] = []
+    rejected = []
+    for command in commands:
+        command_text = str(command or "").strip()
+        if not command_text:
+            rejected.append({"command": command_text, "reason": "empty command"})
+            continue
+        if _SHELL_METACHAR_RE.search(command_text):
+            rejected.append({"command": command_text, "reason": "shell metacharacters are not allowed"})
+            continue
+        try:
+            tokens = shlex.split(command_text)
+        except ValueError as exc:
+            rejected.append({"command": command_text, "reason": f"parse failed: {exc}"})
+            continue
+        if not _matches_allowlist(tokens, allowlist):
+            rejected.append({"command": command_text, "reason": "command not in allowlist"})
+            continue
+        parsed.append((command_text, tokens))
+
+    results = [_rejected_result(item["command"], item["reason"]) for item in rejected]
+    for command_text, tokens in parsed:
+        results.append(_run_command(command_text, tokens, workdir=workdir, timeout=timeout, truncate=truncate))
+
+    passed_count = sum(1 for result in results if result.get("passed"))
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "observed_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "project_root": str(project_root),
+        "workdir": str(workdir),
+        "allowlist": list(allowlist),
+        "results": results,
+        "all_pass": bool(results) and passed_count == len(results),
+        "summary": f"{passed_count}/{len(results)} passed",
+        "privacy": "command_output_truncated",
+        "claim_boundary": (
+            "This is explicit local verification evidence only. It is not executor dispatch, "
+            "implementation, review, CI, merge, or Hermes runtime-load evidence."
+        ),
+    }
+    return _json(payload)
+
+
+def _project_root(args: dict, kwargs: dict) -> Path:
+    value = str(args.get("project_root") or kwargs.get("project_root") or os.getcwd())
+    return Path(os.path.expandvars(value)).expanduser().resolve()
+
+
+def _workdir(args: dict, project_root: Path) -> Path | dict[str, str]:
+    value = str(args.get("workdir") or project_root)
+    workdir = Path(os.path.expandvars(value)).expanduser().resolve()
+    try:
+        workdir.relative_to(project_root)
+    except ValueError:
+        return {"error": "workdir must stay within project_root", "workdir": str(workdir), "project_root": str(project_root)}
+    if not workdir.is_dir():
+        return {"error": "workdir must be an existing directory", "workdir": str(workdir)}
+    return workdir
+
+
+def _positive_int(value: Any, default: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default
+
+
+def _allowlist() -> tuple[str, ...]:
+    configured = _read_config_allowlist(Path(__file__).resolve().parents[1] / "config.yaml")
+    return tuple(configured or _DEFAULT_ALLOWLIST)
+
+
+def _read_config_allowlist(path: Path) -> list[str]:
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return []
+    values: list[str] = []
+    in_evidence = False
+    in_allowlist = False
+    for raw_line in lines:
+        line = raw_line.split("#", 1)[0].rstrip()
+        stripped = line.strip()
+        if not stripped:
+            continue
+        indent = len(line) - len(line.lstrip(" "))
+        if indent == 0:
+            in_evidence = stripped == "evidence:"
+            in_allowlist = False
+            continue
+        if in_evidence and indent == 2:
+            in_allowlist = stripped == "allowlist_prefixes:"
+            continue
+        if in_evidence and in_allowlist and indent >= 4 and stripped.startswith("- "):
+            values.append(_unquote(stripped[2:].strip()))
+    return values
+
+
+def _unquote(value: str) -> str:
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        return value[1:-1]
+    return value
+
+
+def _matches_allowlist(tokens: list[str], allowlist: tuple[str, ...]) -> bool:
+    for prefix in allowlist:
+        prefix_tokens = prefix.split()
+        if prefix_tokens and tokens[: len(prefix_tokens)] == prefix_tokens:
+            return True
+    return False
+
+
+def _run_command(command_text: str, tokens: list[str], *, workdir: Path, timeout: int, truncate: int) -> dict[str, object]:
+    try:
+        proc = subprocess.run(
+            tokens,
+            cwd=str(workdir),
+            shell=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except FileNotFoundError:
+        return _rejected_result(command_text, f"command not found: {tokens[0] if tokens else command_text}")
+    except subprocess.TimeoutExpired:
+        return _rejected_result(command_text, f"timeout after {timeout}s")
+    output = (proc.stdout or "") + (proc.stderr or "")
+    truncated = len(output) > truncate
+    return {
+        "command": command_text,
+        "exit_code": proc.returncode,
+        "output_tail": output[-truncate:] if truncated else output,
+        "truncated": truncated,
+        "passed": proc.returncode == 0,
+        "evidence_type": "observed_local_command",
+    }
+
+
+def _rejected_result(command: str, reason: str) -> dict[str, object]:
+    return {
+        "command": command,
+        "exit_code": -1,
+        "output_tail": reason,
+        "truncated": False,
+        "passed": False,
+        "evidence_type": "rejected",
+    }
+
+
+def _json(payload: dict[str, object]) -> str:
+    return json.dumps(payload, sort_keys=True)

--- a/src/plugin_pack.py
+++ b/src/plugin_pack.py
@@ -264,7 +264,7 @@ def _register_smoke(plugin_dir: Path) -> dict[str, Any]:
         if not callable(register):
             return {"import_smoke": True, "register_smoke": False, "error": "register(ctx) is missing"}
         register(ctx)
-        required_tools = {"omh_hud", "omh_role", "omh_status"}
+        required_tools = {"omh_gather_evidence", "omh_hud", "omh_role", "omh_status"}
         required_hooks = {"on_session_end", "pre_llm_call", "pre_tool_call"}
         return {
             "import_smoke": True,

--- a/tests/test_plugin_distribution.py
+++ b/tests/test_plugin_distribution.py
@@ -98,7 +98,7 @@ class PluginDistributionTests(unittest.TestCase):
             self.assertTrue(plugin["requires_hermes_plugin_enable"])
             self.assertTrue((plugin_dir / "plugin.yaml").exists())
             self.assertTrue((plugin_dir / ".omh-plugin-manifest.json").exists())
-            self.assertEqual(plugin["registered_tools"], ["omh_hud", "omh_role", "omh_status"])
+            self.assertEqual(plugin["registered_tools"], ["omh_gather_evidence", "omh_hud", "omh_role", "omh_status"])
             self.assertEqual(plugin["registered_hooks"], ["on_session_end", "pre_llm_call", "pre_tool_call"])
 
             inspection = inspect_plugin_bundle(resolve_paths(omh_home, hermes_home))
@@ -185,6 +185,7 @@ class PluginDistributionTests(unittest.TestCase):
             module = load_installed_plugin(hermes_home / "plugins" / "omh")
             ctx = FakeHermesContext()
             module.register(ctx)
+            self.assertIn("omh_gather_evidence", ctx.tools)
             self.assertIn("omh_hud", ctx.tools)
             self.assertIn("omh_role", ctx.tools)
             self.assertIn("omh_status", ctx.tools)
@@ -206,6 +207,49 @@ class PluginDistributionTests(unittest.TestCase):
             self.assertTrue(payload["runs"][0]["prepared_handoff"])
             self.assertFalse(payload["runs"][0]["execution_observed"])
             self.assertIn("not execution evidence", payload["evidence_boundary"]["prepared_handoff"])
+
+            evidence_handler = ctx.tools["omh_gather_evidence"]["args"][2]
+            evidence = json.loads(
+                evidence_handler(
+                    {
+                        "commands": ["python3 -m compileall -q ."],
+                        "project_root": str(root),
+                        "workdir": str(root),
+                        "timeout": 30,
+                        "truncate": 1000,
+                    }
+                )
+            )
+            self.assertEqual(evidence["schema_version"], "omh_evidence_probe/v1")
+            self.assertTrue(evidence["all_pass"])
+            self.assertEqual(evidence["results"][0]["evidence_type"], "observed_local_command")
+            self.assertIn("not executor dispatch", evidence["claim_boundary"])
+
+            rejected = json.loads(
+                evidence_handler(
+                    {
+                        "commands": ["python3 -m compileall -q .; echo bad"],
+                        "project_root": str(root),
+                        "workdir": str(root),
+                    }
+                )
+            )
+            self.assertFalse(rejected["all_pass"])
+            self.assertEqual(rejected["results"][0]["evidence_type"], "rejected")
+            self.assertIn("shell metacharacters", rejected["results"][0]["output_tail"])
+
+            bounded_root = root / "inside"
+            bounded_root.mkdir()
+            outside_workdir = json.loads(
+                evidence_handler(
+                    {
+                        "commands": ["python3 -m compileall -q ."],
+                        "project_root": str(bounded_root),
+                        "workdir": str(root),
+                    }
+                )
+            )
+            self.assertIn("workdir must stay within project_root", outside_workdir["error"])
 
             role_handler = ctx.tools["omh_role"]["args"][2]
             roles = json.loads(role_handler({"action": "list"}))


### PR DESCRIPTION
## Feature Report

### What Changed

- Added a bounded Hermes plugin tool, `omh_gather_evidence`, to the OMH plugin bundle.
- Registered the new tool alongside `omh_hud`, `omh_role`, and `omh_status` during plugin import/register smoke checks.
- Updated plugin metadata, config, docs, and parity reporting so the evidence probe is visible as an available OMH capability.
- Added plugin distribution tests for successful local probes, rejected shell metacharacters, and project-root workdir boundaries.

### Why This Exists

OMH already had a Hermes-native skill and plugin bridge, HUD/status tools, role context, and prepared-vs-observed state contracts. The remaining plugin gap was a way for Hermes to gather basic local verification evidence without turning OMH into an arbitrary command runner or claiming hidden executor activity.

### User / Operator Impact

- Hermes/plugin hosts can call `omh_gather_evidence` for explicit local verification checks such as OMH doctor, harness validation, docs workflow checks, unittest, compileall, and whitespace checks.
- Operators get structured pass/fail output and truncated command tails instead of manually pasting terminal logs.
- The tool keeps claim boundaries clear: local command evidence is not executor dispatch, implementation, review, CI, merge, or live Hermes plugin-load evidence.

### How It Works

- `src/plugin_bundle/omh/tools/evidence_tool.py` parses requested commands with `shlex`, rejects shell metacharacters, matches token prefixes against `config.yaml`, and runs commands with `subprocess.run(..., shell=False)`.
- `project_root` bounds `workdir`, timeout/truncation are capped, and results return `omh_evidence_probe/v1` JSON.
- Plugin package smoke checks now require `omh_gather_evidence`, and parity reports the capability as available with conservative caveats.

### Files And Contracts Touched

- `src/plugin_bundle/omh/tools/evidence_tool.py`: new bounded evidence probe contract.
- `src/plugin_bundle/omh/plugin.yaml`, `config.yaml`, `__init__.py`, `runtime_reader.py`: plugin metadata, registration, readiness, and allowlist.
- `src/plugin_pack.py`: register smoke requires the evidence tool.
- `src/parity.py`, `docs/PARITY.md`: parity matrix updated for bounded evidence probes.
- `README.md`, `docs/ARCHITECTURE.md`, `docs/INSTALLATION.md`: public plugin bridge documentation.
- `tests/test_plugin_distribution.py`: success, rejection, and boundary coverage.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_plugin_distribution.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `PYTHONPATH=tests uv run python -m src.cli docs workflows --check`
- [x] `PYTHONPATH=tests uv run python -m src.cli harness validate`
- [x] `PYTHONPATH=tests uv run python -m src.cli probe --parity --json`
- [x] `uv build --out-dir /tmp/omh-build-check`
- [x] `git diff --check`
- [ ] `python3 -m omh.cli release checklist --json` — not run; this PR does not change release channel logic.
- [ ] `python3 -m omh.cli release hermes-smoke` — not run; this PR does not mutate the live Hermes profile.
- [ ] `omh --help` — not run; local repo validation used `uv run python -m src.cli` surfaces.
- [ ] Manual Hermes/TUI check — not run; live host plugin-load remains explicitly unobserved.

## Risk

- The allowlist may need expansion as real operators adopt additional local verification commands.
- A plugin host still needs to load the plugin before this becomes live Hermes runtime evidence; local install/import/register smoke is not enough.

## Compatibility / Rollout

- Backward compatible for existing setup and plugin use.
- The new command runner is intentionally narrow, allowlisted, shell-free, and project-root bounded.
- No new dependency, network call, transport bot, hidden executor dispatch, or Hermes core patch is introduced.

## Release / Claims

- [x] Release-channel impact considered: local/plugin bridge capability only.
- [x] Runtime/native capability claims are backed by local import/register/tool tests or marked as not observed.
- [x] Known manual Hermes checks are listed: live plugin-load evidence remains a future smoke/check surface.

## Follow-Up

- Add host-observed Hermes plugin-load smoke evidence when a stable live Hermes plugin-load signal is available.
- Consider additional allowlisted verifier commands only when tied to clear operator workflows and tests.
