### PR TITLE
Refine menu bar agent status copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ tool, an existing Hermes connector, a generic image tool, or prompt-only mode.
 | Skill pack | Hermes gets workflows like `loop`, `ralplan`, `web-research`, `materials-package`, `img-summary`, and `ultraprocess`. |
 | Setup and repair | `omh setup`, `omh doctor`, `omh update`, and `omh uninstall` keep the local install understandable. |
 | Chat workflow picker | Hermes can answer "what can OMH do?" without making the user approve shell commands. |
-| Coding handoff paths | Hermes can prepare work for Codex, Claude Code, Hermes itself, or another runtime without pretending the work already ran. |
+| Coding agent paths | Hermes can prepare work for Codex, Claude Code, Hermes itself, or another runtime without pretending the work already ran. |
 | Agent ops review | Hermes can explain quality gates, blockers, next actions, and throughput levers for AI-agent work without turning a prepared handoff into evidence. |
 | Evidence-aware status | Plans, handoffs, dispatch, results, verification, review, CI, and merge readiness stay visibly separate. |
 | Organization patterns | Solo, research, product ops, coding runtime, and CTO-style collaboration patterns help Hermes present the right role flow for the request. |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -168,10 +168,10 @@ not the source of truth. The payload separates `hermes_agents` from
 coding tools cannot be rendered as Hermes agents by accident. Compact surfaces
 receive source and model `icon_id` values plus tooltip text rather than Markdown
 tables or prose-only labels. `display.menu_cards` is the human-facing card model
-for the native menu bar helper, grouping the same contract into Connection,
-Agent Status, Coding Handoff, and Evidence sections so compact UI surfaces do
-not need to render raw JSON-like text. The Agent Status section uses an explicit
-`Agent | PID | Status` row shape.
+for the native menu bar helper, grouping the same contract into Agent Status,
+Coding Agent, and Evidence sections so compact UI surfaces do not need to render
+raw JSON-like text. The Agent Status section uses an explicit `Agent | PID |
+Status` row shape.
 
 `current_external_coding_executor` names the selected row explicitly, preferring
 `runtime/state.json` `last_run_id` when it matches the recent executor list, so
@@ -180,12 +180,11 @@ settings and compact summaries do not rely on an unnamed list-order convention.
 The menu bar status contract reports configured Hermes targets and prepared
 handoffs without inventing process state. PID, `running`, and `restarting`
 values are applied only from a caller-provided `menubar_process_overlay/v1`
-payload, normally produced by a native macOS MenuBarExtra app or test harness.
-That overlay is app-local, expires after a short TTL, and applies restarting
-state only inside its restart window. OMH does not scan processes, launch
-agents, infer runtime health, or turn prepared handoffs into observed
-execution. The native macOS helper consumes the card model and keeps PID/process
-detail hidden until that overlay is fresh.
+payload or an explicit `omh menubar status --observe-local-processes` request
+from the native macOS helper. That observation is app-local, expires after a
+short TTL, and applies restarting state only inside its restart window. OMH does
+not turn prepared handoffs into observed execution, review, CI, or merge
+evidence. Plain `omh menubar status` remains metadata-only.
 
 `cli.py` is a compatibility adapter. `commands/main.py` owns parser assembly,
 top-level error handling, and the public command handler re-export surface.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -103,21 +103,23 @@ omh menubar status
 
 `omh menubar status` itself emits `menubar_status/v1` JSON with separate
 `hermes_agents` and `external_coding_executors` sections, friendly labels such
-as `OMH connection: Ready`, `Hermes targets: 2`, `Coding handoff: Codex`, and
-`Send mode: Ask before opening Codex`, plus source/model icon IDs with tooltip
-text. It also includes `display.menu_cards`, a compact Connection/Agent Status/
-Coding Handoff/Evidence card model for native menu bar surfaces. The Agent
-Status card is a small `Agent | PID | Status` list. Codex and other coding tools
-are external executors, not Hermes agents. Without an explicit process overlay,
-the payload reports configured/prepared state only and shows PID as not observed.
+as `OMH connection: Ready`, `Hermes targets: 2`, `Coding agent: Codex`, and
+`Open mode: Ask before opening Codex`, plus source/model icon IDs with tooltip
+text. It also includes `display.menu_cards`, a compact Agent Status/Coding
+Agent/Evidence card model for native menu bar surfaces. The Agent Status card is
+a small `Agent | PID | Status` list. Codex and other coding tools are external
+executors, not Hermes agents. Without an explicit process overlay or local
+process observation, the payload reports configured/prepared state only and
+shows PID as not observed.
 
 On macOS, a normal user-scope `omh setup` also attempts to build and start the
 small OMH menu bar helper when `swiftc` is available. The helper lives under
 `~/.omh/menubar`, is started with a user LaunchAgent, and refreshes the same
-`omh menubar status` payload. The visible menu is intentionally grouped as
-Connection, Agent Status, Coding Handoff, and Evidence sections instead of a raw
-text list, and it shows process/PID detail only when a fresh overlay observed
-that process. Use explicit commands when you want to manage it yourself:
+`omh menubar status --observe-local-processes` payload. The visible menu is
+intentionally grouped as Agent Status, Coding Agent, and Evidence sections
+instead of a raw text list, and it shows process/PID detail only when a fresh
+overlay or explicit local observation saw that process. Use explicit commands
+when you want to manage it yourself:
 
 ```sh
 omh menubar install
@@ -132,15 +134,18 @@ failed helper start does not make the OMH workflow setup fail; setup reports the
 menu bar step separately.
 
 A native macOS MenuBarExtra app, the OMH menu bar helper, or a test harness can
-pass a short-lived `menubar_process_overlay/v1` file when it has actually
-observed local process state:
+pass a short-lived `menubar_process_overlay/v1` file, or ask the backend to do a
+bounded local process observation, when it has actually observed local process
+state:
 
 ```sh
 omh menubar status --overlay /path/to/overlay.json
+omh menubar status --observe-local-processes
 ```
 
-The overlay is app-local and expires by TTL. OMH does not auto-read process
-caches, scan the host, or infer that a prepared coding handoff is running.
+The overlay and local observation are app-local and expire by TTL. OMH does not
+infer that a prepared coding-agent action was executed, reviewed, passed CI, or
+merged.
 
 MCP bridge setup is also optional and intentionally conservative:
 

--- a/src/commands/menubar.py
+++ b/src/commands/menubar.py
@@ -18,6 +18,7 @@ def cmd_menubar_status(args: argparse.Namespace) -> int:
             _paths(args),
             limit=args.limit,
             process_overlay=overlay,
+            observe_local_processes=bool(args.observe_local_processes),
             now=args.now,
         )
     )
@@ -60,6 +61,11 @@ def _add_menubar_commands(sub) -> None:
     status = menubar_sub.add_parser("status", help="Print the macOS menu bar agent-status view model.")
     status.add_argument("--limit", type=int, default=3, help="Maximum recent runtime runs to inspect.")
     status.add_argument("--overlay", default=None, help="Optional menubar_process_overlay/v1 JSON from the menu bar app.")
+    status.add_argument(
+        "--observe-local-processes",
+        action="store_true",
+        help="Opt in to local Hermes process observation for the native menu bar helper.",
+    )
     status.add_argument("--now", default=None, help="Optional ISO timestamp for deterministic overlay TTL evaluation.")
     status.set_defaults(func=cmd_menubar_status)
 

--- a/src/menubar_app.py
+++ b/src/menubar_app.py
@@ -455,7 +455,7 @@ final class OMHMenuBarDelegate: NSObject, NSApplicationDelegate {
         if !hermesHome.isEmpty {
             args.append(contentsOf: ["--hermes-home", hermesHome])
         }
-        args.append(contentsOf: ["menubar", "status"])
+        args.append(contentsOf: ["menubar", "status", "--observe-local-processes"])
         process.arguments = args
         let pipe = Pipe()
         process.standardOutput = pipe

--- a/src/menubar_status.py
+++ b/src/menubar_status.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from datetime import datetime, timezone
 from json import JSONDecodeError
 from pathlib import Path
@@ -47,6 +48,7 @@ def build_menubar_status_payload(
     *,
     limit: int = 3,
     process_overlay: dict[str, Any] | None = None,
+    observe_local_processes: bool = False,
     now: datetime | str | None = None,
 ) -> dict[str, Any]:
     safe_limit = _safe_limit(limit, default=3)
@@ -54,6 +56,8 @@ def build_menubar_status_payload(
     hermes_agents = _hermes_agent_rows(paths)
     external_executors = _external_executor_rows(paths, limit=safe_limit)
     current_executor, current_executor_source = _select_current_external_executor(paths, external_executors)
+    if observe_local_processes and process_overlay is None:
+        process_overlay = _local_process_overlay(hermes_agents, now=now)
     overlay_summary = _apply_process_overlay(
         hermes_agents,
         external_executors,
@@ -74,7 +78,7 @@ def build_menubar_status_payload(
             },
             "external_coding_executors": {
                 "title": "External coding executors",
-                "empty_label": "No external coding executor handoff observed",
+                "empty_label": "No coding agent activity observed",
             },
             "settings": {
                 "title": "Settings",
@@ -95,8 +99,9 @@ def build_menubar_status_payload(
             "rendering_rule": "Render source and model as icons in compact surfaces; expose tooltip text on hover or focus.",
         },
         "evidence_boundary": (
-            "menubar_status/v1 is a metadata-only view projection. Configured Hermes targets and prepared coding "
-            "handoffs are not process, execution, verification, review, CI, merge, or PID evidence."
+            "menubar_status/v1 is a metadata-only view projection unless a caller overlay or explicit local process "
+            "observation is applied. Configured Hermes targets and prepared coding-agent actions are not execution, "
+            "verification, review, CI, merge, or PID evidence."
         ),
         "privacy": "metadata_only",
     }
@@ -113,6 +118,74 @@ def read_process_overlay_file(path: str) -> dict[str, Any]:
     if schema != PROCESS_OVERLAY_SCHEMA_VERSION:
         raise ValueError(f"unsupported process overlay schema: {schema!r}")
     return data
+
+
+def _local_process_overlay(hermes_agents: list[dict[str, Any]], *, now: datetime | str | None) -> dict[str, Any] | None:
+    observed_at = _coerce_datetime(now) or datetime.now(timezone.utc)
+    processes = _local_hermes_process_rows()
+    overlay_agents: list[dict[str, Any]] = []
+    if len(hermes_agents) == 1 and processes:
+        process = processes[0]
+        overlay_agents.append(
+            {
+                "id": str(hermes_agents[0].get("id", "") or ""),
+                "pid": process["pid"],
+                "status": "running",
+                "summary": f"Hermes process observed locally: PID {process['pid']}.",
+            }
+        )
+    elif len(hermes_agents) > 1 and len(hermes_agents) == len(processes):
+        for agent, process in zip(hermes_agents, processes, strict=False):
+            overlay_agents.append(
+                {
+                    "id": str(agent.get("id", "") or ""),
+                    "pid": process["pid"],
+                    "status": "running",
+                    "summary": f"Hermes process observed locally: PID {process['pid']}.",
+                }
+            )
+    return {
+        "schema_version": PROCESS_OVERLAY_SCHEMA_VERSION,
+        "source": "local_process_scan",
+        "observed_at": _format_datetime(observed_at),
+        "ttl_seconds": DEFAULT_PROCESS_OVERLAY_TTL_SECONDS,
+        "restart_window_seconds": DEFAULT_RESTART_WINDOW_SECONDS,
+        "agents": overlay_agents,
+    }
+
+
+def _local_hermes_process_rows() -> list[dict[str, Any]]:
+    try:
+        result = subprocess.run(
+            ["ps", "-axo", "pid=,stat=,command="],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=2,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return []
+    if result.returncode != 0:
+        return []
+    rows: list[dict[str, Any]] = []
+    for raw_line in result.stdout.splitlines():
+        parts = raw_line.strip().split(None, 2)
+        if len(parts) < 3:
+            continue
+        pid, stat, command = parts
+        if not _looks_like_hermes_runtime_process(command):
+            continue
+        parsed_pid = _positive_int(pid, 0)
+        if not parsed_pid:
+            continue
+        rows.append({"pid": parsed_pid, "stat": stat, "command": command})
+    return rows
+
+
+def _looks_like_hermes_runtime_process(command: str) -> bool:
+    padded = f" {command} "
+    return " -m hermes_cli.main " in padded or "hermes_cli.main gateway run" in command
 
 
 def _hermes_agent_rows(paths: OmhPaths) -> list[dict[str, Any]]:
@@ -323,8 +396,8 @@ def _settings(
         ),
         "coding_handoff": _setting(
             value=current_executor,
-            label=f"Coding handoff: {_executor_setting_label(current_executor)}",
-            raw=f"coding_handoff:{current_executor}",
+            label=f"Coding agent: {_executor_setting_label(current_executor)}",
+            raw=f"coding_agent:{current_executor}",
         ),
         "send_mode": _setting(
             value=dispatch_policy,
@@ -360,7 +433,7 @@ def _display(
     if current_executor_row:
         pieces.append(f"{current_executor_row['name']} {current_executor_row['status_label'].lower()}")
     else:
-        pieces.append("no external executor handoff")
+        pieces.append("coding agent idle")
     return {
         "menu_title": "omh",
         "headline": headline,
@@ -376,20 +449,13 @@ def _menu_cards(
 ) -> list[dict[str, Any]]:
     return [
         {
-            "title": "Connection",
-            "rows": [
-                _menu_row("Connection", _setting_value(settings, "omh_connection", default="unknown")),
-                _menu_row("Hermes targets", str(len(hermes_agents)), detail=_target_menu_detail(settings)),
-            ],
-        },
-        {
             "title": "Agent Status",
             "columns": ["Agent", "PID", "Status"],
             "rows": _agent_status_menu_rows(hermes_agents),
-            "footer": "PID is shown only after an observed runtime overlay.",
+            "footer": "PID appears after overlay or explicit local observation.",
         },
         {
-            "title": "Coding Handoff",
+            "title": "Coding Agent",
             "rows": _coding_menu_rows(settings, current_executor_row),
         },
         {
@@ -422,15 +488,6 @@ def _agent_status_row(agent: str, pid: str, status: str, *, tone: str = "neutral
 def _setting_value(settings: dict[str, Any], key: str, *, default: str = "") -> str:
     row = _dict(settings.get(key))
     return str(row.get("value", "") or default)
-
-
-def _target_menu_detail(settings: dict[str, Any]) -> str:
-    value = _setting_value(settings, "hermes_targets", default="unknown")
-    if value.startswith("single"):
-        return "single target"
-    if value.startswith("multi"):
-        return "multi target"
-    return value
 
 
 def _coding_agent_menu_value(settings: dict[str, Any], current_executor_row: dict[str, Any]) -> str:
@@ -476,14 +533,14 @@ def _coding_menu_rows(settings: dict[str, Any], current_executor_row: dict[str, 
     dispatch = _setting_value(settings, "send_mode", default="ask_before_dispatch")
     return [
         _menu_row("Agent", _coding_agent_menu_value(settings, current_executor_row)),
-        _menu_row("Status", "idle", detail="no external handoff"),
-        _menu_row("Send mode", _dispatch_policy_menu_value(dispatch, _setting_value(settings, "coding_handoff"))),
+        _menu_row("Status", "idle", detail="no coding agent selected"),
+        _menu_row("Open mode", _dispatch_policy_menu_value(dispatch, _setting_value(settings, "coding_handoff"))),
     ]
 
 
 def _dispatch_policy_menu_value(dispatch_policy: str, executor: str) -> str:
     label = _dispatch_policy_label(dispatch_policy, executor)
-    prefix = "Send mode: "
+    prefix = "Open mode: "
     return label[len(prefix) :] if label.startswith(prefix) else label
 
 
@@ -773,7 +830,8 @@ def _overlay_summary(
         "skipped": skipped or [],
         "errors": errors or [],
         "claim_boundary": (
-            "Process status is applied only from this caller-provided overlay. OMH does not scan processes or infer PID state."
+            "Process status is applied only from a caller-provided overlay or explicit local process observation. "
+            "Plain `omh menubar status` does not scan processes or infer PID state."
         ),
     }
 
@@ -868,12 +926,12 @@ def _executor_setting_label(executor_profile: str) -> str:
 def _dispatch_policy_label(dispatch_policy: str, executor_profile: str) -> str:
     if dispatch_policy == "ask_before_dispatch":
         target = executor_label(executor_profile)
-        return f"Send mode: Ask before opening {target}" if executor_profile != "choose" else "Send mode: Ask before choosing"
+        return f"Open mode: Ask before opening {target}" if executor_profile != "choose" else "Open mode: Ask before choosing"
     if dispatch_policy == "prepare_only":
-        return "Send mode: Prepare only"
+        return "Open mode: Prepare only"
     if dispatch_policy == "configured_auto_dispatch_reserved":
-        return "Send mode: Auto dispatch reserved"
-    return f"Send mode: {dispatch_policy.replace('_', ' ')}"
+        return "Open mode: Auto dispatch reserved"
+    return f"Open mode: {dispatch_policy.replace('_', ' ')}"
 
 
 def _setting(*, value: str, label: str, raw: str) -> dict[str, str]:

--- a/tests/test_menubar_status.py
+++ b/tests/test_menubar_status.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import json
+import subprocess
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest.mock import patch
 
 from _cli_harness import run_cli
 from _local_package import load_local_package
@@ -56,22 +58,22 @@ class MenubarStatusTests(unittest.TestCase):
             self.assertFalse(payload["versions"]["hermes"]["observed"])
             self.assertEqual(payload["settings"]["omh_connection"]["label"], "OMH connection: Ready")
             self.assertEqual(payload["settings"]["hermes_targets"]["label"], "Hermes targets: 1")
-            self.assertEqual(payload["settings"]["coding_handoff"]["label"], "Coding handoff: Codex")
-            self.assertEqual(payload["settings"]["send_mode"]["label"], "Send mode: Ask before opening Codex")
+            self.assertEqual(payload["settings"]["coding_handoff"]["label"], "Coding agent: Codex")
+            self.assertEqual(payload["settings"]["send_mode"]["label"], "Open mode: Ask before opening Codex")
             menu_cards = payload["display"]["menu_cards"]
             self.assertEqual(
                 [card["title"] for card in menu_cards],
-                ["Connection", "Agent Status", "Coding Handoff", "Evidence"],
+                ["Agent Status", "Coding Agent", "Evidence"],
             )
-            self.assertEqual(menu_cards[1]["columns"], ["Agent", "PID", "Status"])
-            self.assertIn("PID is shown only after an observed runtime overlay.", menu_cards[1]["footer"])
-            self.assertEqual(menu_cards[1]["rows"][0]["kind"], "agent_status")
-            self.assertEqual(menu_cards[1]["rows"][0]["agent"], ".hermes")
-            self.assertEqual(menu_cards[1]["rows"][0]["pid"], "not observed")
-            self.assertEqual(menu_cards[1]["rows"][0]["status"], "Configured")
+            self.assertEqual(menu_cards[0]["columns"], ["Agent", "PID", "Status"])
+            self.assertIn("PID appears after overlay or explicit local observation.", menu_cards[0]["footer"])
+            self.assertEqual(menu_cards[0]["rows"][0]["kind"], "agent_status")
+            self.assertEqual(menu_cards[0]["rows"][0]["agent"], ".hermes")
+            self.assertEqual(menu_cards[0]["rows"][0]["pid"], "not observed")
+            self.assertEqual(menu_cards[0]["rows"][0]["status"], "Configured")
             self.assertNotIn("4312", json.dumps(menu_cards))
-            self.assertEqual(menu_cards[2]["rows"][0]["label"], "Agent")
-            self.assertEqual(menu_cards[2]["rows"][0]["value"], "Codex")
+            self.assertEqual(menu_cards[1]["rows"][0]["label"], "Agent")
+            self.assertEqual(menu_cards[1]["rows"][0]["value"], "Codex")
 
             hermes_agents = payload["hermes_agents"]
             self.assertEqual(len(hermes_agents), 1)
@@ -204,10 +206,10 @@ class MenubarStatusTests(unittest.TestCase):
             self.assertTrue(payload["external_coding_executors"][0]["status_observed"])
             self.assertEqual(payload["external_coding_executors"][0]["model"]["tooltip"], "gpt-5.5")
             menu_cards = payload["display"]["menu_cards"]
-            self.assertEqual(menu_cards[1]["rows"][0]["pid"], "4312")
-            self.assertEqual(menu_cards[1]["rows"][0]["status"], "Running")
-            self.assertEqual(menu_cards[2]["rows"][2]["label"], "PID")
-            self.assertEqual(menu_cards[2]["rows"][2]["value"], "9821")
+            self.assertEqual(menu_cards[0]["rows"][0]["pid"], "4312")
+            self.assertEqual(menu_cards[0]["rows"][0]["status"], "Running")
+            self.assertEqual(menu_cards[1]["rows"][2]["label"], "PID")
+            self.assertEqual(menu_cards[1]["rows"][2]["value"], "9821")
 
             status, stdout, stderr = run_cli(
                 [
@@ -381,6 +383,43 @@ class MenubarStatusTests(unittest.TestCase):
             self.assertEqual(observed_rows[0]["evidence"]["run_id"], current["run_id"])
             self.assertEqual(observed_rows[0]["pid"], 2222)
             self.assertEqual(exact["process_overlay"]["applied_count"], 1)
+
+    def test_local_process_observation_applies_real_hermes_pid_without_false_path_matches(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = resolve_paths(root / ".omh", root / ".hermes-a")
+            record_target_observation(paths, source="setup")
+
+            ps_output = "\n".join(
+                [
+                    " 101 S /Applications/Codex.app/Contents/MacOS/Codex /Users/rlaope/Desktop/khope/hermes-agent",
+                    " 22064 S /Users/rlaope/.hermes/hermes-agent/venv/bin/python -m hermes_cli.main gateway run --replace",
+                ]
+            )
+
+            with patch(
+                "omh.menubar_status.subprocess.run",
+                return_value=subprocess.CompletedProcess(
+                    args=["ps"],
+                    returncode=0,
+                    stdout=ps_output,
+                    stderr="",
+                ),
+            ):
+                payload = build_menubar_status_payload(
+                    paths,
+                    observe_local_processes=True,
+                    now="2026-06-18T00:00:05Z",
+                )
+
+            self.assertEqual(payload["process_overlay"]["status"], "applied")
+            self.assertEqual(payload["process_overlay"]["applied_count"], 1)
+            self.assertEqual(payload["hermes_agents"][0]["pid"], 22064)
+            self.assertEqual(payload["hermes_agents"][0]["status"], "running")
+            self.assertTrue(payload["hermes_agents"][0]["pid_observed"])
+            menu_cards = payload["display"]["menu_cards"]
+            self.assertEqual(menu_cards[0]["rows"][0]["pid"], "22064")
+            self.assertEqual(menu_cards[0]["rows"][0]["status"], "Running")
 
     def test_menubar_status_reports_multi_target_source_icons_without_process_claims(self) -> None:
         with TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- Renames the compact menu bar surface from the ambiguous Coding Handoff card to a clearer Coding Agent card.
- Removes the redundant Connection card so the menu is organized around Agent Status, Coding Agent, and Evidence.
- Adds an explicit local process observation mode for the native macOS menu bar helper so a running Hermes gateway can show PID/Running instead of staying at not observed.
- Keeps plain omh menubar status metadata-only unless the caller provides an overlay or opts into local process observation.

## User Value
- Operators can tell at a glance whether Hermes is actually running and which PID is attached.
- The menu no longer exposes internal handoff wording as the main label.
- Codex, Claude Code, and other coding tools remain separated from Hermes agents and still require observed evidence before execution claims advance.

## Implementation Notes
- src/menubar_status.py now accepts observe_local_processes=True and conservatively matches live Hermes processes by the hermes_cli.main runtime command rather than by loose path strings.
- src/menubar_app.py calls omh menubar status --observe-local-processes for the native helper.
- src/commands/menubar.py exposes the explicit CLI flag for helper/test usage.
- Docs and README copy now describe the card model and visible coding-agent wording.

## Verification
- PYTHONPATH=tests uv run python -m unittest discover -s tests -v: 525 tests passed.
- PYTHONPATH=tests uv run python -m unittest tests/test_menubar_status.py tests/test_menubar_app.py tests/test_router_content.py -v: 46 tests passed after README/docs wording updates.
- uv run python -m compileall -q src tests: passed.
- uv run python -m src.cli menubar status --observe-local-processes: observed local Hermes as PID 22064 / Running.
- git diff --check: passed.

## Risks / Boundaries
- PID visibility is local process evidence only. It is not executor execution, review, CI, merge, or live plugin-load evidence.
- Plain backend status remains metadata-only unless an overlay or explicit local observation flag is used.