### PR TITLE
Link README ArtEngine images

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,15 @@ easier to start, easier to trust, and more natural to apply in real work.
 > Improve OMH System !!
 >
 > <p align="center">
->   <img src="assets/friren-agent-omh-callout.png" alt="Friren Agent explaining OMH in Art&Engine" width="920">
+>   <a href="https://rlaope.github.io/artengine-lab/">
+>     <img src="assets/friren-agent-omh-callout.png" alt="Friren Agent explaining OMH in Art&Engine" width="920">
+>   </a>
 > </p>
 >
 > <p align="center">
->   <img src="assets/artengine-friren-profile-card.png" alt="Art&Engine profile card for Hope Kim and Friren" width="920">
+>   <a href="https://rlaope.github.io/artengine-lab/">
+>     <img src="assets/artengine-friren-profile-card.png" alt="Art&Engine profile card for Hope Kim and Friren" width="920">
+>   </a>
 > </p>
 
 <br>
@@ -111,8 +115,8 @@ registration contracts live in the [installation guide](docs/INSTALLATION.md).
 > **GitHub Follow**
 > Follow [@rlaope](https://github.com/rlaope) on GitHub for OMH updates and
 > related Hermes-native workflow projects.
-> Explore [ArtEngine Lab](https://rlaope.github.io/artengine-lab/) for the
-> Art & Engineering studio behind OMH.
+> Explore [Team Art & Engineering](https://rlaope.github.io/artengine-lab/)
+> for the studio behind OMH.
 
 <br>
 


### PR DESCRIPTION
## Summary
- Makes both README Art&Engine showcase images clickable entry points to ArtEngine Web.
- Renames the lower follow-note link from ArtEngine Lab to Team Art & Engineering.

## Why
The README now includes visual Art&Engine showcase images, but readers could only reach the ArtEngine site through the separate text link below. The images are acting as entry points, so clicking them should take users directly to the ArtEngine web page.

## User Capability
Users reading the README can click either Art&Engine image to open ArtEngine Web, and the lower note now describes the destination as Team Art & Engineering.

## Implementation
- Wrapped `assets/friren-agent-omh-callout.png` in an anchor to `https://rlaope.github.io/artengine-lab/`.
- Wrapped `assets/artengine-friren-profile-card.png` in the same ArtEngine Web anchor.
- Updated the lower GitHub Follow note link text to `Team Art & Engineering`.

## Verification
- `git diff --check -- README.md`
- `uv run python -m src.cli docs workflows --check`

## Risks / Follow-up
- GitHub README rendering was not manually opened in a browser after push.
- Scope is limited to README markup and link text.
