### PR TITLE
Add coding briefing contract for wrapper status

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -537,6 +537,14 @@ observed evidence, and keep review or verification gaps visible in
 verification, review, CI, merge-ready, and merged steps. Wrappers can render
 that card directly instead of inferring progress from prose.
 
+`omh chat session status` also exposes `coding_briefing/v1` as a sibling to the
+compact status card. The briefing is the richer Hermes-facing report surface for
+delegated coding work: it combines persisted route/plan metadata, compact handoff
+contracts, executor-session state, runtime evidence, review/CI/merge status,
+pending evidence gaps, and `user_facing_lines[]`. It remains metadata-only: raw
+prompts and full interview transcripts are not reconstructed, and merge-ready is
+kept distinct from observed merge evidence.
+
 ## Hermes Planning Artifacts
 
 Hermes-facing plans live under the configured Hermes home:

--- a/docs/CHAT_WRAPPER_EXAMPLES.md
+++ b/docs/CHAT_WRAPPER_EXAMPLES.md
@@ -214,6 +214,9 @@ What gets better for the team:
 | Primary status action id | `status_card.primary_action` |
 | Primary status button label | `status_card.primary_action_label`, `status_card.executor_next_action_label`, or the matching `executor_actions[].label` |
 | User-facing executor status | `status_card.executor_display_status_lines[]` |
+| Coding work briefing | `coding_briefing.user_facing_lines[]` |
+| Coding progress ladder | `coding_briefing.progress[]` |
+| Missing coding evidence | `coding_briefing.pending_gaps[]` |
 
 Hermes Agent surfaces should render these fields natively and keep OMH focused
 on the routing, handoff, status, and evidence contract.

--- a/docs/HERMES_AGENT_INTEGRATION_RUNBOOK.md
+++ b/docs/HERMES_AGENT_INTEGRATION_RUNBOOK.md
@@ -148,6 +148,14 @@ Executor result has not been observed yet.
 Hermes verification has not been requested yet.
 ```
 
+When the user asks “what is happening with that coding task?”, prefer the
+`coding_briefing/v1` object from `omh chat session status`. Render
+`coding_briefing.user_facing_lines[]` for a readable answer, and use
+`coding_briefing.progress[]`, `pending_gaps[]`, and `evidence_summary` for
+expanded status. Keep `status_card/v1` compact; do not treat the briefing as
+proof of execution, verification, review, CI, or merge unless the matching
+observed evidence appears in the briefing.
+
 For prompt-only Claude Code or generic agents, the same wrapper session action
 records attached/result metadata without creating a Codex lifecycle run. For
 Hermes/OMX/OMO/OMC runtime handoffs, an observed open also records the

--- a/src/runtime/artifacts.py
+++ b/src/runtime/artifacts.py
@@ -480,6 +480,7 @@ def summarize_delegated_coding_status(paths: OmhPaths, run_id: str) -> dict[str,
             "handoff_available": handoff_available,
             "handoff_schema_version": handoff.get("schema_version"),
         },
+        "handoff_contract": _handoff_contract_summary(handoff),
         "harness_quality": harness_quality,
         "harness_progress": harness_progress,
         "execution": {
@@ -762,6 +763,56 @@ def _downstream_gate_progress_state(
 
 def _object_or_empty(value: Any) -> dict[str, Any]:
     return value if isinstance(value, dict) else {}
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value if str(item)]
+
+
+def _handoff_contract_summary(handoff: dict[str, Any]) -> dict[str, Any]:
+    if not handoff:
+        return {}
+    summary: dict[str, Any] = {
+        "schema_version": handoff.get("schema_version", ""),
+        "selected_executor_profile": handoff.get("selected_executor_profile", handoff.get("executor_target", "")),
+        "execution_brief": _object_or_empty(handoff.get("execution_brief")),
+        "runtime_brief": _object_or_empty(handoff.get("runtime_brief")),
+        "report_contract": _object_or_empty(handoff.get("report_contract")),
+        "evidence_contract": _object_or_empty(handoff.get("evidence_contract")),
+        "acceptance_criteria": _string_list(handoff.get("acceptance_criteria")),
+        "verification": _string_list(handoff.get("verification")),
+    }
+    context_pack = _object_or_empty(handoff.get("context_pack"))
+    if context_pack:
+        summary["context_pack"] = _context_pack_summary(context_pack)
+    context_pack_blocked = _object_or_empty(handoff.get("context_pack_blocked"))
+    if context_pack_blocked:
+        summary["context_pack_blocked"] = _context_pack_blocked_summary(context_pack_blocked)
+    return summary
+
+
+def _context_pack_summary(context_pack: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "schema_version": context_pack.get("schema_version", ""),
+        "executor_target": context_pack.get("executor_target", ""),
+        "session_id": context_pack.get("session_id", ""),
+        "source_ref_count": len(_list_or_empty(context_pack.get("source_refs"))),
+        "included_context_count": len(_list_or_empty(context_pack.get("included_context"))),
+        "excluded_context_count": len(_list_or_empty(context_pack.get("excluded_context"))),
+        "blocked_by_conflicts_count": len(_list_or_empty(context_pack.get("blocked_by_conflicts"))),
+        "redaction_policy": context_pack.get("redaction_policy", ""),
+        "claim_boundary": context_pack.get("claim_boundary", ""),
+    }
+
+
+def _context_pack_blocked_summary(context_pack_blocked: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "schema_version": context_pack_blocked.get("schema_version", ""),
+        "blocked_by_conflicts_count": len(_list_or_empty(context_pack_blocked.get("blocked_by_conflicts"))),
+        "claim_boundary": context_pack_blocked.get("claim_boundary", ""),
+    }
 
 
 def _list_or_empty(value: Any) -> list[dict[str, Any]]:

--- a/src/wrapper/briefing.py
+++ b/src/wrapper/briefing.py
@@ -1,0 +1,571 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+CODING_BRIEFING_SCHEMA_VERSION = "coding_briefing/v1"
+
+
+def build_coding_briefing(
+    session: dict[str, Any],
+    *,
+    runtime_status: dict[str, Any] | None = None,
+    executor_status: dict[str, Any] | None = None,
+    runtime_observation: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a deterministic, user-facing summary from persisted wrapper evidence."""
+
+    runtime_status = runtime_status if isinstance(runtime_status, dict) else {}
+    executor_status = executor_status if isinstance(executor_status, dict) else {}
+    runtime_observation = runtime_observation if isinstance(runtime_observation, dict) else {}
+
+    session_id = str(session.get("session_id", ""))
+    run_id = str(session.get("current_run_id") or runtime_status.get("run_id") or "")
+    selected_executor = _selected_executor(session, runtime_status, executor_status)
+    lifecycle_status = str(runtime_status.get("lifecycle_status") or _session_status_label(session))
+    next_action = str(runtime_status.get("next_action") or _next_action_from_session(session, executor_status, runtime_observation))
+    blocking_reason = str(runtime_status.get("blocking_reason") or _blocking_reason_from_status(next_action))
+    progress = _progress_steps(session, runtime_status, executor_status, runtime_observation)
+    headline = _headline(selected_executor, lifecycle_status, next_action, executor_status, runtime_status, runtime_observation)
+    evidence = _evidence_summary(progress, runtime_status, executor_status)
+    pending_gaps = _pending_gaps(progress, runtime_status, executor_status, runtime_observation)
+    work_summary = _work_summary(session, runtime_status)
+    user_facing_lines = _user_facing_lines(
+        headline=headline,
+        executor_status=executor_status,
+        work_summary=work_summary,
+        pending_gaps=pending_gaps,
+        next_action=next_action,
+    )
+
+    return {
+        "schema_version": CODING_BRIEFING_SCHEMA_VERSION,
+        "session_id": session_id,
+        "run_id": run_id,
+        "thread_key": str(session.get("thread_key", "")),
+        "headline": headline,
+        "narrative": _narrative(headline, pending_gaps, next_action),
+        "current_state": {
+            "session_status": str(session.get("status", "")),
+            "selected_executor_profile": selected_executor,
+            "coding_agent": _coding_agent_status(selected_executor, session, executor_status, runtime_observation),
+            "lifecycle_status": lifecycle_status,
+            "next_action": next_action,
+            "blocking_reason": blocking_reason,
+        },
+        "original_context": _original_context(session, runtime_status),
+        "work_summary": work_summary,
+        "progress": progress,
+        "evidence_summary": evidence,
+        "pending_gaps": pending_gaps,
+        "next_action": next_action,
+        "user_facing_lines": user_facing_lines,
+        "claim_boundary": (
+            "This briefing is derived from persisted wrapper/runtime artifacts only; "
+            "prepared handoffs are not execution, verification, review, CI, or merge evidence."
+        ),
+    }
+
+
+def chat_response_briefing(briefing: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "schema_version": briefing.get("schema_version", CODING_BRIEFING_SCHEMA_VERSION),
+        "headline": briefing.get("headline", ""),
+        "lines": list(briefing.get("user_facing_lines", [])) if isinstance(briefing.get("user_facing_lines"), list) else [],
+        "next_action": briefing.get("next_action", ""),
+        "pending_gaps": list(briefing.get("pending_gaps", [])) if isinstance(briefing.get("pending_gaps"), list) else [],
+        "claim_boundary": briefing.get("claim_boundary", ""),
+    }
+
+
+def _selected_executor(
+    session: dict[str, Any],
+    runtime_status: dict[str, Any],
+    executor_status: dict[str, Any],
+) -> str:
+    prepared = _object(runtime_status.get("prepared"))
+    return str(
+        executor_status.get("selected_executor_profile")
+        or session.get("selected_executor_profile")
+        or prepared.get("executor_target")
+        or "choose"
+    )
+
+
+def _session_status_label(session: dict[str, Any]) -> str:
+    status = str(session.get("status", ""))
+    if status in {"prompt_handoff_prepared", "runtime_handoff_prepared", "handoff_prepared"}:
+        return "handoff_prepared"
+    if status == "executor_choice_required":
+        return "executor_choice_required"
+    if status in {"plan_presented", "plan_accepted", "executor_selected"}:
+        return "planning"
+    return status or "unknown"
+
+
+def _next_action_from_session(
+    session: dict[str, Any],
+    executor_status: dict[str, Any],
+    runtime_observation: dict[str, Any],
+) -> str:
+    action = str(executor_status.get("next_action") or "")
+    if action:
+        return action
+    observation_action = str(runtime_observation.get("next_action") or "")
+    if observation_action and observation_action != "not_applicable":
+        return observation_action
+    return {
+        "plan_presented": "accept_or_revise_plan",
+        "plan_accepted": "prepare_handoff",
+        "executor_choice_required": "choose_executor",
+        "executor_selected": "prepare_handoff",
+        "prompt_handoff_prepared": "show_prompt_handoff",
+        "runtime_handoff_prepared": "show_runtime_handoff",
+        "handoff_prepared": "show_status",
+    }.get(str(session.get("status")), "show_status")
+
+
+def _blocking_reason_from_status(next_action: str) -> str:
+    if next_action in {"report_completion_with_evidence", "report_merge_ready", "report_merged", "show_status"}:
+        return ""
+    return f"{next_action} is required before this can be reported as complete"
+
+
+def _headline(
+    selected_executor: str,
+    lifecycle_status: str,
+    next_action: str,
+    executor_status: dict[str, Any],
+    runtime_status: dict[str, Any],
+    runtime_observation: dict[str, Any],
+) -> str:
+    result = str(executor_status.get("result") or _object(runtime_status.get("execution")).get("status") or "not_observed")
+    verification = str(executor_status.get("verification") or ("observed" if _object(runtime_status.get("verification")).get("observed") else "not_observed"))
+    runtime_result_observed = _runtime_event_observed(runtime_observation, "worker_result")
+    runtime_verification_observed = _runtime_event_observed(runtime_observation, "verification")
+    if _runtime_event_observed(runtime_observation, "merge"):
+        return f"{_label(selected_executor)} work is recorded as merged."
+    if _runtime_event_observed(runtime_observation, "merge_readiness"):
+        return f"{_label(selected_executor)} work is merge-ready with recorded evidence."
+    if runtime_result_observed and not runtime_verification_observed:
+        return f"{_label(selected_executor)} reported completion; verification evidence is still needed."
+    if runtime_result_observed and runtime_verification_observed:
+        return f"{_label(selected_executor)} result and verification are observed."
+    if result == "completed" and verification not in {"observed", "satisfied"}:
+        return f"{_label(selected_executor)} reported completion; verification evidence is still needed."
+    if lifecycle_status == "merge_ready" or next_action == "report_merge_ready":
+        return f"{_label(selected_executor)} work is merge-ready with recorded evidence."
+    if lifecycle_status == "merged" or next_action == "report_merged":
+        return f"{_label(selected_executor)} work is recorded as merged."
+    if str(executor_status.get("dispatch")) == "observed":
+        return f"{_label(selected_executor)} is handling the coding work."
+    if selected_executor == "choose":
+        return "Hermes is waiting for a coding-agent choice."
+    return f"{_label(selected_executor)} handoff is prepared."
+
+
+def _original_context(session: dict[str, Any], runtime_status: dict[str, Any]) -> dict[str, Any]:
+    route = _object(session.get("route"))
+    plan = _object(session.get("plan"))
+    prepared = _object(runtime_status.get("prepared"))
+    return {
+        "source": str(session.get("source", "")),
+        "source_metadata": _string_map(session.get("source_metadata")),
+        "message": {
+            "sha256": str(session.get("message_sha256", "")),
+            "length": int(session.get("message_length", 0) or 0),
+            "raw_text_persisted": False,
+        },
+        "route": {
+            "selected_skill": str(route.get("selected_skill", "")),
+            "selected_harness": str(route.get("selected_harness", "")),
+            "confidence": str(route.get("confidence", "")),
+            "score": int(route.get("score", 0) or 0),
+            "reason": str(route.get("reason", "")),
+        },
+        "plan": {
+            "status": str(plan.get("status", "")),
+            "recommended_workflow": str(plan.get("recommended_workflow") or prepared.get("workflow") or ""),
+            "recommended_harness": str(plan.get("recommended_harness") or prepared.get("harness") or ""),
+            "coding_delegate_available": str(plan.get("coding_delegate_available", "")),
+        },
+        "deep_interview": {
+            "persisted": False,
+            "reason": "wrapper sessions persist compact route/plan metadata, not a full interview transcript",
+        },
+    }
+
+
+def _work_summary(session: dict[str, Any], runtime_status: dict[str, Any]) -> dict[str, Any]:
+    handoff = _active_handoff(session, runtime_status)
+    prepared = _object(runtime_status.get("prepared"))
+    review = _object(handoff.get("review") or runtime_status.get("review"))
+    return {
+        "workflow": str(prepared.get("workflow") or _object(session.get("plan")).get("recommended_workflow") or handoff.get("recommended_workflow") or ""),
+        "harness": str(prepared.get("harness") or _object(session.get("plan")).get("recommended_harness") or handoff.get("recommended_harness") or ""),
+        "executor": str(handoff.get("selected_executor_profile") or prepared.get("executor_target") or session.get("selected_executor_profile") or "choose"),
+        "work_owner_mode": str(session.get("work_owner_mode", "")),
+        "handoff_schema_version": str(handoff.get("schema_version") or prepared.get("handoff_schema_version") or ""),
+        "safe_summary": str(runtime_status.get("safe_summary") or _handoff_summary(session, handoff)),
+        "acceptance_criteria": _string_list(handoff.get("acceptance_criteria")),
+        "verification_expected": _string_list(handoff.get("verification") or _object(runtime_status.get("verification")).get("expected")),
+        "handoff_contract": {
+            "execution_brief": _object(handoff.get("execution_brief")),
+            "runtime_brief": _object(handoff.get("runtime_brief")),
+            "report_contract": _object(handoff.get("report_contract")),
+            "evidence_contract": _object(handoff.get("evidence_contract")),
+            "context_pack": _context_pack_summary(_object(handoff.get("context_pack"))),
+            "context_pack_blocked": _context_pack_blocked_summary(_object(handoff.get("context_pack_blocked"))),
+        },
+        "review": {
+            "required": bool(review.get("required", False)),
+            "workflow": str(review.get("workflow") or ""),
+            "status": str(review.get("status") or ""),
+        },
+    }
+
+
+def _active_handoff(session: dict[str, Any], runtime_status: dict[str, Any]) -> dict[str, Any]:
+    handoff_contract = _object(runtime_status.get("handoff_contract"))
+    if handoff_contract:
+        return handoff_contract
+    prepared = _object(runtime_status.get("prepared"))
+    if prepared:
+        # Runtime status is compact; the session keeps richer prompt/runtime handoff detail for non-run paths.
+        return {
+            "schema_version": prepared.get("handoff_schema_version", ""),
+            "selected_executor_profile": prepared.get("executor_target", ""),
+            "recommended_workflow": prepared.get("workflow", ""),
+            "recommended_harness": prepared.get("harness", ""),
+        }
+    for key in ("prompt_handoff", "runtime_handoff"):
+        handoff = _object(session.get(key))
+        if handoff:
+            return handoff
+    return {}
+
+
+def _handoff_summary(session: dict[str, Any], handoff: dict[str, Any]) -> str:
+    status = str(session.get("status", ""))
+    selected = str(handoff.get("selected_executor_profile") or session.get("selected_executor_profile") or "executor")
+    if status == "prompt_handoff_prepared":
+        return f"A prompt-only handoff for {selected} is prepared; no dispatch or execution is observed."
+    if status == "runtime_handoff_prepared":
+        return f"A runtime handoff for {selected} is prepared; runtime activity is not observed unless recorded separately."
+    if status == "executor_choice_required":
+        return "The plan is accepted, but no coding-agent has been selected."
+    return "The wrapper session has not observed execution evidence."
+
+
+def _progress_steps(
+    session: dict[str, Any],
+    runtime_status: dict[str, Any],
+    executor_status: dict[str, Any],
+    runtime_observation: dict[str, Any],
+) -> list[dict[str, Any]]:
+    handoff_prepared = _handoff_prepared(session, runtime_status, executor_status)
+    dispatch_observed = _bool_path(runtime_status, "execution", "observed") or str(executor_status.get("dispatch")) == "observed"
+    result = str(executor_status.get("result") or _object(runtime_status.get("execution")).get("status") or "not_observed")
+    result_observed = result in {"completed", "blocked", "failed"}
+    verification_observed = bool(_object(runtime_status.get("verification")).get("observed")) or str(executor_status.get("verification")) in {
+        "observed",
+        "satisfied",
+    }
+    verification_requested = str(executor_status.get("verification")) == "requested"
+    review = _object(runtime_status.get("review"))
+    ci = _object(runtime_status.get("ci"))
+    merge_readiness = _object(runtime_status.get("merge_readiness"))
+    merge = _object(runtime_status.get("merge"))
+    runtime_started = _runtime_event_observed(runtime_observation, "runtime_start") or _runtime_event_observed(
+        runtime_observation, "worker_dispatch"
+    )
+    runtime_result_observed = _runtime_event_observed(runtime_observation, "worker_result")
+    runtime_verification_observed = _runtime_event_observed(runtime_observation, "verification")
+    result_summary = "completed" if runtime_result_observed and result == "not_observed" else result
+    verification_state = "complete" if verification_observed or runtime_verification_observed else (
+        "in_progress" if verification_requested else ("pending" if result_observed or runtime_result_observed else "blocked")
+    )
+    verification_state = _runtime_event_state(runtime_observation, "verification", verification_state)
+    return [
+        _step("plan", "Plan", _state(bool(session.get("plan")), False), "Compact route and plan metadata are recorded."),
+        _step("handoff", "Handoff", _state(handoff_prepared, False), "A coding-agent handoff is prepared."),
+        _step(
+            "dispatch",
+            "Dispatch",
+            _runtime_event_state(runtime_observation, "runtime_start", _state(dispatch_observed or runtime_started, handoff_prepared)),
+            "Wrapper/runtime dispatch or start evidence is observed.",
+        ),
+        _step(
+            "executor_result",
+            "Executor result",
+            _runtime_event_state(runtime_observation, "worker_result", _state(result_observed or runtime_result_observed, dispatch_observed or runtime_started)),
+            f"Executor result: {result_summary}.",
+        ),
+        _step(
+            "verification",
+            "Verification",
+            verification_state,
+            "Hermes verification request or observed verification evidence.",
+        ),
+        _step(
+            "review",
+            "Review",
+            _runtime_event_state(runtime_observation, "review", _record_state(review, complete_statuses={"passed"})),
+            "Review evidence recorded separately.",
+        ),
+        _step(
+            "ci",
+            "CI",
+            _runtime_event_state(runtime_observation, "ci", _record_state(ci, complete_statuses={"passed"})),
+            "CI evidence recorded separately.",
+        ),
+        _step(
+            "merge_ready",
+            "Merge ready",
+            _runtime_event_state(runtime_observation, "merge_readiness", _record_state(merge_readiness, complete_statuses={"ready", "merged"})),
+            "Merge readiness evidence recorded separately.",
+        ),
+        _step("merged", "Merged", _runtime_event_state(runtime_observation, "merge", _merged_state(merge)), "Merge evidence recorded separately."),
+    ]
+
+
+def _evidence_summary(
+    progress: list[dict[str, Any]],
+    runtime_status: dict[str, Any],
+    executor_status: dict[str, Any],
+) -> dict[str, Any]:
+    observed = [str(step["id"]) for step in progress if step.get("state") == "complete"]
+    not_observed = [str(step["id"]) for step in progress if step.get("state") in {"pending", "blocked", "in_progress"}]
+    refs: list[str] = []
+    for value in (
+        _object(runtime_status.get("execution")).get("evidence_refs"),
+        _object(runtime_status.get("review")).get("evidence_refs"),
+        _object(runtime_status.get("ci")).get("evidence_refs"),
+        _object(runtime_status.get("merge")).get("evidence_refs"),
+        executor_status.get("evidence_refs"),
+    ):
+        refs.extend(_string_list(value))
+    return {
+        "observed": observed,
+        "not_observed": not_observed,
+        "evidence_refs": _dedupe(refs),
+    }
+
+
+def _pending_gaps(
+    progress: list[dict[str, Any]],
+    runtime_status: dict[str, Any],
+    executor_status: dict[str, Any],
+    runtime_observation: dict[str, Any],
+) -> list[str]:
+    gaps = [str(step["id"]) for step in progress if step.get("state") in {"pending", "blocked", "in_progress"} and str(step.get("id")) != "plan"]
+    wrapper = _object(runtime_status.get("wrapper"))
+    gaps.extend(_string_list(wrapper.get("unobserved_gaps")))
+    if executor_status.get("executor_session_error"):
+        gaps.append("executor_session_error")
+    if runtime_observation.get("errors"):
+        gaps.append("runtime_observation_errors")
+    return _dedupe(gaps)
+
+
+def _user_facing_lines(
+    *,
+    headline: str,
+    executor_status: dict[str, Any],
+    work_summary: dict[str, Any],
+    pending_gaps: list[str],
+    next_action: str,
+) -> list[str]:
+    lines = [headline]
+    display = executor_status.get("display_status_lines")
+    if isinstance(display, list):
+        lines.extend(str(line) for line in display[:4] if str(line))
+    safe_summary = str(work_summary.get("safe_summary", ""))
+    if safe_summary and safe_summary not in lines:
+        lines.append(safe_summary)
+    if pending_gaps:
+        lines.append(f"Still missing evidence: {', '.join(pending_gaps[:5])}.")
+    lines.append(f"Next action: {next_action}.")
+    return _dedupe(lines)
+
+
+def _narrative(headline: str, pending_gaps: list[str], next_action: str) -> str:
+    if pending_gaps:
+        return f"{headline} The wrapper is still waiting on {', '.join(pending_gaps[:4])}; next action is {next_action}."
+    return f"{headline} The wrapper has no additional pending gap in this briefing; next action is {next_action}."
+
+
+def _handoff_prepared(session: dict[str, Any], runtime_status: dict[str, Any], executor_status: dict[str, Any]) -> bool:
+    prepared = _object(runtime_status.get("prepared"))
+    return (
+        bool(prepared.get("handoff_available"))
+        or str(executor_status.get("handoff")) == "prepared"
+        or str(session.get("status")) in {"handoff_prepared", "prompt_handoff_prepared", "runtime_handoff_prepared"}
+    )
+
+
+def _record_state(record: dict[str, Any], *, complete_statuses: set[str]) -> str:
+    if not record:
+        return "pending"
+    status = str(record.get("status", ""))
+    if status == "not_required" and not bool(record.get("required", False)):
+        return "not_required"
+    if status in complete_statuses and (bool(record.get("satisfied")) or bool(record.get("observed"))):
+        return "complete"
+    if bool(record.get("observed")):
+        return "in_progress"
+    if bool(record.get("required")):
+        return "pending"
+    return "pending"
+
+
+def _merged_state(record: dict[str, Any]) -> str:
+    if not record:
+        return "pending"
+    if str(record.get("status", "")) == "not_required" and not bool(record.get("required", False)):
+        return "not_required"
+    return "complete" if str(record.get("status", "")) == "merged" and bool(record.get("satisfied")) else "pending"
+
+
+def _context_pack_summary(context_pack: dict[str, Any]) -> dict[str, Any]:
+    if not context_pack:
+        return {}
+    if "included_context_count" in context_pack:
+        return {
+            "schema_version": str(context_pack.get("schema_version", "")),
+            "executor_target": str(context_pack.get("executor_target", "")),
+            "session_id": str(context_pack.get("session_id", "")),
+            "source_ref_count": int(context_pack.get("source_ref_count", 0) or 0),
+            "included_context_count": int(context_pack.get("included_context_count", 0) or 0),
+            "excluded_context_count": int(context_pack.get("excluded_context_count", 0) or 0),
+            "blocked_by_conflicts_count": int(context_pack.get("blocked_by_conflicts_count", 0) or 0),
+            "redaction_policy": str(context_pack.get("redaction_policy", "")),
+            "claim_boundary": str(context_pack.get("claim_boundary", "")),
+        }
+    return {
+        "schema_version": str(context_pack.get("schema_version", "")),
+        "executor_target": str(context_pack.get("executor_target", "")),
+        "session_id": str(context_pack.get("session_id", "")),
+        "source_ref_count": len(_list_value(context_pack.get("source_refs"))),
+        "included_context_count": len(_list_value(context_pack.get("included_context"))),
+        "excluded_context_count": len(_list_value(context_pack.get("excluded_context"))),
+        "blocked_by_conflicts_count": len(_list_value(context_pack.get("blocked_by_conflicts"))),
+        "redaction_policy": str(context_pack.get("redaction_policy", "")),
+        "claim_boundary": str(context_pack.get("claim_boundary", "")),
+    }
+
+
+def _context_pack_blocked_summary(context_pack_blocked: dict[str, Any]) -> dict[str, Any]:
+    if not context_pack_blocked:
+        return {}
+    if "blocked_by_conflicts_count" in context_pack_blocked:
+        return {
+            "schema_version": str(context_pack_blocked.get("schema_version", "")),
+            "blocked_by_conflicts_count": int(context_pack_blocked.get("blocked_by_conflicts_count", 0) or 0),
+            "claim_boundary": str(context_pack_blocked.get("claim_boundary", "")),
+        }
+    return {
+        "schema_version": str(context_pack_blocked.get("schema_version", "")),
+        "blocked_by_conflicts_count": len(_list_value(context_pack_blocked.get("blocked_by_conflicts"))),
+        "claim_boundary": str(context_pack_blocked.get("claim_boundary", "")),
+    }
+
+
+def _runtime_event_state(runtime_observation: dict[str, Any], event_type: str, default_state: str) -> str:
+    if _runtime_event_failed_or_blocked(runtime_observation, event_type):
+        return "blocked"
+    if _runtime_event_observed(runtime_observation, event_type):
+        return "complete"
+    return default_state
+
+
+def _runtime_event_observed(runtime_observation: dict[str, Any], event_type: str) -> bool:
+    return event_type in _string_list(runtime_observation.get("observed_events"))
+
+
+def _runtime_event_failed_or_blocked(runtime_observation: dict[str, Any], event_type: str) -> bool:
+    return event_type in set(_string_list(runtime_observation.get("failed_events")) + _string_list(runtime_observation.get("blocked_events")))
+
+
+def _state(done: bool, available: bool) -> str:
+    if done:
+        return "complete"
+    return "pending" if available else "blocked"
+
+
+def _step(step_id: str, label: str, state: str, summary: str) -> dict[str, str]:
+    return {"id": step_id, "label": label, "state": state, "summary": summary}
+
+
+def _coding_agent_label(selected_executor: str, session: dict[str, Any]) -> str:
+    status = str(session.get("status", ""))
+    if status in {"handoff_prepared", "prompt_handoff_prepared", "runtime_handoff_prepared"}:
+        return f"prepared({selected_executor})"
+    return f"idle({selected_executor})"
+
+
+def _coding_agent_status(
+    selected_executor: str,
+    session: dict[str, Any],
+    executor_status: dict[str, Any],
+    runtime_observation: dict[str, Any],
+) -> str:
+    if _runtime_event_failed_or_blocked(runtime_observation, "worker_result"):
+        return f"blocked({selected_executor})"
+    if _runtime_event_observed(runtime_observation, "worker_result"):
+        return f"completed({selected_executor})"
+    if _runtime_event_observed(runtime_observation, "runtime_start") or _runtime_event_observed(runtime_observation, "worker_dispatch"):
+        return f"running({selected_executor})"
+    return str(executor_status.get("coding_agent") or _coding_agent_label(selected_executor, session))
+
+
+def _bool_path(source: dict[str, Any], *path: str) -> bool:
+    current: Any = source
+    for key in path:
+        current = current.get(key) if isinstance(current, dict) else None
+    return bool(current)
+
+
+def _object(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _string_map(value: Any) -> dict[str, str]:
+    if not isinstance(value, dict):
+        return {}
+    return {str(key): str(item) for key, item in value.items() if str(item)}
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value if str(item)]
+
+
+def _list_value(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        result.append(value)
+    return result
+
+
+def _label(profile: str) -> str:
+    labels = {
+        "codex": "Codex",
+        "claude-code": "Claude Code",
+        "omx-runtime": "OMX runtime",
+        "omo-runtime": "OMO runtime",
+        "omc-runtime": "OMC runtime",
+        "hermes": "Hermes",
+        "generic": "the selected coding agent",
+        "choose": "Hermes",
+    }
+    return labels.get(profile, profile or "the selected coding agent")

--- a/src/wrapper/sessions.py
+++ b/src/wrapper/sessions.py
@@ -27,6 +27,7 @@ from ..runtime.artifacts import (
     validate_runtime_observations_for_wrapper_session,
 )
 from .contract import build_chat_interaction_payload, build_chat_status_interaction
+from .briefing import build_coding_briefing, chat_response_briefing
 from .executor_sessions import (
     build_executor_session_status,
     build_executor_session_status_card,
@@ -472,6 +473,12 @@ def build_wrapper_session_status(paths: OmhPaths, session_id: str) -> dict[str, 
             interaction["status_card"],
             executor_status,
         )
+        coding_briefing = build_coding_briefing(
+            session,
+            runtime_status=runtime_status,
+            executor_status=executor_status,
+        )
+        chat_response["coding_briefing"] = chat_response_briefing(coding_briefing)
         return {
             "schema_version": WRAPPER_SESSION_RESULT_SCHEMA_VERSION,
             "session_id": session_id,
@@ -480,6 +487,7 @@ def build_wrapper_session_status(paths: OmhPaths, session_id: str) -> dict[str, 
             "session_status": session["status"],
             "runtime_status": runtime_status,
             "executor_session_status": executor_status,
+            "coding_briefing": coding_briefing,
             "status_card": status_card,
             "chat_response": chat_response,
             "claim_boundary": "Execution claims come from the linked runtime run ledger, not the wrapper session.",
@@ -498,6 +506,12 @@ def build_wrapper_session_status(paths: OmhPaths, session_id: str) -> dict[str, 
         executor_status,
     )
     status_card = build_executor_session_status_card(executor_status)
+    coding_briefing = build_coding_briefing(
+        session,
+        executor_status=executor_status,
+        runtime_observation=runtime_observation,
+    )
+    chat_response["coding_briefing"] = chat_response_briefing(coding_briefing)
     return {
         "schema_version": WRAPPER_SESSION_RESULT_SCHEMA_VERSION,
         "session_id": session_id,
@@ -512,6 +526,7 @@ def build_wrapper_session_status(paths: OmhPaths, session_id: str) -> dict[str, 
         "runtime_observation": runtime_observation,
         "runtime_observation_errors": observation_errors,
         "executor_session_status": executor_status,
+        "coding_briefing": coding_briefing,
         "status_card": status_card,
         "next_action": _next_action_for_session(session),
         "chat_response": chat_response,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2265,6 +2265,10 @@ class CliTests(unittest.TestCase):
             session_status = json.loads(stdout)
             self.assertEqual(session_status["current_run_id"], run_id)
             self.assertEqual(session_status["runtime_status"]["next_action"], "dispatch_to_executor")
+            self.assertEqual(session_status["coding_briefing"]["schema_version"], "coding_briefing/v1")
+            self.assertEqual(session_status["chat_response"]["coding_briefing"]["next_action"], "dispatch_to_executor")
+            self.assertNotIn("progress", session_status["chat_response"]["coding_briefing"])
+            self.assertNotIn("coding_briefing", session_status["status_card"])
             self.assertNotIn("omh ", json.dumps(session_status["chat_response"]).lower())
 
             status, stdout, stderr = run_cli(home_args + ["runtime", "validate"])
@@ -2707,6 +2711,8 @@ class CliTests(unittest.TestCase):
             prepared_status = json.loads(stdout)
             self.assertEqual(prepared_status["executor_session_status"]["coding_agent"], "prepared(codex)")
             self.assertEqual(prepared_status["status_card"]["executor_session_status"]["coding_agent"], "prepared(codex)")
+            self.assertEqual(prepared_status["coding_briefing"]["current_state"]["coding_agent"], "prepared(codex)")
+            self.assertIn("dispatch", prepared_status["coding_briefing"]["pending_gaps"])
             action_ids = {action["id"] for action in prepared_status["chat_response"]["actions"]}
             self.assertIn("open_executor_session", action_ids)
             self.assertIn("record_executor_completed", action_ids)

--- a/tests/test_wrapper_sessions.py
+++ b/tests/test_wrapper_sessions.py
@@ -10,9 +10,17 @@ from tempfile import TemporaryDirectory
 from _local_package import load_local_package
 
 load_local_package()
-from omh.coding_lifecycle import record_codex_dispatch, record_codex_result, start_codex_delegation_lifecycle
+from omh.coding_lifecycle import record_codex_dispatch, record_codex_result, record_codex_verification, start_codex_delegation_lifecycle
 from omh.paths import resolve_paths
-from omh.runtime_artifacts import create_run, export_runtime, validate_runtime, write_runtime_observation
+from omh.runtime_artifacts import (
+    create_run,
+    export_runtime,
+    validate_runtime,
+    write_ci_record,
+    write_merge_record,
+    write_review_record,
+    write_runtime_observation,
+)
 from omh.runtime_records import validate_wrapper_session_record
 from omh.wrapper.executor_sessions import (
     ExecutorSessionError,
@@ -170,6 +178,106 @@ class WrapperSessionTests(unittest.TestCase):
             self.assertTrue(validate_runtime(paths)["ok"])
             session_path = paths.runtime_wrapper_sessions_dir / session_id / "session.json"
             self.assertNotIn(message, session_path.read_text(encoding="utf-8"))
+
+    def test_coding_briefing_is_metadata_only_and_keeps_cards_compact(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            message = "risky refactor with private-token-123"
+            started = create_or_resume_wrapper_session(
+                paths,
+                message,
+                source="discord",
+                source_metadata={"source_event_id": "m1", "channel_ref": "c1"},
+            )
+            session_id = str(started["session"]["session_id"])
+            record_plan_decision(paths, session_id, "accept")
+            select_wrapper_session_executor(paths, session_id, "codex")
+            context_pack = {
+                "schema_version": "handoff_context_pack/v1",
+                "executor_target": "codex",
+                "session_id": session_id,
+                "scope": {"kind": "project", "ref": "default"},
+                "source_refs": [{"source": "omh_memory", "truth_level": "approved_context", "precedence": 60, "item_count": 1}],
+                "included_context": [
+                    {
+                        "item_id": "ctx-1",
+                        "key": "default_executor",
+                        "summary": "Use Codex by default for coding work.",
+                        "source": "omh_memory",
+                        "truth_level": "approved_context",
+                        "scope": {"kind": "project", "ref": "default"},
+                    }
+                ],
+                "excluded_context": [],
+                "blocked_by_conflicts": [],
+                "redaction_policy": "metadata_only",
+                "claim_boundary": "Context pack is metadata only.",
+            }
+
+            prepared = prepare_wrapper_session_handoff(paths, session_id, message, context_pack=context_pack)
+            status = prepared["status"]
+            briefing = status["coding_briefing"]
+
+            self.assertEqual(briefing["schema_version"], "coding_briefing/v1")
+            self.assertEqual(
+                set(briefing),
+                {
+                    "schema_version",
+                    "session_id",
+                    "run_id",
+                    "thread_key",
+                    "headline",
+                    "narrative",
+                    "current_state",
+                    "original_context",
+                    "work_summary",
+                    "progress",
+                    "evidence_summary",
+                    "pending_gaps",
+                    "next_action",
+                    "user_facing_lines",
+                    "claim_boundary",
+                },
+            )
+            self.assertEqual(briefing["original_context"]["message"]["sha256"], hashlib.sha256(message.encode("utf-8")).hexdigest())
+            self.assertEqual(briefing["original_context"]["message"]["length"], len(message))
+            self.assertFalse(briefing["original_context"]["message"]["raw_text_persisted"])
+            self.assertFalse(briefing["original_context"]["deep_interview"]["persisted"])
+            self.assertIn("execution_brief", briefing["work_summary"]["handoff_contract"])
+            self.assertIn("evidence_contract", briefing["work_summary"]["handoff_contract"])
+            self.assertEqual(briefing["work_summary"]["handoff_contract"]["context_pack"]["included_context_count"], 1)
+            self.assertNotIn("included_context", briefing["work_summary"]["handoff_contract"]["context_pack"])
+            self.assertNotIn(message, json.dumps(briefing))
+            self.assertNotIn("private-token-123", json.dumps(briefing))
+            self.assertIn("coding_briefing", status["chat_response"])
+            self.assertEqual(status["chat_response"]["coding_briefing"]["schema_version"], "coding_briefing/v1")
+            self.assertEqual(
+                set(status["chat_response"]["coding_briefing"]),
+                {"schema_version", "headline", "lines", "next_action", "pending_gaps", "claim_boundary"},
+            )
+            self.assertNotIn("progress", status["chat_response"]["coding_briefing"])
+            self.assertNotIn("coding_briefing", status["status_card"])
+
+    def test_prompt_only_coding_briefing_reports_prepared_not_dispatched(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            message = "risky refactor"
+            started = create_or_resume_wrapper_session(paths, message, source="discord")
+            session_id = str(started["session"]["session_id"])
+            record_plan_decision(paths, session_id, "accept")
+            select_wrapper_session_executor(paths, session_id, "claude-code")
+
+            prepared = prepare_wrapper_session_handoff(paths, session_id, message)
+            briefing = prepared["status"]["coding_briefing"]
+            states = {step["id"]: step["state"] for step in briefing["progress"]}
+
+            self.assertEqual(briefing["run_id"], "")
+            self.assertEqual(briefing["current_state"]["selected_executor_profile"], "claude-code")
+            self.assertEqual(briefing["work_summary"]["handoff_schema_version"], "coding_prompt_handoff/v1")
+            self.assertEqual(states["handoff"], "complete")
+            self.assertEqual(states["dispatch"], "pending")
+            self.assertIn("dispatch", briefing["pending_gaps"])
+            self.assertIn("prompt-only handoff", json.dumps(briefing["user_facing_lines"]))
 
     def test_revision_and_cancel_do_not_create_run_evidence(self) -> None:
         with TemporaryDirectory() as tmp:
@@ -537,7 +645,119 @@ class WrapperSessionTests(unittest.TestCase):
             verify_request = request_executor_session_verification(paths, session_id)
 
             self.assertEqual(verify_request["status"]["verification"], "requested")
+            status_after_verify_request = build_wrapper_session_status(paths, session_id)
+            briefing = status_after_verify_request["coding_briefing"]
+            states = {step["id"]: step["state"] for step in briefing["progress"]}
+            self.assertEqual(states["executor_result"], "complete")
+            self.assertEqual(states["verification"], "in_progress")
+            self.assertIn("verification", briefing["pending_gaps"])
+            self.assertIn("verification evidence is still needed", briefing["headline"])
             self.assertEqual(validate_runtime(paths)["ok"], True)
+
+    def test_coding_briefing_omits_optional_merge_gaps_when_merge_not_required(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            message = "diagnose installation health"
+            lifecycle = start_codex_delegation_lifecycle(paths, message, source="discord")
+            coding = lifecycle["coding_delegation"]
+            run_id = str(lifecycle["run"]["run_id"])
+            thread_key = "discord:c1:m1"
+            session_id = session_id_for_thread_key(thread_key)
+            write_wrapper_session(
+                paths,
+                {
+                    "session_id": session_id,
+                    "thread_key": thread_key,
+                    "source": "discord",
+                    "source_metadata": {"source_event_id": "m1", "channel_ref": "c1"},
+                    "message_sha256": hashlib.sha256(message.encode("utf-8")).hexdigest(),
+                    "message_length": len(message),
+                    "created_at": "2026-06-15T00:00:00Z",
+                    "updated_at": "2026-06-15T00:00:00Z",
+                    "status": "handoff_prepared",
+                    "decision": "plan_accepted",
+                    "route": {
+                        "action": "route",
+                        "selected_skill": str(coding["recommended_workflow"]),
+                        "selected_harness": str(coding["recommended_harness"]),
+                        "confidence": "high",
+                        "score": 10,
+                    },
+                    "plan": {
+                        "status": "ready",
+                        "recommended_workflow": str(coding["recommended_workflow"]),
+                        "recommended_harness": str(coding["recommended_harness"]),
+                        "coding_delegate_available": "true",
+                    },
+                    "work_owner_mode": "external_executor",
+                    "selected_executor_profile": "codex",
+                    "dispatch_policy": "ask_before_dispatch",
+                    "prompt_handoff": {},
+                    "runtime_handoff": {},
+                    "current_run_id": run_id,
+                },
+            )
+
+            record_codex_dispatch(paths, run_id)
+            record_codex_result(paths, run_id, result="completed", evidence_refs=["codex-summary"])
+            record_codex_verification(paths, run_id)
+
+            status = build_wrapper_session_status(paths, session_id)
+            briefing = status["coding_briefing"]
+            states = {step["id"]: step["state"] for step in briefing["progress"]}
+
+            self.assertEqual(status["runtime_status"]["next_action"], "report_completion_with_evidence")
+            self.assertEqual(states["review"], "not_required")
+            self.assertEqual(states["ci"], "not_required")
+            self.assertEqual(states["merge_ready"], "not_required")
+            self.assertEqual(states["merged"], "not_required")
+            self.assertNotIn("merge_ready", briefing["pending_gaps"])
+            self.assertNotIn("merged", briefing["pending_gaps"])
+
+    def test_coding_briefing_separates_merge_ready_from_merged(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            message = "risky refactor"
+            started = create_or_resume_wrapper_session(paths, message, source="discord")
+            session_id = str(started["session"]["session_id"])
+            record_plan_decision(paths, session_id, "accept")
+            select_wrapper_session_executor(paths, session_id, "codex")
+            handoff = prepare_wrapper_session_handoff(paths, session_id, message)
+            run_id = str(handoff["session"]["current_run_id"])
+            run_dir = paths.runtime_runs_dir / run_id
+
+            record_codex_dispatch(paths, run_id)
+            record_codex_result(paths, run_id, result="completed", evidence_refs=["codex-summary"])
+            record_codex_verification(paths, run_id)
+            write_review_record(run_dir, {"status": "passed", "reviewer": "code-review", "evidence_refs": ["review"]})
+            write_ci_record(run_dir, {"status": "passed", "provider": "local", "checks": ["unit:passed"]})
+            write_merge_record(run_dir, {"status": "ready", "target_branch": "main", "evidence_refs": ["ci"], "summary": "ready"})
+
+            ready_status = build_wrapper_session_status(paths, session_id)
+            ready_states = {step["id"]: step["state"] for step in ready_status["coding_briefing"]["progress"]}
+
+            self.assertEqual(ready_status["runtime_status"]["next_action"], "report_merge_ready")
+            self.assertEqual(ready_states["merge_ready"], "complete")
+            self.assertEqual(ready_states["merged"], "pending")
+            self.assertIn("merged", ready_status["coding_briefing"]["pending_gaps"])
+
+            write_merge_record(
+                run_dir,
+                {
+                    "status": "merged",
+                    "target_branch": "main",
+                    "merge_commit": "abc123",
+                    "evidence_refs": ["https://github.example/repo/pull/1"],
+                    "summary": "merged",
+                },
+            )
+            merged_status = build_wrapper_session_status(paths, session_id)
+            merged_states = {step["id"]: step["state"] for step in merged_status["coding_briefing"]["progress"]}
+
+            self.assertEqual(merged_status["runtime_status"]["next_action"], "report_merged")
+            self.assertEqual(merged_states["merge_ready"], "complete")
+            self.assertEqual(merged_states["merged"], "complete")
+            self.assertNotIn("merged", merged_status["coding_briefing"]["pending_gaps"])
 
     def test_codex_lifecycle_result_allows_executor_session_verification_request(self) -> None:
         with TemporaryDirectory() as tmp:
@@ -724,6 +944,57 @@ class WrapperSessionTests(unittest.TestCase):
             self.assertEqual(status["runtime_observation"]["next_action"], "record_runtime_observation:worktree_creation")
             self.assertEqual(status["executor_session_status"]["result"], "not_observed")
             self.assertTrue(validate_runtime(paths)["ok"])
+
+    def test_runtime_handoff_coding_briefing_uses_observed_ladder_events(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            started = create_or_resume_wrapper_session(paths, "risky refactor", source="discord")
+            session_id = str(started["session"]["session_id"])
+            record_plan_decision(paths, session_id, "accept")
+            select_wrapper_session_executor(paths, session_id, "omx-runtime")
+            prepare_wrapper_session_handoff(paths, session_id, "risky refactor")
+            session_dir = paths.runtime_wrapper_sessions_dir / session_id
+
+            for event_type in (
+                "runtime_start",
+                "worktree_creation",
+                "worker_dispatch",
+                "worker_result",
+                "verification",
+                "review",
+                "ci",
+                "merge_readiness",
+                "merge",
+            ):
+                payload = {
+                    "target_type": "wrapper_session",
+                    "target_id": session_id,
+                    "runtime_profile": "omx-runtime",
+                    "event_type": event_type,
+                    "status": "observed",
+                    "summary": f"{event_type} observed",
+                }
+                if event_type == "worktree_creation":
+                    payload["worktree_ref"] = "worktree-1"
+                if event_type in {"worker_dispatch", "worker_result"}:
+                    payload["worker_ref"] = "worker-1"
+                write_runtime_observation(session_dir, payload)
+
+            status = build_wrapper_session_status(paths, session_id)
+            briefing = status["coding_briefing"]
+            states = {step["id"]: step["state"] for step in briefing["progress"]}
+
+            self.assertEqual(status["runtime_observation"]["next_action"], "report_runtime_observed")
+            self.assertEqual(states["dispatch"], "complete")
+            self.assertEqual(states["executor_result"], "complete")
+            self.assertEqual(states["verification"], "complete")
+            self.assertEqual(states["review"], "complete")
+            self.assertEqual(states["ci"], "complete")
+            self.assertEqual(states["merge_ready"], "complete")
+            self.assertEqual(states["merged"], "complete")
+            self.assertEqual(briefing["current_state"]["coding_agent"], "completed(omx-runtime)")
+            self.assertEqual(briefing["headline"], "OMX runtime work is recorded as merged.")
+            self.assertEqual(briefing["pending_gaps"], [])
 
     def test_non_runtime_session_reports_runtime_observation_not_applicable(self) -> None:
         with TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Feature Report

### What Changed

- Added `coding_briefing/v1` to `omh chat session status` as a richer Hermes-facing report for delegated coding work.
- Added a compact `chat_response.coding_briefing` shape that wrappers can render directly without embedding the full report into `status_card/v1`.
- Added shallow handoff-contract summaries to delegated runtime status so Hermes can explain what was handed off without reconstructing raw prompts.
- Updated wrapper integration docs to point operators at `coding_briefing.user_facing_lines[]`, `progress[]`, and `pending_gaps[]`.

### Why This Exists

Hermes users usually ask in chat, not by manually reading a runtime JSON ledger. When Hermes delegates coding to Codex, Claude Code, Hermes runtime, OMX/OMO/OMC-style runtimes, or another executor, it needs a reliable way to answer follow-up questions such as:

- what are we working on?
- who owns the coding work now?
- did an executor actually start?
- is the result observed or only prepared?
- did review, CI, merge readiness, or merge evidence happen?
- what is still missing before Hermes can say it is done?

Before this change the compact status card carried some executor state, but it was not a full human-readable briefing surface and it was easy for wrappers to either over-explain from prose or under-report evidence gaps.

### User / Operator Impact

- A Hermes chat wrapper can now answer “what happened to that coding task?” with a readable briefing sourced from `coding_briefing.user_facing_lines[]`.
- Users can see progress as an explicit ladder: plan, handoff, dispatch, executor result, verification, review, CI, merge-ready, merged.
- Prepared handoffs remain clearly separated from observed dispatch, execution, verification, review, CI, and merge evidence.
- Prompt-only executor handoffs, Codex lifecycle-backed runs, and runtime-handoff observation records all get consistent status language.
- Runtime handoff observations now influence the briefing headline and `coding_agent` state, so completed/merged runtime evidence does not keep looking merely “prepared”.

### How It Works

- `src/wrapper/briefing.py` builds a deterministic `coding_briefing/v1` object from persisted wrapper session metadata, linked runtime status, executor-session status, and runtime observation status.
- `src/wrapper/sessions.py` attaches the full briefing as a top-level sibling to `status_card`, then adds only the compact renderable subset under `chat_response.coding_briefing`.
- `src/runtime/artifacts.py` exposes a shallow `handoff_contract` summary for delegated coding status, including counts for context packs rather than embedding full context.
- The briefing keeps raw message text and full interview transcripts out of the artifact. It reports only message hash/length, compact route/plan metadata, handoff summaries, progress states, evidence refs, and missing gaps.

### Files And Contracts Touched

- `src/wrapper/briefing.py`: new `coding_briefing/v1` builder and compact chat-response projection.
- `src/wrapper/sessions.py`: status response integration for run-backed, prompt-only, and runtime-handoff sessions.
- `src/runtime/artifacts.py`: shallow handoff contract summaries for delegated coding status.
- `tests/test_wrapper_sessions.py`: metadata-only, compact-card, prompt-only, runtime-observation, no-merge-required, and merge-ready-vs-merged regression coverage.
- `tests/test_cli.py`: CLI contract checks for session status and compact chat response shape.
- `docs/ARCHITECTURE.md`, `docs/CHAT_WRAPPER_EXAMPLES.md`, `docs/HERMES_AGENT_INTEGRATION_RUNBOOK.md`: wrapper/operator docs for the new briefing contract.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — 400 tests passed.
- [x] `uv run python -m compileall -q src tests` — passed.
- [x] `uv run python -m src.cli docs workflows --check` — passed; 34/34 tap skills checked and in sync.
- [x] `uv run python -m src.cli harness validate` — passed; 20 harnesses and 34 skills valid.
- [x] `uv run python -m src.cli release checklist --json` — passed in plan mode.
- [x] `uv run python -m src.cli release hermes-smoke` — passed in plan mode; no live Hermes profile mutation.
- [x] `uv run python -m src.cli --help` — passed; help rendered.
- [x] Relevant dry-run or smoke command: `PYTHONPATH=tests uv run python -m unittest tests/test_wrapper_sessions.py -v` and `PYTHONPATH=tests uv run python -m unittest tests/test_cli.py -v` both passed.
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; this PR is a deterministic backend/wrapper contract change and does not mutate a live Hermes profile.

## Risk

- Additive JSON fields may require wrapper consumers to decide whether to render `status_card` or `coding_briefing`; docs now recommend keeping `status_card` compact and using `coding_briefing` for richer “what is happening?” answers.
- `coding_briefing/v1` is intentionally metadata-only. It improves status narration but does not claim live executor tracking beyond recorded wrapper/runtime evidence.
- Runtime observation summaries are mapped to briefing progress and headline text, but live Hermes/TUI rendering remains unobserved in this PR.

## Compatibility / Rollout

- Backward compatible: existing status card fields remain unchanged and the new briefing is a sibling field.
- No network calls, no Hermes core patching, no hidden executor execution.
- Wrapper consumers can roll out by rendering `chat_response.coding_briefing.lines` first, then optionally exposing expanded `progress[]` and `pending_gaps[]`.

## Release / Claims

- [x] Release-channel impact considered: local contract/backend change, no release channel metadata changed.
- [x] Runtime/native capability claims are backed by persisted wrapper/runtime evidence or marked as not observed.
- [x] Known manual Hermes checks are listed: live Hermes/TUI rendering was not run.

## Follow-Up

- Add live wrapper UI golden screenshots or fixtures once the Hermes Agent surface consumes `coding_briefing/v1`.
- Consider a small wrapper-facing example that renders `coding_briefing.progress[]` into a chat timeline/status thread.
