### PR TITLE
Add OMH workflow context cards

### DIFF
--- a/skills/oh-my-hermes/SKILL.md
+++ b/skills/oh-my-hermes/SKILL.md
@@ -62,17 +62,13 @@ Normal users talk to Hermes; OMH CLI is backend, setup, verification, and wrappe
 - **Automation and status**: scheduled ops, gateway cards, boards, tool readiness, status, health, and release/ops review. Key: `automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`.
 - **Coding handoff**: Codex, Claude Code, Hermes coding, or oh-my runtime paths with observed evidence tracking. Key: `idea-to-deploy`, `cto-loop`, `deploy-and-monitor`, `code-review`.
 
+Workflow context cards:
+
+intent -> deep-interview/ralplan/loop/ultraprocess; signals -> web-research/research-department/feedback-triage/meeting-brief; materials -> materials-package/report-package/img-summary; automation/status -> automation-blueprint/agent-ops-review/doctor; code -> ultraprocess/code-review/team/ultrawork/ultraqa.
+
 Common cues before generic tools:
 
 notes/retros -> operating-rhythm/meeting-brief; PR/issue/bug/feedback/release -> github-event-ops, feedback-triage, report-package, or img-summary; sources/news -> web-research or research-department; decks/PDF/sheets/docs/HWP -> materials-package or report-package; image cards/infographics -> img-summary; coding/status/review/CI/merge -> ultraprocess, code-review, or agent-ops-review.
-
-Cross-lane examples:
-
-- ambitious goal -> loopability check -> loop or ultraprocess -> verification status
-- customer signal -> feedback-triage -> investigation plan -> coding handoff -> status
-- meeting notes -> meeting-brief -> report-package -> img-summary -> delivery evidence
-- daily digest request -> automation-blueprint -> confirmation card -> observed schedule evidence
-- accepted plan -> ultraprocess -> coding handoff -> review and CI evidence
 
 Tools:
 

--- a/src/capabilities/registry.py
+++ b/src/capabilities/registry.py
@@ -130,6 +130,7 @@ def capability_summary() -> dict[str, object]:
             for lane in lanes
             if isinstance(lane, dict)
         ],
+        "workflow_context_cards": awareness.get("workflow_context_cards", []) if isinstance(awareness, dict) else [],
         "direct_response_guidance": [
             "When a user asks what OMH can do, summarize these lanes and offer the workflow picker.",
             "When a request matches a lane, name the likely workflow and the first safe next action.",

--- a/src/plugin_bundle/omh/awareness.py
+++ b/src/plugin_bundle/omh/awareness.py
@@ -45,6 +45,43 @@ LANE_CROSS_LANE_EXAMPLES = {
         "risky change -> ralplan -> executor selection -> observed coding-agent status",
     ],
 }
+WORKFLOW_CONTEXT_CARDS = (
+    {
+        "id": "intent_to_plan",
+        "user_signal": "fuzzy goal, ambitious target, safe feature, or one-cycle delivery request",
+        "omh_pattern": "clarify or plan first, then move to ultragoal, ultraprocess, loop, or handoff only when concrete",
+        "representative_workflows": ("deep-interview", "ralplan", "ultragoal", "loop", "ultraprocess"),
+        "not_evidence_until_observed": ("plan acceptance", "executor dispatch", "verification"),
+    },
+    {
+        "id": "research_and_ops",
+        "user_signal": "customer signal, meeting notes, market question, strategy request, or operating record",
+        "omh_pattern": "collect evidence, separate source notes from synthesis, then create a brief, decision, or status artifact",
+        "representative_workflows": ("web-research", "research-department", "feedback-triage", "meeting-brief", "strategy-brief"),
+        "not_evidence_until_observed": ("source retrieval", "decision approval", "delivery"),
+    },
+    {
+        "id": "materials_and_visuals",
+        "user_signal": "deck, PDF, spreadsheet, document, HWP, report, image card, or shareable summary",
+        "omh_pattern": "shape the deliverable contract, prepare prompts or package metadata, then record generation and QA only when observed",
+        "representative_workflows": ("materials-package", "report-package", "deliverable-package", "img-summary"),
+        "not_evidence_until_observed": ("file export", "image generation", "visual QA", "attachment"),
+    },
+    {
+        "id": "automation_and_status",
+        "user_signal": "recurring digest, cron-like request, gateway command, health check, status confusion, or runtime question",
+        "omh_pattern": "prepare a schedule/status/repair card, name required tools, then keep observed runtime state separate",
+        "representative_workflows": ("automation-blueprint", "agent-ops-review", "toolbelt-readiness", "doctor"),
+        "not_evidence_until_observed": ("schedule creation", "connector I/O", "runtime load"),
+    },
+    {
+        "id": "coding_handoff",
+        "user_signal": "risky code change, issue-to-PR, review, CI, merge, coding-agent progress, or Hermes coding request",
+        "omh_pattern": "choose the coding owner, prepare executor-neutral handoff or Hermes coding team path, then track dispatch and result evidence",
+        "representative_workflows": ("ultraprocess", "code-review", "team", "ultrawork", "ultraqa"),
+        "not_evidence_until_observed": ("dispatch", "implementation", "review", "CI", "merge"),
+    },
+)
 _AWARENESS_MESSAGE_MARKERS = (
     "oh-my-hermes",
     "pull request",
@@ -115,6 +152,20 @@ def router_keyword_summary() -> str:
 def awareness_lane_examples(lane_id: str) -> list[str]:
     """Return compact examples relevant to one OMH awareness lane."""
     return list(LANE_CROSS_LANE_EXAMPLES.get(lane_id, []))
+
+
+def workflow_context_cards() -> list[dict[str, object]]:
+    """Return compact workflow cards that teach Hermes when OMH should help."""
+    return [
+        {
+            "id": card["id"],
+            "user_signal": card["user_signal"],
+            "omh_pattern": card["omh_pattern"],
+            "representative_workflows": list(card["representative_workflows"]),
+            "not_evidence_until_observed": list(card["not_evidence_until_observed"]),
+        }
+        for card in WORKFLOW_CONTEXT_CARDS
+    ]
 
 
 def awareness_context_matches_message(message: str) -> bool:
@@ -231,6 +282,7 @@ def awareness_primer_payload() -> dict[str, object]:
         "skill_coverage": "Every generated workflow skill carries this rail.",
         "chat_rule": "Normal users talk to Hermes; OMH CLI is backend, setup, verification, and wrapper infrastructure.",
         "lanes": lanes,
+        "workflow_context_cards": workflow_context_cards(),
         "cross_lane_examples": [
             example
             for lane_examples in LANE_CROSS_LANE_EXAMPLES.values()
@@ -301,11 +353,7 @@ def awareness_primer_payload() -> dict[str, object]:
 
 def awareness_primer_context() -> str:
     payload = awareness_primer_payload()
-    lane_lines = [
-        f"- {lane['label']}: {lane['use_for']}."
-        for lane in payload["lanes"]
-        if isinstance(lane, dict)
-    ]
+    pattern_line = _compact_workflow_context_cards_line()
     cue_map = _compact_workflow_cue_line()
     return "\n".join(
         [
@@ -315,7 +363,7 @@ def awareness_primer_context() -> str:
             str(payload["all_skill_context_rule"]),
             str(payload["skill_coverage"]),
             str(payload["chat_rule"]),
-            *lane_lines,
+            f"Pattern cards: {pattern_line}.",
             f"Common cues: {cue_map}.",
             (
                 "Tools: omh_capabilities for workflow/playbook catalog context; action=summary for catalog "
@@ -353,13 +401,13 @@ def awareness_primer_markdown() -> str:
             "",
             *lane_lines,
             "",
+            "Workflow context cards:",
+            "",
+            _compact_workflow_context_cards_line() + ".",
+            "",
             "Common cues before generic tools:",
             "",
             _compact_workflow_cue_line() + ".",
-            "",
-            "Cross-lane examples:",
-            "",
-            *[f"- {example}" for example in payload["cross_lane_examples"]],
             "",
             "Tools:",
             "",
@@ -401,6 +449,16 @@ def _compact_workflow_cue_line() -> str:
         "feedback-triage, report-package, or img-summary; sources/news -> web-research or research-department; "
         "decks/PDF/sheets/docs/HWP -> materials-package or report-package; image cards/infographics -> img-summary; "
         "coding/status/review/CI/merge -> ultraprocess, code-review, or agent-ops-review"
+    )
+
+
+def _compact_workflow_context_cards_line() -> str:
+    return (
+        "intent -> deep-interview/ralplan/loop/ultraprocess; "
+        "signals -> web-research/research-department/feedback-triage/meeting-brief; "
+        "materials -> materials-package/report-package/img-summary; "
+        "automation/status -> automation-blueprint/agent-ops-review/doctor; "
+        "code -> ultraprocess/code-review/team/ultrawork/ultraqa"
     )
 
 

--- a/src/plugin_bundle/omh/tools/capability_tool.py
+++ b/src/plugin_bundle/omh/tools/capability_tool.py
@@ -170,6 +170,7 @@ def _standalone_capability_summary() -> dict[str, object]:
             "agent_roles": len(_standalone_items(sections["agent_roles"])),
         },
         "lanes": lanes,
+        "workflow_context_cards": awareness.get("workflow_context_cards", []),
         "direct_response_guidance": [
             "When a user asks what OMH can do, summarize these lanes and offer the workflow picker.",
             "When a request matches a lane, name the likely workflow and the first safe next action.",

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -11,6 +11,7 @@ from ..executors import executor_label
 from ..goal_loop import build_loop_start_card
 from ..hermes_planning import build_hermes_plan_payload
 from ..operator_productivity import build_agent_operator_productivity_card
+from ..plugin_bundle.omh.awareness import workflow_context_cards
 from ..skills.catalog import installable_skill_definitions, primary_harness_for_skill, retained_delegation_skill_names
 from ..visual_summary import image_generation_setup_fallback
 from .hermes_runtime import (
@@ -1472,6 +1473,7 @@ def _context_primer_state() -> dict[str, object]:
             "deliverables, coding handoffs, loops, and status updates without treating prepared guidance as observed work."
         ),
         "workflow_groups": groups,
+        "workflow_context_cards": workflow_context_cards(),
         "routing_rule": "Use Route for me when the user did not choose a workflow; use explicit workflow names when the user did.",
         "evidence_rule": "Prepared plans, prompts, cards, or handoffs are not execution, file generation, delivery, review, CI, merge, or verification evidence.",
         "inventory_rule": "Render the picker for common choices and use search_skills for the full installed catalog.",
@@ -1511,6 +1513,7 @@ def _catalog_capability_summary() -> dict[str, object]:
         "schema_version": summary.get("schema_version", "omh_capability_summary/v1"),
         "purpose": summary.get("purpose", ""),
         "lanes": compact_lanes,
+        "workflow_context_cards": list(summary.get("workflow_context_cards", [])),
         "direct_response_guidance": _as_string_list(summary.get("direct_response_guidance", [])),
         "evidence_boundary": _as_string_list(summary.get("evidence_boundary", [])),
     }

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -80,6 +80,7 @@ class CapabilityManifestTests(unittest.TestCase):
     def test_capability_summary_is_human_facing_catalog_context(self) -> None:
         summary = capability_summary()
         lanes = {lane["id"]: lane for lane in summary["lanes"]}
+        context_cards = {card["id"]: card for card in summary["workflow_context_cards"]}
 
         self.assertEqual(summary["schema_version"], "omh_capability_summary/v1")
         self.assertIn("without requiring shell catalog approval", summary["purpose"])
@@ -95,6 +96,9 @@ class CapabilityManifestTests(unittest.TestCase):
         self.assertIn("request-to-handoff", {item["id"] for item in lanes["intent_to_plan"]["representative_playbooks"]})
         self.assertIn("materials-processing", {item["id"] for item in lanes["materials_and_visuals"]["representative_playbooks"]})
         self.assertTrue(lanes["coding_handoff"]["wrapper_actions"])
+        self.assertIn("feedback-triage", context_cards["research_and_ops"]["representative_workflows"])
+        self.assertIn("img-summary", context_cards["materials_and_visuals"]["representative_workflows"])
+        self.assertIn("implementation", context_cards["coding_handoff"]["not_evidence_until_observed"])
 
     def test_capability_inspect_finds_skill_and_role_without_runtime_claim(self) -> None:
         skill = inspect_capability("ultragoal", section="skills")["capability"]

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -97,13 +97,16 @@ class EfficiencyContractTests(unittest.TestCase):
         self.assertLessEqual(len(awareness_primer_markdown()), AWARENESS_PRIMER_MARKDOWN_CHAR_LIMIT)
         self.assertLessEqual(max(workflow_context_lengths.values()), AWARENESS_WORKFLOW_CONTEXT_CHAR_LIMIT)
         self.assertIn("Common cues:", awareness_primer_context())
+        self.assertIn("Pattern cards:", awareness_primer_context())
         self.assertIn("image cards/infographics -> img-summary", awareness_primer_context())
+        self.assertIn("Workflow context cards", awareness_primer_markdown())
         self.assertIn("Common cues before generic tools", awareness_primer_markdown())
         self.assertEqual(combined.count("## OMH Context Rail"), len(workflow_skill_names))
         self.assertEqual(combined.count("## OMH Awareness Primer"), 1)
 
     def test_omh_awareness_lanes_cover_installable_skills(self) -> None:
         payload = awareness_primer_payload()
+        cards = {str(card["id"]): card for card in payload["workflow_context_cards"]}
         lane_skills = {
             str(skill)
             for lane in payload["lanes"]
@@ -113,6 +116,9 @@ class EfficiencyContractTests(unittest.TestCase):
         installable_skills = {definition.name for definition in builtin_definitions()}
 
         self.assertFalse(installable_skills - lane_skills)
+        self.assertIn("img-summary", cards["materials_and_visuals"]["representative_workflows"])
+        self.assertIn("ultraprocess", cards["coding_handoff"]["representative_workflows"])
+        self.assertIn("not_evidence_until_observed", cards["intent_to_plan"])
 
     def test_mid_session_awareness_detector_is_bounded(self) -> None:
         self.assertTrue(awareness_context_matches_message("회의록을 세로 요약 이미지 카드로 만들어줘"))

--- a/tests/test_plugin_capabilities.py
+++ b/tests/test_plugin_capabilities.py
@@ -53,6 +53,9 @@ class PluginCapabilitiesTests(unittest.TestCase):
             self.assertIn("without requiring shell catalog approval", summary["purpose"])
             self.assertIn("img-summary", summary_lanes["materials_and_visuals"]["primary_skills"])
             self.assertIn("roles", summary["section_aliases"])
+            summary_cards = {card["id"]: card for card in summary["workflow_context_cards"]}
+            self.assertIn("feedback-triage", summary_cards["research_and_ops"]["representative_workflows"])
+            self.assertIn("img-summary", summary_cards["materials_and_visuals"]["representative_workflows"])
 
             inspected = json.loads(handler({"action": "inspect", "id": "handoff-guide"}))
             inspected_by_alias_section = json.loads(handler({"action": "inspect", "id": "handoff-guide", "section": "roles"}))
@@ -158,6 +161,10 @@ class PluginCapabilitiesTests(unittest.TestCase):
                         if lane["id"] == "intent_to_plan"
                         for playbook in lane["representative_playbooks"]
                     ],
+                    "summary_context_cards": {{
+                        card["id"]: card["representative_workflows"]
+                        for card in summary["workflow_context_cards"]
+                    }},
                     "summary_alias_roles": summary["section_aliases"]["roles"],
                     "keyword_schema": keywords["keywords"]["schema_version"],
                     "skill_ids": sorted(item["id"] for item in exported["skills"]),
@@ -223,6 +230,8 @@ class PluginCapabilitiesTests(unittest.TestCase):
             self.assertIn("intent_to_plan", payload["summary_lanes"])
             self.assertIn("img-summary", payload["summary_visual_skills"])
             self.assertIn("request-to-handoff", payload["summary_intent_playbooks"])
+            self.assertIn("feedback-triage", payload["summary_context_cards"]["research_and_ops"])
+            self.assertIn("ultraprocess", payload["summary_context_cards"]["coding_handoff"])
             self.assertEqual(payload["summary_alias_roles"], "agent_roles")
             self.assertEqual(payload["keyword_schema"], "keyword_detector_manifest/v1")
             for skill in (

--- a/tests/test_plugin_distribution.py
+++ b/tests/test_plugin_distribution.py
@@ -358,6 +358,8 @@ class PluginDistributionTests(unittest.TestCase):
             self.assertIn("external image tool", context)
             self.assertIn("[omh]", context)
             self.assertIn("prepared handoffs are not execution", context)
+            self.assertIn("Pattern cards:", context)
+            self.assertIn("signals -> web-research/research-department/feedback-triage/meeting-brief", context)
             self.assertNotIn("this raw prompt should not leak", context)
 
             empty_first_turn_context = ctx.hooks["pre_llm_call"](

--- a/tests/test_wrapper_contract.py
+++ b/tests/test_wrapper_contract.py
@@ -566,13 +566,18 @@ class WrapperContractTests(unittest.TestCase):
                 self.assertIn("loop", groups["intent_to_plan"]["workflows"])
                 self.assertIn("feedback-triage", groups["company_product_ops"]["workflows"])
                 self.assertIn("code-review", groups["coding_and_runtime"]["workflows"])
+                primer_cards = {card["id"]: card for card in primer["workflow_context_cards"]}
+                self.assertIn("img-summary", primer_cards["materials_and_visuals"]["representative_workflows"])
+                self.assertIn("ultraprocess", primer_cards["coding_handoff"]["representative_workflows"])
                 self.assertIn("Prepared plans", primer["evidence_rule"])
                 capability_summary = payload["chat_response"]["state"]["capability_summary"]
                 self.assertEqual(capability_summary["schema_version"], "omh_capability_summary/v1")
                 lanes = {lane["id"]: lane for lane in capability_summary["lanes"]}
+                summary_cards = {card["id"]: card for card in capability_summary["workflow_context_cards"]}
                 self.assertTrue({"intent_to_plan", "materials_and_visuals", "coding_handoff"} <= lanes.keys())
                 self.assertIn("img-summary", lanes["materials_and_visuals"]["primary_skills"])
                 self.assertIn("ultraprocess", lanes["intent_to_plan"]["primary_skills"])
+                self.assertIn("feedback-triage", summary_cards["research_and_ops"]["representative_workflows"])
                 self.assertIn("code-review", lanes["coding_handoff"]["primary_skills"])
                 intent_playbooks = {playbook["id"] for playbook in lanes["intent_to_plan"]["representative_playbooks"]}
                 self.assertIn("request-to-handoff", intent_playbooks)


### PR DESCRIPTION
## Feature Report

### What Changed

- Added compact `workflow_context_cards` to the OMH awareness primer so Hermes can carry stronger context for common OMH work patterns, not only image-summary work.
- Surfaced the same cards through capability summaries, plugin capability output, and wrapper skill-picker context.
- Regenerated the tap-compatible `skills/oh-my-hermes/SKILL.md` so installed Hermes skills receive the updated router guidance.
- Added focused tests that lock the cards into awareness, capabilities, plugin, and wrapper contracts.

### Why This Exists

- Hermes should understand OMH as a workflow operating layer across planning, research, materials, automation/status, and coding handoff work.
- Recent visual summary work exposed the broader issue: if Hermes does not carry enough OMH context, it may use generic tools and miss the right OMH workflow.
- The cards give Hermes a compact mental model: user signal, OMH pattern, representative workflows, and what is not evidence until observed.

### User / Operator Impact

- When a user asks what OMH can do, or sends a workflow-shaped request in chat, Hermes-facing wrappers can explain the relevant OMH lane more directly.
- Requests such as fuzzy product goals, customer signals, reports/images, scheduled ops, runtime status, or coding progress have a stronger shared context before fallback tools are chosen.
- The boundary remains conservative: these cards guide routing and explanation only; they do not claim generation, dispatch, review, CI, delivery, or merge evidence.

### How It Works

- `src/plugin_bundle/omh/awareness.py` defines five workflow context cards: intent-to-plan, research-and-ops, materials-and-visuals, automation-and-status, and coding-handoff.
- `awareness_primer_payload()`, `awareness_primer_context()`, and `awareness_primer_markdown()` expose a bounded version of those cards while staying under existing prompt-size budgets.
- `src/capabilities/registry.py` and the standalone plugin capability tool include the same card list in `omh_capability_summary/v1`.
- `src/wrapper/contract.py` includes the cards in picker/context-primer payloads so chat wrappers can render them without asking users to approve shell catalog commands.

### Files And Contracts Touched

- `src/plugin_bundle/omh/awareness.py`: new `workflow_context_cards()` contract and bounded primer copy.
- `src/capabilities/registry.py`: capability summary includes workflow context cards.
- `src/plugin_bundle/omh/tools/capability_tool.py`: standalone plugin summary includes workflow context cards.
- `src/wrapper/contract.py`: context primer and catalog capability summary include workflow context cards.
- `skills/oh-my-hermes/SKILL.md`: regenerated router skill content.
- Tests updated across efficiency, capability, plugin distribution/capability, and wrapper contract suites.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — 548 tests passed.
- [x] `uv run python -m compileall -q src tests` — passed.
- [x] `uv run python -m src.cli docs workflows --check` — passed; docs and tap skills are fresh.
- [ ] `python3 -m omh.cli harness validate` — not run; change is awareness/capability/picker context, not harness schema.
- [ ] `python3 -m omh.cli release checklist --json` — not run; not a release PR.
- [ ] `python3 -m omh.cli release hermes-smoke` — not run; live Hermes smoke is outside deterministic local contract.
- [ ] `omh --help` — not run; no CLI help changes.
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` — not run; no setup/install behavior changed.
- [x] Relevant dry-run or smoke command: targeted unittest set for awareness, capability summary, wrapper picker, plugin register/capabilities, release smoke.
- [x] Manual Hermes/TUI check, or explicit reason it was not run: not run; deterministic wrapper/plugin contracts were validated locally.

## Risk

- Prompt/context budgets are the main risk. The efficiency tests assert the awareness primer remains bounded.
- The cards could be mistaken for runtime evidence if rendered poorly. Each card carries `not_evidence_until_observed`, and tests assert those boundaries are present.

## Compatibility / Rollout

- Backward compatible JSON addition: consumers that ignore unknown fields continue to work.
- Existing generated skills remain in the same locations and schema; only router guidance copy changes.
- No network, platform SDK, LLM, executor, or Hermes core behavior is added.

## Release / Claims

- [x] Release-channel impact considered (`preview` workflow/context improvement; no stable package release in this PR).
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap.

## Follow-Up

- Use the cards in richer messenger UI rendering if wrappers want a visual “why OMH picked this workflow” card.
