### PR TITLE
Support multilingual catalog availability questions

### DIFF
--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import unicodedata
 from typing import Any
 
 from ..ingress import CHAT_SOURCES, compact_source_metadata, extract_message_text, extract_source_metadata
@@ -997,6 +998,7 @@ def _is_skill_catalog_question(message: str) -> bool:
     lowered = message.strip().lower()
     if not lowered:
         return False
+    search_texts = _catalog_search_texts(lowered)
     explicit_catalog_phrases = (
         "what commands are available",
         "which commands are available",
@@ -1022,17 +1024,98 @@ def _is_skill_catalog_question(message: str) -> bool:
         "skill picker",
         "workflow picker",
         "catalog",
+        "comandos disponibles",
+        "habilidades disponibles",
+        "flujos de trabajo disponibles",
+        "commandes disponibles",
+        "competences disponibles",
+        "fluxos de trabalho disponiveis",
+        "comandos disponiveis",
+        "verfugbare befehle",
+        "verfugbare workflows",
+        "befehle verfugbar",
+        "workflows verfugbar",
+        "使えるスキル",
+        "利用可能なスキル",
+        "利用可能なワークフロー",
+        "有哪些命令",
+        "有哪些技能",
+        "有哪些工作流",
+        "可用命令",
+        "可用技能",
+        "可用工作流",
+        "доступные команды",
+        "доступные навыки",
+        "доступные рабочие процессы",
+        "список команд",
         "목록",
         "리스트",
     )
-    has_context = any(token in lowered for token in ("omh", "oh-my-hermes", "oh my hermes", "hermes", "헤르메스"))
-    has_catalog_word = any(token in lowered for token in ("skill", "workflow", "command", "스킬", "워크플로", "명령", "기능"))
+    context_markers = ("omh", "oh-my-hermes", "oh my hermes", "hermes", "헤르메스")
+    catalog_words = (
+        "skill",
+        "skills",
+        "workflow",
+        "workflows",
+        "command",
+        "commands",
+        "스킬",
+        "워크플로",
+        "워크플로우",
+        "명령",
+        "기능",
+        "comandos",
+        "habilidades",
+        "flujos de trabajo",
+        "fluxos de trabalho",
+        "commandes",
+        "competences",
+        "befehle",
+        "workflows",
+        "スキル",
+        "ワークフロー",
+        "コマンド",
+        "技能",
+        "工作流",
+        "命令",
+        "команды",
+        "навыки",
+        "рабочие процессы",
+    )
+    has_context = _contains_catalog_token(search_texts, context_markers)
+    has_catalog_word = _contains_catalog_token(search_texts, catalog_words)
     if not has_catalog_word:
         return False
-    if any(phrase in lowered for phrase in explicit_catalog_phrases):
+    if _contains_catalog_token(search_texts, explicit_catalog_phrases):
         return True
-    if any(marker in lowered for marker in ("뭐 있어", "뭐 있", "있나요", "가능", "목록", "리스트")):
-        return True
+    catalog_collection_words = (
+        "skills",
+        "skill들",
+        "workflows",
+        "commands",
+        "스킬",
+        "워크플로",
+        "워크플로우",
+        "명령",
+        "기능",
+        "comandos",
+        "habilidades",
+        "flujos de trabajo",
+        "fluxos de trabalho",
+        "commandes",
+        "competences",
+        "befehle",
+        "スキル",
+        "ワークフロー",
+        "コマンド",
+        "技能",
+        "工作流",
+        "命令",
+        "команды",
+        "навыки",
+        "рабочие процессы",
+    )
+    has_catalog_collection_word = _contains_catalog_token(search_texts, catalog_collection_words)
     availability_markers = (
         "available",
         "do you have",
@@ -1041,6 +1124,33 @@ def _is_skill_catalog_question(message: str) -> bool:
         "can you do",
         "menu",
         "picker",
+        "disponible",
+        "disponibles",
+        "disponivel",
+        "disponiveis",
+        "liste",
+        "lista",
+        "mostrar",
+        "afficher",
+        "anzeigen",
+        "gibt es",
+        "verfugbar",
+        "verfuegbar",
+        "使える",
+        "利用可能",
+        "一覧",
+        "有哪些",
+        "可用",
+        "列表",
+        "доступ",
+        "список",
+        "متاحة",
+        "قائمة",
+        "उपलब्ध",
+        "danh sach",
+        "có những",
+        "tersedia",
+        "daftar",
         "뭐",
         "무엇",
         "어떤",
@@ -1049,12 +1159,29 @@ def _is_skill_catalog_question(message: str) -> bool:
         "있어",
         "있나요",
         "가능",
+        "목록",
+        "리스트",
     )
-    if has_context and any(marker in lowered for marker in availability_markers):
+    if not has_context and has_catalog_collection_word and _contains_catalog_token(search_texts, availability_markers):
+        return True
+    if has_context and has_catalog_collection_word and _contains_catalog_token(search_texts, availability_markers):
         return True
     words = lowered.replace("?", " ").replace("!", " ").split()
     plural_catalog_words = ("commands", "skills", "workflows", "워크플로", "워크플로우", "스킬")
-    return has_context and len(words) <= 4 and any(word in lowered for word in plural_catalog_words)
+    return has_context and len(words) <= 4 and _contains_catalog_token(search_texts, plural_catalog_words)
+
+
+def _catalog_search_texts(lowered: str) -> tuple[str, ...]:
+    folded = "".join(
+        character
+        for character in unicodedata.normalize("NFKD", lowered)
+        if not unicodedata.combining(character)
+    )
+    return (lowered,) if folded == lowered else (lowered, folded)
+
+
+def _contains_catalog_token(search_texts: tuple[str, ...], tokens: tuple[str, ...]) -> bool:
+    return any(token in text for text in search_texts for token in tokens)
 
 
 def _is_command_preview_invocation(message: str) -> bool:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2169,7 +2169,18 @@ class CliTests(unittest.TestCase):
                 self.assertIn("choose_skill", {action["id"] for action in payload["chat_response"]["actions"]})
 
     def test_chat_interact_catalog_questions_open_picker_without_shell(self) -> None:
-        for message in ("OMH 명령어 뭐 있어?", "skill들은 뭐 있어?", "what OMH workflows are available?"):
+        for message in (
+            "OMH 명령어 뭐 있어?",
+            "skill들은 뭐 있어?",
+            "what OMH workflows are available?",
+            "¿Qué comandos de OMH están disponibles?",
+            "Quelles commandes OMH sont disponibles ?",
+            "Welche OMH Workflows gibt es?",
+            "OMHで使えるスキルは？",
+            "OMH 有哪些工作流？",
+            "Quais workflows do OMH estão disponíveis?",
+            "Какие команды OMH доступны?",
+        ):
             with self.subTest(message=message):
                 status, stdout, stderr = run_cli(["chat", "interact", "--source", "discord", message])
 
@@ -2186,9 +2197,13 @@ class CliTests(unittest.TestCase):
     def test_chat_interact_non_catalog_command_questions_do_not_open_picker(self) -> None:
         for message in (
             "show me the command to install OMH",
+            "what command is available to install OMH?",
             "what command should I run to verify installation?",
             "what skills are needed to debug this Python error?",
             "list files that mention command injection",
+            "¿Qué comando debería ejecutar para instalar OMH?",
+            "Quel workflow dois-je utiliser pour ce bug Python?",
+            "Welche Datei erwähnt command injection?",
         ):
             with self.subTest(message=message):
                 status, stdout, stderr = run_cli(["chat", "interact", "--source", "discord", message])

--- a/tests/test_wrapper_contract.py
+++ b/tests/test_wrapper_contract.py
@@ -292,7 +292,18 @@ class WrapperContractTests(unittest.TestCase):
         self.assertIn("routing intent only", payload["chat_response"]["claim_boundary"])
 
     def test_natural_catalog_questions_open_picker_without_shell(self) -> None:
-        for message in ("OMH 명령어 뭐 있어?", "skill들은 뭐 있어?", "what OMH workflows are available?"):
+        for message in (
+            "OMH 명령어 뭐 있어?",
+            "skill들은 뭐 있어?",
+            "what OMH workflows are available?",
+            "¿Qué comandos de OMH están disponibles?",
+            "Quelles commandes OMH sont disponibles ?",
+            "Welche OMH Workflows gibt es?",
+            "OMHで使えるスキルは？",
+            "OMH 有哪些工作流？",
+            "Quais workflows do OMH estão disponíveis?",
+            "Какие команды OMH доступны?",
+        ):
             with self.subTest(message=message):
                 payload = build_chat_interaction_payload(message, source="discord")
 
@@ -309,9 +320,13 @@ class WrapperContractTests(unittest.TestCase):
     def test_non_catalog_command_and_skill_questions_do_not_open_picker(self) -> None:
         for message in (
             "show me the command to install OMH",
+            "what command is available to install OMH?",
             "what command should I run to verify installation?",
             "what skills are needed to debug this Python error?",
             "list files that mention command injection",
+            "¿Qué comando debería ejecutar para instalar OMH?",
+            "Quel workflow dois-je utiliser pour ce bug Python?",
+            "Welche Datei erwähnt command injection?",
         ):
             with self.subTest(message=message):
                 payload = build_chat_interaction_payload(message, source="discord")


### PR DESCRIPTION
## Feature Report

### What Changed

- Expanded natural catalog-question routing beyond English and Korean availability phrases.
- Added accent folding for deterministic local matching, so phrases such as Portuguese `disponíveis` and Spanish `están disponibles` route consistently.
- Added multilingual picker coverage for Spanish, French, German, Japanese, Chinese, Portuguese, and Russian availability questions.
- Added false-positive coverage so singular command-help and debugging questions do not open the workflow picker.

### Why This Exists

- The previous follow-up fixed Korean `skill들은 뭐 있어?`, but that was too narrow for chat users who may ask the same catalog-availability question in other languages.
- OMH's direction is command-agnostic chat UX: users should be able to ask what workflows/skills/commands are available without knowing `omh list` or a slash command.

### User / Operator Impact

- More users can ask naturally for available OMH/Hermes skills, workflows, or commands and receive the picker instead of a shell-command approval path.
- Specific command-help questions, such as asking which command installs OMH, still stay out of the picker path.
- Wrapper behavior remains deterministic and local; no translation service, LLM classifier, network call, or hidden runtime behavior is introduced.

### How It Works

- `_is_skill_catalog_question()` now builds folded search variants with `unicodedata` so accent-bearing Latin phrases can be matched by stable ASCII tokens.
- The matcher separates catalog words from availability markers and requires a collection-like catalog term for availability routing. This keeps broad singular command questions from matching merely because they contain `available`.
- Tests cover both direct wrapper payloads and the CLI `chat interact` surface.

### Files And Contracts Touched

- `src/wrapper/contract.py`: deterministic multilingual catalog-question matcher.
- `tests/test_wrapper_contract.py`: wrapper contract multilingual positive and negative cases.
- `tests/test_cli.py`: CLI chat interaction multilingual positive and negative cases.
- Public contract affected: `chat_interaction/v1` routing to `chat_response.kind == skill_picker`; no schema shape changes.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` - 457 tests passed.
- [x] `uv run python -m compileall -q src tests` - passed.
- [x] `uv run python -m src.cli docs workflows --check` - passed.
- [x] `uv run python -m src.cli harness validate` - passed.
- [ ] `python3 -m omh.cli release checklist --json` - not run locally; covered by CI workflow on PR.
- [ ] `python3 -m omh.cli release hermes-smoke` - not run locally; covered by CI workflow on PR.
- [ ] `omh --help` - not run locally; command surface did not change and CI covers installed command smoke.
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` - not run locally; covered by CI workflow on PR.
- [x] Relevant dry-run or smoke command: `PYTHONPATH=tests uv run python -m unittest tests/test_wrapper_contract.py -v` and `PYTHONPATH=tests uv run python -m unittest tests/test_cli.py -v` passed.
- [x] Manual Hermes/TUI check, or explicit reason it was not run: not run; this is a deterministic wrapper contract change and no live Hermes adapter is available in this workspace.

## Risk

- The matcher remains lexical, so future language additions can introduce false positives if they are too broad.
- This PR mitigates that risk by requiring collection-like catalog terms for availability routing and by adding singular command-help negative tests.

## Compatibility / Rollout

- No schema version change and no generated skill output change.
- Existing English/Korean catalog questions continue to work; direct `./omh`, `/omh`, `./skills`, and `/skills` picker aliases are unchanged.

## Release / Claims

- [x] Release-channel impact considered (`local` wrapper routing improvement).
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] Known manual Hermes checks are listed, including the live adapter gap.

## Follow-Up

- If OMH expands supported localized copy, move these token sets toward a catalog-owned data table so future language additions stay easier to review.
