### PR TITLE
Add workflow learning audit cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ tool, an existing Hermes connector, a generic image tool, or prompt-only mode.
 | Coding agent paths | Hermes can prepare work for Codex, Claude Code, Hermes itself, or another runtime without pretending the work already ran. |
 | Agent ops review | Hermes can explain quality gates, blockers, next actions, and throughput levers for AI-agent work without turning a prepared handoff into evidence. |
 | Evidence-aware status | Plans, handoffs, dispatch, results, verification, review, CI, and merge readiness stay visibly separate. |
-| Workflow learning | Hermes can turn a workflow attempt into a metadata-only trace, eval, readiness audit, improvement candidate, and regression case for human-approved improvement. |
+| Workflow learning | Hermes can show a learning-readiness card for a workflow attempt: metadata-only trace, deterministic eval, regression case, audit, export bundle, and human-reviewed improvement candidate. |
 | Organization patterns | Solo, research, product ops, coding runtime, and CTO-style collaboration patterns help Hermes present the right role flow for the request. |
 
 <br>

--- a/docs/HARNESS_QUALITY.md
+++ b/docs/HARNESS_QUALITY.md
@@ -103,8 +103,11 @@ contract shaped like this:
 - `omh learning audit` reads the local learning corpus and returns
   `workflow_learning_audit/v1`: trace/eval/regression/export counts, coverage,
   stale-index blockers, regression replay status, and the next repair or review
-  action. The audit is readiness evidence for the learning corpus only; it does
-  not patch skills, execute workflows, or prove future behavior improved.
+  action. The same payload includes `learning_audit_card/v1` so Hermes wrappers
+  can render a compact review card with record, eval, regression, audit, export,
+  replay, index-check, and index-rebuild actions. The audit is readiness
+  evidence for the learning corpus only; it does not patch skills, execute
+  workflows, or prove future behavior improved.
 - `omh learning export` creates a redacted `workflow_learning_export/v1` review
   bundle from selected traces plus related evals, candidates, and regression
   cases. The bundle omits raw prompts and fixture text; it is review material,

--- a/src/routing/recommend.py
+++ b/src/routing/recommend.py
@@ -115,6 +115,17 @@ _SKILL_POLICIES = {
             "a GPT image tool, existing Hermes connector, generic image tool, or prompt-only path."
         ),
     ),
+    "workflow-learning": RecommendationPolicy(
+        next_action="audit_learning_readiness",
+        evidence_boundary=(
+            "A workflow learning trace, eval, audit, candidate, regression case, or export is process-review evidence only; "
+            "it is not model training, skill mutation, workflow execution, verification, CI, merge, or proof that future behavior is fixed."
+        ),
+        wrapper_guidance=(
+            "Show the workflow learning card: record trace, run eval, add regression case, audit readiness, export a redacted review bundle, "
+            "and keep human-reviewed improvement separate from automatic self-modification."
+        ),
+    ),
     "automation-blueprint": RecommendationPolicy(
         next_action="prepare_scheduled_ops_blueprint",
         evidence_boundary=(

--- a/src/workflow_learning.py
+++ b/src/workflow_learning.py
@@ -18,6 +18,7 @@ REGRESSION_CASE_SCHEMA_VERSION = "regression_case/v1"
 WORKFLOW_LEARNING_INDEX_SCHEMA_VERSION = "workflow_learning_index/v1"
 WORKFLOW_LEARNING_EXPORT_SCHEMA_VERSION = "workflow_learning_export/v1"
 WORKFLOW_LEARNING_AUDIT_SCHEMA_VERSION = "workflow_learning_audit/v1"
+LEARNING_AUDIT_CARD_SCHEMA_VERSION = "learning_audit_card/v1"
 TRACE_REF_PREFIX = "omh-learning-trace"
 EXPORT_REF_PREFIX = "omh-learning-export"
 PRIVACY_MODE = "metadata_only"
@@ -715,7 +716,7 @@ def build_workflow_learning_audit(paths: OmhPaths, *, limit: int | None = 20) ->
         warnings=warnings,
         replay=replay,
     )
-    return {
+    payload = {
         "schema_version": WORKFLOW_LEARNING_AUDIT_SCHEMA_VERSION,
         "status": status,
         "ok": status in {"ready", "no_records"},
@@ -774,6 +775,53 @@ def build_workflow_learning_audit(paths: OmhPaths, *, limit: int | None = 20) ->
             "or upgrade prepared artifacts into observed evidence."
         ),
     }
+    payload["learning_audit_card"] = build_learning_audit_card(payload)
+    return payload
+
+
+def build_learning_audit_card(audit: dict[str, Any]) -> dict[str, Any]:
+    status = str(audit.get("status", "needs_attention"))
+    blocking = [] if status == "no_records" else _list(audit.get("blocking_issues"))
+    warnings = [] if status == "no_records" else _list(audit.get("warnings"))
+    card = {
+        "schema_version": LEARNING_AUDIT_CARD_SCHEMA_VERSION,
+        "status": status,
+        "severity": _learning_audit_card_severity(status),
+        "headline": _learning_audit_card_headline(status),
+        "summary": _learning_audit_card_summary(audit),
+        "primary_action": _learning_audit_primary_action(audit),
+        "steps": _learning_audit_card_steps(audit),
+        "counts": _object(audit.get("counts")),
+        "coverage": _object(audit.get("coverage")),
+        "regression_replay": _object(audit.get("regression_replay")),
+        "blocking_issue_count": len(blocking),
+        "warning_count": len(warnings),
+        "next_actions": _list(audit.get("next_actions")),
+        "wrapper_actions": [
+            "record_workflow_learning_trace",
+            "show_learning_eval",
+            "propose_skill_improvement",
+            "add_regression_case",
+            "audit_learning_readiness",
+            "export_learning_bundle",
+            "replay_regression_cases",
+            "check_learning_index",
+            "rebuild_learning_index",
+            "show_status",
+        ],
+        "not_evidence_yet": [
+            "model training",
+            "automatic skill patch",
+            "workflow execution",
+            "future behavior fixed",
+            "review approval",
+            "CI",
+            "merge",
+        ],
+        "claim_boundary": str(audit.get("claim_boundary", "")),
+    }
+    validate_learning_audit_card(card)
+    return card
 
 
 def attach_learning_trace_ref_to_interaction(interaction: dict[str, Any], trace: dict[str, Any]) -> dict[str, Any]:
@@ -812,6 +860,40 @@ def validate_workflow_learning_trace(trace: dict[str, Any]) -> None:
     if status.get("outcome") not in _LEARNING_OUTCOMES:
         raise WorkflowLearningError("trace status.outcome is invalid")
     _reject_forbidden_payload_keys(trace)
+
+
+def validate_learning_audit_card(card: dict[str, Any]) -> None:
+    _require_schema(card, LEARNING_AUDIT_CARD_SCHEMA_VERSION)
+    if card.get("status") not in {"ready", "no_records", "needs_attention", "blocked"}:
+        raise WorkflowLearningError("learning audit card status is invalid")
+    if card.get("severity") not in {"ok", "empty", "warning", "blocking"}:
+        raise WorkflowLearningError("learning audit card severity is invalid")
+    for key in ("headline", "summary", "primary_action", "claim_boundary"):
+        _require_string(card, key)
+    for key in ("counts", "coverage", "regression_replay"):
+        if not isinstance(card.get(key), dict):
+            raise WorkflowLearningError(f"learning audit card {key} must be an object")
+    for key in ("blocking_issue_count", "warning_count"):
+        if not isinstance(card.get(key), int) or card.get(key) < 0:
+            raise WorkflowLearningError(f"learning audit card {key} must be a non-negative integer")
+    steps = _list(card.get("steps"))
+    if not steps:
+        raise WorkflowLearningError("learning audit card steps must be a non-empty list")
+    for step in steps:
+        item = _object(step)
+        for key in ("id", "label", "state", "detail"):
+            _require_string(item, key)
+        if item.get("state") not in {"ready", "missing", "blocked"}:
+            raise WorkflowLearningError("learning audit card step state is invalid")
+    wrapper_actions = _list(card.get("wrapper_actions"))
+    if not wrapper_actions or any(not isinstance(action, str) or not action for action in wrapper_actions):
+        raise WorkflowLearningError("learning audit card wrapper_actions must be non-empty strings")
+    if str(card.get("primary_action", "")) not in set(wrapper_actions):
+        raise WorkflowLearningError("learning audit card primary_action must be listed in wrapper_actions")
+    not_evidence_yet = _list(card.get("not_evidence_yet"))
+    if not not_evidence_yet or any(not isinstance(item, str) or not item for item in not_evidence_yet):
+        raise WorkflowLearningError("learning audit card not_evidence_yet must be non-empty strings")
+    _reject_forbidden_payload_keys(card)
 
 
 def validate_workflow_eval_result(result: dict[str, Any]) -> None:
@@ -1591,6 +1673,126 @@ def _learning_audit_status(
     if warnings or replay.get("status") not in {"passed", "no_cases"}:
         return "needs_attention"
     return "ready"
+
+
+def _learning_audit_card_severity(status: str) -> str:
+    return {
+        "ready": "ok",
+        "no_records": "empty",
+        "needs_attention": "warning",
+        "blocked": "blocking",
+    }.get(status, "warning")
+
+
+def _learning_audit_card_headline(status: str) -> str:
+    return {
+        "ready": "Workflow learning is ready for review.",
+        "no_records": "No workflow learning records yet.",
+        "needs_attention": "Workflow learning needs one more step.",
+        "blocked": "Workflow learning is blocked.",
+    }.get(status, "Workflow learning needs review.")
+
+
+def _learning_audit_card_summary(audit: dict[str, Any]) -> str:
+    counts = _object(audit.get("counts"))
+    coverage = _object(audit.get("coverage"))
+    replay = _object(audit.get("regression_replay"))
+    status = str(audit.get("status", "needs_attention"))
+    if status == "no_records":
+        return "Record a metadata-only trace before evaluating, replaying, or exporting workflow learning material."
+    if status == "blocked":
+        return "Repair invalid records, failed evals, or the learning index before treating this corpus as learning-ready."
+    return (
+        f"{int(counts.get('traces', 0) or 0)} trace(s), "
+        f"{int(coverage.get('eval_coverage_percent', 0) or 0)}% eval coverage, "
+        f"{int(coverage.get('regression_coverage_percent', 0) or 0)}% regression coverage, "
+        f"replay {replay.get('status', 'unknown')}."
+    )
+
+
+def _learning_audit_primary_action(audit: dict[str, Any]) -> str:
+    status = str(audit.get("status", "needs_attention"))
+    if status == "no_records":
+        return "record_workflow_learning_trace"
+    next_actions = _list(audit.get("next_actions"))
+    if next_actions:
+        action_id = str(_object(next_actions[0]).get("id", ""))
+        return {
+            "rebuild_learning_index": "rebuild_learning_index",
+            "evaluate_trace": "show_learning_eval",
+            "add_regression_case": "add_regression_case",
+            "create_candidate": "propose_skill_improvement",
+            "review_candidate": "propose_skill_improvement",
+            "write_learning_export": "export_learning_bundle",
+        }.get(action_id, "audit_learning_readiness")
+    return "audit_learning_readiness"
+
+
+def _learning_audit_card_steps(audit: dict[str, Any]) -> list[dict[str, Any]]:
+    counts = _object(audit.get("counts"))
+    coverage = _object(audit.get("coverage"))
+    index = _object(audit.get("index"))
+    replay = _object(audit.get("regression_replay"))
+    warnings = {str(item.get("id", "")) for item in _list(audit.get("warnings")) if isinstance(item, dict)}
+    blocking = {str(item.get("id", "")) for item in _list(audit.get("blocking_issues")) if isinstance(item, dict)}
+    trace_count = int(counts.get("traces", 0) or 0)
+    return [
+        _learning_audit_step(
+            "trace",
+            "Trace",
+            "ready" if trace_count else "missing",
+            f"{trace_count} metadata-only trace(s).",
+        ),
+        _learning_audit_step(
+            "eval",
+            "Eval",
+            _learning_audit_step_state("trace_without_eval", warnings, blocking, int(coverage.get("eval_coverage_percent", 0) or 0)),
+            f"{int(coverage.get('eval_coverage_percent', 0) or 0)}% of summarized traces have evals.",
+        ),
+        _learning_audit_step(
+            "regression",
+            "Regression",
+            _learning_audit_step_state("trace_without_regression_case", warnings, blocking, int(coverage.get("regression_coverage_percent", 0) or 0)),
+            f"{int(coverage.get('regression_coverage_percent', 0) or 0)}% of summarized traces have replay cases.",
+        ),
+        _learning_audit_step(
+            "index",
+            "Index",
+            "ready" if index.get("ok") is True else "blocked",
+            f"Index status: {index.get('status', 'unknown')}.",
+        ),
+        _learning_audit_step(
+            "replay",
+            "Replay",
+            "ready" if replay.get("status") in {"passed", "no_cases"} else "blocked",
+            f"Replay status: {replay.get('status', 'unknown')}.",
+        ),
+        _learning_audit_step(
+            "export",
+            "Export",
+            "missing" if "no_learning_export_bundle" in warnings else "ready",
+            f"{int(counts.get('exports', 0) or 0)} redacted review export(s).",
+        ),
+    ]
+
+
+def _learning_audit_step_state(issue_id: str, warnings: set[str], blocking: set[str], coverage_percent: int) -> str:
+    if issue_id in blocking:
+        return "blocked"
+    if issue_id in warnings:
+        return "missing"
+    if coverage_percent >= 100:
+        return "ready"
+    return "missing"
+
+
+def _learning_audit_step(step_id: str, label: str, state: str, detail: str) -> dict[str, Any]:
+    return {
+        "id": step_id,
+        "label": label,
+        "state": state,
+        "detail": detail,
+    }
 
 
 def _learning_audit_replay_blocked(scanned: dict[str, Any]) -> dict[str, Any]:

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -111,8 +111,11 @@ VISIBLE_ACTIONS = (
     "show_learning_eval",
     "propose_skill_improvement",
     "add_regression_case",
+    "audit_learning_readiness",
     "export_learning_bundle",
     "replay_regression_cases",
+    "check_learning_index",
+    "rebuild_learning_index",
     "cancel",
 )
 _ROUTE_TO_MODE = {"dispatch": "plan", "clarify": "clarify", "fallback": "clarify"}
@@ -679,6 +682,71 @@ def build_chat_response_from_route(
                     "blockers": status_card.get("blockers", []),
                     "throughput_levers": card.get("throughput_levers", []),
                     "evidence_not_observed": card.get("not_evidence_until_observed", []),
+                },
+            )
+        if selected == "workflow-learning":
+            evidence_boundary = str(policy.get("evidence_boundary", "")) or (
+                "Workflow learning records are process-review evidence only; they are not automatic improvement evidence."
+            )
+            body = (
+                "I will turn the workflow attempt into learning material without storing raw prompts: "
+                "record the trace, run deterministic evals, add a regression case, audit readiness, "
+                "and export a redacted review bundle when useful. Any skill or routing improvement still needs human review."
+            )
+            return _chat_response(
+                kind="workflow_learning",
+                headline="I can inspect this workflow for learning readiness.",
+                body=body,
+                phase="workflow_learning_prepared",
+                next_action="audit_learning_readiness",
+                thread_key=thread_key,
+                actions=[
+                    _action("record_workflow_learning_trace", "Record trace", "secondary"),
+                    _action("show_learning_eval", "Run eval", "secondary"),
+                    _action("propose_skill_improvement", "Propose improvement", "secondary"),
+                    _action("add_regression_case", "Add regression", "secondary"),
+                    _action("audit_learning_readiness", "Audit readiness", "primary"),
+                    _action("export_learning_bundle", "Export bundle", "secondary"),
+                    _action("replay_regression_cases", "Replay cases", "secondary"),
+                    _action("check_learning_index", "Check index", "secondary"),
+                    _action("rebuild_learning_index", "Rebuild index", "secondary"),
+                    _action("show_status", "Show status", "secondary"),
+                ],
+                claim_boundary=evidence_boundary,
+                extra_state={
+                    "route_action": action,
+                    "confidence": decision.get("confidence", "low"),
+                    "selected_workflow": selected,
+                    "workflow_explanation_reason": workflow_explanation_reason,
+                    "policy_next_action": policy_next_action,
+                    "artifact_schemas": [
+                        "workflow_learning_trace/v1",
+                        "workflow_eval_result/v1",
+                        "regression_case/v1",
+                        "workflow_learning_audit/v1",
+                        "learning_audit_card/v1",
+                        "workflow_learning_export/v1",
+                    ],
+                    "learning_audit_card_schema": "learning_audit_card/v1",
+                    "human_gate_required": True,
+                    "evidence_not_observed": [
+                        "raw prompt storage",
+                        "model training",
+                        "automatic skill patch",
+                        "workflow execution",
+                        "future behavior fixed",
+                        "review approval",
+                        "CI",
+                        "merge",
+                    ],
+                    "learning_flow": [
+                        "record_trace",
+                        "run_eval",
+                        "add_regression_case",
+                        "audit_readiness",
+                        "export_redacted_bundle",
+                        "human_review_improvement_candidate",
+                    ],
                 },
             )
         next_action = policy_next_action if policy_next_action and policy_next_action != "show_workflow_guidance" else "dispatch_to_workflow"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -53,6 +53,33 @@ class CliTests(unittest.TestCase):
         self.assertIn("release smoke", help_text)
         self.assertIn("memory, ops, materials, state", help_text)
 
+    def test_chat_interact_routes_workflow_learning_to_audit_actions(self) -> None:
+        status, stdout, stderr = run_cli(
+            ["chat", "interact", "--source", "discord", "learn from this workflow run"],
+            output_json=False,
+        )
+
+        self.assertEqual(status, 0, stderr)
+        self.assertEqual(stderr, "")
+        payload = json.loads(stdout)
+        self.assertEqual(payload["schema_version"], "chat_interaction/v1")
+        self.assertEqual(payload["mode"], "route")
+        self.assertEqual(payload["route"]["selected_skill"], "workflow-learning")
+        self.assertEqual(payload["next_action"], "audit_learning_readiness")
+        self.assertEqual(payload["chat_response"]["kind"], "workflow_learning")
+        self.assertEqual(payload["chat_response"]["state"]["learning_audit_card_schema"], "learning_audit_card/v1")
+        action_ids = {action["id"] for action in payload["chat_response"]["actions"]}
+        self.assertTrue(
+            {
+                "record_workflow_learning_trace",
+                "propose_skill_improvement",
+                "audit_learning_readiness",
+                "export_learning_bundle",
+                "show_status",
+            }
+            <= action_ids
+        )
+
     def test_learning_record_eval_and_regression_replay(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -158,6 +185,13 @@ class CliTests(unittest.TestCase):
             self.assertEqual(audit["coverage"]["regression_coverage_percent"], 100)
             self.assertEqual(audit["regression_replay"]["status"], "passed")
             self.assertEqual(audit["warnings"], [])
+            card = audit["learning_audit_card"]
+            self.assertEqual(card["schema_version"], "learning_audit_card/v1")
+            self.assertEqual(card["status"], "ready")
+            self.assertEqual(card["primary_action"], "audit_learning_readiness")
+            self.assertEqual(card["coverage"]["eval_coverage_percent"], 100)
+            self.assertIn("export_learning_bundle", card["wrapper_actions"])
+            self.assertIn("automatic skill patch", card["not_evidence_yet"])
             self.assertNotIn(message, json.dumps(audit))
             self.assertNotIn("safely add a feature to this repo", json.dumps(audit))
 
@@ -190,6 +224,8 @@ class CliTests(unittest.TestCase):
             self.assertEqual(stale_audit["status"], "blocked")
             self.assertEqual(stale_audit["index"]["status"], "stale")
             self.assertIn("rebuild_learning_index", {item["id"] for item in stale_audit["next_actions"]})
+            self.assertEqual(stale_audit["learning_audit_card"]["status"], "blocked")
+            self.assertEqual(stale_audit["learning_audit_card"]["primary_action"], "rebuild_learning_index")
 
             status, stdout, stderr = run_cli(base + ["learning", "index", "rebuild"])
 

--- a/tests/test_workflow_learning.py
+++ b/tests/test_workflow_learning.py
@@ -23,6 +23,7 @@ from omh.workflow_learning import (
     list_learning_traces,
     rebuild_learning_index,
     replay_regression_cases,
+    validate_learning_audit_card,
     validate_workflow_learning_trace,
     validate_workflow_learning_export,
     write_learning_trace,
@@ -382,6 +383,15 @@ class WorkflowLearningTests(unittest.TestCase):
             self.assertEqual(empty["schema_version"], "workflow_learning_audit/v1")
             self.assertEqual(empty["status"], "no_records")
             self.assertTrue(empty["ok"])
+            self.assertEqual(empty["learning_audit_card"]["schema_version"], "learning_audit_card/v1")
+            self.assertEqual(empty["learning_audit_card"]["status"], "no_records")
+            self.assertEqual(empty["learning_audit_card"]["primary_action"], "record_workflow_learning_trace")
+            self.assertEqual(empty["learning_audit_card"]["warning_count"], 0)
+            self.assertIn("record_workflow_learning_trace", empty["learning_audit_card"]["wrapper_actions"])
+            self.assertIn("propose_skill_improvement", empty["learning_audit_card"]["wrapper_actions"])
+            self.assertIn("show_status", empty["learning_audit_card"]["wrapper_actions"])
+            self.assertIn("automatic skill patch", empty["learning_audit_card"]["not_evidence_yet"])
+            validate_learning_audit_card(empty["learning_audit_card"])
 
             trace = write_learning_trace(
                 paths,
@@ -392,6 +402,11 @@ class WorkflowLearningTests(unittest.TestCase):
             self.assertEqual(attention["counts"]["traces"], 1)
             self.assertEqual(attention["coverage"]["eval_coverage_percent"], 0)
             self.assertIn("trace_without_eval", {item["id"] for item in attention["warnings"]})
+            self.assertEqual(attention["learning_audit_card"]["status"], "needs_attention")
+            self.assertEqual(attention["learning_audit_card"]["primary_action"], "show_learning_eval")
+            attention_steps = {step["id"]: step for step in attention["learning_audit_card"]["steps"]}
+            self.assertEqual(attention_steps["trace"]["state"], "ready")
+            self.assertEqual(attention_steps["eval"]["state"], "missing")
             self.assertNotIn(message, json.dumps(attention))
             self.assertNotIn("secret-token-123", json.dumps(attention))
 
@@ -410,7 +425,32 @@ class WorkflowLearningTests(unittest.TestCase):
             self.assertEqual(ready["coverage"]["regression_coverage_percent"], 100)
             self.assertEqual(ready["regression_replay"]["status"], "passed")
             self.assertEqual(ready["warnings"], [])
+            card = ready["learning_audit_card"]
+            self.assertEqual(card["schema_version"], "learning_audit_card/v1")
+            self.assertEqual(card["status"], "ready")
+            self.assertEqual(card["severity"], "ok")
+            self.assertEqual(card["primary_action"], "audit_learning_readiness")
+            self.assertEqual(card["blocking_issue_count"], 0)
+            self.assertEqual(card["warning_count"], 0)
+            self.assertEqual(card["coverage"]["eval_coverage_percent"], 100)
+            self.assertEqual(card["regression_replay"]["status"], "passed")
+            self.assertTrue(
+                {"audit_learning_readiness", "propose_skill_improvement", "export_learning_bundle", "replay_regression_cases"}
+                <= set(card["wrapper_actions"])
+            )
+            ready_steps = {step["id"]: step for step in card["steps"]}
+            self.assertEqual(ready_steps["eval"]["state"], "ready")
+            self.assertEqual(ready_steps["regression"]["state"], "ready")
+            self.assertEqual(ready_steps["export"]["state"], "ready")
+            self.assertIn("model training", card["not_evidence_yet"])
+            self.assertIn("automatic skill patch", card["not_evidence_yet"])
+            validate_learning_audit_card(card)
             self.assertNotIn("safely add a feature", json.dumps(ready))
+
+            broken_card = json.loads(json.dumps(card))
+            broken_card["primary_action"] = "missing_action"
+            with self.assertRaises(WorkflowLearningError):
+                validate_learning_audit_card(broken_card)
 
     def test_learning_audit_blocks_on_stale_index(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_wrapper_contract.py
+++ b/tests/test_wrapper_contract.py
@@ -232,6 +232,40 @@ class WrapperContractTests(unittest.TestCase):
         self.assertIn("observed status", payload["chat_response"]["body"])
         self.assertIn("not implementation", payload["chat_response"]["claim_boundary"])
 
+    def test_workflow_learning_route_exposes_audit_card_actions(self) -> None:
+        message = "learn from this workflow run"
+
+        payload = build_chat_interaction_payload(message, source="discord")
+
+        serialized = json.dumps(payload)
+        self.assertEqual(payload["mode"], "route")
+        self.assertEqual(payload["route"]["selected_skill"], "workflow-learning")
+        self.assertEqual(payload["next_action"], "audit_learning_readiness")
+        response = payload["chat_response"]
+        self.assertEqual(response["kind"], "workflow_learning")
+        self.assertEqual(response["state"]["learning_audit_card_schema"], "learning_audit_card/v1")
+        self.assertTrue(response["state"]["human_gate_required"])
+        self.assertIn("workflow_learning_trace/v1", response["state"]["artifact_schemas"])
+        self.assertIn("workflow_eval_result/v1", response["state"]["artifact_schemas"])
+        self.assertIn("regression_case/v1", response["state"]["artifact_schemas"])
+        self.assertIn("workflow_learning_export/v1", response["state"]["artifact_schemas"])
+        actions = {action["id"]: action for action in response["actions"]}
+        self.assertTrue(actions["audit_learning_readiness"]["enabled"])
+        self.assertEqual(actions["audit_learning_readiness"]["style"], "primary")
+        self.assertIn("record_workflow_learning_trace", actions)
+        self.assertIn("show_learning_eval", actions)
+        self.assertIn("propose_skill_improvement", actions)
+        self.assertIn("add_regression_case", actions)
+        self.assertIn("export_learning_bundle", actions)
+        self.assertIn("replay_regression_cases", actions)
+        self.assertIn("check_learning_index", actions)
+        self.assertIn("rebuild_learning_index", actions)
+        self.assertIn("show_status", actions)
+        self.assertIn("automatic skill patch", response["state"]["evidence_not_observed"])
+        self.assertIn("not model training", response["claim_boundary"])
+        self.assertIn("human_review_improvement_candidate", response["state"]["learning_flow"])
+        self.assertNotIn(message, serialized)
+
     def test_route_mode_exposes_visible_omh_usage_trace_for_web_research(self) -> None:
         payload = build_chat_interaction_payload(
             "web-research로 Hermes Agent와 Oh My Codex/OpenCode 계열을 비교해서 OMHM 포지셔닝 근거를 찾아줘.",


### PR DESCRIPTION
## Feature Report

### What Changed

- Added `learning_audit_card/v1` as a validated, wrapper-visible projection over `workflow_learning_audit/v1`.
- Routed `workflow-learning` recommendations and `omh chat interact` responses to a dedicated workflow-learning card with trace, eval, improvement proposal, regression, audit, export, replay, index repair, and status actions.
- Updated README and harness-quality docs to describe the workflow-learning card as human-reviewed process-improvement infrastructure, not automatic model training or skill mutation.

### Why This Exists

OMH already records metadata-only workflow traces, evals, regression cases, readiness audits, and redacted exports. The missing piece was Hermes-facing UX: when a user asks Hermes to learn from a workflow attempt, wrappers needed a compact card that says what can be reviewed, what can be replayed, and what is still not evidence.

This supports the GEPA/VPRM direction: Hermes can inspect process traces, while OMH keeps deterministic evidence boundaries and human review gates around workflow improvement.

### User / Operator Impact

- Hermes can answer workflow-learning requests with a clear card instead of falling through to generic status copy.
- Operators can see whether the learning corpus has traces, eval coverage, regression coverage, replay status, exports, index health, and next repair/review actions.
- Empty installs no longer look falsely warning-heavy: `no_records` cards show `warning_count: 0` while still showing export as a missing later step.
- Users still do not get a false claim that a model was trained, a skill was patched, a workflow executed, CI passed, or future behavior is fixed.

### How It Works

- `build_workflow_learning_audit()` now attaches a `learning_audit_card` projection.
- `build_learning_audit_card()` creates the wrapper card and immediately validates it with `validate_learning_audit_card()`.
- `workflow-learning` recommendation policy now returns `audit_learning_readiness` with explicit evidence-boundary and wrapper guidance.
- `build_chat_response_from_route()` has a dedicated `workflow_learning` response path keyed by the selected workflow, not by a reusable next-action sentinel.
- Wrapper actions now include `record_workflow_learning_trace`, `show_learning_eval`, `propose_skill_improvement`, `add_regression_case`, `audit_learning_readiness`, `export_learning_bundle`, `replay_regression_cases`, `check_learning_index`, `rebuild_learning_index`, and `show_status`.

### Files And Contracts Touched

- `src/workflow_learning.py`: `learning_audit_card/v1` builder, validator, step/status projection, empty-corpus warning handling.
- `src/routing/recommend.py`: workflow-learning recommendation policy.
- `src/wrapper/contract.py`: workflow-learning chat response and visible action alignment.
- `tests/test_workflow_learning.py`: card states, validator, privacy, empty/ready regression coverage.
- `tests/test_wrapper_contract.py`: workflow-learning route/card actions.
- `tests/test_cli.py`: `omh chat interact` and `omh learning audit` card coverage.
- `README.md`, `docs/HARNESS_QUALITY.md`: user-facing contract copy.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — 566 tests passed.
- [x] `uv run python -m compileall -q src tests` — passed.
- [x] `uv run python -m src.cli docs workflows --check` — passed, 41/41 tap skills current.
- [x] `uv run python -m src.cli harness validate` — passed, 48 skills / 34 harnesses valid.
- [ ] `python3 -m omh.cli release checklist --json` — not run; this is not a release PR.
- [ ] `python3 -m omh.cli release hermes-smoke` — not run; no live Hermes surface was available in this task.
- [ ] `omh --help` — not run; this PR does not change help/install behavior.
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` — not run; no install/smoke surface changed.
- [x] Relevant dry-run or smoke command: `uv run python -m src.cli chat interact --source discord "learn from this workflow run"` showed `workflow_learning` with `audit_learning_readiness` and card actions.
- [x] Relevant dry-run or smoke command: temp-home `uv run python -m src.cli --omh-home <tmp> --hermes-home <tmp> learning audit` showed `learning_audit_card/v1`, `warning_count: 0`, and `show_status` for no-records state.
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; this PR adds deterministic wrapper/backend contracts and local CLI smoke evidence only.

Additional review evidence:

- Independent code-reviewer lane found one LOW issue, fixed in this PR, then reported no remaining code blockers.
- Independent architect lane initially marked WATCH, fixes were applied, then marked Architectural Status: CLEAR.
- `git diff --check` passed.

## Risk

- Low to moderate contract-surface risk: wrappers may start rendering the new card, so action ids and status names need to stay stable.
- The card is intentionally a projection over audit records, not a second source of truth.
- No network, LLM, hidden executor, skill mutation, or Hermes core changes are introduced.

## Compatibility / Rollout

- Backward compatible: `workflow_learning_audit/v1` still returns existing audit fields and now includes an additional `learning_audit_card` object.
- Existing learning commands continue to behave as before.
- Wrappers can opt into the new card gradually by reading `learning_audit_card/v1` and the visible action ids.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`): local/backend contract change; release notes can mention wrapper-visible workflow-learning cards.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap.

## Follow-Up

- Add richer wrapper golden fixtures for workflow-learning cards once a real Hermes surface consumes the card.
- Consider a future human-gated candidate-apply path only after preview, review, and regression replay are separately tested.
