### PR TITLE
Add OMH context rail to workflow skills

### DIFF
--- a/skills/agent-ops-review/SKILL.md
+++ b/skills/agent-ops-review/SKILL.md
@@ -38,6 +38,14 @@ Bad example:
 - Expected behavior: Report the missing observed evidence or authority instead of claiming the external step happened.
 - Why: Prepared OMH guidance is not platform, runtime, connector, file, memory, or delivery evidence.
 
+## OMH Context Rail
+
+- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
+- Current lane: **Automation and status** (`automation-blueprint`, `ops-observability-card`, `agent-ops-review`, `doctor`) - scheduled ops blueprints, status cards, runtime health, and release/ops review.
+- If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
+- Normal users talk to Hermes; OMH CLI commands are backend, setup, verification, and wrapper infrastructure.
+- Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+
 ## Use When
 
 Use when Hermes should explain AI-agent work from a manager/operator perspective: quality gates, progress, blockers, next actions, and throughput opportunities across research, coding, review, and status.

--- a/skills/ai-slop-cleaner/SKILL.md
+++ b/skills/ai-slop-cleaner/SKILL.md
@@ -37,6 +37,14 @@ Bad example:
 - Expected behavior: Ask a clarification question or route to a narrower workflow instead of forcing `ai-slop-cleaner`.
 - Why: The request lacks the required inputs or would overclaim work that Hermes did not observe.
 
+## OMH Context Rail
+
+- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
+- Use the `oh-my-hermes` router or `omh_capabilities` manifest when the request crosses workflow lanes.
+- If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
+- Normal users talk to Hermes; OMH CLI commands are backend, setup, verification, and wrapper infrastructure.
+- Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+
 ## Use When
 
 Use for behavior-preserving cleanup with tests before and after edits.

--- a/skills/ask/SKILL.md
+++ b/skills/ask/SKILL.md
@@ -37,6 +37,14 @@ Bad example:
 - Expected behavior: Ask a clarification question or route to a narrower workflow instead of forcing `ask`.
 - Why: The request lacks the required inputs or would overclaim work that Hermes did not observe.
 
+## OMH Context Rail
+
+- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
+- Use the `oh-my-hermes` router or `omh_capabilities` manifest when the request crosses workflow lanes.
+- If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
+- Normal users talk to Hermes; OMH CLI commands are backend, setup, verification, and wrapper infrastructure.
+- Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+
 ## Use When
 
 Use only when an external advisor is configured and would materially improve the answer.

--- a/skills/automation-blueprint/SKILL.md
+++ b/skills/automation-blueprint/SKILL.md
@@ -38,6 +38,14 @@ Bad example:
 - Expected behavior: Ask for observed Hermes/gateway delivery evidence or report the delivery as not_observed instead of claiming it happened.
 - Why: A blueprint can prepare the scheduled operation, but it cannot prove runtime execution or delivery.
 
+## OMH Context Rail
+
+- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
+- Current lane: **Automation and status** (`automation-blueprint`, `ops-observability-card`, `agent-ops-review`, `doctor`) - scheduled ops blueprints, status cards, runtime health, and release/ops review.
+- If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
+- Normal users talk to Hermes; OMH CLI commands are backend, setup, verification, and wrapper infrastructure.
+- Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+
 ## Use When
 
 Use when Hermes should turn a natural recurring/cron-like request into a scheduled ops blueprint without claiming host automation, platform delivery, source retrieval, or no-agent execution.

--- a/skills/autoresearch-goal/SKILL.md
+++ b/skills/autoresearch-goal/SKILL.md
@@ -37,6 +37,14 @@ Bad example:
 - Expected behavior: Ask a clarification question or route to a narrower workflow instead of forcing `autoresearch-goal`.
 - Why: The request lacks the required inputs or would overclaim work that Hermes did not observe.
 
+## OMH Context Rail
+
+- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
+- Use the `oh-my-hermes` router or `omh_capabilities` manifest when the request crosses workflow lanes.
+- If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
+- Normal users talk to Hermes; OMH CLI commands are backend, setup, verification, and wrapper infrastructure.
+- Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+
 ## Use When
 
 Use for validator-gated research that needs durable artifacts.

--- a/skills/best-practice-research/SKILL.md
+++ b/skills/best-practice-research/SKILL.md
@@ -37,6 +37,14 @@ Bad example:
 - Expected behavior: Ask a clarification question or route to a narrower workflow instead of forcing `best-practice-research`.
 - Why: The request lacks the required inputs or would overclaim work that Hermes did not observe.
 
+## OMH Context Rail
+
+- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
+- Use the `oh-my-hermes` router or `omh_capabilities` manifest when the request crosses workflow lanes.
+- If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
+- Normal users talk to Hermes; OMH CLI commands are backend, setup, verification, and wrapper infrastructure.
+- Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+
 ## Use When
 
 Use when correctness depends on current official or upstream guidance.

--- a/skills/cancel/SKILL.md
+++ b/skills/cancel/SKILL.md
@@ -37,6 +37,14 @@ Bad example:
 - Expected behavior: Ask a clarification question or route to a narrower workflow instead of forcing `cancel`.
 - Why: The request lacks the required inputs or would overclaim work that Hermes did not observe.
 
+## OMH Context Rail
+
+- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
+- Use the `oh-my-hermes` router or `omh_capabilities` manifest when the request crosses workflow lanes.
+- If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
+- Normal users talk to Hermes; OMH CLI commands are backend, setup, verification, and wrapper infrastructure.
+- Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+
 ## Use When
 
 Use to cleanly end active adapted workflow state.

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -38,6 +38,14 @@ Bad example:
 - Expected behavior: Route implementation to a selected executor/runtime after review findings are established.
 - Why: Review can identify the issue, but code mutation is a separate execution step.
 
+## OMH Context Rail
+
+- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
+- Current lane: **Coding handoff** (`request-to-handoff`, `executor selection`, `coding runtime handoff`, `code-review`) - Codex, Claude Code, Hermes coding, or oh-my runtime paths with observed evidence tracking.
+- If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
+- Normal users talk to Hermes; OMH CLI commands are backend, setup, verification, and wrapper infrastructure.
+- Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+
 ## Use When
 
 Use for review-shaped requests; findings come first and must cite concrete evidence.

--- a/skills/cto-loop/SKILL.md
+++ b/skills/cto-loop/SKILL.md
@@ -37,6 +37,14 @@ Bad example:
 - Expected behavior: Ask a clarification question or route to a narrower workflow instead of forcing `cto-loop`.
 - Why: The request lacks the required inputs or would overclaim work that Hermes did not observe.
 
+## OMH Context Rail
+
+- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
+- Use the `oh-my-hermes` router or `omh_capabilities` manifest when the request crosses workflow lanes.
+- If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
+- Normal users talk to Hermes; OMH CLI commands are backend, setup, verification, and wrapper infrastructure.
+- Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+
 ## Use When
 
 Use when Hermes should run a leadership-style operating loop that turns signals into roadmap decisions, technical tradeoffs, delivery risk, release readiness, and explicit follow-up handoffs.

--- a/skills/deep-interview/SKILL.md
+++ b/skills/deep-interview/SKILL.md
@@ -38,6 +38,14 @@ Bad example:
 - Expected behavior: Proceed to diagnosis or implementation instead of interviewing.
 - Why: The required facts are already available, so more questions would slow the workflow.
 
+## OMH Context Rail
+
+- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
+- Current lane: **Intent -> plan** (`deep-interview`, `ralplan`, `ultragoal`, `ultraprocess`, `loop`) - ambiguous goals, plans, one-cycle delivery, durable goals, and loopable projects.
+- If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
+- Normal users talk to Hermes; OMH CLI commands are backend, setup, verification, and wrapper infrastructure.
+- Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+
 ## Use When
 
 Use before planning or execution when requirements are materially ambiguous.

--- a/skills/deliverable-package/SKILL.md
+++ b/skills/deliverable-package/SKILL.md
@@ -38,6 +38,14 @@ Bad example:
 - Expected behavior: Report the missing observed evidence or authority instead of claiming the external step happened.
 - Why: Prepared OMH guidance is not platform, runtime, connector, file, memory, or delivery evidence.
 
+## OMH Context Rail
+
+- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
+- Current lane: **Materials and visual summaries** (`materials-package`, `img-summary`, `report-package`, `deliverable-package`) - decks, PDFs, spreadsheets, documents, image summary cards, and shareable packages.
+- If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
+- Normal users talk to Hermes; OMH CLI commands are backend, setup, verification, and wrapper infrastructure.
+- Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+
 ## Use When
 
 Use when Hermes should prepare, request generation, QA, and report attachment status for user-visible file deliverables.

--- a/skills/deploy-and-monitor/SKILL.md
+++ b/skills/deploy-and-monitor/SKILL.md
@@ -37,6 +37,14 @@ Bad example:
 - Expected behavior: Ask a clarification question or route to a narrower workflow instead of forcing `deploy-and-monitor`.
 - Why: The request lacks the required inputs or would overclaim work that Hermes did not observe.
 
+## OMH Context Rail
+
+- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
+- Use the `oh-my-hermes` router or `omh_capabilities` manifest when the request crosses workflow lanes.
+- If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
+- Normal users talk to Hermes; OMH CLI commands are backend, setup, verification, and wrapper infrastructure.
+- Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+
 ## Use When
 
 Use when Hermes should prepare or narrate a release operation with deploy checklist, health signals, rollback criteria, and post-deploy status without pretending to run infrastructure.

--- a/skills/doctor/SKILL.md
+++ b/skills/doctor/SKILL.md
@@ -38,6 +38,14 @@ Bad example:
 - Expected behavior: Route to planning or implementation instead of health diagnostics.
 - Why: That is product development work, not a local health check.
 
+## OMH Context Rail
+
+- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
+- Current lane: **Automation and status** (`automation-blueprint`, `ops-observability-card`, `agent-ops-review`, `doctor`) - scheduled ops blueprints, status cards, runtime health, and release/ops review.
+- If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
+- Normal users talk to Hermes; OMH CLI commands are backend, setup, verification, and wrapper infrastructure.
+- Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+
 ## Use When
 
 Use to diagnose OMH installation and Hermes config registration.

--- a/skills/feedback-triage/SKILL.md
+++ b/skills/feedback-triage/SKILL.md
@@ -38,6 +38,14 @@ Bad example:
 - Expected behavior: Route to planning or coding handoff instead of re-triaging.
 - Why: The decision is already accepted, so triage would add delay without improving evidence.
 
+## OMH Context Rail
+
+- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
+- Current lane: **Research and company ops** (`web-research`, `research-brief`, `strategy-brief`, `feedback-triage`, `research-department`) - source-backed research, customer signals, product operations, and briefing workflows.
+- If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
+- Normal users talk to Hermes; OMH CLI commands are backend, setup, verification, and wrapper infrastructure.
+- Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+
 ## Use When
 
 Use when Hermes should classify feedback, bug reports, and feature asks before deciding whether research, planning, or coding handoff is needed.

--- a/skills/idea-to-deploy/SKILL.md
+++ b/skills/idea-to-deploy/SKILL.md
@@ -37,6 +37,14 @@ Bad example:
 - Expected behavior: Ask a clarification question or route to a narrower workflow instead of forcing `idea-to-deploy`.
 - Why: The request lacks the required inputs or would overclaim work that Hermes did not observe.
 
+## OMH Context Rail
+
+- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
+- Use the `oh-my-hermes` router or `omh_capabilities` manifest when the request crosses workflow lanes.
+- If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
+- Normal users talk to Hermes; OMH CLI commands are backend, setup, verification, and wrapper infrastructure.
+- Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+
 ## Use When
 
 Use when Hermes should carry a product or app idea through shaping, decision gates, plan acceptance, executor handoff, verification, release readiness, deploy, and monitoring boundaries.

--- a/skills/img-summary/SKILL.md
+++ b/skills/img-summary/SKILL.md
@@ -38,6 +38,14 @@ Bad example:
 - Expected behavior: Ask for visual_observation/v1 delivery evidence or report delivery as not_observed.
 - Why: A prompt card cannot prove generated image, QA, or delivery evidence.
 
+## OMH Context Rail
+
+- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
+- Current lane: **Materials and visual summaries** (`materials-package`, `img-summary`, `report-package`, `deliverable-package`) - decks, PDFs, spreadsheets, documents, image summary cards, and shareable packages.
+- If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
+- Normal users talk to Hermes; OMH CLI commands are backend, setup, verification, and wrapper infrastructure.
+- Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+
 ## Use When
 
 Use when Hermes should shape supplied notes, report material, PR context, issue feedback, research/news, or release notes into a source-specific visual prompt whose mood, premium background plate, material texture, camera treatment, lighting, motifs, and poster design grammar adapt without claiming image generation.

--- a/skills/loop/SKILL.md
+++ b/skills/loop/SKILL.md
@@ -40,6 +40,14 @@ Bad example:
 - Expected behavior: Use a direct delivery or PR workflow instead of starting a persistent loop.
 - Why: The task is bounded and should stop after merge evidence rather than create ongoing cycles.
 
+## OMH Context Rail
+
+- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
+- Current lane: **Intent -> plan** (`deep-interview`, `ralplan`, `ultragoal`, `ultraprocess`, `loop`) - ambiguous goals, plans, one-cycle delivery, durable goals, and loopable projects.
+- If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
+- Normal users talk to Hermes; OMH CLI commands are backend, setup, verification, and wrapper infrastructure.
+- Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+
 ## Use When
 
 Use when the user explicitly starts a high-level goal that is concrete enough to verify, open-ended enough to require iterative discovery, and should be shaped from task/project/ambition into a bounded loop before cycling through task discovery, distribution, execution, verification tiers, verifier checks, next-task decisions, runtime tick queueing, handoff, feedback, and status until the authority envelope or evidence gate stops it.

--- a/skills/materials-package/SKILL.md
+++ b/skills/materials-package/SKILL.md
@@ -38,6 +38,14 @@ Bad example:
 - Expected behavior: Ask for observed delivery evidence or record the delivery as not_observed instead of claiming it happened.
 - Why: A prepared material artifact cannot prove export, approval, or delivery.
 
+## OMH Context Rail
+
+- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
+- Current lane: **Materials and visual summaries** (`materials-package`, `img-summary`, `report-package`, `deliverable-package`) - decks, PDFs, spreadsheets, documents, image summary cards, and shareable packages.
+- If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
+- Normal users talk to Hermes; OMH CLI commands are backend, setup, verification, and wrapper infrastructure.
+- Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+
 ## Use When
 
 Use when Hermes should turn source inputs into a material plan for decks, PDFs, spreadsheets, documents, HWP, Markdown, or binary export handoff without claiming file generation.

--- a/skills/meeting-brief/SKILL.md
+++ b/skills/meeting-brief/SKILL.md
@@ -38,6 +38,14 @@ Bad example:
 - Expected behavior: Ask for meeting notes or route to an ops/status summary with explicit evidence gaps.
 - Why: A prepared agenda cannot be treated as observed minutes or decisions.
 
+## OMH Context Rail
+
+- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
+- Use the `oh-my-hermes` router or `omh_capabilities` manifest when the request crosses workflow lanes.
+- If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
+- Normal users talk to Hermes; OMH CLI commands are backend, setup, verification, and wrapper infrastructure.
+- Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+
 ## Use When
 
 Use when Hermes should prepare a meeting agenda, discussion prompts, decision points, and a record template.

--- a/skills/memory-curation-review/SKILL.md
+++ b/skills/memory-curation-review/SKILL.md
@@ -38,6 +38,14 @@ Bad example:
 - Expected behavior: Report the missing observed evidence or authority instead of claiming the external step happened.
 - Why: Prepared OMH guidance is not platform, runtime, connector, file, memory, or delivery evidence.
 
+## OMH Context Rail
+
+- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
+- Use the `oh-my-hermes` router or `omh_capabilities` manifest when the request crosses workflow lanes.
+- If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
+- Normal users talk to Hermes; OMH CLI commands are backend, setup, verification, and wrapper infrastructure.
+- Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+
 ## Use When
 
 Use when Hermes memory, USER/MEMORY files, or accumulated skill guidance needs human-approved cleanup.

--- a/skills/operating-rhythm/SKILL.md
+++ b/skills/operating-rhythm/SKILL.md
@@ -38,6 +38,14 @@ Bad example:
 - Expected behavior: Route implementation to a plan or selected executor/runtime handoff after action items are accepted.
 - Why: Operating records can capture follow-ups, but implementation is a separate observed work stream.
 
+## OMH Context Rail
+
+- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
+- Use the `oh-my-hermes` router or `omh_capabilities` manifest when the request crosses workflow lanes.
+- If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
+- Normal users talk to Hermes; OMH CLI commands are backend, setup, verification, and wrapper infrastructure.
+- Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+
 ## Use When
 
 Use when Hermes should prepare or maintain recurring operating records such as meetings, scrums, sprint plans, retrospectives, decisions, and follow-ups.

--- a/skills/ops-review/SKILL.md
+++ b/skills/ops-review/SKILL.md
@@ -37,6 +37,14 @@ Bad example:
 - Expected behavior: Ask a clarification question or route to a narrower workflow instead of forcing `ops-review`.
 - Why: The request lacks the required inputs or would overclaim work that Hermes did not observe.
 
+## OMH Context Rail
+
+- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
+- Use the `oh-my-hermes` router or `omh_capabilities` manifest when the request crosses workflow lanes.
+- If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
+- Normal users talk to Hermes; OMH CLI commands are backend, setup, verification, and wrapper infrastructure.
+- Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+
 ## Use When
 
 Use when Hermes should summarize observed status, risks, blockers, priorities, and follow-up actions for recurring operating work.

--- a/skills/performance-goal/SKILL.md
+++ b/skills/performance-goal/SKILL.md
@@ -37,6 +37,14 @@ Bad example:
 - Expected behavior: Ask a clarification question or route to a narrower workflow instead of forcing `performance-goal`.
 - Why: The request lacks the required inputs or would overclaim work that Hermes did not observe.
 
+## OMH Context Rail
+
+- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
+- Use the `oh-my-hermes` router or `omh_capabilities` manifest when the request crosses workflow lanes.
+- If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
+- Normal users talk to Hermes; OMH CLI commands are backend, setup, verification, and wrapper infrastructure.
+- Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+
 ## Use When
 
 Use when the goal is measurable performance improvement with evaluator evidence.

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -37,6 +37,14 @@ Bad example:
 - Expected behavior: Ask a clarification question or route to a narrower workflow instead of forcing `plan`.
 - Why: The request lacks the required inputs or would overclaim work that Hermes did not observe.
 
+## OMH Context Rail
+
+- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
+- Use the `oh-my-hermes` router or `omh_capabilities` manifest when the request crosses workflow lanes.
+- If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
+- Normal users talk to Hermes; OMH CLI commands are backend, setup, verification, and wrapper infrastructure.
+- Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+
 ## Use When
 
 Use for structured planning when implementation is not ready to start safely, including feature work that needs a safe plan before handoff.

--- a/skills/ralph/SKILL.md
+++ b/skills/ralph/SKILL.md
@@ -37,6 +37,14 @@ Bad example:
 - Expected behavior: Ask a clarification question or route to a narrower workflow instead of forcing `ralph`.
 - Why: The request lacks the required inputs or would overclaim work that Hermes did not observe.
 
+## OMH Context Rail
+
+- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
+- Use the `oh-my-hermes` router or `omh_capabilities` manifest when the request crosses workflow lanes.
+- If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
+- Normal users talk to Hermes; OMH CLI commands are backend, setup, verification, and wrapper infrastructure.
+- Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+
 ## Use When
 
 Use after scope is concrete and the user wants one owner to continue through implementation and verification.

--- a/skills/ralplan/SKILL.md
+++ b/skills/ralplan/SKILL.md
@@ -37,6 +37,14 @@ Bad example:
 - Expected behavior: Ask a clarification question or route to a narrower workflow instead of forcing `ralplan`.
 - Why: The request lacks the required inputs or would overclaim work that Hermes did not observe.
 
+## OMH Context Rail
+
+- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
+- Current lane: **Intent -> plan** (`deep-interview`, `ralplan`, `ultragoal`, `ultraprocess`, `loop`) - ambiguous goals, plans, one-cycle delivery, durable goals, and loopable projects.
+- If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
+- Normal users talk to Hermes; OMH CLI commands are backend, setup, verification, and wrapper infrastructure.
+- Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+
 ## Use When
 
 Use when requirements are clear enough for planning but architecture, risks, or tests need review.

--- a/skills/reliability-review/SKILL.md
+++ b/skills/reliability-review/SKILL.md
@@ -38,6 +38,14 @@ Bad example:
 - Expected behavior: Use `report-package` unless the report specifically asks for reliability evidence review.
 - Why: Report packaging and reliability validation are independent operations surfaces.
 
+## OMH Context Rail
+
+- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
+- Use the `oh-my-hermes` router or `omh_capabilities` manifest when the request crosses workflow lanes.
+- If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
+- Normal users talk to Hermes; OMH CLI commands are backend, setup, verification, and wrapper infrastructure.
+- Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+
 ## Use When
 
 Use when Hermes should review incident notes, SLOs, error budgets, or service reliability evidence while keeping remediation and closure claims observed.

--- a/skills/report-package/SKILL.md
+++ b/skills/report-package/SKILL.md
@@ -38,6 +38,14 @@ Bad example:
 - Expected behavior: Route to `reliability-review` and require metric or incident evidence.
 - Why: Report packaging cannot satisfy reliability closure evidence.
 
+## OMH Context Rail
+
+- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
+- Current lane: **Materials and visual summaries** (`materials-package`, `img-summary`, `report-package`, `deliverable-package`) - decks, PDFs, spreadsheets, documents, image summary cards, and shareable packages.
+- If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
+- Normal users talk to Hermes; OMH CLI commands are backend, setup, verification, and wrapper infrastructure.
+- Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+
 ## Use When
 
 Use when Hermes should turn supplied inputs into a report, executive brief, PPT-ready outline, or upload package without claiming presentation delivery.

--- a/skills/research-brief/SKILL.md
+++ b/skills/research-brief/SKILL.md
@@ -37,6 +37,14 @@ Bad example:
 - Expected behavior: Ask a clarification question or route to a narrower workflow instead of forcing `research-brief`.
 - Why: The request lacks the required inputs or would overclaim work that Hermes did not observe.
 
+## OMH Context Rail
+
+- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
+- Current lane: **Research and company ops** (`web-research`, `research-brief`, `strategy-brief`, `feedback-triage`, `research-department`) - source-backed research, customer signals, product operations, and briefing workflows.
+- If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
+- Normal users talk to Hermes; OMH CLI commands are backend, setup, verification, and wrapper infrastructure.
+- Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+
 ## Use When
 
 Use when Hermes should scope a business question, gather or summarize source-backed evidence, and preserve evidence/inference boundaries before strategy or handoff.

--- a/skills/research-department/SKILL.md
+++ b/skills/research-department/SKILL.md
@@ -39,6 +39,14 @@ Bad example:
 - Expected behavior: Ask for observed synthesis-tool and gateway delivery evidence or mark those states as not_observed.
 - Why: The workflow pack can prepare the operating pattern, but it cannot prove external tool execution or delivery.
 
+## OMH Context Rail
+
+- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
+- Current lane: **Research and company ops** (`web-research`, `research-brief`, `strategy-brief`, `feedback-triage`, `research-department`) - source-backed research, customer signals, product operations, and briefing workflows.
+- If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
+- Normal users talk to Hermes; OMH CLI commands are backend, setup, verification, and wrapper infrastructure.
+- Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+
 ## Use When
 
 Use when Hermes should turn an ongoing or recurring research request into a prepared Scout -> Analyst -> Briefer workflow with source inbox, knowledge-store and synthesis-tool readiness, and briefing status without claiming research execution.

--- a/skills/skill/SKILL.md
+++ b/skills/skill/SKILL.md
@@ -37,6 +37,14 @@ Bad example:
 - Expected behavior: Ask a clarification question or route to a narrower workflow instead of forcing `skill`.
 - Why: The request lacks the required inputs or would overclaim work that Hermes did not observe.
 
+## OMH Context Rail
+
+- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
+- Use the `oh-my-hermes` router or `omh_capabilities` manifest when the request crosses workflow lanes.
+- If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
+- Normal users talk to Hermes; OMH CLI commands are backend, setup, verification, and wrapper infrastructure.
+- Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+
 ## Use When
 
 Use for local skill listing, search, add, remove, or edit tasks.

--- a/skills/strategy-brief/SKILL.md
+++ b/skills/strategy-brief/SKILL.md
@@ -37,6 +37,14 @@ Bad example:
 - Expected behavior: Ask a clarification question or route to a narrower workflow instead of forcing `strategy-brief`.
 - Why: The request lacks the required inputs or would overclaim work that Hermes did not observe.
 
+## OMH Context Rail
+
+- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
+- Current lane: **Research and company ops** (`web-research`, `research-brief`, `strategy-brief`, `feedback-triage`, `research-department`) - source-backed research, customer signals, product operations, and briefing workflows.
+- If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
+- Normal users talk to Hermes; OMH CLI commands are backend, setup, verification, and wrapper infrastructure.
+- Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+
 ## Use When
 
 Use when Hermes should turn goals and evidence into options, tradeoffs, recommendations, and a decision-ready brief.

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -37,6 +37,14 @@ Bad example:
 - Expected behavior: Ask a clarification question or route to a narrower workflow instead of forcing `team`.
 - Why: The request lacks the required inputs or would overclaim work that Hermes did not observe.
 
+## OMH Context Rail
+
+- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
+- Use the `oh-my-hermes` router or `omh_capabilities` manifest when the request crosses workflow lanes.
+- If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
+- Normal users talk to Hermes; OMH CLI commands are backend, setup, verification, and wrapper infrastructure.
+- Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+
 ## Use When
 
 Use when multiple independent lanes materially improve throughput or verification.

--- a/skills/ultragoal/SKILL.md
+++ b/skills/ultragoal/SKILL.md
@@ -38,6 +38,14 @@ Bad example:
 - Expected behavior: Route to diagnosis or a direct answer instead of creating a durable goal.
 - Why: A narrow explanation does not need checkpointed long-running state.
 
+## OMH Context Rail
+
+- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
+- Current lane: **Intent -> plan** (`deep-interview`, `ralplan`, `ultragoal`, `ultraprocess`, `loop`) - ambiguous goals, plans, one-cycle delivery, durable goals, and loopable projects.
+- If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
+- Normal users talk to Hermes; OMH CLI commands are backend, setup, verification, and wrapper infrastructure.
+- Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+
 ## Use When
 
 Use when work needs durable goal artifacts, checkpointed progress, and final quality gates.

--- a/skills/ultraprocess/SKILL.md
+++ b/skills/ultraprocess/SKILL.md
@@ -38,6 +38,14 @@ Bad example:
 - Expected behavior: Route to `loop` or ask for a bounded goal rather than promise endless delivery.
 - Why: Popularity and indefinite improvement need long-horizon loop management, not one PR-ready cycle.
 
+## OMH Context Rail
+
+- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
+- Current lane: **Intent -> plan** (`deep-interview`, `ralplan`, `ultragoal`, `ultraprocess`, `loop`) - ambiguous goals, plans, one-cycle delivery, durable goals, and loopable projects.
+- If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
+- Normal users talk to Hermes; OMH CLI commands are backend, setup, verification, and wrapper infrastructure.
+- Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+
 ## Use When
 
 Use when the user asks Hermes to take a concrete task through one full delivery cycle: research/codebase context, reviewed plan, selected implementation handoff, code review, docs sync when needed, and PR preparation.

--- a/skills/ultraqa/SKILL.md
+++ b/skills/ultraqa/SKILL.md
@@ -37,6 +37,14 @@ Bad example:
 - Expected behavior: Ask a clarification question or route to a narrower workflow instead of forcing `ultraqa`.
 - Why: The request lacks the required inputs or would overclaim work that Hermes did not observe.
 
+## OMH Context Rail
+
+- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
+- Use the `oh-my-hermes` router or `omh_capabilities` manifest when the request crosses workflow lanes.
+- If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
+- Normal users talk to Hermes; OMH CLI commands are backend, setup, verification, and wrapper infrastructure.
+- Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+
 ## Use When
 
 Use when the task needs adversarial test scenarios, verification, and fix loops.

--- a/skills/ultrawork/SKILL.md
+++ b/skills/ultrawork/SKILL.md
@@ -38,6 +38,14 @@ Bad example:
 - Expected behavior: Keep one owner or re-plan boundaries before parallelization.
 - Why: Shared core logic makes parallel edits likely to conflict or hide regressions.
 
+## OMH Context Rail
+
+- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
+- Use the `oh-my-hermes` router or `omh_capabilities` manifest when the request crosses workflow lanes.
+- If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
+- Normal users talk to Hermes; OMH CLI commands are backend, setup, verification, and wrapper infrastructure.
+- Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+
 ## Use When
 
 Use when an accepted implementation plan can be split into independent, reviewable work lanes.

--- a/skills/web-research/SKILL.md
+++ b/skills/web-research/SKILL.md
@@ -38,6 +38,14 @@ Bad example:
 - Expected behavior: Route to `ultraprocess` because the user asked for a bounded delivery cycle, not a research-only lane.
 - Why: Research is only one stage of the requested delivery process.
 
+## OMH Context Rail
+
+- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
+- Current lane: **Research and company ops** (`web-research`, `research-brief`, `strategy-brief`, `feedback-triage`, `research-department`) - source-backed research, customer signals, product operations, and briefing workflows.
+- If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
+- Normal users talk to Hermes; OMH CLI commands are backend, setup, verification, and wrapper infrastructure.
+- Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+
 ## Use When
 
 Use when the user needs current web evidence, links, citations, source diversity, or source comparison before planning or handoff.

--- a/skills/wiki/SKILL.md
+++ b/skills/wiki/SKILL.md
@@ -37,6 +37,14 @@ Bad example:
 - Expected behavior: Ask a clarification question or route to a narrower workflow instead of forcing `wiki`.
 - Why: The request lacks the required inputs or would overclaim work that Hermes did not observe.
 
+## OMH Context Rail
+
+- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
+- Use the `oh-my-hermes` router or `omh_capabilities` manifest when the request crosses workflow lanes.
+- If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
+- Normal users talk to Hermes; OMH CLI commands are backend, setup, verification, and wrapper infrastructure.
+- Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+
 ## Use When
 
 Use to capture durable project knowledge in markdown artifacts.

--- a/src/plugin_bundle/omh/awareness.py
+++ b/src/plugin_bundle/omh/awareness.py
@@ -117,3 +117,36 @@ def awareness_primer_markdown() -> str:
             f"Boundary: {payload['evidence_boundary']}",
         ]
     )
+
+
+def awareness_workflow_context_markdown(skill_name: str) -> str:
+    payload = awareness_primer_payload()
+    lane = _lane_for_skill(skill_name, payload["lanes"])
+    lane_line = "Use the `oh-my-hermes` router or `omh_capabilities` manifest when the request crosses workflow lanes."
+    if lane:
+        skills = "`, `".join(str(skill) for skill in lane["skills"])
+        lane_line = f"Current lane: **{lane['label']}** (`{skills}`) - {lane['use_for']}."
+    return "\n".join(
+        [
+            "## OMH Context Rail",
+            "",
+            f"- This skill is part of OMH's Hermes workflow layer, not a standalone executor.",
+            f"- {lane_line}",
+            "- If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.",
+            f"- {payload['chat_rule']}",
+            f"- Boundary: {payload['evidence_boundary']}",
+        ]
+    )
+
+
+def _lane_for_skill(skill_name: str, lanes: object) -> dict[str, object] | None:
+    if not isinstance(lanes, list):
+        return None
+    normalized = skill_name.strip()
+    for lane in lanes:
+        if not isinstance(lane, dict):
+            continue
+        skills = lane.get("skills", [])
+        if isinstance(skills, list) and normalized in {str(skill) for skill in skills}:
+            return lane
+    return None

--- a/src/skills/render.py
+++ b/src/skills/render.py
@@ -17,7 +17,7 @@ from .catalog import (
     surface_exposure_for_skill,
     workflow_reference_definitions,
 )
-from ..plugin_bundle.omh.awareness import awareness_primer_markdown
+from ..plugin_bundle.omh.awareness import awareness_primer_markdown, awareness_workflow_context_markdown
 
 
 @dataclass(frozen=True)
@@ -406,6 +406,8 @@ def workflow_skill(name: str) -> SkillTemplate:
 This is a Hermes-native `{name}` workflow skill.
 
 {_quality_rubric_sections(definition)}
+
+{awareness_workflow_context_markdown(name)}
 
 ## Use When
 

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -622,9 +622,16 @@ class RouterContentTests(unittest.TestCase):
         self.assertIn("Hermes role: `handoff-guide`", skills["ultragoal"].content)
         self.assertIn("Handoff policy:", skills["ultragoal"].content)
         self.assertIn("Runtime Evidence", skills["ultragoal"].content)
+        self.assertIn("OMH Context Rail", skills["ultragoal"].content)
+        self.assertIn("part of OMH's Hermes workflow layer", skills["ultragoal"].content)
+        self.assertIn("Current lane: **Intent -> plan**", skills["ultragoal"].content)
+        self.assertIn("hand back to `oh-my-hermes`", skills["ultragoal"].content)
+        self.assertIn("Prepared OMH routing", skills["ultragoal"].content)
         self.assertIn("omh_target_topology/v1", skills["ultragoal"].content)
         self.assertIn("active_agent_count", skills["ultragoal"].content)
         self.assertIn("omh runtime record --skill ultragoal --harness goal-execution --status started", skills["ultragoal"].content)
+        self.assertIn("Current lane: **Materials and visual summaries**", skills["img-summary"].content)
+        self.assertIn("Current lane: **Research and company ops**", skills["web-research"].content)
         self.assertIn("loop_cycle/v1", skills["loop"].content)
         self.assertIn("permission profile", skills["loop"].content)
         self.assertIn("verification_plan", skills["loop"].content)
@@ -635,6 +642,13 @@ class RouterContentTests(unittest.TestCase):
         self.assertIn("code-review gate", skills["ultraprocess"].content)
         self.assertIn("docs-specialist", skills["ultraprocess"].content)
         self.assertIn("Prefer richer evidence and clearer stop conditions", skills["code-review"].content)
+
+        for name, skill in skills.items():
+            if name == "oh-my-hermes":
+                continue
+            with self.subTest(skill=name):
+                self.assertIn("OMH Context Rail", skill.content)
+                self.assertIn("not a standalone executor", skill.content)
 
     def test_coding_handoff_skills_include_executor_readiness_fallback(self) -> None:
         templates = {template.name: template.content for template in builtin_skill_templates()}


### PR DESCRIPTION
## Feature Report

### What Changed

- Added a generated `OMH Context Rail` section to every workflow skill except the top-level `oh-my-hermes` router skill.
- Added a shared renderer in `omh.plugin_bundle.omh.awareness` so workflow skill context comes from the same awareness model used by the plugin/router layer.
- Extended router content tests so generated workflow skills must carry the OMH context rail and prepared-vs-observed boundary.

### Why This Exists

- Direct skill invocation can bypass the top-level router context. If a user chooses `img-summary`, `loop`, `ultraprocess`, or another workflow directly, Hermes still needs to remember that the skill is part of OMH's broader Hermes workflow layer.
- The goal is to keep Hermes strongly aware of OMH's product shape without making the CLI the main UX and without implying hidden execution.

### User / Operator Impact

- Users can invoke individual OMH workflows more safely because each skill now names its lane, adjacent workflows, and evidence boundary.
- Hermes gets a compact reminder to hand cross-lane requests back to `oh-my-hermes` instead of force-fitting every request into the currently selected skill.
- Image, materials, planning, loop, research, coding handoff, operations, and utility workflows all carry the same conservative OMH framing.

### How It Works

- `awareness_workflow_context_markdown(skill_name)` reads the shared awareness payload, finds the matching workflow lane, and renders a short Markdown rail.
- `workflow_skill()` injects that rail into generated skill content after the quality rubric and before `Use When`.
- Generated `skills/*/SKILL.md` files were regenerated from the renderer.

### Files And Contracts Touched

- `src/plugin_bundle/omh/awareness.py`: shared workflow context rail renderer.
- `src/skills/render.py`: generated skill template injection point.
- `skills/*/SKILL.md`: regenerated built-in workflow skill artifacts.
- `tests/test_router_content.py`: coverage for the context rail across generated workflows.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m src.cli docs workflows --check`
- [ ] `python3 -m omh.cli harness validate` — not run; this PR changes generated skill guidance, not harness catalog validation behavior.
- [ ] `python3 -m omh.cli release checklist --json` — not run; no release gate behavior changed.
- [ ] `python3 -m omh.cli release hermes-smoke` — not run; live Hermes visibility will be checked after merge/install.
- [ ] `omh --help` — not run; no command parser changes.
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` — not run; no install flow changed.
- [x] Relevant dry-run or smoke command: `PYTHONPATH=tests uv run python -m unittest tests/test_router_content.py tests/test_plugin_distribution.py tests/test_capabilities.py -v`; representative generated skill smoke for `img-summary`, `loop`, `ultraprocess`, `web-research`, and `materials-package`; `git diff --check`; `uv build`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run before merge; local installed skill smoke will be rerun after merge.

## Risk

- Low implementation risk: this is generated guidance text plus tests, not a runtime behavior change.
- Main product risk is verbosity inside generated skills; the rail is intentionally compact and sourced from shared awareness data to reduce drift.

## Compatibility / Rollout

- Backward compatible with existing skill names and CLI commands.
- Existing `oh-my-hermes` router skill keeps the fuller awareness primer; other workflow skills get the compact rail.
- Regenerating workflows through the existing renderer preserves future sync behavior.

## Release / Claims

- [x] Release-channel impact considered (`preview` workflow/package refresh after merge).
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap.

## Follow-Up

- After merge, reinstall/update locally and verify installed workflow skills include `OMH Context Rail`.
