### PR TITLE
Refine workflow-fit README and site messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 </p>
 
 <p align="center">
-  <strong>Install once. Talk to Hermes. Let OMH shape the work.</strong>
+  <strong>Install once. Keep your Hermes workflow. Let OMH make the next step safe.</strong>
   <br>
-  <em>Hermes-native skills, workflow contracts, evidence-aware status, and executor-ready handoffs.</em>
+  <em>Chat-first skills, workflow contracts, status cards, and handoffs that fit existing Hermes setups without breaking them.</em>
 </p>
 
 <p align="center">
@@ -16,15 +16,14 @@
   <img alt="Status" src="https://img.shields.io/badge/status-1.0.0%20stable-blue">
 </p>
 
-**oh-my-hermes** makes Hermes Agent feel more capable after install. OMH
-adds workflow skills, optional profiles, wrapper-facing contracts, local
-evidence records, and coding/runtime handoff preparation while keeping normal
-users in Hermes chat.
+Most people skip the docs. **oh-my-hermes** is built for that reality: install
+it, keep working in Hermes, and let the added skills, contracts, and status
+cards make the next action obvious without replacing your existing setup.
 
-The product is not "more CLI commands." The `omh` command is bootstrap,
+The product is not "more CLI commands." The `omh` command is setup, repair,
 doctor, verifier, and wrapper/backend infrastructure. For Hermes wrappers and
 routers, that CLI contract is a first-class backend surface; for normal users,
-the main experience is:
+the main experience is still chat:
 
 ```text
 user says a plain request in Hermes
@@ -33,33 +32,11 @@ user says a plain request in Hermes
   -> coding is handed off to the selected runtime only when the user or wrapper accepts that path
 ```
 
-> Have you ever felt that Hermes Agent is powerful, but still has a high
-> barrier to entry? OMH exists for that gap between installation and real use:
-> setup, config checks, verification, workflow choice, and the first useful
-> task. The engine is already strong across Skills, Gateway, Profiles, and
-> Cron; OMH adds a thin practical layer of ready-to-use workflows such as
-> `web-research`, `doctor`, `idea-to-deploy`, `ultragoal`, `loop`, and
-> `ultraprocess` so Hermes can
-> feel easier to start, easier to trust, and more natural to apply in real
-> work.
-
-[Website](https://rlaope.github.io/oh-my-hermes/) -
-[Documentation](docs/README.md) -
-[Installation](docs/INSTALLATION.md) -
-[Capabilities](docs/CAPABILITIES.md) -
-[Agent Install](INSTALL_FOR_AGENTS.md) -
-[Roles](docs/ROLES.md) -
-[Application Cases](docs/APPLICATION_CASES.md) -
-[GitHub Pages site](site/index.html)
-
-> [!NOTE]
-> **GitHub Follow**
-> Follow [@rlaope](https://github.com/rlaope) on GitHub for OMH updates and
-> related Hermes-native workflow projects.
-> Explore [ArtEngine Lab](https://rlaope.github.io/artengine-lab/) for the
-> Art & Engineering studio behind OMH.
-
----
+OMH exists for the gap between installation and real use: config checks,
+workflow choice, evidence boundaries, and the first useful task. It adds a thin
+practical layer of ready-to-use workflows such as `web-research`, `doctor`,
+`idea-to-deploy`, `ultragoal`, `loop`, and `ultraprocess` so Hermes can feel
+easier to start, easier to trust, and more natural to apply in real work.
 
 ## Quick Start
 
@@ -149,6 +126,30 @@ curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes/main/install.sh
 For preview updates before the next release, rerun the same installer. If your
 release automation knows the commit SHA, pass it as `OMH_SOURCE_REF=main@<sha>`
 so OMH can display and record `main@old -> main@new` instead of only `main`.
+
+What OMH changes is intentionally small:
+
+- It installs managed Hermes-visible skills and records local status contracts.
+- It can repair or reapply `skills.external_dirs` when a Hermes profile drifts.
+- It keeps CLI output for setup, doctor, update, and wrapper backends.
+- It does not patch Hermes core, run hidden coding work, or turn a prepared
+  handoff into observed execution.
+
+[Website](https://rlaope.github.io/oh-my-hermes/) -
+[Documentation](docs/README.md) -
+[Installation](docs/INSTALLATION.md) -
+[Capabilities](docs/CAPABILITIES.md) -
+[Agent Install](INSTALL_FOR_AGENTS.md) -
+[Roles](docs/ROLES.md) -
+[Application Cases](docs/APPLICATION_CASES.md) -
+[GitHub Pages site](site/index.html)
+
+> [!NOTE]
+> **GitHub Follow**
+> Follow [@rlaope](https://github.com/rlaope) on GitHub for OMH updates and
+> related Hermes-native workflow projects.
+> Explore [ArtEngine Lab](https://rlaope.github.io/artengine-lab/) for the
+> Art & Engineering studio behind OMH.
 
 ## Why OMH
 

--- a/docs/DIRECTION.md
+++ b/docs/DIRECTION.md
@@ -10,6 +10,11 @@ runtime. It borrows the discipline of staged workflows, local state, and
 evidence gates, then translates that discipline into Hermes-native chat,
 planning, status, and handoff contracts.
 
+The product should feel like a safe fit for an existing Hermes workflow, not a
+separate CLI-first tool that users must learn before they get value. Assume many
+users will skip most docs at first; the install path, first Hermes prompt,
+status language, and repair commands must make the safe path obvious.
+
 ## Design Philosophy
 
 Raise the product's capability level by strengthening contracts, not by hiding

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,7 +25,7 @@ repo-local contract for Codex agents working here.
 | See Discord-style wrapper responses | [Chat Wrapper Examples](CHAT_WRAPPER_EXAMPLES.md) |
 | Render workflow quality gates in wrappers | [Harness Quality Contract](HARNESS_QUALITY.md) |
 | Install Hermes-native skills or bootstrap managed skills | [Installation](INSTALLATION.md) |
-| Run deterministic backend demos | [`omh demo orchestration`](../README.md#backend--operator-surface) and [fixture shims](../examples) |
+| Run deterministic backend demos | [Chat Wrapper Examples](CHAT_WRAPPER_EXAMPLES.md#commands-used) and [fixture shims](../examples) |
 | See the G1-G10 implemented feature surfaces | [Application Cases](APPLICATION_CASES.md) |
 | Check generated skill and harness metadata | [Workflow Reference](WORKFLOWS.md) |
 | Prepare or verify a release | [Release](RELEASE.md) |
@@ -44,6 +44,11 @@ handoff UX. The selected coding executor should own main coding work when work
 leaves Hermes. OMH should own the deterministic local contract between those
 worlds: generated skill guidance, playbooks, wrapper sessions, prepared handoff
 payloads, and evidence records.
+
+Assume most users will try the product before reading the full docs. The public
+surface should therefore make the first install, first Hermes prompt, repair
+path, and evidence boundary obvious without forcing users into a CLI-first
+workflow.
 
 The most important boundary is prepared versus observed evidence. A prepared
 handoff is useful, but it is not execution, review, CI, merge readiness, or a

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -6,7 +6,7 @@
     <title>OMH Documentation</title>
     <meta
       name="description"
-      content="Documentation for OMH installation, chat routing, wrapper contracts, harness evidence, and delegation-first coding handoffs."
+      content="OMH documentation for installing once, keeping Hermes chat-first, and using workflow contracts without breaking existing setups."
     >
     <link rel="stylesheet" href="../styles.css">
   </head>
@@ -54,17 +54,16 @@
       <article class="docs-content">
         <header class="docs-hero" id="overview">
           <p class="eyebrow">Documentation</p>
-          <h1>Use OMH as a local contract layer for Hermes.</h1>
+          <h1>Install once, then keep working in Hermes.</h1>
           <p>
-            OMH gives Hermes installed skill guidance for turning natural language into deterministic
-            routing, clarification, research briefs, feedback triage, meeting prep,
-            strategy planning, status narration, or selected-executor coding handoffs.
+            Most people will not study every page before trying the tool. OMH
+            is designed so the first install keeps Hermes chat-first while this
+            documentation remains the operating map for setup repair, workflow
+            contracts, wrapper status, and conservative evidence boundaries.
             The flagship <code>request-to-handoff</code> path turns a plain
             Hermes request into a responsible role, a next action, and a clear
-            prepared-vs-observed boundary.
-            Local backend contracts and schema-versioned artifacts support wrappers and operators
-            without becoming the normal user UX. Operators can optionally add a thin
-            plugin bridge for metadata-only status context.
+            prepared-vs-observed boundary without making backend CLI commands
+            the normal user experience.
           </p>
         </header>
 

--- a/site/index.html
+++ b/site/index.html
@@ -6,7 +6,7 @@
     <title>OMH - oh-my-hermes</title>
     <meta
       name="description"
-      content="OMH gives Hermes Agent deterministic workflow skills, wrapper contracts, and delegation-first coding handoffs."
+      content="OMH fits workflow skills, status contracts, and executor handoffs into existing Hermes setups without making users learn another CLI-first product."
     >
     <link rel="stylesheet" href="styles.css">
   </head>
@@ -34,10 +34,10 @@
           <p class="eyebrow">Hermes-native workflow orchestration</p>
           <h1>OMH</h1>
           <p class="lead">
-            Install OMH, then talk to Hermes. Plain requests become role-owned
-            next actions for research, feedback triage, meeting prep, strategy,
-            status, or selected-executor coding handoffs with honest evidence
-            boundaries.
+            Most people skip the docs. OMH is designed for that reality:
+            install it once, keep talking to Hermes, and let natural requests
+            become safe next actions, status cards, or selected-executor
+            handoffs without breaking the workflow you already have.
           </p>
           <div class="hero-command" role="region" aria-label="OMH quick start commands" tabindex="0">
             <span>Quick start</span>
@@ -49,7 +49,7 @@ omh setup</code>
             <code>Use OMH request-to-handoff for: I want to safely add a feature to this repo.</code>
           </div>
           <div class="hero-proof" aria-label="Core OMH contracts">
-            <span>Request-to-handoff router</span>
+            <span>Fits existing Hermes setup</span>
             <span>Role-owned next action</span>
             <span>Prepared is not observed</span>
           </div>
@@ -115,68 +115,43 @@ omh setup</code>
         <article class="usage-story">
           <p class="eyebrow">From install to real use</p>
           <blockquote>
-            Have you ever felt that while Hermes Agent is powerful, it has a
-            high barrier to entry?
+            The real magic is not that OMH adds more commands. It is that
+            Hermes feels more useful inside the workflow people already use.
           </blockquote>
           <p>
-            When you actually try to adopt it, the features can feel great while
-            the path to using them feels more fragmented than expected: initial
-            installation, environment setup, gateway and config wiring,
-            verification, service restarts, and then the practical question of
-            what to do next.
+            Hermes Agent is powerful, but teams can still hit a high barrier to
+            entry: installation, profile drift, gateway context, verification,
+            and the practical question of what to ask first. OMH narrows that
+            gap without asking users to memorize another command catalog.
           </p>
           <p>
-            The engine behind Hermes Agent is strong. Looking at core surfaces
-            like Skills, Gateway, Profiles, and Cron, the scalability and
-            potential are clear. The issue is not a lack of features. It is that
-            these pieces do not always present themselves as one natural flow to
-            someone trying to get real work done for the first time.
+            Setup installs managed skills, checks Hermes registration, records
+            safe defaults, and keeps repair commands available for operators.
+            After that, the normal surface is still Hermes chat: ask for
+            research, a plan, feedback triage, a report package, a loop, or a
+            coding handoff, and Hermes can explain the next action and what is
+            still not evidence.
           </p>
           <p>
-            You might finish installation and still wonder whether the setup is
-            correct. You might lose momentum while connecting an external
-            messenger, checking <code>.env</code>, adjusting
-            <code>config.yaml</code>, confirming permissions, or restarting a
-            service. The questions come naturally: what should I check next, and
-            how do I actually make this useful?
+            The engine behind Hermes stays the control tower. OMH is the
+            practical fit layer around it: deterministic skill guidance,
+            wrapper-ready cards, local evidence records, and handoffs that do
+            not pretend code, CI, delivery, or review happened before somebody
+            observed it.
           </p>
           <p>
-            I do not see that as a fundamental flaw of Hermes Agent. It feels
-            more like a product surface that still needs a friendlier path into
-            the power already there. The engine is strong, but reaching that
-            strength should feel less unfamiliar.
+            Representative workflows such as <code>web-research</code>,
+            <code>doctor</code>, <code>idea-to-deploy</code>,
+            <code>ultragoal</code>, <code>loop</code>, and
+            <code>ultraprocess</code> give Hermes a ready path from first
+            request to trustworthy status. Coding work can go to Codex, Claude
+            Code, another runtime, or Hermes coding skills only after the path
+            is selected and visible.
           </p>
           <p>
-            That is why I use oh-my-hermes. It is not a heavy framework,
-            a replacement for Hermes Agent, or another command list users have
-            to memorize. It is a thin practical layer for reducing the friction
-            before you can put Hermes to work, and for giving you representative
-            workflows you can use immediately after setup.
-          </p>
-          <p>
-            That means <code>web-research</code> can help Hermes gather
-            source-backed information while separating evidence, inference, and
-            uncertainty. <code>doctor</code> gives you the smallest useful
-            install and registration checks when something feels off.
-            <code>idea-to-deploy</code> connects idea, decision, planning,
-            handoff, verification, release, and monitoring into one practical
-            operating flow. <code>ultragoal</code> keeps long work tied to goal
-            ledgers, checkpoints, and completion gates so it does not fade into
-            a one-off summary.
-          </p>
-          <p>
-            Beyond those, OMH keeps session memory and evidence boundaries
-            visible, supports role-based collaboration with profiles such as
-            CTO, PM, and Architect, and prepares coding work for selected
-            executors or runtimes like Codex, Claude Code, OMX, OMC, OMO, or
-            Hermes coding skills. Hermes stays the control tower:
-            research, meetings, goal setting, data processing, and coding
-            delegation remain understandable from the chat surface.
-          </p>
-          <p>
-            This is not about making Hermes Agent look bigger than it is. It is
-            about helping people reach the power that is already there with less
-            hesitation, less setup drift, and a more natural path into real work.
+            This is why OMH should feel less like adopting a separate product
+            and more like making Hermes safer to use where your work already
+            happens.
           </p>
         </article>
       </section>

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import inspect
+import re
 from pathlib import Path
 import unittest
 
@@ -58,6 +59,17 @@ FEATURE_SURFACE_EXPOSURES = {
 
 
 class RouterContentTests(unittest.TestCase):
+    def test_docs_readme_does_not_reference_removed_readme_anchors(self) -> None:
+        docs_index = Path("docs/README.md").read_text(encoding="utf-8")
+        root_readme = Path("README.md").read_text(encoding="utf-8")
+        headings = {
+            re.sub(r"[^a-z0-9 -]", "", heading.lower()).replace(" ", "-")
+            for heading in re.findall(r"^#{1,6}\s+(.+)$", root_readme, flags=re.MULTILINE)
+        }
+
+        for anchor in re.findall(r"\]\(\.\./README\.md#([^)]+)\)", docs_index):
+            self.assertIn(anchor, headings, f"docs/README.md links to missing README anchor #{anchor}")
+
     def test_router_documents_best_effort_and_recovery(self) -> None:
         router = next(skill for skill in builtin_skill_templates() if skill.name == "oh-my-hermes")
 
@@ -723,9 +735,11 @@ class RouterContentTests(unittest.TestCase):
         self.assertIn("[Roles](docs/ROLES.md)", readme)
         self.assertIn("[Application Cases](docs/APPLICATION_CASES.md)", readme)
         self.assertIn("[GitHub Pages site](site/index.html)", readme)
-        self.assertIn("Have you ever felt that Hermes Agent is powerful", readme)
+        self.assertIn("Most people skip the docs.", readme)
+        self.assertIn("without replacing your existing setup", readme)
         self.assertIn("ready-to-use workflows such as", readme)
-        self.assertIn("`web-research`, `doctor`, `idea-to-deploy`, `ultragoal`, `loop`, and", readme)
+        self.assertIn("`web-research`, `doctor`", readme)
+        self.assertIn("`idea-to-deploy`, `ultragoal`, `loop`, and `ultraprocess`", readme)
         self.assertIn("`ultraprocess`", readme)
         self.assertIn("Optional team profile packs", readme)
         self.assertIn("omh profile list", readme)
@@ -857,7 +871,10 @@ class RouterContentTests(unittest.TestCase):
         self.assertIn('href="docs/">Read docs</a>', site)
         self.assertIn('id="real-use"', site)
         self.assertIn("From install to real use", site)
-        self.assertIn("high barrier to entry", site)
+        self.assertIn("Most people skip the docs.", site)
+        self.assertIn("Fits existing Hermes setup", site)
+        self.assertIn("high barrier", site)
+        self.assertIn("entry: installation", site)
         self.assertIn("web-research", site)
         self.assertIn("doctor", site)
         self.assertIn("idea-to-deploy", site)
@@ -877,6 +894,8 @@ class RouterContentTests(unittest.TestCase):
         self.assertIn('href="docs/product-ops/"', site)
         self.assertIn('href="docs/executor-handoff/"', site)
         self.assertIn("Hermes Agent Integration Runbook", site_docs)
+        self.assertIn("Install once, then keep working in Hermes.", site_docs)
+        self.assertIn("Most people will not study every page before trying the tool.", site_docs)
         self.assertIn("examples/wrapper-golden/hermes-agent-integration.json", site_docs)
         self.assertIn("Role surface", site_docs)
         self.assertIn("docs/ROLES.md", site_docs)


### PR DESCRIPTION
## Feature Report

### What Changed

- Reworked the README opening so OMH reads as install-once, chat-first workflow fit rather than a CLI-first catalog.
- Moved the public link map and GitHub follow note below Quick Start so the first user path stays install -> setup -> doctor -> first Hermes prompt.
- Updated the homepage and docs homepage copy around the same product promise: most users skip docs, so OMH should fit existing Hermes workflows without breaking them.
- Updated docs direction language to lock this product boundary and fixed a stale docs index link to a removed README anchor.
- Added a regression test that catches docs/README links to removed README anchors.

### Why This Exists

User feedback was: most people skip the docs, but the real magic is how OMH fits into an existing workflow without breaking things. The previous README was accurate but still felt too much like a feature catalog before the first useful install path. This PR makes the first impression match the intended product: install once, keep talking to Hermes, and let OMH make the next action safe and visible.

### User / Operator Impact

- New users see the install path and first Hermes prompt earlier.
- Normal users are not pushed toward backend commands as the main UX.
- Operators still have links to installation, capabilities, roles, app cases, and fixture-backed examples.
- Docs/site copy keeps prepared handoff, execution, review, CI, and merge evidence separate.
- Broken README anchor drift is now covered by a content regression test.

### How It Works

- `README.md` now leads with workflow fit, chat-first usage, and a small list of what OMH changes and does not change.
- `site/index.html` and `site/docs/index.html` mirror the same message for the public site.
- `docs/DIRECTION.md` and `docs/README.md` record the product rule that install, first prompt, repair path, and evidence boundary should be obvious even when users skip the docs.
- `tests/test_router_content.py` updates public content assertions and adds a README-anchor guard for docs index links.

### Files And Contracts Touched

- `README.md`
- `docs/DIRECTION.md`
- `docs/README.md`
- `site/index.html`
- `site/docs/index.html`
- `tests/test_router_content.py`

No runtime schemas, CLI behavior, Hermes setup behavior, plugin behavior, or generated skill catalogs changed.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_router_content.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m src.cli docs workflows --check`
- [x] `uv run python -m src.cli harness validate`
- [x] `uv run python -m compileall -q src tests`
- [x] `git diff --check`
- [x] Relevant dry-run or smoke command: browser smoke on `http://127.0.0.1:8766/` and `/docs/`; verified hero/docs copy and no console errors.
- [x] Manual Hermes/TUI check, or explicit reason it was not run: not run because this PR changes only public/docs/site copy and content tests.

Independent review evidence:

- code-reviewer: APPROVE, no findings.
- architect: initial BLOCK for stale README anchor, fixed; re-review CLEAR.

## Risk

- Prose-heavy surfaces can drift over time. The new anchor regression test reduces one concrete drift class.
- Live Hermes profile behavior was not exercised because behavior did not change.

## Compatibility / Rollout

- No CLI/schema/runtime compatibility impact.
- Public docs and site will update after merge and Pages deployment.

## Release / Claims

- [x] Release-channel impact considered (`preview` docs/site update before next tagged release).
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap.

## Follow-Up

- Consider a future visual polish pass for the public site if the next goal is design rather than product messaging.