### PR TITLE
Recover null Hermes external dirs during setup

### DIFF
--- a/src/config_adapter.py
+++ b/src/config_adapter.py
@@ -14,6 +14,18 @@ class ConfigChange:
     text: str
 
 
+@dataclass(frozen=True)
+class _InlineExternalDirs:
+    matched: bool
+    supported: bool
+    values: list[str]
+
+
+_BARE_YAML_NULLS = {"null", "Null", "NULL", "~"}
+_UNSUPPORTED_EXTERNAL_DIRS_SHAPE = "unsupported skills.external_dirs shape; use a YAML block list or inline list"
+_DUPLICATE_EXTERNAL_DIRS_SHAPE = "duplicate skills.external_dirs entries are unsupported; keep one YAML block list or inline list"
+
+
 def _normalize(value: str | Path) -> str:
     return str(Path(value).expanduser())
 
@@ -40,11 +52,38 @@ def _format_external_dirs(values: list[str]) -> list[str]:
     return ["  external_dirs:", *[f"    - {value}" for value in values]]
 
 
-def _inline_external_dirs(line: str) -> list[str] | None:
+def _classify_inline_external_dirs(line: str) -> _InlineExternalDirs:
+    # Readers stay non-throwing for doctor/probe stability: unsupported inline
+    # scalars mean "no valid dirs observed". Mutations remain strict and reject
+    # matched-but-unsupported shapes instead of guessing YAML semantics.
     match = re.match(r"^  external_dirs:\s*(?P<value>\S.*)$", line)
     if not match:
-        return None
-    return _parse_inline_list(match.group("value"))
+        return _InlineExternalDirs(False, False, [])
+    value = match.group("value").strip()
+    if value in _BARE_YAML_NULLS:
+        return _InlineExternalDirs(True, True, [])
+    parsed = _parse_inline_list(value)
+    if parsed is None:
+        return _InlineExternalDirs(True, False, [])
+    return _InlineExternalDirs(True, True, parsed)
+
+
+def _validate_external_dirs_mutation_shape(config_text: str) -> None:
+    in_skills = False
+    external_dirs_declarations = 0
+    for line in config_text.splitlines():
+        stripped = line.strip()
+        if not line.startswith(" ") and stripped:
+            in_skills = stripped == "skills:"
+            continue
+        if in_skills and line.startswith("  ") and not line.startswith("    "):
+            inline = _classify_inline_external_dirs(line)
+            if inline.matched or stripped == "external_dirs:":
+                external_dirs_declarations += 1
+                if external_dirs_declarations > 1:
+                    raise ValueError(_DUPLICATE_EXTERNAL_DIRS_SHAPE)
+                if inline.matched and not inline.supported:
+                    raise ValueError(_UNSUPPORTED_EXTERNAL_DIRS_SHAPE)
 
 
 def external_dirs(config_text: str) -> list[str]:
@@ -59,9 +98,10 @@ def external_dirs(config_text: str) -> list[str]:
             in_external = False
             continue
         if in_skills and line.startswith("  ") and not line.startswith("    "):
-            inline = _inline_external_dirs(line)
-            if inline is not None:
-                result.extend(inline)
+            inline = _classify_inline_external_dirs(line)
+            if inline.matched:
+                if inline.supported:
+                    result.extend(inline.values)
                 in_external = False
                 continue
             in_external = stripped == "external_dirs:"
@@ -72,6 +112,7 @@ def external_dirs(config_text: str) -> list[str]:
 
 
 def ensure_external_dir(config_text: str, skill_dir: str | Path) -> ConfigChange:
+    _validate_external_dirs_mutation_shape(config_text)
     target = _normalize(skill_dir)
     if target in external_dirs(config_text):
         return ConfigChange(False, "external dir already present", config_text)
@@ -92,15 +133,15 @@ def ensure_external_dir(config_text: str, skill_dir: str | Path) -> ConfigChange
         if line and not line.startswith(" "):
             break
         if line.startswith("  ") and not line.startswith("    "):
-            inline = _inline_external_dirs(line)
-            if inline is not None:
-                values = inline
+            inline = _classify_inline_external_dirs(line)
+            if inline.matched:
+                if not inline.supported:
+                    raise ValueError(_UNSUPPORTED_EXTERNAL_DIRS_SHAPE)
+                values = inline.values
                 if target in values:
                     return ConfigChange(False, "external dir already present", config_text)
                 lines[idx:idx + 1] = _format_external_dirs([*values, target])
                 return ConfigChange(True, "expanded inline external_dirs", "\n".join(lines) + "\n")
-            if line.strip().startswith("external_dirs:") and line.strip() != "external_dirs:":
-                raise ValueError("unsupported skills.external_dirs shape; use a YAML block list or inline list")
             if line.strip() == "external_dirs:":
                 external_index = idx
                 break
@@ -117,6 +158,7 @@ def ensure_external_dir(config_text: str, skill_dir: str | Path) -> ConfigChange
 
 
 def remove_external_dir(config_text: str, skill_dir: str | Path) -> ConfigChange:
+    _validate_external_dirs_mutation_shape(config_text)
     target = _normalize(skill_dir)
     lines = config_text.splitlines()
     changed = False
@@ -131,10 +173,12 @@ def remove_external_dir(config_text: str, skill_dir: str | Path) -> ConfigChange
             output.append(line)
             continue
         if in_skills and line.startswith("  ") and not line.startswith("    "):
-            inline = _inline_external_dirs(line)
-            if inline is not None:
-                values = [value for value in inline if value != target]
-                if len(values) != len(inline):
+            inline = _classify_inline_external_dirs(line)
+            if inline.matched:
+                if not inline.supported:
+                    raise ValueError(_UNSUPPORTED_EXTERNAL_DIRS_SHAPE)
+                values = [value for value in inline.values if value != target]
+                if len(values) != len(inline.values):
                     changed = True
                     output.extend(_format_external_dirs(values))
                     in_external = False

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,6 +14,7 @@ from _cli_harness import run_cli
 from omh.cli import OmhError, cmd_runtime_merge
 from omh.commands.main import build_parser
 from omh.commands.language import LANGUAGE_CODES, MESSAGES
+from omh.config_adapter import external_dirs
 from omh.skill_pack import builtin_skill_templates
 
 
@@ -140,6 +141,47 @@ class CliTests(unittest.TestCase):
             command_check = {check["name"]: check for check in doctor_payload["checks"]}["command_path"]
             self.assertEqual(command_check["severity"], "ok")
             self.assertTrue(command_check["observed"])
+
+    def test_setup_recovers_bare_null_external_dirs_shape(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / ".omh"
+            hermes_home = root / ".hermes"
+            hermes_home.mkdir()
+            config_path = hermes_home / "config.yaml"
+            original_config = "skills:\n  external_dirs: null\n"
+            config_path.write_text(original_config, encoding="utf-8")
+            base = ["--omh-home", str(omh_home), "--hermes-home", str(hermes_home)]
+
+            status, stdout, stderr = run_cli(base + ["setup", "--dry-run", "--no-interactive", "--language", "en"], output_json=False)
+
+            self.assertEqual(status, 0, stderr)
+            self.assertEqual(stderr, "")
+            self.assertIn("OMH setup preview complete.", stdout)
+            self.assertEqual(config_path.read_text(encoding="utf-8"), original_config)
+            self.assertFalse(omh_home.exists())
+
+            with patch("omh.command_path.shutil.which", return_value="/usr/local/bin/omh"):
+                status, stdout, stderr = run_cli(base + ["setup", "--no-interactive", "--language", "en"], output_json=False)
+
+            self.assertEqual(status, 0, stderr)
+            self.assertEqual(stderr, "")
+            self.assertIn("OMH setup complete.", stdout)
+            config_text = config_path.read_text(encoding="utf-8")
+            self.assertEqual(external_dirs(config_text), [str((omh_home / "skills").resolve())])
+            self.assertIn("  external_dirs:\n    - ", config_text)
+            self.assertNotIn("external_dirs: null", config_text)
+
+            with patch("omh.command_path.shutil.which", return_value="/usr/local/bin/omh"):
+                status, stdout, stderr = run_cli(base + ["doctor", "--json"], output_json=False)
+
+            self.assertEqual(status, 0, stderr)
+            self.assertEqual(stderr, "")
+            payload = json.loads(stdout)
+            checks = {check["name"]: check for check in payload["checks"]}
+            self.assertTrue(payload["ok"])
+            self.assertEqual(payload["summary"]["status"], "ok")
+            self.assertTrue(checks["external_dir"]["observed"])
 
     def test_doctor_warns_when_omh_command_is_not_on_path(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_config_adapter.py
+++ b/tests/test_config_adapter.py
@@ -9,6 +9,11 @@ from omh.config_adapter import ensure_external_dir, external_dirs, remove_extern
 
 
 class ConfigAdapterTests(unittest.TestCase):
+    def test_external_dirs_treats_bare_yaml_null_as_empty(self) -> None:
+        for value in ("null", "Null", "NULL", "~"):
+            with self.subTest(value=value):
+                self.assertEqual(external_dirs(f"skills:\n  external_dirs: {value}\n"), [])
+
     def test_ensure_external_dir_creates_empty_config(self) -> None:
         change = ensure_external_dir("", "/tmp/omh/skills")
 
@@ -49,6 +54,51 @@ class ConfigAdapterTests(unittest.TestCase):
         self.assertEqual(external_dirs(change.text), ["/tmp/omh/skills"])
         self.assertEqual(change.text.count("external_dirs:"), 1)
 
+    def test_ensure_external_dir_expands_bare_yaml_null(self) -> None:
+        for value in ("null", "Null", "NULL", "~"):
+            with self.subTest(value=value):
+                original = f"model: test\nskills:\n  disabled:\n    - old\n  external_dirs: {value}\n"
+                first = ensure_external_dir(original, "/tmp/omh/skills")
+                second = ensure_external_dir(first.text, "/tmp/omh/skills")
+
+                self.assertTrue(first.changed)
+                self.assertFalse(second.changed)
+                self.assertIn("model: test", first.text)
+                self.assertIn("disabled:", first.text)
+                self.assertEqual(external_dirs(first.text), ["/tmp/omh/skills"])
+                self.assertIn("  external_dirs:\n    - /tmp/omh/skills\n", first.text)
+                self.assertNotIn(f"external_dirs: {value}", first.text)
+
+    def test_ensure_external_dir_rejects_unsupported_scalar_shapes(self) -> None:
+        for value in ("'null'", '"null"', "null # comment", "~ # comment", "/tmp/omh/skills"):
+            with self.subTest(value=value):
+                original = f"skills:\n  external_dirs: {value}\n"
+                self.assertEqual(external_dirs(original), [])
+                with self.assertRaises(ValueError):
+                    ensure_external_dir(original, "/tmp/omh/skills")
+
+    def test_mutations_reject_duplicate_block_with_unsupported_inline_scalar(self) -> None:
+        original = "skills:\n  external_dirs:\n    - /tmp/omh/skills\n  external_dirs: /bad\n"
+
+        self.assertEqual(external_dirs(original), ["/tmp/omh/skills"])
+        with self.assertRaises(ValueError):
+            ensure_external_dir(original, "/tmp/omh/skills")
+        with self.assertRaises(ValueError):
+            remove_external_dir(original, "/tmp/omh/skills")
+
+    def test_mutations_reject_duplicate_external_dirs_keys_even_when_supported(self) -> None:
+        originals = [
+            "skills:\n  external_dirs:\n    - /tmp/omh/skills\n  external_dirs: null\n",
+            "skills:\n  external_dirs:\n    - /tmp/omh/skills\n  external_dirs: []\n",
+            "skills:\n  external_dirs: [/tmp/omh/skills]\n  external_dirs:\n    - /keep\n",
+        ]
+        for original in originals:
+            with self.subTest(original=original):
+                with self.assertRaises(ValueError):
+                    ensure_external_dir(original, "/tmp/omh/skills")
+                with self.assertRaises(ValueError):
+                    remove_external_dir(original, "/tmp/omh/skills")
+
     def test_remove_external_dir_from_inline_list(self) -> None:
         original = "skills:\n  external_dirs: [/keep, /tmp/omh/skills]\n"
         change = remove_external_dir(original, "/tmp/omh/skills")
@@ -56,6 +106,24 @@ class ConfigAdapterTests(unittest.TestCase):
         self.assertTrue(change.changed)
         self.assertEqual(external_dirs(change.text), ["/keep"])
         self.assertEqual(change.text.count("external_dirs:"), 1)
+
+    def test_remove_external_dir_treats_bare_yaml_null_as_absent(self) -> None:
+        for value in ("null", "Null", "NULL", "~"):
+            with self.subTest(value=value):
+                original = f"skills:\n  external_dirs: {value}\n"
+                change = remove_external_dir(original, "/tmp/omh/skills")
+
+                self.assertFalse(change.changed)
+                self.assertEqual(change.text, original)
+                self.assertEqual(external_dirs(change.text), [])
+
+    def test_remove_external_dir_rejects_unsupported_scalar_shapes(self) -> None:
+        for value in ("'null'", '"null"', "null # comment", "~ # comment", "/tmp/omh/skills"):
+            with self.subTest(value=value):
+                original = f"skills:\n  external_dirs: {value}\n"
+                self.assertEqual(external_dirs(original), [])
+                with self.assertRaises(ValueError):
+                    remove_external_dir(original, "/tmp/omh/skills")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Feature Report

### What Changed

- Recover existing Hermes profiles where `skills.external_dirs` is set to a bare YAML null (`null`, `Null`, `NULL`, or `~`).
- Keep config reads non-throwing for `doctor`/`probe`, while making config mutation paths strict for ambiguous shapes.
- Reject unsupported inline scalar forms and duplicate `skills.external_dirs` declarations during setup/apply/uninstall mutation.
- Add focused config adapter and CLI regression coverage for dry-run immutability, real setup canonicalization, and post-setup doctor success.

### Why This Exists

- A real user profile can contain `skills.external_dirs: null`, which previously made setup/apply fail instead of recovering the managed OMH skills registration.
- OMH should be able to bootstrap an existing Hermes profile without requiring a manual YAML edit when the shape is safely recoverable.
- Ambiguous YAML shapes must not be silently accepted, because duplicate `external_dirs` declarations can be interpreted differently by real YAML consumers.

### User / Operator Impact

- `omh setup --dry-run --no-interactive --language en` can preview recovery against a bare-null profile without writing local state.
- Running setup for real rewrites the recoverable bare-null shape to the canonical block-list registration.
- `omh doctor --json` passes after setup and observes the managed external dir.
- Unsupported scalar or duplicate `skills.external_dirs` declarations now fail clearly instead of being treated as a successful registration.

### How It Works

- `src/config_adapter.py` now classifies inline `skills.external_dirs` entries as matched/supported/value-bearing metadata.
- `external_dirs()` remains read-permissive and returns only observed valid directories, preserving stable doctor/probe behavior.
- `ensure_external_dir()` and `remove_external_dir()` validate the full mutation shape before idempotency/removal, rejecting unsupported scalar and duplicate declarations.
- Supported bare YAML null spellings are treated as an empty inline value and expanded to the canonical block list by setup/apply.

### Files And Contracts Touched

- `src/config_adapter.py`: private classifier and mutation-shape validation for `skills.external_dirs`.
- `tests/test_config_adapter.py`: bare-null recovery, unsupported scalar rejection, duplicate-key rejection, and remove-path tests.
- `tests/test_cli.py`: setup dry-run immutability, real setup canonicalization, and doctor success for a bare-null profile.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_config_adapter.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest tests.test_cli.CliTests.test_setup_recovers_bare_null_external_dirs_shape -v`
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_cli.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` (435 tests)
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m src.cli docs workflows --check`
- [x] `git diff --check`
- [x] Relevant dry-run or smoke command: `uv run python -m src.cli setup --dry-run --no-interactive --language en`
- [x] Relevant install smoke command: `uv run python -m src.cli release install-smoke --repo-root /Users/rlaope/Desktop/khope/omhm --install-script /Users/rlaope/Desktop/khope/omhm/install.sh --live`
- [x] Manual Hermes/TUI check, or explicit reason it was not run: not run; this PR intentionally verifies local config mutation and isolated install smoke, not live Hermes chat loading.

## Risk

- Duplicate `skills.external_dirs` declarations now fail on mutation instead of attempting to guess canonical intent. This is stricter, but avoids false-positive setup success against ambiguous YAML.
- The parser remains line-oriented and conservative; it does not attempt full YAML normalization.

## Compatibility / Rollout

- Existing valid block-list and inline-list configs remain supported.
- Bare YAML null configs are recoverable.
- Unsupported scalar configs now require the operator to use a YAML block list or inline list.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- Consider a future structured config diagnostic that can separately report `absent`, `recoverable`, `unsupported`, and `duplicate` without changing the public read helper.
