### PR TITLE
Improve menu bar status card UI

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -167,7 +167,10 @@ not the source of truth. The payload separates `hermes_agents` from
 `external_coding_executors` so Codex, Claude Code, OMX, OMO, OMC, or generic
 coding tools cannot be rendered as Hermes agents by accident. Compact surfaces
 receive source and model `icon_id` values plus tooltip text rather than Markdown
-tables or prose-only labels.
+tables or prose-only labels. `display.menu_cards` is the human-facing card model
+for the native menu bar helper, grouping the same contract into Overview,
+Hermes, Coding, and Evidence sections so compact UI surfaces do not need to
+render raw JSON-like text.
 
 `current_external_coding_executor` names the selected row explicitly, preferring
 `runtime/state.json` `last_run_id` when it matches the recent executor list, so
@@ -180,8 +183,8 @@ payload, normally produced by a native macOS MenuBarExtra app or test harness.
 That overlay is app-local, expires after a short TTL, and applies restarting
 state only inside its restart window. OMH does not scan processes, launch
 agents, infer runtime health, or turn prepared handoffs into observed
-execution. A native macOS app can be built on top of this contract later; this
-repository slice provides the deterministic backend contract and CLI projection.
+execution. The native macOS helper consumes the card model and keeps PID/process
+detail hidden until that overlay is fresh.
 
 `cli.py` is a compatibility adapter. `commands/main.py` owns parser assembly,
 top-level error handling, and the public command handler re-export surface.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -101,19 +101,23 @@ view model:
 omh menubar status
 ```
 
-`omh menubar status` itself only emits `menubar_status/v1` JSON with separate
-`hermes_agents` and `external_coding_executors` sections, friendly labels such as
-`OMH connection: Ready`, `Hermes targets: 2`, `Coding handoff: Codex`, and
+`omh menubar status` itself emits `menubar_status/v1` JSON with separate
+`hermes_agents` and `external_coding_executors` sections, friendly labels such
+as `OMH connection: Ready`, `Hermes targets: 2`, `Coding handoff: Codex`, and
 `Send mode: Ask before opening Codex`, plus source/model icon IDs with tooltip
-text. Codex and other coding tools are external executors, not Hermes agents.
-Without an explicit process overlay, the payload reports configured/prepared
-state only and leaves PID plus running/restarting unobserved.
+text. It also includes `display.menu_cards`, a compact Overview/Hermes/Coding/
+Evidence card model for native menu bar surfaces. Codex and other coding tools
+are external executors, not Hermes agents. Without an explicit process overlay,
+the payload reports configured/prepared state only and leaves PID plus
+running/restarting unobserved.
 
 On macOS, a normal user-scope `omh setup` also attempts to build and start the
 small OMH menu bar helper when `swiftc` is available. The helper lives under
 `~/.omh/menubar`, is started with a user LaunchAgent, and refreshes the same
-`omh menubar status` payload. Use explicit commands when you want to manage it
-yourself:
+`omh menubar status` payload. The visible menu is intentionally grouped as
+Overview, Hermes, Coding, and Evidence cards instead of a raw text list, and it
+shows process/PID detail only when a fresh overlay observed that process. Use
+explicit commands when you want to manage it yourself:
 
 ```sh
 omh menubar install

--- a/src/menubar_app.py
+++ b/src/menubar_app.py
@@ -242,7 +242,7 @@ final class OMHMenuBarDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
         NSApp.setActivationPolicy(.accessory)
         parseArguments()
-        configureMenu(summary: "Loading OMH status", details: [])
+        configureMenu(headline: "OMH", summary: "Loading status", cards: [])
         refresh()
         timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
             self?.refresh()
@@ -285,36 +285,65 @@ final class OMHMenuBarDelegate: NSObject, NSApplicationDelegate {
     private func refresh() {
         guard let payload = readStatusPayload() else {
             statusItem.button?.title = "omh !"
-            configureMenu(summary: "OMH status unavailable", details: ["Run omh doctor in Terminal."])
+            configureMenu(
+                headline: "OMH needs attention",
+                summary: "Status unavailable",
+                cards: [
+                    [
+                        "title": "Recovery",
+                        "rows": [
+                            ["label": "Next", "value": "Run omh doctor"],
+                            ["label": "Then", "value": "Run omh setup if registration needs repair"]
+                        ]
+                    ]
+                ]
+            )
             return
         }
         let display = payload["display"] as? [String: Any]
         let settings = payload["settings"] as? [String: Any]
         let title = (display?["menu_title"] as? String) ?? "omh"
+        let headline = (display?["headline"] as? String) ?? "OMH ready"
         let summary = (display?["summary_line"] as? String) ?? "OMH ready"
         let connection = ((settings?["omh_connection"] as? [String: Any])?["value"] as? String) ?? "unknown"
         let mark = connection == "ready" ? "✓" : "!"
         statusItem.button?.title = "\(title) \(mark)"
-        statusItem.button?.toolTip = summary
-        var details: [String] = []
-        for key in ["omh_connection", "hermes_targets", "coding_handoff", "send_mode"] {
-            if let row = settings?[key] as? [String: Any], let label = row["label"] as? String {
-                details.append(label)
-            }
-        }
-        configureMenu(summary: summary, details: details)
+        statusItem.button?.toolTip = "\(headline) — \(summary)"
+        configureMenu(headline: headline, summary: summary, cards: menuCards(from: payload))
     }
 
-    private func configureMenu(summary: String, details: [String]) {
+    private func configureMenu(headline: String, summary: String, cards: [[String: Any]]) {
         let menu = NSMenu()
-        let summaryItem = NSMenuItem(title: summary, action: nil, keyEquivalent: "")
-        summaryItem.isEnabled = false
-        menu.addItem(summaryItem)
-        if !details.isEmpty {
+        let headlineItem = disabledItem(" \(headline)")
+        let font = NSFont.menuBarFont(ofSize: 0)
+        headlineItem.attributedTitle = NSAttributedString(
+            string: " \(headline)",
+            attributes: [.font: NSFont.boldSystemFont(ofSize: font.pointSize)]
+        )
+        menu.addItem(headlineItem)
+        menu.addItem(disabledItem(" \(summary)"))
+
+        for card in cards {
             menu.addItem(NSMenuItem.separator())
-            for detail in details {
-                let item = NSMenuItem(title: detail, action: nil, keyEquivalent: "")
-                item.isEnabled = false
+            if let title = card["title"] as? String, !title.isEmpty {
+                let item = disabledItem(" \(title)")
+                item.attributedTitle = NSAttributedString(
+                    string: " \(title)",
+                    attributes: [.font: NSFont.boldSystemFont(ofSize: font.pointSize)]
+                )
+                menu.addItem(item)
+            }
+            if let rows = card["rows"] as? [[String: Any]] {
+                for row in rows.prefix(5) {
+                    let line = rowTitle(row)
+                    let item = disabledItem("   \(line)")
+                    item.toolTip = line
+                    menu.addItem(item)
+                }
+            }
+            if let footer = card["footer"] as? String, !footer.isEmpty {
+                let item = disabledItem("   \(footer)")
+                item.toolTip = footer
                 menu.addItem(item)
             }
         }
@@ -322,6 +351,55 @@ final class OMHMenuBarDelegate: NSObject, NSApplicationDelegate {
         menu.addItem(NSMenuItem(title: "Refresh", action: #selector(refreshClicked(_:)), keyEquivalent: "r"))
         menu.addItem(NSMenuItem(title: "Quit OMH Menu Bar", action: #selector(quitClicked(_:)), keyEquivalent: "q"))
         statusItem.menu = menu
+    }
+
+    private func disabledItem(_ title: String) -> NSMenuItem {
+        let item = NSMenuItem(title: title, action: nil, keyEquivalent: "")
+        item.isEnabled = false
+        return item
+    }
+
+    private func rowTitle(_ row: [String: Any]) -> String {
+        let label = (row["label"] as? String) ?? ""
+        let value = (row["value"] as? String) ?? ""
+        let detail = (row["detail"] as? String) ?? ""
+        var pieces: [String] = []
+        if !label.isEmpty {
+            pieces.append(label)
+        }
+        if !value.isEmpty {
+            pieces.append(value)
+        }
+        var title = pieces.joined(separator: ": ")
+        if !detail.isEmpty {
+            title += " — \(detail)"
+        }
+        return title.isEmpty ? "Unavailable" : title
+    }
+
+    private func menuCards(from payload: [String: Any]) -> [[String: Any]] {
+        if
+            let display = payload["display"] as? [String: Any],
+            let cards = display["menu_cards"] as? [[String: Any]],
+            !cards.isEmpty
+        {
+            return cards
+        }
+        return fallbackCards(from: payload)
+    }
+
+    private func fallbackCards(from payload: [String: Any]) -> [[String: Any]] {
+        let settings = payload["settings"] as? [String: Any]
+        var rows: [[String: String]] = []
+        for key in ["omh_connection", "hermes_targets", "coding_handoff", "send_mode"] {
+            if
+                let row = settings?[key] as? [String: Any],
+                let label = row["label"] as? String
+            {
+                rows.append(["label": label, "value": ""])
+            }
+        }
+        return [["title": "Overview", "rows": rows]]
     }
 
     private func readStatusPayload() -> [String: Any]? {

--- a/src/menubar_status.py
+++ b/src/menubar_status.py
@@ -354,7 +354,7 @@ def _display(
     settings: dict[str, Any],
     hermes_agents: list[dict[str, Any]],
     current_executor_row: dict[str, Any],
-) -> dict[str, str]:
+) -> dict[str, Any]:
     headline = "OMH ready" if settings["omh_connection"]["value"] == "ready" else "OMH needs attention"
     pieces = [f"{len(hermes_agents)} Hermes target(s)"]
     if current_executor_row:
@@ -365,7 +365,140 @@ def _display(
         "menu_title": "omh",
         "headline": headline,
         "summary_line": " · ".join(pieces),
+        "menu_cards": _menu_cards(settings, hermes_agents, current_executor_row),
     }
+
+
+def _menu_cards(
+    settings: dict[str, Any],
+    hermes_agents: list[dict[str, Any]],
+    current_executor_row: dict[str, Any],
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "title": "Overview",
+            "rows": [
+                _menu_row("Connection", _setting_value(settings, "omh_connection", default="unknown")),
+                _menu_row("Hermes targets", str(len(hermes_agents)), detail=_target_menu_detail(settings)),
+                _menu_row("Coding agent", _coding_agent_menu_value(settings, current_executor_row)),
+            ],
+        },
+        {
+            "title": "Hermes",
+            "rows": _hermes_menu_rows(hermes_agents),
+            "footer": "Process details appear only after an observed runtime overlay.",
+        },
+        {
+            "title": "Coding",
+            "rows": _coding_menu_rows(settings, current_executor_row),
+        },
+        {
+            "title": "Evidence",
+            "rows": [
+                _menu_row("Boundary", _evidence_menu_value(hermes_agents, current_executor_row)),
+                _menu_row("Next", _evidence_next_action(current_executor_row)),
+            ],
+        },
+    ]
+
+
+def _menu_row(label: str, value: str, *, detail: str = "", tone: str = "neutral") -> dict[str, str]:
+    row = {"label": label, "value": value, "tone": tone}
+    if detail:
+        row["detail"] = detail
+    return row
+
+
+def _setting_value(settings: dict[str, Any], key: str, *, default: str = "") -> str:
+    row = _dict(settings.get(key))
+    return str(row.get("value", "") or default)
+
+
+def _target_menu_detail(settings: dict[str, Any]) -> str:
+    value = _setting_value(settings, "hermes_targets", default="unknown")
+    if value.startswith("single"):
+        return "single target"
+    if value.startswith("multi"):
+        return "multi target"
+    return value
+
+
+def _coding_agent_menu_value(settings: dict[str, Any], current_executor_row: dict[str, Any]) -> str:
+    if current_executor_row:
+        return str(current_executor_row.get("name", "") or "selected")
+    return _executor_setting_label(_setting_value(settings, "coding_handoff", default="choose"))
+
+
+def _hermes_menu_rows(hermes_agents: list[dict[str, Any]]) -> list[dict[str, str]]:
+    if not hermes_agents:
+        return [_menu_row("Target", "none", detail="run setup or reload Hermes")]
+    rows: list[dict[str, str]] = []
+    for agent in hermes_agents[:3]:
+        name = _short_text(str(agent.get("name", "") or "Hermes Agent"), limit=28)
+        status = str(agent.get("status_label", "") or agent.get("status", "") or "configured")
+        detail = _process_menu_detail(agent)
+        rows.append(_menu_row(name, status, detail=detail, tone="ok" if agent.get("status_observed") else "neutral"))
+    if len(hermes_agents) > 3:
+        rows.append(_menu_row("More", f"{len(hermes_agents) - 3} hidden"))
+    return rows
+
+
+def _coding_menu_rows(settings: dict[str, Any], current_executor_row: dict[str, Any]) -> list[dict[str, str]]:
+    if current_executor_row:
+        name = str(current_executor_row.get("name", "") or "Coding agent")
+        status = str(current_executor_row.get("status_label", "") or current_executor_row.get("status", "") or "prepared")
+        detail = _process_menu_detail(current_executor_row)
+        rows = [_menu_row(name, status, detail=detail)]
+        next_action = str(_dict(current_executor_row.get("evidence")).get("next_action", "") or "")
+        if next_action:
+            rows.append(_menu_row("Next", _short_text(next_action, limit=48)))
+        return rows
+    dispatch = _setting_value(settings, "send_mode", default="ask_before_dispatch")
+    return [
+        _menu_row("Current", "idle", detail="no external handoff"),
+        _menu_row("Send mode", _dispatch_policy_menu_value(dispatch, _setting_value(settings, "coding_handoff"))),
+    ]
+
+
+def _dispatch_policy_menu_value(dispatch_policy: str, executor: str) -> str:
+    label = _dispatch_policy_label(dispatch_policy, executor)
+    prefix = "Send mode: "
+    return label[len(prefix) :] if label.startswith(prefix) else label
+
+
+def _process_menu_detail(row: dict[str, Any]) -> str:
+    if row.get("pid_observed"):
+        return str(row.get("pid_label", "") or f"PID {row.get('pid')}")
+    if row.get("status_observed"):
+        return "runtime observed"
+    return "process not observed"
+
+
+def _evidence_menu_value(hermes_agents: list[dict[str, Any]], current_executor_row: dict[str, Any]) -> str:
+    observed_agents = sum(1 for row in hermes_agents if row.get("status_observed") or row.get("pid_observed"))
+    if current_executor_row:
+        evidence = _dict(current_executor_row.get("evidence"))
+        state = str(evidence.get("state", "") or "prepared_not_observed")
+        return _short_text(state.replace("_", " "), limit=32)
+    if observed_agents:
+        return f"{observed_agents} process observed"
+    return "metadata only"
+
+
+def _evidence_next_action(current_executor_row: dict[str, Any]) -> str:
+    if current_executor_row:
+        evidence = _dict(current_executor_row.get("evidence"))
+        next_action = str(evidence.get("next_action", "") or "")
+        if next_action:
+            return _short_text(next_action, limit=48)
+    return "open Hermes or run omh doctor"
+
+
+def _short_text(value: str, *, limit: int) -> str:
+    text = " ".join(str(value or "").split())
+    if len(text) <= limit:
+        return text
+    return text[: max(0, limit - 1)].rstrip() + "…"
 
 
 def _source_icon_id(source: str) -> str:

--- a/tests/test_menubar_status.py
+++ b/tests/test_menubar_status.py
@@ -58,6 +58,10 @@ class MenubarStatusTests(unittest.TestCase):
             self.assertEqual(payload["settings"]["hermes_targets"]["label"], "Hermes targets: 1")
             self.assertEqual(payload["settings"]["coding_handoff"]["label"], "Coding handoff: Codex")
             self.assertEqual(payload["settings"]["send_mode"]["label"], "Send mode: Ask before opening Codex")
+            menu_cards = payload["display"]["menu_cards"]
+            self.assertEqual([card["title"] for card in menu_cards], ["Overview", "Hermes", "Coding", "Evidence"])
+            self.assertIn("Process details appear only after an observed runtime overlay.", menu_cards[1]["footer"])
+            self.assertNotIn("PID", json.dumps(menu_cards))
 
             hermes_agents = payload["hermes_agents"]
             self.assertEqual(len(hermes_agents), 1)
@@ -189,6 +193,9 @@ class MenubarStatusTests(unittest.TestCase):
             self.assertTrue(payload["external_coding_executors"][0]["pid_observed"])
             self.assertTrue(payload["external_coding_executors"][0]["status_observed"])
             self.assertEqual(payload["external_coding_executors"][0]["model"]["tooltip"], "gpt-5.5")
+            menu_cards = payload["display"]["menu_cards"]
+            self.assertIn("PID 4312", json.dumps(menu_cards[1]["rows"]))
+            self.assertIn("PID 9821", json.dumps(menu_cards[2]["rows"]))
 
             status, stdout, stderr = run_cli(
                 [


### PR DESCRIPTION
## Feature Report

### What Changed

- Reworked the OMH menu bar status projection so native compact surfaces receive `display.menu_cards` grouped into Overview, Hermes, Coding, and Evidence cards.
- Updated the macOS menu bar helper to render those cards with section headers instead of a flat list of raw labels.
- Kept PID and process details hidden unless a fresh `menubar_process_overlay/v1` explicitly observed them.
- Updated menu bar docs to describe the card model and the observed-only PID boundary.

### Why This Exists

- The previous menu read like a text dump and made configured Hermes targets feel too similar to observed running processes.
- Operators need a quick menu bar glance that separates “OMH is connected”, “Hermes target is configured”, “coding agent is idle/prepared”, and “process evidence is observed or not”.

### User / Operator Impact

- The menu bar should now feel more scannable: summary first, then compact sections for connection, Hermes target, coding agent, and evidence state.
- A configured Hermes target no longer surfaces PID wording in the visible menu unless the native overlay actually observed a PID.
- Recovery state now shows a short Recovery card with `Run omh doctor` / `Run omh setup if registration needs repair` instead of one generic unavailable line.

### How It Works

- `src/menubar_status.py` builds `display.menu_cards` from existing HUD, target registry, and runtime status data.
- `src/menubar_app.py` reads `display.menu_cards` and renders bold card headings plus compact rows in the macOS menu.
- The raw JSON still keeps machine-readable `hermes_agents` and `external_coding_executors`; the human-facing menu reads from the new card projection.
- `_process_menu_detail` only emits `PID ...` when `pid_observed` is true.

### Files And Contracts Touched

- `src/menubar_status.py`: adds the card projection contract.
- `src/menubar_app.py`: renders card sections from the status payload.
- `tests/test_menubar_status.py`: locks card titles and observed-only PID visibility.
- `docs/INSTALLATION.md` and `docs/ARCHITECTURE.md`: document the card UI and PID boundary.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m src.cli docs workflows --check`
- [x] `uv run python -m src.cli harness validate`
- [ ] `python3 -m omh.cli release checklist --json` - not run; release checklist is outside this narrow menu UI PR.
- [ ] `python3 -m omh.cli release hermes-smoke` - not run; this PR changes the local menu projection, not live Hermes install smoke.
- [ ] `omh --help` - not run; top-level CLI help is unchanged.
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` - not run; live install smoke is outside this narrow menu UI PR.
- [x] Relevant dry-run or smoke command: `PYTHONPATH=src uv run python -m omh.cli menubar status` showed Overview/Hermes/Coding/Evidence cards for the current local profile.
- [x] Relevant dry-run or smoke command: generated macOS helper compiled and `swiftc -typecheck -framework AppKit` passed.
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run before PR; this needs the rebuilt helper installed and restarted after merge.

## Risk

- Narrow UI projection risk: wrappers that ignore `display.menu_cards` continue using the old raw fields.
- The macOS helper still uses native `NSMenu`, so this is a grouped menu card layout rather than a fully custom popover UI.

## Compatibility / Rollout

- Backward compatible JSON: existing `hermes_agents`, `external_coding_executors`, `settings`, and summary fields remain.
- Users need to reinstall/restart the helper after merge so the compiled Swift app picks up the new renderer.

## Release / Claims

- [x] Release-channel impact considered (`preview` once merged to main).
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap.

## Follow-Up

- Consider a richer custom popover later if native `NSMenu` sections are still too constrained visually.
