### PR TITLE
Separate menu bar agent status sections

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -168,9 +168,10 @@ not the source of truth. The payload separates `hermes_agents` from
 coding tools cannot be rendered as Hermes agents by accident. Compact surfaces
 receive source and model `icon_id` values plus tooltip text rather than Markdown
 tables or prose-only labels. `display.menu_cards` is the human-facing card model
-for the native menu bar helper, grouping the same contract into Overview,
-Hermes, Coding, and Evidence sections so compact UI surfaces do not need to
-render raw JSON-like text.
+for the native menu bar helper, grouping the same contract into Connection,
+Agent Status, Coding Handoff, and Evidence sections so compact UI surfaces do
+not need to render raw JSON-like text. The Agent Status section uses an explicit
+`Agent | PID | Status` row shape.
 
 `current_external_coding_executor` names the selected row explicitly, preferring
 `runtime/state.json` `last_run_id` when it matches the recent executor list, so

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -105,19 +105,19 @@ omh menubar status
 `hermes_agents` and `external_coding_executors` sections, friendly labels such
 as `OMH connection: Ready`, `Hermes targets: 2`, `Coding handoff: Codex`, and
 `Send mode: Ask before opening Codex`, plus source/model icon IDs with tooltip
-text. It also includes `display.menu_cards`, a compact Overview/Hermes/Coding/
-Evidence card model for native menu bar surfaces. Codex and other coding tools
+text. It also includes `display.menu_cards`, a compact Connection/Agent Status/
+Coding Handoff/Evidence card model for native menu bar surfaces. The Agent
+Status card is a small `Agent | PID | Status` list. Codex and other coding tools
 are external executors, not Hermes agents. Without an explicit process overlay,
-the payload reports configured/prepared state only and leaves PID plus
-running/restarting unobserved.
+the payload reports configured/prepared state only and shows PID as not observed.
 
 On macOS, a normal user-scope `omh setup` also attempts to build and start the
 small OMH menu bar helper when `swiftc` is available. The helper lives under
 `~/.omh/menubar`, is started with a user LaunchAgent, and refreshes the same
 `omh menubar status` payload. The visible menu is intentionally grouped as
-Overview, Hermes, Coding, and Evidence cards instead of a raw text list, and it
-shows process/PID detail only when a fresh overlay observed that process. Use
-explicit commands when you want to manage it yourself:
+Connection, Agent Status, Coding Handoff, and Evidence sections instead of a raw
+text list, and it shows process/PID detail only when a fresh overlay observed
+that process. Use explicit commands when you want to manage it yourself:
 
 ```sh
 omh menubar install

--- a/src/menubar_app.py
+++ b/src/menubar_app.py
@@ -333,11 +333,27 @@ final class OMHMenuBarDelegate: NSObject, NSApplicationDelegate {
                 )
                 menu.addItem(item)
             }
+            if let columns = card["columns"] as? [String], !columns.isEmpty {
+                let line = tableHeaderTitle(columns)
+                let item = disabledItem("   \(line)")
+                item.toolTip = line
+                item.attributedTitle = NSAttributedString(
+                    string: "   \(line)",
+                    attributes: [.font: NSFont.monospacedSystemFont(ofSize: font.pointSize, weight: .medium)]
+                )
+                menu.addItem(item)
+            }
             if let rows = card["rows"] as? [[String: Any]] {
                 for row in rows.prefix(5) {
                     let line = rowTitle(row)
                     let item = disabledItem("   \(line)")
                     item.toolTip = line
+                    if (row["kind"] as? String) == "agent_status" {
+                        item.attributedTitle = NSAttributedString(
+                            string: "   \(line)",
+                            attributes: [.font: NSFont.monospacedSystemFont(ofSize: font.pointSize, weight: .regular)]
+                        )
+                    }
                     menu.addItem(item)
                 }
             }
@@ -359,7 +375,34 @@ final class OMHMenuBarDelegate: NSObject, NSApplicationDelegate {
         return item
     }
 
+    private func tableHeaderTitle(_ columns: [String]) -> String {
+        let padded = columns.prefix(3).enumerated().map { index, value in
+            if index == 0 {
+                return fixedWidth(value, 18)
+            }
+            if index == 1 {
+                return fixedWidth(value, 13)
+            }
+            return value
+        }
+        return padded.joined()
+    }
+
+    private func fixedWidth(_ value: String, _ length: Int) -> String {
+        if value.count > length {
+            let endIndex = value.index(value.startIndex, offsetBy: max(0, length - 1))
+            return String(value[..<endIndex]) + "…"
+        }
+        return value.padding(toLength: length, withPad: " ", startingAt: 0)
+    }
+
     private func rowTitle(_ row: [String: Any]) -> String {
+        if (row["kind"] as? String) == "agent_status" {
+            let agent = fixedWidth((row["agent"] as? String) ?? "unknown", 18)
+            let pid = fixedWidth((row["pid"] as? String) ?? "not observed", 13)
+            let status = (row["status"] as? String) ?? "unknown"
+            return "\(agent)\(pid)\(status)"
+        }
         let label = (row["label"] as? String) ?? ""
         let value = (row["value"] as? String) ?? ""
         let detail = (row["detail"] as? String) ?? ""

--- a/src/menubar_status.py
+++ b/src/menubar_status.py
@@ -376,20 +376,20 @@ def _menu_cards(
 ) -> list[dict[str, Any]]:
     return [
         {
-            "title": "Overview",
+            "title": "Connection",
             "rows": [
                 _menu_row("Connection", _setting_value(settings, "omh_connection", default="unknown")),
                 _menu_row("Hermes targets", str(len(hermes_agents)), detail=_target_menu_detail(settings)),
-                _menu_row("Coding agent", _coding_agent_menu_value(settings, current_executor_row)),
             ],
         },
         {
-            "title": "Hermes",
-            "rows": _hermes_menu_rows(hermes_agents),
-            "footer": "Process details appear only after an observed runtime overlay.",
+            "title": "Agent Status",
+            "columns": ["Agent", "PID", "Status"],
+            "rows": _agent_status_menu_rows(hermes_agents),
+            "footer": "PID is shown only after an observed runtime overlay.",
         },
         {
-            "title": "Coding",
+            "title": "Coding Handoff",
             "rows": _coding_menu_rows(settings, current_executor_row),
         },
         {
@@ -407,6 +407,16 @@ def _menu_row(label: str, value: str, *, detail: str = "", tone: str = "neutral"
     if detail:
         row["detail"] = detail
     return row
+
+
+def _agent_status_row(agent: str, pid: str, status: str, *, tone: str = "neutral") -> dict[str, str]:
+    return {
+        "kind": "agent_status",
+        "agent": agent,
+        "pid": pid,
+        "status": status,
+        "tone": tone,
+    }
 
 
 def _setting_value(settings: dict[str, Any], key: str, *, default: str = "") -> str:
@@ -429,17 +439,24 @@ def _coding_agent_menu_value(settings: dict[str, Any], current_executor_row: dic
     return _executor_setting_label(_setting_value(settings, "coding_handoff", default="choose"))
 
 
-def _hermes_menu_rows(hermes_agents: list[dict[str, Any]]) -> list[dict[str, str]]:
+def _agent_status_menu_rows(hermes_agents: list[dict[str, Any]]) -> list[dict[str, str]]:
     if not hermes_agents:
-        return [_menu_row("Target", "none", detail="run setup or reload Hermes")]
+        return [_agent_status_row("none", "not observed", "run setup")]
     rows: list[dict[str, str]] = []
     for agent in hermes_agents[:3]:
         name = _short_text(str(agent.get("name", "") or "Hermes Agent"), limit=28)
         status = str(agent.get("status_label", "") or agent.get("status", "") or "configured")
-        detail = _process_menu_detail(agent)
-        rows.append(_menu_row(name, status, detail=detail, tone="ok" if agent.get("status_observed") else "neutral"))
+        pid = _pid_menu_value(agent)
+        rows.append(
+            _agent_status_row(
+                name,
+                pid,
+                status,
+                tone="ok" if agent.get("status_observed") or agent.get("pid_observed") else "neutral",
+            )
+        )
     if len(hermes_agents) > 3:
-        rows.append(_menu_row("More", f"{len(hermes_agents) - 3} hidden"))
+        rows.append(_agent_status_row(f"+{len(hermes_agents) - 3} more", "not shown", "hidden"))
     return rows
 
 
@@ -447,15 +464,19 @@ def _coding_menu_rows(settings: dict[str, Any], current_executor_row: dict[str, 
     if current_executor_row:
         name = str(current_executor_row.get("name", "") or "Coding agent")
         status = str(current_executor_row.get("status_label", "") or current_executor_row.get("status", "") or "prepared")
-        detail = _process_menu_detail(current_executor_row)
-        rows = [_menu_row(name, status, detail=detail)]
+        rows = [
+            _menu_row("Agent", name),
+            _menu_row("Status", status),
+            _menu_row("PID", _pid_menu_value(current_executor_row)),
+        ]
         next_action = str(_dict(current_executor_row.get("evidence")).get("next_action", "") or "")
         if next_action:
             rows.append(_menu_row("Next", _short_text(next_action, limit=48)))
         return rows
     dispatch = _setting_value(settings, "send_mode", default="ask_before_dispatch")
     return [
-        _menu_row("Current", "idle", detail="no external handoff"),
+        _menu_row("Agent", _coding_agent_menu_value(settings, current_executor_row)),
+        _menu_row("Status", "idle", detail="no external handoff"),
         _menu_row("Send mode", _dispatch_policy_menu_value(dispatch, _setting_value(settings, "coding_handoff"))),
     ]
 
@@ -466,12 +487,10 @@ def _dispatch_policy_menu_value(dispatch_policy: str, executor: str) -> str:
     return label[len(prefix) :] if label.startswith(prefix) else label
 
 
-def _process_menu_detail(row: dict[str, Any]) -> str:
-    if row.get("pid_observed"):
-        return str(row.get("pid_label", "") or f"PID {row.get('pid')}")
-    if row.get("status_observed"):
-        return "runtime observed"
-    return "process not observed"
+def _pid_menu_value(row: dict[str, Any]) -> str:
+    if row.get("pid_observed") and row.get("pid"):
+        return str(row.get("pid"))
+    return "not observed"
 
 
 def _evidence_menu_value(hermes_agents: list[dict[str, Any]], current_executor_row: dict[str, Any]) -> str:

--- a/tests/test_menubar_status.py
+++ b/tests/test_menubar_status.py
@@ -59,9 +59,19 @@ class MenubarStatusTests(unittest.TestCase):
             self.assertEqual(payload["settings"]["coding_handoff"]["label"], "Coding handoff: Codex")
             self.assertEqual(payload["settings"]["send_mode"]["label"], "Send mode: Ask before opening Codex")
             menu_cards = payload["display"]["menu_cards"]
-            self.assertEqual([card["title"] for card in menu_cards], ["Overview", "Hermes", "Coding", "Evidence"])
-            self.assertIn("Process details appear only after an observed runtime overlay.", menu_cards[1]["footer"])
-            self.assertNotIn("PID", json.dumps(menu_cards))
+            self.assertEqual(
+                [card["title"] for card in menu_cards],
+                ["Connection", "Agent Status", "Coding Handoff", "Evidence"],
+            )
+            self.assertEqual(menu_cards[1]["columns"], ["Agent", "PID", "Status"])
+            self.assertIn("PID is shown only after an observed runtime overlay.", menu_cards[1]["footer"])
+            self.assertEqual(menu_cards[1]["rows"][0]["kind"], "agent_status")
+            self.assertEqual(menu_cards[1]["rows"][0]["agent"], ".hermes")
+            self.assertEqual(menu_cards[1]["rows"][0]["pid"], "not observed")
+            self.assertEqual(menu_cards[1]["rows"][0]["status"], "Configured")
+            self.assertNotIn("4312", json.dumps(menu_cards))
+            self.assertEqual(menu_cards[2]["rows"][0]["label"], "Agent")
+            self.assertEqual(menu_cards[2]["rows"][0]["value"], "Codex")
 
             hermes_agents = payload["hermes_agents"]
             self.assertEqual(len(hermes_agents), 1)
@@ -194,8 +204,10 @@ class MenubarStatusTests(unittest.TestCase):
             self.assertTrue(payload["external_coding_executors"][0]["status_observed"])
             self.assertEqual(payload["external_coding_executors"][0]["model"]["tooltip"], "gpt-5.5")
             menu_cards = payload["display"]["menu_cards"]
-            self.assertIn("PID 4312", json.dumps(menu_cards[1]["rows"]))
-            self.assertIn("PID 9821", json.dumps(menu_cards[2]["rows"]))
+            self.assertEqual(menu_cards[1]["rows"][0]["pid"], "4312")
+            self.assertEqual(menu_cards[1]["rows"][0]["status"], "Running")
+            self.assertEqual(menu_cards[2]["rows"][2]["label"], "PID")
+            self.assertEqual(menu_cards[2]["rows"][2]["value"], "9821")
 
             status, stdout, stderr = run_cli(
                 [


### PR DESCRIPTION
## Feature Report

### What Changed

- Reworked the visible menu bar status cards into explicit Connection, Agent Status, Coding Handoff, and Evidence sections.
- Changed the Hermes agent area into an `Agent | PID | Status` list instead of sentence-style status rows.
- Rendered the Agent Status section with a monospaced header and fixed-width rows in the macOS menu helper.
- Kept coding handoff details in a separate section from Hermes agent process status.

### Why This Exists

- The previous menu was grouped, but it still read like text labels rather than a clear status UI.
- Operators need to see the Hermes agent list separately from coding handoff state, with PID and status aligned by category.
- PID should be visible as a field, but actual PID numbers must still require observed runtime overlay evidence.

### User / Operator Impact

- The menu now reads as separate areas: connection health, Hermes agent process list, coding handoff state, and evidence boundary.
- Agent rows show `Agent`, `PID`, and `Status` columns. Before observation, PID reads `not observed`; after a fresh overlay, it shows the observed PID number.
- Coding handoff information is no longer visually mixed into the agent list.

### How It Works

- `src/menubar_status.py` now emits `display.menu_cards` with a structured `Agent Status` card and `columns: ["Agent", "PID", "Status"]`.
- `src/menubar_app.py` detects that table shape and renders the header/rows with a monospaced font and fixed-width columns.
- Tests lock both the unobserved PID state and the observed overlay state.

### Files And Contracts Touched

- `src/menubar_status.py`: card titles, agent table row contract, coding handoff rows.
- `src/menubar_app.py`: monospaced table rendering for agent status rows.
- `tests/test_menubar_status.py`: contract tests for `Agent | PID | Status` and observed-only PID values.
- `docs/INSTALLATION.md`, `docs/ARCHITECTURE.md`: updated menu bar UI contract docs.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m src.cli docs workflows --check`
- [x] `uv run python -m src.cli harness validate`
- [ ] `python3 -m omh.cli release checklist --json` - not run; release checklist is outside this narrow menu UI PR.
- [ ] `python3 -m omh.cli release hermes-smoke` - not run; live Hermes smoke is outside this narrow menu UI PR.
- [ ] `omh --help` - not run; top-level help is unchanged.
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` - not run; live install smoke is outside this narrow menu UI PR.
- [x] Relevant dry-run or smoke command: `PYTHONPATH=src uv run python -m omh.cli menubar status` showed Connection, Agent Status, Coding Handoff, and Evidence sections.
- [x] Relevant dry-run or smoke command: generated macOS helper compiled and `swiftc -typecheck -framework AppKit` passed.
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run before PR; requires installing the rebuilt helper after merge.

## Risk

- Low: this changes the human-facing `display.menu_cards` projection and the bundled helper renderer, while leaving raw status sections intact.
- Native `NSMenu` is still a menu, not a custom dashboard popover, so the result is cleaner and sectioned but not a full graphical panel.

## Compatibility / Rollout

- Existing raw JSON fields remain available.
- Consumers that use `display.menu_cards` should render the new section titles and table-shaped agent rows.
- Users need to reinstall/restart the helper after merge for the compiled menu app to pick up the renderer change.

## Release / Claims

- [x] Release-channel impact considered (`preview` once merged to main).
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap.

## Follow-Up

- If the native menu still feels too constrained, move from `NSMenu` rows to a custom menu bar popover view.
