### PR TITLE
Add OMH awareness route hints

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -147,7 +147,12 @@ OMH directly when Hermes taps are available.
 `omh_hud` tool, a detailed metadata-only `omh_status` tool, an `omh_role` role
 context tool, a bounded `omh_gather_evidence` local verification probe, and
 passive lifecycle hooks for bounded status context, role marker validation, and
-metadata-only session-end checkpointing. `omh hud`
+metadata-only session-end checkpointing. The `pre_llm_call` hook can also add
+`omh_route_hint/v1` for messages that look like planning, research, ops,
+materials, visual summary, automation, workflow-learning, or coding-handoff
+work. That hint carries only hash/length metadata, matched cue labels, candidate
+workflow names, next actions, and boundaries; it does not include the raw user
+message or prove a workflow executed. `omh hud`
 exposes the same status-line payload for local operator smoke tests. The HUD
 line stays limited to version, plugin bridge readiness, target topology, current
 or default coding agent, and evidence state. Host-supplied token metadata

--- a/docs/CHAT_WRAPPER_EXAMPLES.md
+++ b/docs/CHAT_WRAPPER_EXAMPLES.md
@@ -93,6 +93,30 @@ responses also include `omh_capability_summary/v1`, so Hermes can summarize the
 larger lanes, representative playbooks, and evidence boundary before or beside
 the picker.
 
+## Plugin Route Hints
+
+When the optional OMH plugin bridge is loaded, `pre_llm_call` can add a bounded
+`omh_route_hint/v1` context block for messages that look like workflow-shaped
+work. The hint does not include the raw user message. It carries only message
+hash/length metadata, matched cue labels, a candidate workflow, adjacent
+workflows, the next action, and the same prepared-vs-observed boundary.
+
+Example effect:
+
+```text
+User
+make an image explaining the cron feature
+
+Hermes Agent
+[OMH Route Hint]
+- workflow=img-summary; lane=materials_and_visuals; next_action=prepare_visual_prompt_card
+- workflow=automation-blueprint; lane=automation_and_status; next_action=prepare_scheduled_ops_blueprint
+```
+
+The wrapper still owns rendering and state recording. The route hint is prompt
+context only; it is not workflow execution, image generation, scheduled job
+creation, review, CI, or delivery evidence.
+
 ## Missed OMH Route Capture
 
 If Hermes or the user says a response did not use the expected OMH workflow, the

--- a/src/capabilities/hooks.py
+++ b/src/capabilities/hooks.py
@@ -42,6 +42,7 @@ def hook_manifest() -> dict[str, object]:
         "prepared_is_not": PREPARED_NOT_OBSERVED,
         "source_refs": [
             "src/plugin_bundle/omh/metadata.py",
+            "src/plugin_bundle/omh/awareness.py",
             "src/plugin_bundle/omh/plugin.yaml",
             "src/plugin_bundle/omh/__init__.py",
             "src/wrapper/contract.py",
@@ -64,7 +65,7 @@ def _wrapper_event(name: str, payload_fields: tuple[str, ...]) -> dict[str, obje
 
 def _hook_payload_fields(name: str) -> list[str]:
     if name == "pre_llm_call":
-        return ["omh_awareness_primer", "bounded_status_context", "redacted"]
+        return ["omh_awareness_primer", "omh_route_hint", "bounded_status_context", "redacted"]
     if name == "pre_tool_call":
         return ["tool_name", "claim_boundary"]
     if name == "on_session_end":

--- a/src/plugin_bundle/omh/awareness.py
+++ b/src/plugin_bundle/omh/awareness.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import hashlib
 import re
 import unicodedata
 
 OMH_AWARENESS_SCHEMA_VERSION = "omh_awareness/v1"
+OMH_ROUTE_HINT_SCHEMA_VERSION = "omh_route_hint/v1"
 ROUTER_KEYWORD_SKILLS = (
     "deep-interview",
     "ralplan",
@@ -228,6 +230,146 @@ _AWARENESS_TOKEN_MARKERS = frozenset(
         "material",
     }
 )
+_ROUTE_HINT_RULES = (
+    {
+        "id": "visual_summary",
+        "workflow": "img-summary",
+        "lane": "materials_and_visuals",
+        "next_action": "prepare_visual_prompt_card",
+        "reason": "The user is asking for an image card, infographic, poster, or shareable visual summary.",
+        "phrases": (
+            "image card",
+            "summary card",
+            "infographic",
+            "poster",
+            "visual one-pager",
+            "shareable visual",
+            "generate image",
+            "image summary",
+            "이미지",
+            "포스터",
+            "요약 카드",
+            "공유용 카드",
+            "画像",
+            "海报",
+            "海報",
+        ),
+        "tokens": ("image", "infographic", "poster", "visual"),
+        "adjacent_workflows": ("materials-package", "report-package"),
+    },
+    {
+        "id": "missed_workflow",
+        "workflow": "workflow-learning",
+        "lane": "automation_and_status",
+        "next_action": "audit_learning_readiness",
+        "reason": "The user is reporting that OMH or the expected workflow was not used.",
+        "phrases": (
+            "missed route",
+            "missed workflow",
+            "did not use omh",
+            "omh was not used",
+            "omx was not used",
+            "not use omh",
+            "omh 안 썼어",
+            "omh 안 썼",
+            "워크플로 누락",
+            "라우팅 누락",
+        ),
+        "tokens": ("missed",),
+        "adjacent_workflows": ("doctor", "agent-ops-review"),
+    },
+    {
+        "id": "customer_signal",
+        "workflow": "feedback-triage",
+        "lane": "research_and_ops",
+        "next_action": "classify_signal_and_prepare_investigation",
+        "reason": "The user is describing customer feedback, bugs, issues, or product signals that need triage before implementation.",
+        "phrases": (
+            "customer feedback",
+            "payment failure",
+            "payment failures",
+            "bug report",
+            "issue triage",
+            "user feedback",
+            "결제 실패",
+            "고객 피드백",
+            "버그",
+            "이슈",
+            "피드백",
+        ),
+        "tokens": ("feedback", "bug", "issue", "triage"),
+        "adjacent_workflows": ("web-research", "github-event-ops", "coding handoff"),
+    },
+    {
+        "id": "scheduled_ops",
+        "workflow": "automation-blueprint",
+        "lane": "automation_and_status",
+        "next_action": "prepare_scheduled_ops_blueprint",
+        "reason": "The user is asking for recurring, scheduled, cron-like, or digest-style work.",
+        "phrases": (
+            "every morning",
+            "every day",
+            "daily digest",
+            "weekly digest",
+            "cron",
+            "scheduled",
+            "recurring",
+            "매일",
+            "매주",
+            "자동화",
+            "스케줄",
+        ),
+        "tokens": ("cron", "schedule", "scheduled", "recurring", "digest"),
+        "adjacent_workflows": ("research-department", "ops-observability-card"),
+    },
+    {
+        "id": "source_research",
+        "workflow": "web-research",
+        "lane": "research_and_ops",
+        "next_action": "gather_source_backed_evidence",
+        "reason": "The user is asking for current, source-backed, market, competitor, paper, or news research.",
+        "phrases": (
+            "web search",
+            "best practice",
+            "competitor",
+            "market research",
+            "latest news",
+            "source-backed",
+            "paper",
+            "논문",
+            "리서치",
+            "검색",
+            "시장 조사",
+            "경쟁사",
+        ),
+        "tokens": ("research", "sources", "competitor", "market", "paper", "news"),
+        "adjacent_workflows": ("research-brief", "research-department", "strategy-brief"),
+    },
+    {
+        "id": "coding_delivery",
+        "workflow": "ultraprocess",
+        "lane": "coding_handoff",
+        "next_action": "prepare_one_cycle_delivery",
+        "reason": "The user is asking for coding delivery, PR preparation, implementation, review, CI, or merge-oriented work.",
+        "phrases": (
+            "pull request",
+            "code review",
+            "ci failed",
+            "merge this",
+            "implement",
+            "coding agent",
+            "codex",
+            "claude code",
+            "pr 올려",
+            "머지",
+            "코딩",
+            "구현",
+            "리뷰",
+        ),
+        "tokens": ("pr", "implementation", "implement", "review", "ci", "merge", "codex", "claude"),
+        "adjacent_workflows": ("ralplan", "code-review", "agent-ops-review"),
+    },
+)
 
 
 def router_keyword_summary() -> str:
@@ -284,6 +426,83 @@ def awareness_context_matches_message(message: str) -> bool:
     return bool(tokens & _AWARENESS_TOKEN_MARKERS) or any(
         marker in text for marker in _AWARENESS_MESSAGE_MARKERS
     )
+
+
+def awareness_route_hint(message: str, *, max_hints: int = 2) -> dict[str, object]:
+    """Return bounded message-specific workflow hints without exposing raw text."""
+    normalized = unicodedata.normalize("NFKC", message).casefold()
+    tokens = set(re.findall(r"[a-z0-9][a-z0-9_-]*", normalized))
+    hint_limit = max(max_hints, 0)
+    hints: list[dict[str, object]] = []
+    if normalized.strip() and hint_limit:
+        for rule in _ROUTE_HINT_RULES:
+            phrase_matches = [phrase for phrase in rule["phrases"] if phrase in normalized]
+            token_matches = [token for token in rule["tokens"] if token in tokens]
+            if not phrase_matches and not token_matches:
+                continue
+            workflow = str(rule["workflow"])
+            context_card = workflow_context_card_for_workflow(workflow)
+            hints.append(
+                {
+                    "id": str(rule["id"]),
+                    "workflow": workflow,
+                    "lane": str(rule["lane"]),
+                    "next_action": str(rule["next_action"]),
+                    "reason": str(rule["reason"]),
+                    "matched_cues": _bounded_matches(phrase_matches + token_matches),
+                    "adjacent_workflows": list(rule["adjacent_workflows"]),
+                    "workflow_context_card": context_card,
+                    "not_evidence_yet": list(context_card.get("not_evidence_until_observed", []))
+                    if isinstance(context_card, dict)
+                    else [],
+                }
+            )
+            if len(hints) >= hint_limit:
+                break
+    return {
+        "schema_version": OMH_ROUTE_HINT_SCHEMA_VERSION,
+        "status": "hinted" if hints else "no_hint",
+        "message_sha256": hashlib.sha256(message.encode("utf-8")).hexdigest() if message else "",
+        "message_length": len(message),
+        "primary_workflow": str(hints[0]["workflow"]) if hints else "",
+        "primary_next_action": str(hints[0]["next_action"]) if hints else "",
+        "hints": hints,
+        "privacy": {
+            "mode": "metadata_only",
+            "raw_prompt_stored": False,
+            "stored_fields": ["message hash", "message length", "matched cue labels", "workflow hint"],
+        },
+        "claim_boundary": (
+            "OMH route hints are local deterministic prompt context only. They are not workflow execution, "
+            "tool invocation, generated output, verification, review, CI, merge, or proof that routing was correct."
+        ),
+    }
+
+
+def awareness_route_hint_context(message: str, *, max_hints: int = 2) -> str:
+    """Return compact hook text for message-specific workflow hints."""
+    payload = awareness_route_hint(message, max_hints=max_hints)
+    if payload.get("status") != "hinted":
+        return ""
+    lines = [
+        "[OMH Route Hint]",
+        "Use this message-specific OMH hint before generic chat/tools when it fits the user intent.",
+    ]
+    for hint in payload["hints"]:
+        if not isinstance(hint, dict):
+            continue
+        adjacent = ", ".join(str(item) for item in hint.get("adjacent_workflows", []))
+        lines.append(
+            f"- workflow={hint.get('workflow')}; lane={hint.get('lane')}; "
+            f"next_action={hint.get('next_action')}; reason={hint.get('reason')}"
+        )
+        if adjacent:
+            lines.append(f"  adjacent_workflows={adjacent}.")
+        not_evidence = ", ".join(str(item) for item in hint.get("not_evidence_yet", [])[:4])
+        if not_evidence:
+            lines.append(f"  not_evidence_yet={not_evidence}.")
+    lines.append("Boundary: " + str(payload["claim_boundary"]))
+    return "\n".join(lines)
 
 
 def awareness_primer_payload() -> dict[str, object]:
@@ -573,6 +792,17 @@ def _compact_workflow_context_cards_line() -> str:
         "automation/status/learning -> automation-blueprint/agent-ops-review/workflow-learning/doctor; "
         "code -> ultraprocess/code-review/team/ultrawork/ultraqa"
     )
+
+
+def _bounded_matches(matches: list[str]) -> list[str]:
+    seen: list[str] = []
+    for item in matches:
+        value = item.strip()
+        if value and value not in seen:
+            seen.append(value)
+        if len(seen) >= 4:
+            break
+    return seen
 
 
 def _lane_for_skill(skill_name: str, lanes: object) -> dict[str, object] | None:

--- a/src/plugin_bundle/omh/hooks/llm_hooks.py
+++ b/src/plugin_bundle/omh/hooks/llm_hooks.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from ..awareness import awareness_context_matches_message, awareness_primer_context
+from ..awareness import awareness_context_matches_message, awareness_primer_context, awareness_route_hint_context
 from ..omh_roles import extract_role_marker, role_context_payload
 from ..runtime_reader import read_omh_hud, read_omh_status
 
@@ -21,9 +21,12 @@ def pre_llm_call(**kwargs) -> dict[str, str] | None:
     context_parts: list[str] = []
     user_message = str(kwargs.get("user_message", "") or "")
     is_first_turn = bool(kwargs.get("is_first_turn", False))
-    should_include_awareness = is_first_turn or awareness_context_matches_message(user_message)
+    route_hint_context = awareness_route_hint_context(user_message)
+    should_include_awareness = is_first_turn or bool(route_hint_context) or awareness_context_matches_message(user_message)
     if kwargs.get("include_omh_awareness", True) is not False and should_include_awareness:
         context_parts.append(awareness_primer_context())
+        if route_hint_context:
+            context_parts.append(route_hint_context)
 
     marker = extract_role_marker(user_message)
     if marker:

--- a/tests/test_hook_manifest.py
+++ b/tests/test_hook_manifest.py
@@ -7,6 +7,8 @@ from _local_package import load_local_package
 load_local_package()
 
 from omh.capabilities.hooks import hook_manifest
+from omh.plugin_bundle.omh.awareness import awareness_route_hint
+from omh.plugin_bundle.omh.hooks.llm_hooks import pre_llm_call
 
 
 class HookManifestTests(unittest.TestCase):
@@ -24,6 +26,7 @@ class HookManifestTests(unittest.TestCase):
         self.assertFalse(tools["omh_capabilities"]["observed_in_this_environment"])
         self.assertIn("pre_llm_call", hooks)
         self.assertIn("omh_awareness_primer", hooks["pre_llm_call"]["payload_fields"])
+        self.assertIn("omh_route_hint", hooks["pre_llm_call"]["payload_fields"])
         self.assertIn("bounded_status_context", hooks["pre_llm_call"]["payload_fields"])
         self.assertIn("executor_opened", events)
         self.assertIn("selected_executor_profile", events["executor_opened"]["payload_fields"])
@@ -32,3 +35,49 @@ class HookManifestTests(unittest.TestCase):
         self.assertIn("native_command_rendered", events)
         self.assertIn("render_kind", events["native_command_rendered"]["payload_fields"])
         self.assertIn("not proof", hooks["pre_llm_call"]["claim_boundary"])
+
+    def test_awareness_route_hint_is_metadata_only_and_message_specific(self) -> None:
+        message = "make an image explaining the cron feature with secret-token-123"
+
+        payload = awareness_route_hint(message)
+        suppressed = awareness_route_hint(message, max_hints=0)
+        serialized = str(payload)
+
+        self.assertEqual(payload["schema_version"], "omh_route_hint/v1")
+        self.assertEqual(payload["status"], "hinted")
+        self.assertEqual(payload["primary_workflow"], "img-summary")
+        self.assertTrue(payload["message_sha256"])
+        self.assertEqual(payload["message_length"], len(message))
+        self.assertFalse(payload["privacy"]["raw_prompt_stored"])
+        self.assertIn("image", payload["hints"][0]["matched_cues"])
+        self.assertIn("not workflow execution", payload["claim_boundary"])
+        self.assertNotIn(message, serialized)
+        self.assertNotIn("secret-token-123", serialized)
+        self.assertEqual(suppressed["status"], "no_hint")
+        self.assertEqual(suppressed["hints"], [])
+
+    def test_pre_llm_call_includes_bounded_route_hint_without_raw_message(self) -> None:
+        message = "make an image explaining the cron feature with secret-token-123"
+
+        result = pre_llm_call(user_message=message, is_first_turn=False)
+        context = result["context"] if result else ""
+
+        self.assertIn("[OMH Awareness]", context)
+        self.assertIn("[OMH Route Hint]", context)
+        self.assertIn("workflow=img-summary", context)
+        self.assertIn("workflow=automation-blueprint", context)
+        self.assertIn("not_evidence_yet=file export, image generation", context)
+        self.assertNotIn(message, context)
+        self.assertNotIn("secret-token-123", context)
+
+    def test_pre_llm_call_can_disable_awareness_route_hint(self) -> None:
+        result = pre_llm_call(
+            user_message="make an image explaining the cron feature",
+            is_first_turn=False,
+            include_omh_awareness=False,
+        )
+        context = result["context"] if result else ""
+
+        self.assertNotIn("[OMH Awareness]", context)
+        self.assertNotIn("[OMH Route Hint]", context)
+        self.assertNotIn("workflow=img-summary", context)


### PR DESCRIPTION
## Feature Report

### What Changed

- Added `omh_route_hint/v1`, a bounded message-specific route hint payload for the optional Hermes plugin bridge.
- Updated the plugin `pre_llm_call` hook to include `[OMH Route Hint]` context when a message looks like workflow-shaped OMH work.
- Exposed `omh_route_hint` in the hook capability manifest.
- Documented plugin route hints in architecture and chat-wrapper examples.
- Added tests proving route hints are metadata-only, raw prompt content is not echoed, and hook awareness can be disabled.

### Why This Exists

- Users should not need to know OMH commands or manually tell Hermes which workflow to use.
- The generic OMH awareness primer gives Hermes the broad mental model, but individual prompts such as image summaries, scheduled ops, research, missed-route feedback, or coding delivery benefit from a compact per-message hint.
- This reduces the chance that Hermes falls back to generic tools when an OMH workflow should shape the response first.

### User / Operator Impact

- When the optional plugin bridge is loaded, Hermes can receive a prompt-context hint like `workflow=img-summary` or `workflow=automation-blueprint` before it answers.
- The hint carries message hash/length metadata, matched cue labels, candidate workflows, adjacent workflows, next actions, and boundaries.
- Raw user message text is not included in the route hint payload or hook context.
- The hint is guidance only: it does not execute a workflow, generate an image, create a schedule, run a coding agent, review, pass CI, or merge.

### How It Works

- `src/plugin_bundle/omh/awareness.py` now defines deterministic cue rules and emits `awareness_route_hint(...)` plus compact `awareness_route_hint_context(...)` text.
- `src/plugin_bundle/omh/hooks/llm_hooks.py` adds the route hint beside the existing awareness primer when the prompt matches workflow-shaped cues.
- `src/capabilities/hooks.py` advertises the new `omh_route_hint` hook payload field.
- Tests cover image/scheduled-op combined hints, raw prompt redaction, disabled-awareness behavior, plugin packaging, and hook manifest projection.

### Files And Contracts Touched

- `src/plugin_bundle/omh/awareness.py`: `omh_route_hint/v1` payload and cue-to-workflow hint rules.
- `src/plugin_bundle/omh/hooks/llm_hooks.py`: pre-LLM hook injection of route hints.
- `src/capabilities/hooks.py`: hook manifest payload field update.
- `tests/test_hook_manifest.py`: metadata-only and hook-context tests.
- `docs/ARCHITECTURE.md`, `docs/CHAT_WRAPPER_EXAMPLES.md`: operator-facing documentation.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — 593 tests passed.
- [x] `uv run python -m compileall -q src tests` — passed.
- [x] `uv run python -m src.cli docs workflows --check` — passed, 41/41 tap skills current.
- [x] `uv run python -m src.cli harness validate` — passed, 48 skills and 34 harnesses valid.
- [ ] `python3 -m omh.cli release checklist --json` — not run; this PR changes plugin prompt context, not release packaging.
- [ ] `python3 -m omh.cli release hermes-smoke` — not run; no setup/install path changed.
- [ ] `omh --help` — not run; no top-level CLI help changed.
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` — not run; no install smoke path changed.
- [x] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable; no learning schema changed in this PR.
- [x] Relevant dry-run or smoke command: `uv run python -m src.cli release skill-content-smoke --json` — `ok=true`, no awareness or capability budget failures.
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: live host plugin invocation was not run; deterministic plugin unit tests and packaging smoke cover the local payload.
- [x] `uv run python -m src.cli demo grounded-score` — all 28 scenarios stayed 10/10.
- [x] `git diff --check` — passed.

## Risk

- Cue rules are intentionally broad enough to help Hermes notice OMH-shaped work, so they must remain guidance rather than authoritative execution claims.
- Route hints are not a replacement for wrapper routing decisions, user confirmation, or observed runtime evidence.

## Compatibility / Rollout

- Additive plugin/hook behavior only.
- Existing CLI commands, generated skills, setup, and wrapper contracts remain compatible.
- `include_omh_awareness=False` suppresses awareness and route-hint injection.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`): source change only; no version bump in this PR.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed: route hint is prompt context only.
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap: live Hermes host invocation not observed.

## Follow-Up

- Future work can expand cue rules from real missed-route learning cases, but should keep the context bounded and metadata-only.
