### PR TITLE
Fix uninstall command package detection

### DIFF
--- a/src/installer.py
+++ b/src/installer.py
@@ -165,11 +165,11 @@ def _collect_command_package_removal(
     if venv_dir is None:
         kept.append({"path": "omh", "reason": "HOME is not available, so the install.sh-managed command venv cannot be located"})
         return
-    executable = Path(sys.executable).expanduser().resolve()
-    if not _is_relative_to(executable, venv_dir):
+    executable = Path(sys.executable).expanduser()
+    if not _is_relative_to_without_resolving_symlinks(executable, venv_dir):
         kept.append(
             {
-                "path": str(executable),
+                "path": str(executable.resolve()),
                 "reason": "current omh command is not running from the install.sh-managed OMH venv",
             }
         )
@@ -271,3 +271,16 @@ def _is_relative_to(path: Path, parent: Path) -> bool:
     except ValueError:
         return False
     return True
+
+
+def _is_relative_to_without_resolving_symlinks(path: Path, parent: Path) -> bool:
+    try:
+        _normalize_without_final_symlink(path).relative_to(_normalize_without_final_symlink(parent))
+    except ValueError:
+        return False
+    return True
+
+
+def _normalize_without_final_symlink(path: Path) -> Path:
+    expanded = path.expanduser()
+    return expanded.parent.resolve() / expanded.name

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5433,6 +5433,40 @@ class CliTests(unittest.TestCase):
             self.assertFalse(fake_link.exists())
             self.assertFalse(fake_venv.exists())
 
+    def test_uninstall_detects_managed_command_package_when_venv_python_resolves_outside(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / ".omh"
+            hermes_home = root / ".hermes"
+            fake_venv = root / "venv"
+            fake_venv_bin = fake_venv / "bin"
+            fake_venv_bin.mkdir(parents=True)
+            external_python = root / "external" / "python3.14"
+            external_python.parent.mkdir()
+            external_python.write_text("# fake external python\n", encoding="utf-8")
+            fake_python = fake_venv_bin / "python"
+            fake_python.symlink_to(external_python)
+            fake_omh = fake_venv_bin / "omh"
+            fake_omh.write_text("# fake omh\n", encoding="utf-8")
+            fake_bin = root / "bin"
+            fake_bin.mkdir()
+            fake_link = fake_bin / "omh"
+            fake_link.symlink_to(fake_omh)
+            base = ["--omh-home", str(omh_home), "--hermes-home", str(hermes_home)]
+
+            self.assertEqual(run_cli(base + ["setup"])[0], 0)
+            env = {**os.environ, "OMH_VENV_DIR": str(fake_venv), "OMH_BIN_DIR": str(fake_bin)}
+            with patch.dict(os.environ, env, clear=True), patch.object(sys, "executable", str(fake_python)):
+                status, stdout, stderr = run_cli(base + ["uninstall", "--dry-run"])
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            preview = json.loads(stdout)
+            self.assertIn(str(fake_link), preview["command_package_would_remove"])
+            self.assertIn(str(fake_venv.resolve()), preview["command_package_would_remove"])
+            self.assertEqual(preview["command_package"]["status"], "would_remove")
+            self.assertFalse(preview["command_package"]["kept"])
+
     def test_setup_and_chat_detect_persisted_hermes_target_topology_drift(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## Feature Report

### What Changed

- Fixed `omh uninstall` command package detection for macOS/Homebrew-style virtualenvs where the final `python` symlink resolves outside the managed OMH venv.
- Added a regression test that models an install.sh-managed venv whose `bin/python` points at an external interpreter.

### Why This Exists

- Real `omh uninstall --dry-run` could incorrectly say the command package was not install.sh-managed even when `/Users/rlaope/.local/bin/omh` pointed into `/Users/rlaope/.local/share/omh/venv`.
- The false negative happened because uninstall resolved `sys.executable` all the way to the Homebrew Python target before checking whether it lived under the managed OMH venv.

### User / Operator Impact

- `omh uninstall --dry-run` can now show the actual install.sh-managed command paths that would be removed, including the `omh` link and managed venv.
- Operators get a safer preview before destructive uninstall because the command package is no longer hidden behind a misleading "not running from install.sh-managed venv" message.

### How It Works

- `src/installer.py` now checks the executable path without resolving the final symlink, matching the existing update/runtime detection behavior.
- The kept-path diagnostic still resolves the executable for the non-managed case, so pip/pipx or unrelated Python installs remain conservatively protected.

### Files And Contracts Touched

- `src/installer.py`: command package removal detection helper.
- `tests/test_cli.py`: uninstall regression coverage for symlinked venv Python.
- Public contract preserved: `omh_uninstall/v1` and `command_package_status/v1` shape is unchanged; only the status classification changes from false `kept` to `would_remove`/`removed` when the command package is install.sh-managed.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `git diff --check`
- [x] Relevant dry-run or smoke command: `PYTHONPATH=. /Users/rlaope/.local/share/omh/venv/bin/python -m omh.cli uninstall --dry-run`
- [ ] `python3 -m omh.cli docs workflows --check` - not run; generated docs/workflows were not changed.
- [ ] `python3 -m omh.cli harness validate` - not run; harness contracts were not changed.
- [ ] `python3 -m omh.cli release checklist --json` - not run; release checklist was outside this uninstall detection fix.
- [ ] `python3 -m omh.cli release hermes-smoke` - not run; Hermes live smoke was outside this local command-package fix.
- [ ] `omh --help` - not run; command help was not changed.
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` - not run; release smoke was outside this fix.
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; this change affects local uninstall detection only.

## Risk

- Low. The change only broadens install.sh-managed command package detection for venv executable symlinks while keeping non-managed commands protected.

## Compatibility / Rollout

- Existing uninstall JSON schema is unchanged.
- Existing full cleanup, registration-only cleanup, and unmanaged command-package behavior remain covered by tests.
- Users get the improved behavior after updating the installed command package from a release or main installer/update path.

## Release / Claims

- [x] Release-channel impact considered (`preview` once merged to main; stable when released).
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap.

## Follow-Up

- None for this fix.
