### PR TITLE
Fix setup keyboard menu repaint

### DIFF
--- a/src/commands/setup.py
+++ b/src/commands/setup.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 import argparse
 import os
 from pathlib import Path
+import re
+import shutil
 import subprocess
 import sys
 import time
+import unicodedata
 
 try:
     import termios
@@ -55,6 +58,7 @@ DOCTOR_SUMMARY_SCHEMA_VERSION = "doctor_summary/v1"
 MCP_SETUP_SCHEMA_VERSION = "omh_mcp_setup/v1"
 SELF_UPDATE_REENTRY_ENV = "OMH_UPDATE_COMMAND_PACKAGE_REENTERED"
 SELF_UPDATE_SKIP_ENV = "OMH_SKIP_COMMAND_PACKAGE_UPDATE"
+ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
 
 
 def cmd_install(args: argparse.Namespace) -> int:
@@ -1221,7 +1225,7 @@ def _keyboard_single_choice(
     language: str = "en",
 ) -> str:
     cursor = _default_choice_index(options, default_choice)
-    rendered_lines = 0
+    rendered_rows = 0
     while True:
         lines = _choice_menu_lines(
             title,
@@ -1232,11 +1236,11 @@ def _keyboard_single_choice(
             use_color=use_color,
             language=language,
         )
-        if rendered_lines:
-            sys.stdout.write(f"\033[{rendered_lines}F\033[J")
+        if rendered_rows:
+            sys.stdout.write(f"\033[{rendered_rows}F\033[J")
         sys.stdout.write("\n".join(lines) + "\n")
         sys.stdout.flush()
-        rendered_lines = len(lines)
+        rendered_rows = _rendered_terminal_rows(lines)
         key = _read_tui_key()
         if key in {"\x03", "\x04"}:
             raise KeyboardInterrupt
@@ -1279,6 +1283,30 @@ def _choice_menu_lines(
         if option["description"]:
             lines.append(f"      {option['description']}")
     return lines
+
+
+def _rendered_terminal_rows(lines: list[str], columns: int | None = None) -> int:
+    if columns is None:
+        columns = shutil.get_terminal_size((80, 24)).columns
+    columns = max(1, columns)
+    rows = 0
+    for line in lines:
+        width = _visible_text_width(line)
+        rows += max(1, (width + columns - 1) // columns)
+    return rows
+
+
+def _visible_text_width(text: str) -> int:
+    visible = ANSI_ESCAPE_RE.sub("", text)
+    width = 0
+    for character in visible:
+        if unicodedata.combining(character):
+            continue
+        category = unicodedata.category(character)
+        if category in {"Cc", "Cf"}:
+            continue
+        width += 2 if unicodedata.east_asian_width(character) in {"F", "W"} else 1
+    return width
 
 
 def _default_choice_index(options: list[dict[str, str]], default_choice: str) -> int:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import io
 import json
 import os
 import subprocess
@@ -5683,6 +5684,56 @@ class CliTests(unittest.TestCase):
         self.assertIn("  1) Ask every time (recommended)", rendered)
         self.assertNotIn("[x]", rendered)
         self.assertNotIn("[ ]", rendered)
+
+    def test_setup_choice_menu_counts_wrapped_terminal_rows(self) -> None:
+        from omh.commands.setup import _rendered_terminal_rows, _visible_text_width
+
+        self.assertEqual(_visible_text_width("\033[1;36mCodex\033[0m"), 5)
+        self.assertEqual(_visible_text_width("설정"), 4)
+        lines = [
+            "\033[1;36mDefault coding agent\033[0m",
+            "  This option description is intentionally long enough to wrap.",
+            "  설정",
+        ]
+
+        self.assertEqual(_rendered_terminal_rows(lines, columns=20), 6)
+
+    def test_setup_keyboard_menu_repaints_using_wrapped_terminal_rows(self) -> None:
+        options = [
+            {"choice": "1", "value": "codex", "label": "Codex", "description": "Short."},
+            {
+                "choice": "2",
+                "value": "hermes",
+                "label": "Hermes",
+                "description": "This option description is intentionally long enough to wrap.",
+            },
+        ]
+        lines = setup_commands._choice_menu_lines(
+            "Default coding agent",
+            ["Choose who Hermes should suggest for coding work."],
+            options,
+            0,
+            default_choice="1",
+            use_color=False,
+        )
+        expected_rows = setup_commands._rendered_terminal_rows(lines, columns=20)
+        output = io.StringIO()
+
+        with (
+            patch.object(setup_commands.shutil, "get_terminal_size", return_value=os.terminal_size((20, 24))),
+            patch.object(setup_commands, "_read_tui_key", side_effect=["\x1b[B", "\n"]),
+            patch.object(setup_commands.sys, "stdout", output),
+        ):
+            value = setup_commands._keyboard_single_choice(
+                "Default coding agent",
+                ["Choose who Hermes should suggest for coding work."],
+                options,
+                default_choice="1",
+                use_color=False,
+            )
+
+        self.assertEqual(value, "hermes")
+        self.assertIn(f"\033[{expected_rows}F\033[J", output.getvalue())
 
     def test_setup_executor_copy_uses_simple_coding_agent_names(self) -> None:
         from omh.commands.language import tr


### PR DESCRIPTION
## Feature Report

### What Changed

- Fixed the interactive `omh setup` keyboard menu repaint logic so arrow-key navigation uses rendered terminal rows instead of plain Python line count.
- Added tests for wrapped menu text, ANSI-colored labels, CJK-width text, and the actual repaint escape sequence used by the setup keyboard menu.

### Why This Exists

- In narrow terminals or multilingual setup copy, option descriptions can wrap across multiple visible terminal rows.
- The setup menu previously moved the cursor up by `len(lines)`, which under-counted wrapped rows and made the menu drift or appear to slowly scroll when pressing the up/down arrow keys.

### User / Operator Impact

- `omh setup` keyboard navigation should feel stable instead of pushing text around when option descriptions wrap.
- Korean/Japanese/Chinese terminal copy is handled more accurately because wide characters count as two terminal columns.

### How It Works

- `src/commands/setup.py` now strips ANSI escape codes, computes visible terminal width with stdlib Unicode width metadata, and counts rows against the current terminal column width.
- `_keyboard_single_choice` stores the rendered row count and uses that when moving back up before clearing/repainting the menu.

### Files And Contracts Touched

- `src/commands/setup.py`: setup keyboard menu repaint calculation.
- `tests/test_cli.py`: regression coverage for wrapped rows and repaint cursor movement.
- No JSON schema, setup payload, workflow, or Hermes contract changes.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `git diff --check`
- [x] Relevant dry-run or smoke command: `PYTHONPATH=. uv run python -m src.cli --omh-home /tmp/... --hermes-home /tmp/... --scope user setup --interactive --dry-run --language en`
- [ ] `python3 -m omh.cli docs workflows --check` - not run; generated docs/workflows were not changed.
- [ ] `python3 -m omh.cli harness validate` - not run; harness contracts were not changed.
- [ ] `python3 -m omh.cli release checklist --json` - not run; release checklist was outside this terminal repaint fix.
- [ ] `python3 -m omh.cli release hermes-smoke` - not run; Hermes live smoke was outside this terminal repaint fix.
- [ ] `omh --help` - not run; command help was not changed.
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` - not run; release smoke was outside this fix.
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: no exact recording in the user's terminal emulator; behavior is covered by row-count and repaint-sequence tests plus a dry-run setup smoke.

## Risk

- Low. The change affects only the interactive setup menu repaint calculation. Non-interactive setup, JSON output, setup payloads, and generated skills are unchanged.

## Compatibility / Rollout

- No CLI flags or schemas changed.
- Existing fallback number-entry mode remains available when TUI is unavailable or `OMH_NO_TUI=1` is set.

## Release / Claims

- [x] Release-channel impact considered (`preview` once merged to main; stable when released).
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap.

## Follow-Up

- None for this fix.
