### PR TITLE
Make Hermes chat context more human

### DIFF
--- a/src/routing/policy.py
+++ b/src/routing/policy.py
@@ -250,6 +250,93 @@ _VISUAL_SUMMARY_PHRASES = (
     "이미지로 설명",
     "이미지 하나 만들어줘",
 )
+_DELIVERABLE_STRONG_TOKENS = frozenset(
+    {
+        "attachment",
+        "attachments",
+        "attach",
+        "attached",
+        "deliverable",
+        "deliverables",
+        "첨부",
+        "전달",
+    }
+)
+_DELIVERABLE_FILE_TOKENS = frozenset(
+    {
+        "file",
+        "files",
+        "pdf",
+        "ppt",
+        "pptx",
+        "xlsx",
+        "docx",
+        "hwp",
+        "markdown",
+        "report",
+        "deck",
+        "document",
+        "파일",
+        "보고서",
+        "자료",
+        "문서",
+        "피디에프",
+        "엑셀",
+    }
+)
+_DELIVERABLE_PHRASES = (
+    "attach file",
+    "file attachment",
+    "attachment status",
+    "file delivery",
+    "deliverable package",
+    "generated file",
+    "make it attachable",
+    "ready to attach",
+    "파일로 만들어",
+    "파일로 만들어서 첨부",
+    "첨부할 수 있게",
+    "첨부 가능",
+    "첨부 상태",
+    "전달 상태",
+)
+_DELIVERABLE_GATEWAY_CONTEXT_TOKENS = frozenset(
+    {
+        "gateway",
+        "platform",
+        "thread",
+        "silent",
+        "silently",
+        "discord",
+        "slack",
+        "telegram",
+        "message",
+        "messages",
+        "status",
+        "updates",
+        "게이트웨이",
+        "플랫폼",
+        "스레드",
+        "조용히",
+        "디스코드",
+        "슬랙",
+        "텔레그램",
+        "메시지",
+        "상태",
+        "업데이트",
+    }
+)
+_DELIVERABLE_GATEWAY_CONTEXT_PHRASES = (
+    "gateway thread",
+    "discord gateway",
+    "slack gateway",
+    "telegram gateway",
+    "silent attachment status",
+    "silent status update",
+    "status updates",
+    "gateway status",
+    "platform delivery",
+)
 _SCHEDULED_OPS_PHRASES = (
     "every morning",
     "every day",
@@ -352,6 +439,15 @@ VISUAL_SUMMARY_GUARD = RoutingGuardRule(
     why="Matched guard/trigger metadata; visual image-card requests should prepare a visual prompt card before delivery or material packaging.",
     activation_status="active",
 )
+DELIVERABLE_PACKAGE_GUARD = RoutingGuardRule(
+    id="deliverable_package_for_file_attachment",
+    rule="Requests that combine generated files or reports with attachment/delivery status should route to deliverable-package.",
+    matched_label="guard:deliverable_package",
+    preferred_skills=("deliverable-package",),
+    score_boost=28,
+    why="Matched guard/trigger metadata; file attachment or delivery-status requests should prepare a deliverable package before claiming output.",
+    activation_status="active",
+)
 SCHEDULED_OPS_BLUEPRINT_GUARD = RoutingGuardRule(
     id="scheduled_ops_blueprint_before_reliability_or_research",
     rule="Recurring schedule, delivery, or silence-policy requests should route to the scheduled ops blueprint lane before one-off review/research lanes.",
@@ -377,6 +473,7 @@ ROUTING_GUARD_RULES = (
     SCHEDULED_OPS_BLUEPRINT_GUARD,
     WEB_RESEARCH_BEFORE_PROCESS_GUARD,
     VISUAL_SUMMARY_GUARD,
+    DELIVERABLE_PACKAGE_GUARD,
     DELIVERY_CYCLE_GUARD,
 )
 
@@ -436,6 +533,8 @@ def active_routing_guard_rules(
         rules.append(WEB_RESEARCH_BEFORE_PROCESS_GUARD)
     if _visual_summary_guard_applies(normalized_query, query_tokens):
         rules.append(VISUAL_SUMMARY_GUARD)
+    if _deliverable_package_guard_applies(normalized_query, query_tokens):
+        rules.append(DELIVERABLE_PACKAGE_GUARD)
     if delivery_cycle_applies:
         rules.append(DELIVERY_CYCLE_GUARD)
     return tuple(rules)
@@ -587,6 +686,31 @@ def _visual_summary_guard_applies(normalized_query: str, query_tokens: set[str])
     ):
         return True
     return False
+
+
+def _deliverable_package_guard_applies(normalized_query: str, query_tokens: set[str]) -> bool:
+    if _visual_summary_guard_applies(normalized_query, query_tokens):
+        return False
+    if _deliverable_gateway_context_applies(normalized_query, query_tokens):
+        return False
+    explicit_phrase = _contains_phrase(normalized_query, _DELIVERABLE_PHRASES)
+    if explicit_phrase:
+        return True
+    if _DELIVERABLE_STRONG_TOKENS & query_tokens and _DELIVERABLE_FILE_TOKENS & query_tokens:
+        return True
+    return False
+
+
+def _deliverable_gateway_context_applies(normalized_query: str, query_tokens: set[str]) -> bool:
+    gateway_context = bool(_DELIVERABLE_GATEWAY_CONTEXT_TOKENS & query_tokens) or _contains_phrase(
+        normalized_query, _DELIVERABLE_GATEWAY_CONTEXT_PHRASES
+    )
+    if not gateway_context:
+        return False
+    deliverable_file_context = bool(_DELIVERABLE_FILE_TOKENS & query_tokens) or _contains_phrase(
+        normalized_query, ("generated pdf", "generated file", "file attachment", "attach file")
+    )
+    return not deliverable_file_context
 
 
 def _delivery_cycle_guard_applies(normalized_query: str, query_tokens: set[str]) -> bool:

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -25,6 +25,7 @@ CHAT_RESPONSE_SCHEMA_VERSION = "chat_response/v1"
 STATUS_CARD_SCHEMA_VERSION = "status_card/v1"
 SKILL_PICKER_SCHEMA_VERSION = "omh_skill_picker/v1"
 COMMAND_PREVIEW_SCHEMA_VERSION = "omh_command_preview/v1"
+CONTEXT_PRIMER_SCHEMA_VERSION = "omh_context_primer/v1"
 USAGE_TRACE_SCHEMA_VERSION = "omh_usage_trace/v1"
 MESSENGER_RENDERING_SCHEMA_VERSION = "omh_messenger_rendering/v1"
 RENDER_PROFILE_LIMITED_MARKDOWN = "limited_markdown"
@@ -128,6 +129,32 @@ _SKILL_PICKER_ENTRIES = (
     ("img-summary", "Img Summary", "Prepare image-generation-ready summary cards.", "./img-summary <source>"),
     ("automation-blueprint", "Automation Blueprint", "Prepare recurring Hermes scheduled-ops workflows.", "./automation-blueprint <intent>"),
     ("doctor", "Doctor", "Check OMH install and Hermes registration health.", "./doctor"),
+)
+_CONTEXT_PRIMER_GROUPS = (
+    {
+        "id": "intent_to_plan",
+        "label": "Intent to plan",
+        "workflows": ("deep-interview", "ralplan", "ultragoal", "loop", "ultraprocess"),
+        "use_when": "The user has a fuzzy goal, a large goal, or one delivery cycle that needs research, planning, execution, review, and sync.",
+    },
+    {
+        "id": "company_product_ops",
+        "label": "Company and product ops",
+        "workflows": ("feedback-triage", "research-department", "web-research", "strategy-brief", "automation-blueprint"),
+        "use_when": "The user needs customer-signal triage, source-backed research, recurring ops, meeting/report work, or strategy synthesis.",
+    },
+    {
+        "id": "deliverables_and_visuals",
+        "label": "Deliverables and visuals",
+        "workflows": ("materials-package", "deliverable-package", "img-summary", "report-package"),
+        "use_when": "The user wants files, decks, PDFs, reports, image-summary cards, or attachment-ready delivery states.",
+    },
+    {
+        "id": "coding_and_runtime",
+        "label": "Coding and runtime tracking",
+        "workflows": ("idea-to-deploy", "agent-ops-review", "code-review", "ops-observability-card"),
+        "use_when": "The user wants Hermes to prepare coding handoffs, explain executor status, review evidence, CI, or merge readiness.",
+    },
 )
 _RETAINED_DELEGATION_SKILLS = set(retained_delegation_skill_names())
 _DIRECT_WORKFLOW_SKILLS = {
@@ -237,6 +264,25 @@ _STATUS_COPY = {
         "This has been merged.",
         "Execution, verification, review, CI, and merge evidence are observed.",
         "Merged status is backed by runtime ledger evidence.",
+    ),
+}
+_HUMAN_ACK_BODY_BY_SKILL = {
+    "automation-blueprint": (
+        "I will prepare this as a recurring Hermes ops workflow: schedule, source inputs, delivery target, "
+        "silence policy, and the confirmation card. Creating the actual schedule or sending messages still "
+        "needs observed runtime evidence."
+    ),
+    "research-department": (
+        "I will shape this into a research workflow: what to watch, how raw findings move into analysis, "
+        "how the briefing should be delivered, and what still needs source or delivery evidence."
+    ),
+    "materials-package": (
+        "I will shape this into a material package: target files, source inputs, missing data, outline, "
+        "generation owner, and QA checks. I will not claim the files exist until export evidence is observed."
+    ),
+    "deliverable-package": (
+        "I will prepare the deliverable path: which files are needed, who generates them, what QA must pass, "
+        "and how attachment or delivery status should be recorded."
     ),
 }
 
@@ -625,7 +671,10 @@ def build_chat_response_from_route(
         next_action = policy_next_action if policy_next_action and policy_next_action != "show_workflow_guidance" else "dispatch_to_workflow"
         wrapper_guidance = str(policy.get("wrapper_guidance", ""))
         evidence_boundary = str(policy.get("evidence_boundary", "")) or "Routing is not execution evidence."
-        body = wrapper_guidance or f"I will prepare a safe next step for `{selected}` before claiming any work happened."
+        body = _HUMAN_ACK_BODY_BY_SKILL.get(
+            selected,
+            wrapper_guidance or f"I will prepare a safe next step for `{selected}` before claiming any work happened.",
+        )
         return _chat_response(
             kind="ack",
             headline="I know which workflow should handle this.",
@@ -1460,11 +1509,12 @@ def _command_preview_prefix(token: str) -> str:
 def _skill_picker_response(decision: dict[str, object], *, thread_key: str = "", message: str = "") -> dict[str, object]:
     picker = _skill_picker_state(message, source=str(decision.get("source", "generic")))
     catalog_question = _is_skill_catalog_question(message)
+    primer = _context_primer_state()
     return _chat_response(
         kind="skill_picker",
         headline="Here are the OMH workflows." if catalog_question else "Choose an OMH workflow.",
         body=(
-            "You do not need to run a shell command for this. Pick a workflow here, or choose Route for me and Hermes will select the safest next step."
+            "You do not need to run a shell command for this. OMH covers planning, ops, deliverables, coding handoffs, loops, and status. Pick a workflow here, or choose Route for me and Hermes will select the safest next step."
             if catalog_question
             else "Pick a workflow, or choose Route for me and Hermes will select the safest next step from the request."
         ),
@@ -1491,6 +1541,7 @@ def _skill_picker_response(decision: dict[str, object], *, thread_key: str = "",
             "confidence": decision.get("confidence", "low"),
             "selected_workflow": _ROUTER_SKILL,
             "catalog_question": catalog_question,
+            "context_primer": primer,
             "skill_picker": picker,
             "direct_invocation_aliases": ["./omh", "/omh", "./skills", "/skills"],
         },
@@ -1531,6 +1582,34 @@ def _skill_picker_state(message: str, *, source: str) -> dict[str, object]:
             "hermes_tui": "Render options as a compact command list; keep real skill names unchanged.",
         },
         "claim_boundary": "This picker records routing intent only; selected workflows still need their own plan, handoff, or observed evidence.",
+    }
+
+
+def _context_primer_state() -> dict[str, object]:
+    installed = {definition.name for definition in installable_skill_definitions()}
+    groups = []
+    for group in _CONTEXT_PRIMER_GROUPS:
+        workflows = tuple(workflow for workflow in group["workflows"] if workflow in installed)
+        if not workflows:
+            continue
+        groups.append(
+            {
+                "id": group["id"],
+                "label": group["label"],
+                "workflows": workflows,
+                "use_when": group["use_when"],
+            }
+        )
+    return {
+        "schema_version": CONTEXT_PRIMER_SCHEMA_VERSION,
+        "summary": (
+            "OMH is a Hermes workflow layer. It helps Hermes route natural-language work into skills, plans, "
+            "deliverables, coding handoffs, loops, and status updates without treating prepared guidance as observed work."
+        ),
+        "workflow_groups": groups,
+        "routing_rule": "Use Route for me when the user did not choose a workflow; use explicit workflow names when the user did.",
+        "evidence_rule": "Prepared plans, prompts, cards, or handoffs are not execution, file generation, delivery, review, CI, merge, or verification evidence.",
+        "inventory_rule": "Render the picker for common choices and use search_skills for the full installed catalog.",
     }
 
 

--- a/tests/test_wrapper_contract.py
+++ b/tests/test_wrapper_contract.py
@@ -532,9 +532,20 @@ class WrapperContractTests(unittest.TestCase):
                 self.assertEqual(payload["chat_response"]["kind"], "skill_picker")
                 self.assertTrue(payload["chat_response"]["state"]["catalog_question"])
                 self.assertIn("shell command", payload["chat_response"]["body"])
+                self.assertIn("planning, ops, deliverables, coding handoffs, loops, and status", payload["chat_response"]["body"])
                 picker = payload["chat_response"]["state"]["skill_picker"]
                 option_ids = {option["id"] for option in picker["options"]}
                 self.assertTrue({"oh-my-hermes", "loop", "ultraprocess"} <= option_ids)
+                primer = payload["chat_response"]["state"]["context_primer"]
+                self.assertEqual(primer["schema_version"], "omh_context_primer/v1")
+                self.assertIn("Hermes workflow layer", primer["summary"])
+                groups = {group["id"]: group for group in primer["workflow_groups"]}
+                self.assertTrue({"intent_to_plan", "company_product_ops", "deliverables_and_visuals", "coding_and_runtime"} <= groups.keys())
+                self.assertIn("img-summary", groups["deliverables_and_visuals"]["workflows"])
+                self.assertIn("loop", groups["intent_to_plan"]["workflows"])
+                self.assertIn("feedback-triage", groups["company_product_ops"]["workflows"])
+                self.assertIn("code-review", groups["coding_and_runtime"]["workflows"])
+                self.assertIn("Prepared plans", primer["evidence_rule"])
                 self.assertNotIn("run_local_operator_check", json.dumps(payload))
 
     def test_non_catalog_command_and_skill_questions_do_not_open_picker(self) -> None:
@@ -716,6 +727,47 @@ class WrapperContractTests(unittest.TestCase):
                 self.assertNotIn("generate_visual_image", actions)
                 self.assertIn("not generated image", payload["chat_response"]["claim_boundary"])
                 self.assertIn("visual QA", payload["chat_response"]["state"]["evidence_not_observed"])
+
+    def test_ack_workflow_chat_copy_stays_human_friendly(self) -> None:
+        cases = (
+            (
+                "매일 아침 릴리즈 위험을 확인하고 변화가 있으면 슬랙에 알려줘",
+                "automation-blueprint",
+                "prepare_scheduled_ops_blueprint",
+                "recurring Hermes ops workflow",
+            ),
+            (
+                "내 경쟁사 시장 뉴스를 매일 수집하고 분석해서 브리핑해줘",
+                "research-department",
+                "prepare_research_department_plan",
+                "research workflow",
+            ),
+            (
+                "이 회의록을 PPT와 PDF로 정리해줘",
+                "materials-package",
+                "prepare_material_package",
+                "material package",
+            ),
+            (
+                "이 보고서를 파일로 만들어서 첨부할 수 있게 준비해줘",
+                "deliverable-package",
+                "prepare_deliverable_package",
+                "deliverable path",
+            ),
+        )
+
+        for message, selected_workflow, next_action, body_marker in cases:
+            with self.subTest(message=message):
+                payload = build_chat_interaction_payload(message, source="discord")
+
+                self.assertEqual(payload["mode"], "route")
+                self.assertEqual(payload["route"]["selected_skill"], selected_workflow)
+                self.assertEqual(payload["next_action"], next_action)
+                self.assertEqual(payload["chat_response"]["kind"], "ack")
+                self.assertIn(body_marker, payload["chat_response"]["body"])
+                self.assertNotIn("/v1", payload["chat_response"]["body"])
+                self.assertNotIn("schema", payload["chat_response"]["body"].lower())
+                self.assertNotIn("artifact", payload["chat_response"]["body"].lower())
 
     def test_cancel_routes_to_control_action_without_plan_ui(self) -> None:
         payload = build_chat_interaction_payload("cancel", source="discord")


### PR DESCRIPTION
## Feature Report

### What Changed

- Added human-friendly chat acknowledgment copy for retained workflow routes such as `automation-blueprint`, `research-department`, `materials-package`, and `deliverable-package`.
- Added `omh_context_primer/v1` to workflow picker responses so Hermes can explain OMH as a broader workflow layer, not only as a list of commands or an image helper.
- Added a deliverable routing guard for file/report attachment requests.
- Kept gateway/thread/silent attachment-status messages routed to `gateway-intent-card` instead of over-routing them to deliverable packaging.

### Why This Exists

Users often ask Hermes natural-language questions such as "what OMH workflows are available?" or "prepare this report so it can be attached." The wrapper should answer with useful OMH context without requiring shell approval and without exposing internal schema names such as `research_department_plan/v1` in normal chat copy.

This also addresses a routing overlap: file attachment status and messenger gateway attachment/status policy share words, but they are different jobs.

### User / Operator Impact

- Hermes can answer workflow catalog questions with a compact explanation of OMH's main lanes: planning, company/product ops, deliverables/visuals, coding runtime tracking, loops, and status.
- Users see plain-language route acknowledgments instead of schema-heavy payload names.
- "Make this report attachable" routes to deliverable-package.
- "Discord gateway thread should send silent attachment status updates" stays in gateway policy.

### How It Works

- `src/wrapper/contract.py` now includes a compact `omh_context_primer/v1` payload in skill picker state.
- The picker body now gives Hermes a short human-readable summary of the OMH surface.
- Route acknowledgments use a small `selected_skill -> human body` map for workflows whose wrapper guidance is intentionally schema-rich for machine consumers.
- `src/routing/policy.py` adds a deliverable guard and a gateway-context exclusion so platform policy remains distinct from file deliverable preparation.

### Files And Contracts Touched

- `src/wrapper/contract.py`
  - Adds `omh_context_primer/v1`.
  - Adds human-friendly ack copy for retained workflow routes.
- `src/routing/policy.py`
  - Adds `deliverable_package_for_file_attachment` guard.
  - Adds gateway-context exclusion for deliverable routing.
- `tests/test_wrapper_contract.py`
  - Locks the new context primer, plain chat copy, and schema-free visible bodies.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_wrapper_contract.py tests/test_chat_router.py tests/test_cli.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m src.cli docs workflows --check`
- [ ] `python3 -m omh.cli harness validate` (covered by full unittest/docs workflow checks for this wrapper-only change)
- [ ] `python3 -m omh.cli release checklist --json` (not run; no release checklist/schema files changed)
- [ ] `python3 -m omh.cli release hermes-smoke` (not run; no live Hermes profile mutation in this PR)
- [ ] `omh --help` (not run; no root CLI help changed)
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` (not run; install flow unchanged)
- [x] Relevant dry-run or smoke command: `uv run python -m src.cli chat interact --source discord "skill들은 뭐 있어?"`; `uv run python -m src.cli chat interact --source discord "이 보고서를 파일로 만들어서 첨부할 수 있게 준비해줘"`; `uv run python -m src.cli recommend "Discord gateway thread should send silent attachment status updates" --limit 1`
- [x] Manual Hermes/TUI check, or explicit reason it was not run: live Hermes reload was not run; local wrapper payloads and route outputs were observed.

## Risk

- The context primer is intentionally compact and representative, not a full inventory dump. Wrappers should use `search_skills` or the full catalog for exhaustive search.
- Human ack copy must stay conservative; it describes preparation, not observed work.

## Compatibility / Rollout

- Existing machine-readable route payloads and skill picker options remain compatible.
- New `context_primer` state is additive.
- Deliverable/gateway routing behavior is stricter for overlap cases but keeps explicit file deliverable requests on the deliverable lane.

## Release / Claims

- [x] Release-channel impact considered (`preview` behavior only until release/update)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- Consider a fuller Hermes context primer generated from the complete catalog if operators want the picker to expose all installed skills instead of representative workflow lanes.
