### PR TITLE
Add OMH awareness primer

### DIFF
--- a/skills/oh-my-hermes/SKILL.md
+++ b/skills/oh-my-hermes/SKILL.md
@@ -44,6 +44,22 @@ Bad example:
 - Expected behavior: Show the workflow picker or ask what the user wants to do next; do not infer a coding workflow.
 - Why: A bare product name is a picker or clarification signal, not implementation evidence.
 
+## OMH Awareness Primer
+
+When a request looks like planning, research, operations, materials, automation, image summary, coding delegation, review, status, or long-running loop work, consider OMH before treating it as a generic chat.
+
+Normal users talk to Hermes; OMH CLI commands are backend, setup, verification, and wrapper infrastructure.
+
+- **Intent -> plan**: `deep-interview`, `ralplan`, `ultragoal`, `ultraprocess`, `loop` - ambiguous goals, plans, one-cycle delivery, durable goals, and loopable projects.
+- **Research and company ops**: `web-research`, `research-brief`, `strategy-brief`, `feedback-triage`, `research-department` - source-backed research, customer signals, product operations, and briefing workflows.
+- **Materials and visual summaries**: `materials-package`, `img-summary`, `report-package`, `deliverable-package` - decks, PDFs, spreadsheets, documents, image summary cards, and shareable packages.
+- **Automation and status**: `automation-blueprint`, `ops-observability-card`, `agent-ops-review`, `doctor` - scheduled ops blueprints, status cards, runtime health, and release/ops review.
+- **Coding handoff**: `request-to-handoff`, `executor selection`, `coding runtime handoff`, `code-review` - Codex, Claude Code, Hermes coding, or oh-my runtime paths with observed evidence tracking.
+
+If an external image tool, coding agent, connector, credential, or runtime is missing, explain the missing connection and offer a setup/selection fallback instead of claiming the action happened.
+
+Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+
 ## Direct Picker Aliases
 
 If the user has only typed `./`, `/`, `./o`, or `/om`, show a command preview with exactly one top-level suggestion: `omh`. Selecting it should insert `./omh` or `/omh` and then open the workflow picker. Do not preview every installed workflow at the first `./` stage.

--- a/src/capabilities/hooks.py
+++ b/src/capabilities/hooks.py
@@ -64,7 +64,7 @@ def _wrapper_event(name: str, payload_fields: tuple[str, ...]) -> dict[str, obje
 
 def _hook_payload_fields(name: str) -> list[str]:
     if name == "pre_llm_call":
-        return ["bounded_status_context", "redacted"]
+        return ["omh_awareness_primer", "bounded_status_context", "redacted"]
     if name == "pre_tool_call":
         return ["tool_name", "claim_boundary"]
     if name == "on_session_end":

--- a/src/capabilities/registry.py
+++ b/src/capabilities/registry.py
@@ -9,6 +9,7 @@ from .orchestration import orchestration_patterns
 from .schema import CAPABILITY_MANIFEST_SCHEMA_VERSION, CAPABILITY_SECTIONS, PREPARED_NOT_OBSERVED
 from .skills import skill_capabilities
 from .tools import tool_requirements_manifest
+from ..plugin_bundle.omh.awareness import awareness_primer_payload
 
 
 def capability_snapshot() -> dict[str, object]:
@@ -18,11 +19,13 @@ def capability_snapshot() -> dict[str, object]:
     keywords = keyword_detector_manifest()
     patterns = orchestration_patterns()
     tools = tool_requirements_manifest()
+    awareness = awareness_primer_payload()
     snapshot = {
         "schema_version": CAPABILITY_MANIFEST_SCHEMA_VERSION,
         "manifest_id": "omh_capabilities",
         "determinism": "static_projection_no_runtime_clock",
         "summary": {
+            "omh_awareness": 1,
             "agent_roles": len(agent_roles),
             "skills": len(skills),
             "plugin_tools": len(hooks["plugin_tools"]),
@@ -31,6 +34,7 @@ def capability_snapshot() -> dict[str, object]:
             "orchestration_patterns": len(patterns),
             "tool_requirements": len(tools["items"]),
         },
+        "omh_awareness": awareness,
         "agent_roles": agent_roles,
         "skills": skills,
         "hooks": hooks,
@@ -122,6 +126,8 @@ def inspect_capability(identifier: str, section: str | None = None) -> dict[str,
 
 
 def _section_ids(section: str, payload: object) -> list[str]:
+    if section == "omh_awareness":
+        return ["omh_awareness", "first_turn_rule", "workflow_lanes", "fallback_rule", "evidence_boundary"]
     if section == "hooks" and isinstance(payload, dict):
         return sorted(
             [
@@ -146,6 +152,8 @@ def _find_in_section(identifier: str, payload: object) -> object | None:
             if isinstance(item, dict) and _matches_identifier(identifier, item):
                 return item
     if isinstance(payload, dict):
+        if _matches_identifier(identifier, payload):
+            return payload
         for key in ("plugin_tools", "plugin_hooks", "items", "natural_language_rules"):
             values = payload.get(key)
             if isinstance(values, list):

--- a/src/capabilities/schema.py
+++ b/src/capabilities/schema.py
@@ -9,6 +9,7 @@ ORCHESTRATION_PATTERN_SCHEMA_VERSION = "orchestration_pattern/v1"
 TOOL_REQUIREMENT_SCHEMA_VERSION = "tool_requirement_manifest/v1"
 
 CAPABILITY_SECTIONS = (
+    "omh_awareness",
     "agent_roles",
     "skills",
     "hooks",

--- a/src/plugin_bundle/omh/awareness.py
+++ b/src/plugin_bundle/omh/awareness.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+OMH_AWARENESS_SCHEMA_VERSION = "omh_awareness/v1"
+
+
+def awareness_primer_payload() -> dict[str, object]:
+    """Return the compact OMH mental model shared by hooks, tools, and skills."""
+    lanes = [
+        {
+            "id": "intent_to_plan",
+            "label": "Intent -> plan",
+            "skills": ["deep-interview", "ralplan", "ultragoal", "ultraprocess", "loop"],
+            "use_for": "ambiguous goals, plans, one-cycle delivery, durable goals, and loopable projects",
+        },
+        {
+            "id": "research_and_ops",
+            "label": "Research and company ops",
+            "skills": ["web-research", "research-brief", "strategy-brief", "feedback-triage", "research-department"],
+            "use_for": "source-backed research, customer signals, product operations, and briefing workflows",
+        },
+        {
+            "id": "materials_and_visuals",
+            "label": "Materials and visual summaries",
+            "skills": ["materials-package", "img-summary", "report-package", "deliverable-package"],
+            "use_for": "decks, PDFs, spreadsheets, documents, image summary cards, and shareable packages",
+        },
+        {
+            "id": "automation_and_status",
+            "label": "Automation and status",
+            "skills": ["automation-blueprint", "ops-observability-card", "agent-ops-review", "doctor"],
+            "use_for": "scheduled ops blueprints, status cards, runtime health, and release/ops review",
+        },
+        {
+            "id": "coding_handoff",
+            "label": "Coding handoff",
+            "skills": ["request-to-handoff", "executor selection", "coding runtime handoff", "code-review"],
+            "use_for": "Codex, Claude Code, Hermes coding, or oh-my runtime paths with observed evidence tracking",
+        },
+    ]
+    return {
+        "schema_version": OMH_AWARENESS_SCHEMA_VERSION,
+        "id": "omh_awareness",
+        "purpose": "Give Hermes a compact first-turn mental model for using OMH across all workflow-shaped requests.",
+        "first_turn_rule": (
+            "When a request looks like planning, research, operations, materials, automation, image summary, "
+            "coding delegation, review, status, or long-running loop work, consider OMH before treating it as a generic chat."
+        ),
+        "chat_rule": "Normal users talk to Hermes; OMH CLI commands are backend, setup, verification, and wrapper infrastructure.",
+        "lanes": lanes,
+        "tool_hints": [
+            "Use omh_capabilities for the workflow catalog and capability manifest.",
+            "Use omh_status or omh_hud for metadata-only runtime state.",
+            "Use omh_role for responsibility context when a role marker is present.",
+            "Use wrapper cards/actions for user-facing choices instead of asking users to approve shell catalog commands.",
+        ],
+        "evidence_boundary": (
+            "Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, "
+            "delivery, review, CI, merge-readiness, or merge evidence."
+        ),
+        "fallback_rule": (
+            "If an external image tool, coding agent, connector, credential, or runtime is missing, explain the missing "
+            "connection and offer a setup/selection fallback instead of claiming the action happened."
+        ),
+        "non_goals": [
+            "no hidden executor dispatch",
+            "no hidden image generation",
+            "no hidden platform transport",
+            "no Hermes core patching",
+        ],
+        "source_refs": [
+            "src/plugin_bundle/omh/awareness.py",
+            "src/skills/render.py",
+            "src/capabilities/registry.py",
+        ],
+    }
+
+
+def awareness_primer_context() -> str:
+    payload = awareness_primer_payload()
+    lane_lines = [
+        f"- {lane['label']}: {', '.join(lane['skills'])}."
+        for lane in payload["lanes"]
+        if isinstance(lane, dict)
+    ]
+    return "\n".join(
+        [
+            "[OMH Awareness]",
+            str(payload["first_turn_rule"]),
+            str(payload["chat_rule"]),
+            *lane_lines,
+            str(payload["fallback_rule"]),
+            "Boundary: " + str(payload["evidence_boundary"]),
+        ]
+    )
+
+
+def awareness_primer_markdown() -> str:
+    payload = awareness_primer_payload()
+    lane_lines = []
+    for lane in payload["lanes"]:
+        if not isinstance(lane, dict):
+            continue
+        skills = "`, `".join(str(skill) for skill in lane["skills"])
+        lane_lines.append(f"- **{lane['label']}**: `{skills}` - {lane['use_for']}.")
+    return "\n".join(
+        [
+            "## OMH Awareness Primer",
+            "",
+            str(payload["first_turn_rule"]),
+            "",
+            str(payload["chat_rule"]),
+            "",
+            *lane_lines,
+            "",
+            str(payload["fallback_rule"]),
+            "",
+            f"Boundary: {payload['evidence_boundary']}",
+        ]
+    )

--- a/src/plugin_bundle/omh/hooks/llm_hooks.py
+++ b/src/plugin_bundle/omh/hooks/llm_hooks.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from ..awareness import awareness_primer_context
 from ..omh_roles import extract_role_marker, role_context_payload
 from ..runtime_reader import read_omh_hud, read_omh_status
 
@@ -19,6 +20,8 @@ def pre_llm_call(**kwargs) -> dict[str, str] | None:
     """Inject bounded OMH role/status context without storing prompts."""
     context_parts: list[str] = []
     if bool(kwargs.get("is_first_turn", False)):
+        if kwargs.get("include_omh_awareness", True) is not False:
+            context_parts.append(awareness_primer_context())
         marker = extract_role_marker(str(kwargs.get("user_message", "") or ""))
         if marker:
             role_payload = role_context_payload(marker)

--- a/src/plugin_bundle/omh/tools/capability_tool.py
+++ b/src/plugin_bundle/omh/tools/capability_tool.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import json
 
+from ..awareness import awareness_primer_payload
 from ..metadata import PROVIDED_HOOKS, PROVIDED_TOOLS
 
 STANDALONE_CAPABILITY_SECTIONS = (
+    "omh_awareness",
     "agent_roles",
     "skills",
     "hooks",
@@ -163,6 +165,7 @@ def _standalone_capability_inspect(capability_id: str, section: str | None = Non
 
 def _standalone_sections() -> dict[str, object]:
     return {
+        "omh_awareness": awareness_primer_payload(),
         "agent_roles": [
             {
                 "schema_version": "agent_role_capability/v1",
@@ -254,6 +257,7 @@ def _standalone_sections() -> dict[str, object]:
                 {
                     "name": name,
                     "supported_by_plugin_bundle": True,
+                    "payload_fields": _standalone_hook_payload_fields(name),
                     "claim_boundary": "Hook availability is not proof that Hermes loaded or invoked the plugin.",
                     "observed_in_this_environment": False,
                 }
@@ -318,6 +322,16 @@ def _standalone_matches(wanted: str, item: dict[str, object]) -> bool:
         *[str(alias) for alias in legacy_ids],
     }
     return wanted in values
+
+
+def _standalone_hook_payload_fields(name: str) -> list[str]:
+    if name == "pre_llm_call":
+        return ["omh_awareness_primer", "bounded_status_context", "redacted"]
+    if name == "pre_tool_call":
+        return ["tool_name", "claim_boundary"]
+    if name == "on_session_end":
+        return ["session_summary", "metadata_only"]
+    return []
 
 
 def _standalone_item_id(item: dict[str, object], fallback: str) -> str:

--- a/src/skills/render.py
+++ b/src/skills/render.py
@@ -17,6 +17,7 @@ from .catalog import (
     surface_exposure_for_skill,
     workflow_reference_definitions,
 )
+from ..plugin_bundle.omh.awareness import awareness_primer_markdown
 
 
 @dataclass(frozen=True)
@@ -258,6 +259,8 @@ This is best-effort Hermes prompt guidance. It does not override Hermes core rou
 Normal users should talk to Hermes Agent or invoke installed Hermes skills through Hermes' own skill surface. Do not ask chat users to run `omh` commands for ordinary workflow use. The `omh` command is bootstrap, maintenance, verification, and wrapper/backend infrastructure.
 
 {_quality_rubric_sections(_definitions_by_name()["oh-my-hermes"])}
+
+{awareness_primer_markdown()}
 
 ## Direct Picker Aliases
 

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -29,6 +29,9 @@ class CapabilityManifestTests(unittest.TestCase):
         self.assertEqual(first, second)
         self.assertEqual(first["schema_version"], "omh_capability_manifest/v1")
         self.assertEqual(first["determinism"], "static_projection_no_runtime_clock")
+        self.assertEqual(first["omh_awareness"]["schema_version"], "omh_awareness/v1")
+        self.assertIn("workflow-shaped requests", first["omh_awareness"]["purpose"])
+        self.assertIn("img-summary", json.dumps(first["omh_awareness"], sort_keys=True))
         self.assertGreaterEqual(first["summary"]["skills"], 30)
         self.assertGreaterEqual(first["summary"]["agent_roles"], 8)
         self.assertIn("no runtime_topology schema in this PR", first["non_goals"])
@@ -39,6 +42,7 @@ class CapabilityManifestTests(unittest.TestCase):
         listing = list_capabilities()
         sections = {section["section"]: section["ids"] for section in listing["sections"]}
 
+        self.assertIn("omh_awareness", sections["omh_awareness"])
         self.assertIn("handoff-guide", sections["agent_roles"])
         self.assertIn("ultragoal", sections["skills"])
         self.assertIn("omh_capabilities", sections["hooks"])
@@ -49,6 +53,7 @@ class CapabilityManifestTests(unittest.TestCase):
     def test_capability_inspect_finds_skill_and_role_without_runtime_claim(self) -> None:
         skill = inspect_capability("ultragoal", section="skills")["capability"]
         hidden_surface = inspect_capability("ops-observability-card", section="skills")["capability"]
+        awareness = inspect_capability("omh_awareness", section="omh_awareness")["capability"]
         role = inspect_capability("handoff-guide", section="agent_roles")["capability"]
         legacy_role = inspect_capability("coding-handoff", section="agent_roles")
 
@@ -56,6 +61,8 @@ class CapabilityManifestTests(unittest.TestCase):
         self.assertEqual(skill["tool_requirements"]["derivation_status"], "partial")
         self.assertIn("prepared_not_observed", skill["evidence_boundary"])
         self.assertEqual(hidden_surface["exposure"], "harness_only")
+        self.assertEqual(awareness["schema_version"], "omh_awareness/v1")
+        self.assertIn("materials", awareness["first_turn_rule"])
         self.assertFalse(hidden_surface["install_visibility"])
         self.assertTrue(hidden_surface["compatibility_alias"])
         self.assertIn("preferred_usage", hidden_surface)

--- a/tests/test_hook_manifest.py
+++ b/tests/test_hook_manifest.py
@@ -23,6 +23,7 @@ class HookManifestTests(unittest.TestCase):
         self.assertTrue(tools["omh_capabilities"]["supported_by_cli_backend"])
         self.assertFalse(tools["omh_capabilities"]["observed_in_this_environment"])
         self.assertIn("pre_llm_call", hooks)
+        self.assertIn("omh_awareness_primer", hooks["pre_llm_call"]["payload_fields"])
         self.assertIn("bounded_status_context", hooks["pre_llm_call"]["payload_fields"])
         self.assertIn("executor_opened", events)
         self.assertIn("selected_executor_profile", events["executor_opened"]["payload_fields"])

--- a/tests/test_plugin_distribution.py
+++ b/tests/test_plugin_distribution.py
@@ -338,9 +338,26 @@ class PluginDistributionTests(unittest.TestCase):
             )
             self.assertIsNotNone(hook_payload)
             context = hook_payload["context"]
+            self.assertIn("[OMH Awareness]", context)
+            self.assertIn("consider OMH before treating it as a generic chat", context)
+            self.assertIn("img-summary", context)
+            self.assertIn("materials-package", context)
+            self.assertIn("ultraprocess", context)
+            self.assertIn("loop", context)
+            self.assertIn("external image tool", context)
             self.assertIn("[omh]", context)
             self.assertIn("prepared handoffs are not execution", context)
             self.assertNotIn("this raw prompt should not leak", context)
+
+            empty_first_turn_context = ctx.hooks["pre_llm_call"](
+                omh_home=str(root / ".empty-omh"),
+                user_message="make an image summary card for this PR",
+                is_first_turn=True,
+            )
+            self.assertIsNotNone(empty_first_turn_context)
+            self.assertIn("[OMH Awareness]", empty_first_turn_context["context"])
+            self.assertIn("image summary", empty_first_turn_context["context"])
+            self.assertNotIn("make an image summary card for this PR", empty_first_turn_context["context"])
 
 
 if __name__ == "__main__":

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -78,6 +78,11 @@ class RouterContentTests(unittest.TestCase):
 
         self.assertIn("best-effort Hermes prompt guidance", router.content)
         self.assertIn("does not override Hermes core routing", router.content)
+        self.assertIn("OMH Awareness Primer", router.content)
+        self.assertIn("consider OMH before treating it as a generic chat", router.content)
+        self.assertIn("Materials and visual summaries", router.content)
+        self.assertIn("`materials-package`, `img-summary`, `report-package`, `deliverable-package`", router.content)
+        self.assertIn("Coding handoff", router.content)
         self.assertIn("omh chat route", router.content)
         self.assertIn("omh coding delegate", router.content)
         self.assertIn("deterministic wrapper-side decision layer", router.content)


### PR DESCRIPTION
## Feature Report

### What Changed

- Added a shared `omh_awareness/v1` primer that gives Hermes a compact mental model for OMH across planning, research, company ops, materials, image summaries, automation/status, coding handoff, and review work.
- Injected that primer through the plugin `pre_llm_call` hook on the first turn, even when no runtime state exists yet.
- Exposed the same awareness contract through `omh_capabilities`, the standalone plugin fallback, hook manifest metadata, and the generated `oh-my-hermes` router skill.
- Locked the behavior with plugin, capability, hook, and router-content tests so the primer stays compact, deterministic, and prompt-redacted.

### Why This Exists

- Hermes could previously miss OMH for ordinary workflow-shaped requests because the plugin hook returned no context when there was no runtime state or explicit role marker.
- That made OMH feel like a command catalog or a visual-summary-specific helper instead of a general Hermes workflow layer.
- The new primer makes Hermes remember that OMH should be considered before generic chat for planning, research, material processing, image summary cards, automation, status, and coding handoff requests.

### User / Operator Impact

- Users can ask natural requests like "make an image summary card," "turn this meeting into a report package," "plan this risky change," or "hand this coding work to Codex" and Hermes has stronger first-turn context for choosing OMH.
- Operators can inspect the same model through `omh capabilities export --section omh_awareness --json` without shelling out to list every skill.
- If an external image generator, coding agent, connector, credential, or runtime is missing, the primer tells Hermes to offer setup/selection fallback instead of claiming the action happened.

### How It Works

- `src/plugin_bundle/omh/awareness.py` defines the canonical static primer payload, plugin context string, and router-skill markdown.
- `src/plugin_bundle/omh/hooks/llm_hooks.py` appends the primer on first-turn hook calls while preserving raw-prompt redaction.
- `src/capabilities/registry.py` and `src/plugin_bundle/omh/tools/capability_tool.py` expose `omh_awareness` for installed and standalone plugin capability manifests.
- `src/skills/render.py` renders the same primer into `skills/oh-my-hermes/SKILL.md` so tap-installed skills carry the same guidance.

### Files And Contracts Touched

- New contract: `omh_awareness/v1`.
- Updated capability sections: `omh_awareness` added to `CAPABILITY_SECTIONS`.
- Updated hook metadata: `pre_llm_call.payload_fields` now includes `omh_awareness_primer`.
- Generated tap skill updated: `skills/oh-my-hermes/SKILL.md` includes `OMH Awareness Primer`.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_plugin_distribution.py tests/test_plugin_capabilities.py tests/test_hook_manifest.py tests/test_capabilities.py tests/test_router_content.py -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m src.cli docs workflows --check`
- [x] `git diff --check`
- [x] `uv build`
- [x] Relevant dry-run or smoke command: `omh capabilities export --section omh_awareness --json`; `omh capabilities inspect omh_awareness --section omh_awareness --json`
- [x] Manual Hermes/TUI check, or explicit reason it was not run: live external Hermes plugin-load was not run; plugin import/register and hook behavior are covered by local smoke/unit tests.

## Risk

- The hook now injects a small first-turn context even with no runtime state. This is intentional, but it must stay compact so it does not become noisy.
- The primer is guidance only. It does not force all requests through OMH and does not claim runtime execution.

## Compatibility / Rollout

- Backward compatible for existing capability consumers: this adds a new section and payload field without removing existing fields.
- Standalone installed plugin fallback also exposes the new section.
- Release-channel impact: local/preview workflow capability change; no installer or version bump in this PR.

## Release / Claims

- [x] Release-channel impact considered (`preview`/local behavior only in this PR)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Known manual Hermes checks are listed, including live plugin-load gap

## Follow-Up

- After merge and install/update, run a real Hermes chat smoke for image summary, materials, research, and coding handoff prompts to confirm the host surfaces the primer as expected.