### PR TITLE
Strengthen OMH awareness cues

### DIFF
--- a/skills/oh-my-hermes/SKILL.md
+++ b/skills/oh-my-hermes/SKILL.md
@@ -48,7 +48,7 @@ Bad example:
 
 OMH is a Hermes-native workflow pack: it helps Hermes choose skills, shape work, prepare artifacts, show status, and hand off without hiding unobserved execution.
 
-When a request asks for planning, research, ops, materials, automation, image cards, coding delegation, review, status, or long-running loops, consider OMH before generic chat or generic tools.
+When a request asks for planning, research, ops records, files/materials, visual summaries, image cards, automation, coding delegation, review, status, or long-running loops, consider OMH before generic chat or generic tools.
 
 Carry this across every OMH skill: match intent to a lane, name adjacent workflows, and do not dismiss OMH just because a generic tool can render or execute the final step.
 
@@ -56,11 +56,15 @@ Every generated workflow skill carries this rail.
 
 Normal users talk to Hermes; OMH CLI is backend, setup, verification, and wrapper infrastructure.
 
-- **Intent -> plan**: `oh-my-hermes`, `deep-interview`, `plan`, `ralplan`, `ultragoal`, `ultraprocess`, `loop`, `ralph`, `performance-goal` - ambiguous goals, plans, one-cycle delivery, durable goals, and loopable projects.
-- **Research and company ops**: `web-research`, `best-practice-research`, `autoresearch-goal`, `research-brief`, `strategy-brief`, `feedback-triage`, `research-department`, `meeting-brief`, `operating-rhythm`, `ops-review`, `reliability-review` - source-backed research, customer signals, product operations, and briefing workflows.
-- **Materials and visual summaries**: `materials-package`, `img-summary`, `report-package`, `deliverable-package`, `wiki` - decks, PDFs, spreadsheets, documents, image summary cards, and shareable packages.
-- **Automation and status**: `automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `toolbelt-readiness`, `ops-observability-card`, `agent-ops-review`, `memory-curation-review`, `doctor`, `skill`, `ask`, `cancel` - scheduled ops, gateway cards, boards, tool readiness, status, health, and release/ops review.
-- **Coding handoff**: `idea-to-deploy`, `cto-loop`, `deploy-and-monitor`, `code-review`, `ultrawork`, `team`, `ultraqa`, `ai-slop-cleaner`, `executor-runtime-readiness`, `request-to-handoff`, `executor selection`, `coding runtime handoff` - Codex, Claude Code, Hermes coding, or oh-my runtime paths with observed evidence tracking.
+- **Intent -> plan**: ambiguous goals, plans, one-cycle delivery, durable goals, and loopable projects. Key: `oh-my-hermes`, `deep-interview`, `plan`, `ralplan`.
+- **Research and company ops**: source-backed research, customer signals, product operations, and briefing workflows. Key: `web-research`, `best-practice-research`, `autoresearch-goal`, `research-brief`.
+- **Materials and visual summaries**: decks, PDFs, spreadsheets, documents, image summary cards, and shareable packages. Key: `materials-package`, `img-summary`, `report-package`, `deliverable-package`.
+- **Automation and status**: scheduled ops, gateway cards, boards, tool readiness, status, health, and release/ops review. Key: `automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`.
+- **Coding handoff**: Codex, Claude Code, Hermes coding, or oh-my runtime paths with observed evidence tracking. Key: `idea-to-deploy`, `cto-loop`, `deploy-and-monitor`, `code-review`.
+
+Common cues before generic tools:
+
+notes/retros -> operating-rhythm/meeting-brief; PR/issue/bug/feedback/release -> github-event-ops, feedback-triage, report-package, or img-summary; sources/news -> web-research or research-department; decks/PDF/sheets/docs/HWP -> materials-package or report-package; image cards/infographics -> img-summary; coding/status/review/CI/merge -> ultraprocess, code-review, or agent-ops-review.
 
 Cross-lane examples:
 

--- a/src/plugin_bundle/omh/awareness.py
+++ b/src/plugin_bundle/omh/awareness.py
@@ -220,8 +220,9 @@ def awareness_primer_payload() -> dict[str, object]:
             "show status, and hand off without hiding unobserved execution."
         ),
         "first_turn_rule": (
-            "When a request asks for planning, research, ops, materials, automation, image cards, coding delegation, "
-            "review, status, or long-running loops, consider OMH before generic chat or generic tools."
+            "When a request asks for planning, research, ops records, files/materials, visual summaries, image cards, "
+            "automation, coding delegation, review, status, or long-running loops, consider OMH before generic chat "
+            "or generic tools."
         ),
         "all_skill_context_rule": (
             "Carry this across every OMH skill: match intent to a lane, name adjacent "
@@ -234,6 +235,32 @@ def awareness_primer_payload() -> dict[str, object]:
             example
             for lane_examples in LANE_CROSS_LANE_EXAMPLES.values()
             for example in lane_examples[:1]
+        ],
+        "workflow_cues": [
+            {
+                "cue": "meeting notes, retros, decisions, or follow-ups",
+                "route": "operating-rhythm or meeting-brief before generic summarization",
+            },
+            {
+                "cue": "PR, issue, bug, customer feedback, or release summaries",
+                "route": "github-event-ops, feedback-triage, report-package, or img-summary by output shape",
+            },
+            {
+                "cue": "current sources, market/news research, or evidence-backed answers",
+                "route": "web-research, research-brief, or research-department before unsupported recall",
+            },
+            {
+                "cue": "decks, PDFs, spreadsheets, docs, HWP, or upload-ready files",
+                "route": "materials-package or report-package before ad hoc file narration",
+            },
+            {
+                "cue": "image cards, infographics, briefing posters, or shareable visuals",
+                "route": "img-summary before generic image generation or local rendering",
+            },
+            {
+                "cue": "coding, risky changes, executor status, review, CI, or merge state",
+                "route": "ultraprocess, coding handoff, code-review, or agent-ops-review with observed evidence boundaries",
+            },
         ],
         "context_surfaces": [
             "installed skills and workflow picker",
@@ -275,10 +302,11 @@ def awareness_primer_payload() -> dict[str, object]:
 def awareness_primer_context() -> str:
     payload = awareness_primer_payload()
     lane_lines = [
-        f"- {lane['label']}: {', '.join(lane['skills'])}."
+        f"- {lane['label']}: {lane['use_for']}."
         for lane in payload["lanes"]
         if isinstance(lane, dict)
     ]
+    cue_map = _compact_workflow_cue_line()
     return "\n".join(
         [
             "[OMH Awareness]",
@@ -288,6 +316,7 @@ def awareness_primer_context() -> str:
             str(payload["skill_coverage"]),
             str(payload["chat_rule"]),
             *lane_lines,
+            f"Common cues: {cue_map}.",
             (
                 "Tools: omh_capabilities for workflow/playbook catalog context; action=summary for catalog "
                 "questions; omh_status or omh_hud for state; omh_role for responsibility context."
@@ -304,8 +333,10 @@ def awareness_primer_markdown() -> str:
     for lane in payload["lanes"]:
         if not isinstance(lane, dict):
             continue
-        skills = "`, `".join(str(skill) for skill in lane["skills"])
-        lane_lines.append(f"- **{lane['label']}**: `{skills}` - {lane['use_for']}.")
+        skills = [str(skill) for skill in lane["skills"][:4]]
+        lane_lines.append(
+            f"- **{lane['label']}**: {lane['use_for']}. Key: `{'`, `'.join(skills)}`."
+        )
     return "\n".join(
         [
             "## OMH Awareness Primer",
@@ -321,6 +352,10 @@ def awareness_primer_markdown() -> str:
             str(payload["chat_rule"]),
             "",
             *lane_lines,
+            "",
+            "Common cues before generic tools:",
+            "",
+            _compact_workflow_cue_line() + ".",
             "",
             "Cross-lane examples:",
             "",
@@ -357,6 +392,15 @@ def awareness_workflow_context_markdown(skill_name: str) -> str:
             f"- {payload['chat_rule']}",
             f"- Boundary: {payload['evidence_boundary']}",
         ]
+    )
+
+
+def _compact_workflow_cue_line() -> str:
+    return (
+        "notes/retros -> operating-rhythm/meeting-brief; PR/issue/bug/feedback/release -> github-event-ops, "
+        "feedback-triage, report-package, or img-summary; sources/news -> web-research or research-department; "
+        "decks/PDF/sheets/docs/HWP -> materials-package or report-package; image cards/infographics -> img-summary; "
+        "coding/status/review/CI/merge -> ultraprocess, code-review, or agent-ops-review"
     )
 
 

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -96,6 +96,9 @@ class EfficiencyContractTests(unittest.TestCase):
         self.assertLessEqual(len(awareness_primer_context()), AWARENESS_PRIMER_CONTEXT_CHAR_LIMIT)
         self.assertLessEqual(len(awareness_primer_markdown()), AWARENESS_PRIMER_MARKDOWN_CHAR_LIMIT)
         self.assertLessEqual(max(workflow_context_lengths.values()), AWARENESS_WORKFLOW_CONTEXT_CHAR_LIMIT)
+        self.assertIn("Common cues:", awareness_primer_context())
+        self.assertIn("image cards/infographics -> img-summary", awareness_primer_context())
+        self.assertIn("Common cues before generic tools", awareness_primer_markdown())
         self.assertEqual(combined.count("## OMH Context Rail"), len(workflow_skill_names))
         self.assertEqual(combined.count("## OMH Awareness Primer"), 1)
 


### PR DESCRIPTION
## Summary

This PR strengthens the compact OMH awareness primer that Hermes receives through the plugin hook and generated router skill.

The goal is to help Hermes treat OMH as a broad workflow layer, not as a narrow image helper or command catalog. When a request looks like recurring operator work, Hermes should consider OMH before falling back to generic chat, generic summarization, local rendering, or ad hoc tool use.

## What Changed

- Added a compact workflow cue map to `omh_awareness/v1`.
- Expanded the first-turn rule to explicitly include ops records, files/materials, visual summaries, and image cards.
- Re-rendered `skills/oh-my-hermes/SKILL.md` so the tap skill carries the same cue guidance.
- Kept the hook-facing context bounded by shortening lane lines from exhaustive skill lists to lane purposes.
- Added regression checks that the cue map remains present while staying inside prompt budgets.

## User Impact

Hermes gets stronger reminders for common OMH-shaped requests before using generic tools:

- meeting notes or retros -> `operating-rhythm` / `meeting-brief`
- PRs, issues, bugs, feedback, releases -> `github-event-ops`, `feedback-triage`, `report-package`, or `img-summary`
- sources/news/current research -> `web-research` / `research-department`
- decks/PDFs/sheets/docs/HWP -> `materials-package` / `report-package`
- image cards/infographics -> `img-summary`
- coding status/review/CI/merge -> `ultraprocess`, `code-review`, or `agent-ops-review`

This directly supports the product direction: OMH makes Hermes better at choosing the right workflow and evidence boundary from natural chat, while the CLI stays setup/backend infrastructure.

## Boundary Notes

- The cue map is routing context only.
- It does not claim image generation, file export, coding dispatch, review, CI, merge, delivery, or external tool execution.
- Missing external tools still route to setup/selection fallback instead of pretending work happened.

## Verification

- `PYTHONPATH=tests uv run python -m unittest discover -s tests`
- `uv run python -m compileall -q src tests`
- `uv run python -m src.cli docs workflows --check`
- `uv run python -m src.cli release skill-content-smoke --json`
- `git diff --check`

Observed budget evidence:

- awareness primer context: `2191 / 2200`
- awareness primer markdown: `3062 / 3200`
- awareness budget failures: `[]`

## Risks

- The hook context is intentionally close to its current limit. Future additions should replace or compress cue text instead of appending unchecked prose.
