### PR TITLE
Show same-version command updates

### DIFF
--- a/src/commands/setup.py
+++ b/src/commands/setup.py
@@ -1618,22 +1618,39 @@ def _command_package_display_change(payload: dict[str, object], release_update: 
     display = release_update.get("display", {})
     if not isinstance(display, dict):
         display = {}
+    previous = release_update.get("previous", {})
+    if not isinstance(previous, dict):
+        previous = {}
+    current = release_update.get("current", {})
+    if not isinstance(current, dict):
+        current = {}
     channel = str(payload.get("release_channel", "")).strip()
     version_change = str(display.get("version_change", "")).strip()
     source_ref_change = str(display.get("source_ref_change", "")).strip()
-    if channel == "stable" and version_change:
+    package_url_change = str(display.get("package_url_change", "")).strip()
+    previous_version = str(previous.get("release_version", "")).strip()
+    current_version = str(current.get("release_version", "")).strip()
+    previous_ref = str(previous.get("release_source_ref", "")).strip()
+    current_ref = str(current.get("release_source_ref", "")).strip()
+    previous_package_url = str(previous.get("release_package_url", "")).strip()
+    current_package_url = str(current.get("release_package_url", "")).strip()
+    version_changed = bool(current_version and previous_version != current_version)
+    source_ref_changed = bool(current_ref and previous_ref != current_ref)
+    package_url_changed = bool(current_package_url and previous_package_url != current_package_url)
+    if channel == "stable" and version_changed and version_change:
         return version_change
-    if source_ref_change:
+    if channel == "stable" and current_version and source_ref_changed and source_ref_change:
+        return f"{current_version} ({source_ref_change})"
+    if channel == "stable" and current_version and package_url_changed and package_url_change:
+        return f"{current_version} (package URL changed)"
+    if source_ref_changed and source_ref_change:
         return source_ref_change
-    current = release_update.get("current", {})
-    if isinstance(current, dict):
-        if channel == "stable":
-            version = str(current.get("release_version", "")).strip()
-            if version:
-                return version
-        source_ref = str(current.get("release_source_ref", "")).strip()
-        if source_ref:
-            return source_ref
+    if package_url_changed and package_url_change:
+        return package_url_change
+    if channel == "stable" and current_version:
+        return f"{current_version} -> {current_version}" if previous_version == current_version else current_version
+    if current_ref:
+        return f"{current_ref} -> {current_ref}" if previous_ref == current_ref else current_ref
     package_url = str(payload.get("release_package_url", "")).strip()
     return package_url or "updated"
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5510,6 +5510,50 @@ class CliTests(unittest.TestCase):
             self.assertIn("Release state: updated", stdout)
             self.assertIn("OMH command: 1.0.1 -> 1.0.2 (updated)", stdout)
 
+            status, stdout, stderr = run_cli(
+                [
+                    "--omh-home",
+                    str(omh_home),
+                    "update",
+                    "--channel",
+                    "stable",
+                    "--version",
+                    "1.0.2",
+                    "--source-ref",
+                    "v1.0.2@rerun",
+                    "--command-package-updated",
+                ],
+                output_json=False,
+            )
+            self.assertEqual(status, 0, stderr)
+            self.assertEqual(stderr, "")
+            self.assertIn("Release version: 1.0.2 -> 1.0.2", stdout)
+            self.assertIn("Source ref: v1.0.2 -> v1.0.2@rerun", stdout)
+            self.assertIn("Release state: updated", stdout)
+            self.assertIn("OMH command: 1.0.2 (v1.0.2 -> v1.0.2@rerun) (updated)", stdout)
+
+            status, stdout, stderr = run_cli(
+                [
+                    "--omh-home",
+                    str(omh_home),
+                    "update",
+                    "--channel",
+                    "stable",
+                    "--version",
+                    "1.0.2",
+                    "--source-ref",
+                    "v1.0.2@rerun",
+                    "--command-package-updated",
+                ],
+                output_json=False,
+            )
+            self.assertEqual(status, 0, stderr)
+            self.assertEqual(stderr, "")
+            self.assertIn("Release version: 1.0.2 -> 1.0.2", stdout)
+            self.assertIn("Source ref: v1.0.2@rerun -> v1.0.2@rerun", stdout)
+            self.assertIn("Release state: updated", stdout)
+            self.assertIn("OMH command: 1.0.2 -> 1.0.2 (updated)", stdout)
+
     def test_direct_update_source_ref_metadata_does_not_claim_command_package_update(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## Summary

`omh update` now treats same-version command package refreshes as visible updates when there is deterministic installer evidence.

Previously, the human summary could make a command package update look unchanged when the semantic version stayed the same, such as `1.0.1 -> 1.0.1`. That was misleading for preview builds, rerun stable packages, or installer-driven refreshes where the version label is not enough to describe what changed.

This PR updates the display logic so the update summary can show:

- `OMH command: 1.0.1 (v1.0.1 -> v1.0.1@rerun) (updated)` when the source ref changes but the version stays the same.
- `OMH command: 1.0.1 -> 1.0.1 (updated)` when installer evidence says the command package changed even though version/ref labels are identical.
- `package URL changed` when the deterministic package URL changes while the stable version label stays the same.

## Why

Users should be able to trust the update output at a glance. Same version does not always mean same installed command package, especially before or between tagged releases. The CLI should say “updated” when it has evidence of a refresh, instead of hiding that behind an unchanged semantic version label.

## User Impact

After this change, `omh update` can clearly communicate:

- version movement,
- same-version source-ref movement,
- same-version package URL movement,
- workflow-only refreshes versus command package refreshes.

The machine-readable JSON contract is unchanged.

## Implementation Notes

- Refined `_command_package_display_change` in `src/commands/setup.py`.
- Added focused CLI coverage for stable same-version source-ref movement and same-version installer-reported refreshes.
- Kept the evidence boundary conservative: OMH does not infer remote archive content changes without installer/update metadata such as source ref, package URL, or `--command-package-updated`.

## Verification

```sh
PYTHONPATH=tests uv run python -m unittest tests.test_cli.CliTests.test_installer_reported_update_records_version_and_ref_movement -v
PYTHONPATH=tests uv run python -m unittest tests/test_cli.py -v
PYTHONPATH=tests uv run python -m unittest discover -s tests -v
uv run python -m src.cli docs workflows --check
uv run python -m src.cli harness validate
uv run python -m compileall -q src tests
git diff --check
```

Manual smoke:

```sh
tmp=$(mktemp -d)
uv run python -m src.cli --omh-home "$tmp/.omh" install --channel stable --version 1.0.1 --source-ref v1.0.1 --command-package-updated >/dev/null
uv run python -m src.cli --omh-home "$tmp/.omh" update --channel stable --version 1.0.1 --source-ref v1.0.1@rerun --command-package-updated
rm -rf "$tmp"
```

Observed output included:

```text
OMH command: 1.0.1 (v1.0.1 -> v1.0.1@rerun) (updated)
```

## Risks

This intentionally remains metadata-driven. If a remote archive changes without version, source-ref, package URL, or installer evidence changing, OMH does not claim to have detected it.
