### PR TITLE
Fix omh update command package detection

### DIFF
--- a/src/commands/setup.py
+++ b/src/commands/setup.py
@@ -228,12 +228,12 @@ def _managed_command_runtime() -> dict[str, object]:
     venv_dir = _managed_command_venv_dir()
     if venv_dir is None:
         return {"managed": False, "reason": "HOME or OMH_VENV_DIR is not available"}
-    executable = Path(sys.executable).expanduser().resolve()
-    if not _is_relative_to(executable, venv_dir):
+    executable = Path(sys.executable).expanduser()
+    if not _is_relative_to_without_resolving_symlinks(executable, venv_dir):
         return {
             "managed": False,
             "reason": "current omh command is not running from the install.sh-managed OMH venv",
-            "python": str(executable),
+            "python": str(executable.resolve()),
             "venv_dir": str(venv_dir),
         }
     return {"managed": True, "reason": "", "python": str(executable), "venv_dir": str(venv_dir)}
@@ -258,6 +258,19 @@ def _is_relative_to(path: Path, parent: Path) -> bool:
     except ValueError:
         return False
     return True
+
+
+def _is_relative_to_without_resolving_symlinks(path: Path, parent: Path) -> bool:
+    try:
+        _normalize_without_final_symlink(path).relative_to(_normalize_without_final_symlink(parent))
+    except ValueError:
+        return False
+    return True
+
+
+def _normalize_without_final_symlink(path: Path) -> Path:
+    expanded = path.expanduser()
+    return expanded.parent.resolve() / expanded.name
 
 
 def _install_operation(args: argparse.Namespace) -> str:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -716,6 +716,39 @@ class CliTests(unittest.TestCase):
         self.assertFalse(plan["should_update"])
         self.assertIn("local updates require", plan["reason"])
 
+    def test_update_self_update_recognizes_venv_python_symlink_path(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            venv_bin = root / ".local" / "share" / "omh" / "venv" / "bin"
+            venv_bin.mkdir(parents=True)
+            venv_python = venv_bin / "python"
+            venv_python.symlink_to(Path(sys.executable).resolve())
+            args = Namespace(
+                command_package_updated=False,
+                dry_run=False,
+                from_skills_dir=None,
+                source=None,
+                channel="preview",
+                version="",
+                package_url="",
+            )
+
+            env = {
+                "HOME": str(root),
+                "XDG_DATA_HOME": "",
+                "OMH_VENV_DIR": "",
+                setup_commands.SELF_UPDATE_SKIP_ENV: "",
+            }
+            with patch.dict(os.environ, env, clear=False):
+                with patch.object(setup_commands.sys, "executable", str(venv_python)):
+                    runtime = setup_commands._managed_command_runtime()
+                    plan = setup_commands._command_package_self_update_plan(args)
+
+        self.assertTrue(runtime["managed"])
+        self.assertEqual(runtime["python"], str(venv_python))
+        self.assertTrue(plan["should_update"])
+        self.assertEqual(plan["python"], str(venv_python))
+
     def test_goal_cli_records_checkpoints_and_completion_gate(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## Feature Report

### What Changed

- Fixed `omh update` self-update detection for install.sh-managed command packages.
- Added a regression test for the normal venv shape where `venv/bin/python` is a symlink to a system Python binary.

### Why This Exists

Users expect `omh update` to refresh OMH, not to tell them to rerun curl whenever the installed command package itself needs refreshing. OMH already had a guarded self-update path, but on macOS/Homebrew-style venvs it misdetected the command as unmanaged because it resolved `venv/bin/python` to the underlying system Python path.

That made a valid install.sh-managed command package look like this internally:

- actual command path: `~/.local/share/omh/venv/bin/python`
- resolved target: `/opt/homebrew/.../python`
- previous result: `current omh command is not running from the install.sh-managed OMH venv`

### User / Operator Impact

- `omh update` can now enter the existing command-package self-update path when OMH is running from the install.sh-managed venv.
- Users should need the curl installer less often after the fix is present in their installed command package.
- Explicit workflow-only updates still remain workflow-only: `--source`, `--from-skills-dir`, dry-run, unmanaged command paths, and local channel without package source do not claim command package updates.

### How It Works

- `src/commands/setup.py` now checks whether `sys.executable` is textually inside the managed venv after normalizing parent directories, without resolving the final `python` symlink.
- The returned updater Python path remains the venv `python`, so `pip --force-reinstall --upgrade` runs inside the managed command package environment.
- `tests/test_cli.py` creates a temp `~/.local/share/omh/venv/bin/python` symlink and verifies that the update planner marks it managed and chooses self-update.

### Files And Contracts Touched

- `src/commands/setup.py`
  - `_managed_command_runtime()`
  - new symlink-aware path helper for final executable path checks
- `tests/test_cli.py`
  - new regression test for venv Python symlink detection

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests.test_cli.CliTests.test_update_self_update_recognizes_venv_python_symlink_path tests.test_cli.CliTests.test_update_self_update_reenters_with_command_package_marker tests.test_cli.CliTests.test_install_and_update_default_to_human_summary_with_json_escape_hatch tests.test_cli.CliTests.test_installer_reported_update_records_version_and_ref_movement -v`
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_cli.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m src.cli docs workflows --check`
- [x] `git diff --check`
- [ ] `python3 -m omh.cli harness validate` (covered by full unittest/docs workflow checks; harness catalog not changed)
- [ ] `python3 -m omh.cli release checklist --json` (not run; release checklist content unchanged)
- [ ] `python3 -m omh.cli release hermes-smoke` (not run; no live Hermes profile mutation in this PR)
- [ ] `omh --help` (not run; help text unchanged)
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` (not run; release install smoke unchanged)
- [x] Relevant dry-run or smoke command: direct installed-venv/source check showed `_command_package_self_update_plan(...).should_update == True` after the fix.
- [x] Manual Hermes/TUI check, or explicit reason it was not run: live Hermes reload was not relevant; this is CLI command-package detection only.

## Risk

- Narrow path handling change. The main risk is accidentally treating an unmanaged executable as managed, but the check still requires the executable path itself to be under the expected install.sh-managed venv directory.
- The self-update still uses the existing guarded re-entry marker to prevent recursive update loops.

## Compatibility / Rollout

- Additive bug fix to existing self-update behavior.
- Existing workflows-only behavior remains for explicit skill source updates and unmanaged command paths.
- Users need this fixed command package installed once before future `omh update` can self-refresh correctly.

## Release / Claims

- [x] Release-channel impact considered (`preview` update behavior)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- After merge, reinstall once from main, then run `omh update` to verify the live installed command package enters the self-update path.
