### PR TITLE
Add explicit worktree creator evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,8 @@ registration contracts live in the [installation guide](docs/INSTALLATION.md).
 - **Safe handoffs** - coding can go to Codex, Claude Code, Hermes, or another
   selected runtime, while OMH keeps "prepared" separate from "observed."
 - **Workspace-aware starts** - risky, parallel, or runtime-owned coding requests
-  can show Prepare worktree before Open in Codex or another coding agent.
+  can show Prepare worktree before Open in Codex or another coding agent; the
+  backend can explicitly create the local Git worktree when that button is used.
 - **Useful beyond coding** - research, planning, feedback triage, meeting prep,
   reports, automation blueprints, material packages, and loop work all have
   Hermes-facing workflow paths.
@@ -211,7 +212,7 @@ tool, an existing Hermes connector, a generic image tool, or prompt-only mode.
 | Setup and repair | `omh setup`, `omh doctor`, `omh update`, and `omh uninstall` keep the local install understandable. |
 | Chat workflow picker | Hermes can answer "what can OMH do?" without making the user approve shell commands. |
 | Coding agent paths | Hermes can prepare work for Codex, Claude Code, Hermes itself, or another runtime without pretending the work already ran. |
-| Workspace isolation | Hermes can show whether the current workspace is ok, a worktree is recommended, or a worktree is required before opening the coding agent. |
+| Workspace isolation | Hermes can show whether the current workspace is ok, recommend or require a worktree, and use `omh worktree prepare` to create the local Git worktree only when explicitly chosen. |
 | Agent ops review | Hermes can explain quality gates, blockers, next actions, and throughput levers for AI-agent work without turning a prepared handoff into evidence. |
 | Evidence-aware status | Plans, handoffs, dispatch, results, verification, review, CI, and merge readiness stay visibly separate. |
 | Workflow learning | Hermes can show learning-readiness and improvement-review cards for workflow attempts: metadata-only trace, deterministic eval, human review queue, non-applying patch proposal, regression case, audit, and export bundle. |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -369,7 +369,12 @@ worktrees were started. All coding handoff modes also include
 `worktree_session_isolation/v1`, which tells wrappers whether the current
 workspace is acceptable, an isolated worktree is recommended, or an isolated
 worktree is required before opening an executor. That record stores a compact
-snapshot of the generated
+snapshot of the generated workspace policy. When a wrapper or operator chooses
+the explicit workspace action, `omh worktree prepare` creates a local Git
+worktree and records `omh_worktree_observation/v1`; that observation is
+workspace-isolation evidence only. Runtime ladders still need a separate
+`runtime_observation/v1` `worktree_creation` event when the created worktree is
+attached to a prepared runtime handoff. The coding handoff also stores
 acceptance criteria, verification expectations, report contract, and evidence
 contract, runtime-specific invocation templates, and the
 `runtime_observation/v1` recording contract, but not the raw prompt body. With
@@ -474,9 +479,11 @@ distribution, specialist roles, team/swarm workers, worktree isolation, HUD and
 session observability, MCP/tool bridge, loop/autopilot workflow, and
 release maintenance. It is a product and operator contract, not a hidden runtime
 claim. A `partial` row means OMH has deterministic guidance, handoff metadata,
-or observation records for that axis, while the live worker, worktree, MCP tool,
-or plugin runtime event still belongs to Hermes, the selected executor, or a
-future observed integration.
+or observation records for that axis, while the live worker, executor session,
+MCP host load, or plugin runtime event still belongs to Hermes, the selected
+executor, or a future observed integration. Worktree isolation is available only
+for the explicit `omh worktree prepare/list` backend and its local
+`omh_worktree_observation/v1` ledger; it does not auto-launch an executor.
 
 ## Harness Contract
 

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -55,8 +55,8 @@ names shown below.
 ## Claim Boundary
 
 Capability presence means OMH can prepare guidance, status, or a handoff. It
-does not mean Hermes loaded a plugin, a worker ran, a worktree was created, code
-changed, review passed, CI passed, or a PR was merged.
+does not mean Hermes loaded a plugin, a worker ran, code changed, review passed,
+CI passed, or a PR was merged.
 
 Those claims require matching local wrapper or runtime artifacts such as
 `runtime_observation/v1`.
@@ -64,7 +64,10 @@ Those claims require matching local wrapper or runtime artifacts such as
 Workspace-isolation guidance uses `worktree_session_isolation/v1`. It can tell a
 wrapper to keep the same workspace, recommend a worktree, or require a worktree
 before opening a coding agent. It is still prepared guidance until a wrapper or
-runtime observes the workspace action.
+operator invokes or observes the workspace action. `omh worktree prepare` is the
+explicit opt-in backend that can create a local Git worktree and record
+`omh_worktree_observation/v1`; that record proves workspace isolation only, not
+executor dispatch, implementation, review, CI, or merge.
 
 The optional MCP bridge uses `omh mcp serve` and exposes only `omh_status`,
 `omh_recommend`, and `omh_probe`. Bridge availability is not host-load evidence,

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -400,7 +400,10 @@ autopilot, and release maintenance. Partial rows are intentional evidence
 boundaries, not failures. The worktree row includes
 `worktree_session_isolation/v1` wrapper guidance when coding handoffs need same
 workspace, recommended worktree, or required worktree status before opening a
-coding agent; it is still not proof that a Git worktree was created.
+coding agent. If a wrapper or operator chooses the explicit backend action,
+`omh worktree prepare` can create the local Git worktree and record
+`omh_worktree_observation/v1`; that still proves workspace isolation only, not
+executor dispatch or implementation.
 
 For concrete examples that show how the installed skills should affect coding,
 planning, and specialist review flows, see
@@ -706,8 +709,11 @@ Before calling the bot integration ready, verify these points:
   worker-protocol, and worktree guidance without creating a lifecycle run.
 - Coding handoffs include `worktree_session_isolation/v1` so wrappers can show
   Prepare worktree before opening an executor when risk or parallelism calls for
-  isolation. The plan remains `prepared_not_observed` until matching runtime
-  evidence exists.
+  isolation. The plan remains `prepared_not_observed` until a wrapper invokes
+  or observes the workspace action. `omh worktree prepare --repo <repo> --task
+  "<task>"` is the explicit local backend action for creating the Git worktree;
+  linked runtime ladders still require separate `runtime_observation/v1`
+  records.
 - Executor-choice, runtime-handoff, clarify, fallback, and prompt-only handoffs
   return `runtime.recorded=false`; wrappers should not expect
   `runtime.run.run_id` for those paths.

--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -39,7 +39,7 @@ implementation or claim runtime behavior it did not observe.
 | Specialist role/profile system | Available | Skill catalog metadata, operating models, optional visible profile packs, wrapper role narration, plugin `omh_role`, and `[omh-role:name]` context injection. | Observed role execution still requires wrapper or runtime evidence; role context is not a hidden live agent. |
 | Bounded evidence probe | Available | Plugin `omh_gather_evidence` runs shell-free allowlisted local probes such as doctor, harness validation, docs checks, unittest, compileall, and whitespace checks. | It is not a general shell, executor dispatch, PR review, CI, merge, or live Hermes plugin-load signal. |
 | Team, swarm, and worker protocol | Partial | `team`, `ultrawork`, runtime handoff payloads, worker-protocol guidance, wrapper sessions, and runtime observations. | OMH does not launch hidden tmux teams, spawn workers, or manage panes by itself. |
-| Worktree and project-session isolation | Partial | `worktree_session_isolation/v1` plans in coding handoffs, wrapper Prepare worktree actions, executor-session status cards, loop queue metadata, and runtime observations for worktree creation. | OMH prepares and tracks isolation intent but does not create Git worktrees in v1. |
+| Worktree and project-session isolation | Available | `worktree_session_isolation/v1` plans in coding handoffs, wrapper Prepare worktree actions, `omh worktree prepare/list`, executor-session status cards, loop queue metadata, and runtime observations for worktree creation. | OMH creates local Git worktrees only through the explicit opt-in backend command; it does not auto-launch executors or bind host sessions without wrapper/runtime evidence. |
 | HUD, status, and session observability | Available | `omh hud`, plugin `omh_hud`/`omh_status`, wrapper sessions, runtime runs, and status cards. | Live host HUD rendering depends on Hermes/plugin support. |
 | MCP and tool bridge | Available | `omh setup --with-mcp`, `omh mcp manifest`, `omh mcp serve`, `omh mcp observe-host`, and `omh probe` preference/server/runtime/host-session/host-config separation. | OMH does not auto-enable host MCP config or independently inspect live host sessions; the host or wrapper must record load/session evidence. |
 | Loop and autopilot workflow | Available | `loop`, `ultraprocess`, `ralplan`, `ultragoal`, loop queue ticks, verification tiers, and failure-mode cards. | Scheduling, connector I/O, worktree creation, and subagent execution remain prepared or delegated until observed. |
@@ -56,6 +56,11 @@ implementation or claim runtime behavior it did not observe.
 - `worktree_session_isolation/v1`, which gives coding handoffs and wrapper
   status cards a concrete same-workspace/worktree-recommended/worktree-required
   contract before any executor is opened.
+- `omh worktree prepare` and `omh worktree list`, which let wrappers or
+  operators explicitly create a local Git worktree and record
+  `omh_worktree_observation/v1` workspace-isolation evidence. That evidence is
+  still not executor dispatch, implementation, review, CI, merge-readiness, or
+  merge evidence.
 - A dependency-free stdio MCP bridge with allowlisted local `omh_status`,
   `omh_recommend`, and `omh_probe` tools plus manifest and probe evidence.
 - `omh_mcp_host_session/v1` records for host/wrapper-observed MCP bridge load
@@ -68,7 +73,7 @@ Next PR candidates:
 
 | Next PR | Why it matters |
 | --- | --- |
-| Explicit opt-in worktree creator evaluation | Only add real workspace mutation if operators want OMH to create isolated worktrees instead of delegating that to the chosen runtime. |
+| Worktree-to-executor session binding recipes | Shows wrappers how to connect an observed worktree to Codex, Claude Code, Hermes, or an oh-my runtime without auto-launching them. |
 | Host-specific MCP config recipes | Turns the manifest contract into copy-paste recipes for common MCP-capable host config shapes without auto-mutating them. |
 | Live Hermes plugin-load smoke evidence | Separates installed/importable plugin payloads from host-observed plugin runtime use. |
 
@@ -78,23 +83,27 @@ Next PR candidates:
 - `omh probe --parity` prints a human-readable parity section.
 - `omh probe --parity --json` includes `parity_matrix.schema_version` equal to
   `omh_parity_matrix/v1`.
-- Team/swarm and worktree axes are marked `partial`, not `available`, until
-  observed runtime support exists. The MCP bridge axis is `available` only for
-  the local stdio server and allowlisted tools; host-specific load/session use
-  must still be recorded through `omh_mcp_host_session/v1` before it is claimed.
+- Team/swarm worker launch remains `partial` until observed runtime support
+  exists. Worktree isolation is `available` only for explicit local Git
+  worktree creation and `omh_worktree_observation/v1` records; executor/session
+  use still needs separate runtime evidence. The MCP bridge axis is `available`
+  only for the local stdio server and allowlisted tools; host-specific
+  load/session use must still be recorded through `omh_mcp_host_session/v1`
+  before it is claimed.
 - Specialist roles are `available` only as prompt context, marker validation,
   and profile guidance. They are not hidden runtime agents.
 - Bounded evidence probes are `available` only as explicit allowlisted local
   command results. They are not executor dispatch, implementation, review, CI,
   merge, or plugin-load evidence.
-- The matrix never claims hidden worker launch, worktree creation,
+- The matrix never claims hidden worker launch, automatic worktree creation,
   unrecorded MCP host load, plugin runtime load, executor execution, review, CI,
   or merge evidence.
 
 ## Non-Goals
 
 - No hidden tmux team launcher.
-- No Git worktree creator.
+- No automatic Git worktree creator.
+- No executor launch or host-session binding from the worktree creator.
 - No arbitrary MCP shell, connector runner, or auto-enabled host config.
 - No Discord/Slack transport implementation.
 - No Hermes core patch.

--- a/docs/README.md
+++ b/docs/README.md
@@ -60,8 +60,10 @@ verification, review, CI, or merge ladder events.
 
 Coding handoffs also include `worktree_session_isolation/v1`. Hermes can show
 same workspace ok, worktree recommended, or worktree required before opening a
-coding agent, but worktree creation is still not evidence until a wrapper or
-runtime records it.
+coding agent. When a wrapper or operator chooses to proceed, `omh worktree
+prepare` can create the local Git worktree and write
+`omh_worktree_observation/v1`. That record proves workspace isolation only; the
+executor session and runtime ladder still need separate observed evidence.
 
 Executor session buttons use `executor_session/v1` records when a wrapper
 observes Open in Codex, Open in Claude Code, Attach session, Record completed,
@@ -130,7 +132,9 @@ selected.
 - Runtime and wrapper docs should preserve the separation between wrapper
   session state and run-level evidence.
 - Worktree/session isolation docs should describe `worktree_session_isolation/v1`
-  as prepared workspace guidance and wrapper UX, not as Git worktree creation.
+  as prepared workspace guidance and wrapper UX, and `omh worktree prepare` as
+  explicit opt-in Git worktree creation that records workspace-isolation
+  evidence only.
 - Workflow learning docs should state that `workflow_learning_trace/v1` records
   are metadata-only process evidence. They can feed evals, readiness audits,
   review-only improvement candidates, human-review queues, regression cases,
@@ -138,11 +142,11 @@ selected.
   automatic training, hidden skill patches, or proof that future behavior is
   fixed.
 - Parity docs should map common oh-my runtime capability axes to OMH's
-  Hermes-native evidence model instead of promising hidden workers, worktrees,
-  unrecorded MCP host load, arbitrary MCP tools, or plugin runtime load without
-  observation. The local MCP bridge may expose only allowlisted status,
-  recommendation, and probe tools; host/wrapper-observed load is recorded as
-  `omh_mcp_host_session/v1`.
+  Hermes-native evidence model instead of promising hidden workers, automatic
+  worktrees, unrecorded MCP host load, arbitrary MCP tools, or plugin runtime
+  load without observation. The local MCP bridge may expose only allowlisted
+  status, recommendation, and probe tools; host/wrapper-observed load is
+  recorded as `omh_mcp_host_session/v1`.
 - Goal execution docs should describe `.omh/goals` metadata-only ledgers,
   `goal_completion_gate/v1`, `goal_status_card/v1`, and
   `goal_continuation/v1` as wrapper contracts that name the next action before

--- a/site/docs/executor-handoff/index.html
+++ b/site/docs/executor-handoff/index.html
@@ -66,7 +66,8 @@
           Before a wrapper opens Codex, Claude Code, an oh-my runtime, or a
           Hermes coding path, OMH can prepare a
           <code>worktree_session_isolation/v1</code> plan. It keeps workspace
-          risk visible without pretending a Git worktree already exists.
+          risk visible, then lets the wrapper invoke an explicit local worktree
+          creator when isolation is selected.
         </p>
         <div class="usecase-grid">
           <article class="case-card">
@@ -77,12 +78,12 @@
           <article class="case-card">
             <span>Worktree recommended</span>
             <h3>Risky or multi-file work gets a pause.</h3>
-            <p>The first button becomes Prepare worktree, then the open action carries a workspace hint.</p>
+            <p>The first button becomes Prepare worktree; the backend can create the Git worktree before the open action.</p>
           </article>
           <article class="case-card">
             <span>Worktree required</span>
             <h3>Parallel, team, or swarm work needs isolation.</h3>
-            <p>OMH waits for wrapper or runtime evidence before treating worktree creation as observed.</p>
+            <p>OMH records worktree creation as workspace evidence only; executor progress still needs separate runtime evidence.</p>
           </article>
         </div>
       </section>

--- a/site/index.html
+++ b/site/index.html
@@ -484,7 +484,7 @@ omh setup</code>
           <article class="lifecycle-step">
             <span>04</span>
             <h3>Prepare only after acceptance</h3>
-            <p>Handoff payloads include scope, non-goals, acceptance criteria, verification, and review expectations.</p>
+            <p>Handoff payloads include scope, acceptance criteria, verification, review expectations, and optional worktree preparation.</p>
           </article>
           <article class="lifecycle-step">
             <span>05</span>
@@ -695,6 +695,7 @@ omh setup</code>
               <span class="pill">chat_interaction/v1</span>
               <span class="pill">chat_response/v1</span>
               <span class="pill">status_card/v1</span>
+              <span class="pill">omh_worktree_observation/v1</span>
               <span class="pill">harness_quality/v1</span>
               <span class="pill">harness_progress/v1</span>
             </div>

--- a/src/commands/main.py
+++ b/src/commands/main.py
@@ -132,6 +132,7 @@ from .setup import (
 from .state import _add_state_commands, cmd_state_clear, cmd_state_finish, cmd_state_start, cmd_state_status
 from .use_cases import _add_cases_commands, cmd_cases_inspect, cmd_cases_list, cmd_cases_recommend
 from .visual import _add_visual_commands, cmd_visual_observe, cmd_visual_prompt_card
+from .worktree import cmd_worktree_list, cmd_worktree_prepare, _add_worktree_commands
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -167,6 +168,7 @@ def build_parser() -> argparse.ArgumentParser:
             "  omh materials list\n"
             "  omh img-summary prompt-card --kind github_pr --visual-format auto --section summary:What_changed:Safer_setup_copy\n"
             "  omh img-summary prompt-card --kind report --aspect-ratio long_scroll --section summary:Executive_summary:Weekly_metrics_changed\n"
+            "  omh worktree prepare --repo . --task \"risky refactor\" --dry-run\n"
             "  omh runtime status\n\n"
             "Human-facing maintenance, catalog, and operator checklist commands print summaries by default;\n"
             "pass --json or set OMH_OUTPUT=json when a wrapper needs full payloads.\n"
@@ -205,6 +207,7 @@ def build_parser() -> argparse.ArgumentParser:
     _add_ops_commands(sub)
     _add_materials_commands(sub)
     _add_visual_commands(sub)
+    _add_worktree_commands(sub)
     _add_runtime_commands(sub)
     _add_goal_commands(sub)
     _add_state_commands(sub)
@@ -245,6 +248,7 @@ Useful operator commands:
   omh ops list           List local operations artifacts
   omh materials list     List material-processing artifacts
   omh img-summary prompt-card Prepare image-generation-ready summary cards
+  omh worktree prepare --repo . --task "risky refactor" --dry-run
   omh runtime status     Show local evidence artifacts
 
 After setup, restart or reload Hermes Agent and try:

--- a/src/commands/worktree.py
+++ b/src/commands/worktree.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import argparse
+
+from ..installer import OmhError
+from ..worktree_creator import list_worktree_records, prepare_git_worktree
+from .common import _paths, _print_json
+
+
+def cmd_worktree_prepare(args: argparse.Namespace) -> int:
+    try:
+        payload = prepare_git_worktree(
+            _paths(args),
+            repo=args.repo,
+            task=args.task or "",
+            branch=args.branch or "",
+            worktree_path=args.path,
+            base_dir=args.base_dir,
+            from_ref=args.from_ref,
+            dry_run=args.dry_run,
+            allow_dirty_source=args.allow_dirty_source,
+        )
+    except ValueError as exc:
+        raise OmhError(str(exc)) from exc
+    _print_json({"worktree": payload})
+    return 1 if payload["status"] == "blocked" else 0
+
+
+def cmd_worktree_list(args: argparse.Namespace) -> int:
+    if args.limit < 1:
+        raise OmhError("--limit must be at least 1")
+    records, errors = list_worktree_records(_paths(args), limit=args.limit)
+    _print_json(
+        {
+            "schema_version": "omh_worktree_observations/v1",
+            "records": records,
+            "errors": errors,
+            "claim_boundary": (
+                "OMH worktree records are workspace-isolation evidence only. They do not prove executor "
+                "dispatch, implementation, verification, review, CI, merge-readiness, or merge."
+            ),
+        }
+    )
+    return 0
+
+
+def _add_worktree_commands(sub) -> None:
+    worktree = sub.add_parser("worktree", help="Prepare opt-in Git worktrees for isolated coding handoffs.")
+    worktree_sub = worktree.add_subparsers(dest="worktree_command", required=True)
+
+    prepare = worktree_sub.add_parser(
+        "prepare",
+        help="Create an explicit Git worktree and record local workspace-isolation evidence.",
+    )
+    prepare.add_argument("--repo", required=True, help="Existing Git repository/worktree to isolate from.")
+    prepare.add_argument("--task", default="", help="Short task label used for the default branch name.")
+    prepare.add_argument("--branch", default="", help="Branch name for the new worktree. Defaults to omh/<task>-<timestamp>.")
+    prepare.add_argument("--path", default=None, help="Absolute or relative destination path for the new worktree.")
+    prepare.add_argument("--base-dir", default=".worktrees", help="Default worktree parent when --path is omitted.")
+    prepare.add_argument("--from-ref", default="HEAD", help="Starting ref for git worktree add.")
+    prepare.add_argument("--dry-run", action="store_true", help="Show the git worktree command without writing files.")
+    prepare.add_argument(
+        "--allow-dirty-source",
+        action="store_true",
+        help="Allow creating from a source worktree with uncommitted changes; dirty changes are not copied.",
+    )
+    prepare.set_defaults(func=cmd_worktree_prepare)
+
+    listing = worktree_sub.add_parser("list", help="List recent OMH worktree preparation records.")
+    listing.add_argument("--limit", type=int, default=20)
+    listing.set_defaults(func=cmd_worktree_list)

--- a/src/parity.py
+++ b/src/parity.py
@@ -87,13 +87,13 @@ PARITY_CAPABILITIES: tuple[ParityCapability, ...] = (
         id="worktree_isolation",
         title="Worktree and project-session isolation",
         common_pattern="Use isolated workspaces so parallel agents can work without stepping on each other's files.",
-        omh_surface="`worktree_session_isolation/v1` plans inside coding handoffs, wrapper Prepare worktree actions, executor-session status cards, loop queue metadata, and runtime observations for worktree creation.",
-        status="partial",
-        evidence=("src/isolation.py", "src/coding_delegation.py", "src/wrapper/executor_sessions.py", "src/runtime/records.py", "tests/test_wrapper_sessions.py"),
-        missing_piece="OMH prepares and tracks workspace-isolation intent, but it does not create Git worktrees or bind host agent sessions directly.",
-        v1_decision="Show the Prepare worktree action, workspace hint, and status card step before any optional creator command exists.",
+        omh_surface="`worktree_session_isolation/v1` plans inside coding handoffs, wrapper Prepare worktree actions, `omh worktree prepare/list`, executor-session status cards, loop queue metadata, and runtime observations for worktree creation.",
+        status="available",
+        evidence=("src/isolation.py", "src/worktree_creator.py", "src/commands/worktree.py", "src/wrapper/executor_sessions.py", "tests/test_worktree_creator.py"),
+        missing_piece="OMH can explicitly create a local Git worktree, but it does not auto-launch executors or bind host agent sessions without wrapper/runtime evidence.",
+        v1_decision="Make worktree mutation explicit and opt-in: the wrapper may show Prepare worktree, and the backend can create the Git worktree only when invoked.",
         user_value="Teams see when same workspace is acceptable, when an isolated worktree is recommended, and when it is required before opening a coding agent.",
-        claim_boundary="A worktree plan is not a created worktree; only runtime observation can mark it observed.",
+        claim_boundary="A worktree plan is not a created worktree; an OMH-created worktree is workspace-isolation evidence only, not executor dispatch or implementation evidence.",
     ),
     ParityCapability(
         id="hud_session_observability",
@@ -171,9 +171,9 @@ def build_parity_matrix(probe_payload: dict[str, object] | None = None) -> dict[
                 "why": "Separates installed/importable plugin payloads from host-observed plugin runtime use.",
             },
             {
-                "id": "worktree-creator-opt-in",
-                "title": "Evaluate explicit opt-in worktree creator support",
-                "why": "Only add real workspace mutation if operators want OMH to create isolated worktrees instead of delegating that to the chosen runtime.",
+                "id": "worktree-session-binding-guides",
+                "title": "Add worktree-to-executor session binding recipes",
+                "why": "Shows wrappers how to connect an observed worktree to Codex, Claude Code, Hermes, or an oh-my runtime without auto-launching them.",
             },
             {
                 "id": "mcp-host-config-guides",
@@ -183,7 +183,7 @@ def build_parity_matrix(probe_payload: dict[str, object] | None = None) -> dict[
         ],
         "claim_boundary": (
             "The parity matrix is a product and operator contract. It does not claim hidden worker launch, "
-            "worktree creation, host-observed MCP load, plugin runtime load, executor execution, review, CI, or merge evidence."
+            "automatic worktree creation, host-observed MCP load, plugin runtime load, executor execution, review, CI, or merge evidence."
         ),
     }
 
@@ -205,6 +205,7 @@ def _probe_alignment(probe_payload: dict[str, object]) -> dict[str, object]:
         "mcp_bridge_runtime": by_name.get("mcp_bridge_runtime", "unknown"),
         "mcp_host_session": by_name.get("mcp_host_session", "unknown"),
         "mcp_host_config": by_name.get("mcp_host_config", "unknown"),
+        "worktree_creator": by_name.get("worktree_creator", "unknown"),
         "target_topology": by_name.get("target_topology", "unknown"),
         "wrapper_metadata": by_name.get("wrapper_metadata", "unknown"),
     }

--- a/src/paths.py
+++ b/src/paths.py
@@ -39,6 +39,10 @@ class OmhPaths:
         return self.runtime_dir / "mcp_host_sessions.jsonl"
 
     @property
+    def runtime_worktrees_path(self) -> Path:
+        return self.runtime_dir / "worktrees.jsonl"
+
+    @property
     def operations_dir(self) -> Path:
         return self.omh_home / "operations"
 

--- a/src/probe.py
+++ b/src/probe.py
@@ -120,6 +120,15 @@ def _mcp_bridge_server_capability() -> Capability:
     )
 
 
+def _worktree_creator_capability() -> Capability:
+    return Capability(
+        "worktree_creator",
+        "available",
+        "omh worktree prepare; omh worktree list",
+        "OMH can explicitly create local Git worktrees and record omh_worktree_observation/v1 workspace-isolation evidence",
+    )
+
+
 def _mcp_bridge_runtime_capability(paths: OmhPaths) -> Capability:
     state, error = read_state_result(paths)
     evidence = str(paths.runtime_state_path)
@@ -251,6 +260,7 @@ def probe_capabilities(paths: OmhPaths, *, include_parity: bool = False) -> dict
     mcp_markers = [paths.hermes_home / ".mcp.json", paths.hermes_home / "mcp.json"]
     capabilities.append(_mcp_preference_capability(paths))
     capabilities.append(_mcp_bridge_server_capability())
+    capabilities.append(_worktree_creator_capability())
     capabilities.append(_mcp_bridge_runtime_capability(paths))
     mcp_host_session = _mcp_host_session_capability(paths)
     capabilities.append(mcp_host_session)

--- a/src/worktree_creator.py
+++ b/src/worktree_creator.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from .local_store import ensure_dir, ensure_file, read_jsonl_objects, utc_now
+from .paths import OmhPaths, expand_path
+from .runtime.artifacts import update_state
+
+WORKTREE_PREPARE_SCHEMA_VERSION = "omh_worktree_prepare/v1"
+WORKTREE_OBSERVATION_SCHEMA_VERSION = "omh_worktree_observation/v1"
+
+WORKTREE_CLAIM_BOUNDARY = (
+    "An OMH-created Git worktree is observed workspace-isolation evidence only. "
+    "It is not executor dispatch, implementation, verification, review, CI, merge-readiness, or merge evidence."
+)
+
+RUNTIME_OBSERVATION_FOLLOWUP = {
+    "schema_version": "runtime_observation_followup/v1",
+    "event_type": "worktree_creation",
+    "record_with": (
+        "omh runtime observe --run <run-id> --runtime-profile <runtime-profile> --event worktree_creation "
+        "--status observed --worktree-ref <worktree_path> --evidence-ref git-worktree:<worktree_path>"
+    ),
+    "when": "Only when this worktree belongs to a prepared runtime or executor session that needs ladder evidence.",
+    "boundary": "The local worktree ledger is workspace-isolation evidence; runtime ladder evidence remains a separate wrapper/operator observation.",
+}
+
+
+def prepare_git_worktree(
+    paths: OmhPaths,
+    *,
+    repo: str | Path,
+    task: str = "",
+    branch: str = "",
+    worktree_path: str | Path | None = None,
+    base_dir: str | Path = ".worktrees",
+    from_ref: str = "HEAD",
+    dry_run: bool = False,
+    allow_dirty_source: bool = False,
+) -> dict[str, Any]:
+    repo_root = _repo_root(repo)
+    status_text = _git(repo_root, "status", "--porcelain", check=True).stdout.strip()
+    source_dirty = bool(status_text)
+    if source_dirty and not allow_dirty_source:
+        return _blocked_result(
+            paths,
+            repo_root=repo_root,
+            task=task,
+            branch=branch,
+            worktree_path=worktree_path,
+            base_dir=base_dir,
+            from_ref=from_ref,
+            reason="source_dirty",
+            message="Source worktree has uncommitted changes; rerun with --allow-dirty-source if this is intentional.",
+        )
+
+    resolved_branch = _branch_name(branch, task)
+    resolved_path = _worktree_path(repo_root, resolved_branch, worktree_path=worktree_path, base_dir=base_dir)
+    command = ["git", "-C", str(repo_root), "worktree", "add", "-b", resolved_branch, str(resolved_path), from_ref]
+    base_payload = {
+        "schema_version": WORKTREE_PREPARE_SCHEMA_VERSION,
+        "repo_root": str(repo_root),
+        "branch": resolved_branch,
+        "worktree_path": str(resolved_path),
+        "from_ref": from_ref,
+        "source_dirty": source_dirty,
+        "command": command,
+        "claim_boundary": WORKTREE_CLAIM_BOUNDARY,
+        "runtime_observation_followup": RUNTIME_OBSERVATION_FOLLOWUP,
+    }
+    if dry_run:
+        return {
+            **base_payload,
+            "status": "dry_run",
+            "observed": False,
+            "created": False,
+            "evidence_refs": [],
+            "next_action": "rerun_without_dry_run_to_create_worktree",
+        }
+    if resolved_path.exists():
+        return _blocked_result(
+            paths,
+            repo_root=repo_root,
+            task=task,
+            branch=resolved_branch,
+            worktree_path=resolved_path,
+            base_dir=base_dir,
+            from_ref=from_ref,
+            reason="path_exists",
+            message=f"Worktree path already exists: {resolved_path}",
+        )
+
+    completed = _git(repo_root, "worktree", "add", "-b", resolved_branch, str(resolved_path), from_ref, check=False)
+    if completed.returncode != 0:
+        return {
+            **base_payload,
+            "status": "blocked",
+            "observed": False,
+            "created": False,
+            "reason": "git_worktree_add_failed",
+            "stderr": completed.stderr.strip(),
+            "stdout": completed.stdout.strip(),
+            "evidence_refs": [],
+            "next_action": "inspect_git_error_before_opening_executor",
+        }
+
+    evidence_refs = [f"git-worktree:{resolved_path}", f"git-branch:{resolved_branch}"]
+    record = {
+        **base_payload,
+        "status": "created",
+        "observed": True,
+        "created": True,
+        "evidence_refs": evidence_refs,
+        "stdout": completed.stdout.strip(),
+        "stderr": completed.stderr.strip(),
+        "recorded_at": utc_now(),
+        "next_action": "open_executor_in_worktree_or_record_runtime_observation",
+    }
+    _append_worktree_record(paths, _observation_record(record))
+    update_state(paths, {"last_worktree_prepare": record})
+    return record
+
+
+def list_worktree_records(paths: OmhPaths, *, limit: int = 20) -> tuple[list[dict[str, Any]], list[str]]:
+    records, errors = read_jsonl_objects(paths.runtime_worktrees_path)
+    return list(reversed(records))[:limit], errors
+
+
+def _blocked_result(
+    paths: OmhPaths,
+    *,
+    repo_root: Path,
+    task: str,
+    branch: str,
+    worktree_path: str | Path | None,
+    base_dir: str | Path,
+    from_ref: str,
+    reason: str,
+    message: str,
+) -> dict[str, Any]:
+    resolved_branch = _branch_name(branch, task)
+    resolved_path = _worktree_path(repo_root, resolved_branch, worktree_path=worktree_path, base_dir=base_dir)
+    record = {
+        "schema_version": WORKTREE_PREPARE_SCHEMA_VERSION,
+        "status": "blocked",
+        "observed": False,
+        "created": False,
+        "repo_root": str(repo_root),
+        "branch": resolved_branch,
+        "worktree_path": str(resolved_path),
+        "from_ref": from_ref,
+        "reason": reason,
+        "message": message,
+        "evidence_refs": [],
+        "recorded_at": utc_now(),
+        "claim_boundary": WORKTREE_CLAIM_BOUNDARY,
+        "runtime_observation_followup": RUNTIME_OBSERVATION_FOLLOWUP,
+        "next_action": "resolve_blocker_before_opening_executor",
+    }
+    _append_worktree_record(paths, _observation_record(record))
+    update_state(paths, {"last_worktree_prepare": record})
+    return record
+
+
+def _observation_record(result: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "schema_version": WORKTREE_OBSERVATION_SCHEMA_VERSION,
+        "status": result["status"],
+        "observed": result["observed"],
+        "created": result["created"],
+        "repo_root": result["repo_root"],
+        "branch": result["branch"],
+        "worktree_path": result["worktree_path"],
+        "from_ref": result["from_ref"],
+        "evidence_refs": result["evidence_refs"],
+        "reason": result.get("reason", ""),
+        "message": result.get("message", ""),
+        "recorded_at": result.get("recorded_at", utc_now()),
+        "claim_boundary": WORKTREE_CLAIM_BOUNDARY,
+    }
+
+
+def _append_worktree_record(paths: OmhPaths, record: dict[str, Any]) -> None:
+    ensure_dir(paths.runtime_dir, private=True)
+    ensure_file(paths.runtime_worktrees_path, private=True)
+    with paths.runtime_worktrees_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record, sort_keys=True) + "\n")
+
+
+def _repo_root(repo: str | Path) -> Path:
+    repo_path = expand_path(repo)
+    completed = _git(repo_path, "rev-parse", "--show-toplevel", check=False)
+    if completed.returncode != 0:
+        raise ValueError(f"not a Git worktree: {repo_path}")
+    return expand_path(completed.stdout.strip())
+
+
+def _branch_name(branch: str, task: str) -> str:
+    if branch.strip():
+        return branch.strip()
+    slug = re.sub(r"[^a-z0-9]+", "-", task.lower()).strip("-")[:42].strip("-")
+    stamp = utc_now().replace(":", "").replace("-", "").lower()
+    return f"omh/{slug or 'worktree'}-{stamp}"
+
+
+def _worktree_path(repo_root: Path, branch: str, *, worktree_path: str | Path | None, base_dir: str | Path) -> Path:
+    if worktree_path:
+        return expand_path(worktree_path)
+    base = Path(base_dir)
+    if not base.is_absolute():
+        base = repo_root / base
+    safe_branch = re.sub(r"[^a-zA-Z0-9._-]+", "-", branch).strip("-") or "worktree"
+    return expand_path(base / safe_branch)
+
+
+def _git(cwd: Path, *args: str, check: bool) -> subprocess.CompletedProcess[str]:
+    completed = subprocess.run(
+        ["git", "-C", str(cwd), *args],
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if check and completed.returncode != 0:
+        raise ValueError(completed.stderr.strip() or completed.stdout.strip() or "git command failed")
+    return completed

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -690,19 +690,20 @@ class CliTests(unittest.TestCase):
             payload = json.loads(stdout)
             matrix = payload["parity_matrix"]
             self.assertEqual(matrix["schema_version"], "omh_parity_matrix/v1")
-            self.assertGreaterEqual(matrix["summary"]["available"], 4)
-            self.assertGreaterEqual(matrix["summary"]["partial"], 2)
+            self.assertGreaterEqual(matrix["summary"]["available"], 5)
+            self.assertGreaterEqual(matrix["summary"]["partial"], 1)
             capabilities = {item["id"]: item for item in matrix["capabilities"]}
             self.assertEqual(capabilities["skill_plugin_distribution"]["status"], "available")
             self.assertEqual(capabilities["team_swarm_workers"]["status"], "partial")
-            self.assertEqual(capabilities["worktree_isolation"]["status"], "partial")
+            self.assertEqual(capabilities["worktree_isolation"]["status"], "available")
             self.assertEqual(capabilities["mcp_tool_bridge"]["status"], "available")
             self.assertIn("not worker dispatch", capabilities["team_swarm_workers"]["claim_boundary"])
-            self.assertIn("not a created worktree", capabilities["worktree_isolation"]["claim_boundary"])
+            self.assertIn("workspace-isolation evidence only", capabilities["worktree_isolation"]["claim_boundary"])
             self.assertEqual(matrix["probe_alignment"]["managed_skills"], "available")
             self.assertEqual(matrix["probe_alignment"]["omh_plugin_bundle"], "available")
             self.assertEqual(matrix["probe_alignment"]["mcp_bridge_server"], "available")
             self.assertEqual(matrix["probe_alignment"]["mcp_host_session"], "unverified")
+            self.assertEqual(matrix["probe_alignment"]["worktree_creator"], "available")
             self.assertIn("does not claim hidden worker launch", matrix["claim_boundary"])
 
             status, stdout, stderr = run_cli(base + ["probe", "--parity"], output_json=False)
@@ -712,7 +713,7 @@ class CliTests(unittest.TestCase):
             self.assertIn("OMH capability probe", stdout)
             self.assertIn("Parity matrix", stdout)
             self.assertIn("Team, swarm, and worker protocol: partial", stdout)
-            self.assertIn("Worktree and project-session isolation: partial", stdout)
+            self.assertIn("Worktree and project-session isolation: available", stdout)
             self.assertIn("For machine-readable output, rerun with `--json`.", stdout)
             with self.assertRaises(json.JSONDecodeError):
                 json.loads(stdout)

--- a/tests/test_worktree_creator.py
+++ b/tests/test_worktree_creator.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from _cli_harness import run_cli
+
+
+class WorktreeCreatorTests(unittest.TestCase):
+    def test_worktree_prepare_dry_run_does_not_create_path(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo = _init_repo(root / "repo")
+            target = root / "worktrees" / "dry"
+
+            status, stdout, stderr = run_cli(
+                [
+                    "--omh-home",
+                    str(root / ".omh"),
+                    "worktree",
+                    "prepare",
+                    "--repo",
+                    str(repo),
+                    "--task",
+                    "risky refactor",
+                    "--path",
+                    str(target),
+                    "--dry-run",
+                ]
+            )
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            payload = json.loads(stdout)["worktree"]
+            self.assertEqual(payload["schema_version"], "omh_worktree_prepare/v1")
+            self.assertEqual(payload["status"], "dry_run")
+            self.assertFalse(payload["observed"])
+            self.assertFalse(target.exists())
+            self.assertIn("git", payload["command"][0])
+            self.assertEqual(payload["runtime_observation_followup"]["event_type"], "worktree_creation")
+
+    def test_worktree_prepare_creates_git_worktree_and_records_ledger(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo = _init_repo(root / "repo")
+            target = root / "worktrees" / "risky"
+            home = root / ".omh"
+
+            status, stdout, stderr = run_cli(
+                [
+                    "--omh-home",
+                    str(home),
+                    "worktree",
+                    "prepare",
+                    "--repo",
+                    str(repo),
+                    "--task",
+                    "risky refactor",
+                    "--branch",
+                    "omh/risky-refactor-test",
+                    "--path",
+                    str(target),
+                ]
+            )
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0, stdout)
+            payload = json.loads(stdout)["worktree"]
+            self.assertEqual(payload["status"], "created")
+            self.assertTrue(payload["observed"])
+            self.assertTrue(payload["created"])
+            self.assertTrue((target / ".git").exists() or (target / ".git").is_file())
+            self.assertIn(f"git-worktree:{target.resolve()}", payload["evidence_refs"])
+            self.assertIn("not executor dispatch", payload["claim_boundary"])
+            self.assertIn("omh runtime observe", payload["runtime_observation_followup"]["record_with"])
+            worktree_list = _git(repo, "worktree", "list", "--porcelain")
+            self.assertIn(str(target), worktree_list.stdout)
+
+            status, stdout, stderr = run_cli(["--omh-home", str(home), "worktree", "list", "--limit", "1"])
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            records = json.loads(stdout)["records"]
+            self.assertEqual(records[0]["schema_version"], "omh_worktree_observation/v1")
+            self.assertTrue(records[0]["created"])
+
+    def test_worktree_prepare_blocks_dirty_source_by_default(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo = _init_repo(root / "repo")
+            (repo / "dirty.txt").write_text("dirty\n", encoding="utf-8")
+
+            status, stdout, stderr = run_cli(
+                [
+                    "--omh-home",
+                    str(root / ".omh"),
+                    "worktree",
+                    "prepare",
+                    "--repo",
+                    str(repo),
+                    "--task",
+                    "risky refactor",
+                    "--path",
+                    str(root / "worktrees" / "blocked"),
+                ]
+            )
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 1)
+            payload = json.loads(stdout)["worktree"]
+            self.assertEqual(payload["status"], "blocked")
+            self.assertEqual(payload["reason"], "source_dirty")
+            self.assertFalse(payload["created"])
+
+
+def _init_repo(path: Path) -> Path:
+    path.mkdir(parents=True)
+    _git(path, "init")
+    (path / "README.md").write_text("# temp\n", encoding="utf-8")
+    _git(path, "add", "README.md")
+    _git(path, "-c", "user.name=OMH Test", "-c", "user.email=omh@example.com", "commit", "-m", "init")
+    return path
+
+
+def _git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    completed = subprocess.run(
+        ["git", "-C", str(cwd), *args],
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if completed.returncode != 0:
+        raise AssertionError(completed.stderr or completed.stdout)
+    return completed
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- Added `omh worktree prepare` and `omh worktree list` as explicit backend commands for local Git worktree preparation.
- Added `omh_worktree_prepare/v1` and `omh_worktree_observation/v1` payloads, plus a runtime-observation follow-up hint for wrapper-owned ladder evidence.
- Updated `omh probe --parity`, capability probe output, README, docs, and site copy so worktree isolation is now an available opt-in workspace surface instead of only prepared guidance.

### Why This Exists

OMH already told Hermes wrappers when a coding request should use a same workspace, recommended worktree, or required worktree path. The missing slice was a deterministic local backend action that could actually create that Git worktree when a wrapper rendered Prepare worktree. Without this, the UX had a visible action but no OMH-owned local workspace evidence path.

### User / Operator Impact

- A wrapper can show Prepare worktree, call `omh worktree prepare`, then open Codex, Claude Code, Hermes, or another runtime in the created workspace.
- Operators can inspect recent workspace-isolation records with `omh worktree list`.
- Status remains honest: created worktree evidence does not become executor dispatch, implementation, review, CI, merge readiness, or merge evidence.

### How It Works

- `src/worktree_creator.py` resolves the source repository, blocks dirty source worktrees by default, builds an `omh/<task>-<timestamp>` branch/path when omitted, runs `git worktree add`, and appends metadata-only records under `.omh/runtime/worktrees.jsonl`.
- `src/commands/worktree.py` exposes the CLI subcommands and keeps blocked results nonzero while dry-runs stay side-effect-free.
- `src/probe.py` and `src/parity.py` report the explicit worktree creator separately from team/swarm worker launch or executor runtime evidence.

### Files And Contracts Touched

- `src/worktree_creator.py`, `src/commands/worktree.py`, `src/paths.py`, `src/commands/main.py`
- `src/probe.py`, `src/parity.py`
- `tests/test_worktree_creator.py`, `tests/test_cli.py`
- `README.md`, `docs/`, and `site/` worktree/parity copy

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m src.cli docs workflows --check`
- [x] `uv run python -m src.cli harness validate`
- [ ] `python3 -m omh.cli release checklist --json` (not run; this PR changes worktree backend/docs, not release packaging claims)
- [ ] `python3 -m omh.cli release hermes-smoke` (not run; no live Hermes profile mutation in this PR)
- [ ] `omh --help` (covered by CLI unittest/help paths and package build, not manual installed command smoke)
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` (not run; no live install smoke requested for this slice)
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable
- [x] Relevant dry-run or smoke command: `omh worktree prepare --repo <temp repo> --task "risky refactor" --dry-run` covered by `tests/test_worktree_creator.py`
- [x] Manual Hermes/TUI check, or explicit reason it was not run: not run because this PR ships local backend commands and wrapper contract copy only; live wrapper invocation remains host-owned.

Additional observed checks:

- [x] `uv build`
- [x] `git diff --check`

## Risk

- Moderate: this adds an actual local Git mutation path. The command blocks dirty source worktrees by default, supports dry-run, requires explicit invocation, and writes only metadata records under the configured OMH runtime directory.

## Compatibility / Rollout

- Existing `worktree_session_isolation/v1`, coding handoff, loop, and runtime observation contracts remain compatible.
- `omh probe --parity` now marks worktree isolation as available only for explicit local worktree creation; team/swarm worker launch remains partial.
- Wrappers should still record separate `runtime_observation/v1` events when a created worktree is attached to a runtime handoff.

## Release / Claims

- [x] Release-channel impact considered: preview/local backend feature until included in a release.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] Known manual Hermes checks are listed: live Hermes wrapper invocation was not run.

## Follow-Up

- Add wrapper recipes that bind an observed worktree to Codex, Claude Code, Hermes, or an oh-my runtime launch without auto-launching executors.
