### PR TITLE
Recover missed OMH workflow routing

### DIFF
--- a/src/routing/policy.py
+++ b/src/routing/policy.py
@@ -308,6 +308,42 @@ _MISSED_WORKFLOW_ACTION_PHRASES = (
     "놓쳤",
     "빠졌",
 )
+_MISSED_WORKFLOW_RESEARCH_TOKENS = _normalized_token_set(
+    {
+        "research",
+        "researching",
+        "source",
+        "sources",
+        "web",
+        "search",
+        "리서치",
+        "조사",
+        "자료",
+        "출처",
+        "웹서치",
+        "검색",
+    }
+)
+_MISSED_WORKFLOW_OPERATING_RECORD_TOKENS = _normalized_token_set(
+    {
+        "meeting",
+        "minutes",
+        "notes",
+        "summary",
+        "summarize",
+        "decision",
+        "decisions",
+        "action",
+        "actions",
+        "회의",
+        "회의록",
+        "요약",
+        "정리",
+        "결정",
+        "액션",
+        "기록",
+    }
+)
 _EXECUTOR_RUNTIME_READINESS_PHRASES = (
     "executor-runtime-readiness",
     "runtime readiness",
@@ -898,6 +934,24 @@ WEB_RESEARCH_BEFORE_PROCESS_GUARD = RoutingGuardRule(
     why="Matched guard/trigger metadata; web, source, or freshness requests should start with source-backed Hermes research.",
     activation_status="active",
 )
+MISSED_WORKFLOW_WEB_RESEARCH_GUARD = RoutingGuardRule(
+    id="missed_workflow_research_recovery",
+    rule="Missed-OMH feedback about research/source work should recover to web-research instead of broad router help.",
+    matched_label="guard:missed_workflow_research_recovery",
+    preferred_skills=("web-research",),
+    score_boost=32,
+    why="Matched guard/trigger metadata; missed OMH research feedback should recover to source-backed Hermes research.",
+    activation_status="active",
+)
+MISSED_WORKFLOW_OPERATING_RHYTHM_GUARD = RoutingGuardRule(
+    id="missed_workflow_operating_record_recovery",
+    rule="Missed-OMH feedback about meeting notes or operating records should recover to operating-rhythm.",
+    matched_label="guard:missed_workflow_operating_record_recovery",
+    preferred_skills=("operating-rhythm",),
+    score_boost=34,
+    why="Matched guard/trigger metadata; missed OMH meeting/record feedback should prepare an operating record with evidence boundaries.",
+    activation_status="active",
+)
 DELIVERY_CYCLE_GUARD = RoutingGuardRule(
     id="delivery_cycle_before_research_only",
     rule="Requests that ask for PR or delivery-cycle completion should route to Ultraprocess before research-only lanes.",
@@ -1030,6 +1084,8 @@ ROUTING_GUARD_RULES = (
     RESEARCH_DEPARTMENT_GUARD,
     SCHEDULED_OPS_BLUEPRINT_GUARD,
     WEB_RESEARCH_BEFORE_PROCESS_GUARD,
+    MISSED_WORKFLOW_WEB_RESEARCH_GUARD,
+    MISSED_WORKFLOW_OPERATING_RHYTHM_GUARD,
     GITHUB_EVENT_OPS_GUARD,
     MATERIALS_PACKAGE_GUARD,
     MEMORY_CURATION_GUARD,
@@ -1096,8 +1152,12 @@ def active_routing_guard_rules(
         and not research_department_applies
     ):
         rules.append(SCHEDULED_OPS_BLUEPRINT_GUARD)
+    if _missed_workflow_operating_record_guard_applies(normalized_query, query_tokens):
+        rules.append(MISSED_WORKFLOW_OPERATING_RHYTHM_GUARD)
     if _web_research_guard_applies(normalized_query, query_tokens):
         rules.append(WEB_RESEARCH_BEFORE_PROCESS_GUARD)
+    if _missed_workflow_research_guard_applies(normalized_query, query_tokens):
+        rules.append(MISSED_WORKFLOW_WEB_RESEARCH_GUARD)
     if _github_event_ops_guard_applies(normalized_query, query_tokens):
         rules.append(GITHUB_EVENT_OPS_GUARD)
     if _materials_package_guard_applies(normalized_query, query_tokens):
@@ -1215,6 +1275,36 @@ def _web_research_guard_applies(normalized_query: str, query_tokens: set[str]) -
             "자료 찾아",
         ),
     )
+
+
+def _missed_workflow_research_guard_applies(normalized_query: str, query_tokens: set[str]) -> bool:
+    if _scheduled_ops_blueprint_guard_applies(normalized_query, query_tokens):
+        return False
+    if _research_department_guard_applies(normalized_query, query_tokens):
+        return False
+    if not _missed_omh_workflow_context_applies(normalized_query):
+        return False
+    return bool(_MISSED_WORKFLOW_RESEARCH_TOKENS & query_tokens) or _contains_phrase(
+        normalized_query, ("리서치", "조사", "자료", "출처", "research")
+    )
+
+
+def _missed_workflow_operating_record_guard_applies(normalized_query: str, query_tokens: set[str]) -> bool:
+    if _visual_summary_guard_applies(normalized_query, query_tokens):
+        return False
+    if not _missed_omh_workflow_context_applies(normalized_query):
+        return False
+    meeting_context = bool(_MISSED_WORKFLOW_OPERATING_RECORD_TOKENS & query_tokens) or _contains_phrase(
+        normalized_query,
+        ("회의록", "회의 요약", "meeting notes", "meeting minutes"),
+    )
+    if not meeting_context:
+        return False
+    file_package_context = bool(_MATERIALS_PACKAGE_FORMAT_TOKENS & query_tokens) or _contains_phrase(
+        normalized_query,
+        ("ppt", "pdf", "deck", "slides", "엑셀", "피디에프"),
+    )
+    return not file_package_context
 
 
 def _delivery_cycle_terms(normalized_query: str, query_tokens: set[str]) -> bool:

--- a/src/routing/recommend.py
+++ b/src/routing/recommend.py
@@ -43,6 +43,12 @@ _STOPWORDS = {
 }
 _FALLBACK_SKILLS = ("oh-my-hermes", "plan", "deep-interview")
 _FALLBACK_WHY = "No strong catalog metadata match; start with general routing/planning guidance."
+_GUARDRAIL_CANDIDATE_INJECTION_IDS = frozenset(
+    {
+        "missed_workflow_research_recovery",
+        "missed_workflow_operating_record_recovery",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -453,6 +459,7 @@ def recommend_skills(query: str, *, limit: int = 5, apply_guardrails: bool = Tru
         return [recommendation.to_dict() for recommendation in matches[:limit]]
     if apply_guardrails:
         guards = active_routing_guard_rules(normalized_query, query_tokens, explicit_skill=explicit_skill)
+        matches = _ensure_guardrail_candidates(matches, definitions, guards, query)
         matches = _apply_guardrail_reranking(
             matches,
             guards=guards,
@@ -574,6 +581,48 @@ def _fallback_recommendations(definitions: list[SkillDefinition], query: str) ->
             )
         )
     return recommendations
+
+
+def _ensure_guardrail_candidates(
+    recommendations: list[Recommendation],
+    definitions: list[SkillDefinition],
+    guards: tuple[RoutingGuardRule, ...],
+    query: str,
+) -> list[Recommendation]:
+    injectable_guards = tuple(
+        guard for guard in guards if guard.id in _GUARDRAIL_CANDIDATE_INJECTION_IDS
+    )
+    if not injectable_guards:
+        return recommendations
+    by_skill = {recommendation.skill: recommendation for recommendation in recommendations}
+    by_definition = {definition.name: definition for definition in definitions}
+    expanded = list(recommendations)
+    for guard in injectable_guards:
+        for skill_name in guard.preferred_skills:
+            if skill_name in by_skill:
+                continue
+            definition = by_definition.get(skill_name)
+            if definition is None:
+                continue
+            recommendation = Recommendation(
+                skill=definition.name,
+                description=definition.description,
+                category=definition.category,
+                phase=definition.phase,
+                hermes_role=definition.hermes_role,
+                handoff_policy=definition.handoff_policy,
+                score=0,
+                confidence="low",
+                matched=(),
+                why=_FALLBACK_WHY,
+                next_action=_next_action(definition),
+                evidence_boundary=_evidence_boundary(definition),
+                wrapper_guidance=_wrapper_guidance(definition),
+                suggested_prompt=_suggested_prompt(definition.name, query),
+            )
+            by_skill[skill_name] = recommendation
+            expanded.append(recommendation)
+    return expanded
 
 
 def _apply_guardrail_reranking(

--- a/tests/test_chat_router.py
+++ b/tests/test_chat_router.py
@@ -58,6 +58,16 @@ class ChatRouterTests(unittest.TestCase):
                 "operating-rhythm",
             ),
             (
+                "회의록 요약을 부탁했는데 OMH 안 쓰고 일반 답변했어",
+                "operating-rhythm",
+                "operating-rhythm",
+            ),
+            (
+                "리서치 요청했는데 OMH를 안 썼어",
+                "web-research",
+                "research",
+            ),
+            (
                 "create a PPT report package for a monthly leadership status deck",
                 "report-package",
                 "report-package",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1902,6 +1902,7 @@ class CliTests(unittest.TestCase):
             ["ウェブ検索して最新の出典をまとめて"],
             ["查一下最新资料和来源"],
             ["buscar", "en", "la", "web", "fuentes", "actuales"],
+            ["리서치 요청했는데 OMH를 안 썼어"],
         )
 
         for args in cases:
@@ -2052,6 +2053,13 @@ class CliTests(unittest.TestCase):
         cases = (
             (
                 "회의록 히스토리 관리하고 스크럼 스프린트 회고 운영 리듬 정리해줘",
+                "operating-rhythm",
+                "prepare_operating_record",
+                "meeting, scrum, sprint",
+                "prepared",
+            ),
+            (
+                "회의록 요약을 부탁했는데 OMH 안 쓰고 일반 답변했어",
                 "operating-rhythm",
                 "prepare_operating_record",
                 "meeting, scrum, sprint",
@@ -2700,6 +2708,8 @@ class CliTests(unittest.TestCase):
             ("research the repo, plan, implement, code-review, sync docs, and prepare a PR", "ultraprocess", "process", "start_ultraprocess"),
             ("Hermes가 기억하는 맥락을 점검하고 정리해줘", "memory-curation-review", "ack", "prepare_memory_curation_review"),
             ("GitHub issue 들어온 걸 PR 만들 수 있게 정리해줘", "github-event-ops", "ack", "prepare_github_event_ops_card"),
+            ("리서치 요청했는데 OMH를 안 썼어", "web-research", "ack", "run_hermes_research"),
+            ("회의록 요약을 부탁했는데 OMH 안 쓰고 일반 답변했어", "operating-rhythm", "ack", "prepare_operating_record"),
             ("Hermes가 기억하고 있는 프로젝트 맥락이 오래된 것 같아 정리해줘", "memory-curation-review", "ack", "prepare_memory_curation_review"),
             ("첨부한 엑셀을 월간 보고서 PDF랑 PPT로 만들 수 있게 정리해줘", "materials-package", "ack", "prepare_material_package"),
             ("Codex 작업이 어디까지 진행됐는지 알려줘", "agent-ops-review", "agent_ops_review", "show_agent_ops_review"),


### PR DESCRIPTION
## Summary

This PR strengthens OMH's chat-first recovery path when a Hermes user reports that OMH was not used for a workflow-shaped request.

OMH already ships a compact awareness primer, capability manifests, and generated `OMH Context Rail` guidance across every workflow skill. The gap was that some user feedback still fell back to broad router/help behavior even when the missed work clearly belonged to a concrete OMH lane.

## What Changed

- Added missed-workflow routing guards for research/source-backed work.
- Added missed-workflow routing guards for meeting notes, summaries, and operating records.
- Added bounded guardrail candidate injection so recovery guards can promote their preferred skill even when catalog scoring did not produce a candidate.
- Kept candidate injection limited to missed-workflow recovery guards so broader guards cannot over-promote unrelated workflows.
- Added CLI and chat-router coverage for Korean missed-OMH feedback examples.

## User Impact

After this change, Hermes can recover more naturally when the user says OMH was missed:

- `리서치 요청했는데 OMH를 안 썼어` -> `web-research`
- `회의록 요약을 부탁했는데 OMH 안 쓰고 일반 답변했어` -> `operating-rhythm`

This keeps Hermes from treating OMH as a narrow image helper or CLI catalog. It reinforces the product model: OMH is a Hermes workflow layer spanning planning, research, operations, materials, visuals, automation, coding handoff, and status.

## Boundary Notes

- Recovery routing is still prepared guidance, not observed execution.
- The new candidate injection only applies to explicit missed-workflow recovery guard IDs.
- Existing report/material/image/automation guard behavior remains protected by regression tests.

## Verification

- `PYTHONPATH=tests uv run python -m unittest discover -s tests`
- `uv run python -m compileall -q src tests`
- `uv run python -m src.cli docs workflows --check`
- `git diff --check`
- `uv run python -m src.cli release skill-content-smoke --json`

## Risks

- This expands Korean missed-workflow recovery examples. Future work can add more language packs if real usage shows additional phrasing gaps.
- Live Hermes wrapper rendering is not observed in this PR; this locks the local deterministic routing contracts.
