### PR TITLE
Improve messenger rendering and executor launch UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,9 @@ What OMH changes is intentionally small:
 - **Wrapper-native executor sessions** - after a handoff is ready, Hermes chat
   surfaces can render buttons such as Open in Codex, Open in Claude Code,
   Attach session, Refresh status, Record completed, Record blocked, and Ask
-  Hermes to verify. The user does not need to type backend commands.
+  Hermes to verify. Open buttons include copyable Codex or Claude Code launch
+  commands, while backend tracking remains wrapper-owned. The user does not
+  need to type OMH backend commands.
 - **Visible OMH workflow trace** - wrapper responses can start once with
   markers like `[omh] plan`, `[omh] web-research`, or `[omh] status` and carry
   `omh_usage_trace/v1` plus messenger-safe rendering hints, so

--- a/docs/CHAT_WRAPPER_EXAMPLES.md
+++ b/docs/CHAT_WRAPPER_EXAMPLES.md
@@ -134,8 +134,11 @@ from `chat_response.usage_trace.visible_prefix`, for example:
 That marker is product status, not a command the user has to learn. The same
 response includes `chat_response.messenger_rendering`, which tells Discord,
 Slack, Telegram, and Hermes-style adapters to start with the visible prefix,
-prefer short paragraphs or bullets, and convert wide Markdown tables into
-messenger-safe lists or split chunks.
+prefer short paragraphs or bullets, and render
+`chat_response.messenger_rendering.body_text` when posting into narrow
+messenger surfaces. That safe body keeps the original prose but converts wide
+Markdown tables into messenger-safe lists when possible. Adapters that render
+native blocks can use `chat_response.messenger_rendering.body_blocks`.
 
 Apply the prefix once at the first line of one rendered response. Do not repeat
 `[omh] <workflow>` on every paragraph or every line. If an adapter splits a
@@ -193,6 +196,13 @@ User-facing effect:
   runtime handoff with team/swarm, worker-protocol, and worktree guidance.
   Claude Code and generic profiles render a copyable prompt handoff instead of
   lifecycle evidence.
+- `Open in Codex` and `Open in Claude Code` include an
+  `executor_launch/v1` payload. Render that as copyable terminal commands for
+  Codex or Claude Code. Prompt placeholders use
+  `{executor_prompt_shell_quoted}`; workspace command templates use
+  `{workspace_path_shell_quoted}` for shell-safe paths. After the wrapper
+  observes the user or platform open the executor, it records the backend open
+  action; showing the command is still not execution evidence.
 - Execution, verification, CI, merge-readiness, and merge stay separate.
 - The wrapper can keep editing the same thread as evidence arrives.
 
@@ -310,10 +320,12 @@ What gets better for the team:
 | --- | --- |
 | Bot headline | `chat_response.headline` |
 | Bot headline without prefix | `chat_response.plain_headline` |
-| Bot body | `chat_response.body` |
+| Bot body for rich/web surfaces | `chat_response.body` |
+| Messenger-safe bot body | `chat_response.messenger_rendering.body_text` |
+| Messenger-safe body blocks | `chat_response.messenger_rendering.body_blocks` |
 | Visible OMH workflow marker | `chat_response.usage_trace.visible_prefix` |
 | Selected workflow/harness | `chat_response.usage_trace.selected_workflow`, `chat_response.usage_trace.selected_harness` |
-| Messenger-safe body hints | `chat_response.messenger_rendering.preferred_blocks`, `chat_response.messenger_rendering.avoid_blocks`, `chat_response.messenger_rendering.table_policy`, `chat_response.messenger_rendering.prefix_policy` |
+| Messenger-safe body hints | `chat_response.messenger_rendering.transforms_applied`, `chat_response.messenger_rendering.preferred_blocks`, `chat_response.messenger_rendering.avoid_blocks`, `chat_response.messenger_rendering.table_policy`, `chat_response.messenger_rendering.prefix_policy` |
 | Button ids | `chat_response.actions[].id` |
 | Thread key | `thread_key` |
 | Current phase | `chat_response.state.phase` |
@@ -322,6 +334,7 @@ What gets better for the team:
 | Status rows | `status_card.steps[]` |
 | Primary status action id | `status_card.primary_action` |
 | Primary status button label | `status_card.primary_action_label`, `status_card.executor_next_action_label`, or the matching `executor_actions[].label` |
+| Executor launch command UI | `status_card.executor_actions[].payload.launch.command_templates[]`, `status_card.executor_actions[].payload.launch.copy_blocks[]` |
 | User-facing executor status | `status_card.executor_display_status_lines[]` |
 | Coding work briefing | `coding_briefing.user_facing_lines[]` |
 | Coding progress ladder | `coding_briefing.progress[]` |

--- a/docs/DELEGATION_FIRST_COMPLETENESS.md
+++ b/docs/DELEGATION_FIRST_COMPLETENESS.md
@@ -60,8 +60,10 @@ The strongest existing path is:
    runtime-specific templates and a `runtime_observation/v1` contract so
    wrappers know exactly which events must be observed later.
 6. The wrapper renders executor-session buttons instead of asking the user to
-   type backend commands. When it observes Open in Codex, Attach session, Record
-   completed, Record blocked, or Ask Hermes to verify, it writes
+   type backend commands. Open buttons carry `executor_launch/v1` with
+   copyable Codex and Claude Code command templates, while attach/record
+   buttons stay metadata-only. When the wrapper observes Open in Codex, Attach
+   session, Record completed, Record blocked, or Ask Hermes to verify, it writes
    `executor_session/v1` metadata and derives status lines such as
    `coding-agent: running(codex)`, `dispatch: observed`, and
    `verification: requested`.

--- a/docs/HERMES_AGENT_INTEGRATION_RUNBOOK.md
+++ b/docs/HERMES_AGENT_INTEGRATION_RUNBOOK.md
@@ -59,16 +59,19 @@ runtime run exists and the wrapper needs a compact progress card.
 1. Receive the platform event and store only the metadata needed by the wrapper.
 2. Ask OMH for a platform-neutral interaction envelope.
 3. Render `chat_response.headline`, `chat_response.body`,
-   `chat_response.actions`, and `chat_response.claim_boundary`. The headline
-   already includes the visible OMH usage marker, such as `[omh] web-research`;
-   use `chat_response.plain_headline` only when a compact surface needs the
+   `chat_response.actions`, and `chat_response.claim_boundary` on rich or web
+   surfaces that can handle the original Markdown body. The headline already
+   includes the visible OMH usage marker, such as `[omh] web-research`; use
+   `chat_response.plain_headline` only when a compact surface needs the
    unprefixed text.
 4. Apply `chat_response.messenger_rendering` when the target is Discord, Slack,
-   Telegram, or another narrow chat surface. Prefer short paragraphs, bullets,
-   numbered lists, and status lines; convert wide Markdown tables into bullets
-   or split chunks before posting. Render the prefix once per response, not on
-   every paragraph; repeat it only when the adapter posts a long response as
-   separate message chunks.
+   Telegram, or another narrow chat surface. Render
+   `chat_response.messenger_rendering.body_text` instead of raw
+   `chat_response.body`; OMH has already converted Markdown tables into
+   messenger-safe bullets when possible. Adapters that need structured blocks
+   can use `chat_response.messenger_rendering.body_blocks`. Render the prefix
+   once per response, not on every paragraph; repeat it only when the adapter
+   posts a long response as separate message chunks.
 5. If `target_notice.action` is `ask_to_apply_target_change`, render a short
    setup-change comment and an apply action. Until accepted or auto-applied,
    keep the workflow scoped to the current thread target. The
@@ -142,6 +145,16 @@ Hermes-native buttons. A normal user should see actions such as Open in Codex,
 Open in Claude Code, Attach session, Refresh status, Record completed, Record
 blocked, or Ask Hermes to verify. The wrapper process maps those buttons back
 to backend calls; the user does not need to know the command names.
+
+Open buttons include `executor_launch/v1` under
+`executor_actions[].payload.launch`. Render it as a copyable command/prompt UI.
+Codex command templates use `codex` and optional `codex --cd`; Claude Code
+command templates use `claude` and optional `claude --add-dir`. Prompt
+placeholders use `{executor_prompt_shell_quoted}`, and workspace command
+templates use `{workspace_path_shell_quoted}` for shell-safe paths. The wrapper
+substitutes `{executor_prompt}` from the prepared handoff prompt or original
+chat message it already holds, then calls `open-executor --observed` only after
+it sees the user/platform open the executor.
 
 For a Codex handoff, the wrapper can record an observed open and later result:
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -362,11 +362,13 @@ The backend flow is:
    adapters can read `chat_response.usage_trace` for the selected workflow,
    harness, executor, and evidence boundary without parsing prose.
 9. Discord, Slack, Telegram, and similar adapters apply
-   `chat_response.messenger_rendering`: start with the visible prefix, prefer
-   short paragraphs or bullets, and convert wide Markdown tables into
-   messenger-safe lists or split chunks. The prefix appears once per response;
-   repeat it only if the adapter splits a long answer into separate posted
-   chunks.
+   `chat_response.messenger_rendering`: start with the visible prefix and
+   render `chat_response.messenger_rendering.body_text` instead of raw
+   `chat_response.body`. OMH converts wide Markdown tables into
+   messenger-safe bullets when possible; block-based adapters can use
+   `chat_response.messenger_rendering.body_blocks`. The prefix appears once
+   per response; repeat it only if the adapter splits a long answer into
+   separate posted chunks.
 10. If the interaction asks for clarification, the wrapper keeps the answer in
    the same thread and calls `omh chat interact` again with the updated message.
 11. If the interaction presents a plan, the wrapper waits for the user to accept

--- a/examples/discord-bot-runtime-flow.md
+++ b/examples/discord-bot-runtime-flow.md
@@ -24,16 +24,17 @@ status update.
 
    ```sh
    printf '%s' "$interaction_json" |
-     python -c 'import json,sys; data=json.load(sys.stdin)["chat_response"]; print(data["headline"]); print(data["body"])'
+     python -c 'import json,sys; data=json.load(sys.stdin)["chat_response"]; body=data.get("messenger_rendering", {}).get("body_text"); isinstance(body, str) or sys.exit("missing messenger_rendering.body_text"); print(data["headline"]); print(body)'
    ```
 
    `chat_response.headline` already starts with a visible marker such as
    `[omh] web-research`. Render `chat_response.actions` as buttons when the
    platform supports them, and use `chat_response.messenger_rendering` to avoid
-   wide Markdown tables in Discord. Research comparisons should become short
-   sections, bullets, or split messages instead of a single table-heavy block.
-   Keep the prefix on the first line only; repeat it only when posting separate
-   split messages.
+   wide Markdown tables in Discord. Post
+   `chat_response.messenger_rendering.body_text` for the body; it keeps prose
+   intact while converting supported Markdown tables into bullets. Keep the
+   prefix on the first line only; repeat it only when posting separate split
+   messages.
    Typical action ids include `accept_plan`, `revise_plan`, `choose_executor`,
    `show_prompt_handoff`, `copy_prompt_handoff`, `send_to_executor`,
    `show_status`, and `cancel`. `send_to_codex` is only a compatibility alias

--- a/examples/wrapper-golden/hermes-agent-integration.json
+++ b/examples/wrapper-golden/hermes-agent-integration.json
@@ -40,6 +40,8 @@
         "chat_response.actions",
         "chat_response.usage_trace.visible_prefix",
         "chat_response.messenger_rendering",
+        "chat_response.messenger_rendering.body_text",
+        "chat_response.messenger_rendering.body_blocks",
         "chat_response.claim_boundary",
         "chat_response.state"
       ]
@@ -66,6 +68,9 @@
         "usage_trace.visible_prefix",
         "usage_trace.selected_workflow",
         "usage_trace.selected_harness",
+        "messenger_rendering.body_text",
+        "messenger_rendering.body_blocks",
+        "messenger_rendering.transforms_applied",
         "messenger_rendering.preferred_blocks",
         "messenger_rendering.avoid_blocks",
         "messenger_rendering.prefix_policy",

--- a/examples/wrapper_shim_common.py
+++ b/examples/wrapper_shim_common.py
@@ -66,6 +66,14 @@ def _read_json(path: Path) -> dict[str, Any]:
 def _render(source: str, interaction: dict[str, object]) -> dict[str, object]:
     response = _nested(interaction, "chat_response")
     state = _nested(response, "state")
+    rendering = _nested(response, "messenger_rendering")
+    body_text = rendering.get("body_text")
+    if isinstance(body_text, str):
+        rendered_body_text = body_text
+        body_text_source = "messenger_rendering.body_text"
+    else:
+        rendered_body_text = ""
+        body_text_source = "missing_messenger_rendering.body_text"
     status_card = response.get("status_card") or interaction.get("status_card")
     return {
         "schema_version": SCHEMA_VERSION,
@@ -80,11 +88,13 @@ def _render(source: str, interaction: dict[str, object]) -> dict[str, object]:
             "headline": response.get("headline", ""),
             "plain_headline": response.get("plain_headline", ""),
             "body": response.get("body", ""),
+            "body_text": rendered_body_text,
+            "body_text_source": body_text_source,
             "phase": state.get("phase", ""),
             "claim_boundary": response.get("claim_boundary", ""),
         },
         "usage_trace": response.get("usage_trace", {}),
-        "messenger_rendering": response.get("messenger_rendering", {}),
+        "messenger_rendering": rendering,
         "actions": [
             {
                 "id": action.get("id", ""),

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -770,10 +770,7 @@ def build_chat_response_from_delegation(delegation_payload: dict[str, object], *
 
 def build_chat_response_from_status(status_payload: dict[str, Any], *, thread_key: str = "") -> dict[str, object]:
     next_action = str(status_payload.get("next_action", "show_status"))
-    kind, headline, body, claim_boundary = _STATUS_COPY.get(
-        next_action,
-        ("status", "I have a conservative status update.", str(status_payload.get("safe_summary", "")), "Only observed evidence can support completion claims."),
-    )
+    kind, headline, body, claim_boundary = _status_copy(status_payload, next_action)
     actions = [_action("show_status", "Show status", "secondary")]
     if next_action == "dispatch_to_executor":
         actions.insert(0, _action("send_to_executor", "Send to executor", "primary"))
@@ -803,10 +800,7 @@ def build_chat_response_from_status(status_payload: dict[str, Any], *, thread_ke
 
 def build_status_card_from_status(status_payload: dict[str, Any]) -> dict[str, object]:
     next_action = str(status_payload.get("next_action", "show_status"))
-    kind, headline, body, claim_boundary = _STATUS_COPY.get(
-        next_action,
-        ("status", "I have a conservative status update.", str(status_payload.get("safe_summary", "")), "Only observed evidence can support completion claims."),
-    )
+    kind, headline, body, claim_boundary = _status_copy(status_payload, next_action)
     card: dict[str, object] = {
         "schema_version": STATUS_CARD_SCHEMA_VERSION,
         "run_id": str(status_payload.get("run_id", "")),
@@ -823,6 +817,48 @@ def build_status_card_from_status(status_payload: dict[str, Any]) -> dict[str, o
     if isinstance(harness_progress, dict) and harness_progress:
         card["harness_progress"] = harness_progress
     return card
+
+
+def _status_copy(status_payload: dict[str, Any], next_action: str) -> tuple[str, str, str, str]:
+    fallback = (
+        "status",
+        "I have a conservative status update.",
+        str(status_payload.get("safe_summary", "")),
+        "Only observed evidence can support completion claims.",
+    )
+    kind, headline, body, claim_boundary = _STATUS_COPY.get(next_action, fallback)
+    if next_action == "wait_for_executor_evidence":
+        label = _status_executor_label(status_payload)
+        suffix = f" ({label})" if label else ""
+        return (
+            kind,
+            f"The coding handoff{suffix} was dispatched.",
+            f"I am waiting for {label + ' ' if label else ''}executor evidence before reporting completion.",
+            claim_boundary,
+        )
+    if next_action == "dispatch_to_executor":
+        label = _status_executor_label(status_payload)
+        suffix = f" ({label})" if label else ""
+        return (
+            kind,
+            f"The coding handoff{suffix} is ready.",
+            "I have prepared the coding handoff, but executor/runtime dispatch is not observed yet.",
+            claim_boundary,
+        )
+    return kind, headline, body, claim_boundary
+
+
+def _status_executor_label(status_payload: dict[str, Any]) -> str:
+    for value in (
+        _nested(status_payload, "prepared").get("executor_target", ""),
+        _nested(status_payload, "prepared").get("selected_executor_profile", ""),
+        _nested(status_payload, "executor_session_status").get("selected_executor_profile", ""),
+        status_payload.get("selected_executor_profile", ""),
+    ):
+        profile = str(value or "").strip()
+        if profile:
+            return executor_label(profile)
+    return ""
 
 
 def _base_interaction(
@@ -1521,17 +1557,21 @@ def messenger_rendering_contract(
     body: str,
     claim_boundary: str,
 ) -> dict[str, object]:
+    body_text, transforms = _messenger_safe_body(body)
     return {
         "schema_version": MESSENGER_RENDERING_SCHEMA_VERSION,
         "visible_prefix": visible_prefix,
         "first_line": first_line,
         "body_format": "messenger_safe_markdown",
+        "body_text": body_text,
+        "body_blocks": _messenger_body_blocks(body_text),
         "preferred_blocks": ["short_paragraph", "bulleted_list", "numbered_list", "status_lines"],
         "avoid_blocks": ["markdown_table", "wide_table", "large_unbroken_block"],
         "chunking": {
             "max_recommended_chars": 1800,
             "split_on": ["headings", "bullets", "paragraphs"],
         },
+        "transforms_applied": transforms,
         "prefix_policy": {
             "default": "once_per_response_first_line",
             "repeat_when": "adapter_splits_response_across_separate_messages_or_chunks",
@@ -1544,9 +1584,211 @@ def messenger_rendering_contract(
             "hermes": "Render the visible prefix as a compact workflow/status marker before the body.",
         },
         "table_policy": "convert_tables_to_bullets_for_messenger",
-        "body_preview": _short_text(body, limit=180),
+        "body_preview": _short_text(body_text, limit=180),
         "claim_boundary": claim_boundary,
     }
+
+
+def _messenger_safe_body(body: str) -> tuple[str, list[str]]:
+    lines = body.splitlines()
+    if not lines:
+        return body, []
+    output: list[str] = []
+    transforms: list[str] = []
+    index = 0
+    in_code_fence = False
+    while index < len(lines):
+        if _is_code_fence_line(lines[index]):
+            in_code_fence = not in_code_fence
+            output.append(lines[index])
+            index += 1
+            continue
+        if in_code_fence:
+            output.append(lines[index])
+            index += 1
+            continue
+        if not _is_markdown_table_start(lines, index):
+            output.append(lines[index])
+            index += 1
+            continue
+        block: list[str] = []
+        while index < len(lines) and _is_markdown_table_line(lines[index]):
+            block.append(lines[index])
+            index += 1
+        converted = _markdown_table_to_bullets(block)
+        if not converted:
+            output.extend(block)
+            continue
+        if output and output[-1].strip():
+            output.append("")
+        output.extend(converted)
+        transforms.append("markdown_table_to_bullets")
+    return "\n".join(output), sorted(set(transforms))
+
+
+def _is_code_fence_line(line: str) -> bool:
+    stripped = line.strip()
+    return stripped.startswith("```") or stripped.startswith("~~~")
+
+
+def _is_markdown_table_start(lines: list[str], index: int) -> bool:
+    if index + 1 >= len(lines):
+        return False
+    return _is_markdown_table_line(lines[index]) and _is_markdown_separator_line(lines[index + 1])
+
+
+def _is_markdown_table_line(line: str) -> bool:
+    stripped = line.strip()
+    return "|" in stripped and len(_split_markdown_table_row(stripped)) >= 2
+
+
+def _is_markdown_separator_line(line: str) -> bool:
+    cells = _split_markdown_table_row(line)
+    if not cells:
+        return False
+    for cell in cells:
+        marker = cell.replace(":", "").replace("-", "").strip()
+        if marker:
+            return False
+        if cell.count("-") < 3:
+            return False
+    return True
+
+
+def _markdown_table_to_bullets(lines: list[str]) -> list[str]:
+    if len(lines) < 3 or not _is_markdown_separator_line(lines[1]):
+        return []
+    headers = _split_markdown_table_row(lines[0])
+    if not headers:
+        return []
+    bullets: list[str] = []
+    for row in lines[2:]:
+        if _is_markdown_separator_line(row):
+            continue
+        cells = _split_markdown_table_row(row)
+        if not any(cells):
+            continue
+        while len(cells) < len(headers):
+            cells.append("")
+        first = cells[0].strip()
+        details = [
+            f"{header}: {cell}"
+            for header, cell in zip(headers[1:], cells[1:])
+            if header.strip() and cell.strip()
+        ]
+        if first and details:
+            bullets.append(f"- {first}: {'; '.join(details)}")
+        elif first:
+            bullets.append(f"- {headers[0]}: {first}")
+        elif details:
+            bullets.append(f"- {'; '.join(details)}")
+    return bullets
+
+
+def _split_markdown_table_row(line: str) -> list[str]:
+    stripped = line.strip()
+    cells: list[str] = []
+    current: list[str] = []
+    code_tick_length = 0
+    index = 0
+    while index < len(stripped):
+        character = stripped[index]
+        if character == "`" and not _is_escaped(stripped, index):
+            run_end = index
+            while run_end < len(stripped) and stripped[run_end] == "`":
+                run_end += 1
+            run_length = run_end - index
+            if code_tick_length == 0:
+                code_tick_length = run_length
+            elif code_tick_length == run_length:
+                code_tick_length = 0
+            current.append(stripped[index:run_end])
+            index = run_end
+            continue
+        if character == "|" and code_tick_length == 0 and not _is_escaped(stripped, index):
+            cells.append(_normalize_table_cell("".join(current)))
+            current = []
+            index += 1
+            continue
+        current.append(character)
+        index += 1
+    cells.append(_normalize_table_cell("".join(current)))
+    if cells and not cells[0]:
+        cells = cells[1:]
+    if cells and not cells[-1]:
+        cells = cells[:-1]
+    return cells
+
+
+def _is_escaped(value: str, index: int) -> bool:
+    slash_count = 0
+    cursor = index - 1
+    while cursor >= 0 and value[cursor] == "\\":
+        slash_count += 1
+        cursor -= 1
+    return slash_count % 2 == 1
+
+
+def _normalize_table_cell(value: str) -> str:
+    return _unescape_table_pipes(value.strip())
+
+
+def _unescape_table_pipes(value: str) -> str:
+    output: list[str] = []
+    index = 0
+    while index < len(value):
+        if value[index] == "\\" and index + 1 < len(value) and value[index + 1] == "|":
+            output.append("|")
+            index += 2
+            continue
+        output.append(value[index])
+        index += 1
+    return "".join(output)
+
+
+def _messenger_body_blocks(body: str) -> list[dict[str, object]]:
+    blocks: list[dict[str, object]] = []
+    current: list[str] = []
+    for line in body.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            if current:
+                blocks.append({"type": "paragraph", "text": " ".join(current)})
+                current = []
+            continue
+        if stripped.startswith(("- ", "* ")):
+            if current:
+                blocks.append({"type": "paragraph", "text": " ".join(current)})
+                current = []
+            blocks.append({"type": "bullet", "text": stripped[2:].strip()})
+            continue
+        numbered_text = _numbered_list_text(stripped)
+        if numbered_text:
+            if current:
+                blocks.append({"type": "paragraph", "text": " ".join(current)})
+                current = []
+            blocks.append({"type": "numbered", "text": numbered_text})
+            continue
+        current.append(stripped)
+    if current:
+        blocks.append({"type": "paragraph", "text": " ".join(current)})
+    return blocks
+
+
+def _numbered_list_text(stripped: str) -> str:
+    marker = ""
+    for index, character in enumerate(stripped):
+        if character.isdigit():
+            continue
+        if character in {".", ")"} and index > 0:
+            marker = stripped[: index + 1]
+        break
+    if not marker:
+        return ""
+    if len(stripped) <= len(marker) or not stripped[len(marker)].isspace():
+        return ""
+    rest = stripped[len(marker) :].strip()
+    return rest
 
 
 def _short_text(value: str, *, limit: int) -> str:

--- a/src/wrapper/executor_sessions.py
+++ b/src/wrapper/executor_sessions.py
@@ -25,6 +25,7 @@ from .lifecycle import (
 
 EXECUTOR_SESSION_SCHEMA_VERSION = "executor_session/v1"
 EXECUTOR_SESSION_STATUS_SCHEMA_VERSION = "executor_session_status/v1"
+EXECUTOR_LAUNCH_SCHEMA_VERSION = "executor_launch/v1"
 EXECUTOR_SESSION_RECORD_TYPE = "executor_session"
 EXECUTOR_SESSION_STATUSES = ("not_started", "prepared", "running", "completed", "blocked", "failed")
 EXECUTOR_SESSION_RESULTS = ("not_observed", "completed", "blocked", "failed")
@@ -172,7 +173,12 @@ def build_executor_session_actions(
                 and not attached
                 and not dispatch_observed
             ),
-            payload={**base_payload, "backend_action": "open-executor", "disabled_reason": status_blocker},
+            payload={
+                **base_payload,
+                "backend_action": "open-executor",
+                "disabled_reason": status_blocker,
+                "launch": _executor_launch_contract(executor, session),
+            },
         ),
         _action(
             "attach_executor_session",
@@ -774,6 +780,99 @@ def _open_label(executor: str) -> str:
     if executor == "hermes":
         return "Open Hermes coding"
     return f"Open {executor_label(executor)}"
+
+
+def _executor_launch_contract(executor: str, session: dict[str, Any]) -> dict[str, object]:
+    label = _surface_executor_label(executor, handoff_state=_handoff_state(session))
+    prompt_placeholder = "{executor_prompt}"
+    shell_placeholder = "{executor_prompt_shell_quoted}"
+    workspace_placeholder = "{workspace_path}"
+    workspace_shell_placeholder = "{workspace_path_shell_quoted}"
+    templates = _launch_command_templates(
+        executor,
+        prompt_placeholder,
+        shell_placeholder,
+        workspace_placeholder,
+        workspace_shell_placeholder,
+    )
+    return {
+        "schema_version": EXECUTOR_LAUNCH_SCHEMA_VERSION,
+        "selected_executor_profile": executor,
+        "executor_label": label,
+        "mode": "interactive_terminal_or_app",
+        "prompt_placeholder": prompt_placeholder,
+        "prompt_source": "prepared handoff prompt or original chat message held by the wrapper at click time",
+        "workspace_placeholder": workspace_placeholder,
+        "workspace_shell_placeholder": workspace_shell_placeholder,
+        "command_templates": templates,
+        "copy_blocks": [
+            {
+                "id": "copy_prompt",
+                "label": f"Copy prompt for {label}",
+                "text_template": prompt_placeholder,
+            },
+            {
+                "id": "copy_terminal_command",
+                "label": f"Copy {label} terminal command",
+                "text_template": templates[0]["shell_command_template"] if templates else prompt_placeholder,
+            },
+        ],
+        "after_launch_backend_action": "open-executor",
+        "observed_transition": "dispatch/open observed",
+        "claim_boundary": "Launch instructions are not execution evidence; record observed dispatch/open only after the wrapper sees the user or platform open the executor.",
+    }
+
+
+def _launch_command_templates(
+    executor: str,
+    prompt_placeholder: str,
+    shell_placeholder: str,
+    workspace_placeholder: str,
+    workspace_shell_placeholder: str,
+) -> list[dict[str, object]]:
+    if executor == "codex":
+        return [
+            {
+                "id": "codex_interactive_prompt",
+                "label": "Open Codex with this prompt",
+                "argv_template": ["codex", prompt_placeholder],
+                "shell_command_template": f"codex {shell_placeholder}",
+                "when_to_use": "Use when the current terminal is already in the target repository.",
+            },
+            {
+                "id": "codex_interactive_workspace",
+                "label": "Open Codex in a specific workspace",
+                "argv_template": ["codex", "--cd", workspace_placeholder, prompt_placeholder],
+                "shell_command_template": f"codex --cd {workspace_shell_placeholder} {shell_placeholder}",
+                "when_to_use": "Use when the wrapper knows the repository path and wants Codex rooted there.",
+            },
+        ]
+    if executor == "claude-code":
+        return [
+            {
+                "id": "claude_code_interactive_prompt",
+                "label": "Open Claude Code with this prompt",
+                "argv_template": ["claude", prompt_placeholder],
+                "shell_command_template": f"claude {shell_placeholder}",
+                "when_to_use": "Use when the current terminal is already in the target repository.",
+            },
+            {
+                "id": "claude_code_interactive_workspace",
+                "label": "Open Claude Code with workspace access",
+                "argv_template": ["claude", "--add-dir", workspace_placeholder, prompt_placeholder],
+                "shell_command_template": f"claude --add-dir {workspace_shell_placeholder} {shell_placeholder}",
+                "when_to_use": "Use when the wrapper knows the repository path and should grant Claude Code explicit workspace access.",
+            },
+        ]
+    return [
+        {
+            "id": "copy_prompt_to_executor",
+            "label": f"Copy prompt for {executor_label(executor)}",
+            "argv_template": [prompt_placeholder],
+            "shell_command_template": prompt_placeholder,
+            "when_to_use": "Use when this executor does not have a deterministic local launch command in OMH.",
+        }
+    ]
 
 
 def _open_summary(session: dict[str, Any], *, observed: bool) -> str:

--- a/src/wrapper/native_commands.py
+++ b/src/wrapper/native_commands.py
@@ -104,11 +104,24 @@ def render_native_command_response(interaction: dict[str, object], *, source: st
             }
         )
         return payload
+    rendering = _nested(response, "messenger_rendering")
+    body_text = rendering.get("body_text")
+    if isinstance(body_text, str):
+        rendered_body_text = body_text
+        body_text_source = "messenger_rendering.body_text"
+        render_warnings: list[str] = []
+    else:
+        rendered_body_text = ""
+        body_text_source = "missing_messenger_rendering.body_text"
+        render_warnings = ["missing_messenger_safe_body"]
     payload.update(
         {
             "render_kind": "chat_response",
             "headline": response.get("headline", ""),
             "body": response.get("body", ""),
+            "body_text": rendered_body_text,
+            "body_text_source": body_text_source,
+            "render_warnings": render_warnings,
             "actions": response.get("actions", []),
         }
     )

--- a/tests/test_wrapper_contract.py
+++ b/tests/test_wrapper_contract.py
@@ -6,7 +6,12 @@ import unittest
 from _local_package import load_local_package
 
 load_local_package()
-from omh.wrapper_contract import build_chat_interaction_payload, build_chat_response_from_status, build_status_card_from_status
+from omh.wrapper_contract import (
+    build_chat_interaction_payload,
+    build_chat_response_from_status,
+    build_status_card_from_status,
+    messenger_rendering_contract,
+)
 from omh.wrapper.native_commands import build_native_command_surface, render_native_command_response
 
 
@@ -249,6 +254,159 @@ class WrapperContractTests(unittest.TestCase):
         self.assertEqual(rendering["prefix_policy"]["default"], "once_per_response_first_line")
         self.assertEqual(rendering["prefix_policy"]["repeat_when"], "adapter_splits_response_across_separate_messages_or_chunks")
         self.assertIn("not execution evidence", trace["claim_boundary"])
+
+    def test_messenger_rendering_converts_markdown_tables_to_bullets(self) -> None:
+        body = "\n".join(
+            [
+                "비교는 이렇게 보면 됩니다.",
+                "",
+                "| 계열 | 강점 | OMH 포지션 |",
+                "| --- | --- | --- |",
+                "| Hermes Agent | Skills, memory, gateway | Workflow layer |",
+                "| OpenCode | TUI coding loop | Handoff target |",
+                "",
+                "표 이후 문단입니다.",
+            ]
+        )
+
+        rendering = messenger_rendering_contract(
+            visible_prefix="[omh] web-research",
+            first_line="[omh] web-research - 비교 결과입니다.",
+            body=body,
+            claim_boundary="Research summary is not execution evidence.",
+        )
+
+        self.assertIn("markdown_table_to_bullets", rendering["transforms_applied"])
+        self.assertIn("- Hermes Agent: 강점: Skills, memory, gateway; OMH 포지션: Workflow layer", rendering["body_text"])
+        self.assertIn("- OpenCode: 강점: TUI coding loop; OMH 포지션: Handoff target", rendering["body_text"])
+        self.assertNotIn("| --- |", rendering["body_text"])
+        self.assertIn("Hermes Agent", rendering["body_preview"])
+        self.assertTrue(any(block["type"] == "bullet" and "Hermes Agent" in block["text"] for block in rendering["body_blocks"]))
+
+    def test_messenger_rendering_converts_tables_without_outer_pipes(self) -> None:
+        body = "\n".join(
+            [
+                "계열 | 강점",
+                "--- | ---",
+                "Hermes | Gateway",
+            ]
+        )
+
+        rendering = messenger_rendering_contract(
+            visible_prefix="[omh] web-research",
+            first_line="[omh] web-research - 비교 결과입니다.",
+            body=body,
+            claim_boundary="Research summary is not execution evidence.",
+        )
+
+        self.assertEqual(rendering["body_text"], "- Hermes: 강점: Gateway")
+        self.assertIn("markdown_table_to_bullets", rendering["transforms_applied"])
+
+    def test_messenger_rendering_preserves_pipe_characters_inside_cells(self) -> None:
+        body = "\n".join(
+            [
+                "| Case | Example | Notes |",
+                "| --- | --- | --- |",
+                "| Escaped | `a\\|b` | keeps escaped \\| text |",
+                "| Code span | `x|y` | keeps inline code pipe |",
+            ]
+        )
+
+        rendering = messenger_rendering_contract(
+            visible_prefix="[omh] web-research",
+            first_line="[omh] web-research - 비교 결과입니다.",
+            body=body,
+            claim_boundary="Research summary is not execution evidence.",
+        )
+
+        self.assertIn("- Escaped: Example: `a|b`; Notes: keeps escaped | text", rendering["body_text"])
+        self.assertIn("- Code span: Example: `x|y`; Notes: keeps inline code pipe", rendering["body_text"])
+        self.assertIn("markdown_table_to_bullets", rendering["transforms_applied"])
+
+    def test_messenger_rendering_keeps_tables_inside_code_fences(self) -> None:
+        body = "\n".join(
+            [
+                "예제는 그대로 보여줘야 합니다.",
+                "",
+                "```markdown",
+                "| key | value |",
+                "| --- | --- |",
+                "| a | b |",
+                "```",
+            ]
+        )
+
+        rendering = messenger_rendering_contract(
+            visible_prefix="[omh] web-research",
+            first_line="[omh] web-research - 예제입니다.",
+            body=body,
+            claim_boundary="Research summary is not execution evidence.",
+        )
+
+        self.assertEqual(rendering["transforms_applied"], [])
+        self.assertIn("| --- | --- |", rendering["body_text"])
+
+    def test_native_render_uses_messenger_safe_body_for_tables(self) -> None:
+        body = "\n".join(
+            [
+                "| 계열 | 강점 |",
+                "| --- | --- |",
+                "| Hermes | Gateway |",
+            ]
+        )
+        rendering = messenger_rendering_contract(
+            visible_prefix="[omh] web-research",
+            first_line="[omh] web-research - 비교 결과입니다.",
+            body=body,
+            claim_boundary="Not execution evidence.",
+        )
+        rendered = render_native_command_response(
+            {
+                "thread_key": "discord:c1:m1",
+                "chat_response": {
+                    "kind": "plan",
+                    "headline": "[omh] web-research - 비교 결과입니다.",
+                    "body": body,
+                    "state": {"phase": "planning"},
+                    "messenger_rendering": rendering,
+                    "actions": [],
+                },
+            },
+            source="discord",
+        )
+
+        self.assertEqual(rendered["body"], body)
+        self.assertEqual(rendered["body_text"], "- Hermes: 강점: Gateway")
+        self.assertEqual(rendered["body_text_source"], "messenger_rendering.body_text")
+        self.assertEqual(rendered["render_warnings"], [])
+
+    def test_native_render_warns_when_messenger_safe_body_is_missing(self) -> None:
+        body = "\n".join(
+            [
+                "| 계열 | 강점 |",
+                "| --- | --- |",
+                "| Hermes | Gateway |",
+            ]
+        )
+        rendered = render_native_command_response(
+            {
+                "thread_key": "discord:c1:m1",
+                "chat_response": {
+                    "kind": "plan",
+                    "headline": "[omh] web-research - 비교 결과입니다.",
+                    "body": body,
+                    "state": {"phase": "planning"},
+                    "messenger_rendering": {"schema_version": "omh_messenger_rendering/v1"},
+                    "actions": [],
+                },
+            },
+            source="discord",
+        )
+
+        self.assertEqual(rendered["body"], body)
+        self.assertEqual(rendered["body_text"], "")
+        self.assertEqual(rendered["body_text_source"], "missing_messenger_rendering.body_text")
+        self.assertIn("missing_messenger_safe_body", rendered["render_warnings"])
 
     def test_route_mode_exposes_visible_omh_usage_trace_for_multiple_workflows(self) -> None:
         cases = (
@@ -498,6 +656,22 @@ class WrapperContractTests(unittest.TestCase):
         self.assertEqual(response["status_card"]["schema_version"], "status_card/v1")
         self.assertEqual(response["status_card"]["steps"][2]["id"], "verification")
         self.assertEqual(response["status_card"]["steps"][2]["state"], "pending")
+
+    def test_status_copy_names_dispatched_coding_agent(self) -> None:
+        response = build_chat_response_from_status(
+            {
+                "run_id": "run-1",
+                "next_action": "wait_for_executor_evidence",
+                "prepared": {"executor_target": "codex"},
+                "execution": {"observed": False},
+                "verification": {"observed": False},
+                "review": {"required": False},
+            }
+        )
+
+        self.assertEqual(response["plain_headline"], "The coding handoff (Codex) was dispatched.")
+        self.assertEqual(response["status_card"]["headline"], "The coding handoff (Codex) was dispatched.")
+        self.assertIn("waiting for Codex executor evidence", response["body"])
 
     def test_status_card_exposes_platform_neutral_progress_steps(self) -> None:
         card = build_status_card_from_status(

--- a/tests/test_wrapper_sessions.py
+++ b/tests/test_wrapper_sessions.py
@@ -673,6 +673,14 @@ class WrapperSessionTests(unittest.TestCase):
             self.assertEqual(prepared_status["result"], "not_observed")
             self.assertTrue(prepared_actions["open_executor_session"]["enabled"])
             self.assertEqual(prepared_actions["open_executor_session"]["label"], "Open in Codex")
+            codex_launch = prepared_actions["open_executor_session"]["payload"]["launch"]
+            self.assertEqual(codex_launch["schema_version"], "executor_launch/v1")
+            self.assertEqual(codex_launch["command_templates"][0]["argv_template"], ["codex", "{executor_prompt}"])
+            self.assertEqual(codex_launch["command_templates"][0]["shell_command_template"], "codex {executor_prompt_shell_quoted}")
+            self.assertEqual(codex_launch["command_templates"][1]["argv_template"], ["codex", "--cd", "{workspace_path}", "{executor_prompt}"])
+            self.assertEqual(codex_launch["command_templates"][1]["shell_command_template"], "codex --cd {workspace_path_shell_quoted} {executor_prompt_shell_quoted}")
+            self.assertEqual(codex_launch["after_launch_backend_action"], "open-executor")
+            self.assertIn("not execution evidence", codex_launch["claim_boundary"])
             self.assertEqual(prepared_actions["attach_executor_session"]["label"], "Attach existing session")
             self.assertEqual(prepared_actions["attach_executor_session"]["payload"]["input_schema"]["required"], ["external_session_ref"])
             self.assertIn("open_executor_session", {action["id"] for action in prepared["status"]["chat_response"]["actions"]})
@@ -966,6 +974,14 @@ class WrapperSessionTests(unittest.TestCase):
 
             self.assertEqual(prepared["status"]["executor_session_status"]["coding_agent"], "prepared(claude-code)")
             self.assertNotIn("runtime_status", prepared["status"])
+            actions = {action["id"]: action for action in prepared["status"]["executor_session_status"]["actions"]}
+            claude_launch = actions["open_executor_session"]["payload"]["launch"]
+            self.assertEqual(actions["open_executor_session"]["label"], "Open in Claude Code")
+            self.assertEqual(claude_launch["schema_version"], "executor_launch/v1")
+            self.assertEqual(claude_launch["command_templates"][0]["argv_template"], ["claude", "{executor_prompt}"])
+            self.assertEqual(claude_launch["command_templates"][0]["shell_command_template"], "claude {executor_prompt_shell_quoted}")
+            self.assertEqual(claude_launch["command_templates"][1]["argv_template"], ["claude", "--add-dir", "{workspace_path}", "{executor_prompt}"])
+            self.assertEqual(claude_launch["command_templates"][1]["shell_command_template"], "claude --add-dir {workspace_path_shell_quoted} {executor_prompt_shell_quoted}")
 
             opened = open_executor_session(
                 paths,


### PR DESCRIPTION
## Feature Report

### What Changed

- Added canonical messenger-safe response fields under `chat_response.messenger_rendering`: `body_text`, `body_blocks`, and `transforms_applied`.
- Converted Markdown tables in wrapper responses into readable bullet lists for Discord/Slack/Telegram-style surfaces, including support for tables without outer pipes, escaped pipe characters, inline-code pipes, and code-fence preservation.
- Updated native render and shim outputs so raw `body` stays raw while messenger adapters render `body_text`; missing safe-body contracts now produce an explicit warning instead of silently posting raw table Markdown.
- Added `executor_launch/v1` payloads to executor open actions with copyable Codex and Claude Code command templates.
- Updated wrapper runbooks, installation guidance, Discord flow examples, and golden integration docs to point adapters at the safe body and executor launch payloads.

### Why This Exists

Discord-style chat output can break wide Markdown tables, especially for research comparisons. The previous contract only warned adapters to avoid tables, which still left each adapter to reimplement formatting. Operators also needed clearer copyable launch affordances when choosing Codex or Claude Code as the coding handoff target.

### User / Operator Impact

- Research and comparison answers can keep a visible `[omh] web-research` prefix while rendering table-like content as readable bullets in messenger apps.
- Adapter authors can use one deterministic field, `chat_response.messenger_rendering.body_text`, instead of parsing raw Markdown tables themselves.
- Rich/web surfaces can still render the original `chat_response.body`.
- Open-in-Codex and Open-in-Claude buttons can show copyable launch commands without claiming execution happened.

### How It Works

- `messenger_rendering_contract()` derives `body_text` and `body_blocks` from the original response body and records `markdown_table_to_bullets` when a conversion happened.
- The table parser keeps escaped `\|` and inline-code `|` content inside cells, skips fenced code blocks, and only recognizes tables when a header line is followed by a separator line.
- `render_native_command_response()` preserves raw `body`, exposes safe `body_text`, and reports `missing_messenger_safe_body` if a malformed response omits the safe projection.
- Executor session actions now attach `executor_launch/v1` metadata with prompt/workspace placeholders, argv templates, shell command templates, copy blocks, and a clear not-execution-evidence boundary.

### Files And Contracts Touched

- `chat_response/v1`
- `omh_messenger_rendering/v1`
- `omh_native_command_render/v1`
- `executor_session/v1`
- `executor_launch/v1`
- Wrapper docs and Discord/Hermes integration examples

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` (`464` tests)
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m src.cli docs workflows --check`
- [x] `uv run python -m src.cli harness validate`
- [ ] `python3 -m omh.cli release checklist --json` - not run; this is not a release-channel PR.
- [ ] `python3 -m omh.cli release hermes-smoke` - not run; no live Hermes adapter/platform check was required for this local contract change.
- [ ] `omh --help` - not run; command discovery was not changed.
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` - not run; install smoke is outside this PR scope.
- [x] Relevant dry-run or smoke command: dynamic Python smoke for messenger-safe table rendering, escaped pipes, code-fence preservation, native `body_text`, and missing-safe-body warnings.
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; this PR updates local wrapper contracts/examples and has no live Discord/Slack/Telegram adapter in the repo.

Additional review evidence:

- Independent `code-reviewer` re-review: no blocking findings; previous escaped-pipe and raw-body fallback findings fixed.
- Independent `architect` re-review: `CLEAR`; raw-vs-rendered naming concern resolved.

## Risk

- The table conversion is intentionally conservative and lossy: it creates readable bullets, not a full Markdown AST.
- `body_blocks` is a convenience projection for simple paragraphs/bullets/numbered lists, not a full rich-block model.
- Platform-specific renderers may still need their own chunking or mention escaping policies outside this contract.

## Compatibility / Rollout

- Additive contract fields keep existing `chat_response.body` available for rich/web surfaces.
- Messenger adapters should prefer `chat_response.messenger_rendering.body_text` when available.
- Executor launch payloads are UI metadata only; wrappers still record observed open/dispatch separately.

## Release / Claims

- [x] Release-channel impact considered (`local` contract/docs improvement; no release-channel change).
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] Known manual Hermes checks are listed, including the live Discord/Slack/Telegram adapter gap.

## Follow-Up

- If future adapters need richer layout, promote `body_blocks` through a dedicated rich-block schema instead of expanding it ad hoc.
