### PR TITLE
Attach workflow pattern cards to chat explanations

### DIFF
--- a/docs/CHAT_WRAPPER_EXAMPLES.md
+++ b/docs/CHAT_WRAPPER_EXAMPLES.md
@@ -334,6 +334,7 @@ What gets better for the team:
 | Messenger body blocks | `chat_response.messenger_rendering.body_blocks`; use `fallback_body_blocks` when downgrading |
 | Visible OMH workflow marker | `chat_response.usage_trace.visible_prefix` |
 | Selected workflow/harness | `chat_response.usage_trace.selected_workflow`, `chat_response.usage_trace.selected_harness` |
+| Workflow pattern card | `chat_response.state.workflow_explanation.workflow_context_card`, `chat_response.usage_trace.workflow_context_id` |
 | Why/next/not-evidence card | `chat_response.state.workflow_explanation.why_this_workflow`, `chat_response.state.workflow_explanation.next_action_label`, `chat_response.state.workflow_explanation.not_evidence_yet` |
 | Rendering profile and hints | `chat_response.messenger_rendering.render_profile`, `chat_response.messenger_rendering.transforms_applied`, `chat_response.messenger_rendering.fallback_transforms_applied`, `chat_response.messenger_rendering.preferred_blocks`, `chat_response.messenger_rendering.avoid_blocks`, `chat_response.messenger_rendering.table_policy`, `chat_response.messenger_rendering.prefix_policy` |
 | Button ids | `chat_response.actions[].id` |

--- a/src/plugin_bundle/omh/awareness.py
+++ b/src/plugin_bundle/omh/awareness.py
@@ -82,6 +82,53 @@ WORKFLOW_CONTEXT_CARDS = (
         "not_evidence_until_observed": ("dispatch", "implementation", "review", "CI", "merge"),
     },
 )
+_WORKFLOW_CONTEXT_CARD_BY_WORKFLOW = {
+    "deep-interview": "intent_to_plan",
+    "plan": "intent_to_plan",
+    "ralplan": "intent_to_plan",
+    "ralph": "intent_to_plan",
+    "ultragoal": "intent_to_plan",
+    "loop": "intent_to_plan",
+    "ultraprocess": "intent_to_plan",
+    "performance-goal": "intent_to_plan",
+    "web-research": "research_and_ops",
+    "research-department": "research_and_ops",
+    "research-brief": "research_and_ops",
+    "best-practice-research": "research_and_ops",
+    "autoresearch-goal": "research_and_ops",
+    "feedback-triage": "research_and_ops",
+    "meeting-brief": "research_and_ops",
+    "strategy-brief": "research_and_ops",
+    "operating-rhythm": "research_and_ops",
+    "materials-package": "materials_and_visuals",
+    "report-package": "materials_and_visuals",
+    "deliverable-package": "materials_and_visuals",
+    "img-summary": "materials_and_visuals",
+    "automation-blueprint": "automation_and_status",
+    "agent-board": "automation_and_status",
+    "agent-ops-review": "automation_and_status",
+    "doctor": "automation_and_status",
+    "gateway-intent-card": "automation_and_status",
+    "memory-curation-review": "automation_and_status",
+    "ops-observability-card": "automation_and_status",
+    "ops-review": "automation_and_status",
+    "reliability-review": "automation_and_status",
+    "skill": "automation_and_status",
+    "toolbelt-readiness": "automation_and_status",
+    "voice-operator": "automation_and_status",
+    "wiki": "automation_and_status",
+    "ai-slop-cleaner": "coding_handoff",
+    "ask": "coding_handoff",
+    "code-review": "coding_handoff",
+    "cto-loop": "coding_handoff",
+    "deploy-and-monitor": "coding_handoff",
+    "executor-runtime-readiness": "coding_handoff",
+    "github-event-ops": "coding_handoff",
+    "idea-to-deploy": "coding_handoff",
+    "team": "coding_handoff",
+    "ultraqa": "coding_handoff",
+    "ultrawork": "coding_handoff",
+}
 _AWARENESS_MESSAGE_MARKERS = (
     "oh-my-hermes",
     "pull request",
@@ -166,6 +213,24 @@ def workflow_context_cards() -> list[dict[str, object]]:
         }
         for card in WORKFLOW_CONTEXT_CARDS
     ]
+
+
+def workflow_context_card_for_workflow(workflow: str) -> dict[str, object]:
+    """Return the OMH pattern card that should frame one selected workflow."""
+    workflow_key = workflow.strip().casefold()
+    card_id = _WORKFLOW_CONTEXT_CARD_BY_WORKFLOW.get(workflow_key, "")
+    if not card_id:
+        for card in WORKFLOW_CONTEXT_CARDS:
+            representative_workflows = {str(item).casefold() for item in card["representative_workflows"]}
+            if workflow_key in representative_workflows:
+                card_id = str(card["id"])
+                break
+    if not card_id:
+        return {}
+    for card in workflow_context_cards():
+        if card["id"] == card_id:
+            return card
+    return {}
 
 
 def awareness_context_matches_message(message: str) -> bool:

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -11,7 +11,7 @@ from ..executors import executor_label
 from ..goal_loop import build_loop_start_card
 from ..hermes_planning import build_hermes_plan_payload
 from ..operator_productivity import build_agent_operator_productivity_card
-from ..plugin_bundle.omh.awareness import workflow_context_cards
+from ..plugin_bundle.omh.awareness import workflow_context_card_for_workflow, workflow_context_cards
 from ..skills.catalog import installable_skill_definitions, primary_harness_for_skill, retained_delegation_skill_names
 from ..visual_summary import image_generation_setup_fallback
 from .hermes_runtime import (
@@ -1637,7 +1637,7 @@ def workflow_explanation_payload(
     workflow = _usage_workflow(state)
     label = workflow or _usage_label(state, kind=kind, phase=phase, next_action=next_action)
     harness = primary_harness_for_skill(workflow) if workflow else ""
-    return {
+    payload: dict[str, object] = {
         "schema_version": WORKFLOW_EXPLANATION_SCHEMA_VERSION,
         "selected_workflow": workflow,
         "label": label,
@@ -1649,6 +1649,11 @@ def workflow_explanation_payload(
         "claim_boundary": claim_boundary,
         "rendering_hint": "Show this as a compact why/next/not-evidence card in chat surfaces.",
     }
+    context_card = workflow_context_card_for_workflow(workflow)
+    if context_card:
+        payload["workflow_context_card"] = context_card
+        payload["workflow_context_id"] = context_card["id"]
+    return payload
 
 
 def _workflow_explanation_reason(state: dict[str, object], *, workflow: str, label: str) -> str:
@@ -1714,6 +1719,9 @@ def usage_trace_payload(*, kind: str, phase: str, next_action: str, state: dict[
     runtime_family = str(state.get("runtime_family") or "")
     if runtime_family:
         trace["runtime_family"] = runtime_family
+    context_card = workflow_context_card_for_workflow(workflow)
+    if context_card:
+        trace["workflow_context_id"] = context_card["id"]
     return trace
 
 

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -27,6 +27,7 @@ from omh.plugin_bundle.omh.awareness import (
     awareness_primer_context,
     awareness_primer_markdown,
     awareness_workflow_context_markdown,
+    workflow_context_card_for_workflow,
 )
 from omh.skills.catalog import (
     builtin_harnesses,
@@ -119,6 +120,16 @@ class EfficiencyContractTests(unittest.TestCase):
         self.assertIn("img-summary", cards["materials_and_visuals"]["representative_workflows"])
         self.assertIn("ultraprocess", cards["coding_handoff"]["representative_workflows"])
         self.assertIn("not_evidence_until_observed", cards["intent_to_plan"])
+
+    def test_workflow_context_cards_cover_installable_workflow_families(self) -> None:
+        workflow_skills = {definition.name for definition in builtin_definitions()} - {"oh-my-hermes", "cancel"}
+        unmapped = sorted(name for name in workflow_skills if not workflow_context_card_for_workflow(name))
+
+        self.assertEqual(unmapped, [])
+        self.assertEqual(workflow_context_card_for_workflow("img-summary")["id"], "materials_and_visuals")
+        self.assertEqual(workflow_context_card_for_workflow("feedback-triage")["id"], "research_and_ops")
+        self.assertEqual(workflow_context_card_for_workflow("automation-blueprint")["id"], "automation_and_status")
+        self.assertEqual(workflow_context_card_for_workflow("code-review")["id"], "coding_handoff")
 
     def test_mid_session_awareness_detector_is_bounded(self) -> None:
         self.assertTrue(awareness_context_matches_message("회의록을 세로 요약 이미지 카드로 만들어줘"))

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -1340,6 +1340,7 @@ class RouterContentTests(unittest.TestCase):
         self.assertIn("omh_native_command_surface/v1", text)
         self.assertIn("omh_native_command_render/v1", text)
         self.assertIn("chat_response.state.workflow_explanation.why_this_workflow", text)
+        self.assertIn("chat_response.state.workflow_explanation.workflow_context_card", text)
         self.assertIn("chat_response.state.workflow_explanation.not_evidence_yet", text)
         self.assertIn("Telegram can register the `omh` bot command menu", text)
         self.assertIn("Startup Product Triage", text)

--- a/tests/test_wrapper_contract.py
+++ b/tests/test_wrapper_contract.py
@@ -251,6 +251,10 @@ class WrapperContractTests(unittest.TestCase):
         self.assertEqual(explanation["schema_version"], "omh_workflow_explanation/v1")
         self.assertEqual(explanation["selected_workflow"], "web-research")
         self.assertEqual(explanation["selected_harness"], "research")
+        self.assertEqual(explanation["workflow_context_id"], "research_and_ops")
+        self.assertEqual(explanation["workflow_context_card"]["id"], "research_and_ops")
+        self.assertIn("web-research", explanation["workflow_context_card"]["representative_workflows"])
+        self.assertEqual(trace["workflow_context_id"], "research_and_ops")
         self.assertIn("why_this_workflow", explanation)
         self.assertEqual(explanation["next_action"], "run_hermes_research")
         self.assertTrue(explanation["not_evidence_yet"])
@@ -754,6 +758,8 @@ class WrapperContractTests(unittest.TestCase):
                 self.assertIn("PR creation", payload["chat_response"]["state"]["evidence_not_observed"])
                 explanation = payload["chat_response"]["state"]["workflow_explanation"]
                 self.assertEqual(explanation["selected_workflow"], "ultraprocess")
+                self.assertEqual(explanation["workflow_context_id"], "intent_to_plan")
+                self.assertIn("ultraprocess", explanation["workflow_context_card"]["representative_workflows"])
                 self.assertIn("PR creation", explanation["not_evidence_yet"])
                 actions = {action["id"]: action for action in payload["chat_response"]["actions"]}
                 self.assertTrue(actions["start_ultraprocess"]["enabled"])
@@ -800,6 +806,8 @@ class WrapperContractTests(unittest.TestCase):
                 self.assertIn("visual QA", payload["chat_response"]["state"]["evidence_not_observed"])
                 explanation = payload["chat_response"]["state"]["workflow_explanation"]
                 self.assertEqual(explanation["selected_workflow"], "img-summary")
+                self.assertEqual(explanation["workflow_context_id"], "materials_and_visuals")
+                self.assertEqual(explanation["workflow_context_card"]["id"], "materials_and_visuals")
                 self.assertIn("workflow's triggers", explanation["why_this_workflow"])
                 self.assertIn("image_generation_setup/v1", explanation["why_this_workflow"])
                 self.assertIn("visual QA", explanation["not_evidence_yet"])
@@ -887,6 +895,10 @@ class WrapperContractTests(unittest.TestCase):
                     payload["chat_response"]["state"]["workflow_explanation"]["selected_workflow"],
                     selected_workflow,
                 )
+                self.assertIn(
+                    "workflow_context_card",
+                    payload["chat_response"]["state"]["workflow_explanation"],
+                )
 
     def test_ack_workflow_chat_copy_stays_human_friendly(self) -> None:
         cases = (
@@ -925,6 +937,7 @@ class WrapperContractTests(unittest.TestCase):
                 self.assertEqual(payload["next_action"], next_action)
                 self.assertEqual(payload["chat_response"]["kind"], "ack")
                 self.assertIn(body_marker, payload["chat_response"]["body"])
+                self.assertIn("workflow_context_id", payload["chat_response"]["usage_trace"])
                 self.assertNotIn("/v1", payload["chat_response"]["body"])
                 self.assertNotIn("schema", payload["chat_response"]["body"].lower())
                 self.assertNotIn("artifact", payload["chat_response"]["body"].lower())


### PR DESCRIPTION
## Feature Report

### What Changed

- Added a central workflow-to-pattern-card lookup for installed OMH workflows.
- Attached the matching workflow context card to `chat_response.state.workflow_explanation`.
- Added `workflow_context_id` to `chat_response.usage_trace` for compact wrapper rendering.
- Documented the new JSON-to-UI mapping for wrapper surfaces.
- Added tests that ensure installable workflow families are mapped and representative chat routes expose the pattern card.

### Why This Exists

- OMH should help Hermes understand recurring work patterns, not just individual skill names.
- A user should be able to ask a natural complex request and have Hermes explain: this is research ops, materials/visuals, automation/status, intent-to-plan, or coding handoff work.
- This closes the gap between the catalog-level workflow context cards and the actual chat response a Discord/Slack/Hermes wrapper renders.

### User / Operator Impact

- Hermes can say why a selected workflow fits in terms of a recurring OMH pattern instead of only naming a skill.
- Wrappers can render a compact pattern card beside the existing why/next/not-evidence card.
- Complex requests such as research comparison, image-card generation, scheduled ops, and release review now carry the same pattern context through the route result.
- No user has to run additional CLI commands to get this context.

### How It Works

- `workflow_context_card_for_workflow()` maps workflow names to the shared OMH pattern cards.
- `workflow_explanation_payload()` includes `workflow_context_card` and `workflow_context_id` when the selected workflow has a known pattern.
- `usage_trace_payload()` includes the same `workflow_context_id` so lightweight chat renderers can show a small marker without unpacking the full explanation object.
- The mapping covers installable workflow families except router/control-only surfaces.

### Files And Contracts Touched

- `src/plugin_bundle/omh/awareness.py`: central workflow-pattern mapping and lookup helper.
- `src/wrapper/contract.py`: workflow explanation and usage trace expose pattern context.
- `docs/CHAT_WRAPPER_EXAMPLES.md`: JSON-to-UI mapping adds workflow pattern card fields.
- `tests/test_efficiency.py`: all installable workflow families stay mapped to a context card.
- `tests/test_wrapper_contract.py`: route, process, visual, complex, and ack flows expose the card.
- `tests/test_router_content.py`: docs mention the new wrapper field.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — 549 tests passed.
- [x] `uv run python -m compileall -q src tests` — passed.
- [x] `uv run python -m src.cli docs workflows --check` — passed; generated docs/tap skills are fresh.
- [ ] `python3 -m omh.cli harness validate` — not run; no harness schema changed.
- [ ] `python3 -m omh.cli release checklist --json` — not run; not a release PR.
- [ ] `python3 -m omh.cli release hermes-smoke` — not run; live Hermes smoke is outside deterministic local contract.
- [ ] `omh --help` — not run; no CLI help changes.
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` — not run; no setup/install path changed.
- [x] Relevant dry-run or smoke command: manually built representative chat payloads and confirmed `web-research -> research_and_ops`, `img-summary -> materials_and_visuals`, `automation-blueprint -> automation_and_status`, `code-review -> coding_handoff`.
- [x] Manual Hermes/TUI check, or explicit reason it was not run: not run; deterministic wrapper contract tests cover the emitted payloads.

## Risk

- A workflow might be mapped to a pattern that is too broad. The mapping is intentionally compact and test-covered, and it can be adjusted centrally.
- The new fields are additive JSON fields, so existing consumers that ignore them remain compatible.

## Compatibility / Rollout

- Backward compatible additive fields on existing `omh_workflow_explanation/v1` and `omh_usage_trace/v1` payloads.
- No LLM/API/network/platform SDK calls.
- No Hermes core behavior changes.

## Release / Claims

- [x] Release-channel impact considered (`preview` chat-wrapper context improvement; no release tag in this PR).
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap.

## Follow-Up

- Messenger wrappers can render `workflow_context_card.user_signal` and `omh_pattern` as a small “why OMH picked this lane” card.
