### PR TITLE
Add GitHub badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 </p>
 
 <p align="center">
+  <a href="https://github.com/rlaope/oh-my-hermes"><img alt="GitHub" src="https://img.shields.io/badge/github-rlaope%2Foh--my--hermes-181717?logo=github"></a>
   <img alt="Python" src="https://img.shields.io/badge/python-3.11%2B-blue">
   <img alt="License" src="https://img.shields.io/badge/license-MIT-green">
   <img alt="Status" src="https://img.shields.io/badge/status-1.0.0%20stable-blue">


### PR DESCRIPTION
## Feature Report

### What Changed

- Added a linked GitHub badge to the README badge row next to Python, License, and Status.

### Why This Exists

The README already exposes package/runtime basics through badges, but it did not show the canonical GitHub repository in the same compact first-viewport badge area.

### User / Operator Impact

- README visitors can jump directly from the badge row to the GitHub repository.
- The badge row remains concise and visually consistent with the existing shields.

### How It Works

- Uses a standard shields.io static badge with the GitHub logo and links it to `https://github.com/rlaope/oh-my-hermes`.

### Files And Contracts Touched

- `README.md`: top-level badge row only.

## Validation

- [ ] `python3 -m unittest discover -s tests`
- [ ] `python3 -m compileall src`
- [ ] `python3 -m omh.cli docs workflows --check`
- [ ] `python3 -m omh.cli harness validate`
- [ ] `python3 -m omh.cli release checklist --json`
- [ ] `python3 -m omh.cli release hermes-smoke`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [x] Relevant dry-run or smoke command: `git diff --check`
- [x] Manual Hermes/TUI check, or explicit reason it was not run: not run because this is a static README badge change only

## Risk

Low. This is a one-line README badge addition using an external shields.io image like the existing badges.

## Compatibility / Rollout

No runtime, install, CLI, or Hermes compatibility impact.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`): docs-only, no channel behavior change
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- None.
