### PR TITLE
Add agent ops productivity review surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ registration contracts live in the [installation guide](docs/INSTALLATION.md).
 | `materials-package` / `report-package` | Shape decks, PDFs, spreadsheets, documents, HWP, Markdown, and upload-ready packages. | "Turn the revenue spreadsheet into an Excel and PDF package." |
 | `img-summary` | Prepare provider-neutral image-card prompts whose format follows the source, whose scene follows the domain, and whose poster archetype sets the design grammar. | "Make a PR summary card for reviewers." |
 | `idea-to-deploy` / coding runtime handoff / executor selection | Prepare work for Codex, Claude Code, Hermes, or another runtime without hiding execution. | "Turn this issue into a PR-ready plan and hand it to implementation." |
+| `agent-ops-review` | Show a manager view of AI-agent research, coding, review, blockers, next actions, and throughput levers. | "As a manager, show the quality and progress of agent work." |
 
 ### Img Summary Skill
 
@@ -208,6 +209,7 @@ tool, an existing Hermes connector, a generic image tool, or prompt-only mode.
 | Setup and repair | `omh setup`, `omh doctor`, `omh update`, and `omh uninstall` keep the local install understandable. |
 | Chat workflow picker | Hermes can answer "what can OMH do?" without making the user approve shell commands. |
 | Coding handoff paths | Hermes can prepare work for Codex, Claude Code, Hermes itself, or another runtime without pretending the work already ran. |
+| Agent ops review | Hermes can explain quality gates, blockers, next actions, and throughput levers for AI-agent work without turning a prepared handoff into evidence. |
 | Evidence-aware status | Plans, handoffs, dispatch, results, verification, review, CI, and merge readiness stay visibly separate. |
 | Organization patterns | Solo, research, product ops, coding runtime, and CTO-style collaboration patterns help Hermes present the right role flow for the request. |
 

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -2311,6 +2311,54 @@ When wrapper metadata reports `omh_target_topology/v1`, skills bind workflow sta
   - An ops observability card is not billing truth, provider quota truth, complete tracing, performance proof, or successful workflow completion evidence.
   - Do not claim connector, gateway, runtime, file generation, memory mutation, or host automation evidence from prepared guidance.
 
+### agent-ops-review
+
+[omh] Hermes agent ops review workflow: help a manager inspect AI-agent research, coding, review, status, blockers, quality gates, and throughput levers.
+
+- Category: `operator`
+- Phase: `manager-review`
+- Hermes role: `tracker`
+- Quality tier: `workflow-surface-gated`
+- Exposure: `workflow_skill`
+- Install visibility: `true`
+- Docs visibility: `primary_workflow_skill`
+- Compatibility alias: `false`
+- Preferred usage: Use as an installed Hermes workflow skill when a manager wants quality, blockers, next actions, and throughput guidance for AI-agent work.
+- Handoff policy: Keep this as Hermes-facing orchestration guidance first. Prepare executor, connector, gateway, or host-runtime handoff only when the user accepts that next step and observed evidence can be recorded.
+- Why this exists: `agent-ops-review` exists so Hermes users can ask for this workflow in chat and receive a structured, evidence-bounded OMH operating surface instead of ad hoc narration.
+- Use when: Use when Hermes should explain AI-agent work from a manager/operator perspective: quality gates, progress, blockers, next actions, and throughput opportunities across research, coding, review, and status.
+- Do not use when:
+  - The request is already handled by a narrower explicit skill with stronger evidence.
+  - The user asks OMH to secretly run external platforms, connectors, schedulers, file exports, or runtime agents.
+  - The only safe answer is to ask for missing authority, credentials, target, or observed evidence first.
+- Strong routing signals: `agent-ops-review`, `agent ops review`, `agent productivity`, `operator productivity`, `manager view`, `quality dashboard`, `throughput review`, `agent work quality`, `coding progress quality`, `research coding review status`, `ai agent manager`, `third-party manager`, `관리자 입장`, `작업 생산량`, `처리량`, `품질 퀄리티`, `작업 품질`, `진행상황`, `리서치 코딩 리뷰`
+- Good example:
+  - Prompt: agent-ops-review show me quality, blockers, and throughput for AI-agent research, coding, and review work.
+  - Expected behavior: Produce `prepare_agent_ops_review` with required context, wrapper actions, and not-evidence boundaries.
+  - Why: The prompt names a real workflow surface that Hermes can orchestrate without hiding execution.
+- Bad example:
+  - Prompt: agent-ops-review claim Codex finished and CI passed because a handoff exists.
+  - Expected behavior: Report the missing observed evidence or authority instead of claiming the external step happened.
+  - Why: Prepared OMH guidance is not platform, runtime, connector, file, memory, or delivery evidence.
+- Quality bar:
+  - Name the user-facing workflow objective, required context, next action, and stop condition.
+  - Separate prepared guidance from observed platform, runtime, connector, file, memory, or delivery evidence.
+  - Expose missing tools, credentials, targets, or observations as user-visible gaps.
+- Required inputs:
+  - user request
+  - target context
+  - delivery or status expectation
+  - known missing evidence
+- Expected outputs:
+  - agent-ops-review/v1 card or guidance
+  - next action
+  - prepared-vs-observed boundary
+- Artifact expectations:
+  - agent-ops-review/v1 metadata-only runtime or wrapper card when recorded
+- Safety rules:
+  - An agent ops review card is not source retrieval, executor dispatch, coding progress, implementation, review, verification, CI, merge-readiness, merge, platform delivery, provider billing, or live runtime telemetry evidence.
+  - Do not claim connector, gateway, runtime, file generation, memory mutation, or host automation evidence from prepared guidance.
+
 ## Representative Harnesses
 
 ### coding-handling
@@ -4006,4 +4054,57 @@ Report wrapper-safe token, cost, latency, run history, queue, and failure-mode t
 - Privacy default: `metadata_only`
 - Overclaim guards:
   - An ops observability card is not billing truth, provider quota truth, complete tracing, performance proof, or workflow completion evidence.
+- Fallback: If a required target, credential, runtime, or observation is missing, show a blocker or confirmation action instead of claiming completion.
+
+### agent-ops-review
+
+Prepare a manager-facing quality and throughput review for AI-agent research, coding, review, and status work.
+
+- Use when: Use when a third-party operator or team lead wants to understand progress, blockers, quality gates, next actions, and safe throughput levers without running shell catalog commands.
+- Quality tier: `manager-review-gated`
+- Quality bar:
+  - Name the workflow objective, owner, input boundary, next action, and stop condition.
+  - Represent prepared, observed, blocked, and missing evidence as separate states.
+  - Never upgrade a card, blueprint, or readiness check into external execution proof.
+- Inputs:
+  - manager request
+  - work context or run/session references when available
+  - target outcome
+  - known evidence gaps
+- Outputs:
+  - agent_operator_productivity/v1
+  - agent_operator_status_card/v1
+  - quality lanes
+  - blockers
+  - next action
+  - throughput levers
+- Stop conditions:
+  - card is prepared or a missing decision is surfaced
+  - observed evidence is separated from prepared guidance
+- Verification:
+  - validate required fields
+  - check not-evidence boundaries
+  - record only observed external actions
+- Evidence ladder:
+  - `manager_scope_recorded`
+  - `quality_lanes_prepared`
+  - `evidence_gaps_named`
+  - `next_action_selected`
+  - `runtime_observation_recorded_when_available`
+- Wrapper actions:
+  - `show_agent_ops_review`
+  - `choose_ops_lane`
+  - `prepare_research_lane`
+  - `prepare_coding_lane`
+  - `prepare_review_lane`
+  - `refresh_agent_ops_status`
+  - `record_agent_ops_observation`
+- Artifact events:
+  - `agent-ops-review_scoped`
+  - `agent-ops-review_card_prepared`
+  - `agent-ops-review_status_recorded`
+- Delegation expectation: Record this harness as Hermes-retained orchestration; external runtime/platform/file/memory/connector evidence requires a separate observed artifact.
+- Privacy default: `metadata_only`
+- Overclaim guards:
+  - An agent ops review card is not source retrieval, executor dispatch, implementation, verification, review, CI, merge, delivery, provider billing, or live telemetry evidence.
 - Fallback: If a required target, credential, runtime, or observation is missing, show a blocker or confirmation action instead of claiming completion.

--- a/skills/agent-ops-review/SKILL.md
+++ b/skills/agent-ops-review/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: agent-ops-review
+description: [omh] Hermes agent ops review workflow: help a manager inspect AI-agent research, coding, review, status, blockers, quality gates, and throughput levers.
+metadata:
+  hermes:
+    tags: [workflow, oh-my-hermes, operator]
+    category: operator
+    phase: manager-review
+    role: tracker
+    quality_tier: workflow-surface-gated
+---
+
+# Agent Ops Review
+
+This is a Hermes-native `agent-ops-review` workflow skill.
+
+## Why This Exists
+
+`agent-ops-review` exists so Hermes users can ask for this workflow in chat and receive a structured, evidence-bounded OMH operating surface instead of ad hoc narration.
+
+## Do Not Use When
+
+- The request is already handled by a narrower explicit skill with stronger evidence.
+- The user asks OMH to secretly run external platforms, connectors, schedulers, file exports, or runtime agents.
+- The only safe answer is to ask for missing authority, credentials, target, or observed evidence first.
+
+## Examples
+
+Good example:
+
+- Prompt: agent-ops-review show me quality, blockers, and throughput for AI-agent research, coding, and review work.
+- Expected behavior: Produce `prepare_agent_ops_review` with required context, wrapper actions, and not-evidence boundaries.
+- Why: The prompt names a real workflow surface that Hermes can orchestrate without hiding execution.
+
+Bad example:
+
+- Prompt: agent-ops-review claim Codex finished and CI passed because a handoff exists.
+- Expected behavior: Report the missing observed evidence or authority instead of claiming the external step happened.
+- Why: Prepared OMH guidance is not platform, runtime, connector, file, memory, or delivery evidence.
+
+## Use When
+
+Use when Hermes should explain AI-agent work from a manager/operator perspective: quality gates, progress, blockers, next actions, and throughput opportunities across research, coding, review, and status.
+
+    Strong routing signals: `agent-ops-review`, `agent ops review`, `agent productivity`, `operator productivity`, `manager view`, `quality dashboard`, `throughput review`, `agent work quality`, `coding progress quality`, `research coding review status`, `ai agent manager`, `third-party manager`, `관리자 입장`, `작업 생산량`, `처리량`, `품질 퀄리티`, `작업 품질`, `진행상황`, `리서치 코딩 리뷰`
+
+## Catalog Metadata
+
+Category: `operator`
+Phase: `manager-review`
+Hermes role: `tracker`
+Quality tier: `workflow-surface-gated`
+
+Quality bar:
+
+- Name the user-facing workflow objective, required context, next action, and stop condition.
+- Separate prepared guidance from observed platform, runtime, connector, file, memory, or delivery evidence.
+- Expose missing tools, credentials, targets, or observations as user-visible gaps.
+
+Handoff policy:
+
+Keep this as Hermes-facing orchestration guidance first. Prepare executor, connector, gateway, or host-runtime handoff only when the user accepts that next step and observed evidence can be recorded.
+
+Required inputs:
+
+- user request
+- target context
+- delivery or status expectation
+- known missing evidence
+
+Expected outputs:
+
+- agent-ops-review/v1 card or guidance
+- next action
+- prepared-vs-observed boundary
+
+Artifact expectations:
+
+- agent-ops-review/v1 metadata-only runtime or wrapper card when recorded
+
+Safety rules:
+
+- An agent ops review card is not source retrieval, executor dispatch, coding progress, implementation, review, verification, CI, merge-readiness, merge, platform delivery, provider billing, or live runtime telemetry evidence.
+- Do not claim connector, gateway, runtime, file generation, memory mutation, or host automation evidence from prepared guidance.
+
+## Harness Discipline
+
+- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
+- Prefer richer evidence and clearer stop conditions over adding more workflow names.
+- Use specialist lanes only when they change the quality of the answer or verification.
+
+## Runtime Evidence
+
+Preferred harness for this skill: `agent-ops-review`.
+
+When local shell access or a bot wrapper is available, record metadata-only evidence:
+
+```sh
+omh runtime record --skill agent-ops-review --harness agent-ops-review --status started
+omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
+```
+
+Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
+
+## Hermes Compatibility Contract
+
+- Preserve the workflow intent, stop conditions, and verification discipline.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available.
+- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
+- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
+- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
+  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
+  - question renderers -> one concise question in the current Hermes interface,
+  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
+  - shell bridge commands -> optional bridge mode only.
+
+## Execution Rules
+
+1. Load supporting context with `skills_list` / `skill_view` when needed.
+2. State the workflow target, constraints, validation evidence, and stop condition.
+3. Keep progress evidence-backed.
+4. Verify with the smallest relevant test or inspection before claiming completion.
+5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.

--- a/skills/oh-my-hermes/SKILL.md
+++ b/skills/oh-my-hermes/SKILL.md
@@ -78,7 +78,7 @@ Use installed primary workflow skills plus compatibility surfaces in this regist
 - `planner`: `loop`, `deep-interview`, `plan`, `ralplan`
 - `researcher`: `web-research`, `research-brief`, `research-department`, `best-practice-research`, `autoresearch-goal`
 - `reviewer`: `ultraqa`, `code-review`, `ask`
-- `tracker`: `performance-goal`, `cancel`, `skill`, `doctor`, `agent-board`, `toolbelt-readiness`, `ops-observability-card`
+- `tracker`: `performance-goal`, `cancel`, `skill`, `doctor`, `agent-board`, `toolbelt-readiness`, `ops-observability-card`, `agent-ops-review`
 - Installed workflow skill policies live in generated workflow skills; compatibility/reference-only surface policies live in `docs/WORKFLOWS.md` and are not guaranteed to have `skills/<name>/SKILL.md` files.
 
 General rule: Hermes should retain routing, web/source research, deep interview, planning, status, and evidence narration. This role metadata is advisory unless a wrapper/runtime artifact records observed enforcement. When the accepted next action mutates code, the wrapper should ask for or apply the selected executor/runtime profile, prepare the matching handoff, and track only evidence it actually observes instead of implying code ran secretly.
@@ -186,6 +186,7 @@ When Hermes exposes installed skill descriptions to the model, use this registry
 - `voice-operator`: `voice-operator`, `voice operator`, `voice-first`, `mobile command`, `short command`
 - `toolbelt-readiness`: `toolbelt-readiness`, `mcp readiness`, `tool readiness`, `connector readiness`, `needed mcp`
 - `ops-observability-card`: `ops-observability-card`, `observability card`, `cost telemetry`, `latency telemetry`, `token telemetry`
+- `agent-ops-review`: `agent-ops-review`, `agent ops review`, `agent productivity`, `operator productivity`, `manager view`
 
 Routing is conservative: route only on explicit invocation, strong keyword evidence, or a clear workflow-shaped request. A bare common word such as `team`, `ask`, `wiki`, or `review` is not enough when it could mean normal conversation.
 
@@ -225,6 +226,7 @@ Use these harnesses to shape the response before adding new skills. They are qua
 - `voice-operator`: Convert terse voice/mobile requests into safe clarify, plan, status, handoff, or confirmation actions. Tier `accessibility-gated`. Ladder: `voice_request_received` -> `ambiguity_checked` -> `safe_action_prepared` -> `confirmation_observed_when_required`. Actions: `ask_clarification`, `confirm_action`, `show_status`, `prepare_handoff`. Privacy `metadata_only`.
 - `toolbelt-readiness`: Check required MCP servers, CLIs, APIs, credentials, connectors, and local tools for a workflow. Tier `tool-readiness-gated`. Ladder: `workflow_tools_scoped` -> `tool_requirements_listed` -> `installed_state_recorded_when_available` -> `credential_gaps_recorded`. Actions: `show_toolbelt`, `open_setup`, `record_tool_check`, `prepare_handoff`, `show_status`. Privacy `metadata_only`.
 - `ops-observability-card`: Report wrapper-safe token, cost, latency, run history, queue, and failure-mode telemetry boundaries. Tier `observability-gated`. Ladder: `telemetry_scope_recorded` -> `local_metrics_summarized` -> `failure_modes_checked` -> `provider_truth_observed_when_available`. Actions: `show_observability`, `record_metric`, `record_failure_mode`, `show_status`. Privacy `metadata_only`.
+- `agent-ops-review`: Prepare a manager-facing quality and throughput review for AI-agent research, coding, review, and status work. Tier `manager-review-gated`. Ladder: `manager_scope_recorded` -> `quality_lanes_prepared` -> `evidence_gaps_named` -> `next_action_selected`. Actions: `show_agent_ops_review`, `choose_ops_lane`, `prepare_research_lane`, `prepare_coding_lane`, `prepare_review_lane`. Privacy `metadata_only`.
 
 Harness priority:
 

--- a/src/commands/main.py
+++ b/src/commands/main.py
@@ -66,6 +66,9 @@ from .menubar import _add_menubar_commands, cmd_menubar_status
 from .memory import _add_memory_commands, cmd_memory_apply, cmd_memory_inspect, cmd_memory_pack
 from .ops import (
     _add_ops_commands,
+    cmd_ops_agent_review,
+    cmd_ops_agent_review_list,
+    cmd_ops_agent_review_show,
     cmd_ops_blueprint,
     cmd_ops_blueprint_list,
     cmd_ops_blueprint_show,

--- a/src/commands/ops.py
+++ b/src/commands/ops.py
@@ -3,6 +3,14 @@ from __future__ import annotations
 import argparse
 
 from ..installer import OmhError
+from ..operator_productivity import (
+    build_agent_operator_productivity_card,
+    list_agent_operator_productivity_cards,
+    show_agent_operator_productivity_card,
+    summarize_agent_operator_productivity_card,
+    validate_agent_operator_productivity_store,
+    write_agent_operator_productivity_card,
+)
 from ..hermes_ops import (
     build_scheduled_ops_blueprint,
     list_hermes_ops_blueprints,
@@ -38,6 +46,7 @@ DEFAULT_OPS_LIST_LIMIT = 20
 DEFAULT_OPS_EXPORT_LIMIT = 20
 DEFAULT_BLUEPRINT_LIST_LIMIT = 20
 DEFAULT_RESEARCH_DEPARTMENT_LIST_LIMIT = 20
+DEFAULT_AGENT_OPS_LIST_LIMIT = 20
 
 
 def cmd_ops_write(args: argparse.Namespace) -> int:
@@ -168,6 +177,48 @@ def cmd_ops_research_department(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_ops_agent_review(args: argparse.Namespace) -> int:
+    try:
+        paths = _paths(args)
+        card = build_agent_operator_productivity_card(
+            " ".join(args.request),
+            title=args.title,
+            focus=args.focus,
+            source=args.source,
+        )
+        written = card if args.dry_run else write_agent_operator_productivity_card(paths, card)
+    except ValueError as exc:
+        raise OmhError(str(exc)) from exc
+    _print_json(
+        {
+            "schema_version": "omh_ops_agent_review_result/v1",
+            "card": written,
+            "store": {
+                "omh_home": str(paths.omh_home),
+                "agent_ops_dir": str(paths.agent_operator_productivity_dir),
+                "cards_dir": str(paths.agent_operator_productivity_cards_dir),
+                "index_path": str(paths.agent_operator_productivity_index_path),
+                "index_authority": "cache_only",
+                "written": not args.dry_run,
+            },
+            "boundary": {
+                "prepared_is_not_observed": True,
+                "source_retrieval_observed": False,
+                "executor_dispatch_observed": False,
+                "executor_session_attached": False,
+                "implementation_observed": False,
+                "verification_passed": False,
+                "review_passed": False,
+                "ci_passed": False,
+                "merge_observed": False,
+                "not_evidence_until_observed": list(written["not_evidence_until_observed"]),
+                "observed_evidence_required": list(written["observed_evidence_required"]),
+            },
+        }
+    )
+    return 0
+
+
 def cmd_ops_list(args: argparse.Namespace) -> int:
     try:
         paths = _paths(args)
@@ -193,6 +244,29 @@ def cmd_ops_list(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_ops_agent_review_list(args: argparse.Namespace) -> int:
+    paths = _paths(args)
+    try:
+        limit = _limit_from_args(args, default=DEFAULT_AGENT_OPS_LIST_LIMIT)
+    except ValueError as exc:
+        raise OmhError(str(exc)) from exc
+    all_records = list_agent_operator_productivity_cards(paths)
+    records = all_records if limit is None else all_records[-limit:]
+    _print_json(
+        {
+            "schema_version": "omh_ops_agent_review_list/v1",
+            "count": len(records),
+            "total_count": len(all_records),
+            "limit": limit if limit is not None else "all",
+            "truncated": limit is not None and len(all_records) > len(records),
+            "summary_only": True,
+            "index_authority": "cache_only",
+            "cards": [summarize_agent_operator_productivity_card(record) for record in records],
+        }
+    )
+    return 0
+
+
 def cmd_ops_research_department_list(args: argparse.Namespace) -> int:
     paths = _paths(args)
     try:
@@ -213,6 +287,16 @@ def cmd_ops_research_department_list(args: argparse.Namespace) -> int:
             "plans": [summarize_research_department_plan(record) for record in records],
         }
     )
+    return 0
+
+
+def cmd_ops_agent_review_show(args: argparse.Namespace) -> int:
+    try:
+        paths = _paths(args)
+        card = show_agent_operator_productivity_card(paths, args.card_id)
+    except (FileNotFoundError, ValueError) as exc:
+        raise OmhError(str(exc)) from exc
+    _print_json({"schema_version": "omh_ops_agent_review_show/v1", "card": card})
     return 0
 
 
@@ -251,9 +335,16 @@ def cmd_ops_validate(args: argparse.Namespace) -> int:
     result = validate_operations_store(paths)
     blueprint_result = validate_hermes_ops_store(paths)
     research_department_result = validate_research_department_store(paths)
+    agent_ops_result = validate_agent_operator_productivity_store(paths)
     result["hermes_ops_blueprints"] = blueprint_result
     result["research_department_plans"] = research_department_result
-    result["ok"] = bool(result["ok"]) and bool(blueprint_result["ok"]) and bool(research_department_result["ok"])
+    result["agent_ops_reviews"] = agent_ops_result
+    result["ok"] = (
+        bool(result["ok"])
+        and bool(blueprint_result["ok"])
+        and bool(research_department_result["ok"])
+        and bool(agent_ops_result["ok"])
+    )
     _print_json(result)
     return 0 if result["ok"] else 1
 
@@ -403,6 +494,17 @@ def _add_ops_commands(sub) -> None:
     research_department.add_argument("--dry-run", action="store_true", help="Print the prepared plan without writing it.")
     research_department.set_defaults(func=cmd_ops_research_department)
 
+    agent_review = ops_sub.add_parser(
+        "agent-review",
+        help="Prepare a manager-facing agent ops review card for research, coding, review, and status productivity.",
+    )
+    agent_review.add_argument("request", nargs="+", help="Natural-language agent operations management request.")
+    agent_review.add_argument("--title", default="")
+    agent_review.add_argument("--focus", choices=("auto", "mixed", "research", "coding", "review", "status"), default="auto")
+    agent_review.add_argument("--source", default="", help="Optional metadata source label.")
+    agent_review.add_argument("--dry-run", action="store_true", help="Print the prepared card without writing it.")
+    agent_review.set_defaults(func=cmd_ops_agent_review)
+
     blueprint_list = ops_sub.add_parser("blueprint-list", help="List prepared Hermes scheduled ops blueprints.")
     blueprint_list.add_argument("--limit", type=int, default=None)
     blueprint_list.add_argument("--all", action="store_true", help="Return all blueprint summaries instead of the default bounded window.")
@@ -420,6 +522,15 @@ def _add_ops_commands(sub) -> None:
     research_department_show = ops_sub.add_parser("research-department-show", help="Show one research department plan by id.")
     research_department_show.add_argument("plan_id")
     research_department_show.set_defaults(func=cmd_ops_research_department_show)
+
+    agent_review_list = ops_sub.add_parser("agent-review-list", help="List prepared agent ops review cards.")
+    agent_review_list.add_argument("--limit", type=int, default=None)
+    agent_review_list.add_argument("--all", action="store_true", help="Return all cards instead of the default bounded window.")
+    agent_review_list.set_defaults(func=cmd_ops_agent_review_list)
+
+    agent_review_show = ops_sub.add_parser("agent-review-show", help="Show one prepared agent ops review card by id.")
+    agent_review_show.add_argument("card_id")
+    agent_review_show.set_defaults(func=cmd_ops_agent_review_show)
 
     list_cmd = ops_sub.add_parser("list", help="List operations artifacts from local storage.")
     list_cmd.add_argument("--surface", choices=SURFACES, default="")

--- a/src/operator_productivity.py
+++ b/src/operator_productivity.py
@@ -1,0 +1,610 @@
+from __future__ import annotations
+
+import re
+import secrets
+from datetime import datetime, timezone
+from typing import Any
+
+from .local_store import atomic_write_json, read_json_object_result, utc_now
+from .paths import OmhPaths
+
+
+AGENT_OPERATOR_PRODUCTIVITY_SCHEMA_VERSION = "agent_operator_productivity/v1"
+AGENT_OPERATOR_STATUS_CARD_SCHEMA_VERSION = "agent_operator_status_card/v1"
+AGENT_OPERATOR_INDEX_SCHEMA_VERSION = "agent_operator_productivity_index/v1"
+AGENT_OPERATOR_VALIDATION_SCHEMA_VERSION = "agent_operator_productivity_validation/v1"
+
+CARD_KIND = "agent-ops-review"
+CARD_STATUSES = ("prepared", "blocked", "archived")
+OBSERVATION_STATUSES = ("prepared", "not_observed")
+FOCUS_AREAS = ("auto", "mixed", "research", "coding", "review", "status")
+SUMMARY_LIMIT = 240
+PROJECTION_SOURCE_REFS = (
+    "src/operator_productivity.py",
+    "src/skills/catalog.py",
+    "src/routing/recommend.py",
+    "src/wrapper/contract.py",
+    "src/runtime/artifacts.py",
+)
+PREPARED_IS_NOT_OBSERVED = (
+    "An agent ops review is projection metadata only. It is not source retrieval, executor dispatch, "
+    "coding progress, implementation, review completion, verification, CI, merge-readiness, merge, "
+    "platform delivery, provider billing, or live runtime telemetry evidence."
+)
+DEFAULT_NOT_EVIDENCE = (
+    "source_retrieval_observed",
+    "executor_dispatch_observed",
+    "executor_session_attached",
+    "implementation_observed",
+    "verification_passed",
+    "review_passed",
+    "ci_passed",
+    "merge_ready",
+    "merge_observed",
+    "platform_delivery_sent",
+    "provider_cost_or_token_truth",
+    "live_runtime_telemetry",
+)
+OBSERVED_EVIDENCE_REQUIRED = (
+    "Observed source records or supplied source artifacts before claiming research findings.",
+    "Runtime or wrapper observation before claiming executor dispatch, session attachment, or coding progress.",
+    "Executor result records before claiming implementation completed.",
+    "Verification, review, CI, and merge records before reporting those states as complete.",
+    "Provider or host telemetry before reporting exact token, cost, latency, or queue truth.",
+)
+OBSERVED_CLAIM_STATUSES = {
+    "observed",
+    "complete",
+    "completed",
+    "ready",
+    "passed",
+    "success",
+    "succeeded",
+    "running",
+    "dispatched",
+    "attached",
+    "merged",
+    "delivered",
+    "sent",
+}
+
+_CARD_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9-]{0,159}$")
+_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+_FOCUS_TERMS = {
+    "research": (
+        "research",
+        "search",
+        "source",
+        "web",
+        "market",
+        "competitor",
+        "paper",
+        "조사",
+        "리서치",
+        "서치",
+        "검색",
+        "자료",
+        "출처",
+    ),
+    "coding": (
+        "coding",
+        "code",
+        "implement",
+        "implementation",
+        "codex",
+        "claude",
+        "executor",
+        "handoff",
+        "pr",
+        "worktree",
+        "worker",
+        "코딩",
+        "구현",
+        "코드",
+        "코덱스",
+        "클로드",
+        "위임",
+        "작업",
+    ),
+    "review": (
+        "review",
+        "qa",
+        "verify",
+        "verification",
+        "test",
+        "ci",
+        "quality",
+        "gate",
+        "리뷰",
+        "검증",
+        "테스트",
+        "품질",
+        "게이트",
+    ),
+    "status": (
+        "status",
+        "progress",
+        "blocker",
+        "blocked",
+        "throughput",
+        "productivity",
+        "manager",
+        "operator",
+        "dashboard",
+        "관리자",
+        "진행",
+        "상태",
+        "막힘",
+        "블로커",
+        "생산량",
+        "처리량",
+    ),
+}
+
+
+def build_agent_operator_productivity_card(
+    request: str,
+    *,
+    title: str = "",
+    focus: str = "auto",
+    source: str = "",
+    card_id: str | None = None,
+    created_at: str | None = None,
+) -> dict[str, Any]:
+    clean_request = " ".join(str(request).split())
+    if not clean_request:
+        raise ValueError("agent ops review request is required")
+    normalized_focus = _normalize_focus(focus)
+    created = created_at or utc_now()
+    detected_focus = _detect_focus(clean_request, normalized_focus)
+    lanes = _quality_lanes(detected_focus)
+    card = {
+        "schema_version": AGENT_OPERATOR_PRODUCTIVITY_SCHEMA_VERSION,
+        "card_id": card_id or new_agent_operator_productivity_card_id(clean_request, created),
+        "kind": CARD_KIND,
+        "title": title.strip() or _default_title(clean_request, detected_focus),
+        "status": "prepared",
+        "observation_status": "prepared",
+        "created_at": created,
+        "updated_at": created,
+        "projection": {
+            "authority": "projection_only",
+            "derived_from": [
+                "catalog skill metadata",
+                "routing policy metadata",
+                "wrapper chat contract",
+                "runtime evidence ladder",
+                "operations projection patterns",
+            ],
+            "source_refs": list(PROJECTION_SOURCE_REFS),
+        },
+        "source": source.strip(),
+        "request_summary": _preview(clean_request, limit=SUMMARY_LIMIT),
+        "manager_view": {
+            "role": "third_party_operator",
+            "goal": "maximize useful agent throughput without losing quality or evidence boundaries",
+            "focus": detected_focus,
+            "headline": _headline(detected_focus),
+            "risk_level": _risk_level(detected_focus),
+        },
+        "workflow_quality": {
+            "schema_version": "agent_workflow_quality/v1",
+            "lanes": lanes,
+            "readiness_summary": _readiness_summary(lanes),
+            "quality_gate": "Do not advance a lane from prepared to observed without matching source, runtime, verification, review, CI, or merge evidence.",
+        },
+        "throughput_levers": _throughput_levers(detected_focus),
+        "skill_chain": _skill_chain(detected_focus),
+        "status_card": _status_card(detected_focus, lanes),
+        "wrapper_actions": [
+            "show_agent_ops_review",
+            "choose_ops_lane",
+            "prepare_research_lane",
+            "prepare_coding_lane",
+            "prepare_review_lane",
+            "refresh_agent_ops_status",
+            "record_agent_ops_observation",
+            "show_status",
+        ],
+        "not_evidence_until_observed": list(DEFAULT_NOT_EVIDENCE),
+        "observed_evidence_required": list(OBSERVED_EVIDENCE_REQUIRED),
+        "prepared_is_not": PREPARED_IS_NOT_OBSERVED,
+        "next_action": _next_action(detected_focus),
+    }
+    errors = validate_agent_operator_productivity_card(card)
+    if errors:
+        raise ValueError("; ".join(errors))
+    return card
+
+
+def new_agent_operator_productivity_card_id(request: str, now: datetime | str | None = None) -> str:
+    stamp = _stamp(now)
+    slug = _slugify(request)[:48] or "agent-ops-review"
+    return f"{stamp}-agent-ops-{slug}-{secrets.token_hex(3)}"
+
+
+def validate_agent_operator_productivity_card(record: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if record.get("schema_version") != AGENT_OPERATOR_PRODUCTIVITY_SCHEMA_VERSION:
+        errors.append("schema_version must be agent_operator_productivity/v1")
+    if record.get("kind") != CARD_KIND:
+        errors.append(f"unsupported agent ops review kind: {record.get('kind', '')}")
+    card_id = str(record.get("card_id", ""))
+    if not card_id.strip():
+        errors.append("card_id is required")
+    elif not _valid_card_id(card_id):
+        errors.append("card_id must contain only letters, digits, and hyphens, and must not contain path separators")
+    if not str(record.get("title", "")).strip():
+        errors.append("title is required")
+    if record.get("status") not in CARD_STATUSES:
+        errors.append(f"unsupported status: {record.get('status', '')}")
+    if record.get("observation_status") not in OBSERVATION_STATUSES:
+        errors.append(f"unsupported observation_status: {record.get('observation_status', '')}")
+    projection = record.get("projection")
+    if not isinstance(projection, dict):
+        errors.append("projection must be an object")
+    else:
+        if projection.get("authority") != "projection_only":
+            errors.append("projection.authority must be projection_only")
+        source_refs = projection.get("source_refs")
+        if not isinstance(source_refs, list) or not source_refs:
+            errors.append("projection.source_refs must be a non-empty list")
+    for key in ("manager_view", "workflow_quality", "status_card"):
+        if not isinstance(record.get(key), dict):
+            errors.append(f"{key} must be an object")
+    for key in ("throughput_levers", "skill_chain", "wrapper_actions", "not_evidence_until_observed", "observed_evidence_required"):
+        if not isinstance(record.get(key), list):
+            errors.append(f"{key} must be a list")
+    not_evidence = set(_string_list(record.get("not_evidence_until_observed", [])))
+    if not set(DEFAULT_NOT_EVIDENCE).issubset(not_evidence):
+        errors.append("not_evidence_until_observed must include the default agent ops guard list")
+    status_card = record.get("status_card")
+    if isinstance(status_card, dict):
+        if status_card.get("schema_version") != AGENT_OPERATOR_STATUS_CARD_SCHEMA_VERSION:
+            errors.append("status_card.schema_version must be agent_operator_status_card/v1")
+        status_not_observed = set(_string_list(status_card.get("not_observed", [])))
+        if not set(DEFAULT_NOT_EVIDENCE).issubset(status_not_observed):
+            errors.append("status_card.not_observed must include the default agent ops guard list")
+    errors.extend(_nested_observed_claim_errors(record))
+    return errors
+
+
+def write_agent_operator_productivity_card(paths: OmhPaths, record: dict[str, Any]) -> dict[str, Any]:
+    errors = validate_agent_operator_productivity_card(record)
+    if errors:
+        raise ValueError("; ".join(errors))
+    card_id = str(record["card_id"])
+    if _card_path(paths, card_id).exists():
+        raise ValueError(f"agent ops review already exists: {card_id}")
+    atomic_write_json(_card_path(paths, card_id), record, private=True)
+    _write_index_cache(paths)
+    return record
+
+
+def list_agent_operator_productivity_cards(paths: OmhPaths, *, limit: int | None = None) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for card_path in sorted(paths.agent_operator_productivity_cards_dir.glob("*.json")):
+        record, error = read_json_object_result(card_path)
+        if error:
+            continue
+        if record:
+            records.append(record)
+    records.sort(key=lambda item: str(item.get("created_at", "")))
+    if limit is not None:
+        if limit < 1:
+            raise ValueError("limit must be at least 1")
+        return records[-limit:]
+    return records
+
+
+def show_agent_operator_productivity_card(paths: OmhPaths, card_id: str) -> dict[str, Any]:
+    record, error = read_json_object_result(_card_path(paths, card_id))
+    if error or record is None:
+        raise FileNotFoundError(f"agent ops review not found: {card_id}")
+    return record
+
+
+def summarize_agent_operator_productivity_card(record: dict[str, Any]) -> dict[str, Any]:
+    status_card = record.get("status_card", {}) if isinstance(record.get("status_card"), dict) else {}
+    return {
+        "schema_version": AGENT_OPERATOR_PRODUCTIVITY_SCHEMA_VERSION,
+        "card_id": record.get("card_id", ""),
+        "title": record.get("title", ""),
+        "status": record.get("status", ""),
+        "observation_status": record.get("observation_status", ""),
+        "focus": (record.get("manager_view", {}) or {}).get("focus", ""),
+        "created_at": record.get("created_at", ""),
+        "next_action": record.get("next_action", ""),
+        "quality_state": status_card.get("quality_state", ""),
+        "blockers": list(status_card.get("blockers", [])) if isinstance(status_card.get("blockers"), list) else [],
+    }
+
+
+def validate_agent_operator_productivity_store(paths: OmhPaths) -> dict[str, Any]:
+    errors: list[str] = []
+    count = 0
+    for card_path in sorted(paths.agent_operator_productivity_cards_dir.glob("*.json")):
+        record, read_error = read_json_object_result(card_path)
+        if read_error:
+            errors.append(f"{card_path}: {read_error}")
+            continue
+        if record is None:
+            continue
+        count += 1
+        for error in validate_agent_operator_productivity_card(record):
+            errors.append(f"{card_path}: {error}")
+    return {
+        "schema_version": AGENT_OPERATOR_VALIDATION_SCHEMA_VERSION,
+        "ok": not errors,
+        "card_count": count,
+        "errors": errors,
+    }
+
+
+def _write_index_cache(paths: OmhPaths) -> dict[str, Any]:
+    cards = [summarize_agent_operator_productivity_card(record) for record in list_agent_operator_productivity_cards(paths)]
+    payload = {
+        "schema_version": AGENT_OPERATOR_INDEX_SCHEMA_VERSION,
+        "updated_at": utc_now(),
+        "count": len(cards),
+        "cards": cards,
+    }
+    atomic_write_json(paths.agent_operator_productivity_index_path, payload, private=True)
+    return payload
+
+
+def _quality_lanes(focus: str) -> list[dict[str, Any]]:
+    lane_ids = ["intake", "research", "coding", "review", "status"]
+    lanes = [_lane(lane_id, focus) for lane_id in lane_ids]
+    if focus == "research":
+        return _prioritize(lanes, ("research", "status", "intake", "review", "coding"))
+    if focus == "coding":
+        return _prioritize(lanes, ("coding", "review", "status", "intake", "research"))
+    if focus == "review":
+        return _prioritize(lanes, ("review", "coding", "status", "intake", "research"))
+    if focus == "status":
+        return _prioritize(lanes, ("status", "intake", "coding", "review", "research"))
+    return lanes
+
+
+def _lane(lane_id: str, focus: str) -> dict[str, Any]:
+    data = {
+        "intake": {
+            "label": "Intake and routing",
+            "quality_gate": "Classify task shape before dispatch.",
+            "missing_evidence": ["accepted workflow", "owner or executor choice"],
+            "next_action": "choose workflow lane and stop condition",
+            "throughput_lever": "Batch similar requests only after they share the same owner and verification gate.",
+        },
+        "research": {
+            "label": "Research quality",
+            "quality_gate": "Sources, freshness, conflicts, and retrieval gaps are named.",
+            "missing_evidence": ["source_retrieval_observed", "source_quality_recorded"],
+            "next_action": "prepare source boundaries or record observed sources",
+            "throughput_lever": "Reuse source boundaries and brief templates across similar research tasks.",
+        },
+        "coding": {
+            "label": "Coding delegation",
+            "quality_gate": "Executor/runtime, acceptance criteria, and verification expectations are explicit.",
+            "missing_evidence": ["executor_dispatch_observed", "executor_result_observed"],
+            "next_action": "choose Codex, Claude Code, Hermes coding, or runtime handoff before dispatch",
+            "throughput_lever": "Cache first-use executor readiness and split work only when file ownership is independent.",
+        },
+        "review": {
+            "label": "Review and verification",
+            "quality_gate": "Fast checks and slower review/CI gates are separated.",
+            "missing_evidence": ["verification_passed", "review_passed", "ci_passed"],
+            "next_action": "run or request the smallest proof that can advance the claim",
+            "throughput_lever": "Use cheap inner checks frequently and reserve expensive review gates for risky changes.",
+        },
+        "status": {
+            "label": "Manager status",
+            "quality_gate": "Prepared, dispatched, executed, verified, reviewed, CI, and merge states stay separate.",
+            "missing_evidence": ["live_runtime_telemetry", "runtime_observation_records"],
+            "next_action": "refresh status from local artifacts or ask the wrapper to record observations",
+            "throughput_lever": "Report blockers and next actions instead of re-running broad scans.",
+        },
+    }[lane_id]
+    return {
+        "lane": lane_id,
+        "label": data["label"],
+        "state": "prepared",
+        "priority": "primary" if focus in {lane_id, "mixed"} or (focus == "coding" and lane_id == "review") else "supporting",
+        "quality_gate": data["quality_gate"],
+        "missing_evidence": data["missing_evidence"],
+        "next_action": data["next_action"],
+        "throughput_lever": data["throughput_lever"],
+    }
+
+
+def _prioritize(lanes: list[dict[str, Any]], order: tuple[str, ...]) -> list[dict[str, Any]]:
+    rank = {lane: index for index, lane in enumerate(order)}
+    return sorted(lanes, key=lambda lane: rank.get(str(lane.get("lane", "")), 999))
+
+
+def _readiness_summary(lanes: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "overall": "prepared_not_observed",
+        "primary_lanes": [lane["lane"] for lane in lanes if lane.get("priority") == "primary"],
+        "blocking_gaps": sorted({gap for lane in lanes for gap in lane.get("missing_evidence", [])}),
+        "manager_can_report": ["workflow choice", "quality gates", "missing evidence", "next action", "throughput levers"],
+        "manager_cannot_report_yet": list(DEFAULT_NOT_EVIDENCE),
+    }
+
+
+def _status_card(focus: str, lanes: list[dict[str, Any]]) -> dict[str, Any]:
+    blocking = sorted({gap for lane in lanes if lane.get("priority") == "primary" for gap in lane.get("missing_evidence", [])})
+    return {
+        "schema_version": AGENT_OPERATOR_STATUS_CARD_SCHEMA_VERSION,
+        "headline": _headline(focus),
+        "quality_state": "prepared_not_observed",
+        "progress_summary": "Quality gates and next actions are ready; external runtime evidence has not been observed.",
+        "blockers": blocking or ["accepted_workflow_or_observation_missing"],
+        "next_action": _next_action(focus),
+        "not_observed": list(DEFAULT_NOT_EVIDENCE),
+        "small_copy": f"agent-ops: prepared({focus}) evidence:prepared_not_observed",
+    }
+
+
+def _skill_chain(focus: str) -> list[dict[str, str]]:
+    chains = {
+        "research": ("web-research", "research-brief", "research-department", "ops-observability-card"),
+        "coding": ("executor-runtime-readiness", "plan", "ultraprocess", "code-review", "ops-observability-card"),
+        "review": ("code-review", "ultraqa", "reliability-review", "ops-observability-card"),
+        "status": ("agent-board", "ops-observability-card", "goal-execution", "executor-runtime-readiness"),
+        "mixed": ("oh-my-hermes", "executor-runtime-readiness", "web-research", "code-review", "ops-observability-card"),
+    }
+    skills = chains.get(focus, chains["mixed"])
+    return [{"skill": skill, "role": _skill_role(skill)} for skill in skills]
+
+
+def _skill_role(skill: str) -> str:
+    if skill in {"web-research", "research-brief", "research-department"}:
+        return "research quality"
+    if skill in {"executor-runtime-readiness", "plan", "ultraprocess"}:
+        return "coding handoff quality"
+    if skill in {"code-review", "ultraqa", "reliability-review"}:
+        return "verification quality"
+    if skill in {"agent-board", "ops-observability-card", "goal-execution"}:
+        return "status and throughput"
+    return "routing"
+
+
+def _throughput_levers(focus: str) -> list[dict[str, str]]:
+    base = [
+        {
+            "lever": "make the next action singular",
+            "operator_value": "Less context switching; every update has one next step.",
+            "guardrail": "Do not hide unresolved ownership or verification gaps.",
+        },
+        {
+            "lever": "cache readiness after the first successful executor check",
+            "operator_value": "Avoid repeating Codex, Claude Code, or runtime setup probes.",
+            "guardrail": "Cached readiness is not dispatch or execution evidence.",
+        },
+        {
+            "lever": "separate cheap checks from expensive gates",
+            "operator_value": "Fast feedback stays fast; deep review runs only when it changes confidence.",
+            "guardrail": "A cheap check cannot replace required review, CI, or semantic verification.",
+        },
+    ]
+    if focus in {"research", "mixed"}:
+        base.append(
+            {
+                "lever": "reuse source boundaries",
+                "operator_value": "Recurring research work starts from known source scopes.",
+                "guardrail": "Reused source boundaries are not fresh retrieval evidence.",
+            }
+        )
+    if focus in {"coding", "review", "mixed"}:
+        base.append(
+            {
+                "lever": "split only independent lanes",
+                "operator_value": "Parallel work increases output when ownership and files do not collide.",
+                "guardrail": "Parallel lane plans are not worker dispatch or result evidence.",
+            }
+        )
+    return base
+
+
+def _detect_focus(request: str, requested_focus: str) -> str:
+    if requested_focus != "auto":
+        return requested_focus
+    value = request.lower()
+    scores = {
+        focus: sum(1 for term in terms if term.lower() in value)
+        for focus, terms in _FOCUS_TERMS.items()
+    }
+    matched = [focus for focus, score in scores.items() if score > 0]
+    if len(matched) > 1:
+        return "mixed"
+    if matched:
+        return matched[0]
+    return "mixed"
+
+
+def _normalize_focus(value: str) -> str:
+    normalized = str(value or "auto").strip().lower()
+    if normalized not in FOCUS_AREAS:
+        raise ValueError(f"unsupported focus: {value}")
+    return normalized
+
+
+def _headline(focus: str) -> str:
+    return {
+        "research": "Research quality and source evidence need management.",
+        "coding": "Coding handoff, execution, and review gates need management.",
+        "review": "Verification, review, and CI evidence need management.",
+        "status": "Progress, blockers, and throughput need a manager view.",
+        "mixed": "Research, coding, review, and status need one manager view.",
+    }.get(focus, "Agent work needs one manager view.")
+
+
+def _risk_level(focus: str) -> str:
+    return "high" if focus in {"coding", "review", "mixed"} else "medium"
+
+
+def _next_action(focus: str) -> str:
+    return {
+        "research": "prepare_research_lane",
+        "coding": "prepare_coding_lane",
+        "review": "prepare_review_lane",
+        "status": "refresh_agent_ops_status",
+        "mixed": "show_agent_ops_review",
+    }.get(focus, "show_agent_ops_review")
+
+
+def _default_title(request: str, focus: str) -> str:
+    return f"Agent ops review: {focus} - {_preview(request, limit=72)}"
+
+
+def _preview(value: str, *, limit: int) -> str:
+    text = " ".join(str(value).split())
+    return text if len(text) <= limit else text[: limit - 1].rstrip() + "..."
+
+
+def _slugify(value: str) -> str:
+    slug = _SLUG_RE.sub("-", value.lower()).strip("-")
+    return (slug or "agent-ops-review")[:64].strip("-") or "agent-ops-review"
+
+
+def _stamp(value: datetime | str | None) -> str:
+    if value is None:
+        value = datetime.now(timezone.utc)
+    if isinstance(value, str):
+        return re.sub(r"[^0-9A-Za-z]+", "", value)[:24] or "00000000T000000Z"
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _valid_card_id(value: str) -> bool:
+    return bool(_CARD_ID_RE.fullmatch(value)) and "/" not in value and "\\" not in value
+
+
+def _card_path(paths: OmhPaths, card_id: str):
+    if not _valid_card_id(str(card_id)):
+        raise ValueError("agent ops review id must contain only letters, digits, and hyphens")
+    return paths.agent_operator_productivity_cards_dir / f"{card_id}.json"
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value]
+
+
+def _nested_observed_claim_errors(value: Any, *, path: str = "$") -> list[str]:
+    errors: list[str] = []
+    if isinstance(value, dict):
+        for key, item in value.items():
+            current_path = f"{path}.{key}"
+            if str(key).lower() in {"status", "state", "observation_status", "quality_state", "delivery_status", "runtime_status"}:
+                if str(item).strip().lower() in OBSERVED_CLAIM_STATUSES:
+                    errors.append(f"{current_path} must not claim observed runtime or completion status")
+            errors.extend(_nested_observed_claim_errors(item, path=current_path))
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            errors.extend(_nested_observed_claim_errors(item, path=f"{path}[{index}]"))
+    return errors

--- a/src/paths.py
+++ b/src/paths.py
@@ -67,6 +67,18 @@ class OmhPaths:
         return self.research_department_dir / "index.json"
 
     @property
+    def agent_operator_productivity_dir(self) -> Path:
+        return self.omh_home / "agent-ops"
+
+    @property
+    def agent_operator_productivity_cards_dir(self) -> Path:
+        return self.agent_operator_productivity_dir / "reviews"
+
+    @property
+    def agent_operator_productivity_index_path(self) -> Path:
+        return self.agent_operator_productivity_dir / "index.json"
+
+    @property
     def materials_dir(self) -> Path:
         return self.omh_home / "materials"
 

--- a/src/routing/recommend.py
+++ b/src/routing/recommend.py
@@ -201,6 +201,19 @@ _SKILL_POLICIES.update(
             evidence_boundary="An ops observability card is not billing truth, provider quota truth, complete tracing, performance proof, or workflow completion evidence.",
             wrapper_guidance="Report token/cost/latency/run-history telemetry as wrapper-safe status with clear local-estimate vs provider-observed boundaries.",
         ),
+        "agent-ops-review": RecommendationPolicy(
+            next_action="prepare_agent_ops_review",
+            evidence_boundary=(
+                "An agent ops review card is not source retrieval, executor dispatch, coding progress, "
+                "implementation, review, verification, CI, merge-readiness, merge, platform delivery, "
+                "provider billing, or live runtime telemetry evidence."
+            ),
+            wrapper_guidance=(
+                "Render a manager-facing quality and throughput card: workflow quality lanes, blockers, "
+                "next actions, and throughput levers. Keep shell commands hidden from normal chat users and "
+                "record only observed runtime/source/review evidence."
+            ),
+        ),
     }
 )
 _CATEGORY_POLICIES = {

--- a/src/skills/catalog.py
+++ b/src/skills/catalog.py
@@ -336,6 +336,7 @@ _CODING_INTENT_BY_SKILL.update(
         "voice-operator": "planning",
         "toolbelt-readiness": "planning",
         "ops-observability-card": "planning",
+        "agent-ops-review": "planning",
     }
 )
 
@@ -2436,6 +2437,38 @@ _FEATURE_SURFACE_SKILLS = (
         good_prompt="ops-observability-card show token, cost, latency, and last run status for this loop.",
         bad_prompt="ops-observability-card claim exact provider billing from local estimates.",
     ),
+    _feature_surface_skill(
+        "agent-ops-review",
+        "Hermes agent ops review workflow: help a manager inspect AI-agent research, coding, review, status, blockers, quality gates, and throughput levers.",
+        (
+            "agent-ops-review",
+            "agent ops review",
+            "agent productivity",
+            "operator productivity",
+            "manager view",
+            "quality dashboard",
+            "throughput review",
+            "agent work quality",
+            "coding progress quality",
+            "research coding review status",
+            "ai agent manager",
+            "third-party manager",
+            "관리자 입장",
+            "작업 생산량",
+            "처리량",
+            "품질 퀄리티",
+            "작업 품질",
+            "진행상황",
+            "리서치 코딩 리뷰",
+        ),
+        "Use when Hermes should explain AI-agent work from a manager/operator perspective: quality gates, progress, blockers, next actions, and throughput opportunities across research, coding, review, and status.",
+        category="operator",
+        phase="manager-review",
+        next_action="prepare_agent_ops_review",
+        boundary="An agent ops review card is not source retrieval, executor dispatch, coding progress, implementation, review, verification, CI, merge-readiness, merge, platform delivery, provider billing, or live runtime telemetry evidence.",
+        good_prompt="agent-ops-review show me quality, blockers, and throughput for AI-agent research, coding, and review work.",
+        bad_prompt="agent-ops-review claim Codex finished and CI passed because a handoff exists.",
+    ),
 )
 
 
@@ -2530,6 +2563,14 @@ _SURFACE_EXPOSURES = (
         "harness_reference",
         "Use as a telemetry/status harness for token, cost, latency, run history, and failure-mode boundaries.",
         True,
+    ),
+    SurfaceExposure(
+        "agent-ops-review",
+        "workflow_skill",
+        ("routable", "installable", "playbook", "harness", "workflow_reference", "capability"),
+        True,
+        "primary_workflow_skill",
+        "Use as an installed Hermes workflow skill when a manager wants quality, blockers, next actions, and throughput guidance for AI-agent work.",
     ),
 )
 
@@ -3513,6 +3554,31 @@ _FEATURE_SURFACE_HARNESSES = (
         wrapper_actions=("show_observability", "record_metric", "record_failure_mode", "show_status"),
         overclaim_guard="An ops observability card is not billing truth, provider quota truth, complete tracing, performance proof, or workflow completion evidence.",
     ),
+    _feature_surface_harness(
+        "agent-ops-review",
+        "Prepare a manager-facing quality and throughput review for AI-agent research, coding, review, and status work.",
+        "Use when a third-party operator or team lead wants to understand progress, blockers, quality gates, next actions, and safe throughput levers without running shell catalog commands.",
+        ("manager request", "work context or run/session references when available", "target outcome", "known evidence gaps"),
+        ("agent_operator_productivity/v1", "agent_operator_status_card/v1", "quality lanes", "blockers", "next action", "throughput levers"),
+        quality_tier="manager-review-gated",
+        evidence_ladder=(
+            "manager_scope_recorded",
+            "quality_lanes_prepared",
+            "evidence_gaps_named",
+            "next_action_selected",
+            "runtime_observation_recorded_when_available",
+        ),
+        wrapper_actions=(
+            "show_agent_ops_review",
+            "choose_ops_lane",
+            "prepare_research_lane",
+            "prepare_coding_lane",
+            "prepare_review_lane",
+            "refresh_agent_ops_status",
+            "record_agent_ops_observation",
+        ),
+        overclaim_guard="An agent ops review card is not source retrieval, executor dispatch, implementation, verification, review, CI, merge, delivery, provider billing, or live telemetry evidence.",
+    ),
 )
 
 
@@ -3568,6 +3634,7 @@ _PRIMARY_HARNESSES.update(
         "voice-operator": "voice-operator",
         "toolbelt-readiness": "toolbelt-readiness",
         "ops-observability-card": "ops-observability-card",
+        "agent-ops-review": "agent-ops-review",
     }
 )
 

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -10,6 +10,7 @@ from ..coding_delegation import build_coding_delegation_payload
 from ..executors import executor_label
 from ..goal_loop import build_loop_start_card
 from ..hermes_planning import build_hermes_plan_payload
+from ..operator_productivity import build_agent_operator_productivity_card
 from ..skills.catalog import installable_skill_definitions, primary_harness_for_skill, retained_delegation_skill_names
 from ..visual_summary import image_generation_setup_fallback
 from .hermes_runtime import (
@@ -96,6 +97,13 @@ VISIBLE_ACTIONS = (
     "record_visual_qa",
     "record_visual_delivery",
     "show_visual_status",
+    "show_agent_ops_review",
+    "choose_ops_lane",
+    "prepare_research_lane",
+    "prepare_coding_lane",
+    "prepare_review_lane",
+    "refresh_agent_ops_status",
+    "record_agent_ops_observation",
     "cancel",
 )
 _ROUTE_TO_MODE = {"dispatch": "plan", "clarify": "clarify", "fallback": "clarify"}
@@ -114,6 +122,7 @@ _SKILL_PICKER_ENTRIES = (
     ("feedback-triage", "Feedback Triage", "Turn customer or product signals into investigation.", "./feedback-triage <signal>"),
     ("web-research", "Web Research", "Gather source-backed current evidence.", "./web-research <question>"),
     ("research-department", "Research Department", "Prepare Scout, Analyst, and Briefer research ops.", "./research-department <topic>"),
+    ("agent-ops-review", "Agent Ops Review", "See quality, blockers, next action, and throughput levers.", "./agent-ops-review <request>"),
     ("code-review", "Code Review", "Review completed work without overclaiming evidence.", "./code-review <scope>"),
     ("materials-package", "Materials Package", "Shape PPT, PDF, spreadsheet, document, or Markdown deliverables.", "./materials-package <brief>"),
     ("img-summary", "Img Summary", "Prepare image-generation-ready summary cards.", "./img-summary <source>"),
@@ -570,6 +579,46 @@ def build_chat_response_from_route(
                         "Show generate_visual_image only when wrapper context reports image_generation_capability/v1 "
                         "with state connected; that action is still not generation evidence."
                     ),
+                },
+            )
+        if selected == "agent-ops-review" or policy_next_action == "prepare_agent_ops_review":
+            evidence_boundary = str(policy.get("evidence_boundary", "")) or "An agent ops review card is not runtime evidence."
+            card = build_agent_operator_productivity_card(
+                message or selected,
+                source=str(decision.get("source", "generic")),
+            )
+            status_card = card["status_card"]
+            return _chat_response(
+                kind="agent_ops_review",
+                headline=str(status_card.get("headline", "I can prepare an agent ops review for this.")),
+                body=(
+                    "I will show quality gates, current gaps, blockers, next actions, and throughput levers "
+                    "without asking the user to approve shell catalog commands."
+                ),
+                phase="agent_ops_review_prepared",
+                next_action=str(card.get("next_action", "show_agent_ops_review")),
+                thread_key=thread_key,
+                actions=[
+                    _action("show_agent_ops_review", "Show agent ops review", "primary"),
+                    _action("prepare_research_lane", "Prepare research lane", "secondary"),
+                    _action("prepare_coding_lane", "Prepare coding lane", "secondary"),
+                    _action("prepare_review_lane", "Prepare review lane", "secondary"),
+                    _action("refresh_agent_ops_status", "Refresh status", "secondary"),
+                    _action("record_agent_ops_observation", "Record observation", "secondary"),
+                ],
+                claim_boundary=evidence_boundary,
+                extra_state={
+                    "route_action": action,
+                    "confidence": decision.get("confidence", "low"),
+                    "selected_workflow": selected,
+                    "policy_next_action": policy_next_action,
+                    "artifact_schema": card["schema_version"],
+                    "status_card_schema": status_card.get("schema_version", ""),
+                    "agent_ops_review": card,
+                    "quality_state": status_card.get("quality_state", "prepared_not_observed"),
+                    "blockers": status_card.get("blockers", []),
+                    "throughput_levers": card.get("throughput_levers", []),
+                    "evidence_not_observed": card.get("not_evidence_until_observed", []),
                 },
             )
         next_action = policy_next_action if policy_next_action and policy_next_action != "show_workflow_guidance" else "dispatch_to_workflow"

--- a/tests/test_operator_productivity.py
+++ b/tests/test_operator_productivity.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from _cli_harness import run_cli
+from _local_package import load_local_package
+
+load_local_package()
+from omh.operator_productivity import (
+    build_agent_operator_productivity_card,
+    validate_agent_operator_productivity_card,
+)
+from omh.routing.recommend import recommend_skills
+from omh.skills.catalog import harness_definition, installable_skill_names, primary_harness_for_skill
+
+
+class OperatorProductivityTests(unittest.TestCase):
+    def test_card_exposes_manager_quality_and_throughput_boundaries(self) -> None:
+        card = build_agent_operator_productivity_card(
+            "관리자 입장에서 AI agent 서치 코딩 리뷰 작업 품질과 생산량을 점검해줘",
+            created_at="2026-06-18T00:00:00Z",
+            card_id="20260618T000000Z-agent-ops-test",
+        )
+
+        self.assertEqual(card["schema_version"], "agent_operator_productivity/v1")
+        self.assertEqual(card["kind"], "agent-ops-review")
+        self.assertEqual(card["observation_status"], "prepared")
+        self.assertEqual(card["projection"]["authority"], "projection_only")
+        self.assertEqual(card["manager_view"]["role"], "third_party_operator")
+        self.assertEqual(card["manager_view"]["focus"], "mixed")
+        self.assertIn("quality", card["manager_view"]["goal"])
+        lane_ids = [lane["lane"] for lane in card["workflow_quality"]["lanes"]]
+        self.assertEqual(lane_ids, ["intake", "research", "coding", "review", "status"])
+        self.assertIn("executor_dispatch_observed", card["status_card"]["blockers"])
+        self.assertIn("verification_passed", card["not_evidence_until_observed"])
+        self.assertIn("provider_cost_or_token_truth", card["status_card"]["not_observed"])
+        self.assertIn("separate cheap checks", " ".join(item["lever"] for item in card["throughput_levers"]))
+        self.assertEqual(validate_agent_operator_productivity_card(card), [])
+
+    def test_card_rejects_observed_runtime_claims(self) -> None:
+        card = build_agent_operator_productivity_card(
+            "show coding progress quality",
+            created_at="2026-06-18T00:00:00Z",
+            card_id="20260618T000000Z-agent-ops-claim",
+        )
+        card["status_card"]["quality_state"] = "passed"
+
+        errors = validate_agent_operator_productivity_card(card)
+
+        self.assertIn("must not claim observed runtime or completion status", "; ".join(errors))
+
+    def test_ops_cli_prepares_stores_lists_and_validates_agent_review_cards(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+
+            status, stdout, stderr = run_cli(
+                base
+                + [
+                    "ops",
+                    "agent-review",
+                    "--dry-run",
+                    "--focus",
+                    "coding",
+                    "show manager quality and throughput for Codex coding review work",
+                ]
+            )
+
+            self.assertEqual(status, 0, stderr)
+            preview = json.loads(stdout)
+            self.assertFalse(preview["store"]["written"])
+            self.assertEqual(preview["card"]["manager_view"]["focus"], "coding")
+            self.assertEqual(preview["card"]["status_card"]["next_action"], "prepare_coding_lane")
+            self.assertFalse((root / ".omh" / "agent-ops").exists())
+
+            status, stdout, stderr = run_cli(
+                base
+                + [
+                    "ops",
+                    "agent-review",
+                    "--focus",
+                    "review",
+                    "review AI agent work quality blockers and CI gaps",
+                ]
+            )
+
+            self.assertEqual(status, 0, stderr)
+            created = json.loads(stdout)
+            card_id = created["card"]["card_id"]
+            self.assertTrue(created["store"]["written"])
+            self.assertTrue((root / ".omh" / "agent-ops" / "reviews" / f"{card_id}.json").exists())
+
+            status, stdout, stderr = run_cli(base + ["ops", "agent-review-list"])
+            self.assertEqual(status, 0, stderr)
+            listed = json.loads(stdout)
+            self.assertEqual(listed["count"], 1)
+            self.assertEqual(listed["cards"][0]["card_id"], card_id)
+
+            status, stdout, stderr = run_cli(base + ["ops", "agent-review-show", card_id])
+            self.assertEqual(status, 0, stderr)
+            shown = json.loads(stdout)
+            self.assertEqual(shown["card"]["card_id"], card_id)
+
+            status, stdout, stderr = run_cli(base + ["ops", "agent-review-show", "../outside"])
+            self.assertNotEqual(status, 0)
+            self.assertIn("letters, digits, and hyphens", stderr)
+
+            status, stdout, stderr = run_cli(base + ["ops", "validate"])
+            self.assertEqual(status, 0, stderr)
+            validation = json.loads(stdout)
+            self.assertTrue(validation["ok"])
+            self.assertEqual(validation["agent_ops_reviews"]["card_count"], 1)
+
+    def test_recommend_routes_manager_productivity_requests_to_agent_ops_review(self) -> None:
+        recommendations = recommend_skills(
+            "관리자 입장에서 AI agent 서치 코딩 리뷰 작업 품질과 생산량을 점검해줘",
+            limit=3,
+        )
+
+        self.assertEqual(recommendations[0]["skill"], "agent-ops-review")
+        self.assertEqual(recommendations[0]["next_action"], "prepare_agent_ops_review")
+        self.assertIn("manager-facing", recommendations[0]["wrapper_guidance"])
+        self.assertIn("not source retrieval", recommendations[0]["evidence_boundary"])
+
+    def test_chat_interact_renders_manager_card_without_shell_catalog_approval(self) -> None:
+        status, stdout, stderr = run_cli(
+            [
+                "chat",
+                "interact",
+                "--source",
+                "discord",
+                "as a manager, show AI agent research coding review quality blockers and throughput",
+            ]
+        )
+
+        self.assertEqual(status, 0, stderr)
+        payload = json.loads(stdout)
+        self.assertEqual(payload["chat_response"]["kind"], "agent_ops_review")
+        self.assertEqual(payload["next_action"], "show_agent_ops_review")
+        state = payload["chat_response"]["state"]
+        self.assertEqual(state["artifact_schema"], "agent_operator_productivity/v1")
+        self.assertEqual(state["quality_state"], "prepared_not_observed")
+        self.assertIn("executor_dispatch_observed", state["blockers"])
+        self.assertIn("show_agent_ops_review", {action["id"] for action in payload["chat_response"]["actions"]})
+        self.assertNotIn("omh list", json.dumps(payload))
+
+    def test_catalog_installs_agent_ops_review_and_maps_harness(self) -> None:
+        self.assertIn("agent-ops-review", installable_skill_names())
+        self.assertEqual(primary_harness_for_skill("agent-ops-review"), "agent-ops-review")
+        harness = harness_definition("agent-ops-review")
+        self.assertEqual(harness.quality_tier, "manager-review-gated")
+        self.assertIn("show_agent_ops_review", harness.wrapper_actions)

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -57,6 +57,7 @@ FEATURE_SURFACE_EXPOSURES = {
     "voice-operator": ("agent_context", False),
     "toolbelt-readiness": ("harness_only", False),
     "ops-observability-card": ("harness_only", False),
+    "agent-ops-review": ("workflow_skill", True),
 }
 
 
@@ -334,6 +335,7 @@ class RouterContentTests(unittest.TestCase):
                 "voice-operator",
                 "toolbelt-readiness",
                 "ops-observability-card",
+                "agent-ops-review",
             },
             harnesses,
         )


### PR DESCRIPTION
## Feature Report

### What Changed

- Added a deterministic `agent-ops-review` workflow surface for third-party managers/operators who want to inspect AI-agent research, coding, review, and status work quality.
- Added `agent_operator_productivity/v1` and `agent_operator_status_card/v1` projection artifacts with quality lanes, blockers, next actions, throughput levers, and explicit not-evidence boundaries.
- Added `omh ops agent-review`, `agent-review-list`, and `agent-review-show` backend commands, plus store validation through `omh ops validate`.
- Wired the new surface into recommendation policy, chat wrapper responses, visible wrapper actions, harness metadata, generated tap skill docs, and README/workflow references.
- Added focused regression tests for routing, chat rendering, storage, validation, catalog exposure, and path-safe card lookup.

### Why This Exists

- OMH already tracks handoffs and evidence boundaries, but a manager asking “how is the AI-agent work going, what is blocked, and how do we improve throughput?” needed a first-class projection instead of ad hoc narration or raw shell commands.
- This makes Hermes better at summarizing quality and productivity without pretending research, coding, review, CI, merge, provider telemetry, or platform delivery happened.

### User / Operator Impact

- Hermes can now answer manager-style prompts such as “show AI agent research coding review quality blockers and throughput” with a chat-safe card and buttons rather than asking the user to approve `omh list` or inspect raw JSON.
- Operators get a single view of intake, research, coding, review, and status lanes with missing evidence called out directly.
- Throughput guidance stays practical: one next action, cached readiness after first successful executor checks, cheap-vs-expensive verification separation, reusable source boundaries, and safe parallel-lane guidance.

### How It Works

- `src/operator_productivity.py` builds and validates metadata-only cards. It rejects observed/completed runtime states inside prepared cards and records guardrails such as `prepared_not_observed`.
- `src/commands/ops.py` persists cards under the OMH home, lists summaries, shows a card by id, and folds this store into operations validation.
- `src/routing/recommend.py` and `src/wrapper/contract.py` route manager/productivity prompts to `agent-ops-review` and render wrapper-native actions: show review, prepare research/coding/review lane, refresh status, and record observation.
- `src/skills/catalog.py` exposes the surface as an installable Hermes workflow skill and representative harness; generated docs and tap skill files stay in sync.

### Files And Contracts Touched

- New artifact schemas: `agent_operator_productivity/v1`, `agent_operator_status_card/v1`, `agent_operator_productivity_index/v1`, `agent_operator_productivity_validation/v1`.
- New commands: `omh ops agent-review`, `omh ops agent-review-list`, `omh ops agent-review-show`.
- New installed skill: `skills/agent-ops-review/SKILL.md`.
- Updated wrapper action ids: `show_agent_ops_review`, `choose_ops_lane`, `prepare_research_lane`, `prepare_coding_lane`, `prepare_review_lane`, `refresh_agent_ops_status`, `record_agent_ops_observation`.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` passed, 515 tests.
- [x] `uv run python -m compileall -q src tests` passed.
- [x] `uv run python -m src.cli docs workflows --check` passed.
- [x] `uv run python -m src.cli harness validate` passed.
- [ ] `python3 -m omh.cli release checklist --json` was not run; this PR does not change release packaging.
- [ ] `python3 -m omh.cli release hermes-smoke` was not run; this PR changes local deterministic workflow surfaces, not live Hermes profile loading.
- [ ] `omh --help` was not run; command parser coverage and ops command tests were run instead.
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` was not run; install smoke is outside this manager projection change.
- [x] Relevant dry-run or smoke command: `uv run python -m src.cli recommend "관리자 입장에서 AI agent 서치 코딩 리뷰 작업 품질과 생산량을 점검해줘" --limit 1` routed to `agent-ops-review`.
- [x] Relevant dry-run or smoke command: `uv run python -m src.cli chat interact --source discord "as a manager, show AI agent research coding review quality blockers and throughput"` rendered an `agent_ops_review` chat response with wrapper actions and prepared-not-observed state.
- [ ] Manual Hermes/TUI check was not run; the wrapper contract was validated through deterministic CLI/tests instead.

## Risk

- Moderate catalog surface growth: one more installable workflow skill and harness appear in generated docs and pickers.
- The card can be mistaken for live telemetry if a wrapper hides the boundary copy; tests and contract fields keep the boundary visible, but wrapper rendering still matters.

## Compatibility / Rollout

- Backward compatible: existing commands and schemas are unchanged.
- New ops commands are additive and metadata-only.
- `omh ops validate` now includes agent ops review cards, so malformed local cards can make the ops validation report fail as intended.

## Release / Claims

- [x] Release-channel impact considered: local/preview-safe additive workflow surface.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] Known manual Hermes checks are listed, including the live Hermes/TUI gap above.

## Follow-Up

- A future wrapper UI can render `agent_operator_status_card/v1` as a compact manager dashboard and record real runtime/source/review observations when available.
