### PR TITLE
Clarify img-summary README card

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,9 +164,26 @@ separate until they are recorded as observed evidence. If no image generator is
 connected yet, Hermes can ask which tool to use: a GPT image tool, an existing
 Hermes connector, a generic image tool, or prompt-only mode.
 
-<p align="center">
-  <img src="assets/omh-img-summary-card.png" alt="OMH img-summary workflow card showing prompt preparation and observed image evidence boundaries" width="680">
-</p>
+> <p align="center">
+>   <img src="assets/omh-img-summary-card.png" alt="OMH img-summary workflow card showing prompt preparation and observed image evidence boundaries" width="680">
+> </p>
+>
+> **Made with `img-summary`.** Hermes uses this skill to turn notes, PRs,
+> issues, research, reports, or release notes into a shareable image-card
+> prompt for a connected image tool.
+>
+> **How it works.** OMH prepares `visual_prompt_card/v1`: source kind,
+> source-specific format, readable card copy, generation prompt, negative
+> prompt, QA checklist, and wrapper actions.
+>
+> **Rules.** A prepared card is not a generated image. Image generation,
+> visual QA, attachment, and delivery stay unobserved until a wrapper or user
+> records `visual_observation/v1`.
+>
+> **Screen meaning.** The card shows the expected flow: source material ->
+> prompt card -> connected image tool -> observed evidence. If no image tool is
+> connected, Hermes asks the user to choose GPT image, a Hermes connector, a
+> generic image tool, or prompt-only mode.
 
 <br>
 


### PR DESCRIPTION
## Feature Report

### What Changed

- Updated the root README `img-summary` section so the generated poster image appears inside a quoted callout.
- Added short reader-facing copy explaining that the screen was made with `img-summary`, how the workflow operates, what rules it follows, and what the image means.
- Kept the copy conservative: prepared image-card prompts are still separated from generated image, visual QA, attachment, and delivery evidence.

### Why This Exists

The README image looked useful but did not clearly explain what the reader was looking at. This change makes the public README tell a clearer story: `img-summary` is a Hermes-facing workflow skill that prepares prompt cards for connected image tools, with explicit evidence boundaries.

### User / Operator Impact

A new reader can now understand the image without hunting through docs: OMH prepares `visual_prompt_card/v1`, a wrapper or user uses a connected image tool, and `visual_observation/v1` is required before claiming generation, QA, or delivery.

### Implementation Notes

- README-only change.
- No CLI, schema, runtime, routing, site, or generated skill behavior changed.
- Existing local untracked files were left untouched.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_router_content.py -v` -> passed.
- [x] `git diff --check` -> passed.
- [ ] Full test suite -> not run; this is a README-only copy/layout change and the relevant router/content test was run.

## Risk

- GitHub Markdown rendering of HTML inside blockquotes can vary slightly by client, but the content remains readable as plain Markdown and keeps the image URL intact.
