### PR TITLE
Fix catalog follow-up rendering review issues

### DIFF
--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -897,6 +897,15 @@ def _chat_response_with_target_notice(response: dict[str, object], target_notice
         )
     updated["actions"] = actions
     updated["claim_boundary"] = f"{updated.get('claim_boundary', '')} {target_notice.get('claim_boundary', '')}".strip()
+    trace = updated.get("usage_trace")
+    visible_prefix = str(trace.get("visible_prefix", "")) if isinstance(trace, dict) else ""
+    if visible_prefix:
+        updated["messenger_rendering"] = messenger_rendering_contract(
+            visible_prefix=visible_prefix,
+            first_line=str(updated.get("headline", "")),
+            body=str(updated.get("body", "")),
+            claim_boundary=str(updated.get("claim_boundary", "")),
+        )
     return updated
 
 
@@ -1021,6 +1030,8 @@ def _is_skill_catalog_question(message: str) -> bool:
     if not has_catalog_word:
         return False
     if any(phrase in lowered for phrase in explicit_catalog_phrases):
+        return True
+    if any(marker in lowered for marker in ("뭐 있어", "뭐 있", "있나요", "가능", "목록", "리스트")):
         return True
     availability_markers = (
         "available",

--- a/tests/test_wrapper_contract.py
+++ b/tests/test_wrapper_contract.py
@@ -95,6 +95,9 @@ class WrapperContractTests(unittest.TestCase):
         self.assertEqual(apply_action["payload"]["target_observation"]["source_metadata"]["agent_ref"], "agent-b")
         self.assertNotIn("message", json.dumps(apply_action["payload"]))
         self.assertIn("Target topology is setup evidence only", payload["chat_response"]["claim_boundary"])
+        rendering = payload["chat_response"]["messenger_rendering"]
+        self.assertIn("multiple Hermes agent targets", rendering["body_preview"])
+        self.assertIn("Target topology is setup evidence only", rendering["claim_boundary"])
 
     def test_clarify_mode_has_no_handoff_actions(self) -> None:
         payload = build_chat_interaction_payload("fix maybe", mode="delegate")


### PR DESCRIPTION
## Feature Report

### What Changed

- Refresh `chat_response.messenger_rendering` after target-change notices append final body and claim-boundary text.
- Preserve Korean catalog availability routing for messages such as `skill들은 뭐 있어?` while keeping the narrowed catalog detector from hijacking ordinary command/help/debugging questions.
- Add regression coverage for target-notice rendering previews staying in sync with final response content.

### Why This Exists

- Follow-up review on #120 found one merge-blocking presentation bug: `_chat_response_with_target_notice()` mutated `body` and `claim_boundary` after `messenger_rendering` had already been computed.
- The same review pass also tightened the catalog detector to avoid broad lexical matching; this follow-up keeps that safety while restoring the intended Korean catalog question path.

### User / Operator Impact

- Discord, Slack, Telegram, and Hermes adapters can trust `messenger_rendering.body_preview` and `messenger_rendering.claim_boundary` to describe the final response, including target setup notices.
- Users asking what OMH skills/workflows are available still get the workflow picker instead of a local shell-command approval path.
- Users asking for a specific command, debugging advice, or repo listing are not forced into the picker.

### How It Works

- `_chat_response_with_target_notice()` now rebuilds `messenger_rendering` from the finalized headline, body, and claim boundary after applying target notice mutations.
- `_is_skill_catalog_question()` keeps explicit catalog phrases narrow, then accepts Korean availability markers only after a catalog word is present.

### Files And Contracts Touched

- `src/wrapper/contract.py`: target-notice response finalization and catalog-question matching.
- `tests/test_wrapper_contract.py`: regression coverage for refreshed rendering metadata.
- Contract affected: `chat_response/v1` with `omh_messenger_rendering/v1` metadata; no runtime execution, review, CI, merge, or adapter transport claims are added.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` - 457 tests passed.
- [x] `uv run python -m compileall -q src tests` - passed.
- [x] `uv run python -m src.cli docs workflows --check` - passed.
- [x] `uv run python -m src.cli harness validate` - passed.
- [ ] `python3 -m omh.cli release checklist --json` - not run; this is a narrow review follow-up, not release packaging.
- [ ] `python3 -m omh.cli release hermes-smoke` - not run; no live Hermes install check was required for this local contract fix.
- [ ] `omh --help` - not run; CLI command surface did not change.
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` - not run; release/install smoke is outside this patch's scope.
- [x] Relevant dry-run or smoke command: `PYTHONPATH=tests uv run python -m unittest tests/test_wrapper_contract.py -v`, `PYTHONPATH=tests uv run python -m unittest tests/test_cli.py -v`, and `PYTHONPATH=tests uv run python -m unittest tests/test_runtime_artifacts.py -v` passed.
- [x] Manual Hermes/TUI check, or explicit reason it was not run: not run; no live Hermes/TUI adapter is available in this workspace, and wrapper contract tests cover the affected rendering payload.

## Risk

- Narrow risk: adapters that cached the stale `messenger_rendering` preview behavior would now see the corrected final notice text. That is the intended fix.
- Catalog matching remains lexical and should stay covered with negative routing tests before expansion.

## Compatibility / Rollout

- No schema version change. `chat_response/v1` and `omh_messenger_rendering/v1` keep their existing shapes.
- This is a follow-up to #120 and should roll out with the same wrapper-facing migration notes around visible `[omh]` prefixes and `plain_headline`.

## Release / Claims

- [x] Release-channel impact considered (`local` follow-up to merged wrapper contract work).
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] Known manual Hermes checks are listed, including the live adapter gap.

## Follow-Up

- Consider moving catalog question normalization into a data-backed matcher if more localized phrases are added.
