### PR TITLE
Add workflow learning contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ tool, an existing Hermes connector, a generic image tool, or prompt-only mode.
 | Coding agent paths | Hermes can prepare work for Codex, Claude Code, Hermes itself, or another runtime without pretending the work already ran. |
 | Agent ops review | Hermes can explain quality gates, blockers, next actions, and throughput levers for AI-agent work without turning a prepared handoff into evidence. |
 | Evidence-aware status | Plans, handoffs, dispatch, results, verification, review, CI, and merge readiness stay visibly separate. |
+| Workflow learning | Hermes can turn a workflow attempt into a metadata-only trace, eval, improvement candidate, and regression case for human-approved improvement. |
 | Organization patterns | Solo, research, product ops, coding runtime, and CTO-style collaboration patterns help Hermes present the right role flow for the request. |
 
 <br>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -247,6 +247,16 @@ ladder step such as runtime start, worktree creation, worker dispatch, worker
 result, verification, review, CI, merge readiness, or merge. Missing records
 remain missing evidence; OMH does not infer them from prepared handoff text.
 
+`workflow_learning.py` owns the metadata-only learning plane above routing,
+wrapper sessions, and runtime artifacts. It projects workflow attempts into
+`workflow_learning_trace/v1`, evaluates them with deterministic
+`workflow_eval_result/v1` rubrics, creates review-only
+`improvement_candidate/v1` records, and stores `regression_case/v1` fixtures for
+future replay. It is deliberately projection-first: trace recording does not
+mutate skills, patch Hermes, train a model, or upgrade prepared work into
+observed evidence. This gives Hermes good process data to review while keeping
+status, verification, CI, merge, and skill changes separately observed.
+
 `wrapper/sessions.py` owns metadata-only chat session persistence for wrappers.
 It records chat continuity, plan decisions, and a link to a prepared run id, but
 it does not own execution, review, CI, merge readiness, or merge evidence.

--- a/docs/HARNESS_QUALITY.md
+++ b/docs/HARNESS_QUALITY.md
@@ -31,6 +31,9 @@ state:
 - "A coding handoff is prepared, but execution is not observed yet" for coding
   lanes.
 - "Review or CI is still missing" before merge-ready status is shown.
+- "This workflow attempt is now a learning trace" when Hermes records the route,
+  next action, missing evidence, eval result, and future regression case without
+  storing the raw prompt or silently patching a skill.
 
 The wrapper can choose buttons from `wrapper_actions`, show progress from
 `evidence_ladder`, and avoid false claims with `overclaim_guards`.
@@ -88,6 +91,11 @@ contract shaped like this:
 - `omh runtime delegation-status --run <run-id>` includes
   `harness_progress/v1`, which marks ladder steps complete only when the
   corresponding runtime or wrapper evidence is observed.
+- `omh learning record`, `omh learning eval`, and `omh learning regression
+  replay` expose the `workflow-learning` harness for process-supervision data:
+  why a workflow was chosen, what was prepared, what was observed, which
+  deterministic checks passed, and what improvement candidate still needs human
+  approval.
 
 ## Wrapper Rules
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -124,6 +124,10 @@ selected.
   operator wants real Hermes profile evidence.
 - Runtime and wrapper docs should preserve the separation between wrapper
   session state and run-level evidence.
+- Workflow learning docs should state that `workflow_learning_trace/v1` records
+  are metadata-only process evidence. They can feed evals, review-only
+  improvement candidates, and regression cases, but they are not automatic
+  training, hidden skill patches, or proof that future behavior is fixed.
 - Parity docs should map common oh-my runtime capability axes to OMH's
   Hermes-native evidence model instead of promising hidden workers, worktrees,
   MCP tools, or plugin runtime load without observation.

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -2359,6 +2359,54 @@ When wrapper metadata reports `omh_target_topology/v1`, skills bind workflow sta
   - An agent ops review card is not source retrieval, executor dispatch, coding progress, implementation, review, verification, CI, merge-readiness, merge, platform delivery, provider billing, or live runtime telemetry evidence.
   - Do not claim connector, gateway, runtime, file generation, memory mutation, or host automation evidence from prepared guidance.
 
+### workflow-learning
+
+[omh] Hermes workflow learning workflow: turn a completed or attempted workflow into a metadata-only trace, eval, improvement candidate, and regression case.
+
+- Category: `optimization`
+- Phase: `workflow-learning`
+- Hermes role: `tracker`
+- Quality tier: `workflow-surface-gated`
+- Exposure: `workflow_skill`
+- Install visibility: `true`
+- Docs visibility: `primary_workflow_skill`
+- Compatibility alias: `false`
+- Preferred usage: Use as an installed Hermes workflow skill when the user wants to learn from a workflow run, review an improvement candidate, or create a regression case.
+- Handoff policy: Keep this as Hermes-facing orchestration guidance first. Prepare executor, connector, gateway, or host-runtime handoff only when the user accepts that next step and observed evidence can be recorded.
+- Why this exists: `workflow-learning` exists so Hermes users can ask for this workflow in chat and receive a structured, evidence-bounded OMH operating surface instead of ad hoc narration.
+- Use when: Use after a Hermes/OMH workflow attempt when the user wants the process to become inspectable, evaluable, and reusable as a future regression without storing raw prompts.
+- Do not use when:
+  - The request is already handled by a narrower explicit skill with stronger evidence.
+  - The user asks OMH to secretly run external platforms, connectors, schedulers, file exports, or runtime agents.
+  - The only safe answer is to ask for missing authority, credentials, target, or observed evidence first.
+- Strong routing signals: `workflow-learning`, `workflow learning`, `learning trace`, `execution trace`, `skill improvement`, `improvement candidate`, `regression corpus`, `GEPA`, `VPRM`, `process supervision`, `why did this route`, `learn from this run`, `이번 실행 학습`, `스킬 개선`, `회귀 케이스`, `실행 기록`, `학습 기록`
+- Good example:
+  - Prompt: workflow-learning record why this request went to plan and make a regression case.
+  - Expected behavior: Produce `record_workflow_learning_trace` with required context, wrapper actions, and not-evidence boundaries.
+  - Why: The prompt names a real workflow surface that Hermes can orchestrate without hiding execution.
+- Bad example:
+  - Prompt: workflow-learning silently patch the skill and claim future behavior is fixed.
+  - Expected behavior: Report the missing observed evidence or authority instead of claiming the external step happened.
+  - Why: Prepared OMH guidance is not platform, runtime, connector, file, memory, or delivery evidence.
+- Quality bar:
+  - Name the user-facing workflow objective, required context, next action, and stop condition.
+  - Separate prepared guidance from observed platform, runtime, connector, file, memory, or delivery evidence.
+  - Expose missing tools, credentials, targets, or observations as user-visible gaps.
+- Required inputs:
+  - user request
+  - target context
+  - delivery or status expectation
+  - known missing evidence
+- Expected outputs:
+  - workflow-learning/v1 card or guidance
+  - next action
+  - prepared-vs-observed boundary
+- Artifact expectations:
+  - workflow-learning/v1 metadata-only runtime or wrapper card when recorded
+- Safety rules:
+  - A workflow learning trace is process evidence for review. It is not automatic model training, skill mutation, execution, verification, CI, or merge evidence.
+  - Do not claim connector, gateway, runtime, file generation, memory mutation, or host automation evidence from prepared guidance.
+
 ## Representative Harnesses
 
 ### coding-handling
@@ -4107,4 +4155,54 @@ Prepare a manager-facing quality and throughput review for AI-agent research, co
 - Privacy default: `metadata_only`
 - Overclaim guards:
   - An agent ops review card is not source retrieval, executor dispatch, implementation, verification, review, CI, merge, delivery, provider billing, or live telemetry evidence.
+- Fallback: If a required target, credential, runtime, or observation is missing, show a blocker or confirmation action instead of claiming completion.
+
+### workflow-learning
+
+Record workflow attempts as metadata-only learning traces, deterministic evals, review-only improvement candidates, and regression cases.
+
+- Use when: Use after chat routing, wrapper sessions, runtime runs, or manual feedback should improve future workflow behavior without hidden self-modification.
+- Quality tier: `learning-gated`
+- Quality bar:
+  - Name the workflow objective, owner, input boundary, next action, and stop condition.
+  - Represent prepared, observed, blocked, and missing evidence as separate states.
+  - Never upgrade a card, blueprint, or readiness check into external execution proof.
+- Inputs:
+  - source trace or run id
+  - selected workflow
+  - observed evidence refs when available
+  - feedback or failure summary
+- Outputs:
+  - workflow_learning_trace/v1
+  - workflow_eval_result/v1
+  - improvement_candidate/v1
+  - regression_case/v1
+- Stop conditions:
+  - card is prepared or a missing decision is surfaced
+  - observed evidence is separated from prepared guidance
+- Verification:
+  - validate required fields
+  - check not-evidence boundaries
+  - record only observed external actions
+- Evidence ladder:
+  - `trace_recorded`
+  - `eval_recorded`
+  - `improvement_candidate_reviewed`
+  - `regression_case_recorded`
+  - `future_replay_passed_when_available`
+- Wrapper actions:
+  - `record_workflow_learning_trace`
+  - `show_learning_eval`
+  - `propose_skill_improvement`
+  - `add_regression_case`
+  - `replay_regression_cases`
+  - `show_status`
+- Artifact events:
+  - `workflow-learning_scoped`
+  - `workflow-learning_card_prepared`
+  - `workflow-learning_status_recorded`
+- Delegation expectation: Record this harness as Hermes-retained orchestration; external runtime/platform/file/memory/connector evidence requires a separate observed artifact.
+- Privacy default: `metadata_only`
+- Overclaim guards:
+  - A workflow learning artifact is not automatic model training, skill mutation, execution, verification, review, CI, merge, or proof that future behavior is fixed.
 - Fallback: If a required target, credential, runtime, or observation is missing, show a blocker or confirmation action instead of claiming completion.

--- a/skills/agent-ops-review/SKILL.md
+++ b/skills/agent-ops-review/SKILL.md
@@ -42,7 +42,7 @@ Bad example:
 
 - This skill is part of OMH's Hermes workflow layer, not a standalone executor.
 - Product context: OMH is a Hermes-native workflow pack: it helps Hermes choose skills, shape work, prepare artifacts, show status, and hand off without hiding unobserved execution.
-- Current lane: **Automation and status** (`automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `toolbelt-readiness`, `ops-observability-card`, `agent-ops-review`, `memory-curation-review`, `doctor`, `skill`, `ask`, `cancel`) - scheduled ops, gateway cards, boards, tool readiness, status, health, and release/ops review.
+- Current lane: **Automation and status** (`automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `toolbelt-readiness`, `ops-observability-card`, `agent-ops-review`, `memory-curation-review`, `workflow-learning`, `doctor`, `skill`, `ask`, `cancel`) - scheduled ops, gateway cards, boards, tool readiness, status, health, and release/ops review.
 - If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
 - Cross-skill context: Carry this across every OMH skill: match intent to a lane, name adjacent workflows, and do not dismiss OMH just because a generic tool can render or execute the final step.
 - Coverage: Every generated workflow skill carries this rail.

--- a/skills/automation-blueprint/SKILL.md
+++ b/skills/automation-blueprint/SKILL.md
@@ -42,7 +42,7 @@ Bad example:
 
 - This skill is part of OMH's Hermes workflow layer, not a standalone executor.
 - Product context: OMH is a Hermes-native workflow pack: it helps Hermes choose skills, shape work, prepare artifacts, show status, and hand off without hiding unobserved execution.
-- Current lane: **Automation and status** (`automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `toolbelt-readiness`, `ops-observability-card`, `agent-ops-review`, `memory-curation-review`, `doctor`, `skill`, `ask`, `cancel`) - scheduled ops, gateway cards, boards, tool readiness, status, health, and release/ops review.
+- Current lane: **Automation and status** (`automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `toolbelt-readiness`, `ops-observability-card`, `agent-ops-review`, `memory-curation-review`, `workflow-learning`, `doctor`, `skill`, `ask`, `cancel`) - scheduled ops, gateway cards, boards, tool readiness, status, health, and release/ops review.
 - If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
 - Cross-skill context: Carry this across every OMH skill: match intent to a lane, name adjacent workflows, and do not dismiss OMH just because a generic tool can render or execute the final step.
 - Coverage: Every generated workflow skill carries this rail.

--- a/skills/cancel/SKILL.md
+++ b/skills/cancel/SKILL.md
@@ -41,7 +41,7 @@ Bad example:
 
 - This skill is part of OMH's Hermes workflow layer, not a standalone executor.
 - Product context: OMH is a Hermes-native workflow pack: it helps Hermes choose skills, shape work, prepare artifacts, show status, and hand off without hiding unobserved execution.
-- Current lane: **Automation and status** (`automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `toolbelt-readiness`, `ops-observability-card`, `agent-ops-review`, `memory-curation-review`, `doctor`, `skill`, `ask`, `cancel`) - scheduled ops, gateway cards, boards, tool readiness, status, health, and release/ops review.
+- Current lane: **Automation and status** (`automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `toolbelt-readiness`, `ops-observability-card`, `agent-ops-review`, `memory-curation-review`, `workflow-learning`, `doctor`, `skill`, `ask`, `cancel`) - scheduled ops, gateway cards, boards, tool readiness, status, health, and release/ops review.
 - If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
 - Cross-skill context: Carry this across every OMH skill: match intent to a lane, name adjacent workflows, and do not dismiss OMH just because a generic tool can render or execute the final step.
 - Coverage: Every generated workflow skill carries this rail.

--- a/skills/doctor/SKILL.md
+++ b/skills/doctor/SKILL.md
@@ -42,7 +42,7 @@ Bad example:
 
 - This skill is part of OMH's Hermes workflow layer, not a standalone executor.
 - Product context: OMH is a Hermes-native workflow pack: it helps Hermes choose skills, shape work, prepare artifacts, show status, and hand off without hiding unobserved execution.
-- Current lane: **Automation and status** (`automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `toolbelt-readiness`, `ops-observability-card`, `agent-ops-review`, `memory-curation-review`, `doctor`, `skill`, `ask`, `cancel`) - scheduled ops, gateway cards, boards, tool readiness, status, health, and release/ops review.
+- Current lane: **Automation and status** (`automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `toolbelt-readiness`, `ops-observability-card`, `agent-ops-review`, `memory-curation-review`, `workflow-learning`, `doctor`, `skill`, `ask`, `cancel`) - scheduled ops, gateway cards, boards, tool readiness, status, health, and release/ops review.
 - If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
 - Cross-skill context: Carry this across every OMH skill: match intent to a lane, name adjacent workflows, and do not dismiss OMH just because a generic tool can render or execute the final step.
 - Coverage: Every generated workflow skill carries this rail.

--- a/skills/memory-curation-review/SKILL.md
+++ b/skills/memory-curation-review/SKILL.md
@@ -42,7 +42,7 @@ Bad example:
 
 - This skill is part of OMH's Hermes workflow layer, not a standalone executor.
 - Product context: OMH is a Hermes-native workflow pack: it helps Hermes choose skills, shape work, prepare artifacts, show status, and hand off without hiding unobserved execution.
-- Current lane: **Automation and status** (`automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `toolbelt-readiness`, `ops-observability-card`, `agent-ops-review`, `memory-curation-review`, `doctor`, `skill`, `ask`, `cancel`) - scheduled ops, gateway cards, boards, tool readiness, status, health, and release/ops review.
+- Current lane: **Automation and status** (`automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `toolbelt-readiness`, `ops-observability-card`, `agent-ops-review`, `memory-curation-review`, `workflow-learning`, `doctor`, `skill`, `ask`, `cancel`) - scheduled ops, gateway cards, boards, tool readiness, status, health, and release/ops review.
 - If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
 - Cross-skill context: Carry this across every OMH skill: match intent to a lane, name adjacent workflows, and do not dismiss OMH just because a generic tool can render or execute the final step.
 - Coverage: Every generated workflow skill carries this rail.

--- a/skills/oh-my-hermes/SKILL.md
+++ b/skills/oh-my-hermes/SKILL.md
@@ -12,7 +12,7 @@ metadata:
 
 # Oh My Hermes Router
 
-Use this skill when the user mentions oh-my-hermes or a workflow keyword such as `deep-interview`, `ralplan`, `ultragoal`, `loop`, `ultraprocess`, `web-research`, `research-department`, `feedback-triage`, `materials-package`, `img-summary`, `automation-blueprint`, `code-review`, `team`, `ultrawork`, `ultraqa`, `doctor`.
+Use this skill when the user mentions oh-my-hermes or a workflow keyword such as `deep-interview`, `ralplan`, `ultragoal`, `loop`, `ultraprocess`, `web-research`, `research-department`, `feedback-triage`, `materials-package`, `img-summary`, `automation-blueprint`, `workflow-learning`, `code-review`, `team`, `ultrawork`, `ultraqa`, `doctor`.
 
 ## Routing Contract
 
@@ -64,11 +64,11 @@ Normal users talk to Hermes; OMH CLI is backend, setup, verification, and wrappe
 
 Workflow context cards:
 
-intent -> deep-interview/ralplan/loop/ultraprocess; signals -> web-research/research-department/feedback-triage/meeting-brief; materials -> materials-package/report-package/img-summary; automation/status -> automation-blueprint/agent-ops-review/doctor; code -> ultraprocess/code-review/team/ultrawork/ultraqa.
+intent -> deep-interview/ralplan/loop/ultraprocess; signals -> web-research/research-department/feedback-triage/meeting-brief; materials -> materials-package/report-package/img-summary; automation/status/learning -> automation-blueprint/agent-ops-review/workflow-learning/doctor; code -> ultraprocess/code-review/team/ultrawork/ultraqa.
 
 Common cues before generic tools:
 
-notes/retros -> operating-rhythm/meeting-brief; PR/issue/bug/feedback/release -> github-event-ops, feedback-triage, report-package, or img-summary; sources/news -> web-research or research-department; decks/PDF/sheets/docs/HWP -> materials-package or report-package; image cards/infographics -> img-summary; coding/status/review/CI/merge -> ultraprocess, code-review, or agent-ops-review.
+notes/retros -> operating-rhythm/meeting-brief; PR/issue/bug/feedback/release -> github-event-ops, feedback-triage, report-package, or img-summary; sources/news -> web-research or research-department; decks/PDF/sheets/docs/HWP -> materials-package or report-package; image cards/infographics -> img-summary; coding/status/review/CI/merge -> ultraprocess, code-review, or agent-ops-review; trace/improve/regression -> workflow-learning.
 
 Tools:
 
@@ -112,7 +112,7 @@ Use installed primary workflow skills plus compatibility surfaces in this regist
 - `planner`: `loop`, `deep-interview`, `plan`, `ralplan`
 - `researcher`: `web-research`, `research-brief`, `research-department`, `best-practice-research`, `autoresearch-goal`
 - `reviewer`: `ultraqa`, `code-review`, `ask`
-- `tracker`: `performance-goal`, `cancel`, `skill`, `doctor`, `agent-board`, `toolbelt-readiness`, `ops-observability-card`, `agent-ops-review`
+- `tracker`: `performance-goal`, `cancel`, `skill`, `doctor`, `agent-board`, `toolbelt-readiness`, `ops-observability-card`, `agent-ops-review`, `workflow-learning`
 - Installed workflow skill policies live in generated workflow skills; compatibility/reference-only surface policies live in `docs/WORKFLOWS.md` and are not guaranteed to have `skills/<name>/SKILL.md` files.
 
 General rule: Hermes should retain routing, web/source research, deep interview, planning, status, and evidence narration. This role metadata is advisory unless a wrapper/runtime artifact records observed enforcement. When the accepted next action mutates code, the wrapper should ask for or apply the selected executor/runtime profile, prepare the matching handoff, and track only evidence it actually observes instead of implying code ran secretly.
@@ -221,6 +221,7 @@ When Hermes exposes installed skill descriptions to the model, use this registry
 - `toolbelt-readiness`: `toolbelt-readiness`, `mcp readiness`, `tool readiness`, `connector readiness`, `needed mcp`
 - `ops-observability-card`: `ops-observability-card`, `observability card`, `cost telemetry`, `latency telemetry`, `token telemetry`
 - `agent-ops-review`: `agent-ops-review`, `agent ops review`, `agent productivity`, `operator productivity`, `manager view`
+- `workflow-learning`: `workflow-learning`, `workflow learning`, `learning trace`, `execution trace`, `skill improvement`
 
 Routing is conservative: route only on explicit invocation, strong keyword evidence, or a clear workflow-shaped request. A bare common word such as `team`, `ask`, `wiki`, or `review` is not enough when it could mean normal conversation.
 
@@ -261,6 +262,7 @@ Use these harnesses to shape the response before adding new skills. They are qua
 - `toolbelt-readiness`: Check required MCP servers, CLIs, APIs, credentials, connectors, and local tools for a workflow. Tier `tool-readiness-gated`. Ladder: `workflow_tools_scoped` -> `tool_requirements_listed` -> `installed_state_recorded_when_available` -> `credential_gaps_recorded`. Actions: `show_toolbelt`, `open_setup`, `record_tool_check`, `prepare_handoff`, `show_status`. Privacy `metadata_only`.
 - `ops-observability-card`: Report wrapper-safe token, cost, latency, run history, queue, and failure-mode telemetry boundaries. Tier `observability-gated`. Ladder: `telemetry_scope_recorded` -> `local_metrics_summarized` -> `failure_modes_checked` -> `provider_truth_observed_when_available`. Actions: `show_observability`, `record_metric`, `record_failure_mode`, `show_status`. Privacy `metadata_only`.
 - `agent-ops-review`: Prepare a manager-facing quality and throughput review for AI-agent research, coding, review, and status work. Tier `manager-review-gated`. Ladder: `manager_scope_recorded` -> `quality_lanes_prepared` -> `evidence_gaps_named` -> `next_action_selected`. Actions: `show_agent_ops_review`, `choose_ops_lane`, `prepare_research_lane`, `prepare_coding_lane`, `prepare_review_lane`. Privacy `metadata_only`.
+- `workflow-learning`: Record workflow attempts as metadata-only learning traces, deterministic evals, review-only improvement candidates, and regression cases. Tier `learning-gated`. Ladder: `trace_recorded` -> `eval_recorded` -> `improvement_candidate_reviewed` -> `regression_case_recorded`. Actions: `record_workflow_learning_trace`, `show_learning_eval`, `propose_skill_improvement`, `add_regression_case`, `replay_regression_cases`. Privacy `metadata_only`.
 
 Harness priority:
 

--- a/skills/skill/SKILL.md
+++ b/skills/skill/SKILL.md
@@ -41,7 +41,7 @@ Bad example:
 
 - This skill is part of OMH's Hermes workflow layer, not a standalone executor.
 - Product context: OMH is a Hermes-native workflow pack: it helps Hermes choose skills, shape work, prepare artifacts, show status, and hand off without hiding unobserved execution.
-- Current lane: **Automation and status** (`automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `toolbelt-readiness`, `ops-observability-card`, `agent-ops-review`, `memory-curation-review`, `doctor`, `skill`, `ask`, `cancel`) - scheduled ops, gateway cards, boards, tool readiness, status, health, and release/ops review.
+- Current lane: **Automation and status** (`automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `toolbelt-readiness`, `ops-observability-card`, `agent-ops-review`, `memory-curation-review`, `workflow-learning`, `doctor`, `skill`, `ask`, `cancel`) - scheduled ops, gateway cards, boards, tool readiness, status, health, and release/ops review.
 - If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
 - Cross-skill context: Carry this across every OMH skill: match intent to a lane, name adjacent workflows, and do not dismiss OMH just because a generic tool can render or execute the final step.
 - Coverage: Every generated workflow skill carries this rail.

--- a/skills/workflow-learning/SKILL.md
+++ b/skills/workflow-learning/SKILL.md
@@ -1,41 +1,42 @@
 ---
-name: ask
-description: [omh] Hermes adaptation for consulting an external advisor when configured.
+name: workflow-learning
+description: [omh] Hermes workflow learning workflow: turn a completed or attempted workflow into a metadata-only trace, eval, improvement candidate, and regression case.
 metadata:
   hermes:
-    tags: [workflow, oh-my-hermes, review]
-    category: review
-    phase: external-advice
-    role: reviewer
-    quality_tier: evidence-gated
+    tags: [workflow, oh-my-hermes, optimization]
+    category: optimization
+    phase: workflow-learning
+    role: tracker
+    quality_tier: workflow-surface-gated
 ---
 
-# Ask
+# Workflow Learning
 
-This is a Hermes-native `ask` workflow skill.
+This is a Hermes-native `workflow-learning` workflow skill.
 
 ## Why This Exists
 
-`ask` exists to keep `review` work explicit, evidence-backed, and inside the Hermes/executor boundary instead of relying on ad hoc chat narration.
+`workflow-learning` exists so Hermes users can ask for this workflow in chat and receive a structured, evidence-bounded OMH operating surface instead of ad hoc narration.
 
 ## Do Not Use When
 
-- The request is casual chat, a status-only acknowledgement, or another workflow has stronger routing evidence.
-- The user needs implementation, review, CI, merge, or external publishing evidence that has not been delegated or observed.
+- The request is already handled by a narrower explicit skill with stronger evidence.
+- The user asks OMH to secretly run external platforms, connectors, schedulers, file exports, or runtime agents.
+- The only safe answer is to ask for missing authority, credentials, target, or observed evidence first.
 
 ## Examples
 
 Good example:
 
-- Prompt: ask: handle a review request that needs explicit evidence boundaries and a clear stop condition.
-- Expected behavior: Run `ask` only after naming the target, evidence boundary, and stop condition.
-- Why: The request matches the catalog use case and keeps observed evidence separate from prepared guidance.
+- Prompt: workflow-learning record why this request went to plan and make a regression case.
+- Expected behavior: Produce `record_workflow_learning_trace` with required context, wrapper actions, and not-evidence boundaries.
+- Why: The prompt names a real workflow surface that Hermes can orchestrate without hiding execution.
 
 Bad example:
 
-- Prompt: ask: treat casual chat or unaccepted work as if this workflow already produced verified results.
-- Expected behavior: Ask a clarification question or route to a narrower workflow instead of forcing `ask`.
-- Why: The request lacks the required inputs or would overclaim work that Hermes did not observe.
+- Prompt: workflow-learning silently patch the skill and claim future behavior is fixed.
+- Expected behavior: Report the missing observed evidence or authority instead of claiming the external step happened.
+- Why: Prepared OMH guidance is not platform, runtime, connector, file, memory, or delivery evidence.
 
 ## OMH Context Rail
 
@@ -50,47 +51,48 @@ Bad example:
 
 ## Use When
 
-Use only when an external advisor is configured and would materially improve the answer.
+Use after a Hermes/OMH workflow attempt when the user wants the process to become inspectable, evaluable, and reusable as a future regression without storing raw prompts.
 
-    Strong routing signals: `ask`, `$ask`, `external advisor`, `claude`, `gemini`
+    Strong routing signals: `workflow-learning`, `workflow learning`, `learning trace`, `execution trace`, `skill improvement`, `improvement candidate`, `regression corpus`, `GEPA`, `VPRM`, `process supervision`, `why did this route`, `learn from this run`, `이번 실행 학습`, `스킬 개선`, `회귀 케이스`, `실행 기록`, `학습 기록`
 
 ## Catalog Metadata
 
-Category: `review`
-Phase: `external-advice`
-Hermes role: `reviewer`
-Quality tier: `evidence-gated`
+Category: `optimization`
+Phase: `workflow-learning`
+Hermes role: `tracker`
+Quality tier: `workflow-surface-gated`
 
 Quality bar:
 
-- Name the workflow target, constraints, validation evidence, and stop condition.
-- Separate Hermes guidance from executor or wrapper behavior unless evidence proves the step happened.
+- Name the user-facing workflow objective, required context, next action, and stop condition.
+- Separate prepared guidance from observed platform, runtime, connector, file, memory, or delivery evidence.
+- Expose missing tools, credentials, targets, or observations as user-visible gaps.
 
 Handoff policy:
 
-Use as optional advice gathering; evaluate the advice in Hermes and delegate coding changes separately.
+Keep this as Hermes-facing orchestration guidance first. Prepare executor, connector, gateway, or host-runtime handoff only when the user accepts that next step and observed evidence can be recorded.
 
 Required inputs:
 
-- question
-- context summary
-- why external advice helps
+- user request
+- target context
+- delivery or status expectation
+- known missing evidence
 
 Expected outputs:
 
-- advisor summary
-- accepted/rejected advice
-- decision note
+- workflow-learning/v1 card or guidance
+- next action
+- prepared-vs-observed boundary
 
 Artifact expectations:
 
-- advisor transcript reference only when explicitly captured
+- workflow-learning/v1 metadata-only runtime or wrapper card when recorded
 
 Safety rules:
 
-- Use only when configured and materially useful.
-- Treat advisor output as evidence to evaluate, not authority.
-- Do not send secrets or private prompts without explicit opt-in.
+- A workflow learning trace is process evidence for review. It is not automatic model training, skill mutation, execution, verification, CI, or merge evidence.
+- Do not claim connector, gateway, runtime, file generation, memory mutation, or host automation evidence from prepared guidance.
 
 ## Harness Discipline
 
@@ -100,12 +102,12 @@ Safety rules:
 
 ## Runtime Evidence
 
-Preferred harness for this skill: `critic`.
+Preferred harness for this skill: `workflow-learning`.
 
 When local shell access or a bot wrapper is available, record metadata-only evidence:
 
 ```sh
-omh runtime record --skill ask --harness critic --status started
+omh runtime record --skill workflow-learning --harness workflow-learning --status started
 omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
@@ -118,7 +120,7 @@ Record observed delegation results when Hermes or the wrapper exposes them. If d
 - Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
 - Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
 - When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
-- When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
+- Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
 - When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
   - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
   - question renderers -> one concise question in the current Hermes interface,

--- a/src/commands/learning.py
+++ b/src/commands/learning.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+import argparse
+import json
+
+from ..ingress import CHAT_SOURCES
+from ..installer import OmhError
+from ..routing.chat import CONFIDENCE_LEVELS
+from ..workflow_learning import (
+    WorkflowLearningError,
+    attach_learning_trace_ref_to_interaction,
+    build_improvement_candidate,
+    build_regression_case_from_trace,
+    build_trace_from_chat_interaction,
+    build_trace_from_runtime_run,
+    build_workflow_eval_result,
+    learning_trace_ref,
+    list_learning_traces,
+    replay_regression_cases,
+    show_learning_trace,
+    write_improvement_candidate,
+    write_learning_trace,
+    write_regression_case,
+    write_workflow_eval,
+)
+from ..wrapper.contract import INTERACTION_MODES, build_chat_interaction_payload
+from .common import _chat_input_and_metadata, _explicit_source_metadata, _paths, _print_json
+
+
+def cmd_learning_record(args: argparse.Namespace) -> int:
+    try:
+        paths = _paths(args)
+        if args.from_runtime_run:
+            trace = build_trace_from_runtime_run(
+                paths,
+                args.from_runtime_run,
+                outcome=args.outcome,
+                feedback_summary=args.feedback_summary or "",
+            )
+            write_learning_trace(paths, trace)
+            payload: dict[str, object] = {
+                "schema_version": "learning_record_result/v1",
+                "source_kind": "runtime_run",
+                "learning_trace_ref": learning_trace_ref(str(trace["trace_id"])),
+                "trace": trace,
+                "claim_boundary": "The trace records existing runtime metadata only; it does not add execution evidence.",
+            }
+        else:
+            event_or_message, source_metadata = _chat_input_and_metadata(args)
+            interaction = build_chat_interaction_payload(
+                event_or_message,
+                source=args.source,
+                mode=args.mode,
+                limit=args.limit,
+                min_confidence=args.min_confidence,
+                include_message=False,
+                source_metadata={**source_metadata, **_explicit_source_metadata(args)},
+                executor_target=args.executor,
+            )
+            trace = build_trace_from_chat_interaction(
+                interaction,
+                source_ref=args.source_ref or args.source_event_id or "",
+                outcome=args.outcome,
+                feedback_summary=args.feedback_summary or "",
+            )
+            write_learning_trace(paths, trace)
+            payload = {
+                "schema_version": "learning_record_result/v1",
+                "source_kind": "chat_interaction",
+                "learning_trace_ref": learning_trace_ref(str(trace["trace_id"])),
+                "trace": trace,
+                "interaction": attach_learning_trace_ref_to_interaction(interaction, trace),
+                "claim_boundary": "The learning ref is exposed only after the trace is written; it is not execution evidence.",
+            }
+    except (OSError, json.JSONDecodeError, ValueError, WorkflowLearningError) as exc:
+        raise OmhError(str(exc)) from exc
+    _print_json(payload)
+    return 0
+
+
+def cmd_learning_list(args: argparse.Namespace) -> int:
+    try:
+        traces = list_learning_traces(_paths(args), limit=args.limit)
+    except (OSError, WorkflowLearningError) as exc:
+        raise OmhError(str(exc)) from exc
+    _print_json(
+        {
+            "schema_version": "learning_trace_list/v1",
+            "traces": traces,
+            "claim_boundary": "Trace lists summarize local learning records only; they do not prove workflow execution.",
+        }
+    )
+    return 0
+
+
+def cmd_learning_show(args: argparse.Namespace) -> int:
+    try:
+        trace = show_learning_trace(_paths(args), args.trace_id)
+    except FileNotFoundError as exc:
+        raise OmhError(f"learning trace not found: {args.trace_id}") from exc
+    except (OSError, WorkflowLearningError) as exc:
+        raise OmhError(str(exc)) from exc
+    _print_json(trace)
+    return 0
+
+
+def cmd_learning_eval(args: argparse.Namespace) -> int:
+    try:
+        paths = _paths(args)
+        trace = show_learning_trace(paths, args.trace_id)
+        result = build_workflow_eval_result(trace, rubric_id=args.rubric)
+        if not args.dry_run:
+            write_workflow_eval(paths, result)
+    except FileNotFoundError as exc:
+        raise OmhError(f"learning trace not found: {args.trace_id}") from exc
+    except (OSError, WorkflowLearningError) as exc:
+        raise OmhError(str(exc)) from exc
+    _print_json(
+        {
+            "schema_version": "learning_eval_result/v1",
+            "recorded": not args.dry_run,
+            "eval": result,
+        }
+    )
+    return 0
+
+
+def cmd_learning_candidate(args: argparse.Namespace) -> int:
+    try:
+        paths = _paths(args)
+        trace = show_learning_trace(paths, args.trace_id)
+        eval_result = build_workflow_eval_result(trace, rubric_id=args.rubric)
+        candidate = build_improvement_candidate(trace, eval_result, target_type=args.target_type, title=args.title or "")
+        if not args.dry_run:
+            write_workflow_eval(paths, eval_result)
+            write_improvement_candidate(paths, candidate)
+    except FileNotFoundError as exc:
+        raise OmhError(f"learning trace not found: {args.trace_id}") from exc
+    except (OSError, WorkflowLearningError) as exc:
+        raise OmhError(str(exc)) from exc
+    _print_json(
+        {
+            "schema_version": "learning_candidate_result/v1",
+            "recorded": not args.dry_run,
+            "eval": eval_result,
+            "candidate": candidate,
+        }
+    )
+    return 0
+
+
+def cmd_learning_regression_add(args: argparse.Namespace) -> int:
+    try:
+        paths = _paths(args)
+        trace = show_learning_trace(paths, args.trace_id)
+        case = build_regression_case_from_trace(
+            trace,
+            redacted_message=args.fixture_message or args.redacted_message or "",
+            expected_workflow=args.expected_workflow or None,
+            expected_harness=args.expected_harness or None,
+            expected_next_action=args.expected_next_action or None,
+        )
+        write_regression_case(paths, case)
+    except FileNotFoundError as exc:
+        raise OmhError(f"learning trace not found: {args.trace_id}") from exc
+    except (OSError, WorkflowLearningError) as exc:
+        raise OmhError(str(exc)) from exc
+    _print_json(
+        {
+            "schema_version": "learning_regression_case_result/v1",
+            "regression_case": case,
+            "claim_boundary": (
+                "The case stores only operator-provided minimized fixture text when provided; "
+                "OMH cannot prove redaction and does not treat the fixture as observed workflow execution."
+            ),
+        }
+    )
+    return 0
+
+
+def cmd_learning_regression_replay(args: argparse.Namespace) -> int:
+    try:
+        payload = replay_regression_cases(_paths(args), limit=args.limit)
+    except (OSError, WorkflowLearningError, ValueError) as exc:
+        raise OmhError(str(exc)) from exc
+    _print_json(payload)
+    return 0
+
+
+def _add_learning_commands(sub) -> None:
+    learning = sub.add_parser(
+        "learning",
+        help="Record workflow learning traces, evals, improvement candidates, and regression cases.",
+    )
+    learning_sub = learning.add_subparsers(dest="learning_command", required=True)
+
+    record = learning_sub.add_parser("record", help="Persist a metadata-only learning trace from chat or runtime evidence.")
+    record.add_argument("message", nargs="*", help="Chat message to route and record as a learning trace.")
+    record.add_argument("--source", choices=CHAT_SOURCES, default="generic")
+    record.add_argument("--mode", choices=INTERACTION_MODES, default="auto")
+    record.add_argument("--limit", type=int, default=3)
+    record.add_argument("--min-confidence", choices=CONFIDENCE_LEVELS, default="high")
+    record.add_argument("--stdin", action="store_true")
+    record.add_argument("--event-json", default=None)
+    record.add_argument("--executor", default="choose")
+    record.add_argument("--source-ref", default="")
+    record.add_argument("--source-event-id", default="")
+    record.add_argument("--channel-ref", default="")
+    record.add_argument("--user-ref", default="")
+    record.add_argument("--from-runtime-run", default="")
+    record.add_argument("--outcome", choices=("unknown", "useful", "not_useful", "blocked", "failed"), default="unknown")
+    record.add_argument("--feedback-summary", default="")
+    record.set_defaults(func=cmd_learning_record)
+
+    list_cmd = learning_sub.add_parser("list", help="List local workflow learning traces.")
+    list_cmd.add_argument("--limit", type=int, default=None)
+    list_cmd.set_defaults(func=cmd_learning_list)
+
+    show_cmd = learning_sub.add_parser("show", help="Show one workflow learning trace.")
+    show_cmd.add_argument("trace_id")
+    show_cmd.set_defaults(func=cmd_learning_show)
+
+    eval_cmd = learning_sub.add_parser("eval", help="Evaluate one learning trace against deterministic rubrics.")
+    eval_cmd.add_argument("trace_id")
+    eval_cmd.add_argument("--rubric", default="default")
+    eval_cmd.add_argument("--dry-run", action="store_true")
+    eval_cmd.set_defaults(func=cmd_learning_eval)
+
+    candidate = learning_sub.add_parser("candidate", help="Create a review-only improvement candidate from a trace eval.")
+    candidate.add_argument("trace_id")
+    candidate.add_argument("--rubric", default="default")
+    candidate.add_argument("--target-type", default="workflow_rubric")
+    candidate.add_argument("--title", default="")
+    candidate.add_argument("--dry-run", action="store_true")
+    candidate.set_defaults(func=cmd_learning_candidate)
+
+    regression = learning_sub.add_parser("regression", help="Manage deterministic workflow regression cases.")
+    regression_sub = regression.add_subparsers(dest="regression_command", required=True)
+
+    regression_add = regression_sub.add_parser("add", help="Create a regression case from a learning trace.")
+    regression_add.add_argument("trace_id")
+    regression_add.add_argument("--fixture-message", default="", help="Operator-minimized replay fixture text.")
+    regression_add.add_argument(
+        "--redacted-message",
+        default="",
+        help="Deprecated alias for --fixture-message; caller is responsible for minimizing private content.",
+    )
+    regression_add.add_argument("--expected-workflow", default="")
+    regression_add.add_argument("--expected-harness", default="")
+    regression_add.add_argument("--expected-next-action", default="")
+    regression_add.set_defaults(func=cmd_learning_regression_add)
+
+    regression_replay = regression_sub.add_parser("replay", help="Replay local workflow regression cases.")
+    regression_replay.add_argument("--limit", type=int, default=None)
+    regression_replay.set_defaults(func=cmd_learning_regression_replay)

--- a/src/commands/main.py
+++ b/src/commands/main.py
@@ -52,6 +52,16 @@ from .goal import (
 )
 from .hermes import _add_hermes_commands, cmd_hermes_plan
 from .hud import _add_hud_commands, cmd_hud
+from .learning import (
+    _add_learning_commands,
+    cmd_learning_candidate,
+    cmd_learning_eval,
+    cmd_learning_list,
+    cmd_learning_record,
+    cmd_learning_regression_add,
+    cmd_learning_regression_replay,
+    cmd_learning_show,
+)
 from .loop import _add_loop_commands, cmd_loop_feedback, cmd_loop_permit, cmd_loop_run_once, cmd_loop_start, cmd_loop_status
 from .materials import (
     _add_materials_commands,
@@ -155,7 +165,7 @@ def build_parser() -> argparse.ArgumentParser:
             "Human-facing maintenance, catalog, and operator checklist commands print summaries by default;\n"
             "pass --json or set OMH_OUTPUT=json when a wrapper needs full payloads.\n"
             "Backend/control-plane commands such as chat, coding, runtime, goal, loop,\n"
-            "memory, ops, materials, state, harness, release smoke, and demo print JSON by design."
+            "learning, memory, ops, materials, state, harness, release smoke, and demo print JSON by design."
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -181,6 +191,7 @@ def build_parser() -> argparse.ArgumentParser:
     _add_coding_commands(sub)
     _add_hermes_commands(sub)
     _add_hud_commands(sub)
+    _add_learning_commands(sub)
     _add_loop_commands(sub)
     _add_memory_commands(sub)
     _add_menubar_commands(sub)

--- a/src/paths.py
+++ b/src/paths.py
@@ -131,6 +131,30 @@ class OmhPaths:
         return self.omh_home / "state"
 
     @property
+    def learning_dir(self) -> Path:
+        return self.omh_home / "learning"
+
+    @property
+    def learning_traces_dir(self) -> Path:
+        return self.learning_dir / "traces"
+
+    @property
+    def learning_evals_dir(self) -> Path:
+        return self.learning_dir / "evals"
+
+    @property
+    def learning_candidates_dir(self) -> Path:
+        return self.learning_dir / "candidates"
+
+    @property
+    def learning_regressions_dir(self) -> Path:
+        return self.learning_dir / "regressions"
+
+    @property
+    def learning_index_path(self) -> Path:
+        return self.learning_dir / "index.json"
+
+    @property
     def hermes_config_path(self) -> Path:
         return self.hermes_home / "config.yaml"
 

--- a/src/plugin_bundle/omh/awareness.py
+++ b/src/plugin_bundle/omh/awareness.py
@@ -16,6 +16,7 @@ ROUTER_KEYWORD_SKILLS = (
     "materials-package",
     "img-summary",
     "automation-blueprint",
+    "workflow-learning",
     "code-review",
     "team",
     "ultrawork",
@@ -38,6 +39,7 @@ LANE_CROSS_LANE_EXAMPLES = {
     ],
     "automation_and_status": [
         "daily digest request -> automation-blueprint -> confirmation card -> observed schedule evidence",
+        "workflow attempt -> workflow-learning -> eval -> improvement candidate or regression case",
         "runtime confusion -> doctor or agent-ops-review -> status card -> next repair action",
     ],
     "coding_handoff": [
@@ -79,12 +81,21 @@ WORKFLOW_CONTEXT_CARDS = (
     {
         "id": "automation_and_status",
         "label": "Automation and status",
-        "user_signal": "recurring digest, cron-like request, gateway command, health check, status confusion, or runtime question",
-        "omh_pattern": "prepare a schedule/status/repair card, name required tools, then keep observed runtime state separate",
-        "representative_workflows": ("automation-blueprint", "agent-ops-review", "toolbelt-readiness", "doctor"),
-        "user_examples": ("Every morning send a digest if something changed", "What is currently blocked?"),
-        "first_response_shape": "Show the prepared status or schedule shape, name the missing connector/runtime evidence, and expose refresh or repair actions.",
-        "not_evidence_until_observed": ("schedule creation", "connector I/O", "runtime load"),
+        "user_signal": "recurring digest, cron-like request, gateway command, health check, status confusion, workflow learning, or runtime question",
+        "omh_pattern": "prepare a schedule/status/repair/learning card, name required tools or evidence, then keep observed runtime state separate",
+        "representative_workflows": (
+            "automation-blueprint",
+            "agent-ops-review",
+            "workflow-learning",
+            "toolbelt-readiness",
+            "doctor",
+        ),
+        "user_examples": (
+            "Every morning send a digest if something changed",
+            "Why did this route to plan? Make it a regression.",
+        ),
+        "first_response_shape": "Show the prepared status, schedule, or learning shape, name the missing evidence, and expose refresh, repair, or review actions.",
+        "not_evidence_until_observed": ("schedule creation", "connector I/O", "runtime load", "skill patch approval"),
     },
     {
         "id": "coding_handoff",
@@ -132,6 +143,7 @@ _WORKFLOW_CONTEXT_CARD_BY_WORKFLOW = {
     "toolbelt-readiness": "automation_and_status",
     "voice-operator": "automation_and_status",
     "wiki": "automation_and_status",
+    "workflow-learning": "automation_and_status",
     "ai-slop-cleaner": "coding_handoff",
     "ask": "coding_handoff",
     "code-review": "coding_handoff",
@@ -318,6 +330,7 @@ def awareness_primer_payload() -> dict[str, object]:
                 "ops-observability-card",
                 "agent-ops-review",
                 "memory-curation-review",
+                "workflow-learning",
                 "doctor",
                 "skill",
                 "ask",
@@ -395,6 +408,10 @@ def awareness_primer_payload() -> dict[str, object]:
             {
                 "cue": "coding, risky changes, executor status, review, CI, or merge state",
                 "route": "ultraprocess, coding handoff, code-review, or agent-ops-review with observed evidence boundaries",
+            },
+            {
+                "cue": "workflow trace, skill improvement, regression corpus, or why-routing questions",
+                "route": "workflow-learning before ad hoc self-critique or automatic skill patching",
             },
         ],
         "context_surfaces": [
@@ -531,7 +548,8 @@ def _compact_workflow_cue_line() -> str:
         "notes/retros -> operating-rhythm/meeting-brief; PR/issue/bug/feedback/release -> github-event-ops, "
         "feedback-triage, report-package, or img-summary; sources/news -> web-research or research-department; "
         "decks/PDF/sheets/docs/HWP -> materials-package or report-package; image cards/infographics -> img-summary; "
-        "coding/status/review/CI/merge -> ultraprocess, code-review, or agent-ops-review"
+        "coding/status/review/CI/merge -> ultraprocess, code-review, or agent-ops-review; "
+        "trace/improve/regression -> workflow-learning"
     )
 
 
@@ -540,7 +558,7 @@ def _compact_workflow_context_cards_line() -> str:
         "intent -> deep-interview/ralplan/loop/ultraprocess; "
         "signals -> web-research/research-department/feedback-triage/meeting-brief; "
         "materials -> materials-package/report-package/img-summary; "
-        "automation/status -> automation-blueprint/agent-ops-review/doctor; "
+        "automation/status/learning -> automation-blueprint/agent-ops-review/workflow-learning/doctor; "
         "code -> ultraprocess/code-review/team/ultrawork/ultraqa"
     )
 

--- a/src/skills/catalog.py
+++ b/src/skills/catalog.py
@@ -337,6 +337,7 @@ _CODING_INTENT_BY_SKILL.update(
         "toolbelt-readiness": "planning",
         "ops-observability-card": "planning",
         "agent-ops-review": "planning",
+        "workflow-learning": "planning",
     }
 )
 
@@ -2586,6 +2587,36 @@ _FEATURE_SURFACE_SKILLS = (
         good_prompt="agent-ops-review show me quality, blockers, and throughput for AI-agent research, coding, and review work.",
         bad_prompt="agent-ops-review claim Codex finished and CI passed because a handoff exists.",
     ),
+    _feature_surface_skill(
+        "workflow-learning",
+        "Hermes workflow learning workflow: turn a completed or attempted workflow into a metadata-only trace, eval, improvement candidate, and regression case.",
+        (
+            "workflow-learning",
+            "workflow learning",
+            "learning trace",
+            "execution trace",
+            "skill improvement",
+            "improvement candidate",
+            "regression corpus",
+            "GEPA",
+            "VPRM",
+            "process supervision",
+            "why did this route",
+            "learn from this run",
+            "이번 실행 학습",
+            "스킬 개선",
+            "회귀 케이스",
+            "실행 기록",
+            "학습 기록",
+        ),
+        "Use after a Hermes/OMH workflow attempt when the user wants the process to become inspectable, evaluable, and reusable as a future regression without storing raw prompts.",
+        category="optimization",
+        phase="workflow-learning",
+        next_action="record_workflow_learning_trace",
+        boundary="A workflow learning trace is process evidence for review. It is not automatic model training, skill mutation, execution, verification, CI, or merge evidence.",
+        good_prompt="workflow-learning record why this request went to plan and make a regression case.",
+        bad_prompt="workflow-learning silently patch the skill and claim future behavior is fixed.",
+    ),
 )
 
 
@@ -2688,6 +2719,14 @@ _SURFACE_EXPOSURES = (
         True,
         "primary_workflow_skill",
         "Use as an installed Hermes workflow skill when a manager wants quality, blockers, next actions, and throughput guidance for AI-agent work.",
+    ),
+    SurfaceExposure(
+        "workflow-learning",
+        "workflow_skill",
+        ("routable", "installable", "playbook", "harness", "workflow_reference", "capability"),
+        True,
+        "primary_workflow_skill",
+        "Use as an installed Hermes workflow skill when the user wants to learn from a workflow run, review an improvement candidate, or create a regression case.",
     ),
 )
 
@@ -3696,6 +3735,30 @@ _FEATURE_SURFACE_HARNESSES = (
         ),
         overclaim_guard="An agent ops review card is not source retrieval, executor dispatch, implementation, verification, review, CI, merge, delivery, provider billing, or live telemetry evidence.",
     ),
+    _feature_surface_harness(
+        "workflow-learning",
+        "Record workflow attempts as metadata-only learning traces, deterministic evals, review-only improvement candidates, and regression cases.",
+        "Use after chat routing, wrapper sessions, runtime runs, or manual feedback should improve future workflow behavior without hidden self-modification.",
+        ("source trace or run id", "selected workflow", "observed evidence refs when available", "feedback or failure summary"),
+        ("workflow_learning_trace/v1", "workflow_eval_result/v1", "improvement_candidate/v1", "regression_case/v1"),
+        quality_tier="learning-gated",
+        evidence_ladder=(
+            "trace_recorded",
+            "eval_recorded",
+            "improvement_candidate_reviewed",
+            "regression_case_recorded",
+            "future_replay_passed_when_available",
+        ),
+        wrapper_actions=(
+            "record_workflow_learning_trace",
+            "show_learning_eval",
+            "propose_skill_improvement",
+            "add_regression_case",
+            "replay_regression_cases",
+            "show_status",
+        ),
+        overclaim_guard="A workflow learning artifact is not automatic model training, skill mutation, execution, verification, review, CI, merge, or proof that future behavior is fixed.",
+    ),
 )
 
 
@@ -3752,6 +3815,7 @@ _PRIMARY_HARNESSES.update(
         "toolbelt-readiness": "toolbelt-readiness",
         "ops-observability-card": "ops-observability-card",
         "agent-ops-review": "agent-ops-review",
+        "workflow-learning": "workflow-learning",
     }
 )
 

--- a/src/workflow_learning.py
+++ b/src/workflow_learning.py
@@ -1,0 +1,936 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Any, Callable
+
+from .local_store import atomic_write_json, ensure_dir, read_json_object, utc_now
+from .paths import OmhPaths
+from .runtime.artifacts import show_run
+
+
+WORKFLOW_LEARNING_TRACE_SCHEMA_VERSION = "workflow_learning_trace/v1"
+WORKFLOW_EVAL_RESULT_SCHEMA_VERSION = "workflow_eval_result/v1"
+IMPROVEMENT_CANDIDATE_SCHEMA_VERSION = "improvement_candidate/v1"
+REGRESSION_CASE_SCHEMA_VERSION = "regression_case/v1"
+WORKFLOW_LEARNING_INDEX_SCHEMA_VERSION = "workflow_learning_index/v1"
+TRACE_REF_PREFIX = "omh-learning-trace"
+PRIVACY_MODE = "metadata_only"
+LEARNING_EVENT_KIND = "workflow_learning"
+FORBIDDEN_TRACE_KEYS = {
+    "message",
+    "raw_message",
+    "prompt",
+    "raw_prompt",
+    "prompt_body",
+    "body_text",
+    "body_preview",
+    "routing_prompt",
+    "dispatch_text_template",
+}
+_OBSERVED_STATES = {"observed", "verified", "complete", "completed", "ready", "merged"}
+_LEARNING_OUTCOMES = {"unknown", "useful", "not_useful", "blocked", "failed"}
+
+
+class WorkflowLearningError(ValueError):
+    pass
+
+
+def learning_trace_ref(trace_id: str) -> str:
+    return f"{TRACE_REF_PREFIX}:{trace_id}"
+
+
+def build_trace_from_chat_interaction(
+    interaction: dict[str, Any],
+    *,
+    source_ref: str = "",
+    outcome: str = "unknown",
+    feedback_summary: str = "",
+    trace_id: str | None = None,
+) -> dict[str, Any]:
+    if interaction.get("schema_version") != "chat_interaction/v1":
+        raise WorkflowLearningError("learning trace requires chat_interaction/v1")
+    if outcome not in _LEARNING_OUTCOMES:
+        raise WorkflowLearningError(f"unsupported learning outcome: {outcome}")
+
+    route = _object(interaction.get("route"))
+    chat_response = _object(interaction.get("chat_response"))
+    state = _object(chat_response.get("state"))
+    explanation = _object(state.get("workflow_explanation"))
+    usage_trace = _object(chat_response.get("usage_trace"))
+    selected_workflow = _first_nonempty(
+        explanation.get("selected_workflow"),
+        usage_trace.get("selected_workflow"),
+        state.get("selected_workflow"),
+        route.get("selected_skill"),
+        "unknown",
+    )
+    selected_harness = _first_nonempty(
+        explanation.get("selected_harness"),
+        usage_trace.get("selected_harness"),
+        route.get("selected_harness"),
+        "unknown",
+    )
+    evidence_state = _first_nonempty(
+        usage_trace.get("evidence_state"),
+        state.get("observation_status"),
+        _nested(interaction, "delegation", "status"),
+        "prepared_not_observed",
+    )
+    now = utc_now()
+    source = {
+        "kind": "chat_interaction",
+        "source": str(interaction.get("source", "generic")),
+        "source_ref": source_ref,
+        "thread_key": str(interaction.get("thread_key", "")),
+        "message_sha256": str(interaction.get("message_sha256", "")),
+        "message_length": int(interaction.get("message_length", 0) or 0),
+        "source_metadata": _safe_metadata(_object(interaction.get("source_metadata"))),
+    }
+    seed = json.dumps(
+        {
+            "source": source,
+            "workflow": selected_workflow,
+            "harness": selected_harness,
+            "next_action": interaction.get("next_action", ""),
+            "source_ref": source_ref,
+        },
+        sort_keys=True,
+    )
+    trace = {
+        "schema_version": WORKFLOW_LEARNING_TRACE_SCHEMA_VERSION,
+        "record_type": "workflow_learning_trace",
+        "trace_id": trace_id or _id("wlt", seed),
+        "created_at": now,
+        "updated_at": now,
+        "privacy": {
+            "mode": PRIVACY_MODE,
+            "raw_prompt_stored": False,
+            "raw_platform_event_stored": False,
+            "redaction_policy": str(interaction.get("redaction_policy", PRIVACY_MODE)),
+            "stored_fields": [
+                "message hash",
+                "message length",
+                "source metadata",
+                "route summary",
+                "workflow explanation",
+                "evidence references",
+            ],
+        },
+        "source": source,
+        "route": {
+            "action": str(route.get("action", "")),
+            "selected_workflow": str(selected_workflow),
+            "selected_harness": str(selected_harness),
+            "confidence": str(route.get("confidence", "")),
+            "score": route.get("score", 0),
+            "matched": _list(route.get("matched")),
+        },
+        "workflow": {
+            "selected_workflow": str(selected_workflow),
+            "selected_harness": str(selected_harness),
+            "workflow_context_id": str(explanation.get("workflow_context_id") or usage_trace.get("workflow_context_id") or ""),
+            "phase": str(usage_trace.get("phase") or state.get("phase") or ""),
+            "next_action": str(interaction.get("next_action") or usage_trace.get("next_action") or state.get("next_action") or ""),
+        },
+        "reasoning_summary": {
+            "why_this_workflow": str(explanation.get("why_this_workflow", "")),
+            "next_action": str(explanation.get("next_action") or state.get("next_action") or interaction.get("next_action") or ""),
+            "not_evidence_yet": _strings(explanation.get("not_evidence_yet") or state.get("evidence_not_observed") or []),
+            "claim_boundary": str(explanation.get("claim_boundary") or chat_response.get("claim_boundary") or ""),
+        },
+        "prepared_refs": _prepared_refs(interaction),
+        "observed_refs": [],
+        "status": {
+            "evidence_state": str(evidence_state),
+            "learning_state": "recorded",
+            "outcome": outcome,
+            "feedback_summary": feedback_summary,
+        },
+        "improvement": {
+            "candidate_available": False,
+            "candidate_refs": [],
+            "regression_case_refs": [],
+        },
+        "overclaim_guard": _strings(interaction.get("overclaim_guard"))
+        or [
+            "Prepared workflow artifacts are not observed execution evidence.",
+            "Learning traces are review material, not automatic skill patches.",
+        ],
+    }
+    validate_workflow_learning_trace(trace)
+    return trace
+
+
+def build_trace_from_runtime_run(
+    paths: OmhPaths,
+    run_id: str,
+    *,
+    outcome: str = "unknown",
+    feedback_summary: str = "",
+    trace_id: str | None = None,
+) -> dict[str, Any]:
+    if outcome not in _LEARNING_OUTCOMES:
+        raise WorkflowLearningError(f"unsupported learning outcome: {outcome}")
+    shown = show_run(paths, run_id)
+    run = _object(shown.get("run"))
+    routing = _object(shown.get("routing"))
+    coding = _object(shown.get("coding_delegation"))
+    wrapper = _object(shown.get("wrapper"))
+    observations = [record for record in _list(shown.get("runtime_observations")) if isinstance(record, dict)]
+    selected_workflow = _first_nonempty(coding.get("recommended_workflow"), routing.get("selected_skill"), run.get("skill"), "unknown")
+    selected_harness = _first_nonempty(coding.get("recommended_harness"), routing.get("selected_harness"), run.get("harness"), "unknown")
+    evidence_state = str(run.get("observation_status") or coding.get("status") or "prepared_not_observed")
+    observed_refs = [
+        {
+            "kind": "runtime_observation",
+            "ref": f"runtime:{run_id}:{record.get('event_type', 'unknown')}",
+            "event_type": str(record.get("event_type", "")),
+            "status": str(record.get("status", "")),
+            "evidence_refs": _strings(record.get("evidence_refs")),
+        }
+        for record in observations
+    ]
+    if any(ref["status"] == "observed" for ref in observed_refs):
+        evidence_state = "observed"
+    now = utc_now()
+    trace = {
+        "schema_version": WORKFLOW_LEARNING_TRACE_SCHEMA_VERSION,
+        "record_type": "workflow_learning_trace",
+        "trace_id": trace_id or _id("wlt", f"runtime:{run_id}:{selected_workflow}:{selected_harness}"),
+        "created_at": now,
+        "updated_at": now,
+        "privacy": {
+            "mode": PRIVACY_MODE,
+            "raw_prompt_stored": False,
+            "raw_platform_event_stored": False,
+            "redaction_policy": PRIVACY_MODE,
+            "stored_fields": ["run id", "route summary", "runtime observation refs", "evidence refs"],
+        },
+        "source": {
+            "kind": "runtime_run",
+            "source": str(coding.get("source") or run.get("trigger") or "runtime"),
+            "source_ref": f"runtime:{run_id}",
+            "thread_key": "",
+            "message_sha256": str(coding.get("message_sha256") or routing.get("message_sha256") or ""),
+            "message_length": int(coding.get("message_length") or routing.get("message_length") or 0),
+            "source_metadata": _safe_metadata(_object(coding.get("source_metadata") or routing.get("source_metadata"))),
+        },
+        "route": {
+            "action": str(coding.get("action") or routing.get("action") or ""),
+            "selected_workflow": str(selected_workflow),
+            "selected_harness": str(selected_harness),
+            "confidence": str(routing.get("confidence", "")),
+            "score": routing.get("score", 0),
+            "matched": _strings(routing.get("matched")),
+        },
+        "workflow": {
+            "selected_workflow": str(selected_workflow),
+            "selected_harness": str(selected_harness),
+            "workflow_context_id": "",
+            "phase": str(run.get("phase") or "runtime"),
+            "next_action": "show_status",
+        },
+        "reasoning_summary": {
+            "why_this_workflow": "Projected from a local runtime run artifact.",
+            "next_action": "review_trace_or_record_more_evidence",
+            "not_evidence_yet": _runtime_not_evidence_yet(shown),
+            "claim_boundary": (
+                "Runtime traces include only observed runtime_observation/v1 records. "
+                "Missing ladder steps remain unobserved."
+            ),
+        },
+        "prepared_refs": _runtime_prepared_refs(run_id, shown),
+        "observed_refs": observed_refs,
+        "status": {
+            "evidence_state": evidence_state,
+            "learning_state": "recorded",
+            "outcome": outcome,
+            "feedback_summary": feedback_summary or str(wrapper.get("summary", "")),
+        },
+        "improvement": {
+            "candidate_available": False,
+            "candidate_refs": [],
+            "regression_case_refs": [],
+        },
+        "overclaim_guard": [
+            "Runtime traces do not prove missing review, CI, merge-readiness, or merge events.",
+            "Learning traces are review material, not automatic skill patches.",
+        ],
+    }
+    validate_workflow_learning_trace(trace)
+    return trace
+
+
+def write_learning_trace(paths: OmhPaths, trace: dict[str, Any]) -> dict[str, Any]:
+    validate_workflow_learning_trace(trace)
+    path = trace_path(paths, str(trace["trace_id"]))
+    atomic_write_json(path, trace, private=True)
+    _update_learning_index(paths, trace, "trace")
+    return trace
+
+
+def list_learning_traces(paths: OmhPaths, *, limit: int | None = None) -> list[dict[str, Any]]:
+    indexed = [_trace_summary(trace) for trace in _records_from_index(paths, "trace", trace_path, validate_workflow_learning_trace)]
+    if indexed:
+        return _apply_limit(indexed, limit)
+    if not paths.learning_traces_dir.exists():
+        return []
+    records: list[dict[str, Any]] = []
+    for path in sorted(paths.learning_traces_dir.glob("*.json")):
+        item = read_json_object(path)
+        if item:
+            validate_workflow_learning_trace(item)
+            records.append(_trace_summary(item))
+    return _apply_limit(records, limit)
+
+
+def show_learning_trace(paths: OmhPaths, trace_id: str) -> dict[str, Any]:
+    trace = read_json_object(trace_path(paths, trace_id))
+    if not trace:
+        raise FileNotFoundError(trace_id)
+    validate_workflow_learning_trace(trace)
+    return trace
+
+
+def build_workflow_eval_result(
+    trace: dict[str, Any],
+    *,
+    rubric_id: str = "default",
+    eval_id: str | None = None,
+) -> dict[str, Any]:
+    validate_workflow_learning_trace(trace)
+    checks = [
+        _check(
+            "schema_valid",
+            "passed",
+            "workflow_learning_trace/v1 validated.",
+            [learning_trace_ref(str(trace["trace_id"]))],
+        ),
+        _privacy_check(trace),
+        _routing_check(trace),
+        _boundary_check(trace),
+        _workflow_specific_check(trace),
+    ]
+    failed = any(check["status"] == "failed" for check in checks)
+    warnings = [check for check in checks if check["status"] == "warning"]
+    now = utc_now()
+    result = {
+        "schema_version": WORKFLOW_EVAL_RESULT_SCHEMA_VERSION,
+        "record_type": "workflow_eval_result",
+        "eval_id": eval_id or _id("wle", f"{trace['trace_id']}:{rubric_id}:{now}"),
+        "trace_id": str(trace["trace_id"]),
+        "created_at": now,
+        "rubric_id": rubric_id,
+        "status": "failed" if failed else ("warning" if warnings else "passed"),
+        "checks": checks,
+        "summary": _eval_summary(failed=failed, warnings=warnings),
+        "claim_boundary": "Workflow evals judge recorded metadata and evidence refs only; they do not execute workflows or patch skills.",
+    }
+    validate_workflow_eval_result(result)
+    return result
+
+
+def write_workflow_eval(paths: OmhPaths, result: dict[str, Any]) -> dict[str, Any]:
+    validate_workflow_eval_result(result)
+    atomic_write_json(eval_path(paths, str(result["eval_id"])), result, private=True)
+    _update_learning_index(paths, result, "eval")
+    return result
+
+
+def build_improvement_candidate(
+    trace: dict[str, Any],
+    eval_result: dict[str, Any],
+    *,
+    candidate_id: str | None = None,
+    target_type: str = "workflow_rubric",
+    title: str = "",
+) -> dict[str, Any]:
+    validate_workflow_learning_trace(trace)
+    validate_workflow_eval_result(eval_result)
+    failed_or_warned = [check for check in _list(eval_result.get("checks")) if isinstance(check, dict) and check.get("status") in {"failed", "warning"}]
+    now = utc_now()
+    candidate = {
+        "schema_version": IMPROVEMENT_CANDIDATE_SCHEMA_VERSION,
+        "record_type": "improvement_candidate",
+        "candidate_id": candidate_id or _id("wic", f"{trace['trace_id']}:{eval_result['eval_id']}:{now}"),
+        "trace_id": str(trace["trace_id"]),
+        "eval_id": str(eval_result["eval_id"]),
+        "created_at": now,
+        "target_type": target_type,
+        "title": title or _candidate_title(trace, failed_or_warned),
+        "status": "proposed",
+        "human_gate": {
+            "required": True,
+            "decision": "pending",
+            "allowed_decisions": ["approve", "revise", "reject"],
+        },
+        "proposal": {
+            "problem_summary": _candidate_problem_summary(failed_or_warned),
+            "suggested_change": _candidate_suggested_change(trace, failed_or_warned),
+            "regression_case_recommended": True,
+        },
+        "diff_preview": {
+            "available": False,
+            "reason": "v1 records a reviewable candidate only; it does not mutate skill files or routing tables.",
+        },
+        "claim_boundary": "Improvement candidates are review material. They do not apply patches until a later explicit human-approved workflow exists.",
+    }
+    validate_improvement_candidate(candidate)
+    return candidate
+
+
+def write_improvement_candidate(paths: OmhPaths, candidate: dict[str, Any]) -> dict[str, Any]:
+    validate_improvement_candidate(candidate)
+    atomic_write_json(candidate_path(paths, str(candidate["candidate_id"])), candidate, private=True)
+    _update_learning_index(paths, candidate, "candidate")
+    return candidate
+
+
+def build_regression_case_from_trace(
+    trace: dict[str, Any],
+    *,
+    case_id: str | None = None,
+    redacted_message: str = "",
+    expected_workflow: str | None = None,
+    expected_harness: str | None = None,
+    expected_next_action: str | None = None,
+) -> dict[str, Any]:
+    validate_workflow_learning_trace(trace)
+    workflow = _object(trace.get("workflow"))
+    reasoning = _object(trace.get("reasoning_summary"))
+    source = _object(trace.get("source"))
+    fixture_text = redacted_message
+    fixture_sha256 = hashlib.sha256(fixture_text.encode("utf-8")).hexdigest() if fixture_text else ""
+    expected = {
+        "selected_workflow": expected_workflow or str(workflow.get("selected_workflow", "")),
+        "selected_harness": expected_harness or str(workflow.get("selected_harness", "")),
+        "next_action": expected_next_action or str(workflow.get("next_action", "")),
+        "claim_boundary_contains": _first_sentence(str(reasoning.get("claim_boundary", ""))),
+        "not_evidence_yet_includes": _strings(reasoning.get("not_evidence_yet"))[:5],
+    }
+    case_seed = json.dumps(
+        {
+            "trace_id": str(trace["trace_id"]),
+            "fixture_sha256": fixture_sha256,
+            "expected": expected,
+        },
+        sort_keys=True,
+    )
+    now = utc_now()
+    case = {
+        "schema_version": REGRESSION_CASE_SCHEMA_VERSION,
+        "record_type": "regression_case",
+        "case_id": case_id or _id("wrc", case_seed),
+        "trace_id": str(trace["trace_id"]),
+        "created_at": now,
+        "fixture": {
+            "source": str(source.get("source", "generic")),
+            "fixture_text": fixture_text,
+            "fixture_sha256": fixture_sha256,
+            "message_sha256": str(source.get("message_sha256", "")),
+            "message_length": int(source.get("message_length", 0) or 0),
+            "privacy": {
+                "mode": "operator_provided_minimized_fixture" if fixture_text else "missing_fixture",
+                "raw_prompt_stored": False,
+                "operator_must_redact_private_content": True,
+                "redaction_provable_by_omh": False,
+            },
+        },
+        "expected": expected,
+        "replay_policy": {
+            "mode": "deterministic_router",
+            "requires_fixture_text": True,
+            "skip_reason": "" if fixture_text else "No operator-provided minimized fixture was provided.",
+        },
+        "claim_boundary": (
+            "Regression cases replay only operator-provided minimized fixture text. "
+            "OMH cannot prove that the fixture is redacted, and it must not be treated "
+            "as raw prompt storage or observed workflow execution."
+        ),
+    }
+    validate_regression_case(case)
+    return case
+
+
+def write_regression_case(paths: OmhPaths, case: dict[str, Any]) -> dict[str, Any]:
+    validate_regression_case(case)
+    atomic_write_json(regression_case_path(paths, str(case["case_id"])), case, private=True)
+    _update_learning_index(paths, case, "regression_case")
+    return case
+
+
+def replay_regression_cases(paths: OmhPaths, *, limit: int | None = None) -> dict[str, Any]:
+    cases = _apply_limit(_read_regression_cases(paths), limit)
+    results = [_replay_regression_case(case) for case in cases]
+    failed = [item for item in results if item["status"] == "failed"]
+    skipped = [item for item in results if item["status"] == "skipped"]
+    passed = [item for item in results if item["status"] == "passed"]
+    return {
+        "schema_version": "workflow_regression_replay/v1",
+        "status": _regression_replay_status(total=len(results), failed=len(failed), skipped=len(skipped)),
+        "total": len(results),
+        "passed": len(passed),
+        "failed": len(failed),
+        "skipped": len(skipped),
+        "results": results,
+        "claim_boundary": "Replay checks deterministic routing contracts only; it does not execute workflows, call networks, or patch skills.",
+    }
+
+
+def attach_learning_trace_ref_to_interaction(interaction: dict[str, Any], trace: dict[str, Any]) -> dict[str, Any]:
+    validate_workflow_learning_trace(trace)
+    enriched = json.loads(json.dumps(interaction))
+    ref = learning_trace_ref(str(trace["trace_id"]))
+    enriched["learning_trace_ref"] = ref
+    chat_response = _object(enriched.get("chat_response"))
+    state = _object(chat_response.get("state"))
+    state["learning_trace_ref"] = ref
+    chat_response["state"] = state
+    enriched["chat_response"] = chat_response
+    return enriched
+
+
+def validate_workflow_learning_trace(trace: dict[str, Any]) -> None:
+    _require_schema(trace, WORKFLOW_LEARNING_TRACE_SCHEMA_VERSION)
+    _require_string(trace, "trace_id")
+    _require_string(trace, "created_at")
+    _require_string(trace, "updated_at")
+    for key in ("privacy", "source", "route", "workflow", "reasoning_summary", "status"):
+        if not isinstance(trace.get(key), dict):
+            raise WorkflowLearningError(f"trace.{key} must be an object")
+    privacy = _object(trace["privacy"])
+    if privacy.get("mode") != PRIVACY_MODE:
+        raise WorkflowLearningError("trace privacy mode must be metadata_only")
+    if privacy.get("raw_prompt_stored") is not False or privacy.get("raw_platform_event_stored") is not False:
+        raise WorkflowLearningError("learning traces must not store raw prompts or platform events")
+    source = _object(trace["source"])
+    if str(source.get("kind", "")) not in {"chat_interaction", "runtime_run"}:
+        raise WorkflowLearningError("trace source.kind must be chat_interaction or runtime_run")
+    workflow = _object(trace["workflow"])
+    if not workflow.get("selected_workflow"):
+        raise WorkflowLearningError("trace workflow.selected_workflow is required")
+    status = _object(trace["status"])
+    if status.get("outcome") not in _LEARNING_OUTCOMES:
+        raise WorkflowLearningError("trace status.outcome is invalid")
+    _reject_forbidden_payload_keys(trace)
+
+
+def validate_workflow_eval_result(result: dict[str, Any]) -> None:
+    _require_schema(result, WORKFLOW_EVAL_RESULT_SCHEMA_VERSION)
+    _require_string(result, "eval_id")
+    _require_string(result, "trace_id")
+    if result.get("status") not in {"passed", "warning", "failed"}:
+        raise WorkflowLearningError("eval status must be passed, warning, or failed")
+    checks = result.get("checks")
+    if not isinstance(checks, list) or not checks:
+        raise WorkflowLearningError("eval checks must be a non-empty list")
+    for check in checks:
+        if not isinstance(check, dict):
+            raise WorkflowLearningError("eval check must be an object")
+        if check.get("status") not in {"passed", "warning", "failed", "not_applicable"}:
+            raise WorkflowLearningError("eval check status is invalid")
+
+
+def validate_improvement_candidate(candidate: dict[str, Any]) -> None:
+    _require_schema(candidate, IMPROVEMENT_CANDIDATE_SCHEMA_VERSION)
+    _require_string(candidate, "candidate_id")
+    _require_string(candidate, "trace_id")
+    if candidate.get("status") not in {"proposed", "accepted", "rejected", "superseded"}:
+        raise WorkflowLearningError("candidate status is invalid")
+    gate = _object(candidate.get("human_gate"))
+    if gate.get("required") is not True or gate.get("decision") not in {"pending", "approve", "revise", "reject"}:
+        raise WorkflowLearningError("candidate human_gate must require a pending/approve/revise/reject decision")
+    diff = _object(candidate.get("diff_preview"))
+    if diff.get("available") is not False:
+        raise WorkflowLearningError("v1 candidates must not include applied diff previews")
+
+
+def validate_regression_case(case: dict[str, Any]) -> None:
+    _require_schema(case, REGRESSION_CASE_SCHEMA_VERSION)
+    _require_string(case, "case_id")
+    _require_string(case, "trace_id")
+    if not isinstance(case.get("fixture"), dict) or not isinstance(case.get("expected"), dict):
+        raise WorkflowLearningError("regression case fixture and expected must be objects")
+    fixture = _object(case.get("fixture"))
+    privacy = _object(fixture.get("privacy"))
+    fixture_text = str(fixture.get("fixture_text") or fixture.get("redacted_message") or "")
+    if fixture_text:
+        if privacy.get("raw_prompt_stored") is not False:
+            raise WorkflowLearningError("regression fixture privacy.raw_prompt_stored must be false")
+        if privacy.get("operator_must_redact_private_content") is not True:
+            raise WorkflowLearningError("regression fixture privacy must require operator redaction")
+
+
+def trace_path(paths: OmhPaths, trace_id: str) -> Path:
+    return paths.learning_traces_dir / f"{_safe_id(trace_id)}.json"
+
+
+def eval_path(paths: OmhPaths, eval_id: str) -> Path:
+    return paths.learning_evals_dir / f"{_safe_id(eval_id)}.json"
+
+
+def candidate_path(paths: OmhPaths, candidate_id: str) -> Path:
+    return paths.learning_candidates_dir / f"{_safe_id(candidate_id)}.json"
+
+
+def regression_case_path(paths: OmhPaths, case_id: str) -> Path:
+    return paths.learning_regressions_dir / f"{_safe_id(case_id)}.json"
+
+
+def _prepared_refs(interaction: dict[str, Any]) -> list[dict[str, str]]:
+    refs: list[dict[str, str]] = []
+    for key in (
+        "chat_response",
+        "plan",
+        "delegation",
+        "loop_start_card",
+        "status_card",
+        "target_notice",
+        "target_topology",
+    ):
+        if key in interaction:
+            schema = _object(interaction.get(key)).get("schema_version", "")
+            if key == "plan":
+                schema = _nested(interaction, "plan", "schema_version") or _nested(interaction, "plan", "plan", "schema_version")
+            refs.append({"kind": key, "ref": key, "schema_version": str(schema)})
+    return refs
+
+
+def _runtime_prepared_refs(run_id: str, shown: dict[str, Any]) -> list[dict[str, str]]:
+    refs = [{"kind": "run", "ref": f"runtime:{run_id}:run", "schema_version": str(_nested(shown, "run", "schema_version") or "")}]
+    for key in ("routing", "coding_delegation", "delegation", "wrapper", "review", "ci", "merge"):
+        if isinstance(shown.get(key), dict):
+            refs.append({"kind": key, "ref": f"runtime:{run_id}:{key}", "schema_version": str(_nested(shown, key, "schema_version") or "")})
+    return refs
+
+
+def _runtime_not_evidence_yet(shown: dict[str, Any]) -> list[str]:
+    missing = []
+    if not shown.get("delegation"):
+        missing.append("executor result")
+    if not shown.get("review"):
+        missing.append("review")
+    if not shown.get("ci"):
+        missing.append("CI")
+    if not shown.get("merge"):
+        missing.append("merge")
+    return missing
+
+
+def _privacy_check(trace: dict[str, Any]) -> dict[str, Any]:
+    privacy = _object(trace.get("privacy"))
+    if privacy.get("mode") == PRIVACY_MODE and privacy.get("raw_prompt_stored") is False:
+        return _check("privacy_metadata_only", "passed", "Trace stores metadata and refs only.", [learning_trace_ref(str(trace["trace_id"]))])
+    return _check("privacy_metadata_only", "failed", "Trace must stay metadata-only and raw_prompt_stored=false.", [])
+
+
+def _routing_check(trace: dict[str, Any]) -> dict[str, Any]:
+    workflow = _object(trace.get("workflow"))
+    selected = str(workflow.get("selected_workflow", ""))
+    if selected and selected != "unknown":
+        return _check("route_selected", "passed", f"Workflow selected: {selected}.", [])
+    return _check("route_selected", "warning", "No concrete workflow was selected.", [])
+
+
+def _boundary_check(trace: dict[str, Any]) -> dict[str, Any]:
+    state = str(_nested(trace, "status", "evidence_state"))
+    observed_refs = _list(trace.get("observed_refs"))
+    if state in _OBSERVED_STATES and not observed_refs:
+        return _check(
+            "prepared_vs_observed_boundary",
+            "failed",
+            f"Evidence state is {state}, but no observed evidence refs were recorded.",
+            [],
+        )
+    return _check(
+        "prepared_vs_observed_boundary",
+        "passed",
+        "Prepared and observed evidence remain separated.",
+        [str(ref.get("ref", "")) for ref in observed_refs if isinstance(ref, dict)],
+    )
+
+
+def _workflow_specific_check(trace: dict[str, Any]) -> dict[str, Any]:
+    selected = str(_nested(trace, "workflow", "selected_workflow"))
+    reasoning = _object(trace.get("reasoning_summary"))
+    not_evidence = _strings(reasoning.get("not_evidence_yet"))
+    if selected in {"plan", "ralplan", "ultragoal", "ultraprocess", "loop", "idea-to-deploy"} and not not_evidence:
+        return _check("workflow_rubric", "warning", "Planning/coding lanes should name what is not evidence yet.", [])
+    if selected in {"img-summary", "materials-package"} and any("generated" in str(ref).lower() for ref in trace.get("observed_refs", [])):
+        return _check("workflow_rubric", "passed", "Deliverable/image lane has explicit observed refs.", [])
+    return _check("workflow_rubric", "passed", "Workflow-specific rubric has no blocking gap.", [])
+
+
+def _check(check_id: str, status: str, summary: str, evidence_refs: list[str]) -> dict[str, Any]:
+    return {
+        "id": check_id,
+        "status": status,
+        "summary": summary,
+        "evidence_refs": [ref for ref in evidence_refs if ref],
+    }
+
+
+def _eval_summary(*, failed: bool, warnings: list[dict[str, Any]]) -> str:
+    if failed:
+        return "Workflow trace has a blocking learning/evidence contract issue."
+    if warnings:
+        return "Workflow trace is usable for learning, with non-blocking rubric warnings."
+    return "Workflow trace is valid and safe to use as learning material."
+
+
+def _candidate_title(trace: dict[str, Any], failed_or_warned: list[dict[str, Any]]) -> str:
+    selected = str(_nested(trace, "workflow", "selected_workflow") or "workflow")
+    if failed_or_warned:
+        return f"Improve {selected} after {failed_or_warned[0]['id']}"
+    return f"Review {selected} workflow learning signal"
+
+
+def _candidate_problem_summary(failed_or_warned: list[dict[str, Any]]) -> str:
+    if not failed_or_warned:
+        return "No failing eval checks were found; candidate is a manual review placeholder."
+    return "; ".join(str(check.get("summary", "")) for check in failed_or_warned)
+
+
+def _candidate_suggested_change(trace: dict[str, Any], failed_or_warned: list[dict[str, Any]]) -> str:
+    selected = str(_nested(trace, "workflow", "selected_workflow") or "workflow")
+    check_ids = {str(check.get("id", "")) for check in failed_or_warned}
+    if "prepared_vs_observed_boundary" in check_ids:
+        return f"Tighten {selected} status copy or observation recording so prepared work cannot be reported as observed."
+    if "workflow_rubric" in check_ids:
+        return f"Add clearer not-evidence-yet guidance to the {selected} workflow or its wrapper response."
+    if "route_selected" in check_ids:
+        return "Improve routing metadata so the selected workflow and harness are always explicit."
+    return f"Review the {selected} workflow for a possible routing, rubric, or status-card improvement."
+
+
+def _read_regression_cases(paths: OmhPaths) -> list[dict[str, Any]]:
+    indexed = _records_from_index(paths, "regression_case", regression_case_path, validate_regression_case)
+    if indexed:
+        return indexed
+    if not paths.learning_regressions_dir.exists():
+        return []
+    cases: list[dict[str, Any]] = []
+    for path in sorted(paths.learning_regressions_dir.glob("*.json")):
+        case = read_json_object(path)
+        if case:
+            validate_regression_case(case)
+            cases.append(case)
+    return cases
+
+
+def _replay_regression_case(case: dict[str, Any]) -> dict[str, Any]:
+    fixture = _object(case.get("fixture"))
+    expected = _object(case.get("expected"))
+    fixture_text = str(fixture.get("fixture_text") or fixture.get("redacted_message") or "")
+    if not fixture_text:
+        return {
+            "case_id": case["case_id"],
+            "status": "skipped",
+            "reason": "No operator-provided minimized fixture was provided.",
+        }
+    from .wrapper.contract import build_chat_interaction_payload
+
+    payload = build_chat_interaction_payload(fixture_text, source=str(fixture.get("source", "generic")))
+    actual_workflow = str(_nested(payload, "chat_response", "state", "selected_workflow") or _nested(payload, "route", "selected_skill"))
+    actual_harness = str(_nested(payload, "route", "selected_harness") or _nested(payload, "chat_response", "usage_trace", "selected_harness"))
+    actual_next_action = str(payload.get("next_action", ""))
+    failures = []
+    if expected.get("selected_workflow") and actual_workflow != expected.get("selected_workflow"):
+        failures.append(f"selected_workflow expected {expected.get('selected_workflow')} got {actual_workflow}")
+    if expected.get("selected_harness") and actual_harness != expected.get("selected_harness"):
+        failures.append(f"selected_harness expected {expected.get('selected_harness')} got {actual_harness}")
+    if expected.get("next_action") and actual_next_action != expected.get("next_action"):
+        failures.append(f"next_action expected {expected.get('next_action')} got {actual_next_action}")
+    return {
+        "case_id": case["case_id"],
+        "status": "failed" if failures else "passed",
+        "actual": {
+            "selected_workflow": actual_workflow,
+            "selected_harness": actual_harness,
+            "next_action": actual_next_action,
+        },
+        "failures": failures,
+    }
+
+
+def _regression_replay_status(*, total: int, failed: int, skipped: int) -> str:
+    if failed:
+        return "failed"
+    if total == 0:
+        return "no_cases"
+    if skipped == total:
+        return "skipped"
+    if skipped:
+        return "incomplete"
+    return "passed"
+
+
+def _records_from_index(
+    paths: OmhPaths,
+    kind: str,
+    path_for_id: Callable[[OmhPaths, str], Path],
+    validator: Callable[[dict[str, Any]], None],
+) -> list[dict[str, Any]]:
+    index = read_json_object(paths.learning_index_path) or {}
+    if index.get("schema_version") != WORKFLOW_LEARNING_INDEX_SCHEMA_VERSION:
+        return []
+    records: list[dict[str, Any]] = []
+    for entry in _list(index.get("records")):
+        if not isinstance(entry, dict) or entry.get("kind") != kind:
+            continue
+        identifier = str(entry.get("id", ""))
+        if not identifier:
+            continue
+        payload = read_json_object(path_for_id(paths, identifier))
+        if payload:
+            validator(payload)
+            records.append(payload)
+    return records
+
+
+def _apply_limit(records: list[dict[str, Any]], limit: int | None) -> list[dict[str, Any]]:
+    if limit is None:
+        return records
+    if limit <= 0:
+        return []
+    return records[-limit:]
+
+
+def _update_learning_index(paths: OmhPaths, record: dict[str, Any], kind: str) -> None:
+    current = read_json_object(paths.learning_index_path) or {
+        "schema_version": WORKFLOW_LEARNING_INDEX_SCHEMA_VERSION,
+        "updated_at": "",
+        "records": [],
+    }
+    records = [item for item in _list(current.get("records")) if isinstance(item, dict)]
+    identifier = _record_identifier(record, kind)
+    entry = {
+        "kind": kind,
+        "id": identifier,
+        "schema_version": str(record.get("schema_version", "")),
+        "updated_at": utc_now(),
+        "ref": _record_ref(kind, identifier),
+    }
+    records = [item for item in records if not (item.get("kind") == kind and item.get("id") == identifier)]
+    records.append(entry)
+    index = {
+        "schema_version": WORKFLOW_LEARNING_INDEX_SCHEMA_VERSION,
+        "updated_at": entry["updated_at"],
+        "records": records[-500:],
+    }
+    atomic_write_json(paths.learning_index_path, index, private=True)
+
+
+def _record_ref(kind: str, identifier: str) -> str:
+    if kind == "trace":
+        return learning_trace_ref(identifier)
+    return f"omh-learning-{kind}:{identifier}"
+
+
+def _record_identifier(record: dict[str, Any], kind: str) -> str:
+    if kind == "trace":
+        return str(record.get("trace_id", ""))
+    if kind == "eval":
+        return str(record.get("eval_id", ""))
+    if kind == "candidate":
+        return str(record.get("candidate_id", ""))
+    if kind == "regression_case":
+        return str(record.get("case_id", ""))
+    return str(record.get("id", ""))
+
+
+def _trace_summary(trace: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "schema_version": "workflow_learning_trace_summary/v1",
+        "trace_id": trace.get("trace_id", ""),
+        "created_at": trace.get("created_at", ""),
+        "source_kind": _nested(trace, "source", "kind"),
+        "source": _nested(trace, "source", "source"),
+        "selected_workflow": _nested(trace, "workflow", "selected_workflow"),
+        "selected_harness": _nested(trace, "workflow", "selected_harness"),
+        "evidence_state": _nested(trace, "status", "evidence_state"),
+        "outcome": _nested(trace, "status", "outcome"),
+        "learning_trace_ref": learning_trace_ref(str(trace.get("trace_id", ""))),
+    }
+
+
+def _id(prefix: str, seed: str) -> str:
+    digest = hashlib.sha256(seed.encode("utf-8")).hexdigest()[:20]
+    return f"{prefix}-{digest}"
+
+
+def _safe_id(value: str) -> str:
+    return re.sub(r"[^a-zA-Z0-9_.:-]+", "-", value).strip("-")[:120] or "record"
+
+
+def _first_nonempty(*values: object) -> object:
+    for value in values:
+        if value not in (None, ""):
+            return value
+    return ""
+
+
+def _first_sentence(value: str) -> str:
+    return value.split(".", 1)[0].strip() if value else ""
+
+
+def _object(value: object) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: object) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _strings(value: object) -> list[str]:
+    if isinstance(value, list):
+        return [str(item) for item in value if str(item)]
+    if isinstance(value, tuple):
+        return [str(item) for item in value if str(item)]
+    if isinstance(value, str) and value:
+        return [value]
+    return []
+
+
+def _nested(data: object, *keys: str) -> object:
+    current: object = data
+    for key in keys:
+        if not isinstance(current, dict):
+            return ""
+        current = current.get(key, "")
+    return current
+
+
+def _safe_metadata(value: dict[str, Any]) -> dict[str, str]:
+    safe: dict[str, str] = {}
+    for key, raw in value.items():
+        key_text = str(key)
+        if key_text.startswith("raw") or key_text in FORBIDDEN_TRACE_KEYS:
+            continue
+        safe[key_text] = str(raw)
+    return safe
+
+
+def _require_schema(payload: dict[str, Any], expected: str) -> None:
+    if payload.get("schema_version") != expected:
+        raise WorkflowLearningError(f"expected {expected}")
+
+
+def _require_string(payload: dict[str, Any], key: str) -> None:
+    if not isinstance(payload.get(key), str) or not payload[key]:
+        raise WorkflowLearningError(f"{key} is required")
+
+
+def _reject_forbidden_payload_keys(value: object, *, path: str = "") -> None:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            key_text = str(key)
+            if key_text in FORBIDDEN_TRACE_KEYS:
+                raise WorkflowLearningError(f"learning trace contains forbidden raw field: {path + key_text}")
+            _reject_forbidden_payload_keys(child, path=f"{path}{key_text}.")
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            _reject_forbidden_payload_keys(child, path=f"{path}{index}.")

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -107,6 +107,11 @@ VISIBLE_ACTIONS = (
     "prepare_review_lane",
     "refresh_agent_ops_status",
     "record_agent_ops_observation",
+    "record_workflow_learning_trace",
+    "show_learning_eval",
+    "propose_skill_improvement",
+    "add_regression_case",
+    "replay_regression_cases",
     "cancel",
 )
 _ROUTE_TO_MODE = {"dispatch": "plan", "clarify": "clarify", "fallback": "clarify"}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -53,6 +53,64 @@ class CliTests(unittest.TestCase):
         self.assertIn("release smoke", help_text)
         self.assertIn("memory, ops, materials, state", help_text)
 
+    def test_learning_record_eval_and_regression_replay(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+            message = "I want to safely add a feature to this repo"
+
+            status, stdout, stderr = run_cli(base + ["learning", "record", message, "--source", "discord"])
+
+            self.assertEqual(status, 0, stderr)
+            self.assertEqual(stderr, "")
+            record = json.loads(stdout)
+            trace = record["trace"]
+            trace_id = trace["trace_id"]
+            self.assertEqual(record["schema_version"], "learning_record_result/v1")
+            self.assertEqual(trace["schema_version"], "workflow_learning_trace/v1")
+            self.assertEqual(trace["privacy"]["mode"], "metadata_only")
+            self.assertFalse(trace["privacy"]["raw_prompt_stored"])
+            self.assertEqual(trace["workflow"]["selected_workflow"], "plan")
+            self.assertEqual(record["interaction"]["chat_response"]["state"]["learning_trace_ref"], record["learning_trace_ref"])
+            self.assertNotIn(message, json.dumps(trace))
+
+            status, stdout, stderr = run_cli(base + ["learning", "eval", trace_id])
+
+            self.assertEqual(status, 0, stderr)
+            self.assertEqual(stderr, "")
+            eval_payload = json.loads(stdout)
+            self.assertTrue(eval_payload["recorded"])
+            self.assertEqual(eval_payload["eval"]["schema_version"], "workflow_eval_result/v1")
+            self.assertIn(eval_payload["eval"]["status"], {"passed", "warning"})
+
+            status, stdout, stderr = run_cli(
+                base
+                + [
+                    "learning",
+                    "regression",
+                    "add",
+                    trace_id,
+                    "--fixture-message",
+                    "safely add a feature to this repo",
+                ]
+            )
+
+            self.assertEqual(status, 0, stderr)
+            self.assertEqual(stderr, "")
+            regression = json.loads(stdout)
+            self.assertEqual(regression["regression_case"]["schema_version"], "regression_case/v1")
+            self.assertEqual(regression["regression_case"]["fixture"]["fixture_text"], "safely add a feature to this repo")
+            self.assertFalse(regression["regression_case"]["fixture"]["privacy"]["redaction_provable_by_omh"])
+
+            status, stdout, stderr = run_cli(base + ["learning", "regression", "replay"])
+
+            self.assertEqual(status, 0, stderr)
+            self.assertEqual(stderr, "")
+            replay = json.loads(stdout)
+            self.assertEqual(replay["schema_version"], "workflow_regression_replay/v1")
+            self.assertEqual(replay["status"], "passed")
+            self.assertEqual(replay["passed"], 1)
+
     def test_setup_and_doctor_default_to_human_summary_with_json_escape_hatch(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -60,6 +60,7 @@ FEATURE_SURFACE_EXPOSURES = {
     "toolbelt-readiness": ("harness_only", False),
     "ops-observability-card": ("harness_only", False),
     "agent-ops-review": ("workflow_skill", True),
+    "workflow-learning": ("workflow_skill", True),
 }
 
 
@@ -353,6 +354,7 @@ class RouterContentTests(unittest.TestCase):
                 "toolbelt-readiness",
                 "ops-observability-card",
                 "agent-ops-review",
+                "workflow-learning",
             },
             harnesses,
         )

--- a/tests/test_workflow_learning.py
+++ b/tests/test_workflow_learning.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import json
+import unittest
+from tempfile import TemporaryDirectory
+from pathlib import Path
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.paths import resolve_paths
+from omh.workflow_learning import (
+    attach_learning_trace_ref_to_interaction,
+    build_improvement_candidate,
+    build_regression_case_from_trace,
+    build_trace_from_chat_interaction,
+    build_workflow_eval_result,
+    learning_trace_ref,
+    list_learning_traces,
+    replay_regression_cases,
+    validate_workflow_learning_trace,
+    write_learning_trace,
+    write_regression_case,
+)
+from omh.wrapper.contract import build_chat_interaction_payload
+
+
+class WorkflowLearningTests(unittest.TestCase):
+    def test_chat_trace_is_metadata_only_and_ref_is_explicit_attachment(self) -> None:
+        message = "I want to safely add a feature with secret-token-123"
+        interaction = build_chat_interaction_payload(message, source="discord")
+
+        self.assertNotIn("learning_trace_ref", json.dumps(interaction))
+        trace = build_trace_from_chat_interaction(interaction, source_ref="discord:msg-1", outcome="useful")
+        validate_workflow_learning_trace(trace)
+        serialized = json.dumps(trace)
+
+        self.assertEqual(trace["schema_version"], "workflow_learning_trace/v1")
+        self.assertEqual(trace["privacy"]["mode"], "metadata_only")
+        self.assertFalse(trace["privacy"]["raw_prompt_stored"])
+        self.assertEqual(trace["source"]["message_length"], len(message))
+        self.assertEqual(trace["workflow"]["selected_workflow"], "plan")
+        self.assertIn("plan acceptance", trace["reasoning_summary"]["not_evidence_yet"])
+        self.assertNotIn(message, serialized)
+        self.assertNotIn("secret-token-123", serialized)
+        self.assertNotIn("body_text", serialized)
+
+        enriched = attach_learning_trace_ref_to_interaction(interaction, trace)
+        ref = learning_trace_ref(trace["trace_id"])
+        self.assertEqual(enriched["learning_trace_ref"], ref)
+        self.assertEqual(enriched["chat_response"]["state"]["learning_trace_ref"], ref)
+
+    def test_eval_blocks_observed_claim_without_observed_refs(self) -> None:
+        interaction = build_chat_interaction_payload("make a risky refactor plan", source="discord")
+        trace = build_trace_from_chat_interaction(interaction)
+        trace["status"]["evidence_state"] = "observed"
+
+        result = build_workflow_eval_result(trace)
+        checks = {check["id"]: check for check in result["checks"]}
+
+        self.assertEqual(result["status"], "failed")
+        self.assertEqual(checks["prepared_vs_observed_boundary"]["status"], "failed")
+
+    def test_candidate_is_review_only_and_regression_replay_is_deterministic(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            message = "I want to safely add a feature to this repo"
+            fixture = "safely add a feature to this repo"
+            interaction = build_chat_interaction_payload(message, source="discord")
+            trace = write_learning_trace(paths, build_trace_from_chat_interaction(interaction))
+            eval_result = build_workflow_eval_result(trace)
+            candidate = build_improvement_candidate(trace, eval_result)
+            case = write_regression_case(paths, build_regression_case_from_trace(trace, redacted_message=fixture))
+            replay = replay_regression_cases(paths)
+
+            self.assertEqual(candidate["schema_version"], "improvement_candidate/v1")
+            self.assertTrue(candidate["human_gate"]["required"])
+            self.assertEqual(candidate["human_gate"]["decision"], "pending")
+            self.assertFalse(candidate["diff_preview"]["available"])
+            self.assertEqual(case["schema_version"], "regression_case/v1")
+            self.assertEqual(case["fixture"]["fixture_text"], fixture)
+            self.assertFalse(case["fixture"]["privacy"]["raw_prompt_stored"])
+            self.assertTrue(case["fixture"]["privacy"]["operator_must_redact_private_content"])
+            self.assertFalse(case["fixture"]["privacy"]["redaction_provable_by_omh"])
+            self.assertEqual(replay["status"], "passed")
+            self.assertEqual(replay["passed"], 1)
+            self.assertEqual(list_learning_traces(paths, limit=0), [])
+            limited_replay = replay_regression_cases(paths, limit=0)
+            self.assertEqual(limited_replay["status"], "no_cases")
+            self.assertEqual(limited_replay["total"], 0)
+            self.assertEqual(limited_replay["passed"], 0)
+
+    def test_regression_replay_does_not_pass_when_cases_are_skipped(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            interaction = build_chat_interaction_payload("I want to safely add a feature to this repo", source="discord")
+            trace = write_learning_trace(paths, build_trace_from_chat_interaction(interaction))
+            write_regression_case(paths, build_regression_case_from_trace(trace))
+
+            replay = replay_regression_cases(paths)
+
+            self.assertEqual(replay["status"], "skipped")
+            self.assertEqual(replay["total"], 1)
+            self.assertEqual(replay["passed"], 0)
+            self.assertEqual(replay["skipped"], 1)
+
+    def test_regression_case_id_includes_fixture_and_expected_shape(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            interaction = build_chat_interaction_payload("I want to safely add a feature to this repo", source="discord")
+            trace = write_learning_trace(paths, build_trace_from_chat_interaction(interaction))
+            first = write_regression_case(
+                paths,
+                build_regression_case_from_trace(trace, redacted_message="safely add a feature"),
+            )
+            second = write_regression_case(
+                paths,
+                build_regression_case_from_trace(
+                    trace,
+                    redacted_message="risky refactor",
+                    expected_workflow="ai-slop-cleaner",
+                    expected_harness="code-quality",
+                ),
+            )
+
+            replay = replay_regression_cases(paths)
+
+            self.assertNotEqual(first["case_id"], second["case_id"])
+            self.assertEqual(replay["total"], 2)
+
+    def test_learning_index_is_read_before_directory_scan(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            first_trace = write_learning_trace(
+                paths,
+                build_trace_from_chat_interaction(build_chat_interaction_payload("safely add a feature", source="discord")),
+            )
+            second_trace = write_learning_trace(
+                paths,
+                build_trace_from_chat_interaction(build_chat_interaction_payload("diagnose installation health", source="discord")),
+            )
+            first_case = write_regression_case(
+                paths,
+                build_regression_case_from_trace(first_trace, redacted_message="safely add a feature"),
+            )
+            second_case = write_regression_case(paths, build_regression_case_from_trace(second_trace))
+            index = json.loads(paths.learning_index_path.read_text(encoding="utf-8"))
+            index["records"] = [
+                record
+                for record in index["records"]
+                if not (
+                    (record["kind"] == "trace" and record["id"] == second_trace["trace_id"])
+                    or (record["kind"] == "regression_case" and record["id"] == first_case["case_id"])
+                )
+            ]
+            paths.learning_index_path.write_text(json.dumps(index), encoding="utf-8")
+
+            traces = list_learning_traces(paths)
+            replay = replay_regression_cases(paths)
+
+            self.assertEqual([trace["trace_id"] for trace in traces], [first_trace["trace_id"]])
+            self.assertEqual(replay["status"], "skipped")
+            self.assertEqual(replay["results"][0]["case_id"], second_case["case_id"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- Added `omh learning` backend commands for metadata-only workflow traces, deterministic evals, review-only improvement candidates, and replayable regression cases.
- Added local learning artifact paths under `.omh/learning/...` plus `workflow_learning_trace/v1`, `workflow_eval_result/v1`, `improvement_candidate/v1`, `regression_case/v1`, and `workflow_learning_index/v1` contracts.
- Added the generated `workflow-learning` Hermes workflow skill and wired it into catalog, harness, awareness, wrapper action ids, docs, and workflow references.
- Hardened regression replay semantics so empty/all-skipped/incomplete replay cannot be reported as successful execution evidence.

### Why This Exists

OMH needs a GEPA/VPRM-friendly workflow learning layer: Hermes can improve individual skills/prompts from process traces, while OMH should provide the workflow-level evidence structure that makes those traces inspectable, reviewable, and safe to learn from. This PR gives operators a local, deterministic way to capture why a workflow routed a request, what was prepared, what was actually observed, what failed validation, and what should become a future regression case.

### User / Operator Impact

- Hermes/wrappers can expose a `learning_trace_ref` after a trace is persisted, without storing raw chat prompts by default.
- Operators can run `omh learning record`, `eval`, `candidate`, and `regression replay` to turn real workflow outcomes into review material and regression coverage.
- Improvement candidates are explicitly human-gated and do not mutate skills, routing, docs, validators, or runtime behavior automatically.
- Regression fixtures use operator-provided minimized fixture text; OMH records that it cannot prove redaction and does not treat replay as observed workflow execution.

### How It Works

- `src/workflow_learning.py` builds and validates learning artifacts as projections over existing chat/runtime metadata.
- `src/commands/learning.py` exposes backend CLI operations while keeping chat-first surfaces as the normal product UX.
- `learning_index.json` records kind-specific ids and is read by trace listing and regression replay before directory fallback.
- `replay_regression_cases` reports `no_cases`, `skipped`, `incomplete`, `failed`, or `passed`, so skipped cases cannot silently pass.
- Regression case ids are based on trace id, fixture hash, and expected routing shape, making identical cases idempotent and distinct cases collision-resistant.

### Files And Contracts Touched

- New: `src/workflow_learning.py`, `src/commands/learning.py`, `tests/test_workflow_learning.py`, `skills/workflow-learning/SKILL.md`.
- Updated: `src/paths.py`, `src/commands/main.py`, `src/skills/catalog.py`, `src/wrapper/contract.py`, `src/plugin_bundle/omh/awareness.py`.
- Updated docs/generated references: `README.md`, `docs/ARCHITECTURE.md`, `docs/HARNESS_QUALITY.md`, `docs/README.md`, `docs/WORKFLOWS.md`, and generated skill docs touched by the new automation/status lane entry.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_workflow_learning.py -v` (6 tests OK)
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_cli.py -v` (170 tests OK)
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` (556 tests OK)
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m src.cli docs workflows --check`
- [x] `uv run python -m src.cli harness validate`
- [x] `git diff --check`
- [x] Relevant dry-run or smoke command: `omh learning record` -> `eval` -> `regression add --fixture-message` -> `regression replay` against temp `.omh`/`.hermes`; replay returned `passed`, total 1, failed 0.
- [x] Package check: `uv build` and inspected wheel/sdist for `omh/workflow_learning.py` and `omh/commands/learning.py`.
- [x] Code review: independent `code-reviewer` returned APPROVE; independent `architect` returned CLEAR.
- [ ] Manual Hermes/TUI check was not run; this PR adds deterministic backend/contracts and generated workflow guidance, not live Hermes runtime loading.

## Risk

- The learning index is now a real read path for trace listing and regression replay. If it becomes stale or corrupted, records may require a future repair/rebuild command.
- `--redacted-message` remains as a deprecated alias for compatibility; callers should migrate to `--fixture-message`.
- Regression replay validates deterministic routing shape only. It does not execute workflows, call networks, run LLMs, verify implementation, review PRs, pass CI, or prove future behavior is fixed.

## Compatibility / Rollout

- Existing OMH commands keep their current behavior.
- New learning artifacts live under `.omh/learning/...` and are local/private by default.
- Generated skill/docs changes are compatible with the existing tap skill pack.

## Release / Claims

- [x] Release-channel impact considered: this is a preview/stable-compatible backend and workflow-skill addition with no release channel migration.
- [x] Runtime/native capability claims are backed by local schema/tests or marked not observed.
- [x] Known manual Hermes checks are listed; no live `omh release hermes-smoke --live` was performed.

## Follow-Up

- Add a learning index repair/rebuild command if operators start editing or syncing learning artifact files manually.
- Add GEPA-readable export bundles after enough learning traces exist.
- Add human-approved apply flows only after preview, diff, regression replay, and rollback behavior are designed and tested.
