### PR TITLE
Add OMH menu bar status contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,10 @@ artifact changes, add or update tests that lock the public contract.
 ## Git And Commits
 
 Use `codex/` branch names unless the user requests another prefix.
+Before editing files for a coding task, create or switch to a dedicated
+`codex/` task branch unless the current branch is already clearly dedicated to
+that exact user goal. Do this before the first implementation edit so the work
+does not mix with unrelated branch history or user changes.
 
 Every commit must include DCO signoff and the local Lore-style trailers used by
 this repository:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -160,6 +160,29 @@ patch Hermes core, or claim execution evidence from prepared handoffs. Role
 context is prompt guidance only; it is not proof
 that a separate role, worker, or executor ran.
 
+`menubar_status.py` owns the platform-neutral macOS menu bar view model exposed
+by `omh menubar status`. Its `menubar_status/v1` payload is a UI projection over
+the same local HUD, target registry, and runtime evidence. It is intentionally
+not the source of truth. The payload separates `hermes_agents` from
+`external_coding_executors` so Codex, Claude Code, OMX, OMO, OMC, or generic
+coding tools cannot be rendered as Hermes agents by accident. Compact surfaces
+receive source and model `icon_id` values plus tooltip text rather than Markdown
+tables or prose-only labels.
+
+`current_external_coding_executor` names the selected row explicitly, preferring
+`runtime/state.json` `last_run_id` when it matches the recent executor list, so
+settings and compact summaries do not rely on an unnamed list-order convention.
+
+The menu bar status contract reports configured Hermes targets and prepared
+handoffs without inventing process state. PID, `running`, and `restarting`
+values are applied only from a caller-provided `menubar_process_overlay/v1`
+payload, normally produced by a native macOS MenuBarExtra app or test harness.
+That overlay is app-local, expires after a short TTL, and applies restarting
+state only inside its restart window. OMH does not scan processes, launch
+agents, infer runtime health, or turn prepared handoffs into observed
+execution. A native macOS app can be built on top of this contract later; this
+repository slice provides the deterministic backend contract and CLI projection.
+
 `cli.py` is a compatibility adapter. `commands/main.py` owns parser assembly,
 top-level error handling, and the public command handler re-export surface.
 Domain command modules under `commands/` own support JSON output for bootstrap,

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -94,6 +94,33 @@ Hermes has loaded it.
 If the target Hermes runtime requires a separate plugin enable command, follow
 that runtime's plugin enable/reload step.
 
+For native menu bar or status-widget integrations, use the platform-neutral
+view model:
+
+```sh
+omh menubar status
+```
+
+It emits `menubar_status/v1` JSON with separate `hermes_agents` and
+`external_coding_executors` sections, friendly labels such as
+`OMH connection: Ready`, `Hermes targets: 2`, `Coding handoff: Codex`, and
+`Send mode: Ask before opening Codex`, plus source/model icon IDs with tooltip
+text. Codex and other coding tools are external executors, not Hermes agents.
+Without an explicit process overlay, the payload reports configured/prepared
+state only and leaves PID plus running/restarting unobserved.
+
+A native macOS MenuBarExtra app or test harness can pass a short-lived
+`menubar_process_overlay/v1` file when it has actually observed local process
+state:
+
+```sh
+omh menubar status --overlay /path/to/overlay.json
+```
+
+The overlay is app-local and expires by TTL. OMH does not auto-read process
+caches, scan the host, launch agents, or infer that a prepared coding handoff
+is running.
+
 MCP bridge setup is also optional and intentionally conservative:
 
 ```sh

--- a/src/commands/main.py
+++ b/src/commands/main.py
@@ -62,6 +62,7 @@ from .materials import (
     cmd_materials_show,
     cmd_materials_validate,
 )
+from .menubar import _add_menubar_commands, cmd_menubar_status
 from .memory import _add_memory_commands, cmd_memory_apply, cmd_memory_inspect, cmd_memory_pack
 from .ops import (
     _add_ops_commands,
@@ -140,6 +141,7 @@ def build_parser() -> argparse.ArgumentParser:
             "  omh playbook recommend \"turn this issue into a PR\"\n"
             "  omh chat interact \"turn this issue into a PR-ready plan\"\n"
             "  omh hud\n"
+            "  omh menubar status\n"
             "  omh loop status\n"
             "  omh ops list\n"
             "  omh materials list\n"
@@ -175,6 +177,7 @@ def build_parser() -> argparse.ArgumentParser:
     _add_hud_commands(sub)
     _add_loop_commands(sub)
     _add_memory_commands(sub)
+    _add_menubar_commands(sub)
     _add_ops_commands(sub)
     _add_materials_commands(sub)
     _add_runtime_commands(sub)
@@ -211,6 +214,7 @@ Useful operator commands:
   omh playbook recommend "turn this issue into a PR"
   omh chat interact "turn this issue into a PR-ready plan"
   omh hud                Show the compact OMH status line
+  omh menubar status     Show the menu bar app status view model
   omh loop status        Show loopable goal cycle state
   omh ops list           List local operations artifacts
   omh materials list     List material-processing artifacts

--- a/src/commands/menubar.py
+++ b/src/commands/menubar.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import argparse
+
+from ..installer import OmhError
+from ..menubar_status import build_menubar_status_payload, read_process_overlay_file
+from .common import _paths, _print_json
+
+
+def cmd_menubar_status(args: argparse.Namespace) -> int:
+    try:
+        overlay = read_process_overlay_file(args.overlay) if args.overlay else None
+    except ValueError as exc:
+        raise OmhError(str(exc)) from exc
+    _print_json(
+        build_menubar_status_payload(
+            _paths(args),
+            limit=args.limit,
+            process_overlay=overlay,
+            now=args.now,
+        )
+    )
+    return 0
+
+
+def _add_menubar_commands(sub) -> None:
+    menubar = sub.add_parser("menubar", help="Print OMH menu bar app view-model payloads.")
+    menubar_sub = menubar.add_subparsers(dest="menubar_command", required=True)
+
+    status = menubar_sub.add_parser("status", help="Print the macOS menu bar agent-status view model.")
+    status.add_argument("--limit", type=int, default=3, help="Maximum recent runtime runs to inspect.")
+    status.add_argument("--overlay", default=None, help="Optional menubar_process_overlay/v1 JSON from the menu bar app.")
+    status.add_argument("--now", default=None, help="Optional ISO timestamp for deterministic overlay TTL evaluation.")
+    status.set_defaults(func=cmd_menubar_status)

--- a/src/menubar_status.py
+++ b/src/menubar_status.py
@@ -1,0 +1,764 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from json import JSONDecodeError
+from pathlib import Path
+from typing import Any
+
+from .executors import executor_label
+from .hud import build_hud_payload
+from .local_store import read_json_object
+from .paths import OmhPaths
+from .runtime.artifacts import summarize_delegated_coding_status
+from .targets import read_target_registry_result
+
+
+MENUBAR_STATUS_SCHEMA_VERSION = "menubar_status/v1"
+PROCESS_OVERLAY_SCHEMA_VERSION = "menubar_process_overlay/v1"
+DEFAULT_PROCESS_OVERLAY_TTL_SECONDS = 10
+DEFAULT_RESTART_WINDOW_SECONDS = 20
+_OBSERVED_PROCESS_STATUSES = {"running", "restarting"}
+
+_SOURCE_ICON_LABELS = {
+    "source.discord": "Discord",
+    "source.slack": "Slack",
+    "source.telegram": "Telegram",
+    "source.whatsapp": "WhatsApp",
+    "source.signal": "Signal",
+    "source.hermes": "Hermes",
+    "source.cli": "CLI",
+    "source.local": "Local",
+    "source.unknown": "Unknown source",
+}
+
+_MODEL_ICON_LABELS = {
+    "model.openai": "OpenAI",
+    "model.anthropic": "Anthropic",
+    "model.google": "Google",
+    "model.local": "Local model",
+    "model.other": "Other model",
+    "model.unknown": "Model not observed",
+}
+
+
+def build_menubar_status_payload(
+    paths: OmhPaths,
+    *,
+    limit: int = 3,
+    process_overlay: dict[str, Any] | None = None,
+    now: datetime | str | None = None,
+) -> dict[str, Any]:
+    safe_limit = _safe_limit(limit, default=3)
+    hud = build_hud_payload(paths, preset="full", limit=safe_limit)
+    hermes_agents = _hermes_agent_rows(paths)
+    external_executors = _external_executor_rows(paths, limit=safe_limit)
+    current_executor, current_executor_source = _select_current_external_executor(paths, external_executors)
+    overlay_summary = _apply_process_overlay(
+        hermes_agents,
+        external_executors,
+        process_overlay=process_overlay,
+        now=now,
+    )
+    settings = _settings(hud, hermes_agents, current_executor)
+    return {
+        "schema_version": MENUBAR_STATUS_SCHEMA_VERSION,
+        "package": "oh-my-hermes",
+        "omh_home": str(paths.omh_home),
+        "hermes_home": str(paths.hermes_home),
+        "display": _display(settings, hermes_agents, current_executor),
+        "sections": {
+            "hermes_agents": {
+                "title": "Hermes agents",
+                "empty_label": "No Hermes target observed",
+            },
+            "external_coding_executors": {
+                "title": "External coding executors",
+                "empty_label": "No external coding executor handoff observed",
+            },
+            "settings": {
+                "title": "Settings",
+            },
+        },
+        "hermes_agents": hermes_agents,
+        "external_coding_executors": external_executors,
+        "current_external_coding_executor": _current_external_executor_payload(
+            current_executor,
+            selection_source=current_executor_source,
+        ),
+        "process_overlay": overlay_summary,
+        "versions": _versions(hud),
+        "settings": settings,
+        "icon_contract": {
+            "source_icons": _icon_catalog(_SOURCE_ICON_LABELS),
+            "model_icons": _icon_catalog(_MODEL_ICON_LABELS),
+            "rendering_rule": "Render source and model as icons in compact surfaces; expose tooltip text on hover or focus.",
+        },
+        "evidence_boundary": (
+            "menubar_status/v1 is a metadata-only view projection. Configured Hermes targets and prepared coding "
+            "handoffs are not process, execution, verification, review, CI, merge, or PID evidence."
+        ),
+        "privacy": "metadata_only",
+    }
+
+
+def read_process_overlay_file(path: str) -> dict[str, Any]:
+    try:
+        data = json.loads(Path(path).expanduser().read_text(encoding="utf-8"))
+    except (OSError, JSONDecodeError) as exc:
+        raise ValueError(f"could not read process overlay: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ValueError("process overlay must be a JSON object")
+    schema = str(data.get("schema_version", "") or "")
+    if schema != PROCESS_OVERLAY_SCHEMA_VERSION:
+        raise ValueError(f"unsupported process overlay schema: {schema!r}")
+    return data
+
+
+def _hermes_agent_rows(paths: OmhPaths) -> list[dict[str, Any]]:
+    registry, error = read_target_registry_result(paths)
+    if error or not registry:
+        return []
+    targets = registry.get("targets", {})
+    if not isinstance(targets, dict):
+        return []
+    rows = [_hermes_agent_row(record) for _, record in sorted(targets.items()) if isinstance(record, dict)]
+    return rows
+
+
+def _hermes_agent_row(record: dict[str, Any]) -> dict[str, Any]:
+    source = str(record.get("source", "") or "")
+    return {
+        "kind": "hermes_agent",
+        "id": str(record.get("target_id", "")),
+        "name": str(record.get("display_name", "") or "Hermes Agent"),
+        "pid": None,
+        "pid_label": "PID not observed",
+        "pid_observed": False,
+        "status": "configured",
+        "status_label": "Configured",
+        "status_observed": False,
+        "summary": _hermes_agent_summary(record),
+        "source": source_icon_descriptor(source, channel_ref=str(record.get("target_ref", "") or "")),
+        "model": model_icon_descriptor(_model_value(record)),
+        "is_hermes_agent": True,
+        "evidence": {
+            "state": "configured_not_process_observed",
+            "source": "target_registry",
+            "observed_at": str(record.get("observed_at", "") or ""),
+        },
+    }
+
+
+def _external_executor_rows(paths: OmhPaths, *, limit: int) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for run_id in _recent_run_ids(paths, limit=limit):
+        try:
+            status = summarize_delegated_coding_status(paths, run_id)
+        except (FileNotFoundError, OSError, JSONDecodeError, ValueError):
+            continue
+        prepared = _dict(status.get("prepared"))
+        executor_profile = str(prepared.get("executor_target", "") or "")
+        if not executor_profile or executor_profile == "hermes":
+            continue
+        rows.append(_external_executor_row(status, executor_profile, _run_coding_record(paths, run_id)))
+    return rows
+
+
+def _external_executor_row(status: dict[str, Any], executor_profile: str, coding: dict[str, Any]) -> dict[str, Any]:
+    prepared = _dict(status.get("prepared"))
+    execution = _dict(status.get("execution"))
+    source_metadata = _dict(status.get("source_metadata"))
+    handoff = _dict(coding.get("executor_handoff"))
+    source = str(status.get("source", "") or "")
+    evidence_state = str(prepared.get("status") or "unknown")
+    execution_observed = bool(execution.get("observed", False))
+    row_status = "observed" if execution_observed else "prepared" if prepared.get("available") else "not_observed"
+    return {
+        "kind": "external_coding_executor",
+        "id": f"{executor_profile}:{status.get('run_id', '')}",
+        "name": executor_label(executor_profile),
+        "executor_profile": executor_profile,
+        "is_hermes_agent": False,
+        "pid": None,
+        "pid_label": "PID not observed",
+        "pid_observed": False,
+        "status": row_status,
+        "status_label": _external_executor_status_label(row_status),
+        "status_observed": execution_observed,
+        "summary": str(status.get("safe_summary", "") or _external_executor_summary(prepared, executor_profile, source_metadata)),
+        "source": source_icon_descriptor(source, channel_ref=str(source_metadata.get("channel_ref", "") or "")),
+        "model": model_icon_descriptor(_model_value(source_metadata)),
+        "handoff": {
+            "selected": True,
+            "dispatch_policy": _dispatch_policy(status, coding),
+            "dispatchable": bool(handoff.get("dispatchable", coding.get("dispatchable", False))),
+            "workflow": str(prepared.get("workflow", "") or ""),
+            "harness": str(prepared.get("harness", "") or ""),
+        },
+        "evidence": {
+            "state": evidence_state,
+            "run_id": str(status.get("run_id", "") or ""),
+            "prepared_available": bool(prepared.get("available", False)),
+            "execution_observed": execution_observed,
+            "next_action": str(status.get("next_action", "") or ""),
+        },
+    }
+
+
+def source_icon_descriptor(source: str, *, channel_ref: str = "") -> dict[str, Any]:
+    icon_id = _source_icon_id(source)
+    label = _SOURCE_ICON_LABELS[icon_id]
+    tooltip = f"{label}: {channel_ref}" if channel_ref else label
+    return {
+        "value": source or "unknown",
+        "icon_id": icon_id,
+        "tooltip": tooltip,
+        "channel_ref": channel_ref,
+    }
+
+
+def model_icon_descriptor(model: str) -> dict[str, Any]:
+    normalized = str(model or "").strip()
+    icon_id = _model_icon_id(normalized)
+    tooltip = normalized if normalized else _MODEL_ICON_LABELS[icon_id]
+    return {
+        "value": normalized or "unknown",
+        "icon_id": icon_id,
+        "tooltip": tooltip,
+        "observed": bool(normalized),
+    }
+
+
+def _recent_run_ids(paths: OmhPaths, *, limit: int) -> list[str]:
+    runs_dir = paths.runtime_runs_dir
+    if not runs_dir.exists():
+        return []
+    run_ids: list[str] = []
+    for run_json in sorted(runs_dir.glob("*/run.json"), reverse=True)[:limit]:
+        try:
+            run = read_json_object(run_json)
+        except (OSError, JSONDecodeError, ValueError):
+            continue
+        if isinstance(run, dict):
+            run_ids.append(str(run.get("run_id", "") or run_json.parent.name))
+    return run_ids
+
+
+def _run_coding_record(paths: OmhPaths, run_id: str) -> dict[str, Any]:
+    try:
+        coding = read_json_object(paths.runtime_runs_dir / run_id / "coding_delegation.json")
+    except (OSError, JSONDecodeError, ValueError):
+        return {}
+    return coding if isinstance(coding, dict) else {}
+
+
+def _select_current_external_executor(
+    paths: OmhPaths,
+    external_executors: list[dict[str, Any]],
+) -> tuple[dict[str, Any], str]:
+    if not external_executors:
+        return {}, "none"
+    try:
+        state = read_json_object(paths.runtime_state_path)
+    except (OSError, JSONDecodeError, ValueError):
+        state = None
+    last_run_id = str(state.get("last_run_id", "") if isinstance(state, dict) else "")
+    if last_run_id:
+        for row in external_executors:
+            if str(_dict(row.get("evidence")).get("run_id", "") or "") == last_run_id:
+                return row, "runtime_state.last_run_id"
+    return external_executors[0], "recent_runtime_runs[0]"
+
+
+def _current_external_executor_payload(row: dict[str, Any], *, selection_source: str) -> dict[str, Any]:
+    if not row:
+        return {
+            "selected": False,
+            "selection_source": selection_source,
+            "row_id": "",
+            "run_id": "",
+            "executor_profile": "",
+        }
+    return {
+        "selected": True,
+        "selection_source": selection_source,
+        "row_id": str(row.get("id", "") or ""),
+        "run_id": str(_dict(row.get("evidence")).get("run_id", "") or ""),
+        "executor_profile": str(row.get("executor_profile", "") or ""),
+        "name": str(row.get("name", "") or ""),
+        "status": str(row.get("status", "") or ""),
+        "status_label": str(row.get("status_label", "") or ""),
+    }
+
+
+def _settings(
+    hud: dict[str, Any],
+    hermes_agents: list[dict[str, Any]],
+    current_executor_row: dict[str, Any],
+) -> dict[str, Any]:
+    plugin = _dict(hud.get("plugin"))
+    topology = _dict(hud.get("target_topology"))
+    executor = _dict(hud.get("executor"))
+    current_executor = (
+        str(current_executor_row.get("executor_profile", "") or "")
+        if current_executor_row
+        else str(executor.get("default", "") or "choose")
+    )
+    dispatch_policy = (
+        str(_dict(current_executor_row.get("handoff")).get("dispatch_policy", "") or "ask_before_dispatch")
+        if current_executor_row
+        else str(executor.get("dispatch_policy", "") or "ask_before_dispatch")
+    )
+    return {
+        "omh_connection": _setting(
+            value=str(plugin.get("status", "") or "unknown"),
+            label=_plugin_status_label(str(plugin.get("status", "") or "unknown")),
+            raw=f"plugin:{plugin.get('status', 'unknown')}",
+        ),
+        "hermes_targets": _setting(
+            value=_target_value(topology, hermes_agents),
+            label=_target_label(topology, hermes_agents),
+            raw=f"target:{_target_value(topology, hermes_agents)}",
+        ),
+        "coding_handoff": _setting(
+            value=current_executor,
+            label=f"Coding handoff: {_executor_setting_label(current_executor)}",
+            raw=f"coding_handoff:{current_executor}",
+        ),
+        "send_mode": _setting(
+            value=dispatch_policy,
+            label=_dispatch_policy_label(dispatch_policy, current_executor),
+            raw=f"dispatch_policy:{dispatch_policy}",
+        ),
+    }
+
+
+def _versions(hud: dict[str, Any]) -> dict[str, Any]:
+    omh_version = str(hud.get("version", "") or "unknown")
+    return {
+        "omh": {
+            "value": omh_version,
+            "label": f"OMH version: {omh_version}",
+            "observed": omh_version != "unknown",
+        },
+        "hermes": {
+            "value": "unknown",
+            "label": "Hermes version: Not observed",
+            "observed": False,
+        },
+    }
+
+
+def _display(
+    settings: dict[str, Any],
+    hermes_agents: list[dict[str, Any]],
+    current_executor_row: dict[str, Any],
+) -> dict[str, str]:
+    headline = "OMH ready" if settings["omh_connection"]["value"] == "ready" else "OMH needs attention"
+    pieces = [f"{len(hermes_agents)} Hermes target(s)"]
+    if current_executor_row:
+        pieces.append(f"{current_executor_row['name']} {current_executor_row['status_label'].lower()}")
+    else:
+        pieces.append("no external executor handoff")
+    return {
+        "menu_title": "omh",
+        "headline": headline,
+        "summary_line": " · ".join(pieces),
+    }
+
+
+def _source_icon_id(source: str) -> str:
+    normalized = source.strip().lower()
+    if "discord" in normalized:
+        return "source.discord"
+    if "slack" in normalized:
+        return "source.slack"
+    if "telegram" in normalized:
+        return "source.telegram"
+    if "whatsapp" in normalized:
+        return "source.whatsapp"
+    if "signal" in normalized:
+        return "source.signal"
+    if "hermes" in normalized:
+        return "source.hermes"
+    if "cli" in normalized:
+        return "source.cli"
+    if normalized in {"setup", "local", "generic"}:
+        return "source.local"
+    return "source.unknown"
+
+
+def _model_icon_id(model: str) -> str:
+    normalized = model.strip().lower()
+    if not normalized:
+        return "model.unknown"
+    if normalized.startswith(("gpt-", "o1", "o3", "o4", "o5")) or "openai" in normalized:
+        return "model.openai"
+    if "claude" in normalized or "anthropic" in normalized:
+        return "model.anthropic"
+    if "gemini" in normalized or "google" in normalized:
+        return "model.google"
+    if any(token in normalized for token in ("local", "ollama", "lm studio", "lmstudio")):
+        return "model.local"
+    return "model.other"
+
+
+def _icon_catalog(labels: dict[str, str]) -> list[dict[str, str]]:
+    return [{"icon_id": icon_id, "label": label} for icon_id, label in sorted(labels.items())]
+
+
+def _hermes_agent_summary(record: dict[str, Any]) -> str:
+    source = source_icon_descriptor(str(record.get("source", "") or ""), channel_ref=str(record.get("target_ref", "") or ""))
+    return f"Hermes target configured from {source['tooltip']}; process status is not observed."
+
+
+def _external_executor_summary(prepared: dict[str, Any], executor_profile: str, source_metadata: dict[str, Any]) -> str:
+    workflow = str(prepared.get("workflow", "") or "workflow")
+    channel_ref = str(source_metadata.get("channel_ref", "") or "")
+    channel = f" in channel {channel_ref}" if channel_ref else ""
+    return f"{executor_label(executor_profile)} handoff prepared for {workflow}{channel}; execution is not observed."
+
+
+def _apply_process_overlay(
+    hermes_agents: list[dict[str, Any]],
+    external_executors: list[dict[str, Any]],
+    *,
+    process_overlay: dict[str, Any] | None,
+    now: datetime | str | None,
+) -> dict[str, Any]:
+    if not process_overlay:
+        return _overlay_summary("not_supplied")
+    schema = str(process_overlay.get("schema_version", "") or "")
+    if schema != PROCESS_OVERLAY_SCHEMA_VERSION:
+        return _overlay_summary("invalid", errors=[f"unsupported process overlay schema: {schema!r}"])
+    observed_at = _parse_datetime(str(process_overlay.get("observed_at", "") or ""))
+    if observed_at is None:
+        return _overlay_summary("invalid", errors=["process overlay observed_at must be an ISO timestamp"])
+    current = _coerce_datetime(now)
+    if now is not None and current is None:
+        return _overlay_summary("invalid", errors=["process overlay now must be an ISO timestamp"])
+    if current is None:
+        current = datetime.now(timezone.utc)
+    age_seconds = max(0.0, (current - observed_at).total_seconds())
+    ttl_seconds = _positive_int(process_overlay.get("ttl_seconds"), DEFAULT_PROCESS_OVERLAY_TTL_SECONDS)
+    restart_window_seconds = _positive_int(process_overlay.get("restart_window_seconds"), DEFAULT_RESTART_WINDOW_SECONDS)
+    if age_seconds > ttl_seconds:
+        return _overlay_summary(
+            "expired",
+            observed_at=observed_at,
+            age_seconds=age_seconds,
+            ttl_seconds=ttl_seconds,
+            restart_window_seconds=restart_window_seconds,
+        )
+    overlay_rows = _overlay_rows(process_overlay)
+    applied: list[dict[str, str]] = []
+    skipped: list[dict[str, str]] = _external_overlay_identity_skips(overlay_rows, external_executors)
+    for row in hermes_agents:
+        _apply_overlay_to_row(
+            row,
+            overlay_rows,
+            kind="hermes_agent",
+            observed_at=observed_at,
+            age_seconds=age_seconds,
+            ttl_seconds=ttl_seconds,
+            restart_window_seconds=restart_window_seconds,
+            applied=applied,
+            skipped=skipped,
+        )
+    for row in external_executors:
+        _apply_overlay_to_row(
+            row,
+            overlay_rows,
+            kind="external_coding_executor",
+            observed_at=observed_at,
+            age_seconds=age_seconds,
+            ttl_seconds=ttl_seconds,
+            restart_window_seconds=restart_window_seconds,
+            applied=applied,
+            skipped=skipped,
+        )
+    return _overlay_summary(
+        "applied",
+        observed_at=observed_at,
+        age_seconds=age_seconds,
+        ttl_seconds=ttl_seconds,
+        restart_window_seconds=restart_window_seconds,
+        applied=applied,
+        skipped=skipped,
+    )
+
+
+def _apply_overlay_to_row(
+    row: dict[str, Any],
+    overlay_rows: list[dict[str, Any]],
+    *,
+    kind: str,
+    observed_at: datetime,
+    age_seconds: float,
+    ttl_seconds: int,
+    restart_window_seconds: int,
+    applied: list[dict[str, str]],
+    skipped: list[dict[str, str]],
+) -> None:
+    overlay = _matching_overlay(row, overlay_rows, kind=kind)
+    if not overlay:
+        return
+    status = str(overlay.get("status", "") or "").strip().lower()
+    if status not in _OBSERVED_PROCESS_STATUSES:
+        skipped.append({"row_id": str(row.get("id", "")), "reason": "unsupported_status"})
+        return
+    if status == "restarting" and age_seconds > restart_window_seconds:
+        skipped.append({"row_id": str(row.get("id", "")), "reason": "restart_window_expired"})
+        return
+    pid = _positive_int(overlay.get("pid"), 0)
+    if pid:
+        row["pid"] = pid
+        row["pid_label"] = f"PID {pid}"
+        row["pid_observed"] = True
+    row["status"] = status
+    row["status_label"] = status.title()
+    row["status_observed"] = True
+    summary = str(overlay.get("summary", "") or "").strip()
+    if summary:
+        row["summary"] = summary
+    model = _model_value(overlay)
+    if model:
+        row["model"] = model_icon_descriptor(model)
+    evidence = _dict(row.get("evidence"))
+    evidence["process_overlay"] = {
+        "schema_version": PROCESS_OVERLAY_SCHEMA_VERSION,
+        "state": "observed",
+        "observed_at": _format_datetime(observed_at),
+        "age_seconds": round(age_seconds, 3),
+        "ttl_seconds": ttl_seconds,
+        "restart_window_seconds": restart_window_seconds,
+    }
+    row["evidence"] = evidence
+    applied.append({"row_id": str(row.get("id", "")), "status": status})
+
+
+def _overlay_rows(process_overlay: dict[str, Any]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for item in _list(process_overlay.get("items")):
+        rows.append(item)
+    for item in _list(process_overlay.get("agents")):
+        rows.append({"kind": "hermes_agent", **item})
+    for item in _list(process_overlay.get("hermes_agents")):
+        rows.append({"kind": "hermes_agent", **item})
+    for item in _list(process_overlay.get("external_coding_executors")):
+        rows.append({"kind": "external_coding_executor", **item})
+    return rows
+
+
+def _matching_overlay(row: dict[str, Any], overlay_rows: list[dict[str, Any]], *, kind: str) -> dict[str, Any]:
+    row_id = str(row.get("id", "") or "")
+    name = str(row.get("name", "") or "")
+    executor_profile = str(row.get("executor_profile", "") or "")
+    run_id = str(_dict(row.get("evidence")).get("run_id", "") or "")
+    for overlay in overlay_rows:
+        if str(overlay.get("kind", "") or "") != kind:
+            continue
+        overlay_id = str(overlay.get("id", "") or "")
+        if overlay_id and overlay_id == row_id:
+            return overlay
+        if kind == "external_coding_executor":
+            overlay_profile = str(overlay.get("executor_profile", "") or "")
+            overlay_run_id = str(overlay.get("run_id", "") or "")
+            if overlay_profile == executor_profile and overlay_run_id and overlay_run_id == run_id:
+                return overlay
+            continue
+        overlay_name = str(overlay.get("name", "") or "")
+        if overlay_name and overlay_name == name:
+            return overlay
+    return {}
+
+
+def _external_overlay_identity_skips(
+    overlay_rows: list[dict[str, Any]],
+    external_executors: list[dict[str, Any]],
+) -> list[dict[str, str]]:
+    executor_profiles = {str(row.get("executor_profile", "") or "") for row in external_executors}
+    skipped: list[dict[str, str]] = []
+    for overlay in overlay_rows:
+        if str(overlay.get("kind", "") or "") != "external_coding_executor":
+            continue
+        if str(overlay.get("id", "") or "") or str(overlay.get("run_id", "") or ""):
+            continue
+        profile = str(overlay.get("executor_profile", "") or "")
+        if profile and profile in executor_profiles:
+            skipped.append(
+                {
+                    "row_id": "",
+                    "reason": "external_executor_run_id_required",
+                    "executor_profile": profile,
+                }
+            )
+    return skipped
+
+
+def _overlay_summary(
+    status: str,
+    *,
+    observed_at: datetime | None = None,
+    age_seconds: float | None = None,
+    ttl_seconds: int = DEFAULT_PROCESS_OVERLAY_TTL_SECONDS,
+    restart_window_seconds: int = DEFAULT_RESTART_WINDOW_SECONDS,
+    applied: list[dict[str, str]] | None = None,
+    skipped: list[dict[str, str]] | None = None,
+    errors: list[str] | None = None,
+) -> dict[str, Any]:
+    return {
+        "schema_version": PROCESS_OVERLAY_SCHEMA_VERSION,
+        "status": status,
+        "observed_at": _format_datetime(observed_at) if observed_at else "",
+        "age_seconds": round(age_seconds, 3) if age_seconds is not None else None,
+        "ttl_seconds": ttl_seconds,
+        "restart_window_seconds": restart_window_seconds,
+        "applied_count": len(applied or []),
+        "skipped_count": len(skipped or []),
+        "applied": applied or [],
+        "skipped": skipped or [],
+        "errors": errors or [],
+        "claim_boundary": (
+            "Process status is applied only from this caller-provided overlay. OMH does not scan processes or infer PID state."
+        ),
+    }
+
+
+def _parse_datetime(value: str) -> datetime | None:
+    if not value:
+        return None
+    normalized = value.replace("Z", "+00:00")
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _coerce_datetime(value: datetime | str | None) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        parsed = value
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
+    return _parse_datetime(str(value))
+
+
+def _format_datetime(value: datetime) -> str:
+    return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _list(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, dict)]
+
+
+def _external_executor_status_label(status: str) -> str:
+    labels = {
+        "observed": "Observed",
+        "prepared": "Prepared",
+        "not_observed": "Not observed",
+    }
+    return labels.get(status, status.replace("_", " ").title())
+
+
+def _dispatch_policy(status: dict[str, Any], coding: dict[str, Any]) -> str:
+    prepared = _dict(status.get("prepared"))
+    handoff = _dict(status.get("handoff_contract"))
+    raw_handoff = _dict(coding.get("executor_handoff"))
+    for source in (raw_handoff, coding, handoff, prepared):
+        value = str(source.get("dispatch_policy", "") or "")
+        if value:
+            return value
+    return "ask_before_dispatch"
+
+
+def _plugin_status_label(status: str) -> str:
+    labels = {
+        "ready": "OMH connection: Ready",
+        "stale": "OMH connection: Update needed",
+        "installed": "OMH connection: Installed",
+        "missing": "OMH connection: Not installed",
+        "unknown": "OMH connection: Unknown",
+    }
+    return labels.get(status, f"OMH connection: {status.replace('_', ' ').title()}")
+
+
+def _target_value(topology: dict[str, Any], hermes_agents: list[dict[str, Any]]) -> str:
+    count = _safe_int(topology.get("active_agent_count"), len(hermes_agents))
+    if count > 1:
+        return f"multi:{count}"
+    if count == 1:
+        return "single:1"
+    return "none"
+
+
+def _target_label(topology: dict[str, Any], hermes_agents: list[dict[str, Any]]) -> str:
+    count = _safe_int(topology.get("active_agent_count"), len(hermes_agents))
+    if count == 0:
+        return "Hermes targets: None observed"
+    return f"Hermes targets: {count}"
+
+
+def _executor_setting_label(executor_profile: str) -> str:
+    if executor_profile == "choose":
+        return "Ask each time"
+    return executor_label(executor_profile)
+
+
+def _dispatch_policy_label(dispatch_policy: str, executor_profile: str) -> str:
+    if dispatch_policy == "ask_before_dispatch":
+        target = executor_label(executor_profile)
+        return f"Send mode: Ask before opening {target}" if executor_profile != "choose" else "Send mode: Ask before choosing"
+    if dispatch_policy == "prepare_only":
+        return "Send mode: Prepare only"
+    if dispatch_policy == "configured_auto_dispatch_reserved":
+        return "Send mode: Auto dispatch reserved"
+    return f"Send mode: {dispatch_policy.replace('_', ' ')}"
+
+
+def _setting(*, value: str, label: str, raw: str) -> dict[str, str]:
+    return {
+        "value": value,
+        "label": label,
+        "raw": raw,
+    }
+
+
+def _model_value(record: dict[str, Any]) -> str:
+    for key in ("model", "model_ref", "model_name", "model_id"):
+        value = str(record.get(key, "") or "").strip()
+        if value:
+            return value
+    provider = str(record.get("model_provider", "") or "").strip()
+    return provider
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _safe_int(value: Any, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _positive_int(value: Any, default: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default
+
+
+def _safe_limit(value: Any, *, default: int, maximum: int = 20) -> int:
+    return max(0, min(_safe_int(value, default), maximum))

--- a/tests/test_menubar_status.py
+++ b/tests/test_menubar_status.py
@@ -1,0 +1,407 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from _cli_harness import run_cli
+from _local_package import load_local_package
+
+load_local_package()
+from omh.menubar_status import build_menubar_status_payload, model_icon_descriptor, source_icon_descriptor
+from omh.paths import resolve_paths
+from omh.targets import record_target_observation
+
+
+class MenubarStatusTests(unittest.TestCase):
+    def test_menubar_status_keeps_hermes_agents_and_external_executors_separate(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / ".omh"
+            hermes_home = root / ".hermes"
+            self.assertEqual(run_cli(["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "setup"])[0], 0)
+            status, stdout, stderr = run_cli(
+                [
+                    "--omh-home",
+                    str(omh_home),
+                    "--hermes-home",
+                    str(hermes_home),
+                    "coding",
+                    "delegate",
+                    "--record",
+                    "--executor",
+                    "codex",
+                    "--source",
+                    "discord",
+                    "--channel-ref",
+                    "C123",
+                    "Safely add feature without overclaiming.",
+                ]
+            )
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+
+            status, stdout, stderr = run_cli(
+                ["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "menubar", "status"]
+            )
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            payload = json.loads(stdout)
+            self.assertEqual(payload["schema_version"], "menubar_status/v1")
+            self.assertEqual(payload["display"]["menu_title"], "omh")
+            self.assertEqual(payload["versions"]["omh"]["value"], "1.0.0")
+            self.assertEqual(payload["versions"]["hermes"]["value"], "unknown")
+            self.assertFalse(payload["versions"]["hermes"]["observed"])
+            self.assertEqual(payload["settings"]["omh_connection"]["label"], "OMH connection: Ready")
+            self.assertEqual(payload["settings"]["hermes_targets"]["label"], "Hermes targets: 1")
+            self.assertEqual(payload["settings"]["coding_handoff"]["label"], "Coding handoff: Codex")
+            self.assertEqual(payload["settings"]["send_mode"]["label"], "Send mode: Ask before opening Codex")
+
+            hermes_agents = payload["hermes_agents"]
+            self.assertEqual(len(hermes_agents), 1)
+            self.assertEqual(hermes_agents[0]["kind"], "hermes_agent")
+            self.assertTrue(hermes_agents[0]["is_hermes_agent"])
+            self.assertEqual(hermes_agents[0]["status"], "configured")
+            self.assertFalse(hermes_agents[0]["status_observed"])
+            self.assertIsNone(hermes_agents[0]["pid"])
+            self.assertFalse(hermes_agents[0]["pid_observed"])
+            self.assertEqual(hermes_agents[0]["source"]["icon_id"], "source.local")
+            self.assertEqual(hermes_agents[0]["model"]["icon_id"], "model.unknown")
+
+            executors = payload["external_coding_executors"]
+            self.assertEqual(len(executors), 1)
+            self.assertEqual(executors[0]["kind"], "external_coding_executor")
+            self.assertFalse(executors[0]["is_hermes_agent"])
+            self.assertEqual(executors[0]["name"], "Codex")
+            self.assertEqual(executors[0]["executor_profile"], "codex")
+            self.assertEqual(executors[0]["status"], "prepared")
+            self.assertFalse(executors[0]["status_observed"])
+            self.assertIsNone(executors[0]["pid"])
+            self.assertFalse(executors[0]["pid_observed"])
+            self.assertEqual(executors[0]["source"]["icon_id"], "source.discord")
+            self.assertEqual(executors[0]["source"]["tooltip"], "Discord: C123")
+            self.assertEqual(executors[0]["model"]["icon_id"], "model.unknown")
+            self.assertTrue(executors[0]["handoff"]["dispatchable"])
+            self.assertEqual(executors[0]["handoff"]["dispatch_policy"], "ask_before_dispatch")
+            self.assertEqual(executors[0]["evidence"]["state"], "prepared_not_observed")
+            self.assertNotIn("Codex", [agent["name"] for agent in hermes_agents])
+            current = payload["current_external_coding_executor"]
+            self.assertTrue(current["selected"])
+            self.assertEqual(current["selection_source"], "runtime_state.last_run_id")
+            self.assertEqual(current["row_id"], executors[0]["id"])
+            self.assertEqual(current["run_id"], executors[0]["evidence"]["run_id"])
+
+    def test_process_overlay_applies_pid_status_and_model_only_when_fresh(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / ".omh"
+            hermes_home = root / ".hermes"
+            self.assertEqual(run_cli(["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "setup"])[0], 0)
+            self.assertEqual(
+                run_cli(
+                    [
+                        "--omh-home",
+                        str(omh_home),
+                        "--hermes-home",
+                        str(hermes_home),
+                        "coding",
+                        "delegate",
+                        "--record",
+                        "--executor",
+                        "codex",
+                        "--source",
+                        "discord",
+                        "--channel-ref",
+                        "C123",
+                        "Safely add feature without overclaiming.",
+                    ]
+                )[0],
+                0,
+            )
+            base_status, base_stdout, _ = run_cli(
+                ["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "menubar", "status"]
+            )
+            self.assertEqual(base_status, 0)
+            base = json.loads(base_stdout)
+            run_id = base["external_coding_executors"][0]["evidence"]["run_id"]
+            target_id = base["hermes_agents"][0]["id"]
+            overlay_path = root / "overlay.json"
+            overlay_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": "menubar_process_overlay/v1",
+                        "observed_at": "2026-06-18T00:00:00Z",
+                        "ttl_seconds": 10,
+                        "restart_window_seconds": 20,
+                        "agents": [
+                            {
+                                "id": target_id,
+                                "pid": 4312,
+                                "status": "running",
+                                "summary": "Hermes agent is serving Discord.",
+                                "model": "gpt-5.5",
+                            }
+                        ],
+                        "external_coding_executors": [
+                            {
+                                "executor_profile": "codex",
+                                "run_id": run_id,
+                                "pid": 9821,
+                                "status": "restarting",
+                                "summary": "Codex handoff window is reopening.",
+                                "model": "gpt-5.5",
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            status, stdout, stderr = run_cli(
+                [
+                    "--omh-home",
+                    str(omh_home),
+                    "--hermes-home",
+                    str(hermes_home),
+                    "menubar",
+                    "status",
+                    "--overlay",
+                    str(overlay_path),
+                    "--now",
+                    "2026-06-18T00:00:05Z",
+                ]
+            )
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            payload = json.loads(stdout)
+            self.assertEqual(payload["process_overlay"]["status"], "applied")
+            self.assertEqual(payload["process_overlay"]["applied_count"], 2)
+            self.assertEqual(payload["hermes_agents"][0]["pid"], 4312)
+            self.assertEqual(payload["hermes_agents"][0]["status"], "running")
+            self.assertTrue(payload["hermes_agents"][0]["pid_observed"])
+            self.assertTrue(payload["hermes_agents"][0]["status_observed"])
+            self.assertEqual(payload["hermes_agents"][0]["model"]["icon_id"], "model.openai")
+            self.assertEqual(payload["external_coding_executors"][0]["pid"], 9821)
+            self.assertEqual(payload["external_coding_executors"][0]["status"], "restarting")
+            self.assertTrue(payload["external_coding_executors"][0]["pid_observed"])
+            self.assertTrue(payload["external_coding_executors"][0]["status_observed"])
+            self.assertEqual(payload["external_coding_executors"][0]["model"]["tooltip"], "gpt-5.5")
+
+            status, stdout, stderr = run_cli(
+                [
+                    "--omh-home",
+                    str(omh_home),
+                    "--hermes-home",
+                    str(hermes_home),
+                    "menubar",
+                    "status",
+                    "--overlay",
+                    str(overlay_path),
+                    "--now",
+                    "2026-06-18T00:00:30Z",
+                ]
+            )
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            expired = json.loads(stdout)
+            self.assertEqual(expired["process_overlay"]["status"], "expired")
+            self.assertEqual(expired["process_overlay"]["applied_count"], 0)
+            self.assertIsNone(expired["hermes_agents"][0]["pid"])
+            self.assertEqual(expired["hermes_agents"][0]["status"], "configured")
+            self.assertIsNone(expired["external_coding_executors"][0]["pid"])
+            self.assertEqual(expired["external_coding_executors"][0]["status"], "prepared")
+
+    def test_restart_overlay_expires_independently_inside_ttl(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = resolve_paths(root / ".omh", root / ".hermes-a")
+            record_target_observation(paths, source="setup")
+            target_id = build_menubar_status_payload(paths)["hermes_agents"][0]["id"]
+
+            payload = build_menubar_status_payload(
+                paths,
+                process_overlay={
+                    "schema_version": "menubar_process_overlay/v1",
+                    "observed_at": "2026-06-18T00:00:00Z",
+                    "ttl_seconds": 60,
+                    "restart_window_seconds": 20,
+                    "agents": [{"id": target_id, "pid": 4312, "status": "restarting"}],
+                },
+                now="2026-06-18T00:00:30Z",
+            )
+
+            self.assertEqual(payload["process_overlay"]["status"], "applied")
+            self.assertEqual(payload["process_overlay"]["applied_count"], 0)
+            self.assertEqual(payload["process_overlay"]["skipped_count"], 1)
+            self.assertEqual(payload["process_overlay"]["skipped"][0]["reason"], "restart_window_expired")
+            self.assertIsNone(payload["hermes_agents"][0]["pid"])
+            self.assertEqual(payload["hermes_agents"][0]["status"], "configured")
+
+    def test_invalid_overlay_now_is_reported_without_applying_process_state(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = resolve_paths(root / ".omh", root / ".hermes-a")
+            record_target_observation(paths, source="setup")
+            target_id = build_menubar_status_payload(paths)["hermes_agents"][0]["id"]
+
+            payload = build_menubar_status_payload(
+                paths,
+                process_overlay={
+                    "schema_version": "menubar_process_overlay/v1",
+                    "observed_at": "2026-06-18T00:00:00Z",
+                    "agents": [{"id": target_id, "pid": 4312, "status": "running"}],
+                },
+                now="not-a-time",
+            )
+
+            self.assertEqual(payload["process_overlay"]["status"], "invalid")
+            self.assertIn("now must be an ISO timestamp", payload["process_overlay"]["errors"][0])
+            self.assertIsNone(payload["hermes_agents"][0]["pid"])
+            self.assertEqual(payload["hermes_agents"][0]["status"], "configured")
+
+    def test_direct_overlay_schema_is_validated_before_applying_process_state(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = resolve_paths(root / ".omh", root / ".hermes-a")
+            record_target_observation(paths, source="setup")
+            target_id = build_menubar_status_payload(paths)["hermes_agents"][0]["id"]
+
+            payload = build_menubar_status_payload(
+                paths,
+                process_overlay={
+                    "schema_version": "wrong/v1",
+                    "observed_at": "2026-06-18T00:00:00Z",
+                    "agents": [{"id": target_id, "pid": 4312, "status": "running"}],
+                },
+                now="2026-06-18T00:00:05Z",
+            )
+
+            self.assertEqual(payload["process_overlay"]["status"], "invalid")
+            self.assertIn("unsupported process overlay schema", payload["process_overlay"]["errors"][0])
+            self.assertIsNone(payload["hermes_agents"][0]["pid"])
+            self.assertEqual(payload["hermes_agents"][0]["status"], "configured")
+
+    def test_external_executor_overlay_requires_run_identity_when_multiple_runs_exist(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / ".omh"
+            hermes_home = root / ".hermes"
+            self.assertEqual(run_cli(["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "setup"])[0], 0)
+            for message in ("First coding task.", "Second coding task."):
+                self.assertEqual(
+                    run_cli(
+                        [
+                            "--omh-home",
+                            str(omh_home),
+                            "--hermes-home",
+                            str(hermes_home),
+                            "coding",
+                            "delegate",
+                            "--record",
+                            "--executor",
+                            "codex",
+                            "--source",
+                            "discord",
+                            "--channel-ref",
+                            "C123",
+                            message,
+                        ]
+                    )[0],
+                    0,
+                )
+            paths = resolve_paths(omh_home, hermes_home)
+            base = build_menubar_status_payload(paths, limit=5)
+            self.assertEqual(len(base["external_coding_executors"]), 2)
+            current = base["current_external_coding_executor"]
+            self.assertTrue(current["selected"])
+            self.assertEqual(current["selection_source"], "runtime_state.last_run_id")
+
+            ambiguous = build_menubar_status_payload(
+                paths,
+                limit=5,
+                process_overlay={
+                    "schema_version": "menubar_process_overlay/v1",
+                    "observed_at": "2026-06-18T00:00:00Z",
+                    "external_coding_executors": [
+                        {"executor_profile": "codex", "pid": 1111, "status": "running"}
+                    ],
+                },
+                now="2026-06-18T00:00:05Z",
+            )
+
+            self.assertEqual(ambiguous["process_overlay"]["applied_count"], 0)
+            self.assertEqual(ambiguous["process_overlay"]["skipped_count"], 1)
+            self.assertEqual(ambiguous["process_overlay"]["skipped"][0]["reason"], "external_executor_run_id_required")
+            self.assertTrue(all(row["pid"] is None for row in ambiguous["external_coding_executors"]))
+            self.assertTrue(all(row["status"] == "prepared" for row in ambiguous["external_coding_executors"]))
+
+            exact = build_menubar_status_payload(
+                paths,
+                limit=5,
+                process_overlay={
+                    "schema_version": "menubar_process_overlay/v1",
+                    "observed_at": "2026-06-18T00:00:00Z",
+                    "external_coding_executors": [
+                        {
+                            "executor_profile": "codex",
+                            "run_id": current["run_id"],
+                            "pid": 2222,
+                            "status": "running",
+                        }
+                    ],
+                },
+                now="2026-06-18T00:00:05Z",
+            )
+
+            observed_rows = [row for row in exact["external_coding_executors"] if row["pid_observed"]]
+            self.assertEqual(len(observed_rows), 1)
+            self.assertEqual(observed_rows[0]["evidence"]["run_id"], current["run_id"])
+            self.assertEqual(observed_rows[0]["pid"], 2222)
+            self.assertEqual(exact["process_overlay"]["applied_count"], 1)
+
+    def test_menubar_status_reports_multi_target_source_icons_without_process_claims(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = resolve_paths(root / ".omh", root / ".hermes-a")
+            record_target_observation(paths, source="setup")
+            record_target_observation(
+                paths,
+                source="chat:slack",
+                source_metadata={
+                    "agent_ref": "agent-b",
+                    "target_ref": "workspace-b",
+                    "hermes_home": str(root / ".hermes-b"),
+                    "agent_count": "2",
+                },
+            )
+
+            payload = build_menubar_status_payload(paths)
+
+            self.assertEqual(payload["settings"]["hermes_targets"]["value"], "multi:2")
+            self.assertEqual(payload["settings"]["hermes_targets"]["label"], "Hermes targets: 2")
+            self.assertEqual(len(payload["hermes_agents"]), 2)
+            slack_rows = [row for row in payload["hermes_agents"] if row["source"]["icon_id"] == "source.slack"]
+            self.assertEqual(len(slack_rows), 1)
+            self.assertEqual(slack_rows[0]["source"]["tooltip"], "Slack: workspace-b")
+            self.assertEqual(slack_rows[0]["status"], "configured")
+            self.assertFalse(slack_rows[0]["status_observed"])
+            self.assertIsNone(slack_rows[0]["pid"])
+            self.assertFalse(slack_rows[0]["pid_observed"])
+
+    def test_icon_descriptors_keep_logo_ids_and_tooltips_separate(self) -> None:
+        self.assertEqual(source_icon_descriptor("chat:telegram", channel_ref="room-7")["icon_id"], "source.telegram")
+        self.assertEqual(source_icon_descriptor("chat:telegram", channel_ref="room-7")["tooltip"], "Telegram: room-7")
+        self.assertEqual(source_icon_descriptor("signal")["icon_id"], "source.signal")
+        self.assertEqual(source_icon_descriptor("whatsapp")["icon_id"], "source.whatsapp")
+        self.assertEqual(model_icon_descriptor("gpt-5.5")["icon_id"], "model.openai")
+        self.assertEqual(model_icon_descriptor("claude-sonnet")["icon_id"], "model.anthropic")
+        self.assertEqual(model_icon_descriptor("gemini-3")["icon_id"], "model.google")
+        self.assertEqual(model_icon_descriptor("ollama/llama")["icon_id"], "model.local")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- Added `omh menubar status`, a deterministic `menubar_status/v1` backend payload for future macOS menu bar/status-widget integrations.
- Added separate `hermes_agents` and `external_coding_executors` sections so Codex and other coding tools cannot be rendered as Hermes agents by accident.
- Added source/model `icon_id` values with tooltip text for compact renderers such as Discord, Slack, Telegram, and native menu bar UI.
- Added optional `menubar_process_overlay/v1` support so PID, `running`, and `restarting` status are applied only from caller-provided observed process state.
- Added AGENTS.md guidance requiring future coding tasks to start from a dedicated `codex/` task branch unless the current branch is already clearly dedicated to the exact user goal.

### Why This Exists

The user asked for a macOS header/menu bar OMH surface that can show which Hermes agents are present, what they are doing, which channel/source they came from, what model is configured, and which coding handoff is selected. The same discussion also clarified an important product boundary: Codex is not a Hermes agent. OMH should expose a usable status contract without turning prepared handoffs into observed execution or silently scanning host processes.

### User / Operator Impact

- Operators can run `omh menubar status` and inspect the exact JSON contract a future native menu bar app can consume.
- Compact UI consumers get icon IDs and tooltips instead of fragile Markdown tables or prose-only labels.
- The payload can show friendly settings such as `OMH connection: Ready`, `Hermes targets: 2`, `Coding handoff: Codex`, and `Send mode: Ask before opening Codex`.
- Process status remains conservative: without an explicit overlay, PID and running/restarting values stay unobserved.
- Future agents are now instructed to branch before implementation work, reducing accidental mixing with unrelated branch history or user changes.

### How It Works

- `src/menubar_status.py` builds `menubar_status/v1` from the existing HUD payload, Hermes target registry, and delegated coding runtime records.
- Hermes rows are emitted as `kind: hermes_agent` with `is_hermes_agent: true`.
- External coding rows are emitted as `kind: external_coding_executor` with `is_hermes_agent: false`, preserving the Hermes-agent versus Codex-executor boundary.
- `current_external_coding_executor` explicitly names the selected row, preferring `runtime/state.json` `last_run_id` when it matches the recent executor list.
- `menubar_process_overlay/v1` is accepted only from `--overlay` or direct test/backend input, validates schema and timestamps, expires by TTL, and requires exact external executor identity by row id or `(executor_profile, run_id)`.
- `src/commands/menubar.py` wires the CLI adapter while `src/commands/main.py` exposes the command in help and parser setup.

### Files And Contracts Touched

- `AGENTS.md`: branch hygiene rule for future agents.
- `src/menubar_status.py`: new status projection and overlay contract.
- `src/commands/menubar.py`: new CLI command adapter.
- `src/commands/main.py`: command registration and help copy.
- `tests/test_menubar_status.py`: regression coverage for separation, icon descriptors, overlay TTL/restart behavior, invalid overlay handling, and exact external executor identity.
- `docs/ARCHITECTURE.md`: backend contract and evidence-boundary documentation.
- `docs/INSTALLATION.md`: operator usage for `omh menubar status` and `--overlay`.

## Validation

- [x] `python3 -m unittest discover -s tests`
  - Observed equivalent: `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` passed with 488 tests.
- [x] `python3 -m compileall src`
  - Observed equivalent: `uv run python -m compileall -q src tests` passed.
- [x] `python3 -m omh.cli docs workflows --check`
  - Observed equivalent: `uv run python -m src.cli docs workflows --check` passed.
- [ ] `python3 -m omh.cli harness validate`
  - Not run; this change is limited to menu bar projection, docs, and command wiring. Existing workflow docs check and full unittest discovery were run instead.
- [ ] `python3 -m omh.cli release checklist --json`
  - Not run; this is not a release checklist change.
- [ ] `python3 -m omh.cli release hermes-smoke`
  - Not run; no Hermes runtime/native transport behavior is claimed.
- [x] `omh --help`
  - Independent reviewer observed `omh menubar status --help`; parser/help wiring was also covered by CLI smoke and tests.
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
  - Not run; this PR does not change install packaging or Hermes plugin loading.
- [x] Relevant dry-run or smoke command:
  - `uv run python -m src.cli menubar status` emitted `menubar_status/v1` JSON.
- [x] Manual Hermes/TUI check, or explicit reason it was not run:
  - Native macOS MenuBarExtra rendering was not run because this PR intentionally adds only the backend JSON contract, not the native app.

Additional checks:

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_menubar_status.py -v` passed with 8 tests.
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_menubar_status.py tests/test_hud.py tests/test_architecture_layout.py -v` passed with 16 tests.
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_router_content.py -v` passed with 32 tests.
- [x] `git diff --check` passed.
- [x] Independent code review returned `APPROVE`.
- [x] Independent architecture review returned `CLEAR`.

## Risk

- The native menu bar app is not implemented here, so renderer behavior still needs a follow-up app-side PR.
- The `recent_runtime_runs[0]` fallback remains order-based when `runtime_state.last_run_id` is absent, but the payload reports `selection_source` explicitly and does not turn that fallback into process evidence.
- Overlay producers must provide exact run identity for external executor process state; broad profile-only overlays are intentionally skipped.

## Compatibility / Rollout

- Additive CLI surface: existing commands and runtime artifacts remain compatible.
- Additive JSON contract: native or wrapper consumers can adopt `menubar_status/v1` without requiring Hermes core changes.
- Release-channel impact: local/preview backend contract; no stable native UI claim yet.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- Build the actual macOS MenuBarExtra consumer that renders the `omh` menu bar item, source/model icons, hover tooltips, and overlay observations.
- Decide the final tiny menu bar symbol. The backend currently exposes `display.menu_title: "omh"`; visual icon design should happen in the native app/UI PR.