### PR TITLE
Recover missed OMH visual workflow routing

### DIFF
--- a/src/routing/catalog_questions.py
+++ b/src/routing/catalog_questions.py
@@ -116,6 +116,31 @@ _CONTEXT_CAPABILITY_MARKERS = (
     "할 수",
     "가능",
 )
+_MISSED_WORKFLOW_MARKERS = (
+    "did not use",
+    "didn't use",
+    "didnt use",
+    "does not use",
+    "doesn't use",
+    "doesnt use",
+    "not using",
+    "without omh",
+    "missed omh",
+    "skipped omh",
+    "forgot omh",
+    "not aware",
+    "did not know",
+    "didn't know",
+    "does not know",
+    "몰랐",
+    "모르",
+    "안 썼",
+    "안 써",
+    "안쓰",
+    "안 쓰",
+    "놓쳤",
+    "빠졌",
+)
 _NAMED_WORKFLOW_MARKERS = (
     "deep-interview",
     "ralplan",
@@ -353,6 +378,8 @@ def is_skill_catalog_question(message: str) -> bool:
         return False
     if _is_file_or_text_search_question(search_texts):
         return False
+    if _is_missed_workflow_feedback(search_texts):
+        return False
     if _contains_catalog_token(search_texts, _EXPLICIT_OMH_CAPABILITY_PHRASES):
         return True
     if _is_named_workflow_catalog_question(search_texts):
@@ -417,6 +444,12 @@ def _is_named_workflow_catalog_question(search_texts: tuple[str, ...]) -> bool:
 def _is_context_capability_question(search_texts: tuple[str, ...]) -> bool:
     return _contains_catalog_token(search_texts, _OMH_CONTEXT_MARKERS) and _contains_catalog_token(
         search_texts, _CONTEXT_CAPABILITY_MARKERS
+    )
+
+
+def _is_missed_workflow_feedback(search_texts: tuple[str, ...]) -> bool:
+    return _contains_catalog_token(search_texts, _OMH_CONTEXT_MARKERS) and _contains_catalog_token(
+        search_texts, _MISSED_WORKFLOW_MARKERS
     )
 
 

--- a/src/routing/policy.py
+++ b/src/routing/policy.py
@@ -271,6 +271,43 @@ _VISUAL_SUMMARY_PHRASES = (
     "이미지로 설명",
     "이미지 하나 만들어줘",
 )
+_OMH_MISSED_WORKFLOW_PHRASES = (
+    "did not use omh",
+    "didn't use omh",
+    "didnt use omh",
+    "not using omh",
+    "without omh",
+    "missed omh",
+    "skipped omh",
+    "forgot omh",
+    "not aware of omh",
+    "did not know omh",
+    "didn't know omh",
+)
+_MISSED_WORKFLOW_ACTION_PHRASES = (
+    "did not use",
+    "didn't use",
+    "didnt use",
+    "does not use",
+    "doesn't use",
+    "doesnt use",
+    "not using",
+    "missed",
+    "skipped",
+    "forgot",
+    "not aware",
+    "did not know",
+    "didn't know",
+    "does not know",
+    "몰랐",
+    "모르",
+    "안 썼",
+    "안 써",
+    "안쓰",
+    "안 쓰",
+    "놓쳤",
+    "빠졌",
+)
 _EXECUTOR_RUNTIME_READINESS_PHRASES = (
     "executor-runtime-readiness",
     "runtime readiness",
@@ -1331,6 +1368,12 @@ def _visual_summary_guard_applies(normalized_query: str, query_tokens: set[str])
     explicit_visual_phrase = _contains_phrase(normalized_query, _VISUAL_SUMMARY_PHRASES)
     if explicit_visual_phrase:
         return True
+    if (
+        _missed_omh_workflow_context_applies(normalized_query)
+        and _VISUAL_SUMMARY_MODALITY_TOKENS & query_tokens
+        and not _VISUAL_SUMMARY_NON_VISUAL_WORK_TOKENS & query_tokens
+    ):
+        return True
     if _VISUAL_SUMMARY_CARD_TOKENS & query_tokens and _VISUAL_SUMMARY_OUTPUT_CONTEXT_TOKENS & query_tokens:
         return True
     if _VISUAL_SUMMARY_NON_VISUAL_WORK_TOKENS & query_tokens:
@@ -1343,6 +1386,14 @@ def _visual_summary_guard_applies(normalized_query: str, query_tokens: set[str])
     ):
         return True
     return False
+
+
+def _missed_omh_workflow_context_applies(normalized_query: str) -> bool:
+    if _contains_phrase(normalized_query, _OMH_MISSED_WORKFLOW_PHRASES):
+        return True
+    return ("omh" in normalized_query or "oh-my-hermes" in normalized_query) and _contains_phrase(
+        normalized_query, _MISSED_WORKFLOW_ACTION_PHRASES
+    )
 
 
 def _deliverable_package_guard_applies(normalized_query: str, query_tokens: set[str]) -> bool:

--- a/tests/test_catalog_questions.py
+++ b/tests/test_catalog_questions.py
@@ -74,6 +74,8 @@ class CatalogQuestionTests(unittest.TestCase):
             "이 파일에서 command injection 언급 목록 찾아줘",
             "이 파일에서 기능 목록 찾아줘",
             "이 경로에서 workflow 언급 찾아줘",
+            "프리렌이 OMH 안 쓰고 일반 도구로 이미지 만들었어",
+            "이미지 생성 요청을 했는데 OMH를 안 썼어",
         )
 
         for message in cases:

--- a/tests/test_chat_router.py
+++ b/tests/test_chat_router.py
@@ -93,6 +93,8 @@ class ChatRouterTests(unittest.TestCase):
             "이미지 요약 카드 만들어줘",
             "이 내용을 공유용 요약 카드로 만들어줘",
             "Create an image summary card from these notes.",
+            "프리렌이 OMH 안 쓰고 일반 도구로 이미지 만들었어",
+            "The Hermes agent did not use OMH for this summary image.",
         )
 
         for message in cases:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2128,6 +2128,7 @@ class CliTests(unittest.TestCase):
             "이 내용을 공유용 요약 카드로 만들어줘",
             "이 기능을 설명하는 인포그래픽 만들어줘",
             "워크플로우 이미지로 설명해줘",
+            "이미지 생성 요청을 했는데 OMH를 안 썼어",
         )
 
         for message in cases:

--- a/tests/test_wrapper_contract.py
+++ b/tests/test_wrapper_contract.py
@@ -750,6 +750,7 @@ class WrapperContractTests(unittest.TestCase):
             "Make a PR summary card",
             "크론 기능 설명 이미지 하나 만들어줘",
             "이 회의록을 세로 이미지 카드로 만들어줘",
+            "프리렌이 OMH 안 쓰고 일반 도구로 이미지 만들었어",
         )
 
         for message in cases:


### PR DESCRIPTION
## Summary

This PR tightens Hermes-first routing for a real usability failure: a user asks for an image/explainer card, Hermes handles it through generic tools, and the user later says OMH was not used or was not known.

After this change, missed-workflow feedback such as `프리렌이 OMH 안 쓰고 일반 도구로 이미지 만들었어` or `이미지 생성 요청을 했는데 OMH를 안 썼어` no longer opens the broad OMH catalog picker. It routes back to the concrete `img-summary` workflow so Hermes can show the visual prompt-card actions, image-tool setup fallback, and prepared-vs-observed image evidence boundary.

## Why

OMH is supposed to make Hermes feel more capable in chat without requiring users to know commands. If a user reports that Hermes skipped OMH for image-card work, showing a generic workflow list is too weak. The wrapper should recover to the workflow that would have handled the request and make the next action visible.

## What changed

- Added missed-workflow feedback markers for Korean and English phrases such as "didn't use OMH", "OMH를 안 썼어", "몰랐", and "놓쳤".
- Prevented those feedback messages from being misclassified as simple catalog/capability questions.
- Extended the `img-summary` guard so OMH-mentioned missed workflow feedback plus visual/image terms reroutes to `img-summary`.
- Added regression coverage across catalog detection, chat routing, CLI recommendation, and wrapper chat response actions.

## User-facing behavior

A Discord/Hermes-style message like:

```text
프리렌이 OMH 안 쓰고 일반 도구로 이미지 만들었어
```

now produces an `img-summary` response with actions such as:

- Show card
- Copy prompt
- Choose image tool
- Set up image tool
- Record generated image
- Record visual QA
- Record delivery

It still does not claim that OMH generated the image. The response remains explicit that prepared prompt cards are not generated image, QA, sharing, attachment, or delivery evidence.

## Verification

- `PYTHONPATH=tests uv run python -m unittest tests/test_catalog_questions.py tests/test_chat_router.py tests/test_wrapper_contract.py -v`
- `PYTHONPATH=tests uv run python -m unittest tests.test_cli.CliTests.test_recommend_visual_summary_routes_to_visual_prompt_cards -v`
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- `uv run python -m compileall -q src tests`
- `uv run python -m src.cli docs workflows --check`
- `git diff --check`
- Manual probe: `uv run python -m src.cli chat interact "프리렌이 OMH 안 쓰고 일반 도구로 이미지 만들었어" --source discord`
- Manual probe: `uv run python -m src.cli recommend "이미지 생성 요청을 했는데 OMH를 안 썼어" --limit 3 --json`

## Risk

Narrow routing change. The new guard only activates when the message both references OMH/missed use and has visual/image modality terms. Generic catalog questions and unrelated image upload/debug requests remain covered by existing tests.
