### PR TITLE
Improve chat-first routing quality guards

### DIFF
--- a/src/routing/policy.py
+++ b/src/routing/policy.py
@@ -401,6 +401,111 @@ _MISSED_WORKFLOW_OPERATING_RECORD_TOKENS = _normalized_token_set(
         "기록",
     }
 )
+_PRODUCT_SHAPING_PHRASES = (
+    "where to start",
+    "do not know where to start",
+    "don't know where to start",
+    "dont know where to start",
+    "not sure where to start",
+    "improve our onboarding",
+    "improve onboarding",
+    "make onboarding smoother",
+    "make onboarding feel smoother",
+    "make the user experience smoother",
+    "make the product experience better",
+    "온보딩을 더 부드럽게",
+    "온보딩 개선",
+    "어디서 시작",
+    "어디부터 시작",
+)
+_PRODUCT_SHAPING_CONTEXT_TOKENS = _normalized_token_set(
+    {
+        "onboarding",
+        "activation",
+        "conversion",
+        "funnel",
+        "ux",
+        "product",
+        "feature",
+        "experience",
+        "customer",
+        "user",
+        "users",
+        "온보딩",
+        "제품",
+        "기능",
+        "사용자",
+        "고객",
+        "경험",
+    }
+)
+_PRODUCT_SHAPING_UNCERTAINTY_TOKENS = _normalized_token_set(
+    {
+        "improve",
+        "improvement",
+        "better",
+        "smoother",
+        "smooth",
+        "start",
+        "where",
+        "unclear",
+        "vague",
+        "fuzzy",
+        "unknown",
+        "개선",
+        "부드럽게",
+        "어디",
+        "시작",
+        "모호",
+    }
+)
+_WORKFLOW_LEARNING_PHRASES = (
+    "learn from this workflow",
+    "learn from this workflow run",
+    "learn from this run",
+    "improve the skill next time",
+    "improve this skill next time",
+    "improve routing next time",
+    "make a regression case",
+    "add a regression case",
+    "why did this route",
+    "record why this request",
+    "future workflow behavior",
+    "workflow should learn",
+    "hermes should learn",
+    "이번 실행 학습",
+    "이번 워크플로우 학습",
+    "다음에 스킬 개선",
+    "라우팅 회귀",
+    "회귀 케이스",
+)
+_WORKFLOW_LEARNING_CONTEXT_TOKENS = _normalized_token_set(
+    {
+        "learn",
+        "learning",
+        "workflow",
+        "run",
+        "trace",
+        "skill",
+        "routing",
+        "route",
+        "regression",
+        "eval",
+        "audit",
+        "improve",
+        "improvement",
+        "candidate",
+        "next",
+        "future",
+        "학습",
+        "스킬",
+        "워크플로우",
+        "라우팅",
+        "회귀",
+        "개선",
+        "실행",
+    }
+)
 _EXECUTOR_RUNTIME_READINESS_PHRASES = (
     "executor-runtime-readiness",
     "runtime readiness",
@@ -982,6 +1087,24 @@ FEEDBACK_BEFORE_CODING_GUARD = RoutingGuardRule(
     why="Product feedback and bug reports should get triage/investigation before coding handoff.",
     activation_status="cataloged",
 )
+PRODUCT_SHAPING_GUARD = RoutingGuardRule(
+    id="product_shaping_before_ops_review",
+    rule="Fuzzy product, onboarding, UX, or growth-shaping requests should start with deep interview before ops/status review.",
+    matched_label="guard:product_shaping",
+    preferred_skills=("deep-interview",),
+    score_boost=30,
+    why="Matched guard/trigger metadata; fuzzy product-shaping requests need one clarifying interview before plan or execution.",
+    activation_status="active",
+)
+WORKFLOW_LEARNING_GUARD = RoutingGuardRule(
+    id="workflow_learning_before_skill_management",
+    rule="Requests to learn from a workflow, improve a skill next time, or add routing regressions should route to workflow-learning before generic skill management.",
+    matched_label="guard:workflow_learning",
+    preferred_skills=("workflow-learning",),
+    score_boost=34,
+    why="Matched guard/trigger metadata; workflow improvement requests should become a learning trace, review candidate, or regression instead of generic skill management.",
+    activation_status="active",
+)
 WEB_RESEARCH_BEFORE_PROCESS_GUARD = RoutingGuardRule(
     id="web_research_before_process",
     rule="Plain web/source/current-evidence requests should route to web research before one-cycle delivery.",
@@ -1138,6 +1261,8 @@ RESEARCH_DEPARTMENT_GUARD = RoutingGuardRule(
 ROUTING_GUARD_RULES = (
     RISKY_REFACTOR_GUARD,
     FEEDBACK_BEFORE_CODING_GUARD,
+    PRODUCT_SHAPING_GUARD,
+    WORKFLOW_LEARNING_GUARD,
     RESEARCH_DEPARTMENT_GUARD,
     SCHEDULED_OPS_BLUEPRINT_GUARD,
     WEB_RESEARCH_BEFORE_PROCESS_GUARD,
@@ -1197,6 +1322,10 @@ def active_routing_guard_rules(
     rules: list[RoutingGuardRule] = []
     if _risky_refactor_guard_applies(normalized_query, query_tokens):
         rules.append(RISKY_REFACTOR_GUARD)
+    if _product_shaping_guard_applies(normalized_query, query_tokens):
+        rules.append(PRODUCT_SHAPING_GUARD)
+    if _workflow_learning_guard_applies(normalized_query, query_tokens):
+        rules.append(WORKFLOW_LEARNING_GUARD)
     delivery_cycle_applies = _delivery_cycle_guard_applies(normalized_query, query_tokens)
     research_department_applies = (
         not delivery_cycle_applies and _research_department_guard_applies(normalized_query, query_tokens)
@@ -1250,6 +1379,29 @@ def _risky_refactor_guard_applies(normalized_query: str, query_tokens: set[str])
     if _RISKY_REFACTOR_TOKENS & query_tokens:
         return True
     return _contains_phrase(normalized_query, _RISKY_REFACTOR_RISK_PHRASES)
+
+
+def _product_shaping_guard_applies(normalized_query: str, query_tokens: set[str]) -> bool:
+    if _delivery_cycle_terms(normalized_query, query_tokens):
+        return False
+    if _contains_phrase(normalized_query, _PRODUCT_SHAPING_PHRASES):
+        return True
+    product_context = bool(_PRODUCT_SHAPING_CONTEXT_TOKENS & query_tokens)
+    shaping_uncertainty = bool(_PRODUCT_SHAPING_UNCERTAINTY_TOKENS & query_tokens)
+    return product_context and shaping_uncertainty
+
+
+def _workflow_learning_guard_applies(normalized_query: str, query_tokens: set[str]) -> bool:
+    if _contains_phrase(normalized_query, _WORKFLOW_LEARNING_PHRASES):
+        return True
+    learning = bool({"learn", "learning", "학습"} & query_tokens)
+    workflow_or_skill = bool({"workflow", "run", "trace", "skill", "routing", "route", "워크플로우", "스킬", "라우팅"} & query_tokens)
+    future_improvement = bool({"improve", "improvement", "next", "future", "regression", "개선", "회귀"} & query_tokens)
+    if learning and workflow_or_skill:
+        return True
+    if future_improvement and workflow_or_skill and bool(_WORKFLOW_LEARNING_CONTEXT_TOKENS & query_tokens):
+        return True
+    return False
 
 
 def _scheduled_ops_blueprint_guard_applies(normalized_query: str, query_tokens: set[str]) -> bool:

--- a/src/routing/recommend.py
+++ b/src/routing/recommend.py
@@ -48,6 +48,8 @@ _GUARDRAIL_CANDIDATE_INJECTION_IDS = frozenset(
         "img_summary_before_materials_or_delivery",
         "missed_workflow_research_recovery",
         "missed_workflow_operating_record_recovery",
+        "product_shaping_before_ops_review",
+        "workflow_learning_before_skill_management",
     }
 )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2392,6 +2392,34 @@ class CliTests(unittest.TestCase):
                 self.assertIn(boundary_fragment, top["evidence_boundary"])
                 self.assertIn(wrapper_fragment, top["wrapper_guidance"].lower())
 
+    def test_recommend_chat_first_quality_guards_route_common_operator_intent(self) -> None:
+        cases = (
+            (
+                "I need to improve our onboarding but I don't know where to start",
+                "deep-interview",
+                "ask_clarification",
+                "guard:product_shaping",
+            ),
+            (
+                "I want Hermes to learn from this workflow and improve the skill next time",
+                "workflow-learning",
+                "audit_learning_readiness",
+                "guard:workflow_learning",
+            ),
+        )
+
+        for message, skill, next_action, guard_label in cases:
+            with self.subTest(message=message):
+                status, stdout, stderr = run_cli(["recommend", message, "--limit", "3"])
+
+                self.assertEqual(stderr, "")
+                self.assertEqual(status, 0)
+                top = json.loads(stdout)["recommendations"][0]
+                self.assertEqual(top["skill"], skill)
+                self.assertEqual(top["confidence"], "high")
+                self.assertEqual(top["next_action"], next_action)
+                self.assertIn(guard_label, top["matched"])
+
     def test_recommend_material_processing_routes_to_materials_package(self) -> None:
         cases = (
             "엑셀로 매출 리포트 만들고 PDF로 공유해줘",
@@ -2998,6 +3026,12 @@ class CliTests(unittest.TestCase):
             ("이거 위험한 리팩터링 같아", "ralplan", "plan", "present_plan"),
             ("AI가 했다고 했는데 실제로 뭐 했는지 모르겠다", "code-review", "ack", "prepare_review_or_followup_handoff"),
             ("온보딩을 더 부드럽게 만들고 싶어", "deep-interview", "clarification", "answer_clarification"),
+            (
+                "I need to improve our onboarding but I don't know where to start",
+                "deep-interview",
+                "clarification",
+                "answer_clarification",
+            ),
             ("릴리즈 전에 README claim이 실제 코드와 맞는가, doctor/harness가 통과하는가 봐줘", "code-review", "ack", "prepare_review_or_followup_handoff"),
             ("위험 분석, 변경 범위 제한, 테스트 전략, Codex 구현, 리뷰, 회귀 테스트로 리팩터링 표준화해줘", "ai-slop-cleaner", "plan", "present_plan"),
             ("지금은 Hermes가 답할 차례인지, coding handoff를 준비할 차례인지, review gate를 열 차례인지 정리해줘", "plan", "plan", "present_plan"),
@@ -3020,6 +3054,12 @@ class CliTests(unittest.TestCase):
             ("Claude Code로 넘길지 Codex로 넘길지 정해줘", "executor-runtime-readiness", "ack", "prepare_executor_runtime_readiness"),
             ("우리 팀 Hermes agent 여러 명이 같이 일할 때 역할과 보드를 잡아줘", "agent-board", "ack", "prepare_agent_board_card"),
             ("릴리즈 전에 README 주장과 실제 기능이 맞는지 검토해줘", "code-review", "ack", "prepare_review_or_followup_handoff"),
+            (
+                "I want Hermes to learn from this workflow and improve the skill next time",
+                "workflow-learning",
+                "workflow_learning",
+                "audit_learning_readiness",
+            ),
         )
 
         for message, selected_skill, response_kind, next_action in cases:

--- a/tests/test_wrapper_contract.py
+++ b/tests/test_wrapper_contract.py
@@ -233,57 +233,62 @@ class WrapperContractTests(unittest.TestCase):
         self.assertIn("not implementation", payload["chat_response"]["claim_boundary"])
 
     def test_workflow_learning_route_exposes_audit_card_actions(self) -> None:
-        message = "learn from this workflow run"
-
-        payload = build_chat_interaction_payload(message, source="discord")
-
-        serialized = json.dumps(payload)
-        self.assertEqual(payload["mode"], "route")
-        self.assertEqual(payload["route"]["selected_skill"], "workflow-learning")
-        self.assertEqual(payload["next_action"], "audit_learning_readiness")
-        response = payload["chat_response"]
-        self.assertEqual(response["kind"], "workflow_learning")
-        self.assertEqual(response["state"]["learning_audit_card_schema"], "learning_audit_card/v1")
-        self.assertTrue(response["state"]["human_gate_required"])
-        self.assertIn("workflow_learning_trace/v1", response["state"]["artifact_schemas"])
-        self.assertIn("workflow_eval_result/v1", response["state"]["artifact_schemas"])
-        self.assertIn("improvement_candidate/v1", response["state"]["artifact_schemas"])
-        self.assertIn("improvement_candidate_review_card/v1", response["state"]["artifact_schemas"])
-        self.assertIn("improvement_patch_proposal/v1", response["state"]["artifact_schemas"])
-        self.assertIn("workflow_learning_review_queue/v1", response["state"]["artifact_schemas"])
-        self.assertIn("regression_case/v1", response["state"]["artifact_schemas"])
-        self.assertIn("workflow_learning_export/v1", response["state"]["artifact_schemas"])
-        self.assertEqual(
-            response["state"]["learning_review_queue_schema"],
-            "workflow_learning_review_queue/v1",
+        messages = (
+            "learn from this workflow run",
+            "I want Hermes to learn from this workflow and improve the skill next time",
         )
-        self.assertEqual(
-            response["state"]["improvement_candidate_review_card_schema"],
-            "improvement_candidate_review_card/v1",
-        )
-        actions = {action["id"]: action for action in response["actions"]}
-        self.assertTrue(actions["audit_learning_readiness"]["enabled"])
-        self.assertEqual(actions["audit_learning_readiness"]["style"], "primary")
-        self.assertIn("record_workflow_learning_trace", actions)
-        self.assertIn("show_learning_review_queue", actions)
-        self.assertIn("show_learning_eval", actions)
-        self.assertIn("propose_skill_improvement", actions)
-        self.assertIn("review_improvement", actions)
-        self.assertIn("prepare_patch_proposal", actions)
-        self.assertIn("show_patch_proposal", actions)
-        self.assertIn("copy_patch_handoff", actions)
-        self.assertIn("add_regression_case", actions)
-        self.assertIn("export_learning_bundle", actions)
-        self.assertIn("replay_regression_cases", actions)
-        self.assertIn("check_learning_index", actions)
-        self.assertIn("rebuild_learning_index", actions)
-        self.assertIn("show_status", actions)
-        self.assertIn("automatic skill patch", response["state"]["evidence_not_observed"])
-        self.assertIn("not model training", response["claim_boundary"])
-        self.assertIn("review_queue", response["state"]["learning_flow"])
-        self.assertIn("prepare_patch_proposal", response["state"]["learning_flow"])
-        self.assertIn("human_review_improvement_candidate", response["state"]["learning_flow"])
-        self.assertNotIn(message, serialized)
+
+        for message in messages:
+            with self.subTest(message=message):
+                payload = build_chat_interaction_payload(message, source="discord")
+
+                serialized = json.dumps(payload)
+                self.assertEqual(payload["mode"], "route")
+                self.assertEqual(payload["route"]["selected_skill"], "workflow-learning")
+                self.assertEqual(payload["next_action"], "audit_learning_readiness")
+                response = payload["chat_response"]
+                self.assertEqual(response["kind"], "workflow_learning")
+                self.assertEqual(response["state"]["learning_audit_card_schema"], "learning_audit_card/v1")
+                self.assertTrue(response["state"]["human_gate_required"])
+                self.assertIn("workflow_learning_trace/v1", response["state"]["artifact_schemas"])
+                self.assertIn("workflow_eval_result/v1", response["state"]["artifact_schemas"])
+                self.assertIn("improvement_candidate/v1", response["state"]["artifact_schemas"])
+                self.assertIn("improvement_candidate_review_card/v1", response["state"]["artifact_schemas"])
+                self.assertIn("improvement_patch_proposal/v1", response["state"]["artifact_schemas"])
+                self.assertIn("workflow_learning_review_queue/v1", response["state"]["artifact_schemas"])
+                self.assertIn("regression_case/v1", response["state"]["artifact_schemas"])
+                self.assertIn("workflow_learning_export/v1", response["state"]["artifact_schemas"])
+                self.assertEqual(
+                    response["state"]["learning_review_queue_schema"],
+                    "workflow_learning_review_queue/v1",
+                )
+                self.assertEqual(
+                    response["state"]["improvement_candidate_review_card_schema"],
+                    "improvement_candidate_review_card/v1",
+                )
+                actions = {action["id"]: action for action in response["actions"]}
+                self.assertTrue(actions["audit_learning_readiness"]["enabled"])
+                self.assertEqual(actions["audit_learning_readiness"]["style"], "primary")
+                self.assertIn("record_workflow_learning_trace", actions)
+                self.assertIn("show_learning_review_queue", actions)
+                self.assertIn("show_learning_eval", actions)
+                self.assertIn("propose_skill_improvement", actions)
+                self.assertIn("review_improvement", actions)
+                self.assertIn("prepare_patch_proposal", actions)
+                self.assertIn("show_patch_proposal", actions)
+                self.assertIn("copy_patch_handoff", actions)
+                self.assertIn("add_regression_case", actions)
+                self.assertIn("export_learning_bundle", actions)
+                self.assertIn("replay_regression_cases", actions)
+                self.assertIn("check_learning_index", actions)
+                self.assertIn("rebuild_learning_index", actions)
+                self.assertIn("show_status", actions)
+                self.assertIn("automatic skill patch", response["state"]["evidence_not_observed"])
+                self.assertIn("not model training", response["claim_boundary"])
+                self.assertIn("review_queue", response["state"]["learning_flow"])
+                self.assertIn("prepare_patch_proposal", response["state"]["learning_flow"])
+                self.assertIn("human_review_improvement_candidate", response["state"]["learning_flow"])
+                self.assertNotIn(message, serialized)
 
     def test_route_mode_exposes_visible_omh_usage_trace_for_web_research(self) -> None:
         payload = build_chat_interaction_payload(


### PR DESCRIPTION
## Feature Report

### What Changed

- Added a product-shaping routing guard so fuzzy onboarding/product/UX requests start with `deep-interview` instead of drifting into broad agent-ops/status routing.
- Added a workflow-learning routing guard so requests like "learn from this workflow and improve the skill next time" route to `workflow-learning` instead of generic `skill` management.
- Allowed both guards to inject recommendation candidates, so `omh recommend` and Hermes chat routing stay aligned.
- Added regression coverage for recommend, chat interaction, and wrapper workflow-learning actions.

### Why This Exists

- Live local routing checks showed two chat-first usability failures:
  - `I need to improve our onboarding but I don't know where to start` clarified against `agent-ops-review` because the broad `where` trigger won.
  - `I want Hermes to learn from this workflow and improve the skill next time` selected the generic `skill` surface because `skill` keyword matching outranked workflow learning intent.
- These are exactly the kinds of natural Hermes messages OMH should understand without requiring users to know workflow names.

### User / Operator Impact

- Product-shaping requests now get a one-question `deep-interview` path before planning or execution claims.
- Workflow improvement requests now expose the learning card actions: record trace, run eval, add regression, audit readiness, review candidate, and prepare patch proposal.
- The fix keeps existing broad catalog triggers intact for other contexts while making common operator intent route correctly.

### How It Works

- `src/routing/policy.py` adds deterministic phrase/token guards for product shaping and workflow learning.
- `src/routing/recommend.py` permits the new guards to inject candidates when a phrase would otherwise be too weak or would be beaten by broad keyword matches.
- `tests/test_cli.py` locks both `recommend` and `chat interact` behavior.
- `tests/test_wrapper_contract.py` verifies the stronger workflow-learning phrase still produces the full learning action card without storing raw prompts.

### Files And Contracts Touched

- `src/routing/policy.py`
- `src/routing/recommend.py`
- `tests/test_cli.py`
- `tests/test_wrapper_contract.py`

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — 585 tests passed.
- [x] `uv run python -m compileall -q src tests` — passed.
- [x] `uv run python -m src.cli docs workflows --check` — passed; 41/41 tap skills checked.
- [ ] `python3 -m omh.cli harness validate` — not run; routing-only change covered by full unittest suite and docs workflow check.
- [ ] `python3 -m omh.cli release checklist --json` — not run; no release metadata change.
- [ ] `python3 -m omh.cli release hermes-smoke` — not run; no install path change.
- [ ] `omh --help` — not run; no help text change.
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` — not run; no setup path change.
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not run; this PR changes routing to the existing workflow-learning card, not learning persistence internals.
- [x] Relevant dry-run or smoke command: `uv run python -m src.cli chat interact "I need to improve our onboarding but I don't know where to start"`; `uv run python -m src.cli chat interact "I want Hermes to learn from this workflow and improve the skill next time"`; matching `omh recommend` JSON checks.
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; deterministic routing policy only.

## Risk

- Product-shaping guard could route some broad product requests to clarification before plan. This is intentional for fuzzy requests and suppressed when delivery-cycle terms are present.
- Workflow-learning guard could beat generic skill management when the user says both `skill` and `learn/improve`; this is intentional because the user is asking for workflow improvement rather than inventory.

## Compatibility / Rollout

- Backward compatible with existing routing payload schemas.
- Existing broad `skill`, `agent-ops-review`, and other catalog triggers remain available.
- No migration or setup change required.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- Continue expanding the chat-first regression corpus as real Hermes usage reveals more natural-language misses.
