### PR TITLE
Add release smoke for OMH skill context

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -232,11 +232,14 @@ After installing OMH into the target runtime, verify the command path too:
 ```sh
 command -v omh
 omh --help
+omh release skill-content-smoke --json
 omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke
 ```
 
-When an operator explicitly wants live evidence from the target Hermes profile,
-run one of these:
+`release skill-content-smoke` checks the installed command package's generated
+skill guidance, including router awareness and workflow context rails. It is
+not Hermes chat-load evidence. When an operator explicitly wants live evidence
+from the target Hermes profile, run one of these:
 
 ```sh
 omh release hermes-smoke --live --install-path tap --target-confirmed

--- a/docs/README.md
+++ b/docs/README.md
@@ -117,10 +117,11 @@ selected.
 - Harness catalog changes should pass `omh harness validate`, and user-facing
   harness examples should stay backed by conformance tests.
 - Release checks should include `omh release checklist --json`,
-  `omh release hermes-smoke`, `omh release install-smoke`, and installed
-  command smoke (`omh --help`). Use `release install-smoke --live` for an
-  isolated first-time downloader check, and use `hermes-smoke --live` only from
-  the target Hermes profile when an operator wants real Hermes profile evidence.
+  `omh release skill-content-smoke --json`, `omh release hermes-smoke`,
+  `omh release install-smoke`, and installed command smoke (`omh --help`). Use
+  `release install-smoke --live` for an isolated first-time downloader check,
+  and use `hermes-smoke --live` only from the target Hermes profile when an
+  operator wants real Hermes profile evidence.
 - Runtime and wrapper docs should preserve the separation between wrapper
   session state and run-level evidence.
 - Parity docs should map common oh-my runtime capability axes to OMH's

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -59,6 +59,7 @@ python3 -m compileall src
 python3 -m omh.cli docs workflows --check
 python3 -m omh.cli harness validate
 python3 -m omh.cli release checklist --json
+python3 -m omh.cli release skill-content-smoke --json
 python3 -m omh.cli --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke install --dry-run --channel stable --version 1.0.1
 python3 -m omh.cli --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke setup --dry-run --channel stable --version 1.0.1
 python3 -m omh.cli --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke probe
@@ -71,6 +72,7 @@ uv build
 python3 -m venv /tmp/omh-wheel-smoke
 /tmp/omh-wheel-smoke/bin/python -m pip install --upgrade dist/oh_my_hermes-1.0.1-py3-none-any.whl
 /tmp/omh-wheel-smoke/bin/omh --help
+/tmp/omh-wheel-smoke/bin/omh release skill-content-smoke --json
 /tmp/omh-wheel-smoke/bin/omh --omh-home /tmp/omh-wheel-home --hermes-home /tmp/hermes-wheel-home release hermes-smoke --install-path setup --omh-command /tmp/omh-wheel-smoke/bin/omh --include-command-smoke
 /tmp/omh-wheel-smoke/bin/omh --omh-home /tmp/omh-wheel-home --hermes-home /tmp/hermes-wheel-home setup --dry-run --channel stable --version 1.0.1
 OMH_PYTHON=/tmp/omh-wheel-smoke/bin/python OMH_PACKAGE_URL=file://$PWD/dist/oh_my_hermes-1.0.1-py3-none-any.whl OMH_VENV_DIR=/tmp/omh-installer-venv OMH_BIN_DIR=/tmp/omh-installer-bin sh install.sh
@@ -131,8 +133,15 @@ Run the installed command smoke in CI or a release shell after installing OMH:
 ```sh
 command -v omh
 omh --help
+omh release skill-content-smoke --json
 omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke
 ```
+
+`release skill-content-smoke` is non-mutating package-content evidence. It
+checks that the command package can render the router awareness primer and the
+generated workflow context rails that keep direct skill invocation inside the
+broader OMH model. It does not prove Hermes loaded those skills or selected
+them in chat.
 
 For release candidates, run exactly one live smoke against the target Hermes
 profile and paste the JSON result into the release note. Use the native tap

--- a/src/commands/release.py
+++ b/src/commands/release.py
@@ -12,6 +12,7 @@ from ..release import (
     release_readiness_checklist,
     run_hermes_release_smoke,
     run_installed_command_smoke,
+    skill_content_smoke,
 )
 from ..release_install_smoke import install_script_smoke_plan, run_install_script_smoke
 from .common import _print_json, _wants_json
@@ -109,6 +110,15 @@ def cmd_release_install_smoke(args: argparse.Namespace) -> int:
     return 0 if payload["ok"] else 1
 
 
+def cmd_release_skill_content_smoke(args: argparse.Namespace) -> int:
+    payload = skill_content_smoke()
+    if _wants_json(args):
+        _print_json(payload)
+    else:
+        _print_skill_content_smoke_summary(payload)
+    return 0 if payload["ok"] else 1
+
+
 def _add_release_commands(sub) -> None:
     release = sub.add_parser("release", help="Plan or run release smoke checks for real Hermes installation paths.")
     release_sub = release.add_subparsers(dest="release_command", required=True)
@@ -180,6 +190,13 @@ def _add_release_commands(sub) -> None:
     install_smoke.add_argument("--json", action="store_true", help="Print the machine-readable install smoke payload.")
     install_smoke.set_defaults(func=cmd_release_install_smoke)
 
+    skill_content = release_sub.add_parser(
+        "skill-content-smoke",
+        help="Verify generated OMH skill guidance in the current command package.",
+    )
+    skill_content.add_argument("--json", action="store_true", help="Print the machine-readable skill content smoke payload.")
+    skill_content.set_defaults(func=cmd_release_skill_content_smoke)
+
 
 def _print_release_checklist_summary(payload: dict[str, object]) -> None:
     print(f"OMH release checklist for {payload['version']} ({payload['tag']})")
@@ -235,4 +252,24 @@ def _print_install_smoke_summary(payload: dict[str, object]) -> None:
         print(f"    Boundary: {step.get('proof_boundary', '')}")
     print("")
     print(f"Next: {payload.get('recommended_next_action')}")
+    print("For machine-readable output, rerun with `--json`.")
+
+
+def _print_skill_content_smoke_summary(payload: dict[str, object]) -> None:
+    print("OMH skill content smoke")
+    print(f"Status: {'ok' if payload.get('ok') else 'failed'}")
+    print(f"Skills checked: {payload.get('skill_count')}")
+    print(f"Markers checked: {payload.get('checked_marker_count')}")
+    failed = payload.get("failed_checks", [])
+    missing = payload.get("missing_representative_skills", [])
+    if missing:
+        print("Missing representative skills: " + ", ".join(str(item) for item in missing))
+    if isinstance(failed, list) and failed:
+        print("Failed markers:")
+        for check in failed[:12]:
+            if isinstance(check, dict):
+                print(f"  - {check.get('skill')}: {check.get('marker')}")
+        if len(failed) > 12:
+            print(f"  ... {len(failed) - 12} more")
+    print(f"Boundary: {payload.get('proof_boundary')}")
     print("For machine-readable output, rerun with `--json`.")

--- a/src/release.py
+++ b/src/release.py
@@ -14,6 +14,7 @@ from .command_path import (
     path_check_kind,
 )
 from .release_smoke_core import CommandResult, Runner, bounded_text, expand_home, subprocess_runner
+from .skill_pack import builtin_skill_templates
 
 REPOSITORY_ARCHIVE_ROOT = "https://github.com/rlaope/oh-my-hermes/archive/refs"
 RELEASE_CHANNELS = ("stable", "preview", "local")
@@ -21,11 +22,15 @@ HERMES_SMOKE_SCHEMA = "hermes_release_smoke/v1"
 RELEASE_CHECKLIST_SCHEMA = "release_readiness_checklist/v1"
 INSTALLED_COMMAND_SMOKE_SCHEMA = "installed_omh_command_smoke/v1"
 FIRST_USE_STATUS_SMOKE_SCHEMA = "first_use_status_smoke/v1"
+SKILL_CONTENT_SMOKE_SCHEMA = "skill_content_smoke/v1"
 RELEASE_VERSION_RE = re.compile(r"^[0-9]+(?:\.[0-9]+)*(?:[-_+.]?[A-Za-z0-9][A-Za-z0-9._+-]*)?$")
 DEFAULT_HERMES_TAP = "rlaope/oh-my-hermes"
 DEFAULT_HERMES_SKILL = "oh-my-hermes"
 DEFAULT_FIRST_USE_MESSAGE = "I want to safely add a feature to this repo"
 INSTALL_PATHS = ("tap", "setup")
+REPRESENTATIVE_CONTEXT_RAIL_SKILLS = ("img-summary", "loop", "ultraprocess", "web-research", "materials-package")
+ROUTER_CONTENT_MARKERS = ("OMH Awareness Primer", "img-summary", "Normal users talk to Hermes")
+WORKFLOW_CONTEXT_MARKERS = ("OMH Context Rail", "not a standalone executor", "Prepared OMH routing")
 
 
 @dataclass(frozen=True)
@@ -215,6 +220,16 @@ def release_readiness_checklist(
             "This proves console-script importability only.",
         ),
         ReleaseChecklistItem(
+            "skill_content_smoke",
+            "Check installed command package skill content",
+            f"{omh_display} release skill-content-smoke --json",
+            "installed-command",
+            True,
+            False,
+            "Skill content smoke reports ok=true for router awareness and generated workflow context rails.",
+            "This proves the installed OMH command package can render expected skill guidance; it does not prove Hermes loaded or selected it in chat.",
+        ),
+        ReleaseChecklistItem(
             "installed_command_smoke",
             "Observe installed command smoke without Hermes mutation",
             (
@@ -224,8 +239,8 @@ def release_readiness_checklist(
             "installed-command",
             True,
             False,
-            "Nested installed_command_smoke is mode=live, observed=true, and ok=true.",
-            "This observes the installed OMH command path while keeping the outer Hermes profile smoke plan-only.",
+            "Nested installed_command_smoke is mode=live, observed=true, ok=true, and includes installed skill content smoke.",
+            "This observes the installed OMH command path and generated skill guidance while keeping the outer Hermes profile smoke plan-only.",
         ),
         ReleaseChecklistItem(
             "build_artifacts",
@@ -536,6 +551,16 @@ def installed_command_smoke_plan(
             proof_boundary="Verifies the installed OMH console script is importable and runnable from the current PATH.",
         ),
         HermesSmokeStep(
+            "installed_omh_skill_content",
+            (omh_command, "release", "skill-content-smoke", "--json"),
+            "verify",
+            False,
+            proof_boundary=(
+                "Verifies the installed OMH command package can render router awareness and workflow context rails. "
+                "This is package-content evidence only, not Hermes runtime-load evidence."
+            ),
+        ),
+        HermesSmokeStep(
             "installed_omh_setup_plan",
             _omh_release_plan_command(
                 omh_command,
@@ -564,6 +589,52 @@ def installed_command_smoke_plan(
             "--include-command-smoke to observe PATH resolution and the installed OMH executable."
         ),
         "steps": [step.to_payload() for step in steps],
+    }
+
+
+def skill_content_smoke() -> dict[str, object]:
+    templates = {template.name: template.content for template in builtin_skill_templates()}
+    checks: list[dict[str, object]] = []
+
+    def add_check(name: str, marker: str, ok: bool, *, scope: str) -> None:
+        checks.append(
+            {
+                "scope": scope,
+                "skill": name,
+                "marker": marker,
+                "ok": ok,
+            }
+        )
+
+    router = templates.get(DEFAULT_HERMES_SKILL, "")
+    for marker in ROUTER_CONTENT_MARKERS:
+        add_check(DEFAULT_HERMES_SKILL, marker, marker in router, scope="router_awareness")
+
+    missing_representative = [name for name in REPRESENTATIVE_CONTEXT_RAIL_SKILLS if name not in templates]
+    for name, content in sorted(templates.items()):
+        if name == DEFAULT_HERMES_SKILL:
+            continue
+        for marker in WORKFLOW_CONTEXT_MARKERS:
+            add_check(name, marker, marker in content, scope="workflow_context_rail")
+
+    failed_checks = [check for check in checks if not check["ok"]]
+    ok = not failed_checks and not missing_representative
+    return {
+        "schema_version": SKILL_CONTENT_SMOKE_SCHEMA,
+        "mode": "live",
+        "ok": ok,
+        "observed": True,
+        "skill_count": len(templates),
+        "router_skill": DEFAULT_HERMES_SKILL,
+        "workflow_skill_count": max(len(templates) - 1, 0),
+        "representative_skills": list(REPRESENTATIVE_CONTEXT_RAIL_SKILLS),
+        "missing_representative_skills": missing_representative,
+        "checked_marker_count": len(checks),
+        "failed_checks": failed_checks,
+        "proof_boundary": (
+            "This validates generated skill guidance inside the current OMH command package. "
+            "It does not prove the target Hermes profile installed, loaded, selected, or used those skills in chat."
+        ),
     }
 
 
@@ -932,7 +1003,7 @@ def run_installed_command_smoke(
             command_under_test=omh_command,
         ),
         "proof_boundary": (
-            "Installed command smoke observes the OMH console script and plan rendering only. "
+            "Installed command smoke observes the OMH console script, generated skill guidance, and plan rendering only. "
             "It does not mutate Hermes or prove live chat usage."
         ),
     }
@@ -1020,7 +1091,11 @@ def _hermes_smoke_next_action(ok: bool, failed_step: str) -> str:
     if failed_step == "setup_doctor":
         return "Run `omh doctor` manually and repair the OMH-managed skill registration reported there."
     if failed_step == "installed_command_smoke":
-        return "Repair the installed `omh` console script path, then rerun the smoke with --include-command-smoke."
+        return (
+            "Inspect installed_command_smoke.failed_step, then repair the installed `omh` command path, "
+            "console script importability, generated skill content, or setup plan rendering before rerunning "
+            "with --include-command-smoke."
+        )
     if failed_step in {"tap_list", "skills_list", "skill_check", "skill_inspect"}:
         return "Inspect the failing Hermes skills command output and confirm the target Hermes profile is the one OMH was installed into."
     return "Inspect the failed Hermes release smoke step and rerun after repair."
@@ -1047,6 +1122,8 @@ def _installed_command_smoke_next_action(
         )
     if failed_step == "installed_omh_help":
         return "Check PATH, package installation, and console-script importability for `omh`."
+    if failed_step == "installed_omh_skill_content":
+        return "Run `omh release skill-content-smoke --json` directly and inspect missing router awareness or workflow context rail markers."
     if failed_step == "installed_omh_setup_plan":
         return "Run `omh release hermes-smoke --install-path setup` directly and inspect the console-script error."
     return "Inspect the failed installed command smoke step and rerun after repair."

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -833,6 +833,7 @@ class CliTests(unittest.TestCase):
         self.assertNotIn(["hermes", "skills", "inspect", "oh-my-hermes"], commands)
         installed_commands = [step["command"] for step in payload["installed_command_smoke"]["steps"]]
         self.assertEqual(installed_commands[0], ["omh-dev", "--help"])
+        self.assertIn(["omh-dev", "release", "skill-content-smoke", "--json"], installed_commands)
         self.assertIn(
             [
                 "omh-dev",
@@ -883,8 +884,31 @@ class CliTests(unittest.TestCase):
         self.assertFalse(payload["observed"])
         items = {item["id"]: item for item in payload["items"]}
         self.assertIn("uv build", items["build_artifacts"]["command"])
+        self.assertIn("skill-content-smoke", items["skill_content_smoke"]["command"])
         self.assertIn("setup --dry-run --channel stable --version 1.0.0", items["wheel_setup_dry_run"]["command"])
         self.assertTrue(items["live_tap_smoke"]["requires_release_authority"])
+
+    def test_release_skill_content_smoke_cli_checks_generated_guidance(self) -> None:
+        status, stdout, stderr = run_cli(["release", "skill-content-smoke", "--json"], output_json=False)
+
+        self.assertEqual(status, 0, stderr)
+        self.assertEqual(stderr, "")
+        payload = json.loads(stdout)
+        self.assertEqual(payload["schema_version"], "skill_content_smoke/v1")
+        self.assertTrue(payload["ok"])
+        self.assertTrue(payload["observed"])
+        self.assertEqual(payload["failed_checks"], [])
+        self.assertIn("img-summary", payload["representative_skills"])
+
+        status, stdout, stderr = run_cli(["release", "skill-content-smoke"], output_json=False)
+
+        self.assertEqual(status, 0, stderr)
+        self.assertEqual(stderr, "")
+        self.assertIn("OMH skill content smoke", stdout)
+        self.assertIn("Status: ok", stdout)
+        self.assertIn("For machine-readable output", stdout)
+        with self.assertRaises(json.JSONDecodeError):
+            json.loads(stdout)
 
     def test_release_install_smoke_defaults_to_human_plan_with_json_escape_hatch(self) -> None:
         with TemporaryDirectory() as tmp:
@@ -976,6 +1000,10 @@ class CliTests(unittest.TestCase):
         self.assertEqual(payload["installed_command_smoke"]["mode"], "live")
         self.assertTrue(payload["installed_command_smoke"]["ok"])
         self.assertEqual(payload["installed_command_smoke"]["results"][0]["command"], [str(fake_omh), "--help"])
+        self.assertEqual(
+            payload["installed_command_smoke"]["results"][1]["command"],
+            [str(fake_omh), "release", "skill-content-smoke", "--json"],
+        )
         self.assertFalse(payload["first_use_status_smoke"]["observed"])
 
     def test_release_hermes_smoke_cli_fails_when_installed_command_is_not_on_path(self) -> None:

--- a/tests/test_release_smoke.py
+++ b/tests/test_release_smoke.py
@@ -10,6 +10,7 @@ from omh.release import (
     hermes_release_smoke_plan,
     release_readiness_checklist,
     run_hermes_release_smoke,
+    skill_content_smoke,
 )
 from omh.release_install_smoke import install_script_smoke_plan, run_install_script_smoke
 from omh.release_smoke_core import CommandResult, subprocess_runner, subprocess_runner_exact_env
@@ -27,12 +28,15 @@ class ReleaseSmokeTests(unittest.TestCase):
         self.assertIn("does not run commands", payload["proof_boundary"])
         items = {item["id"]: item for item in payload["items"]}
         self.assertIn("unit_tests", items)
+        self.assertIn("skill_content_smoke", items)
         self.assertIn("installed_command_smoke", items)
         self.assertIn("installed_command_path", items)
         self.assertIn("live_tap_smoke", items)
         self.assertIn("tag_and_publish", items)
         self.assertEqual(items["installed_command_path"]["command"], "command -v /tmp/omh")
         self.assertEqual(items["installed_command_help"]["command"], "/tmp/omh --help")
+        self.assertEqual(items["skill_content_smoke"]["command"], "/tmp/omh release skill-content-smoke --json")
+        self.assertIn("generated workflow context rails", items["skill_content_smoke"]["evidence_required"])
         self.assertIn("--include-command-smoke", items["installed_command_smoke"]["command"])
         self.assertIn("dist/oh_my_hermes-1.0.0-py3-none-any.whl", items["wheel_install"]["command"])
         self.assertIn("wheel_setup_dry_run", items)
@@ -54,8 +58,23 @@ class ReleaseSmokeTests(unittest.TestCase):
         items = {item["id"]: item for item in payload["items"]}
         self.assertEqual(items["installed_command_help"]["command"], "'/tmp/omh command' --help")
         self.assertEqual(items["installed_command_path"]["command"], "command -v '/tmp/omh command'")
+        self.assertEqual(items["skill_content_smoke"]["command"], "'/tmp/omh command' release skill-content-smoke --json")
         self.assertIn("--omh-command '/tmp/omh command'", items["installed_command_smoke"]["command"])
         self.assertIn("'/tmp/omh command' release hermes-smoke --live", items["live_tap_smoke"]["command"])
+
+    def test_skill_content_smoke_checks_router_and_workflow_context(self) -> None:
+        payload = skill_content_smoke()
+
+        self.assertEqual(payload["schema_version"], "skill_content_smoke/v1")
+        self.assertTrue(payload["ok"])
+        self.assertTrue(payload["observed"])
+        self.assertEqual(payload["router_skill"], "oh-my-hermes")
+        self.assertIn("img-summary", payload["representative_skills"])
+        self.assertEqual(payload["missing_representative_skills"], [])
+        self.assertEqual(payload["failed_checks"], [])
+        self.assertGreaterEqual(payload["skill_count"], 40)
+        self.assertGreaterEqual(payload["checked_marker_count"], 100)
+        self.assertIn("does not prove the target Hermes profile", payload["proof_boundary"])
 
     def test_release_readiness_checklist_rejects_empty_version(self) -> None:
         with self.assertRaises(ValueError):
@@ -87,6 +106,7 @@ class ReleaseSmokeTests(unittest.TestCase):
         self.assertFalse(payload["installed_command_smoke"]["path_check"]["observed"])
         installed_commands = [step["command"] for step in payload["installed_command_smoke"]["steps"]]
         self.assertEqual(installed_commands[0], ["omh", "--help"])
+        self.assertIn(["omh", "release", "skill-content-smoke", "--json"], installed_commands)
         self.assertIn(
             ["omh", "--omh-home", omh_home, "--hermes-home", hermes_home, "release", "hermes-smoke", "--install-path", "setup", "--omh-command", "omh"],
             installed_commands,
@@ -122,6 +142,7 @@ class ReleaseSmokeTests(unittest.TestCase):
         self.assertNotIn(["hermes", "skills", "inspect", "oh-my-hermes"], commands)
         installed_commands = [step["command"] for step in payload["installed_command_smoke"]["steps"]]
         self.assertEqual(installed_commands[0], ["omh-dev", "--help"])
+        self.assertIn(["omh-dev", "release", "skill-content-smoke", "--json"], installed_commands)
         self.assertIn(
             [
                 "omh-dev",
@@ -356,6 +377,7 @@ class ReleaseSmokeTests(unittest.TestCase):
         self.assertTrue(payload["installed_command_smoke"]["path_check"]["ok"])
         self.assertEqual(payload["installed_command_smoke"]["path_check"]["mode"], "live")
         self.assertIn(["omh-dev", "--help"], seen)
+        self.assertIn(["omh-dev", "release", "skill-content-smoke", "--json"], seen)
         self.assertIn(
             [
                 "omh-dev",
@@ -386,6 +408,20 @@ class ReleaseSmokeTests(unittest.TestCase):
         self.assertEqual(payload["failed_step"], "installed_command_smoke")
         self.assertEqual(payload["installed_command_smoke"]["failed_step"], "installed_omh_help")
         self.assertIn("console script", payload["recommended_next_action"])
+
+    def test_installed_command_smoke_failure_from_skill_content_marks_release_smoke_failed(self) -> None:
+        def runner(command, _timeout, _env):
+            if list(command) == ["omh-dev", "release", "skill-content-smoke", "--json"]:
+                return CommandResult(command, 1, '{"ok": false}', "missing context rail")
+            return CommandResult(command, 0, "ok", "")
+
+        with patch("omh.release.shutil.which", return_value="/usr/local/bin/hermes"):
+            payload = run_hermes_release_smoke(runner=runner, omh_command="omh-dev", include_command_smoke=True)
+
+        self.assertFalse(payload["ok"])
+        self.assertEqual(payload["failed_step"], "installed_command_smoke")
+        self.assertEqual(payload["installed_command_smoke"]["failed_step"], "installed_omh_skill_content")
+        self.assertIn("skill-content-smoke", payload["installed_command_smoke"]["recommended_next_action"])
 
     def test_installed_command_smoke_fails_before_help_when_omh_is_not_on_path(self) -> None:
         def runner(command, _timeout, _env):  # pragma: no cover - path check should stop first


### PR DESCRIPTION
## Summary
- add a non-mutating `omh release skill-content-smoke` command that verifies the installed command package can render the OMH router awareness primer and generated workflow context rails
- fold that skill-content check into the release checklist and installed command smoke so release candidates catch packaged guidance drift before users hit Hermes chat
- document the new release/install verification step while preserving the boundary that package-content smoke is not live Hermes chat-load evidence

## Why
Hermes needs strong OMH context across all workflows, not only img-summary. The generated skills already carry that context, but the release path did not have a direct smoke gate proving the packaged command can still render it. This PR turns that expectation into repeatable release evidence.

## User/operator impact
- Operators can run `omh release skill-content-smoke --json` to verify packaged skill guidance before shipping or updating.
- Release smoke now catches missing OMH awareness/context rails in generated skills instead of only checking that the console script imports.
- Hermes-facing claims stay conservative: this proves package content, not live Hermes selection or chat usage.

## Implementation notes
- `src/release.py` adds `skill_content_smoke()` plus checklist and installed-command-smoke integration.
- `src/commands/release.py` exposes the new human and JSON CLI command.
- `tests/test_release_smoke.py` and `tests/test_cli.py` lock router markers, workflow context markers, command shape, failure propagation, and human output.
- `docs/RELEASE.md`, `docs/README.md`, and `docs/INSTALLATION.md` include the new smoke step and its proof boundary.

## Verification
- `PYTHONPATH=tests uv run python -m unittest tests/test_release_smoke.py tests/test_cli.py -v`
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- `uv run python -m compileall -q src tests`
- `uv run python -m src.cli docs workflows --check`
- `PYTHONPATH=tests uv run python -m src.cli release skill-content-smoke --json`
- `git diff --check`
- `uv build`

## Risks and follow-up
- This intentionally does not prove that a target Hermes profile loaded or selected OMH in live chat. Live smoke remains a separate operator-controlled check.
- The marker set is conservative; future major skill copy changes should update the smoke markers deliberately.
