### PR TITLE
Add OMH capability manifests for Hermes orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ user says a plain request in Hermes
 [Website](https://rlaope.github.io/oh-my-hermes/) -
 [Documentation](docs/README.md) -
 [Installation](docs/INSTALLATION.md) -
+[Capabilities](docs/CAPABILITIES.md) -
 [Agent Install](INSTALL_FOR_AGENTS.md) -
 [Roles](docs/ROLES.md) -
 [Application Cases](docs/APPLICATION_CASES.md) -
@@ -214,7 +215,8 @@ so OMH can display and record `main@old -> main@new` instead of only `main`.
 | Memory context review | Review OMH-local and wrapper-supplied context, flag stale assumptions, and attach conflict-free summaries to executor handoffs. |
 | Strict goal progress | `.omh/goals` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, and `goal_continuation/v1` keep long-running goals from being treated as done before evidence is ready. |
 | Hermes chat contracts | `chat_interaction/v1`, status cards, action ids, and local runtime artifacts for Hermes Agent chat surfaces. |
-| Hermes plugin bridge | `omh setup` installs `~/.hermes/plugins/omh` with metadata-only `omh_hud`, `omh_role`, `omh_status`, bounded `omh_gather_evidence`, role marker validation, and session checkpoint support. |
+| Capability manifests | `omh capabilities export --json` and the plugin `omh_capabilities` tool expose installed roles, skills, hooks, keyword policy, orchestration patterns, tool derivation status, and evidence boundaries for Hermes/wrapper use. |
+| Hermes plugin bridge | `omh setup` installs `~/.hermes/plugins/omh` with metadata-only `omh_capabilities`, `omh_hud`, `omh_role`, `omh_status`, bounded `omh_gather_evidence`, role marker validation, and session checkpoint support. |
 | Optional MCP bridge preference | `omh setup --with-mcp` records MCP bridge intent without claiming a host loaded or called it; `omh probe` separates `mcp_preference` from `mcp_host_config`. |
 | Parity verifier | `omh probe --parity` maps common oh-my runtime capability axes to OMH surfaces, gaps, and evidence boundaries. |
 | Operating models | `omh setup --operating-model <id>` records the default Hermes collaboration posture: solo operator, small team, research ops, or coding runtime team. |
@@ -335,6 +337,8 @@ curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes/main/install.sh
 | AI-agent pasteable install protocol | [Agent Install](INSTALL_FOR_AGENTS.md) |
 | Product direction and boundaries | [Direction](docs/DIRECTION.md) |
 | Architecture and module ownership | [Architecture](docs/ARCHITECTURE.md) |
+| Capability manifests for Hermes/plugin/wrapper use | [Capabilities](docs/CAPABILITIES.md) |
+| Orchestration pattern contracts | [Orchestration Patterns](docs/ORCHESTRATION_PATTERNS.md) |
 | Common oh-my runtime parity and gaps | [Parity Matrix](docs/PARITY.md) |
 | Situation playbooks | [Playbooks](docs/PLAYBOOKS.md) |
 | Role surfaces and profile packs | [Roles](docs/ROLES.md) |

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -1,0 +1,58 @@
+# OMH Capability Manifests
+
+OMH capability manifests are runtime-readable maps for Hermes, plugin tools, and
+wrapper backends. They answer one bounded question:
+
+What can this installed OMH surface prepare, explain, or observe, and what is
+still not evidence?
+
+The manifests are not a new source of truth. They are deterministic projections
+over existing OMH catalogs and contracts:
+
+- skill metadata from `src/skills/catalog.py`
+- role descriptors from `src/catalogs/roles.py`
+- routing and locale policy from `src/routing/*`
+- wrapper action ids from `src/wrapper/contract.py`
+- runtime observation events from `src/runtime/records.py`
+- plugin hook/tool metadata from `src/plugin_bundle/omh/*`
+
+Use:
+
+```sh
+omh capabilities export --json
+omh capabilities export --section keywords --json
+omh capabilities list
+omh capabilities inspect ultragoal --json
+```
+
+The Hermes plugin exposes the same contract through the metadata-only
+`omh_capabilities` tool.
+
+## Sections
+
+| Section | Purpose |
+| --- | --- |
+| `agent_roles` | Responsibility roles such as research, planning, review, and coding handoff. They are descriptors, not runtime agents. |
+| `skills` | Skill capabilities, triggers, harnesses, quality bars, handoff policy, and orchestration eligibility derived from the generated skill catalog. |
+| `hooks` | Plugin tools/hooks plus wrapper event contracts and whether each surface is only supported or actually observed. |
+| `keywords` | Explicit invocation prefixes, natural-language routing rules, locale aliases, conflict policy, and guard rules. |
+| `orchestration_patterns` | Safe workflow patterns such as clarify-then-plan, plan-execute-verify, team pipeline, worktree isolation, loop tick, and executor session handoff. |
+| `tool_requirements` | Tool/MCP requirements when derivable. PR1 marks this as partial rather than inventing host requirements. |
+| `evidence_boundaries` | The shared prepared-vs-observed claim rule. |
+
+## Claim Boundary
+
+Capability presence means OMH can prepare guidance, status, or a handoff. It
+does not mean Hermes loaded a plugin, a worker ran, a worktree was created, code
+changed, review passed, CI passed, or a PR was merged.
+
+Those claims require matching local wrapper or runtime artifacts such as
+`runtime_observation/v1`.
+
+## Why This Exists
+
+Hermes and wrapper surfaces should not need to scrape README prose to know which
+skills exist, which actions are safe, or why a route was selected. The capability
+manifest gives them a compact local contract while preserving OMH's direction:
+Hermes remains the chat surface, selected executors own implementation, and OMH
+keeps the evidence boundary visible.

--- a/docs/ORCHESTRATION_PATTERNS.md
+++ b/docs/ORCHESTRATION_PATTERNS.md
@@ -1,0 +1,48 @@
+# OMH Orchestration Patterns
+
+OMH orchestration patterns describe how Hermes should shape work before any
+executor or runtime claims are made. They are metadata contracts, not hidden
+automation.
+
+Each pattern names:
+
+- when to use it
+- when not to use it
+- owner role
+- compatible skills
+- required decisions
+- prepared artifacts
+- observed evidence required before status can advance
+- wrapper actions that can render the UX
+
+Inspect them locally:
+
+```sh
+omh capabilities export --section orchestration_patterns --json
+omh capabilities inspect executor_session_handoff --json
+```
+
+## Included Patterns
+
+| Pattern | Use |
+| --- | --- |
+| `single_lane` | Direct Hermes-retained work with one owner and one status lane. |
+| `clarify_then_plan` | Fuzzy intent that needs a blocking question, plan, and accept/revise gate. |
+| `plan_execute_verify` | Work that needs a plan, owner, execution evidence, and verification gate. |
+| `fanout_synthesize` | Independent research or option gathering followed by synthesis. |
+| `adversarial_review` | A verifier or reviewer challenges a plan, output, or release claim. |
+| `team_staged_pipeline` | Multi-lane work where lead/member/verifier ownership is explicit. |
+| `swarm_batch` | Independent high-throughput batches with clear ownership. |
+| `worktree_isolated_workers` | Parallel implementation that should use isolated workspaces. |
+| `loop_run_once` | A bounded loop tick without a daemon or hidden execution. |
+| `executor_session_handoff` | Prepared handoff for Codex, Claude Code, Hermes coding skills, or oh-my runtimes. |
+| `materials_generation_handoff` | Documents, decks, spreadsheets, PDFs, or other material packages needing generation/QA. |
+
+## Evidence Rule
+
+Prepared pattern metadata is not runtime evidence. For example,
+`worktree_isolated_workers` can recommend a worktree policy, but OMH cannot say a
+worktree exists until a wrapper or operator records a matching runtime
+observation.
+
+This keeps Hermes helpful in chat without pretending to be a hidden executor.

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,8 @@ repo-local contract for Codex agents working here.
 | Understand what OMH is and is not | [Direction](DIRECTION.md) |
 | Understand module boundaries and local artifacts | [Architecture](ARCHITECTURE.md) |
 | Compare common oh-my runtime axes and OMH gaps | [Parity Matrix](PARITY.md) |
+| Inspect runtime-readable OMH capability manifests | [Capabilities](CAPABILITIES.md) |
+| Understand safe orchestration pattern contracts | [Orchestration Patterns](ORCHESTRATION_PATTERNS.md) |
 | Understand chat wrapper UX, sessions, and handoffs | [Delegation-First Completeness](DELEGATION_FIRST_COMPLETENESS.md) |
 | Review stale local context and executor handoff packs | [Memory Context Review](MEMORY_CONTEXT.md) |
 | Operate a Hermes-agent wrapper safely | [Hermes Agent Integration Runbook](HERMES_AGENT_INTEGRATION_RUNBOOK.md) |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ Repository = "https://github.com/rlaope/oh-my-hermes"
 [tool.setuptools]
 packages = [
   "omh",
+  "omh.capabilities",
   "omh.catalogs",
   "omh.commands",
   "omh.core",
@@ -51,6 +52,7 @@ packages = [
 omh = "src"
 "omh.catalogs" = "src/catalogs"
 "omh.commands" = "src/commands"
+"omh.capabilities" = "src/capabilities"
 "omh.core" = "src/core"
 "omh.profiles" = "src/profiles"
 "omh.routing" = "src/routing"

--- a/src/capabilities/__init__.py
+++ b/src/capabilities/__init__.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from .registry import capability_snapshot, filtered_capability_snapshot, inspect_capability, list_capabilities
+
+__all__ = [
+    "capability_snapshot",
+    "filtered_capability_snapshot",
+    "inspect_capability",
+    "list_capabilities",
+]

--- a/src/capabilities/agents.py
+++ b/src/capabilities/agents.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from ..catalogs.roles import RoleDefinition, role_definitions
+from .schema import AGENT_ROLE_CAPABILITY_SCHEMA_VERSION, PREPARED_NOT_OBSERVED
+
+
+_TEAM_ELIGIBILITY = {
+    "research-lead": "member",
+    "planning-lead": "lead",
+    "review-gate": "verifier",
+    "coding-handoff": "lead",
+}
+
+
+def agent_role_capabilities() -> list[dict[str, object]]:
+    return [_role_capability(role) for role in sorted(role_definitions(), key=lambda item: item.id)]
+
+
+def _role_capability(role: RoleDefinition) -> dict[str, object]:
+    return {
+        "schema_version": AGENT_ROLE_CAPABILITY_SCHEMA_VERSION,
+        "id": role.id,
+        "display_name": role.title,
+        "mode": "descriptor",
+        "runtime_claim": "descriptor_not_runtime_agent",
+        "owns": list(role.owns),
+        "does_not_own": [
+            "hidden runtime execution",
+            "unobserved worker dispatch",
+            "unobserved worktree creation",
+            "review, CI, merge-readiness, or merge evidence without matching runtime records",
+        ],
+        "primary_skills": list(role.primary_skills),
+        "primary_harnesses": list(role.primary_harnesses),
+        "allowed_wrapper_actions": list(role.wrapper_actions),
+        "default_orchestration_patterns": _default_patterns(role),
+        "team_eligibility": _TEAM_ELIGIBILITY.get(role.id, "not_eligible"),
+        "tool_requirements": {
+            "derivation_status": "partial",
+            "required_tools": [],
+            "reason": "Current role catalog does not declare concrete tool or MCP requirements.",
+        },
+        "evidence_ladder": [
+            "role_descriptor_available",
+            "wrapper_action_prepared",
+            "runtime_observation_required_for_execution_claim",
+        ],
+        "evidence_boundary": role.evidence_boundary,
+        "prepared_is_not": PREPARED_NOT_OBSERVED,
+        "install_surface": ["generated_role_reference", "plugin_tool", "wrapper_descriptor"],
+        "source_refs": ["src/catalogs/roles.py"],
+    }
+
+
+def _default_patterns(role: RoleDefinition) -> list[str]:
+    if role.id == "research-lead":
+        return ["clarify_then_plan", "fanout_synthesize"]
+    if role.id == "planning-lead":
+        return ["clarify_then_plan", "plan_execute_verify"]
+    if role.id == "review-gate":
+        return ["adversarial_review", "plan_execute_verify"]
+    if role.id == "coding-handoff":
+        return ["executor_session_handoff", "team_staged_pipeline", "worktree_isolated_workers"]
+    return ["single_lane"]

--- a/src/capabilities/hooks.py
+++ b/src/capabilities/hooks.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from ..plugin_bundle.omh.metadata import PROVIDED_HOOKS, PROVIDED_TOOLS
+from .schema import HOOK_EVENT_CAPABILITY_SCHEMA_VERSION, PREPARED_NOT_OBSERVED
+
+
+def hook_manifest() -> dict[str, object]:
+    return {
+        "schema_version": HOOK_EVENT_CAPABILITY_SCHEMA_VERSION,
+        "plugin_tools": [
+            {
+                "name": name,
+                "supported_by_plugin_bundle": True,
+                "supported_by_wrapper_contract": name in {"omh_status", "omh_hud", "omh_capabilities"},
+                "supported_by_cli_backend": name == "omh_capabilities",
+                "observed_in_this_environment": False,
+            }
+            for name in PROVIDED_TOOLS
+        ],
+        "plugin_hooks": [
+            {
+                "name": name,
+                "supported_by_plugin_bundle": True,
+                "payload_fields": _hook_payload_fields(name),
+                "claim_boundary": "Hook availability is not proof that Hermes loaded or invoked the plugin.",
+                "observed_in_this_environment": False,
+            }
+            for name in PROVIDED_HOOKS
+        ],
+        "wrapper_events": [
+            _wrapper_event("prompt_submitted", ("source", "message_length", "message_sha256")),
+            _wrapper_event("status_refresh", ("session_id", "run_id")),
+            _wrapper_event("executor_opened", ("session_id", "selected_executor_profile", "external_session_ref")),
+            _wrapper_event("session_attached", ("session_id", "external_session_ref")),
+            _wrapper_event("result_recorded", ("session_id", "result", "evidence_refs")),
+            _wrapper_event("verification_requested", ("session_id", "evidence_refs")),
+            _wrapper_event("target_topology_changed", ("agent_count", "target_count", "runtime_ref")),
+            _wrapper_event("loop_tick_requested", ("loop_id", "queue_id")),
+        ],
+        "prepared_is_not": PREPARED_NOT_OBSERVED,
+        "source_refs": [
+            "src/plugin_bundle/omh/metadata.py",
+            "src/plugin_bundle/omh/plugin.yaml",
+            "src/plugin_bundle/omh/__init__.py",
+            "src/wrapper/contract.py",
+        ],
+    }
+
+
+def _wrapper_event(name: str, payload_fields: tuple[str, ...]) -> dict[str, object]:
+    return {
+        "name": name,
+        "payload_fields": list(payload_fields),
+        "supported_by_plugin_bundle": False,
+        "supported_by_wrapper_contract": True,
+        "supported_by_cli_backend": True,
+        "observed_in_this_environment": False,
+        "claim_boundary": "Wrapper event support is a contract; only recorded wrapper/runtime artifacts prove the event happened.",
+    }
+
+
+def _hook_payload_fields(name: str) -> list[str]:
+    if name == "pre_llm_call":
+        return ["bounded_status_context", "redacted"]
+    if name == "pre_tool_call":
+        return ["tool_name", "claim_boundary"]
+    if name == "on_session_end":
+        return ["session_summary", "metadata_only"]
+    return []

--- a/src/capabilities/keywords.py
+++ b/src/capabilities/keywords.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from ..routing.policy import EXPLICIT_INVOCATION_PREFIXES, ROUTING_GUARD_RULES
+from ..routing.localization import locale_aliases
+from ..skills.catalog import builtin_definitions
+from .schema import KEYWORD_DETECTOR_SCHEMA_VERSION, PREPARED_NOT_OBSERVED
+
+
+def keyword_detector_manifest() -> dict[str, object]:
+    definitions = sorted(builtin_definitions(), key=lambda item: item.name)
+    aliases = locale_aliases()
+    return {
+        "schema_version": KEYWORD_DETECTOR_SCHEMA_VERSION,
+        "explicit_invocation_prefixes": [
+            {"prefix": prefix, "strength": "exact", "precedence": 1, "surface": _prefix_surface(prefix)}
+            for prefix in EXPLICIT_INVOCATION_PREFIXES
+        ],
+        "natural_language_rules": [
+            {
+                "skill": definition.name,
+                "strength": "strong" if len(definition.triggers) >= 3 else "weak",
+                "triggers": list(definition.triggers),
+                "category": definition.category,
+                "phase": definition.phase,
+            }
+            for definition in definitions
+        ],
+        "locale_policy": {
+            "derived_from": "src/routing/localization.py",
+            "supported_alias_locales": sorted({alias.locale for alias in aliases}),
+            "alias_labels": sorted({alias.label for alias in aliases}),
+            "fallback": "Unsupported-language or weak multilingual matches should clarify instead of forcing direct dispatch.",
+        },
+        "conflict_policy": {
+            "explicit_wins": True,
+            "high_confidence_dispatch": True,
+            "tied_scores": "clarify",
+            "unsafe_direct_dispatch": "requires_plan_or_explicit_invocation",
+        },
+        "guard_rules": [
+            {
+                "id": rule.id,
+                "rule": rule.rule,
+                "preferred_skills": list(rule.preferred_skills),
+                "activation_status": rule.activation_status,
+            }
+            for rule in ROUTING_GUARD_RULES
+            if rule.activation_status == "active"
+        ],
+        "guard_policy_catalog": [
+            {
+                "id": rule.id,
+                "rule": rule.rule,
+                "preferred_skills": list(rule.preferred_skills),
+                "activation_status": rule.activation_status,
+            }
+            for rule in ROUTING_GUARD_RULES
+        ],
+        "prepared_is_not": PREPARED_NOT_OBSERVED,
+        "source_refs": ["src/routing/chat.py", "src/routing/recommend.py", "src/routing/localization.py", "src/skills/catalog.py"],
+    }
+
+
+def _prefix_surface(prefix: str) -> str:
+    return {
+        "$": "Codex/oh-my skill invocation",
+        "/": "slash skill invocation",
+        "./": "Hermes direct skill invocation",
+        "@": "agent or role mention",
+    }.get(prefix, "explicit skill invocation")

--- a/src/capabilities/orchestration.py
+++ b/src/capabilities/orchestration.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+from ..wrapper.contract import VISIBLE_ACTIONS
+from .schema import ORCHESTRATION_PATTERN_SCHEMA_VERSION, PREPARED_NOT_OBSERVED
+
+
+def orchestration_patterns() -> list[dict[str, object]]:
+    actions = set(VISIBLE_ACTIONS)
+    return [
+        _pattern(
+            "single_lane",
+            "Use for direct Hermes-retained work with one owner and one status lane.",
+            "Do not use when parallel workers, executor sessions, or staged verification are required.",
+            "planning-lead",
+            ("oh-my-hermes", "doctor", "web-research"),
+            ("show_status",),
+            actions,
+            ("request_received", "response_prepared", "evidence_or_gap_reported"),
+        ),
+        _pattern(
+            "clarify_then_plan",
+            "Use when intent is fuzzy and a plan or accepted next action is needed before handoff.",
+            "Do not use when the user explicitly invoked a concrete direct task.",
+            "planning-lead",
+            ("deep-interview", "plan", "ralplan"),
+            ("answer:clarify", "accept_plan", "revise_plan"),
+            actions,
+            ("clarification_answered", "plan_accepted", "handoff_prepared_or_declined"),
+        ),
+        _pattern(
+            "plan_execute_verify",
+            "Use when implementation or operational work needs a plan, execution owner, and verification gate.",
+            "Do not treat the plan as observed execution.",
+            "coding-handoff",
+            ("ultragoal", "ultraprocess", "ralph"),
+            ("prepare_handoff", "show_status", "ask_hermes_verify"),
+            actions,
+            ("plan_accepted", "execution_observed", "verification_observed"),
+        ),
+        _pattern(
+            "fanout_synthesize",
+            "Use when research, options, or evidence can be gathered in independent lanes and synthesized.",
+            "Do not use when sources, tools, or authority boundaries are unclear.",
+            "research-lead",
+            ("web-research", "research-brief", "strategy-brief"),
+            ("show_status",),
+            actions,
+            ("sources_observed", "synthesis_prepared", "unknowns_reported"),
+        ),
+        _pattern(
+            "adversarial_review",
+            "Use when a verifier or reviewer should challenge a plan, output, or release claim.",
+            "Do not call review passed until findings and required checks are observed.",
+            "review-gate",
+            ("code-review", "ultraqa", "ops-review"),
+            ("ask_hermes_verify", "show_status", "prepare_handoff"),
+            actions,
+            ("review_requested", "findings_reported", "fix_or_approval_observed"),
+        ),
+        _pattern(
+            "team_staged_pipeline",
+            "Use for staged multi-lane work where lead/member/verifier ownership is explicit.",
+            "Do not imply hidden workers ran; require worker_dispatch observations.",
+            "coding-handoff",
+            ("team", "ultrawork", "ultraprocess"),
+            ("start_team", "start_swarm", "show_status"),
+            actions,
+            ("topology_prepared", "worker_dispatch_observed", "worker_result_observed"),
+        ),
+        _pattern(
+            "swarm_batch",
+            "Use for high-throughput batches only when lanes are independent and ownership is clear.",
+            "Do not use for tightly coupled edits or unbounded scope.",
+            "coding-handoff",
+            ("ultrawork", "team"),
+            ("start_swarm", "show_status"),
+            actions,
+            ("batch_prepared", "worker_dispatch_observed", "verification_observed"),
+        ),
+        _pattern(
+            "worktree_isolated_workers",
+            "Use when parallel implementation needs isolated working directories.",
+            "Do not claim worktrees exist until runtime observation records them.",
+            "coding-handoff",
+            ("team", "ultrawork", "ultragoal"),
+            ("prepare_worktree", "start_team", "show_status"),
+            actions,
+            ("worktree_policy_prepared", "worktree_creation_observed", "merge_readiness_observed"),
+        ),
+        _pattern(
+            "loop_run_once",
+            "Use when a loop should advance one bounded tick without a daemon or hidden execution.",
+            "Do not use as a claim that automation, connectors, or subagents ran.",
+            "planning-lead",
+            ("loop",),
+            ("run_loop_tick", "show_loop_status", "prepare_loop_handoff"),
+            actions,
+            ("tick_prepared", "queue_item_prepared", "feedback_or_evidence_required"),
+        ),
+        _pattern(
+            "executor_session_handoff",
+            "Use when Hermes prepares work for Codex, Claude Code, Hermes coding skills, or oh-my runtimes.",
+            "Do not report completion before dispatch/result/verification evidence is recorded.",
+            "coding-handoff",
+            ("ultragoal", "ultrawork", "code-review", "ai-slop-cleaner"),
+            ("choose_executor", "show_prompt_handoff", "show_runtime_handoff", "open_executor_session", "refresh_executor_status"),
+            actions,
+            ("handoff_prepared", "dispatch_observed", "result_observed", "verification_observed"),
+        ),
+        _pattern(
+            "materials_generation_handoff",
+            "Use when documents, decks, spreadsheets, PDFs, or other materials need generation/QA handoff.",
+            "Do not claim binary export, render QA, formula recalculation, approval, or delivery without evidence.",
+            "planning-lead",
+            ("materials-package", "report-package"),
+            ("prepare_handoff", "show_status"),
+            actions,
+            ("material_plan_prepared", "generation_observed", "qa_observed"),
+        ),
+    ]
+
+
+def _pattern(
+    pattern_id: str,
+    use_when: str,
+    do_not_use_when: str,
+    owner_role: str,
+    compatible_skills: tuple[str, ...],
+    required_actions: tuple[str, ...],
+    available_actions: set[str],
+    observed_evidence_required: tuple[str, ...],
+) -> dict[str, object]:
+    return {
+        "schema_version": ORCHESTRATION_PATTERN_SCHEMA_VERSION,
+        "id": pattern_id,
+        "use_when": use_when,
+        "do_not_use_when": do_not_use_when,
+        "owner_role": owner_role,
+        "compatible_skills": list(compatible_skills),
+        "required_decisions": _required_decisions(pattern_id),
+        "prepared_artifacts": _prepared_artifacts(pattern_id),
+        "wrapper_actions": [action for action in required_actions if action in available_actions],
+        "observed_evidence_required": list(observed_evidence_required),
+        "status_card_copy": _status_copy(pattern_id),
+        "prepared_is_not": PREPARED_NOT_OBSERVED,
+        "source_refs": ["src/wrapper/contract.py", "src/skills/catalog.py", "src/runtime/records.py"],
+    }
+
+
+def _required_decisions(pattern_id: str) -> list[str]:
+    if pattern_id in {"executor_session_handoff", "team_staged_pipeline", "swarm_batch", "worktree_isolated_workers"}:
+        return ["executor_or_runtime_profile", "authority_scope", "verification_gate"]
+    if pattern_id == "loop_run_once":
+        return ["permission_profile", "next_verification", "feedback_or_wait_policy"]
+    if pattern_id == "clarify_then_plan":
+        return ["blocking_question", "accept_or_revise_plan"]
+    return ["owner_role", "stop_condition"]
+
+
+def _prepared_artifacts(pattern_id: str) -> list[str]:
+    mapping = {
+        "executor_session_handoff": ["coding_delegation/v1", "wrapper_session/v1"],
+        "loop_run_once": ["loop_runtime/v1", "loop_status_card/v1"],
+        "materials_generation_handoff": ["material_artifact/v1"],
+        "worktree_isolated_workers": ["runtime_observation/v1 when observed"],
+    }
+    return mapping.get(pattern_id, ["chat_interaction/v1", "status_card/v1"])
+
+
+def _status_copy(pattern_id: str) -> str:
+    return f"Pattern `{pattern_id}` is prepared guidance until matching observed evidence is recorded."

--- a/src/capabilities/registry.py
+++ b/src/capabilities/registry.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+from .agents import agent_role_capabilities
+from .hooks import hook_manifest
+from .keywords import keyword_detector_manifest
+from .orchestration import orchestration_patterns
+from .schema import CAPABILITY_MANIFEST_SCHEMA_VERSION, CAPABILITY_SECTIONS, PREPARED_NOT_OBSERVED
+from .skills import skill_capabilities
+from .tools import tool_requirements_manifest
+
+
+def capability_snapshot() -> dict[str, object]:
+    agent_roles = agent_role_capabilities()
+    skills = skill_capabilities()
+    hooks = hook_manifest()
+    keywords = keyword_detector_manifest()
+    patterns = orchestration_patterns()
+    tools = tool_requirements_manifest()
+    snapshot = {
+        "schema_version": CAPABILITY_MANIFEST_SCHEMA_VERSION,
+        "manifest_id": "omh_capabilities",
+        "determinism": "static_projection_no_runtime_clock",
+        "summary": {
+            "agent_roles": len(agent_roles),
+            "skills": len(skills),
+            "plugin_tools": len(hooks["plugin_tools"]),
+            "plugin_hooks": len(hooks["plugin_hooks"]),
+            "keyword_rules": len(keywords["natural_language_rules"]),
+            "orchestration_patterns": len(patterns),
+            "tool_requirements": len(tools["items"]),
+        },
+        "agent_roles": agent_roles,
+        "skills": skills,
+        "hooks": hooks,
+        "keywords": keywords,
+        "orchestration_patterns": patterns,
+        "tool_requirements": tools,
+        "evidence_boundaries": evidence_boundaries(),
+        "non_goals": [
+            "no hidden executor dispatch",
+            "no worktree creation",
+            "no worker or subagent spawn",
+            "no MCP server runtime",
+            "no Hermes core patching",
+            "no runtime_topology schema in this PR",
+        ],
+    }
+    return deepcopy(snapshot)
+
+
+def evidence_boundaries() -> dict[str, object]:
+    return {
+        "prepared_is_not": PREPARED_NOT_OBSERVED,
+        "observed_required_for": [
+            "runtime_start",
+            "worktree_creation",
+            "worker_dispatch",
+            "worker_result",
+            "verification",
+            "review",
+            "ci",
+            "merge_readiness",
+            "merge",
+        ],
+        "claim_rule": "Capability presence means OMH can prepare guidance or status; it does not prove host/plugin/runtime execution.",
+    }
+
+
+def filtered_capability_snapshot(section: str | None = None) -> dict[str, object]:
+    snapshot = capability_snapshot()
+    if not section:
+        return snapshot
+    if section not in CAPABILITY_SECTIONS:
+        raise ValueError(f"unknown capability section: {section}")
+    return {
+        "schema_version": snapshot["schema_version"],
+        "manifest_id": snapshot["manifest_id"],
+        "section": section,
+        section: snapshot[section],
+    }
+
+
+def list_capabilities(section: str | None = None) -> dict[str, object]:
+    snapshot = capability_snapshot()
+    sections = [section] if section else list(CAPABILITY_SECTIONS)
+    unknown = [item for item in sections if item not in CAPABILITY_SECTIONS]
+    if unknown:
+        raise ValueError(f"unknown capability section: {unknown[0]}")
+    return {
+        "schema_version": "omh_capability_list/v1",
+        "sections": [
+            {
+                "section": name,
+                "ids": _section_ids(name, snapshot[name]),
+            }
+            for name in sections
+        ],
+    }
+
+
+def inspect_capability(identifier: str, section: str | None = None) -> dict[str, object]:
+    if not identifier:
+        raise ValueError("capabilities inspect requires an id")
+    snapshot = capability_snapshot()
+    sections = [section] if section else list(CAPABILITY_SECTIONS)
+    for name in sections:
+        if name not in CAPABILITY_SECTIONS:
+            raise ValueError(f"unknown capability section: {name}")
+        found = _find_in_section(identifier, snapshot[name])
+        if found is not None:
+            return {
+                "schema_version": "omh_capability_inspect/v1",
+                "section": name,
+                "id": identifier,
+                "capability": found,
+            }
+    raise ValueError(f"capability not found: {identifier}")
+
+
+def _section_ids(section: str, payload: object) -> list[str]:
+    if section == "hooks" and isinstance(payload, dict):
+        return sorted(
+            [
+                *[str(item["name"]) for item in payload.get("plugin_tools", []) if isinstance(item, dict)],
+                *[str(item["name"]) for item in payload.get("plugin_hooks", []) if isinstance(item, dict)],
+            ]
+        )
+    if section == "keywords" and isinstance(payload, dict):
+        return ["explicit_invocation_prefixes", "natural_language_rules", "locale_policy", "guard_rules"]
+    if section == "tool_requirements" and isinstance(payload, dict):
+        return sorted(str(item["skill"]) for item in payload.get("items", []) if isinstance(item, dict))
+    if section == "evidence_boundaries":
+        return ["prepared_is_not", "observed_required_for", "claim_rule"]
+    if isinstance(payload, list):
+        return sorted(str(item.get("id", item.get("name", ""))) for item in payload if isinstance(item, dict))
+    return []
+
+
+def _find_in_section(identifier: str, payload: object) -> object | None:
+    if isinstance(payload, list):
+        for item in payload:
+            if isinstance(item, dict) and identifier in {str(item.get("id", "")), str(item.get("name", ""))}:
+                return item
+    if isinstance(payload, dict):
+        for key in ("plugin_tools", "plugin_hooks", "items", "natural_language_rules"):
+            values = payload.get(key)
+            if isinstance(values, list):
+                found = _find_in_section(identifier, values)
+                if found is not None:
+                    return found
+        if identifier in payload:
+            return payload[identifier]
+    return None

--- a/src/capabilities/schema.py
+++ b/src/capabilities/schema.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+CAPABILITY_MANIFEST_SCHEMA_VERSION = "omh_capability_manifest/v1"
+AGENT_ROLE_CAPABILITY_SCHEMA_VERSION = "agent_role_capability/v1"
+SKILL_CAPABILITY_SCHEMA_VERSION = "skill_capability/v1"
+HOOK_EVENT_CAPABILITY_SCHEMA_VERSION = "omh_hook_manifest/v1"
+KEYWORD_DETECTOR_SCHEMA_VERSION = "keyword_detector_manifest/v1"
+ORCHESTRATION_PATTERN_SCHEMA_VERSION = "orchestration_pattern/v1"
+TOOL_REQUIREMENT_SCHEMA_VERSION = "tool_requirement_manifest/v1"
+
+CAPABILITY_SECTIONS = (
+    "agent_roles",
+    "skills",
+    "hooks",
+    "keywords",
+    "orchestration_patterns",
+    "tool_requirements",
+    "evidence_boundaries",
+)
+
+PREPARED_NOT_OBSERVED = (
+    "Prepared OMH capability, handoff, topology, or routing metadata is not execution, "
+    "worker dispatch, worktree creation, review, CI, merge-readiness, or merge evidence."
+)

--- a/src/capabilities/skills.py
+++ b/src/capabilities/skills.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from ..skills.catalog import SkillDefinition, builtin_definitions, primary_harness_for_skill
+from .schema import PREPARED_NOT_OBSERVED, SKILL_CAPABILITY_SCHEMA_VERSION
+
+
+def skill_capabilities() -> list[dict[str, object]]:
+    return [_skill_capability(definition) for definition in sorted(builtin_definitions(), key=lambda item: item.name)]
+
+
+def _skill_capability(definition: SkillDefinition) -> dict[str, object]:
+    harness = primary_harness_for_skill(definition.name)
+    return {
+        "schema_version": SKILL_CAPABILITY_SCHEMA_VERSION,
+        "id": definition.name,
+        "display_name": definition.name,
+        "description": definition.description,
+        "category": definition.category,
+        "phase": definition.phase,
+        "hermes_role": definition.hermes_role,
+        "primary_harness": harness,
+        "triggers": list(definition.triggers),
+        "required_inputs": list(definition.required_inputs),
+        "expected_outputs": list(definition.expected_outputs),
+        "artifact_expectations": list(definition.artifact_expectations),
+        "safety_rules": list(definition.safety_rules),
+        "quality_tier": definition.quality_tier,
+        "quality_bar": list(definition.quality_bar),
+        "handoff_policy": definition.handoff_policy,
+        "delegation_boundary": definition.delegation_boundary,
+        "do_not_use_when": list(definition.do_not_use_when),
+        "orchestration_eligibility": _orchestration_eligibility(definition),
+        "tool_requirements": {
+            "derivation_status": "partial",
+            "required_tools": [],
+            "fallback": "No concrete tool or MCP requirement is declared by the existing skill catalog.",
+        },
+        "evidence_boundary": _skill_evidence_boundary(definition),
+        "prepared_is_not": PREPARED_NOT_OBSERVED,
+        "source_refs": ["src/skills/catalog.py"],
+    }
+
+
+def _orchestration_eligibility(definition: SkillDefinition) -> list[str]:
+    patterns = {"single_lane"}
+    if definition.category in {"planning", "clarification", "strategy", "meeting", "triage"}:
+        patterns.add("clarify_then_plan")
+    if definition.category in {"execution", "process", "goal-loop", "delivery"}:
+        patterns.add("plan_execute_verify")
+    if definition.name in {"code-review", "ultraqa"} or definition.category == "review":
+        patterns.add("adversarial_review")
+    if definition.name in {"ultrawork", "team", "ultraprocess"}:
+        patterns.add("team_staged_pipeline")
+        patterns.add("worktree_isolated_workers")
+    if definition.name in {"loop"}:
+        patterns.add("loop_run_once")
+    if "handoff" in definition.handoff_policy.lower() or "runtime" in definition.hermes_role:
+        patterns.add("executor_session_handoff")
+    if definition.category == "materials":
+        patterns.add("materials_generation_handoff")
+    return sorted(patterns)
+
+
+def _skill_evidence_boundary(definition: SkillDefinition) -> str:
+    if definition.category == "review":
+        return "Review guidance or findings are not fix, verification, CI, merge-readiness, or merge evidence."
+    if definition.category in {"execution", "process", "goal-loop"}:
+        return "Execution-oriented workflow guidance remains prepared_not_observed until matching executor/runtime evidence exists."
+    return "Skill routing and Hermes guidance are not execution evidence."

--- a/src/capabilities/tools.py
+++ b/src/capabilities/tools.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from ..skills.catalog import builtin_definitions
+from .schema import TOOL_REQUIREMENT_SCHEMA_VERSION
+
+
+def tool_requirements_manifest() -> dict[str, object]:
+    items = []
+    for definition in sorted(builtin_definitions(), key=lambda item: item.name):
+        items.append(
+            {
+                "skill": definition.name,
+                "derivation_status": "partial",
+                "required_tools": [],
+                "required_mcps": [],
+                "fallback": "Use Hermes-native guidance or selected executor handoff; no concrete tool/MCP requirement is declared by the current catalog.",
+                "source_refs": ["src/skills/catalog.py"],
+            }
+        )
+    return {
+        "schema_version": TOOL_REQUIREMENT_SCHEMA_VERSION,
+        "derivation_status": "partial",
+        "items": items,
+        "claim_boundary": "Tool requirements are advisory until a host/plugin/wrapper reports observed tool availability.",
+    }

--- a/src/coding_delegation.py
+++ b/src/coding_delegation.py
@@ -82,7 +82,7 @@ def build_coding_delegation_payload(
     if limit < 1:
         raise ValueError("coding delegate --limit must be at least 1")
 
-    full_recommendations = recommend_skills(message, limit=max(limit, 5))
+    full_recommendations = recommend_skills(message, limit=max(limit, 5), apply_guardrails=False)
     recommendations = _compact_recommendations(full_recommendations[:limit])
     top = full_recommendations[0]
     workflow = str(top["skill"])

--- a/src/commands/capabilities.py
+++ b/src/commands/capabilities.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import argparse
+
+from ..capabilities.registry import filtered_capability_snapshot, inspect_capability, list_capabilities
+from ..capabilities.schema import CAPABILITY_SECTIONS
+from ..installer import OmhError
+from .common import _print_json, _wants_json
+
+
+def cmd_capabilities_export(args: argparse.Namespace) -> int:
+    try:
+        _print_json(filtered_capability_snapshot(args.section))
+    except ValueError as exc:
+        raise OmhError(str(exc)) from exc
+    return 0
+
+
+def cmd_capabilities_list(args: argparse.Namespace) -> int:
+    try:
+        payload = list_capabilities(args.section)
+    except ValueError as exc:
+        raise OmhError(str(exc)) from exc
+    if _wants_json(args):
+        _print_json(payload)
+        return 0
+    print("OMH capabilities")
+    for section in payload["sections"]:
+        ids = section["ids"]
+        print(f"- {section['section']}: {len(ids)}")
+        if ids:
+            print(f"  {', '.join(str(item) for item in ids[:12])}")
+            if len(ids) > 12:
+                print(f"  ... {len(ids) - 12} more")
+    print("For machine-readable output, rerun with `--json`.")
+    return 0
+
+
+def cmd_capabilities_inspect(args: argparse.Namespace) -> int:
+    try:
+        payload = inspect_capability(args.identifier, section=args.section)
+    except ValueError as exc:
+        raise OmhError(str(exc)) from exc
+    if _wants_json(args):
+        _print_json(payload)
+        return 0
+    capability = payload["capability"]
+    print(f"OMH capability: {payload['id']}")
+    print(f"Section: {payload['section']}")
+    if isinstance(capability, dict):
+        for key in ("schema_version", "display_name", "category", "phase", "runtime_claim", "evidence_boundary"):
+            if capability.get(key):
+                print(f"{key.replace('_', ' ').title()}: {capability[key]}")
+    print("For machine-readable output, rerun with `--json`.")
+    return 0
+
+
+def _add_capabilities_commands(sub) -> None:
+    capabilities = sub.add_parser("capabilities", help="Inspect OMH capability manifests for Hermes/plugin/wrapper use.")
+    capabilities_sub = capabilities.add_subparsers(dest="capabilities_command", required=True)
+
+    export = capabilities_sub.add_parser("export", help="Export the deterministic OMH capability manifest.")
+    export.add_argument("--section", choices=CAPABILITY_SECTIONS, default=None)
+    export.add_argument("--json", action="store_true", help="Accepted for consistency; export is always machine-readable JSON.")
+    export.set_defaults(func=cmd_capabilities_export)
+
+    list_cmd = capabilities_sub.add_parser("list", help="List capability ids by section.")
+    list_cmd.add_argument("--section", choices=CAPABILITY_SECTIONS, default=None)
+    list_cmd.add_argument("--json", action="store_true", help="Print machine-readable capability id lists.")
+    list_cmd.set_defaults(func=cmd_capabilities_list)
+
+    inspect = capabilities_sub.add_parser("inspect", help="Inspect one capability by id.")
+    inspect.add_argument("identifier")
+    inspect.add_argument("--section", choices=CAPABILITY_SECTIONS, default=None)
+    inspect.add_argument("--json", action="store_true", help="Print the full machine-readable capability.")
+    inspect.set_defaults(func=cmd_capabilities_inspect)

--- a/src/commands/main.py
+++ b/src/commands/main.py
@@ -4,6 +4,12 @@ import argparse
 import sys
 
 from ..installer import OmhError
+from .capabilities import (
+    _add_capabilities_commands,
+    cmd_capabilities_export,
+    cmd_capabilities_inspect,
+    cmd_capabilities_list,
+)
 from .chat import (
     _add_chat_commands,
     cmd_chat_interact,
@@ -147,6 +153,7 @@ def build_parser() -> argparse.ArgumentParser:
     _add_release_commands(sub)
     _add_demo_commands(sub)
     _add_chat_commands(sub)
+    _add_capabilities_commands(sub)
     _add_coding_commands(sub)
     _add_hermes_commands(sub)
     _add_hud_commands(sub)

--- a/src/plugin_bundle/omh/__init__.py
+++ b/src/plugin_bundle/omh/__init__.py
@@ -8,11 +8,19 @@ def register(ctx):
     from .hooks.llm_hooks import pre_llm_call
     from .hooks.session_hooks import on_session_end
     from .hooks.tool_hooks import pre_tool_call
+    from .tools.capability_tool import OMH_CAPABILITIES_SCHEMA, omh_capabilities_handler
     from .tools.evidence_tool import OMH_EVIDENCE_SCHEMA, omh_evidence_handler
     from .tools.hud_tool import OMH_HUD_SCHEMA, omh_hud_handler
     from .tools.role_tool import OMH_ROLE_SCHEMA, omh_role_handler
     from .tools.status_tool import OMH_STATUS_SCHEMA, omh_status_handler
 
+    ctx.register_tool(
+        "omh_capabilities",
+        _TOOLSET,
+        OMH_CAPABILITIES_SCHEMA,
+        omh_capabilities_handler,
+        description=OMH_CAPABILITIES_SCHEMA["description"],
+    )
     ctx.register_tool(
         "omh_gather_evidence",
         _TOOLSET,

--- a/src/plugin_bundle/omh/metadata.py
+++ b/src/plugin_bundle/omh/metadata.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+PROVIDED_TOOLS = ("omh_capabilities", "omh_gather_evidence", "omh_hud", "omh_role", "omh_status")
+PROVIDED_HOOKS = ("on_session_end", "pre_llm_call", "pre_tool_call")
+
+TOOL_FILE_STEMS = {
+    "omh_capabilities": "capability_tool",
+    "omh_gather_evidence": "evidence_tool",
+    "omh_hud": "hud_tool",
+    "omh_role": "role_tool",
+    "omh_status": "status_tool",
+}
+
+TOOLS_REQUIRING_ROLE_CATALOG = frozenset({"omh_role"})

--- a/src/plugin_bundle/omh/plugin.yaml
+++ b/src/plugin_bundle/omh/plugin.yaml
@@ -3,6 +3,7 @@ version: "1.0.0"
 description: "Oh My Hermes native bridge for metadata-only runtime status, HUD, role context, bounded evidence probes, and evidence-boundary context."
 author: oh-my-hermes maintainers
 provides_tools:
+  - omh_capabilities
   - omh_gather_evidence
   - omh_hud
   - omh_role

--- a/src/plugin_bundle/omh/runtime_reader.py
+++ b/src/plugin_bundle/omh/runtime_reader.py
@@ -5,11 +5,13 @@ import os
 from pathlib import Path
 from typing import Any
 
+from .metadata import PROVIDED_HOOKS, PROVIDED_TOOLS, TOOL_FILE_STEMS, TOOLS_REQUIRING_ROLE_CATALOG
+
 STATUS_SCHEMA_VERSION = "omh_status/v1"
 HUD_SCHEMA_VERSION = "omh_hud/v1"
 HUD_PRESETS = {"minimal", "focused", "full"}
-HUD_REQUIRED_TOOLS = ("omh_gather_evidence", "omh_hud", "omh_role", "omh_status")
-HUD_REQUIRED_HOOKS = ("on_session_end", "pre_llm_call", "pre_tool_call")
+HUD_REQUIRED_TOOLS = PROVIDED_TOOLS
+HUD_REQUIRED_HOOKS = PROVIDED_HOOKS
 
 
 def _expand_path(value: str | Path) -> Path:
@@ -174,13 +176,15 @@ def _plugin_capabilities(plugin_dir: Path, last_distribution: dict[str, Any]) ->
     files = {
         "plugin_yaml": (plugin_dir / "plugin.yaml").is_file(),
         "init_py": (plugin_dir / "__init__.py").is_file(),
-        "evidence_tool": (plugin_dir / "tools" / "evidence_tool.py").is_file(),
-        "hud_tool": (plugin_dir / "tools" / "hud_tool.py").is_file(),
-        "role_tool": (plugin_dir / "tools" / "role_tool.py").is_file(),
-        "status_tool": (plugin_dir / "tools" / "status_tool.py").is_file(),
         "role_catalog": any((plugin_dir / "references").glob("role-*.md")) if (plugin_dir / "references").is_dir() else False,
         "managed_manifest": (plugin_dir / ".omh-plugin-manifest.json").is_file(),
     }
+    files.update(
+        {
+            stem: (plugin_dir / "tools" / f"{stem}.py").is_file()
+            for stem in sorted(set(TOOL_FILE_STEMS.values()))
+        }
+    )
     yaml_text = _read_text(plugin_dir / "plugin.yaml")
     advertised_tools = set(_yaml_list_values(yaml_text, "provides_tools"))
     advertised_hooks = set(_yaml_list_values(yaml_text, "provides_hooks"))
@@ -190,20 +194,21 @@ def _plugin_capabilities(plugin_dir: Path, last_distribution: dict[str, Any]) ->
     hook_sources = advertised_hooks | registered_hooks
     return {
         "files": files,
-        "tools": {
-            "omh_gather_evidence": files["evidence_tool"] and "omh_gather_evidence" in tool_sources,
-            "omh_hud": files["hud_tool"] and "omh_hud" in tool_sources,
-            "omh_role": files["role_tool"] and files["role_catalog"] and "omh_role" in tool_sources,
-            "omh_status": files["status_tool"] and "omh_status" in tool_sources,
-        },
-        "hooks": {
-            "on_session_end": "on_session_end" in hook_sources,
-            "pre_llm_call": "pre_llm_call" in hook_sources,
-            "pre_tool_call": "pre_tool_call" in hook_sources,
-        },
+        "tools": _plugin_tool_capabilities(files, tool_sources),
+        "hooks": {hook: hook in hook_sources for hook in HUD_REQUIRED_HOOKS},
         "advertised_tools": sorted(advertised_tools),
         "advertised_hooks": sorted(advertised_hooks),
     }
+
+
+def _plugin_tool_capabilities(files: dict[str, bool], tool_sources: set[str]) -> dict[str, bool]:
+    capabilities = {}
+    for tool in HUD_REQUIRED_TOOLS:
+        file_ready = files[TOOL_FILE_STEMS[tool]]
+        if tool in TOOLS_REQUIRING_ROLE_CATALOG:
+            file_ready = file_ready and files["role_catalog"]
+        capabilities[tool] = file_ready and tool in tool_sources
+    return capabilities
 
 
 def _read_text(path: Path) -> str:

--- a/src/plugin_bundle/omh/tools/capability_tool.py
+++ b/src/plugin_bundle/omh/tools/capability_tool.py
@@ -1,0 +1,368 @@
+from __future__ import annotations
+
+import json
+
+from ..metadata import PROVIDED_HOOKS, PROVIDED_TOOLS
+
+STANDALONE_CAPABILITY_SECTIONS = (
+    "agent_roles",
+    "skills",
+    "hooks",
+    "keywords",
+    "orchestration_patterns",
+    "tool_requirements",
+    "evidence_boundaries",
+)
+
+
+OMH_CAPABILITIES_SCHEMA = {
+    "name": "omh_capabilities",
+    "description": (
+        "Read OMH agent, skill, hook, keyword, orchestration, tool, and evidence capability manifests. "
+        "Capability presence is metadata only, not observed execution evidence."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["export", "list", "inspect"],
+                "description": "Capability action to perform.",
+            },
+            "section": {
+                "type": "string",
+                "description": "Optional capability section filter.",
+            },
+            "id": {
+                "type": "string",
+                "description": "Capability id for action=inspect.",
+            },
+        },
+    },
+}
+
+
+def omh_capabilities_handler(args: dict, **kwargs) -> str:
+    action = str(args.get("action", "export") or "export")
+    section = str(args.get("section", "") or "") or None
+    try:
+        payload = _handle_capability_action(action, section, str(args.get("id", "") or ""))
+    except ValueError as exc:
+        payload = {"error": str(exc)}
+    return json.dumps(payload, sort_keys=True)
+
+
+def _handle_capability_action(action: str, section: str | None, capability_id: str) -> dict[str, object]:
+    registry = _load_package_registry()
+    if registry:
+        if action == "export":
+            return registry["filtered_capability_snapshot"](section)
+        if action == "list":
+            return registry["list_capabilities"](section)
+        if action == "inspect":
+            return registry["inspect_capability"](capability_id, section=section)
+        return {"error": f"unknown action: {action}"}
+    if action == "export":
+        return _standalone_capability_snapshot(section)
+    if action == "list":
+        return _standalone_capability_list(section)
+    if action == "inspect":
+        return _standalone_capability_inspect(capability_id, section)
+    return {"error": f"unknown action: {action}"}
+
+
+def _load_package_registry() -> dict[str, object]:
+    try:
+        from omh.capabilities.registry import filtered_capability_snapshot, inspect_capability, list_capabilities
+    except ModuleNotFoundError:
+        return {}
+    return {
+        "filtered_capability_snapshot": filtered_capability_snapshot,
+        "inspect_capability": inspect_capability,
+        "list_capabilities": list_capabilities,
+    }
+
+
+def _standalone_capability_snapshot(section: str | None = None) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "schema_version": "omh_capability_manifest/v1",
+        "source": "standalone_plugin_bundle_fallback",
+        "degraded": True,
+        "determinism": "static_plugin_metadata_no_runtime_clock",
+        "summary": {name: len(value) if isinstance(value, list) else len(value.keys()) for name, value in _standalone_sections().items()},
+        "evidence_boundaries": _standalone_evidence_boundaries(),
+        "non_goals": [
+            "standalone plugin fallback does not expose the full installed skill catalog",
+            "capability presence is not Hermes plugin load, execution, review, CI, or merge evidence",
+        ],
+    }
+    sections = _standalone_sections()
+    if section:
+        if section not in sections:
+            raise ValueError(f"unknown capability section: {section}")
+        payload["section"] = section
+        payload[section] = sections[section]
+        return payload
+    payload.update(sections)
+    return payload
+
+
+def _standalone_capability_list(section: str | None = None) -> dict[str, object]:
+    sections = _standalone_sections()
+    if section:
+        if section not in sections:
+            raise ValueError(f"unknown capability section: {section}")
+        return {
+            "schema_version": "omh_capability_list/v1",
+            "section": section,
+            "ids": _standalone_ids(sections[section]),
+            "degraded": True,
+        }
+    return {
+        "schema_version": "omh_capability_list/v1",
+        "sections": [
+            {"section": name, "ids": _standalone_ids(value)}
+            for name, value in sorted(sections.items())
+        ],
+        "degraded": True,
+    }
+
+
+def _standalone_capability_inspect(capability_id: str, section: str | None = None) -> dict[str, object]:
+    wanted = str(capability_id or "").strip()
+    if not wanted:
+        raise ValueError("capabilities inspect requires an id")
+    sections = _standalone_sections()
+    if section and section not in sections:
+        raise ValueError(f"unknown capability section: {section}")
+    search = {section: sections[section]} if section else sections
+    for section_name, values in search.items():
+        for item in _standalone_items(values):
+            if str(item.get("id") or item.get("name") or item.get("skill") or "") == wanted:
+                return {
+                    "schema_version": "omh_capability_inspect/v1",
+                    "section": section_name,
+                    "id": wanted,
+                    "capability": item,
+                    "degraded": True,
+                }
+        if isinstance(values, dict) and wanted in values:
+            return {
+                "schema_version": "omh_capability_inspect/v1",
+                "section": section_name,
+                "id": wanted,
+                "capability": values[wanted],
+                "degraded": True,
+            }
+    raise ValueError(f"unknown capability id: {wanted}")
+
+
+def _standalone_sections() -> dict[str, object]:
+    return {
+        "agent_roles": [
+            {
+                "schema_version": "agent_role_capability/v1",
+                "id": "coding-handoff",
+                "display_name": "Coding Handoff",
+                "runtime_claim": "descriptor_not_runtime_agent",
+                "owns": ["executor-neutral handoff guidance", "prepared-vs-observed status narration"],
+                "does_not_own": ["hidden coding execution", "review", "CI", "merge"],
+            },
+            {
+                "schema_version": "agent_role_capability/v1",
+                "id": "planning-lead",
+                "display_name": "Planning Lead",
+                "runtime_claim": "descriptor_not_runtime_agent",
+                "owns": ["plan shaping", "acceptance criteria"],
+                "does_not_own": ["executor dispatch", "implementation evidence"],
+            },
+            {
+                "schema_version": "agent_role_capability/v1",
+                "id": "research-lead",
+                "display_name": "Research Lead",
+                "runtime_claim": "descriptor_not_runtime_agent",
+                "owns": ["source-backed research guidance"],
+                "does_not_own": ["implementation evidence"],
+            },
+            {
+                "schema_version": "agent_role_capability/v1",
+                "id": "review-gate",
+                "display_name": "Review Gate",
+                "runtime_claim": "descriptor_not_runtime_agent",
+                "owns": ["review evidence interpretation"],
+                "does_not_own": ["unobserved review claims"],
+            },
+        ],
+        "skills": _standalone_skill_capabilities(),
+        "hooks": {
+            "schema_version": "omh_hook_manifest/v1",
+            "plugin_tools": [
+                {
+                    "name": name,
+                    "supported_by_plugin_bundle": True,
+                    "supported_by_wrapper_contract": name in {"omh_status", "omh_hud", "omh_capabilities"},
+                    "supported_by_cli_backend": name == "omh_capabilities",
+                    "observed_in_this_environment": False,
+                }
+                for name in PROVIDED_TOOLS
+            ],
+            "plugin_hooks": [
+                {
+                    "name": name,
+                    "supported_by_plugin_bundle": True,
+                    "claim_boundary": "Hook availability is not proof that Hermes loaded or invoked the plugin.",
+                    "observed_in_this_environment": False,
+                }
+                for name in PROVIDED_HOOKS
+            ],
+        },
+        "keywords": {
+            "schema_version": "keyword_detector_manifest/v1",
+            "explicit_invocation_prefixes": [
+                {"prefix": "$", "strength": "exact", "precedence": 1},
+                {"prefix": "/", "strength": "exact", "precedence": 1},
+                {"prefix": "./", "strength": "exact", "precedence": 1},
+                {"prefix": "@", "strength": "exact", "precedence": 1},
+            ],
+            "guard_policy_catalog": [
+                {
+                    "id": "risky_refactor_before_cleanup",
+                    "rule": "Risky refactor language should route to planning/review before cleanup unless explicit invocation overrides.",
+                    "activation_status": "active",
+                },
+                {
+                    "id": "feedback_before_coding",
+                    "rule": "Product feedback and bug reports should route through triage/investigation before coding handoff unless code work is explicit.",
+                    "activation_status": "cataloged",
+                },
+            ],
+            "degraded": True,
+        },
+        "orchestration_patterns": [
+            {
+                "schema_version": "orchestration_pattern/v1",
+                "id": "executor_session_handoff",
+                "owner_role": "coding-handoff",
+                "observed_evidence_required": [
+                    "handoff_prepared",
+                    "dispatch_observed",
+                    "result_observed",
+                    "verification_observed",
+                ],
+                "prepared_is_not": _standalone_evidence_boundaries()["prepared_is_not"],
+            },
+            {
+                "schema_version": "orchestration_pattern/v1",
+                "id": "plan_execute_verify",
+                "owner_role": "planning-lead",
+                "observed_evidence_required": ["plan_accepted", "execution_observed", "verification_observed"],
+                "prepared_is_not": _standalone_evidence_boundaries()["prepared_is_not"],
+            },
+        ],
+        "tool_requirements": _standalone_tool_requirements(),
+        "evidence_boundaries": _standalone_evidence_boundaries(),
+    }
+
+
+def _standalone_skill_capabilities() -> list[dict[str, object]]:
+    return [
+        {
+            "schema_version": "skill_capability/v1",
+            "id": "deep-interview",
+            "display_name": "Deep Interview",
+            "runtime_claim": "skill_guidance_not_execution",
+            "primary_owner_role": "planning-lead",
+            "degraded": True,
+        },
+        {
+            "schema_version": "skill_capability/v1",
+            "id": "ralplan",
+            "display_name": "Ralplan",
+            "runtime_claim": "skill_guidance_not_execution",
+            "primary_owner_role": "planning-lead",
+            "degraded": True,
+        },
+        {
+            "schema_version": "skill_capability/v1",
+            "id": "ultragoal",
+            "display_name": "Ultragoal",
+            "runtime_claim": "skill_guidance_not_execution",
+            "primary_owner_role": "coding-handoff",
+            "degraded": True,
+        },
+        {
+            "schema_version": "skill_capability/v1",
+            "id": "loop",
+            "display_name": "Loop",
+            "runtime_claim": "skill_guidance_not_execution",
+            "primary_owner_role": "planning-lead",
+            "degraded": True,
+        },
+        {
+            "schema_version": "skill_capability/v1",
+            "id": "code-review",
+            "display_name": "Code Review",
+            "runtime_claim": "skill_guidance_not_execution",
+            "primary_owner_role": "review-gate",
+            "degraded": True,
+        },
+        {
+            "schema_version": "skill_capability/v1",
+            "id": "feedback-triage",
+            "display_name": "Feedback Triage",
+            "runtime_claim": "skill_guidance_not_execution",
+            "primary_owner_role": "research-lead",
+            "degraded": True,
+        },
+    ]
+
+
+def _standalone_tool_requirements() -> dict[str, object]:
+    return {
+        "schema_version": "tool_requirement_manifest/v1",
+        "derivation_status": "degraded_partial",
+        "items": [
+            {
+                "skill": item["id"],
+                "derivation_status": "degraded_partial",
+                "required_tools": [],
+                "required_mcps": [],
+                "fallback": "Standalone plugin fallback cannot inspect the installed skill catalog; use Hermes-native guidance or selected executor handoff.",
+                "source_refs": ["src/plugin_bundle/omh/tools/capability_tool.py"],
+            }
+            for item in _standalone_skill_capabilities()
+        ],
+        "claim_boundary": "Tool requirements are advisory until a host/plugin/wrapper reports observed tool availability.",
+    }
+
+
+def _standalone_evidence_boundaries() -> dict[str, str]:
+    return {
+        "prepared_is_not": (
+            "Prepared OMH capability, handoff, topology, or routing metadata is not execution, worker dispatch, "
+            "worktree creation, review, CI, merge-readiness, or merge evidence."
+        ),
+        "observed_required_for": "Runtime status changes require recorded wrapper/runtime/plugin evidence.",
+        "claim_rule": "Standalone plugin metadata is a capability hint, not proof of host invocation.",
+    }
+
+
+def _standalone_ids(value: object) -> list[str]:
+    if isinstance(value, dict) and not _standalone_items(value):
+        return sorted(str(key) for key in value)
+    return sorted(str(item.get("id") or item.get("name") or item.get("skill")) for item in _standalone_items(value))
+
+
+def _standalone_items(value: object) -> list[dict[str, object]]:
+    if isinstance(value, list):
+        return [item for item in value if isinstance(item, dict)]
+    if isinstance(value, dict):
+        items = []
+        for key in ("plugin_tools", "plugin_hooks", "items"):
+            nested = value.get(key)
+            if isinstance(nested, list):
+                items.extend(item for item in nested if isinstance(item, dict))
+        if not items and "schema_version" in value:
+            items.append(value)
+        return items
+    return []

--- a/src/plugin_pack.py
+++ b/src/plugin_pack.py
@@ -12,6 +12,7 @@ from . import __version__
 from .hashutil import sha256_file, sha256_text
 from .local_store import atomic_write_json, ensure_dir, read_json_object, utc_now
 from .paths import OmhPaths
+from .plugin_bundle.omh.metadata import PROVIDED_HOOKS, PROVIDED_TOOLS
 
 PLUGIN_NAME = "omh"
 PLUGIN_SCHEMA_VERSION = "plugin_distribution/v1"
@@ -264,8 +265,8 @@ def _register_smoke(plugin_dir: Path) -> dict[str, Any]:
         if not callable(register):
             return {"import_smoke": True, "register_smoke": False, "error": "register(ctx) is missing"}
         register(ctx)
-        required_tools = {"omh_gather_evidence", "omh_hud", "omh_role", "omh_status"}
-        required_hooks = {"on_session_end", "pre_llm_call", "pre_tool_call"}
+        required_tools = set(PROVIDED_TOOLS)
+        required_hooks = set(PROVIDED_HOOKS)
         return {
             "import_smoke": True,
             "register_smoke": required_tools.issubset(set(ctx.tools)) and required_hooks.issubset(set(ctx.hooks)),

--- a/src/routing/chat.py
+++ b/src/routing/chat.py
@@ -5,7 +5,13 @@ import hashlib
 from typing import Any
 
 from ..ingress import CHAT_SOURCES, extract_message_text
-from .policy import CONFIDENCE_LEVELS, ROUTE_ACTIONS, is_ambiguous_scores, meets_confidence_threshold
+from .policy import (
+    CONFIDENCE_LEVELS,
+    ROUTE_ACTIONS,
+    explicit_skill_invocation as explicit_skill_name,
+    is_ambiguous_scores,
+    meets_confidence_threshold,
+)
 from .recommend import recommend_skills
 from ..skills.catalog import SkillDefinition, builtin_definitions, primary_harness_for_skill
 
@@ -143,14 +149,7 @@ def public_route_payload(decision: dict[str, object], *, include_message: bool =
 
 def explicit_skill_invocation(message: str, definitions: list[SkillDefinition] | None = None) -> str | None:
     definitions = definitions or builtin_definitions()
-    names = {definition.name for definition in definitions}
-    first = message.strip().split(maxsplit=1)[0].strip(":,")
-    for prefix in ("./", "/", "$", "@"):
-        if first.startswith(prefix):
-            first = first[len(prefix) :]
-            break
-    first = first.lower().strip(":,")
-    return first if first in names else None
+    return explicit_skill_name(message, {definition.name for definition in definitions})
 
 
 def routing_record_payload(

--- a/src/routing/localization.py
+++ b/src/routing/localization.py
@@ -241,6 +241,10 @@ _ALIASES: tuple[LocaleAlias, ...] = (
 )
 
 
+def locale_aliases() -> tuple[LocaleAlias, ...]:
+    return _ALIASES
+
+
 def prepare_routing_text(value: str) -> RoutingText:
     original = value.strip()
     folded = _fold_for_match(original)

--- a/src/routing/policy.py
+++ b/src/routing/policy.py
@@ -1,10 +1,45 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 
 ROUTE_ACTIONS = ("dispatch", "clarify", "fallback")
 CONFIDENCE_LEVELS = ("low", "medium", "high")
+EXPLICIT_INVOCATION_PREFIXES = ("$", "/", "./", "@")
 
 _CONFIDENCE_RANK = {name: index for index, name in enumerate(CONFIDENCE_LEVELS, start=1)}
+
+
+@dataclass(frozen=True)
+class RoutingGuardRule:
+    id: str
+    rule: str
+    matched_label: str
+    preferred_skills: tuple[str, ...]
+    score_boost: int
+    why: str
+    activation_status: str
+
+
+RISKY_REFACTOR_GUARD = RoutingGuardRule(
+    id="risky_refactor_before_cleanup",
+    rule="Risky refactor language should route to planning/review before cleanup unless explicit invocation overrides.",
+    matched_label="guard:risky_refactor_before_cleanup",
+    preferred_skills=("plan", "ralplan"),
+    score_boost=20,
+    why="Matched guard/trigger metadata; risky code-change requests should get a reviewed plan before cleanup.",
+    activation_status="active",
+)
+FEEDBACK_BEFORE_CODING_GUARD = RoutingGuardRule(
+    id="feedback_before_coding",
+    rule="Product feedback and bug reports should route through triage/investigation before coding handoff unless code work is explicit.",
+    matched_label="guard:feedback_before_coding",
+    preferred_skills=("feedback-triage",),
+    score_boost=0,
+    why="Product feedback and bug reports should get triage/investigation before coding handoff.",
+    activation_status="cataloged",
+)
+ROUTING_GUARD_RULES = (RISKY_REFACTOR_GUARD, FEEDBACK_BEFORE_CODING_GUARD)
 
 
 def is_ambiguous_scores(first_score: int, second_score: int | None) -> bool:
@@ -13,3 +48,44 @@ def is_ambiguous_scores(first_score: int, second_score: int | None) -> bool:
 
 def meets_confidence_threshold(confidence: str, threshold: str) -> bool:
     return _CONFIDENCE_RANK[confidence] >= _CONFIDENCE_RANK[threshold]
+
+
+def explicit_skill_invocation(message: str, names: set[str]) -> str | None:
+    first = message.strip().split(maxsplit=1)[0].strip(":,").lower()
+    for prefix in sorted(EXPLICIT_INVOCATION_PREFIXES, key=len, reverse=True):
+        if first.startswith(prefix):
+            first = first[len(prefix) :].strip(":,")
+            break
+    return first if first in names else None
+
+
+def active_routing_guard_rules(
+    normalized_query: str,
+    query_tokens: set[str],
+    *,
+    explicit_skill: str | None = None,
+) -> tuple[RoutingGuardRule, ...]:
+    if explicit_skill:
+        return ()
+    rules: list[RoutingGuardRule] = []
+    if _risky_refactor_guard_applies(normalized_query, query_tokens):
+        rules.append(RISKY_REFACTOR_GUARD)
+    return tuple(rules)
+
+
+def _risky_refactor_guard_applies(normalized_query: str, query_tokens: set[str]) -> bool:
+    if not ({"refactor", "refactoring"} & query_tokens):
+        return False
+    if {"risky", "dangerous", "unsafe"} & query_tokens:
+        return True
+    return any(
+        phrase in normalized_query
+        for phrase in (
+            "feels risky",
+            "seems risky",
+            "위험한 리팩터링",
+            "위험한 리팩토링",
+            "리팩터링 위험",
+            "리팩토링 위험",
+        )
+    )

--- a/src/routing/recommend.py
+++ b/src/routing/recommend.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, replace
 
 from ..skills.catalog import SkillDefinition, builtin_definitions
 from .localization import normalized_phrase, prepare_routing_text, routing_tokens
+from .policy import RoutingGuardRule, active_routing_guard_rules, explicit_skill_invocation
 
 
 _STOPWORDS = {
@@ -244,7 +245,7 @@ class Recommendation:
         return data
 
 
-def recommend_skills(query: str, *, limit: int = 5) -> list[dict[str, object]]:
+def recommend_skills(query: str, *, limit: int = 5, apply_guardrails: bool = True) -> list[dict[str, object]]:
     if limit < 1:
         raise ValueError("recommend --limit must be at least 1")
 
@@ -260,6 +261,13 @@ def recommend_skills(query: str, *, limit: int = 5) -> list[dict[str, object]]:
     if not matches:
         matches = _fallback_recommendations(definitions, query)
         return [recommendation.to_dict() for recommendation in matches[:limit]]
+    if apply_guardrails:
+        matches = _apply_guardrail_reranking(
+            matches,
+            normalized_query=normalized_query,
+            query_tokens=query_tokens,
+            explicit_skill=explicit_skill_invocation(query, {definition.name for definition in definitions}),
+        )
     matches.sort(key=lambda recommendation: (-recommendation.score, recommendation.skill))
     return [recommendation.to_dict() for recommendation in matches[:limit]]
 
@@ -359,6 +367,40 @@ def _fallback_recommendations(definitions: list[SkillDefinition], query: str) ->
             )
         )
     return recommendations
+
+
+def _apply_guardrail_reranking(
+    recommendations: list[Recommendation],
+    *,
+    normalized_query: str,
+    query_tokens: set[str],
+    explicit_skill: str | None,
+) -> list[Recommendation]:
+    guards = active_routing_guard_rules(normalized_query, query_tokens, explicit_skill=explicit_skill)
+    if not guards:
+        return recommendations
+    reranked = []
+    for recommendation in recommendations:
+        reranked.append(_apply_guard_rules_to_recommendation(recommendation, guards))
+    return reranked
+
+
+def _apply_guard_rules_to_recommendation(
+    recommendation: Recommendation,
+    guards: tuple[RoutingGuardRule, ...],
+) -> Recommendation:
+    updated = recommendation
+    for guard in guards:
+        if updated.skill in guard.preferred_skills:
+            score = updated.score + guard.score_boost
+            updated = replace(
+                updated,
+                score=score,
+                confidence=_confidence(score),
+                matched=tuple(sorted({*updated.matched, guard.matched_label})),
+                why=guard.why,
+            )
+    return updated
 
 
 def _tokens(value: str) -> set[str]:

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import json
+import tomllib
+import unittest
+from pathlib import Path
+
+from _cli_harness import run_cli
+from _local_package import load_local_package
+
+load_local_package()
+
+from omh.capabilities.registry import capability_snapshot, inspect_capability, list_capabilities
+
+
+class CapabilityManifestTests(unittest.TestCase):
+    def test_capability_snapshot_is_deterministic_and_boundary_safe(self) -> None:
+        first = capability_snapshot()
+        second = capability_snapshot()
+
+        self.assertEqual(first, second)
+        self.assertEqual(first["schema_version"], "omh_capability_manifest/v1")
+        self.assertEqual(first["determinism"], "static_projection_no_runtime_clock")
+        self.assertGreaterEqual(first["summary"]["skills"], 30)
+        self.assertGreaterEqual(first["summary"]["agent_roles"], 4)
+        self.assertIn("no runtime_topology schema in this PR", first["non_goals"])
+        self.assertNotIn("runtime_topology", first)
+        self.assertIn("Prepared OMH capability", first["evidence_boundaries"]["prepared_is_not"])
+
+    def test_capability_sections_have_expected_ids(self) -> None:
+        listing = list_capabilities()
+        sections = {section["section"]: section["ids"] for section in listing["sections"]}
+
+        self.assertIn("coding-handoff", sections["agent_roles"])
+        self.assertIn("ultragoal", sections["skills"])
+        self.assertIn("omh_capabilities", sections["hooks"])
+        self.assertIn("executor_session_handoff", sections["orchestration_patterns"])
+        self.assertIn("ultragoal", sections["tool_requirements"])
+
+    def test_capability_inspect_finds_skill_and_role_without_runtime_claim(self) -> None:
+        skill = inspect_capability("ultragoal", section="skills")["capability"]
+        role = inspect_capability("coding-handoff", section="agent_roles")["capability"]
+
+        self.assertEqual(skill["schema_version"], "skill_capability/v1")
+        self.assertEqual(skill["tool_requirements"]["derivation_status"], "partial")
+        self.assertIn("prepared_not_observed", skill["evidence_boundary"])
+        self.assertEqual(role["runtime_claim"], "descriptor_not_runtime_agent")
+        self.assertIn("executor_session_handoff", role["default_orchestration_patterns"])
+
+    def test_cli_export_list_and_inspect(self) -> None:
+        status, stdout, stderr = run_cli(["capabilities", "export", "--json"], output_json=False)
+
+        self.assertEqual(status, 0, stderr)
+        self.assertEqual(stderr, "")
+        payload = json.loads(stdout)
+        self.assertEqual(payload["schema_version"], "omh_capability_manifest/v1")
+
+        status, stdout, stderr = run_cli(["capabilities", "list"], output_json=False)
+
+        self.assertEqual(status, 0, stderr)
+        self.assertIn("OMH capabilities", stdout)
+        self.assertIn("For machine-readable output", stdout)
+
+        status, stdout, stderr = run_cli(["capabilities", "inspect", "executor_session_handoff", "--json"], output_json=False)
+
+        self.assertEqual(status, 0, stderr)
+        inspected = json.loads(stdout)
+        self.assertEqual(inspected["section"], "orchestration_patterns")
+        self.assertEqual(inspected["capability"]["owner_role"], "coding-handoff")
+
+    def test_package_metadata_includes_capabilities_package(self) -> None:
+        pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+        packages = set(pyproject["tool"]["setuptools"]["packages"])
+
+        self.assertIn("omh.capabilities", packages)
+        self.assertEqual(pyproject["tool"]["setuptools"]["package-dir"]["omh.capabilities"], "src/capabilities")
+
+    def test_runtime_topology_is_deferred_from_first_pr(self) -> None:
+        self.assertFalse(Path("src/capabilities/runtime_topology.py").exists())
+        payload = capability_snapshot()
+        exported = json.dumps(payload, sort_keys=True)
+
+        self.assertNotIn('"runtime_topology"', exported)
+        self.assertIn("no runtime_topology schema in this PR", payload["non_goals"])

--- a/tests/test_chat_router.py
+++ b/tests/test_chat_router.py
@@ -20,8 +20,8 @@ class ChatRouterTests(unittest.TestCase):
         decision = route_chat_message("risky refactor", source="discord")
 
         self.assertEqual(decision["action"], "dispatch")
-        self.assertEqual(decision["selected_skill"], "ai-slop-cleaner")
-        self.assertEqual(decision["selected_harness"], "coding-handling")
+        self.assertEqual(decision["selected_skill"], "ralplan")
+        self.assertEqual(decision["selected_harness"], "planning")
         self.assertEqual(decision["confidence"], "high")
         self.assertIn("User message:\nrisky refactor", decision["routing_prompt"])
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1072,6 +1072,9 @@ class CliTests(unittest.TestCase):
         self.assertEqual(payload["query"], "risky refactor")
         recommendations = payload["recommendations"]
         self.assertTrue(recommendations)
+        self.assertEqual(recommendations[0]["skill"], "ralplan")
+        self.assertIn("guard:risky_refactor_before_cleanup", recommendations[0]["matched"])
+        self.assertEqual(recommendations[0]["next_action"], "present_plan")
         self.assertIn("ai-slop-cleaner", {recommendation["skill"] for recommendation in recommendations[:3]})
         self.assertTrue(any(recommendation["why"] and recommendation["suggested_prompt"] for recommendation in recommendations))
         cleanup = next(recommendation for recommendation in recommendations if recommendation["skill"] == "ai-slop-cleaner")
@@ -1634,7 +1637,8 @@ class CliTests(unittest.TestCase):
         self.assertEqual(status, 0)
         route = json.loads(stdout)["route"]
         self.assertEqual(route["action"], "dispatch")
-        self.assertEqual(route["selected_skill"], "ai-slop-cleaner")
+        self.assertEqual(route["selected_skill"], "ralplan")
+        self.assertIn("guard:risky_refactor_before_cleanup", route["recommendations"][0]["matched"])
         self.assertIn("routing_prompt_template", route)
         self.assertIn("{message}", route["routing_prompt_template"])
         self.assertNotIn("risky refactor", json.dumps(route))
@@ -2186,7 +2190,7 @@ class CliTests(unittest.TestCase):
             self.assertEqual(status, 0)
             payload = json.loads(stdout)
             run_id = payload["runtime"]["run"]["run_id"]
-            self.assertEqual(payload["runtime"]["routing"]["selected_skill"], "ai-slop-cleaner")
+            self.assertEqual(payload["runtime"]["routing"]["selected_skill"], "ralplan")
 
             status, stdout, stderr = run_cli(["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes"), "runtime", "show", run_id])
 

--- a/tests/test_hook_manifest.py
+++ b/tests/test_hook_manifest.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import unittest
+
+from _local_package import load_local_package
+
+load_local_package()
+
+from omh.capabilities.hooks import hook_manifest
+
+
+class HookManifestTests(unittest.TestCase):
+    def test_hook_manifest_projects_plugin_yaml_and_wrapper_events(self) -> None:
+        manifest = hook_manifest()
+
+        self.assertEqual(manifest["schema_version"], "omh_hook_manifest/v1")
+        tools = {item["name"]: item for item in manifest["plugin_tools"]}
+        hooks = {item["name"]: item for item in manifest["plugin_hooks"]}
+        events = {item["name"]: item for item in manifest["wrapper_events"]}
+
+        self.assertIn("omh_capabilities", tools)
+        self.assertTrue(tools["omh_capabilities"]["supported_by_plugin_bundle"])
+        self.assertTrue(tools["omh_capabilities"]["supported_by_cli_backend"])
+        self.assertFalse(tools["omh_capabilities"]["observed_in_this_environment"])
+        self.assertIn("pre_llm_call", hooks)
+        self.assertIn("bounded_status_context", hooks["pre_llm_call"]["payload_fields"])
+        self.assertIn("executor_opened", events)
+        self.assertIn("selected_executor_profile", events["executor_opened"]["payload_fields"])
+        self.assertIn("not proof", hooks["pre_llm_call"]["claim_boundary"])

--- a/tests/test_hud.py
+++ b/tests/test_hud.py
@@ -129,6 +129,51 @@ class HudCliTests(unittest.TestCase):
             self.assertTrue(payload["plugin"]["capabilities"]["tools"]["omh_status"])
             self.assertIn("plugin:update-needed", payload["display"]["line"])
 
+    def test_hud_marks_legacy_complete_plugin_without_capabilities_tool_as_stale(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / ".omh"
+            hermes_home = root / ".hermes"
+            plugin_dir = hermes_home / "plugins" / "omh"
+            tools_dir = plugin_dir / "tools"
+            refs_dir = plugin_dir / "references"
+            tools_dir.mkdir(parents=True)
+            refs_dir.mkdir()
+            (plugin_dir / "__init__.py").write_text("def register(ctx):\n    pass\n", encoding="utf-8")
+            (plugin_dir / "plugin.yaml").write_text(
+                "\n".join(
+                    [
+                        "name: omh",
+                        'version: "0.9.0"',
+                        "provides_tools:",
+                        "  - omh_gather_evidence",
+                        "  - omh_hud",
+                        "  - omh_role",
+                        "  - omh_status",
+                        "provides_hooks:",
+                        "  - on_session_end",
+                        "  - pre_llm_call",
+                        "  - pre_tool_call",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            for stem in ("evidence_tool", "hud_tool", "role_tool", "status_tool"):
+                (tools_dir / f"{stem}.py").write_text("SCHEMA = {}\n", encoding="utf-8")
+            (refs_dir / "role-planning-lead.md").write_text("# Planning Lead\n", encoding="utf-8")
+
+            status, stdout, stderr = run_cli(
+                ["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "hud", "--json"]
+            )
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            payload = json.loads(stdout)
+            self.assertEqual(payload["plugin"]["status"], "stale")
+            self.assertFalse(payload["plugin"]["capabilities"]["tools"]["omh_capabilities"])
+            self.assertTrue(payload["plugin"]["capabilities"]["tools"]["omh_status"])
+            self.assertIn("plugin:update-needed", payload["display"]["line"])
+
     def test_hud_plugin_tool_tolerates_untrusted_limit_argument(self) -> None:
         from omh.plugin_bundle.omh.tools.hud_tool import omh_hud_handler
 

--- a/tests/test_keyword_manifest.py
+++ b/tests/test_keyword_manifest.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import unittest
+
+from _local_package import load_local_package
+
+load_local_package()
+
+from omh.capabilities.keywords import keyword_detector_manifest
+
+
+class KeywordManifestTests(unittest.TestCase):
+    def test_keyword_manifest_exports_invocation_precedence_and_locale_policy(self) -> None:
+        manifest = keyword_detector_manifest()
+
+        self.assertEqual(manifest["schema_version"], "keyword_detector_manifest/v1")
+        prefixes = {item["prefix"]: item for item in manifest["explicit_invocation_prefixes"]}
+        for prefix in ("$", "/", "./", "@"):
+            self.assertEqual(prefixes[prefix]["strength"], "exact")
+            self.assertEqual(prefixes[prefix]["precedence"], 1)
+        self.assertTrue(manifest["conflict_policy"]["explicit_wins"])
+        self.assertEqual(manifest["conflict_policy"]["tied_scores"], "clarify")
+        self.assertIn("ja", manifest["locale_policy"]["supported_alias_locales"])
+        self.assertIn("payment_failure", manifest["locale_policy"]["alias_labels"])
+
+    def test_keyword_manifest_includes_guard_rules_and_skill_triggers(self) -> None:
+        manifest = keyword_detector_manifest()
+        rules = {item["id"]: item["rule"] for item in manifest["guard_rules"]}
+        catalog = {item["id"]: item for item in manifest["guard_policy_catalog"]}
+        skills = {item["skill"]: item for item in manifest["natural_language_rules"]}
+
+        self.assertIn("risky_refactor_before_cleanup", rules)
+        self.assertIn("planning/review", rules["risky_refactor_before_cleanup"])
+        self.assertEqual(catalog["risky_refactor_before_cleanup"]["activation_status"], "active")
+        self.assertEqual(catalog["feedback_before_coding"]["activation_status"], "cataloged")
+        self.assertIn("ultragoal", skills)
+        self.assertIn("$ultragoal", skills["ultragoal"]["triggers"])

--- a/tests/test_orchestration_patterns.py
+++ b/tests/test_orchestration_patterns.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import unittest
+
+from _local_package import load_local_package
+
+load_local_package()
+
+from omh.capabilities.orchestration import orchestration_patterns
+
+
+class OrchestrationPatternTests(unittest.TestCase):
+    def test_orchestration_patterns_include_team_worktree_loop_and_handoff_without_claiming_execution(self) -> None:
+        patterns = {item["id"]: item for item in orchestration_patterns()}
+
+        for expected in {
+            "single_lane",
+            "clarify_then_plan",
+            "plan_execute_verify",
+            "team_staged_pipeline",
+            "swarm_batch",
+            "worktree_isolated_workers",
+            "loop_run_once",
+            "executor_session_handoff",
+            "materials_generation_handoff",
+        }:
+            self.assertIn(expected, patterns)
+
+        handoff = patterns["executor_session_handoff"]
+        self.assertEqual(handoff["owner_role"], "coding-handoff")
+        self.assertIn("choose_executor", handoff["wrapper_actions"])
+        self.assertIn("dispatch_observed", handoff["observed_evidence_required"])
+        self.assertIn("not execution", handoff["prepared_is_not"])
+
+        worktree = patterns["worktree_isolated_workers"]
+        self.assertIn("worktree_creation_observed", worktree["observed_evidence_required"])
+        self.assertIn("Do not claim worktrees exist", worktree["do_not_use_when"])

--- a/tests/test_plugin_capabilities.py
+++ b/tests/test_plugin_capabilities.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import textwrap
+import unittest
+from tempfile import TemporaryDirectory
+from pathlib import Path
+
+from _cli_harness import run_cli
+from _local_package import load_local_package
+
+load_local_package()
+
+from omh.capabilities.schema import CAPABILITY_SECTIONS
+from omh.plugin_bundle.omh.metadata import PROVIDED_HOOKS, PROVIDED_TOOLS
+from test_plugin_distribution import FakeHermesContext, load_installed_plugin
+
+
+class PluginCapabilitiesTests(unittest.TestCase):
+    def test_installed_plugin_registers_capabilities_tool_and_returns_bounded_json(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / ".omh"
+            hermes_home = root / ".hermes"
+            status, _, stderr = run_cli(["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "setup", "--with-plugin"])
+            self.assertEqual(status, 0, stderr)
+
+            module = load_installed_plugin(hermes_home / "plugins" / "omh")
+            ctx = FakeHermesContext()
+            module.register(ctx)
+
+            self.assertIn("omh_capabilities", ctx.tools)
+            handler = ctx.tools["omh_capabilities"]["args"][2]
+            payload = json.loads(handler({"action": "export", "section": "keywords"}))
+            self.assertEqual(payload["schema_version"], "omh_capability_manifest/v1")
+            self.assertEqual(payload["section"], "keywords")
+            self.assertIn("explicit_invocation_prefixes", payload["keywords"])
+
+            inspected = json.loads(handler({"action": "inspect", "id": "coding-handoff"}))
+            self.assertEqual(inspected["section"], "agent_roles")
+            self.assertEqual(inspected["capability"]["runtime_claim"], "descriptor_not_runtime_agent")
+
+    def test_installed_plugin_capabilities_tool_loads_without_installed_omh_package(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / ".omh"
+            hermes_home = root / ".hermes"
+            status, _, stderr = run_cli(["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "setup", "--with-plugin"])
+            self.assertEqual(status, 0, stderr)
+            plugin_dir = hermes_home / "plugins" / "omh"
+            script = textwrap.dedent(
+                f"""
+                import importlib.util
+                import json
+                import sys
+
+                class FakeCtx:
+                    def __init__(self):
+                        self.tools = {{}}
+                        self.hooks = {{}}
+
+                    def register_tool(self, name, *args, **kwargs):
+                        self.tools[name] = {{"args": args, "kwargs": kwargs}}
+
+                    def register_hook(self, name, handler):
+                        self.hooks[name] = handler
+
+                spec = importlib.util.spec_from_file_location(
+                    "_standalone_omh_plugin",
+                    {str(plugin_dir / "__init__.py")!r},
+                    submodule_search_locations=[{str(plugin_dir)!r}],
+                )
+                module = importlib.util.module_from_spec(spec)
+                sys.modules["_standalone_omh_plugin"] = module
+                spec.loader.exec_module(module)
+                ctx = FakeCtx()
+                module.register(ctx)
+                handler = ctx.tools["omh_capabilities"]["args"][2]
+                keywords = json.loads(handler({{"action": "export", "section": "keywords"}}))
+                exported = json.loads(handler({{"action": "export"}}))
+                listed_tools = json.loads(handler({{"action": "list", "section": "tool_requirements"}}))
+                evidence = json.loads(handler({{"action": "export", "section": "evidence_boundaries"}}))
+                inspected = json.loads(handler({{"action": "inspect", "id": "coding-handoff"}}))
+                inspected_loop = json.loads(handler({{"action": "inspect", "section": "skills", "id": "loop"}}))
+                inspected_boundary = json.loads(
+                    handler({{"action": "inspect", "section": "evidence_boundaries", "id": "prepared_is_not"}})
+                )
+                invalid_section = json.loads(handler({{"action": "inspect", "section": "missing", "id": "loop"}}))
+                print(json.dumps({{
+                    "tool_registered": "omh_capabilities" in ctx.tools,
+                    "sections": sorted(key for key in exported if key in {set(CAPABILITY_SECTIONS)!r}),
+                    "plugin_tools": sorted(item["name"] for item in exported["hooks"]["plugin_tools"]),
+                    "plugin_hooks": sorted(item["name"] for item in exported["hooks"]["plugin_hooks"]),
+                    "source": exported["source"],
+                    "keyword_schema": keywords["keywords"]["schema_version"],
+                    "tool_requirement_schema": exported["tool_requirements"]["schema_version"],
+                    "tool_requirement_ids": listed_tools["ids"],
+                    "evidence_section": evidence["section"],
+                    "prepared_boundary": inspected_boundary["capability"],
+                    "inspect_section": inspected["section"],
+                    "loop_section": inspected_loop["section"],
+                    "loop_runtime_claim": inspected_loop["capability"]["runtime_claim"],
+                    "runtime_claim": inspected["capability"]["runtime_claim"],
+                    "invalid_section_error": invalid_section["error"],
+                    "degraded": inspected["degraded"],
+                }}, sort_keys=True))
+                """
+            )
+
+            result = subprocess.run(
+                [sys.executable, "-S", "-c", script],
+                cwd=str(root),
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            payload = json.loads(result.stdout)
+            self.assertTrue(payload["tool_registered"])
+            self.assertEqual(payload["sections"], sorted(CAPABILITY_SECTIONS))
+            self.assertEqual(payload["plugin_tools"], sorted(PROVIDED_TOOLS))
+            self.assertEqual(payload["plugin_hooks"], sorted(PROVIDED_HOOKS))
+            self.assertEqual(payload["source"], "standalone_plugin_bundle_fallback")
+            self.assertEqual(payload["keyword_schema"], "keyword_detector_manifest/v1")
+            self.assertEqual(payload["tool_requirement_schema"], "tool_requirement_manifest/v1")
+            self.assertIn("loop", payload["tool_requirement_ids"])
+            self.assertEqual(payload["evidence_section"], "evidence_boundaries")
+            self.assertIn("Prepared OMH capability", payload["prepared_boundary"])
+            self.assertEqual(payload["inspect_section"], "agent_roles")
+            self.assertEqual(payload["loop_section"], "skills")
+            self.assertEqual(payload["loop_runtime_claim"], "skill_guidance_not_execution")
+            self.assertEqual(payload["runtime_claim"], "descriptor_not_runtime_agent")
+            self.assertIn("unknown capability section", payload["invalid_section_error"])
+            self.assertTrue(payload["degraded"])

--- a/tests/test_plugin_distribution.py
+++ b/tests/test_plugin_distribution.py
@@ -16,6 +16,7 @@ load_local_package()
 
 from omh.paths import resolve_paths
 from omh.plugin_pack import inspect_plugin_bundle
+from omh.plugin_bundle.omh.metadata import PROVIDED_HOOKS, PROVIDED_TOOLS, TOOL_FILE_STEMS
 
 
 class FakeHermesContext:
@@ -64,6 +65,19 @@ class PluginDistributionTests(unittest.TestCase):
             pyproject["tool"]["setuptools"]["package-data"]["omh.plugin_bundle.omh.references"],
         )
 
+    def test_plugin_yaml_advertises_metadata_tools_and_hooks(self) -> None:
+        root = resources.files("omh.plugin_bundle.omh")
+        text = root.joinpath("plugin.yaml").read_text(encoding="utf-8")
+
+        for tool in PROVIDED_TOOLS:
+            self.assertIn(f"  - {tool}", text)
+            self.assertTrue(
+                root.joinpath("tools", f"{TOOL_FILE_STEMS[tool]}.py").is_file(),
+                f"{tool} must have a bundled tool file declared by metadata.py",
+            )
+        for hook in PROVIDED_HOOKS:
+            self.assertIn(f"  - {hook}", text)
+
     def test_setup_default_installs_plugin(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -98,7 +112,10 @@ class PluginDistributionTests(unittest.TestCase):
             self.assertTrue(plugin["requires_hermes_plugin_enable"])
             self.assertTrue((plugin_dir / "plugin.yaml").exists())
             self.assertTrue((plugin_dir / ".omh-plugin-manifest.json").exists())
-            self.assertEqual(plugin["registered_tools"], ["omh_gather_evidence", "omh_hud", "omh_role", "omh_status"])
+            self.assertEqual(
+                plugin["registered_tools"],
+                ["omh_capabilities", "omh_gather_evidence", "omh_hud", "omh_role", "omh_status"],
+            )
             self.assertEqual(plugin["registered_hooks"], ["on_session_end", "pre_llm_call", "pre_tool_call"])
 
             inspection = inspect_plugin_bundle(resolve_paths(omh_home, hermes_home))
@@ -185,6 +202,7 @@ class PluginDistributionTests(unittest.TestCase):
             module = load_installed_plugin(hermes_home / "plugins" / "omh")
             ctx = FakeHermesContext()
             module.register(ctx)
+            self.assertIn("omh_capabilities", ctx.tools)
             self.assertIn("omh_gather_evidence", ctx.tools)
             self.assertIn("omh_hud", ctx.tools)
             self.assertIn("omh_role", ctx.tools)

--- a/tests/test_runtime_artifacts.py
+++ b/tests/test_runtime_artifacts.py
@@ -203,7 +203,7 @@ class RuntimeArtifactTests(unittest.TestCase):
                 routing_record_payload(decision, message, source_event_id="m1"),
             )
 
-            self.assertEqual(routing["selected_skill"], "ai-slop-cleaner")
+            self.assertEqual(routing["selected_skill"], "ralplan")
             self.assertEqual(routing["source_event_id"], "m1")
             self.assertTrue(validate_runtime(paths, run["run_id"])["ok"])
             shown = show_run(paths, run["run_id"])


### PR DESCRIPTION
## Feature Report

### What Changed

- Added deterministic OMH capability manifests for agent roles, skills, plugin hooks/tools, keyword policy, orchestration patterns, tool requirements, and evidence boundaries.
- Added the `omh capabilities export/list/inspect` CLI surface for backend, wrapper, and operator inspection.
- Added the Hermes plugin `omh_capabilities` metadata tool and advertised it through the plugin bundle.
- Centralized plugin tool/hook metadata so plugin registration, HUD readiness, register smoke, and tests share the same source.
- Hardened risky-refactor routing so natural chat routes to planning before cleanup, while explicit coding delegation still prepares the selected coding runtime handoff.

### Why This Exists

OMH needs to feel Hermes-native without turning into a hidden runtime patch or a CLI-first product. Hermes/wrapper/plugin surfaces need a stable way to ask what OMH can prepare, which skills own which work, which hooks/tools exist, and which claims still require observed evidence.

This closes the agent/skill/hook/keyword/orchestration parity gap by making those capabilities inspectable as deterministic local contracts rather than scattered docs or implicit code paths.

### User / Operator Impact

- Hermes wrappers can call `omh_capabilities` or `omh capabilities export --json` to understand available OMH lanes and safe next actions.
- Operators can inspect a specific capability, such as `executor_session_handoff`, without reading source files.
- Risky refactor chat messages now present a reviewed plan before cleanup unless the user explicitly invokes a coding skill.
- Older plugin bundles missing the new capability tool show as stale instead of looking fully ready.

### How It Works

- `src/capabilities/` projects existing catalogs and contracts into schema-versioned manifests. It is not a new authoring source.
- `src/commands/capabilities.py` exposes export/list/inspect commands with JSON and human-readable output.
- `src/plugin_bundle/omh/tools/capability_tool.py` loads the full package registry when available and falls back to a clearly degraded standalone bundle snapshot when the plugin is copied without the package installed.
- `src/plugin_bundle/omh/metadata.py` defines provided tools/hooks once for plugin registration, smoke checks, HUD readiness, and tests.
- `src/routing/policy.py` owns explicit invocation parsing and guard-rule metadata; recommendation and chat routing consume it.

### Files And Contracts Touched

- Capability contracts: `src/capabilities/*`, `docs/CAPABILITIES.md`, `docs/ORCHESTRATION_PATTERNS.md`
- CLI: `src/commands/capabilities.py`, `src/commands/main.py`
- Plugin: `src/plugin_bundle/omh/__init__.py`, `metadata.py`, `plugin.yaml`, `runtime_reader.py`, `tools/capability_tool.py`, `src/plugin_pack.py`
- Routing: `src/routing/policy.py`, `recommend.py`, `chat.py`, `localization.py`, `src/coding_delegation.py`
- Tests: capability, plugin fallback, hook, keyword, orchestration, HUD, chat/router, CLI, and runtime artifact tests

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` - 395 tests OK
- [x] `uv run python -m compileall -q src tests` - OK
- [x] `uv run python -m src.cli docs workflows --check` - OK, 34 expected skills checked
- [ ] `python3 -m omh.cli harness validate` - not run; this PR locks capability contracts through focused manifest/plugin tests instead
- [ ] `python3 -m omh.cli release checklist --json` - not run; no release metadata change
- [ ] `python3 -m omh.cli release hermes-smoke` - not run; no live Hermes profile mutation in this PR
- [x] Relevant dry-run or smoke command: `uv run omh capabilities list`; `uv run omh capabilities inspect executor_session_handoff --json`; `uv run omh capabilities export --section keywords --json`; `uv run omh recommend "this refactor feels risky"`; `uv run omh chat route --source discord "risky refactor"`; `uv run omh coding delegate --executor hermes "risky refactor"`
- [x] Package build: `uv build` - OK, wheel/sdist include `omh.capabilities` and plugin bundle files
- [x] Diff hygiene: `git diff --check` - OK
- [x] Independent review: code-reviewer APPROVE, architect CLEAR
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; plugin host invocation is still an external Hermes runtime observation and this PR only adds deterministic local contracts plus import/register smoke coverage

## Risk

- Standalone copied plugin fallback intentionally exposes a degraded subset, not the full installed skill catalog. Tests assert this boundary and the fallback marks itself `degraded`.
- Capability presence can be mistaken for runtime evidence if consumers ignore the manifest boundary fields. Docs and schemas repeat that prepared metadata is not execution/review/CI/merge evidence.
- Routing guard policy is now more explicit for risky refactors; explicit skill invocation and coding delegation retain the existing direct handoff path.

## Compatibility / Rollout

- Existing setup and routing commands remain compatible.
- Plugin bundles missing `omh_capabilities` will now be considered stale, so users may need to rerun `omh setup` to refresh the managed plugin payload.
- No Hermes core patching, no network/LLM/API calls, and no runtime topology implementation are introduced.

## Release / Claims

- [x] Release-channel impact considered: local contract/API expansion only; no version bump in this PR
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Known manual Hermes checks are listed, including live host plugin invocation gap

## Follow-Up

- Add runtime topology capability manifests only in a separate PR with explicit observed-runtime semantics.
- Consider richer host-observed plugin load evidence when Hermes exposes a stable plugin invocation signal.
