### PR TITLE
Add Hermes G1-G10 use-case catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,12 +198,20 @@ so OMH can display and record `main@old -> main@new` instead of only `main`.
 | `materials-package` / `report-package` | Hermes shapes decks, PDFs, spreadsheets, documents, HWP, Markdown, and upload-ready packages while keeping binary export and render QA observed-only. | "Turn the revenue spreadsheet into an Excel and PDF package with render QA." |
 | `idea-to-deploy` / coding runtime handoff / executor selection | Hermes prepares work for Codex, Claude Code, another coding agent, an oh-my runtime, or Hermes coding skills without hiding unobserved execution. | "Turn this issue into a PR-ready plan and hand it to implementation." |
 
+OMH also keeps a deterministic G1-G10 Hermes use-case map for release checks
+and wrapper routing. It covers startup triage, issue-to-PR readiness,
+real-world agent QA, chat-to-workflow routing, AI coding safety, feature
+shaping, release gates, refactor standardization, multi-agent work hubs, and
+scheduled ops blueprints. Normal users still talk to Hermes; wrappers and
+operators can inspect the map with `omh cases list --json`.
+
 ## What You Get
 
 | Surface | What it provides |
 | --- | --- |
 | Hermes skill tap | Tap-compatible skills under `skills/<name>/SKILL.md`. |
 | Bootstrap setup | `omh setup` installs generated skills and registers `skills.external_dirs` in user or project scope. |
+| G1-G10 use-case catalog | `omh cases list/inspect/recommend` maps real Hermes situations to the right skill, playbook, harness, next action, and evidence boundary without claiming runtime execution. |
 | Flagship playbook | `request-to-handoff` turns a plain Hermes message into a role-owned next action with an evidence boundary. |
 | App operation loops | `idea-to-deploy`, `cto-loop`, and `deploy-and-monitor` make Hermes feel like an app delivery operator while keeping evidence boundaries strict. |
 | Loopable goal cycles | `loop` lets Hermes classify a request as task, project, ambition, external waiting, or unclear before cycling. North-star ambitions stay visible, but the current loop goal must name a bounded arena, observable problem, next verification, and stop condition. Start cards, `loopability_assessment/v1`, `loop_engineering/v1` snapshots, `loop_status_card/v1` failure-mode warnings, and queue lifecycle actions help wrappers show what can start, what is only prepared, what verification is cheap or expensive, and what was later observed or blocked. |

--- a/docs/APPLICATION_CASES.md
+++ b/docs/APPLICATION_CASES.md
@@ -1,8 +1,40 @@
 # Application Cases
 
-This guide documents the first three proof cases for `oh-my-hermes`.
-Each case is designed to show visible skill impact without claiming hidden
-Hermes runtime behavior.
+This guide documents the representative ways OMH makes Hermes Agent feel more
+capable without claiming hidden Hermes runtime behavior. The first section is
+the G1-G10 use-case map that wrappers and operators can inspect through
+`omh cases`; the later sections keep the original deeper proof cases.
+
+## G1-G10 Hermes Use-Case Map
+
+These are product-facing situations, not new hidden runtimes. Each case maps a
+natural Hermes chat request to a skill, playbook, harness, and evidence
+boundary.
+
+| Goal | Situation | Primary OMH surface | Example request | Boundary |
+| --- | --- | --- | --- | --- |
+| G1 | Startup product triage | `feedback-triage` / `feedback-triage` | "Payment failures keep showing up from customers." | Triage is not reproduction, a fix, or customer confirmation. |
+| G2 | Issue-to-PR readiness | `ultraprocess` / `request-to-handoff` | "Turn this issue into a PR-ready implementation plan." | Handoff is not dispatch, code result, review, CI, or merge. |
+| G3 | Real-world agent product QA | `ultraqa` / `reliability-incident-review` | "Check whether our agent handles a Kubernetes outage diagnosis scenario well." | Scenario design is not a passed test or verified remediation. |
+| G4 | Chat-to-workflow routing | `oh-my-hermes` / `safe-feature-change` | "This feels like a risky refactor before release." | Routing is advisory guidance, not an accepted plan. |
+| G5 | AI coding safety boundary | `code-review` / `request-to-handoff` | "Prepare this for a coding agent, but show what is only prepared versus observed." | Prepared coding context is not dispatch, execution, verification, review, CI, or merge. |
+| G6 | Product feature shaping | `deep-interview` / `deep-interview-to-plan` | "I want onboarding to feel smoother." | A shaped brief is not user validation, implementation, or release evidence. |
+| G7 | Release gate and README claim check | `deploy-and-monitor` / `deploy-and-monitor` | "Before release, check that README claims match commands and tests." | A checklist is not a published release, deployment, or monitoring result. |
+| G8 | Repeatable refactor workflow | `ultraprocess` / `safe-feature-change` | "This risky refactor needs plan, implementation, review, and docs sync." | A refactor plan is not behavior preservation, test pass, review approval, or merge. |
+| G9 | Multi-agent work hub | `team` / `local-pipeline-buildout` | "What is the current coding-agent status and what did we decide in the interview?" | A status card is not new execution, dispatch, review, CI, or merge evidence. |
+| G10 | Scheduled ops blueprint | `automation-blueprint` / `scheduled-ops-blueprint` | "Every morning, check competitor news and send a Slack digest only if something changed." | A blueprint is not cron creation, source retrieval, gateway delivery, plugin load, or no-agent execution. |
+
+Machine-readable operator checks:
+
+```sh
+omh cases list --json
+omh cases inspect G10 --json
+omh cases recommend "daily competitor digest" --json
+```
+
+Normal users should not need those commands. They exist so Hermes wrappers,
+tests, and release checks can verify that the chat-first story has deterministic
+local backing.
 
 ## Case 1: Coding Request Handling
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,7 @@ repo-local contract for Codex agents working here.
 | Render workflow quality gates in wrappers | [Harness Quality Contract](HARNESS_QUALITY.md) |
 | Install Hermes-native skills or bootstrap managed skills | [Installation](INSTALLATION.md) |
 | Run deterministic backend demos | [`omh demo orchestration`](../README.md#backend--operator-surface) and [fixture shims](../examples) |
-| See realistic user-facing flows | [Application Cases](APPLICATION_CASES.md) |
+| See realistic G1-G10 user-facing flows | [Application Cases](APPLICATION_CASES.md) |
 | Check generated skill and harness metadata | [Workflow Reference](WORKFLOWS.md) |
 | Prepare or verify a release | [Release](RELEASE.md) |
 | Track public sequencing | [Roadmap](ROADMAP.md) |

--- a/src/commands/main.py
+++ b/src/commands/main.py
@@ -107,6 +107,7 @@ from .setup import (
     cmd_update,
 )
 from .state import _add_state_commands, cmd_state_clear, cmd_state_finish, cmd_state_start, cmd_state_status
+from .use_cases import _add_cases_commands, cmd_cases_inspect, cmd_cases_list, cmd_cases_recommend
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -125,6 +126,7 @@ def build_parser() -> argparse.ArgumentParser:
             "  Use OMH request-to-handoff for: I want to safely add a feature to this repo.\n\n"
             "Operator examples:\n"
             "  omh recommend \"risky refactor\"\n"
+            "  omh cases recommend \"daily competitor digest\"\n"
             "  omh playbook recommend \"turn this issue into a PR\"\n"
             "  omh chat interact \"turn this issue into a PR-ready plan\"\n"
             "  omh hud\n"
@@ -152,6 +154,7 @@ def build_parser() -> argparse.ArgumentParser:
     _add_top_level_commands(sub)
     _add_docs_commands(sub)
     _add_harness_commands(sub)
+    _add_cases_commands(sub)
     _add_playbook_commands(sub)
     _add_release_commands(sub)
     _add_demo_commands(sub)
@@ -188,6 +191,7 @@ Start:
 
 Useful operator commands:
   omh recommend "risky refactor"
+  omh cases recommend "daily competitor digest"
   omh playbook recommend "turn this issue into a PR"
   omh chat interact "turn this issue into a PR-ready plan"
   omh hud                Show the compact OMH status line

--- a/src/commands/use_cases.py
+++ b/src/commands/use_cases.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import argparse
+
+from ..installer import OmhError
+from ..use_cases import inspect_use_case, list_use_cases, recommend_use_cases
+from .common import _print_json, _wants_json
+
+
+def cmd_cases_list(args: argparse.Namespace) -> int:
+    payload = list_use_cases()
+    if _wants_json(args):
+        _print_json(payload)
+    else:
+        _print_cases_list_summary(payload)
+    return 0
+
+
+def cmd_cases_inspect(args: argparse.Namespace) -> int:
+    try:
+        payload = inspect_use_case(args.id)
+    except KeyError as exc:
+        raise OmhError(f"unknown use case: {args.id}") from exc
+    if _wants_json(args):
+        _print_json(payload)
+    else:
+        _print_case_summary(payload["use_case"])
+    return 0
+
+
+def cmd_cases_recommend(args: argparse.Namespace) -> int:
+    query = " ".join(args.task).strip()
+    try:
+        payload = recommend_use_cases(query, limit=args.limit)
+    except ValueError as exc:
+        raise OmhError(str(exc)) from exc
+    if _wants_json(args):
+        _print_json(payload)
+    else:
+        _print_cases_recommend_summary(payload)
+    return 0
+
+
+def _print_cases_list_summary(payload: dict[str, object]) -> None:
+    cases = payload.get("use_cases", [])
+    if not isinstance(cases, list):
+        cases = []
+    print("OMH Hermes use cases")
+    print("Summary")
+    print(f"  Mapped use cases: {len(cases)}")
+    for case in cases:
+        if not isinstance(case, dict):
+            continue
+        print(f"  - {case.get('goal')}: {case.get('title')} ({case.get('primary_skill')})")
+    print("Boundary")
+    print("  These are Hermes-facing routing examples, not runtime execution evidence.")
+    print("Next")
+    print("  Inspect one with `omh cases inspect G10`.")
+    print("  Recommend one with `omh cases recommend <task>`.")
+    print("  For machine-readable output, rerun with `--json`.")
+
+
+def _print_case_summary(case: dict[str, object]) -> None:
+    print(f"OMH use case: {case.get('goal')} - {case.get('title')}")
+    print("Situation")
+    print(f"  {case.get('situation')}")
+    print("Route")
+    print(f"  Skill: {case.get('primary_skill')}")
+    print(f"  Playbook: {case.get('playbook')}")
+    print(f"  Harness: {case.get('harness')}")
+    print(f"  Next action: {case.get('next_action')}")
+    print("User value")
+    print(f"  {case.get('user_value')}")
+    print("Boundary")
+    print(f"  {case.get('evidence_boundary')}")
+    print("  For machine-readable output, rerun with `--json`.")
+
+
+def _print_cases_recommend_summary(payload: dict[str, object]) -> None:
+    recommendations = payload.get("recommendations", [])
+    if not isinstance(recommendations, list):
+        recommendations = []
+    print("OMH use-case recommendation")
+    query = str(payload.get("query", "")).strip()
+    if query:
+        print(f"Query: {query}")
+    for index, case in enumerate(recommendations, start=1):
+        if not isinstance(case, dict):
+            continue
+        print(f"{index}. {case.get('goal')} {case.get('id')} [{case.get('confidence')}]")
+        print(f"   Skill: {case.get('primary_skill')} | playbook: {case.get('playbook')}")
+        print(f"   Next action: {case.get('next_action')}")
+        print(f"   Boundary: {case.get('evidence_boundary')}")
+    print("Boundary")
+    print("  A use-case recommendation is routing guidance, not accepted work or observed evidence.")
+    print("  For machine-readable output, rerun with `--json`.")
+
+
+def _add_cases_commands(sub) -> None:
+    cases = sub.add_parser("cases", help="List, inspect, or recommend the G1-G10 Hermes use-case catalog.")
+    cases_sub = cases.add_subparsers(dest="cases_command", required=True)
+
+    list_cmd = cases_sub.add_parser("list")
+    list_cmd.add_argument("--json", action="store_true", help="Print the full machine-readable use-case catalog.")
+    list_cmd.set_defaults(func=cmd_cases_list)
+
+    inspect_cmd = cases_sub.add_parser("inspect")
+    inspect_cmd.add_argument("id", help="Use-case id such as G10 or scheduled-ops-blueprint.")
+    inspect_cmd.add_argument("--json", action="store_true", help="Print the full machine-readable use-case payload.")
+    inspect_cmd.set_defaults(func=cmd_cases_inspect)
+
+    recommend_cmd = cases_sub.add_parser("recommend")
+    recommend_cmd.add_argument("task", nargs="+", help="Natural-language request to map to a representative OMH use case.")
+    recommend_cmd.add_argument("--limit", type=int, default=3, help="Maximum use cases to return.")
+    recommend_cmd.add_argument("--json", action="store_true", help="Print the full machine-readable recommendation payload.")
+    recommend_cmd.set_defaults(func=cmd_cases_recommend)

--- a/src/use_cases.py
+++ b/src/use_cases.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import re
+from typing import Any
+
+
+USE_CASE_CATALOG_SCHEMA_VERSION = "omh_use_case_catalog/v1"
+USE_CASE_RECOMMENDATION_SCHEMA_VERSION = "omh_use_case_recommendation/v1"
+
+
+@dataclass(frozen=True)
+class UseCase:
+    goal: str
+    id: str
+    title: str
+    situation: str
+    example_request: str
+    primary_skill: str
+    playbook: str
+    harness: str
+    next_action: str
+    user_value: str
+    evidence_boundary: str
+    proof_surfaces: tuple[str, ...]
+    keywords: tuple[str, ...]
+
+
+USE_CASES: tuple[UseCase, ...] = (
+    UseCase(
+        goal="G1",
+        id="startup-product-triage",
+        title="Startup product triage",
+        situation="A small SaaS team receives customer feedback, bugs, and feature asks in Hermes chat.",
+        example_request="Payment failures keep showing up from customers.",
+        primary_skill="feedback-triage",
+        playbook="feedback-triage",
+        harness="customer-insight-triage",
+        next_action="triage_feedback",
+        user_value="Hermes separates investigate, reproduce, handoff, and verification instead of pretending the bug is already fixed.",
+        evidence_boundary="A triage record is not reproduction, code execution, customer confirmation, or incident closure.",
+        proof_surfaces=("omh recommend", "omh chat interact", "omh runtime status"),
+        keywords=("payment", "결제", "failure", "feedback", "customer", "triage", "bug", "repro"),
+    ),
+    UseCase(
+        goal="G2",
+        id="issue-to-pr-readiness",
+        title="Issue to PR readiness",
+        situation="An open-source maintainer wants Hermes to turn a loose issue into a reviewable PR unit.",
+        example_request="Turn this issue into a PR-ready implementation plan.",
+        primary_skill="ultraprocess",
+        playbook="request-to-handoff",
+        harness="goal-execution",
+        next_action="start_ultraprocess",
+        user_value="Hermes produces acceptance criteria, verification commands, and executor-ready handoff instead of a vague coding prompt.",
+        evidence_boundary="A prepared handoff is not executor dispatch, code result, review, CI, or merge evidence.",
+        proof_surfaces=("omh playbook recommend", "omh chat interact", "omh coding delegate"),
+        keywords=("issue", "PR", "pull request", "implementation", "acceptance", "handoff", "이슈"),
+    ),
+    UseCase(
+        goal="G3",
+        id="agent-product-qa",
+        title="Real-world agent product QA",
+        situation="A team validates whether an AI agent product handles realistic user scenarios safely.",
+        example_request="Check whether our agent handles a Kubernetes outage diagnosis scenario well.",
+        primary_skill="ultraqa",
+        playbook="reliability-incident-review",
+        harness="qa-specialist",
+        next_action="prepare_adversarial_qa",
+        user_value="Hermes shapes scenarios, expected behavior, checks, and observed gaps without mixing expectations with evidence.",
+        evidence_boundary="A QA scenario is not a passed test, production diagnosis, or verified remediation until observed results are recorded.",
+        proof_surfaces=("omh recommend", "omh ops reliability", "omh runtime record"),
+        keywords=("QA", "scenario", "test", "outage", "kubernetes", "diagnosis", "검증", "장애"),
+    ),
+    UseCase(
+        goal="G4",
+        id="chat-to-workflow-routing",
+        title="Chat to workflow routing",
+        situation="A development organization works in Hermes chat and expects natural messages to become the right workflow.",
+        example_request="This feels like a risky refactor before release.",
+        primary_skill="oh-my-hermes",
+        playbook="safe-feature-change",
+        harness="planning",
+        next_action="route_or_clarify",
+        user_value="Hermes routes to clarify, plan, research, handoff, review, or status without making users memorize commands.",
+        evidence_boundary="A routing decision is advisory wrapper guidance, not an accepted plan or execution result.",
+        proof_surfaces=("omh chat route", "omh recommend", "omh playbook recommend"),
+        keywords=("route", "workflow", "risky", "refactor", "release", "chat", "라우팅", "위험"),
+    ),
+    UseCase(
+        goal="G5",
+        id="ai-coding-safety",
+        title="AI coding safety boundary",
+        situation="A company adopts Codex, Claude Code, or another coding executor but needs clear evidence boundaries.",
+        example_request="Prepare this for a coding agent, but show what is only prepared versus observed.",
+        primary_skill="code-review",
+        playbook="request-to-handoff",
+        harness="coding-handling",
+        next_action="prepare_executor_handoff",
+        user_value="Hermes keeps prepared handoff, dispatch, result, verification, review, CI, and merge status separate.",
+        evidence_boundary="Prepared coding context is not dispatch, execution, verification, review, CI, merge readiness, or merge.",
+        proof_surfaces=("omh coding delegate", "omh runtime delegation-status", "omh coding lifecycle report"),
+        keywords=("coding agent", "codex", "claude", "executor", "observed", "evidence", "코딩", "검증"),
+    ),
+    UseCase(
+        goal="G6",
+        id="feature-shaping",
+        title="Product feature shaping",
+        situation="A product person describes a fuzzy improvement that should not go straight to implementation.",
+        example_request="I want onboarding to feel smoother.",
+        primary_skill="deep-interview",
+        playbook="deep-interview-to-plan",
+        harness="deep-interview",
+        next_action="ask_one_clarifying_question",
+        user_value="Hermes turns fuzzy intent into goals, non-goals, user value, acceptance criteria, and then handoff only when ready.",
+        evidence_boundary="A shaped feature brief is not user validation, implementation, or release evidence.",
+        proof_surfaces=("omh chat interact", "omh hermes plan", "omh recommend"),
+        keywords=("feature", "onboarding", "smooth", "product", "shape", "clarify", "기획", "온보딩"),
+    ),
+    UseCase(
+        goal="G7",
+        id="release-gate",
+        title="Release gate and README claim check",
+        situation="A maintainer wants Hermes to verify release readiness and public claims before shipping.",
+        example_request="Before release, check that README claims match commands and tests.",
+        primary_skill="deploy-and-monitor",
+        playbook="deploy-and-monitor",
+        harness="app-delivery-loop",
+        next_action="prepare_release_gate",
+        user_value="Hermes separates checklist, observed tests, docs claims, review status, and release readiness.",
+        evidence_boundary="A release checklist is not a published release, deployment, monitoring result, or user adoption signal.",
+        proof_surfaces=("omh release checklist", "omh doctor", "omh runtime status"),
+        keywords=("release", "README", "claim", "doctor", "checklist", "deploy", "릴리즈", "배포"),
+    ),
+    UseCase(
+        goal="G8",
+        id="refactor-standardization",
+        title="Repeatable refactor workflow",
+        situation="A team repeatedly refactors legacy code and wants a standard safety loop.",
+        example_request="This risky refactor needs plan, implementation, review, and docs sync.",
+        primary_skill="ultraprocess",
+        playbook="safe-feature-change",
+        harness="goal-execution",
+        next_action="start_single_cycle_plan_to_pr",
+        user_value="Hermes applies research, plan, implementation handoff, code review, docs sync, and PR discipline as one cycle.",
+        evidence_boundary="A refactor plan is not behavior preservation, test pass, code review approval, or merge evidence.",
+        proof_surfaces=("omh recommend", "omh chat interact", "omh runtime status"),
+        keywords=("refactor", "legacy", "plan", "review", "docs", "sync", "리팩터링", "레거시"),
+    ),
+    UseCase(
+        goal="G9",
+        id="multi-agent-work-hub",
+        title="Multi-agent work hub",
+        situation="A power user coordinates Hermes, Codex-like executors, plugin runtimes, reviews, and PR status.",
+        example_request="What is the current coding-agent status and what did we decide in the interview?",
+        primary_skill="team",
+        playbook="local-pipeline-buildout",
+        harness="goal-execution",
+        next_action="summarize_work_hub_status",
+        user_value="Hermes reports current plan context, attached executor session, evidence ladder, and next action without forcing CLI spelunking.",
+        evidence_boundary="A hub status card is not new execution, dispatch, review, CI, or merge evidence.",
+        proof_surfaces=("omh capabilities inspect", "omh runtime delegation-status", "omh chat session status"),
+        keywords=("multi-agent", "status", "session", "team", "executor", "interview", "에이전트", "상태"),
+    ),
+    UseCase(
+        goal="G10",
+        id="scheduled-ops-blueprint",
+        title="Scheduled ops blueprint",
+        situation="An operator wants Hermes to prepare recurring research, monitoring, digest, or reporting work.",
+        example_request="Every morning, check competitor news and send a Slack digest only if something changed.",
+        primary_skill="automation-blueprint",
+        playbook="scheduled-ops-blueprint",
+        harness="scheduled-ops-blueprint",
+        next_action="prepare_scheduled_ops_blueprint",
+        user_value="Hermes prepares schedule, delivery, silence policy, skill chain, and missing evidence before any host automation claim.",
+        evidence_boundary="A scheduled ops blueprint is not cron creation, source retrieval, gateway delivery, plugin load, or no-agent execution.",
+        proof_surfaces=("omh ops blueprint", "omh ops blueprint-list", "omh ops validate"),
+        keywords=("every morning", "daily", "weekly", "digest", "slack", "competitor", "scheduled", "매일", "정기"),
+    ),
+)
+
+
+def list_use_cases() -> dict[str, Any]:
+    return {
+        "schema_version": USE_CASE_CATALOG_SCHEMA_VERSION,
+        "count": len(USE_CASES),
+        "use_cases": [_public_case(case) for case in USE_CASES],
+    }
+
+
+def inspect_use_case(case_id: str) -> dict[str, Any]:
+    case = _find_case(case_id)
+    if case is None:
+        raise KeyError(case_id)
+    return {
+        "schema_version": USE_CASE_CATALOG_SCHEMA_VERSION,
+        "use_case": _public_case(case),
+    }
+
+
+def recommend_use_cases(query: str, *, limit: int = 3) -> dict[str, Any]:
+    clean_query = " ".join(query.split())
+    if limit < 1:
+        raise ValueError("limit must be at least 1")
+    if not clean_query:
+        raise ValueError("task description must not be empty")
+    tokens = _tokens(clean_query)
+    scored: list[tuple[int, int, UseCase]] = []
+    for case in USE_CASES:
+        score = _score_case(case, tokens, clean_query)
+        if score:
+            scored.append((score, int(case.goal[1:]), case))
+    if not scored:
+        scored = [(1, index, case) for index, case in enumerate((USE_CASES[3], USE_CASES[5], USE_CASES[1]))]
+    scored.sort(key=lambda item: (-item[0], item[1]))
+    recommendations = []
+    for score, _, case in scored[:limit]:
+        payload = _public_case(case)
+        payload["score"] = score
+        payload["confidence"] = _confidence(score)
+        recommendations.append(payload)
+    return {
+        "schema_version": USE_CASE_RECOMMENDATION_SCHEMA_VERSION,
+        "query": clean_query,
+        "recommendations": recommendations,
+        "boundary": "Use-case recommendations are routing and product-fit guidance, not accepted plans, runtime execution, or observed evidence.",
+    }
+
+
+def _public_case(case: UseCase) -> dict[str, Any]:
+    payload = asdict(case)
+    payload["proof_surfaces"] = list(case.proof_surfaces)
+    payload["keywords"] = list(case.keywords)
+    return payload
+
+
+def _find_case(case_id: str) -> UseCase | None:
+    normalized = case_id.strip().casefold()
+    for case in USE_CASES:
+        if normalized in {case.goal.casefold(), case.id.casefold(), f"{case.goal}-{case.id}".casefold()}:
+            return case
+    return None
+
+
+def _tokens(value: str) -> set[str]:
+    return {token.casefold() for token in re.findall(r"[A-Za-z0-9가-힣_+-]+", value)}
+
+
+def _score_case(case: UseCase, tokens: set[str], query: str) -> int:
+    lowered = query.casefold()
+    score = 0
+    for keyword in case.keywords:
+        key = keyword.casefold()
+        if " " in key:
+            if key in lowered:
+                score += 3
+        elif key in tokens:
+            score += 2
+        elif key and key in lowered:
+            score += 1
+    if case.primary_skill.casefold() in lowered or case.playbook.casefold() in lowered:
+        score += 4
+    return score
+
+
+def _confidence(score: int) -> str:
+    if score >= 6:
+        return "high"
+    if score >= 3:
+        return "medium"
+    return "low"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -39,6 +39,7 @@ class CliTests(unittest.TestCase):
         self.assertIn("Install managed skills and connect them", help_text)
         self.assertIn("chat", help_text)
         self.assertIn("wrapper chat events", help_text)
+        self.assertIn("omh cases recommend", help_text)
         self.assertIn("omh ops list", help_text)
         self.assertIn("omh materials list", help_text)
         self.assertIn("Human-facing maintenance, catalog, and operator checklist commands print summaries", help_text)
@@ -131,6 +132,9 @@ class CliTests(unittest.TestCase):
                 "OMH playbook recommendation",
                 "recommendations",
             ),
+            (["cases", "recommend", "daily", "competitor", "digest"], "OMH use-case recommendation", "recommendations"),
+            (["cases", "list"], "OMH Hermes use cases", "use_cases"),
+            (["cases", "inspect", "G10"], "OMH use case:", "use_case"),
             (["playbook", "list"], "OMH playbooks", "playbooks"),
             (["playbook", "inspect", "safe-feature-change"], "OMH playbook:", "playbook"),
             (["profile", "list"], "OMH profile packs", "packs"),
@@ -154,6 +158,59 @@ class CliTests(unittest.TestCase):
                 self.assertEqual(stderr, "")
                 self.assertEqual(status, 0)
                 self.assertIn(json_key, json.loads(stdout))
+
+    def test_cases_catalog_exposes_g1_to_g10_and_recommends_real_situations(self) -> None:
+        status, stdout, stderr = run_cli(["cases", "list", "--json"], output_json=False)
+
+        self.assertEqual(status, 0, stderr)
+        self.assertEqual(stderr, "")
+        payload = json.loads(stdout)
+        self.assertEqual(payload["schema_version"], "omh_use_case_catalog/v1")
+        self.assertEqual(payload["count"], 10)
+        self.assertEqual([case["goal"] for case in payload["use_cases"]], [f"G{index}" for index in range(1, 11)])
+
+        status, stdout, stderr = run_cli(["cases", "inspect", "G10", "--json"], output_json=False)
+
+        self.assertEqual(status, 0, stderr)
+        self.assertEqual(stderr, "")
+        inspected = json.loads(stdout)["use_case"]
+        self.assertEqual(inspected["id"], "scheduled-ops-blueprint")
+        self.assertEqual(inspected["primary_skill"], "automation-blueprint")
+        self.assertIn("not cron creation", inspected["evidence_boundary"])
+
+        examples = (
+            ("Payment failures keep showing up from customers", "G1", "feedback-triage"),
+            ("Turn this issue into a PR-ready implementation plan", "G2", "ultraprocess"),
+            ("Check whether our agent handles a Kubernetes outage diagnosis scenario well", "G3", "ultraqa"),
+            ("This feels like a risky refactor before release", "G4", "oh-my-hermes"),
+            ("Prepare this for Codex but show prepared versus observed evidence", "G5", "code-review"),
+            ("I want onboarding to feel smoother", "G6", "deep-interview"),
+            ("Before release check README claims and commands", "G7", "deploy-and-monitor"),
+            ("Risky refactor needs plan implementation review and docs sync", "G8", "ultraprocess"),
+            ("What is the current executor session status", "G9", "team"),
+            ("Every morning send a competitor digest only if changed", "G10", "automation-blueprint"),
+        )
+        for query, goal, skill in examples:
+            with self.subTest(query=query):
+                status, stdout, stderr = run_cli(["cases", "recommend", *query.split(), "--limit", "1", "--json"], output_json=False)
+
+                self.assertEqual(status, 0, stderr)
+                self.assertEqual(stderr, "")
+                recommendation = json.loads(stdout)["recommendations"][0]
+                self.assertEqual(recommendation["goal"], goal)
+                self.assertEqual(recommendation["primary_skill"], skill)
+
+        status, stdout, stderr = run_cli(["cases", "recommend", "zzzzzz", "--limit", "1", "--json"], output_json=False)
+
+        self.assertEqual(status, 0, stderr)
+        self.assertEqual(stderr, "")
+        self.assertEqual(json.loads(stdout)["recommendations"][0]["goal"], "G4")
+
+        status, stdout, stderr = run_cli(["cases", "recommend", "", "--json"], output_json=False)
+
+        self.assertEqual(status, 2)
+        self.assertEqual(stdout, "")
+        self.assertIn("task description must not be empty", stderr)
 
     def test_local_operator_commands_default_to_human_summary_with_json_escape_hatch(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -10,6 +10,7 @@ load_local_package()
 from omh.routing import recommend as recommend_module
 from omh.roles import role_definitions, role_file_markdown, roles_reference_markdown
 from omh.skill_pack import builtin_definitions, builtin_harnesses, builtin_skill_templates
+from omh.playbooks import list_playbooks
 from omh.runtime.records import validate_harness_quality
 from omh.skills.catalog import (
     SkillDefinition,
@@ -19,6 +20,7 @@ from omh.skills.catalog import (
     retained_delegation_skill_names,
 )
 from omh.skills.render import workflow_reference_markdown, workflow_reference_payload
+from omh.use_cases import USE_CASES, list_use_cases
 
 
 FLAGSHIP_SKILLS = {
@@ -110,6 +112,29 @@ class RouterContentTests(unittest.TestCase):
             "code-review",
         }:
             self.assertIn(expected, names)
+
+    def test_g1_to_g10_use_case_catalog_is_complete_and_boundary_safe(self) -> None:
+        payload = list_use_cases()
+
+        self.assertEqual(payload["schema_version"], "omh_use_case_catalog/v1")
+        self.assertEqual(payload["count"], 10)
+        self.assertEqual([case.goal for case in USE_CASES], [f"G{index}" for index in range(1, 11)])
+        names = {skill.name for skill in builtin_skill_templates()}
+        harnesses = {harness.name for harness in builtin_harnesses()}
+        playbooks = {playbook["id"] for playbook in list_playbooks()["playbooks"]}
+        playbook_doc = Path("docs/APPLICATION_CASES.md").read_text(encoding="utf-8")
+        readme = Path("README.md").read_text(encoding="utf-8")
+        for case in USE_CASES:
+            with self.subTest(case=case.id):
+                self.assertIn(case.primary_skill, names)
+                self.assertIn(case.harness, harnesses)
+                self.assertIn(case.playbook, playbooks)
+                self.assertNotIn("secret", case.evidence_boundary.lower())
+                self.assertNotIn("hidden", case.evidence_boundary.lower())
+                self.assertIn(case.goal, playbook_doc)
+                self.assertIn(case.primary_skill, playbook_doc)
+        self.assertIn("G1-G10", readme)
+        self.assertIn("omh cases list --json", readme)
 
     def test_recommendation_policies_are_data_driven_for_business_categories(self) -> None:
         expected = {


### PR DESCRIPTION
## Feature Report

### What Changed

- Added a deterministic G1-G10 Hermes use-case catalog with `omh cases list`, `omh cases inspect <id>`, and `omh cases recommend <task>`.
- Documented the representative G1-G10 situations in `docs/APPLICATION_CASES.md` and surfaced the catalog from README/docs index copy.
- Added regression coverage that locks all 10 goals, recommendation examples, weak-query fallback, empty-query rejection, and registry-safe skill/playbook/harness references.

### Why This Exists

- The previous Scheduled Ops Blueprint slice covered only one of the intended ten representative Hermes use cases.
- OMH needs an explicit, test-backed map for startup triage, issue-to-PR readiness, real-world agent QA, chat routing, AI coding safety, feature shaping, release gates, refactor workflows, multi-agent work hub status, and scheduled ops blueprints.
- This keeps the chat-first product story grounded without making normal users memorize backend commands.

### User / Operator Impact

- Hermes wrappers and operators can now inspect or recommend a concrete G1-G10 use case deterministically.
- Users get clearer routing from realistic work situations to a skill, playbook, harness, next action, and evidence boundary.
- Weak unknown requests fall back to chat-to-workflow routing guidance; empty requests fail clearly instead of pretending a route was found.

### How It Works

- `src/use_cases.py` owns the frozen catalog and deterministic scoring.
- `src/commands/use_cases.py` renders human summaries by default and JSON when requested.
- `src/commands/main.py` registers the new backend/operator surface and help examples.
- Tests validate every case against live skill, playbook, and harness registries to avoid drift.

### Files And Contracts Touched

- New schema versions: `omh_use_case_catalog/v1` and `omh_use_case_recommendation/v1`.
- New command group: `omh cases list|inspect|recommend`.
- Docs updated: `README.md`, `docs/README.md`, `docs/APPLICATION_CASES.md`.
- Tests updated: `tests/test_cli.py`, `tests/test_router_content.py`.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m src.cli docs workflows --check`
- [x] `uv run python -m src.cli harness validate`
- [ ] `python3 -m omh.cli release checklist --json` - Not run; this PR changes catalog/routing docs, not release packaging metadata.
- [ ] `python3 -m omh.cli release hermes-smoke` - Not run; no live Hermes install/profile mutation required for this backend catalog slice.
- [x] `uv run python -m src.cli cases list --json`
- [x] `uv run python -m src.cli cases recommend "Every morning send a competitor digest only if changed" --limit 1 --json`
- [x] `uv run python -m src.cli cases inspect G1`
- [x] `uv run python -m src.cli cases recommend "Prepare this for Codex but show prepared versus observed evidence" --limit 1 --json`
- [x] `uv build`
- [x] `git diff --check`
- [ ] Manual Hermes/TUI check - Not run; this is deterministic local backend/operator catalog support, not a live wrapper rendering change.

## Risk

- The catalog is editorial product metadata, so drift is possible if new skill/playbook/harness names change later. Regression tests now guard the concrete registry references.
- Recommendation scoring is intentionally deterministic and simple; it is routing guidance, not semantic LLM classification.

## Compatibility / Rollout

- Existing commands and schemas remain compatible.
- `omh cases` defaults to human summaries like other catalog/operator commands; wrappers can pass `--json`.
- No network, LLM, hidden executor, or Hermes core behavior changes.

## Release / Claims

- [x] Release-channel impact considered: no channel metadata change.
- [x] Runtime/native capability claims are bounded: recommendations are routing/product-fit guidance only.
- [x] Known manual Hermes checks are listed above as not run for this backend catalog PR.

## Follow-Up

- Consider projecting future case entries from richer catalog metadata if the G1-G10 map grows beyond the current curated release-check surface.