### PR TITLE
Add deterministic multilingual routing hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes/main/install.sh
 omh setup --language ko
 ```
 
+Setup language controls terminal copy only. Chat routing also has deterministic
+phrase packs for common Japanese, Chinese, Spanish, French, and German operator
+requests such as payment failures, risky refactors, safe feature work, and
+issue-to-PR preparation. OMH does not call a translation API; unsupported
+phrasing falls back to the normal clarify or planning path.
+
 The installer normally runs setup for you. Keep `omh setup` in the quick start
 because it is the repeatable repair step that installs generated skills under
 `~/.omh/skills` and registers them with Hermes through `skills.external_dirs`.
@@ -140,7 +146,8 @@ so OMH can display and record `main@old -> main@new` instead of only `main`.
   <img src="assets/omh-flagship-workflows-poster.png" alt="OMH flagship command sets poster" width="920">
 </p>
 
-- **Natural-language first** - users in chat do not need to know `omh` commands.
+- **Natural-language first** - users in chat do not need to know `omh` commands,
+  and common non-English operator requests get deterministic routing hints.
 - **Install-first, not dashboard-first** - get Hermes-visible skills without
   adopting a separate dashboard or app.
 - **Hermes-native boundary** - OMH extends Hermes Agent with skills,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -99,6 +99,7 @@ src/
   roles.py                   # compatibility adapter to catalogs/roles.py
   routing/
     chat.py
+    localization.py
     policy.py
     recommend.py
   runtime_artifacts.py        # compatibility adapter to runtime/artifacts.py
@@ -177,6 +178,10 @@ as setup evidence rather than runtime execution proof.
 `routing/chat.py` owns deterministic pre-dispatch routing decisions for chat
 wrappers. It consumes plain messages or platform-shaped event payloads and
 returns `dispatch`, `clarify`, or `fallback` decisions from local catalog data.
+`routing/localization.py` owns deterministic locale phrase expansion for common
+non-English operator requests. It preserves the raw message, adds only canonical
+scoring hints, and makes locale-match metadata available to scored
+recommendations without calling translation services.
 `routing/policy.py` owns shared confidence and ambiguity policy, and
 `routing/recommend.py` owns local catalog recommendation scoring.
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -200,6 +200,14 @@ curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes/main/install.sh
 omh setup --language ko
 ```
 
+Installer localization is separate from routing localization. Backend routing
+surfaces such as `omh recommend`, `omh playbook recommend`, and
+`omh chat interact` use a deterministic local phrase layer for tested Japanese,
+Chinese, Spanish, French, and German operator requests. The layer expands known
+phrases into canonical routing signals, includes `locale:<code>:<label>` in the
+matched evidence for scored recommendations, and never calls external
+translation services.
+
 From the user's point of view, the intended final state matches the Hermes tap
 path: Hermes can discover OMH skills and the user talks to Hermes. `omh setup`
 is the bootstrap/maintenance route that produces that state through generated
@@ -486,6 +494,12 @@ Before calling the bot integration ready, verify these points:
 - `omh chat interact --source discord "<message>"` or
   `omh chat interact --source slack "<message>"` returns a
   `chat_interaction/v1` envelope with a renderable `chat_response/v1`.
+- Common non-English requests should preserve the user's original text while
+  routing through deterministic locale hints when a tested phrase matches. For
+  example, Japanese or Chinese payment-failure reports route to
+  `feedback-triage`, French safe-feature requests route to a plan surface, and
+  Spanish issue-to-PR requests route to a request-to-handoff playbook without
+  claiming machine translation happened.
 - The rendered `chat_response` does not expose `omh`, argv arrays, or shell
   command text to the end user.
 - Clarification and fallback interactions do not expose `send_to_executor` or

--- a/src/catalogs/playbooks.py
+++ b/src/catalogs/playbooks.py
@@ -1,16 +1,23 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-import re
+
+from ..routing.localization import normalized_phrase, prepare_routing_text, routing_terms, routing_tokens
 
 
 PLAYBOOK_CATALOG_SCHEMA_VERSION = "playbook_catalog/v1"
 PLAYBOOK_RECOMMENDATION_SCHEMA_VERSION = "playbook_recommendation/v1"
-_TOKEN_RE = re.compile(r"[a-z0-9가-힣][a-z0-9가-힣-]*")
 _STOPWORDS = {
     "the",
     "and",
+    "are",
+    "as",
     "for",
+    "in",
+    "is",
+    "of",
+    "or",
+    "to",
     "with",
     "that",
     "this",
@@ -1655,7 +1662,11 @@ def recommend_playbooks(query: str, *, limit: int = 3) -> dict[str, object]:
     task = query.strip()
     if not task:
         raise ValueError("playbook recommend requires a task description")
-    scored = [_score_playbook(playbook, task) for playbook in _PLAYBOOKS]
+    routing_text = prepare_routing_text(task)
+    scored = [
+        _score_playbook(playbook, routing_text.scoring_text, routing_text.locale_matches)
+        for playbook in _PLAYBOOKS
+    ]
     scored.sort(key=lambda item: (-int(item["score"]), str(item["id"])))
     matches = [item for item in scored if int(item["score"]) > 0] or [_fallback_playbook(task)]
     return {
@@ -1672,7 +1683,7 @@ def _playbook_by_id(playbook_id: str) -> Playbook:
     raise KeyError(playbook_id)
 
 
-def _score_playbook(playbook: Playbook, query: str) -> dict[str, object]:
+def _score_playbook(playbook: Playbook, query: str, locale_matches: tuple[str, ...] = ()) -> dict[str, object]:
     query_tokens = _tokens(query)
     query_terms = _terms(query)
     score = 0
@@ -1703,6 +1714,9 @@ def _score_playbook(playbook: Playbook, query: str) -> dict[str, object]:
         if not playbook.delegated_to_executor:
             score += 2
             matched.add("boundary:hermes")
+
+    if score > 0:
+        matched.update(f"locale:{match}" for match in locale_matches)
 
     return _recommendation_payload(playbook, score=score, matched=tuple(sorted(matched)))
 
@@ -1737,24 +1751,15 @@ def _recommendation_payload(playbook: Playbook, *, score: int, matched: tuple[st
 
 
 def _tokens(value: str) -> set[str]:
-    tokens: set[str] = set()
-    for raw_token in _terms(value):
-        for token in (raw_token, *raw_token.split("-")):
-            if len(token) >= 3 and token not in _STOPWORDS:
-                tokens.add(token)
-    return tokens
+    return routing_tokens(value, stopwords=_STOPWORDS)
 
 
 def _terms(value: str) -> set[str]:
-    terms: set[str] = set()
-    for raw_token in _TOKEN_RE.findall(value.lower()):
-        terms.add(raw_token)
-        terms.update(raw_token.split("-"))
-    return terms
+    return routing_terms(value)
 
 
 def _matches_term(term: str, query_terms: set[str]) -> bool:
-    term_tokens = tuple(_terms(term))
+    term_tokens = tuple(_terms(normalized_phrase(term)))
     if not term_tokens:
         return False
     return all(token in query_terms for token in term_tokens)

--- a/src/routing/localization.py
+++ b/src/routing/localization.py
@@ -1,0 +1,285 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+import unicodedata
+
+
+_TOKEN_RE = re.compile(r"[^\W_][^\W_'-]*(?:-[^\W_][^\W_'-]*)?", re.UNICODE)
+_STOPWORDS = {
+    "the",
+    "and",
+    "are",
+    "as",
+    "for",
+    "in",
+    "is",
+    "of",
+    "or",
+    "to",
+    "with",
+    "that",
+    "this",
+    "when",
+    "use",
+    "user",
+    "task",
+    "request",
+    "workflow",
+    "skill",
+    "agent",
+    "hermes",
+}
+_CANONICAL_PAYMENT_FAILURE = (
+    "payment failure payment failure issue payment failure feedback "
+    "customer feedback feedback triage bug reports reproduce"
+)
+_CANONICAL_RISKY_REFACTOR = (
+    "dangerous refactor risky refactor unsafe refactor reviewed plan consensus planning acceptance criteria"
+)
+_CANONICAL_SAFE_FEATURE = "safely add a feature to this repo feature add safe plan"
+_CANONICAL_ISSUE_TO_PR = "issue to pr pr-ready issue plan acceptance criteria coding handoff request-to-handoff"
+
+
+@dataclass(frozen=True)
+class LocaleAlias:
+    locale: str
+    label: str
+    phrases: tuple[str, ...]
+    canonical: str
+
+
+@dataclass(frozen=True)
+class RoutingText:
+    original: str
+    scoring_text: str
+    locale_matches: tuple[str, ...]
+
+
+_ALIASES: tuple[LocaleAlias, ...] = (
+    LocaleAlias(
+        "ja",
+        "payment_failure",
+        (
+            "支払い失敗",
+            "支払いエラー",
+            "支払いの失敗",
+            "決済失敗",
+            "決済エラー",
+            "決済の失敗",
+        ),
+        _CANONICAL_PAYMENT_FAILURE,
+    ),
+    LocaleAlias(
+        "zh",
+        "payment_failure",
+        (
+            "支付失败",
+            "支付失敗",
+            "付款失败",
+            "付款失敗",
+            "支付错误",
+            "支付錯誤",
+            "支付故障",
+        ),
+        _CANONICAL_PAYMENT_FAILURE,
+    ),
+    LocaleAlias(
+        "es",
+        "payment_failure",
+        ("fallo de pago", "fallos de pago", "problema de pago", "pagos fallan", "error de pago"),
+        _CANONICAL_PAYMENT_FAILURE,
+    ),
+    LocaleAlias(
+        "fr",
+        "payment_failure",
+        (
+            "échec de paiement",
+            "echec de paiement",
+            "problème de paiement",
+            "paiement échoue",
+            "erreur de paiement",
+        ),
+        _CANONICAL_PAYMENT_FAILURE,
+    ),
+    LocaleAlias(
+        "de",
+        "payment_failure",
+        ("zahlungsfehler", "zahlung fehlgeschlagen", "problem mit der zahlung", "zahlungsausfall"),
+        _CANONICAL_PAYMENT_FAILURE,
+    ),
+    LocaleAlias(
+        "ja",
+        "risky_refactor",
+        (
+            "危険なリファクタリング",
+            "危ないリファクタリング",
+            "リファクタリングが危険",
+            "リファクタリングは危険",
+        ),
+        _CANONICAL_RISKY_REFACTOR,
+    ),
+    LocaleAlias(
+        "zh",
+        "risky_refactor",
+        (
+            "危险的重构",
+            "危險的重構",
+            "重构风险",
+            "重構風險",
+            "这个重构很危险",
+            "這個重構很危險",
+        ),
+        _CANONICAL_RISKY_REFACTOR,
+    ),
+    LocaleAlias(
+        "es",
+        "risky_refactor",
+        ("refactorización peligrosa", "refactorizacion peligrosa", "refactorización riesgosa", "refactor inseguro"),
+        _CANONICAL_RISKY_REFACTOR,
+    ),
+    LocaleAlias(
+        "fr",
+        "risky_refactor",
+        ("refactorisation risquée", "refactorisation risquee", "refactorisation dangereuse"),
+        _CANONICAL_RISKY_REFACTOR,
+    ),
+    LocaleAlias(
+        "de",
+        "risky_refactor",
+        ("riskantes refactoring", "gefährliches refactoring", "gefaehrliches refactoring", "riskante refaktorierung"),
+        _CANONICAL_RISKY_REFACTOR,
+    ),
+    LocaleAlias(
+        "ja",
+        "safe_feature",
+        (
+            "機能を安全に追加",
+            "安全に機能追加",
+            "機能追加を安全に",
+        ),
+        _CANONICAL_SAFE_FEATURE,
+    ),
+    LocaleAlias(
+        "zh",
+        "safe_feature",
+        (
+            "安全地添加功能",
+            "安全地新增功能",
+            "安全地给这个仓库添加功能",
+            "安全地給這個倉庫新增功能",
+        ),
+        _CANONICAL_SAFE_FEATURE,
+    ),
+    LocaleAlias(
+        "es",
+        "safe_feature",
+        (
+            "añadir una función de forma segura",
+            "anadir una funcion de forma segura",
+            "agregar una función de forma segura",
+            "agregar una funcion de forma segura",
+            "añadir una característica de forma segura",
+            "anadir una caracteristica de forma segura",
+        ),
+        _CANONICAL_SAFE_FEATURE,
+    ),
+    LocaleAlias(
+        "fr",
+        "safe_feature",
+        (
+            "ajouter une fonctionnalité en toute sécurité",
+            "ajouter une fonctionnalite en toute securite",
+            "fonctionnalité en toute sécurité",
+            "fonctionnalite en toute securite",
+        ),
+        _CANONICAL_SAFE_FEATURE,
+    ),
+    LocaleAlias(
+        "de",
+        "safe_feature",
+        ("sicher eine funktion hinzufügen", "sicher eine funktion hinzufuegen"),
+        _CANONICAL_SAFE_FEATURE,
+    ),
+    LocaleAlias(
+        "ja",
+        "issue_to_pr",
+        ("issueをpr", "issueからpr", "イシューをpr", "prにできるよう", "プルリクにできるよう"),
+        _CANONICAL_ISSUE_TO_PR,
+    ),
+    LocaleAlias(
+        "zh",
+        "issue_to_pr",
+        (
+            "issue 变成 pr",
+            "issue 變成 pr",
+            "把这个 issue 整理成 pr",
+            "把這個 issue 整理成 pr",
+            "转成 pr",
+            "轉成 pr",
+        ),
+        _CANONICAL_ISSUE_TO_PR,
+    ),
+    LocaleAlias(
+        "es",
+        "issue_to_pr",
+        ("convertir este issue en un pr", "convertir este issue a pr", "preparar este issue para un pr"),
+        _CANONICAL_ISSUE_TO_PR,
+    ),
+    LocaleAlias(
+        "fr",
+        "issue_to_pr",
+        ("transformer cette issue en pr", "préparer cette issue pour une pr", "preparer cette issue pour une pr"),
+        _CANONICAL_ISSUE_TO_PR,
+    ),
+    LocaleAlias(
+        "de",
+        "issue_to_pr",
+        ("issue in einen pr", "dieses issue für einen pr vorbereiten", "dieses issue fuer einen pr vorbereiten"),
+        _CANONICAL_ISSUE_TO_PR,
+    ),
+)
+
+
+def prepare_routing_text(value: str) -> RoutingText:
+    original = value.strip()
+    folded = _fold_for_match(original)
+    additions: list[str] = []
+    matches: list[str] = []
+    for alias in _ALIASES:
+        if any(_fold_for_match(phrase) in folded for phrase in alias.phrases):
+            additions.append(alias.canonical)
+            matches.append(f"{alias.locale}:{alias.label}")
+    scoring_text = " ".join((original, *additions)).strip()
+    return RoutingText(original=original, scoring_text=scoring_text, locale_matches=tuple(sorted(set(matches))))
+
+
+def routing_tokens(value: str, *, stopwords: set[str] | None = None) -> set[str]:
+    stopwords = _STOPWORDS if stopwords is None else stopwords
+    tokens: set[str] = set()
+    for raw_token in routing_terms(value):
+        for token in (raw_token, *raw_token.split("-")):
+            if len(token) >= 3 and token not in stopwords:
+                tokens.add(token)
+    return tokens
+
+
+def routing_terms(value: str) -> set[str]:
+    folded = _fold_for_match(value)
+    terms: set[str] = set()
+    for raw_token in _TOKEN_RE.findall(folded):
+        token = raw_token.strip("-")
+        if token:
+            terms.add(token)
+            terms.update(part for part in token.split("-") if part)
+    return terms
+
+
+def normalized_phrase(value: str) -> str:
+    return _fold_for_match(value)
+
+
+def _fold_for_match(value: str) -> str:
+    normalized = unicodedata.normalize("NFKC", value).casefold()
+    decomposed = unicodedata.normalize("NFKD", normalized)
+    return "".join(char for char in decomposed if not unicodedata.combining(char))

--- a/src/routing/recommend.py
+++ b/src/routing/recommend.py
@@ -1,16 +1,22 @@
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass
-import re
 
 from ..skills.catalog import SkillDefinition, builtin_definitions
+from .localization import normalized_phrase, prepare_routing_text, routing_tokens
 
 
-_TOKEN_RE = re.compile(r"[a-z0-9가-힣][a-z0-9가-힣-]*")
 _STOPWORDS = {
     "the",
     "and",
+    "are",
+    "as",
     "for",
+    "in",
+    "is",
+    "of",
+    "or",
+    "to",
     "with",
     "that",
     "this",
@@ -220,10 +226,14 @@ def recommend_skills(query: str, *, limit: int = 5) -> list[dict[str, object]]:
     if limit < 1:
         raise ValueError("recommend --limit must be at least 1")
 
-    normalized_query = query.strip().lower()
+    routing_text = prepare_routing_text(query)
+    normalized_query = normalized_phrase(routing_text.scoring_text)
     query_tokens = _tokens(normalized_query)
     definitions = list(builtin_definitions())
-    scored = [_score_definition(definition, normalized_query, query_tokens, query) for definition in definitions]
+    scored = [
+        _score_definition(definition, normalized_query, query_tokens, query, routing_text.locale_matches)
+        for definition in definitions
+    ]
     matches = [recommendation for recommendation in scored if recommendation.score > 0]
     if not matches:
         matches = _fallback_recommendations(definitions, query)
@@ -237,33 +247,34 @@ def _score_definition(
     normalized_query: str,
     query_tokens: set[str],
     original_query: str,
+    locale_matches: tuple[str, ...],
 ) -> Recommendation:
     score = 0
     matched: set[str] = set()
 
     for trigger in definition.triggers:
-        trigger_normalized = trigger.lower()
+        trigger_normalized = normalized_phrase(trigger)
         if _phrase_match(normalized_query, trigger_normalized):
             score += 6
             matched.add(f"trigger:{trigger_normalized}")
 
-    name_normalized = definition.name.lower()
+    name_normalized = normalized_phrase(definition.name)
     if _phrase_match(normalized_query, name_normalized):
         score += 5
         matched.add(f"name:{name_normalized}")
 
-    description_normalized = definition.description.lower()
+    description_normalized = normalized_phrase(definition.description)
     if _phrase_match(normalized_query, description_normalized):
         score += 3
         matched.add("description:phrase")
 
-    use_when_normalized = definition.use_when.lower()
+    use_when_normalized = normalized_phrase(definition.use_when)
     if _phrase_match(normalized_query, use_when_normalized):
         score += 3
         matched.add("use_when:phrase")
 
     for field_name, value in (("category", definition.category), ("phase", definition.phase)):
-        normalized_value = value.lower()
+        normalized_value = normalized_phrase(value)
         if _phrase_match(normalized_query, normalized_value):
             score += 2
             matched.add(f"{field_name}:{normalized_value}")
@@ -277,6 +288,9 @@ def _score_definition(
     for token in sorted(query_tokens & metadata_tokens):
         score += 1
         matched.add(f"metadata:{token}")
+
+    if score > 0:
+        matched.update(f"locale:{match}" for match in locale_matches)
 
     matched_tuple = tuple(sorted(matched))
     return Recommendation(
@@ -326,12 +340,7 @@ def _fallback_recommendations(definitions: list[SkillDefinition], query: str) ->
 
 
 def _tokens(value: str) -> set[str]:
-    tokens: set[str] = set()
-    for raw_token in _TOKEN_RE.findall(value.lower()):
-        for token in (raw_token, *raw_token.split("-")):
-            if len(token) >= 3 and token not in _STOPWORDS:
-                tokens.add(token)
-    return tokens
+    return routing_tokens(value, stopwords=_STOPWORDS)
 
 
 def _phrase_match(query: str, value: str) -> bool:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1013,6 +1013,28 @@ class CliTests(unittest.TestCase):
         self.assertEqual(recommendations[0]["next_action"], "triage_feedback")
         self.assertIn("Feedback triage", recommendations[0]["evidence_boundary"])
 
+    def test_recommend_multilingual_signals_route_without_external_translation(self) -> None:
+        cases = (
+            ("支払い失敗がよく起きています", "feedback-triage", "locale:ja:payment_failure"),
+            ("支付失败问题经常出现", "feedback-triage", "locale:zh:payment_failure"),
+            ("危険なリファクタリングだと思います", "ralplan", "locale:ja:risky_refactor"),
+            ("这个重构很危险", "ralplan", "locale:zh:risky_refactor"),
+            ("Quiero convertir este issue en un PR", "plan", "locale:es:issue_to_pr"),
+            ("Je veux transformer cette issue en PR", "plan", "locale:fr:issue_to_pr"),
+            ("Ich möchte dieses Issue für einen PR vorbereiten", "plan", "locale:de:issue_to_pr"),
+        )
+
+        for message, expected_skill, locale_match in cases:
+            with self.subTest(message=message):
+                status, stdout, stderr = run_cli(["recommend", message, "--limit", "3"])
+
+                self.assertEqual(stderr, "")
+                self.assertEqual(status, 0)
+                top = json.loads(stdout)["recommendations"][0]
+                self.assertEqual(top["skill"], expected_skill)
+                self.assertIn(locale_match, top["matched"])
+                self.assertNotEqual(top["confidence"], "low")
+
     def test_recommend_dangerous_refactor_routes_to_reviewed_plan_first(self) -> None:
         cases = (
             "이거 위험한 리팩터링 같아",
@@ -1169,6 +1191,73 @@ class CliTests(unittest.TestCase):
         self.assertIn("process orchestration", top["evidence_boundary"])
         self.assertIn("prepared_not_observed", top["wrapper_guidance"])
 
+    def test_chat_interact_multilingual_feature_request_uses_plan_surface(self) -> None:
+        status, stdout, stderr = run_cli(
+            ["chat", "interact", "--source", "hermes", "Ajoute une fonctionnalité en toute sécurité à ce dépôt"]
+        )
+
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        payload = json.loads(stdout)
+        self.assertEqual(payload["mode"], "plan")
+        self.assertEqual(payload["chat_response"]["kind"], "plan")
+        self.assertEqual(payload["chat_response"]["state"]["selected_workflow"], "plan")
+        self.assertIn("Accept plan", {action["label"] for action in payload["chat_response"]["actions"]})
+
+    def test_plain_multilingual_feature_request_does_not_invent_safety_signal(self) -> None:
+        cases = (
+            "agregar una función",
+            "ajoute une fonctionnalité",
+            "新增功能",
+            "このリポジトリに機能を追加",
+        )
+
+        for message in cases:
+            with self.subTest(message=message):
+                status, stdout, stderr = run_cli(["recommend", message, "--limit", "5"])
+
+                self.assertEqual(stderr, "")
+                self.assertEqual(status, 0)
+                matched = {
+                    item
+                    for recommendation in json.loads(stdout)["recommendations"]
+                    for item in recommendation["matched"]
+                }
+                self.assertFalse(any(item.endswith(":safe_feature") for item in matched))
+                self.assertNotIn("metadata:safe", matched)
+                self.assertNotIn("metadata:safely", matched)
+                self.assertNotIn("trigger:safe", matched)
+                self.assertNotIn("trigger:safely", matched)
+
+    def test_unsupported_multilingual_text_keeps_fallback_boundary(self) -> None:
+        cases = (
+            ("今日はチームの雑談を整理して", "recommend"),
+            ("今天想整理一下团队闲聊", "playbook"),
+        )
+
+        for message, surface in cases:
+            with self.subTest(surface=surface, message=message):
+                args = ["recommend", message, "--limit", "3"]
+                if surface == "playbook":
+                    args = ["playbook", "recommend", message, "--limit", "3"]
+                status, stdout, stderr = run_cli(args)
+
+                self.assertEqual(stderr, "")
+                self.assertEqual(status, 0)
+                recommendations = json.loads(stdout)["recommendations"]
+                matched = {item for recommendation in recommendations for item in recommendation["matched"]}
+                self.assertFalse(any(item.startswith("locale:") for item in matched))
+                self.assertTrue(all(recommendation["confidence"] == "low" for recommendation in recommendations[:3]))
+
+    def test_short_tokens_do_not_drive_recommendation_scoring(self) -> None:
+        status, stdout, stderr = run_cli(["recommend", "pr ai ux", "--limit", "5"])
+
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        recommendations = json.loads(stdout)["recommendations"]
+        self.assertTrue(all(recommendation["score"] == 0 for recommendation in recommendations))
+        self.assertTrue(all(recommendation["confidence"] == "low" for recommendation in recommendations))
+
     def test_recommend_diagnose_installation_health_includes_doctor(self) -> None:
         status, stdout, stderr = run_cli(["recommend", "diagnose", "installation", "health"])
 
@@ -1283,6 +1372,24 @@ class CliTests(unittest.TestCase):
                 recommendation_ids = [item["id"] for item in json.loads(stdout)["recommendations"]]
                 self.assertEqual(recommendation_ids[0], "source-backed-research")
                 self.assertNotEqual(recommendation_ids[0], "release-readiness-review")
+
+    def test_playbook_recommend_routes_multilingual_operator_requests(self) -> None:
+        cases = (
+            ("Quiero convertir este issue en un PR", "request-to-handoff", "locale:es:issue_to_pr"),
+            ("このissueをPRにできるように整理して", "request-to-handoff", "locale:ja:issue_to_pr"),
+            ("支付失败问题经常出现", "feedback-triage", "locale:zh:payment_failure"),
+        )
+
+        for message, expected_id, locale_match in cases:
+            with self.subTest(message=message):
+                status, stdout, stderr = run_cli(["playbook", "recommend", message, "--limit", "3"])
+
+                self.assertEqual(stderr, "")
+                self.assertEqual(status, 0)
+                top = json.loads(stdout)["recommendations"][0]
+                self.assertEqual(top["id"], expected_id)
+                self.assertIn(locale_match, top["matched"])
+                self.assertNotEqual(top["confidence"], "low")
 
     def test_playbook_recommend_routes_business_workflows_without_coding_defaults(self) -> None:
         cases = (


### PR DESCRIPTION
## Feature Report

### What Changed

- Added deterministic multilingual routing hints for common non-English Hermes operator requests.
- Shared Unicode-aware normalization and phrase expansion across `omh recommend` and `omh playbook recommend`.
- Extended chat interaction coverage so tested French safe-feature wording routes to the planning surface.
- Added positive and negative routing tests for Japanese, Chinese, Spanish, French, and German examples.
- Documented the distinction between terminal setup language and routing-localization hints.

### Why This Exists

- OMH setup already supports localized terminal copy, but chat/workflow routing was mostly English/Korean-centered.
- Hermes users may talk to installed OMH workflows from Japanese, Chinese, Spanish, French, or German environments.
- The product needs a local deterministic bridge for common operator phrases without turning OMH into a translation service, LLM router, network service, or hidden executor.

### User / Operator Impact

- Japanese or Chinese payment-failure reports now route to `feedback-triage` instead of generic fallback.
- Japanese or Chinese risky-refactor wording now routes to `ralplan` first, preserving the safe planning path.
- Spanish, French, and German issue-to-PR wording now routes to planning / request-to-handoff surfaces.
- Plain feature-add wording no longer invents `safe_feature` evidence; only tested safety wording expands to safe-feature routing hints.
- Unsupported non-English phrasing falls back conservatively instead of pretending translation happened.

### How It Works

- `src/routing/localization.py` normalizes Unicode text with NFKC/casefold/accent folding, detects tested locale phrases, and appends canonical English scoring hints only for local routing.
- `recommend_skills` and `recommend_playbooks` score against the prepared routing text while preserving the original user query in public output.
- Scored recommendations include `locale:<code>:<label>` matched evidence when a locale phrase contributed to the score.
- Fallback recommendations keep empty match evidence and low confidence.

### Files And Contracts Touched

- `src/routing/localization.py`: new shared deterministic routing-localization helper.
- `src/routing/recommend.py`: skill recommendation now consumes locale-prepared scoring text.
- `src/catalogs/playbooks.py`: playbook recommendation now shares the same normalization and locale hints.
- `tests/test_cli.py`: positive multilingual routing, plain-feature negative tests, unsupported fallback tests, and short-token stability tests.
- `README.md`, `docs/INSTALLATION.md`, `docs/ARCHITECTURE.md`: conservative docs for the routing-localization boundary.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_cli.py -v` - 137 tests passed.
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_router_content.py -v` - 24 tests passed.
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` - 373 tests passed.
- [x] `uv run python -m compileall -q src tests` - passed.
- [x] `PYTHONPATH=tests uv run python -m src.cli docs workflows --check` - passed; 33 tap skills checked.
- [x] `PYTHONPATH=tests uv run python -m src.cli harness validate` - passed; 19 harnesses and 33 skills validated.
- [x] `git diff --check` - passed.
- [x] Relevant dry-run or smoke command:
  - `uv run python -m src.cli recommend "支払い失敗がよく起きています" --limit 1` - top result `feedback-triage`.
  - `uv run python -m src.cli recommend "危険なリファクタリングだと思います" --limit 1` - top result `ralplan`.
  - `uv run python -m src.cli playbook recommend "Quiero convertir este issue en un PR" --limit 1` - top result `request-to-handoff`.
  - `uv run python -m src.cli recommend "このリポジトリに機能を追加" --limit 5 --json` - fallback/low-confidence recommendations with empty matched evidence.
  - `uv run python -m src.cli recommend "機能を安全に追加" --limit 1 --json` - top result `plan` with `locale:ja:safe_feature`.
- [x] Manual Hermes/TUI check, or explicit reason it was not run: not run; this changes deterministic backend routing and docs, not a live Hermes profile or TUI surface.
- [ ] `python3 -m unittest discover -s tests` - not run directly; equivalent `uv run` suite passed.
- [ ] `python3 -m compileall src` - not run directly; `uv run python -m compileall -q src tests` passed.
- [ ] `python3 -m omh.cli docs workflows --check` - not run directly; `uv run python -m src.cli docs workflows --check` passed.
- [ ] `python3 -m omh.cli harness validate` - not run directly; `uv run python -m src.cli harness validate` passed.
- [ ] `python3 -m omh.cli release checklist --json` - not run; not a release PR.
- [ ] `python3 -m omh.cli release hermes-smoke` - not run; not an install/release smoke change.
- [ ] `omh --help` - not run; no command-discovery surface changed.
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` - not run; no setup/install surface changed.

## Risk

- The locale phrase pack is intentionally narrow. Unsupported phrasing may still fall back until new phrase coverage is added with tests.
- Manual locale aliases can drift from catalog semantics if expanded casually. This PR adds negative tests to keep safety claims from being invented.

## Compatibility / Rollout

- Backward compatible: existing English/Korean routing tests continue to pass.
- No schema version change. The existing `matched` array can include new `locale:<code>:<label>` evidence on scored recommendations.
- No network, LLM, API, Hermes core, executor, Discord, or Slack behavior added.

## Release / Claims

- [x] Release-channel impact considered (`preview`): safe to ship as a local deterministic routing enhancement.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap: live Hermes reload was not run because no install/plugin setup path changed.

## Code Review

- Code-reviewer lane initially requested changes for over-broad safe-feature aliases. Fixed by requiring explicit safety wording and adding negative tests; final recommendation: `APPROVE`.
- Architect lane initially marked `WATCH` for locale evidence wording, short-token scoring, and negative coverage. Fixed by tightening docs, restoring 3-character token scoring, and adding fallback/short-token tests; final status: `CLEAR`.

## Follow-Up

- Consider moving locale phrase packs into structured catalog metadata if phrase coverage grows beyond a small deterministic routing layer.
