### PR TITLE
Simplify update docs around omh update

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -696,14 +696,19 @@ Update the managed skill pack from the currently installed `omh` command
 package:
 
 ```sh
-omh update --channel preview
+omh update
 omh doctor
 ```
 
-Use `omh update --channel stable --version <version>` to record a pinned stable
-managed-skill refresh, or `omh update --channel local --from-skills-dir ./skills`
-for a local fixture. Local modifications block updates unless `--force` is
-supplied.
+Most users should run only `omh update`. The command uses the channel and
+version metadata that were installed with the local `omh` package, refreshes the
+managed skills, and records a concise update log.
+
+Advanced operators can still pin or test a different source with
+`omh update --channel stable --version <version>` or
+`omh update --channel local --from-skills-dir ./skills`, but those flags are for
+release validation, fixtures, or intentional rollback testing. Local
+modifications block updates unless `--force` is supplied.
 
 Run `omh doctor` after an update. Use `omh setup` only when doctor reports that
 Hermes registration needs repair, then restart Hermes Agent. `omh update` does

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -893,6 +893,11 @@ class RouterContentTests(unittest.TestCase):
         self.assertIn("OMH_CHANNEL=stable OMH_VERSION=<version>", installation)
         self.assertIn("v<version>", installation)
         self.assertIn("installs generated managed skills", installation)
+        update_section = installation.split("## Update", 1)[1].split("\n## ", 1)[0]
+        self.assertIn("```sh\nomh update\nomh doctor\n```", update_section)
+        self.assertIn("Most users should run only `omh update`.", update_section)
+        self.assertLess(update_section.index("omh update\nomh doctor"), update_section.index("Advanced operators"))
+        self.assertNotIn("omh update --channel preview", update_section)
         self.assertIn("omh setup", readme)
         self.assertIn("omh doctor", readme)
         self.assertLess(readme.index("## Quick Start"), readme.index("## Why OMH"))


### PR DESCRIPTION
## Feature Report

### What Changed

- Updated the installation guide so the normal update path is `omh update` followed by `omh doctor`.
- Moved `--channel`, `--version`, and local fixture update flags into an advanced-operator note.
- Added a docs regression test so the update section keeps the simple command first.

### Why This Exists

- The docs made routine updates look like release validation by leading with `omh update --channel preview` and `omh update --channel stable --version <version>`.
- Normal users should not need to understand channel/version flags to update their managed OMH skills.

### User / Operator Impact

- A user who already installed OMH can read the install guide and run the expected command:

```sh
omh update
omh doctor
```

- Advanced operators can still pin a stable version or use local fixtures, but those flags no longer look like the default user path.

### How It Works

- `docs/INSTALLATION.md` now states that most users should run only `omh update`.
- `tests/test_router_content.py` locks the update section so `omh update` appears before advanced flags and `omh update --channel preview` is not presented as the default.

### Files And Contracts Touched

- `docs/INSTALLATION.md`
- `tests/test_router_content.py`

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_router_content.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m src.cli docs workflows --check`
- [x] `uv run python -m src.cli harness validate`
- [x] `uv run python -m compileall -q src tests`
- [x] `git diff --check`

## Risk

- Narrow documentation-only change. No runtime behavior changes.

## Compatibility / Rollout

- Existing advanced flags remain documented and supported.
- Default user-facing guidance is now simpler.

## Release / Claims

- [x] Release-channel impact considered: docs-only patch.
- [x] Runtime/native capability claims are not changed.
- [x] Live installed `omh update` against a user profile was not run for this docs-only PR.

## Follow-Up

- Keep release docs free to use explicit `--version` where they are clearly release-smoke commands.
