### PR TITLE
Add route hint wrapper golden shims

### DIFF
--- a/docs/CHAT_WRAPPER_EXAMPLES.md
+++ b/docs/CHAT_WRAPPER_EXAMPLES.md
@@ -15,6 +15,8 @@ uv run python examples/discord-adapter-shim.py
 uv run python examples/discord-adapter-shim.py examples/wrapper-events/discord-command-preview.json
 uv run python examples/slack-adapter-shim.py examples/wrapper-events/slack-command-preview.json
 uv run python examples/telegram-adapter-shim.py examples/wrapper-events/telegram-command-preview.json
+uv run python examples/discord-adapter-shim.py --route-hint examples/wrapper-events/discord-route-hint-visual.json
+uv run python examples/slack-adapter-shim.py --route-hint examples/wrapper-events/slack-route-hint-missed-route.json
 uv run python -m src.cli chat route-hint --source discord "make an image explaining the cron feature"
 uv run python -m src.cli chat native-command --source discord
 uv run python -m src.cli chat native-command --source slack
@@ -146,6 +148,30 @@ State
 Use `--prompt-context` only when a wrapper intentionally injects the compact
 `[OMH Route Hint]` text into Hermes context itself. The default response is the
 safer card/JSON contract and never echoes the raw prompt.
+
+The transport-free adapter shims can render the same card directly from fixture
+events:
+
+```sh
+uv run python examples/discord-adapter-shim.py --route-hint examples/wrapper-events/discord-route-hint-visual.json
+uv run python examples/slack-adapter-shim.py --route-hint examples/wrapper-events/slack-route-hint-missed-route.json
+```
+
+Those examples lock the wrapper behavior in `examples/wrapper-golden/route-hints.json`:
+
+```text
+Hermes Agent  BOT
+[omh] img-summary looks relevant.
+
+I can open `img-summary` first because this request matches the materials and
+visuals lane. Next action: `prepare_visual_prompt_card`.
+
+[ Open img-summary ] [ Route for me ] [ Open omh ]
+```
+
+For missed OMH usage feedback, the Slack fixture routes to `workflow-learning`
+instead of treating the message as normal prose. The card still stays
+metadata-only and hint-only until the user or wrapper chooses a workflow.
 
 ## Missed OMH Route Capture
 

--- a/examples/wrapper-events/discord-route-hint-visual.json
+++ b/examples/wrapper-events/discord-route-hint-visual.json
@@ -1,0 +1,13 @@
+{
+  "id": "discord-route-hint-visual-001",
+  "guild_id": "omh-demo-guild",
+  "message": {
+    "id": "discord-message-route-hint-visual-001",
+    "channel": "design-share",
+    "content": "make an image explaining the cron feature",
+    "author": {
+      "id": "maintainer-1"
+    },
+    "timestamp": "2026-06-20T04:05:00Z"
+  }
+}

--- a/examples/wrapper-events/slack-route-hint-missed-route.json
+++ b/examples/wrapper-events/slack-route-hint-missed-route.json
@@ -1,0 +1,11 @@
+{
+  "event_id": "slack-route-hint-missed-route-001",
+  "team_id": "omh-demo-team",
+  "event": {
+    "client_msg_id": "slack-message-route-hint-missed-route-001",
+    "channel": "repo-maintenance",
+    "user": "maintainer-1",
+    "text": "missed route: OMH was not used",
+    "ts": "1782033900.000100"
+  }
+}

--- a/examples/wrapper-golden/route-hints.json
+++ b/examples/wrapper-golden/route-hints.json
@@ -1,0 +1,44 @@
+{
+  "schema_version": "route_hint_golden_examples/v1",
+  "purpose": "Transport-free route-hint examples for Hermes chat wrappers that want an OMH card before shell approval or plugin load.",
+  "examples": [
+    {
+      "scenario": "visual_summary_hint",
+      "source": "discord",
+      "fixture": "examples/wrapper-events/discord-route-hint-visual.json",
+      "expected_response": {
+        "schema_version": "chat_route_hint_response/v1",
+        "kind": "workflow_route_hint",
+        "primary_workflow": "img-summary",
+        "next_action": "prepare_visual_prompt_card",
+        "action_ids": [
+          "open_workflow",
+          "route_for_me",
+          "open_picker"
+        ],
+        "messenger_rendering": "messenger_route_hint_rendering/v1",
+        "safe_to_render_without_shell_approval": true
+      },
+      "claim_boundary": "Hint-only card; not workflow selection, image generation, visual QA, attachment, delivery, or observed execution evidence."
+    },
+    {
+      "scenario": "missed_route_learning_hint",
+      "source": "slack",
+      "fixture": "examples/wrapper-events/slack-route-hint-missed-route.json",
+      "expected_response": {
+        "schema_version": "chat_route_hint_response/v1",
+        "kind": "workflow_route_hint",
+        "primary_workflow": "workflow-learning",
+        "next_action": "audit_learning_readiness",
+        "action_ids": [
+          "open_workflow",
+          "route_for_me",
+          "open_picker"
+        ],
+        "messenger_rendering": "messenger_route_hint_rendering/v1",
+        "safe_to_render_without_shell_approval": true
+      },
+      "claim_boundary": "Hint-only card; not regression capture, skill patch approval, future behavior proof, or observed workflow evidence."
+    }
+  ]
+}

--- a/examples/wrapper_shim_common.py
+++ b/examples/wrapper_shim_common.py
@@ -11,8 +11,15 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from src.wrapper.contract import INTERACTION_MODES, build_chat_interaction_payload, build_chat_status_interaction  # noqa: E402
+from src.ingress import extract_message_text, extract_source_metadata  # noqa: E402
+from src.wrapper.contract import (  # noqa: E402
+    INTERACTION_MODES,
+    build_chat_interaction_payload,
+    build_chat_status_interaction,
+    usage_trace_payload,
+)
 from src.wrapper.native_commands import build_native_command_surface, render_native_command_response  # noqa: E402
+from src.wrapper.route_hints import build_chat_route_hint_payload  # noqa: E402
 
 
 SCHEMA_VERSION = "wrapper_adapter_shim/v1"
@@ -29,15 +36,34 @@ def run_shim(source: str, argv: list[str] | None = None) -> int:
     parser.add_argument("--mode", choices=INTERACTION_MODES, default="auto")
     parser.add_argument("--limit", type=int, default=3)
     parser.add_argument(
+        "--route-hint",
+        action="store_true",
+        help="Render a metadata-only route-hint card from the fixture event instead of a full interaction.",
+    )
+    parser.add_argument(
         "--status-json",
         default=None,
         help="Optional delegated_coding_status/v1 JSON to render as a status card instead of routing the event.",
     )
     args = parser.parse_args(argv)
 
+    if args.route_hint and args.status_json:
+        parser.error("--route-hint cannot be combined with --status-json")
+
     if args.status_json:
         status_payload = _read_json(Path(args.status_json))
         interaction = build_chat_status_interaction(status_payload, source=source)
+    elif args.route_hint:
+        event = _read_json(Path(args.event_json))
+        message = extract_message_text(event)
+        payload = build_chat_route_hint_payload(
+            message,
+            source=source,
+            max_hints=args.limit,
+            source_metadata=extract_source_metadata(event),
+        )
+        print(json.dumps(_render_route_hint(source, payload), indent=2, sort_keys=True))
+        return 0
     else:
         event = _read_json(Path(args.event_json))
         interaction = build_chat_interaction_payload(event, source=source, mode=args.mode, limit=args.limit)
@@ -61,6 +87,66 @@ def _read_json(path: Path) -> dict[str, Any]:
     if not isinstance(payload, dict):
         raise ValueError(f"fixture must be a JSON object: {path}")
     return payload
+
+
+def _render_route_hint(source: str, payload: dict[str, object]) -> dict[str, object]:
+    response = _nested(payload, "chat_response")
+    state = _nested(response, "state")
+    rendering = _nested(response, "messenger_rendering")
+    source_metadata = _nested(payload, "source_metadata")
+    next_action = str(state.get("next_action", "open_picker_or_clarify"))
+    usage_trace = usage_trace_payload(
+        kind=str(response.get("kind") or "workflow_route_hint"),
+        phase="route_hint",
+        next_action=next_action,
+        state=state,
+    )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "source": source,
+        "thread_key": _thread_key(source, source_metadata),
+        "mode": "route_hint",
+        "next_action": next_action,
+        "redaction_policy": "metadata_only",
+        "source_metadata": source_metadata,
+        "response": {
+            "kind": response.get("kind", ""),
+            "headline": response.get("headline", ""),
+            "plain_headline": response.get("headline", ""),
+            "body": response.get("body", ""),
+            "body_text": rendering.get("body_text", response.get("body", "")),
+            "body_text_source": "messenger_rendering.body_text",
+            "phase": "route_hint",
+            "claim_boundary": response.get("claim_boundary", payload.get("claim_boundary", "")),
+        },
+        "route_hint": payload.get("route_hint", {}),
+        "wrapper_contract": payload.get("wrapper_contract", {}),
+        "privacy": payload.get("privacy", {}),
+        "usage_trace": usage_trace,
+        "messenger_rendering": rendering,
+        "actions": [
+            {
+                "id": action.get("id", ""),
+                "label": action.get("label", ""),
+                "enabled": action.get("enabled", False),
+                "submit_text": action.get("submit_text", ""),
+                "backend_command": action.get("backend_command", ""),
+            }
+            for action in _list_of_dicts(response.get("actions", []))
+        ],
+        "native_command_registration": build_native_command_surface(source),
+        "native_render": None,
+        "status_card": None,
+        "not_evidence_until_observed": [
+            "workflow_selection",
+            "workflow_execution",
+            "executor_dispatch",
+            "executor_result",
+            "verification",
+            "review",
+            "delivery",
+        ],
+    }
 
 
 def _render(source: str, interaction: dict[str, object]) -> dict[str, object]:
@@ -127,3 +213,9 @@ def _list_of_dicts(value: object) -> list[dict[str, Any]]:
     if not isinstance(value, list):
         return []
     return [item for item in value if isinstance(item, dict)]
+
+
+def _thread_key(source: str, metadata: dict[str, Any]) -> str:
+    channel = str(metadata.get("channel_ref") or "unknown")
+    event_id = str(metadata.get("source_event_id") or "unknown")
+    return f"{source}:{channel}:{event_id}"

--- a/tests/test_wrapper_golden_examples.py
+++ b/tests/test_wrapper_golden_examples.py
@@ -11,7 +11,9 @@ from _local_package import load_local_package
 load_local_package()
 from omh.coding_delegation import build_coding_delegation_payload
 from omh.hermes_planning import build_hermes_plan_payload
+from omh.ingress import extract_message_text, extract_source_metadata
 from omh.skills.render import workflow_reference_payload
+from omh.wrapper.route_hints import build_chat_route_hint_payload
 
 
 class WrapperGoldenExampleTests(unittest.TestCase):
@@ -283,6 +285,93 @@ class WrapperGoldenExampleTests(unittest.TestCase):
                 self.assertEqual(registration["schema_version"], "omh_native_command_surface/v1")
                 self.assertEqual(registration["preview_contract"]["only_top_level_suggestions"], ["omh"])
                 self.assertIn("workflow selected", native_render["not_evidence"])
+
+    def test_route_hint_golden_examples_match_live_contract_sources(self) -> None:
+        payload = json.loads(Path("examples/wrapper-golden/route-hints.json").read_text(encoding="utf-8"))
+        self.assertEqual(payload["schema_version"], "route_hint_golden_examples/v1")
+
+        for item in payload["examples"]:
+            with self.subTest(item["scenario"]):
+                event = json.loads(Path(item["fixture"]).read_text(encoding="utf-8"))
+                message = extract_message_text(event)
+                live = build_chat_route_hint_payload(
+                    message,
+                    source=item["source"],
+                    source_metadata=extract_source_metadata(event),
+                )
+                expected = item["expected_response"]
+                response = live["chat_response"]
+
+                self.assertEqual(response["schema_version"], expected["schema_version"])
+                self.assertEqual(response["kind"], expected["kind"])
+                self.assertEqual(live["route_hint"]["primary_workflow"], expected["primary_workflow"])
+                self.assertEqual(response["state"]["next_action"], expected["next_action"])
+                self.assertEqual(response["messenger_rendering"]["schema_version"], expected["messenger_rendering"])
+                self.assertEqual(
+                    [action["id"] for action in response["actions"]],
+                    expected["action_ids"],
+                )
+                self.assertEqual(
+                    live["wrapper_contract"]["safe_to_render_without_shell_approval"],
+                    expected["safe_to_render_without_shell_approval"],
+                )
+                self.assertIn("not workflow execution", live["claim_boundary"].lower())
+                self.assertNotIn(message, json.dumps(live))
+
+    def test_route_hint_shims_render_workflow_hint_cards(self) -> None:
+        cases = (
+            (
+                "examples/discord-adapter-shim.py",
+                "examples/wrapper-events/discord-route-hint-visual.json",
+                "discord",
+                "img-summary",
+                "prepare_visual_prompt_card",
+                "make an image explaining the cron feature",
+            ),
+            (
+                "examples/slack-adapter-shim.py",
+                "examples/wrapper-events/slack-route-hint-missed-route.json",
+                "slack",
+                "workflow-learning",
+                "audit_learning_readiness",
+                "missed route: OMH was not used",
+            ),
+        )
+
+        for script, fixture, source, workflow, next_action, raw_message in cases:
+            with self.subTest(source=source):
+                result = subprocess.run(
+                    [sys.executable, script, "--route-hint", fixture],
+                    cwd=Path.cwd(),
+                    text=True,
+                    capture_output=True,
+                    check=False,
+                )
+
+                self.assertEqual(result.stderr, "")
+                self.assertEqual(result.returncode, 0)
+                payload = json.loads(result.stdout)
+                action_ids = {action["id"] for action in payload["actions"]}
+
+                self.assertEqual(payload["schema_version"], "wrapper_adapter_shim/v1")
+                self.assertEqual(payload["source"], source)
+                self.assertEqual(payload["mode"], "route_hint")
+                self.assertEqual(payload["redaction_policy"], "metadata_only")
+                self.assertEqual(payload["response"]["kind"], "workflow_route_hint")
+                self.assertEqual(payload["route_hint"]["primary_workflow"], workflow)
+                self.assertEqual(payload["next_action"], next_action)
+                self.assertEqual(payload["usage_trace"]["schema_version"], "omh_usage_trace/v1")
+                self.assertEqual(payload["usage_trace"]["visible_prefix"], f"[omh] {workflow}")
+                self.assertEqual(payload["messenger_rendering"]["schema_version"], "messenger_route_hint_rendering/v1")
+                self.assertEqual(payload["wrapper_contract"]["schema_version"], "omh_route_hint_wrapper_contract/v1")
+                self.assertTrue(payload["wrapper_contract"]["safe_to_render_without_shell_approval"])
+                self.assertTrue(payload["wrapper_contract"]["does_not_require_plugin_load"])
+                self.assertIsNone(payload["native_render"])
+                self.assertIn("workflow_selection", payload["not_evidence_until_observed"])
+                self.assertIn("workflow_execution", payload["not_evidence_until_observed"])
+                self.assertEqual(action_ids, {"open_workflow", "route_for_me", "open_picker"})
+                self.assertIn(f"Open {workflow}", {action["label"] for action in payload["actions"]})
+                self.assertNotIn(raw_message, result.stdout)
 
     def _source_harness_quality(self, item: dict[str, object]) -> dict[str, object]:
         source = item["source_payload"]


### PR DESCRIPTION
## Feature Report

### What Changed

- Added transport-free route-hint rendering to the example Discord/Slack wrapper shims through `--route-hint`.
- Added fixture events for an image-summary request and a missed-OMH-route report.
- Added `examples/wrapper-golden/route-hints.json` so route-hint cards are locked as golden examples.
- Extended wrapper golden tests to compare route-hint fixtures against the live `chat_route_hint/v1` contract and to execute the adapter shims directly.
- Updated chat wrapper docs with concrete commands and card copy for route-hint rendering.

### Why This Exists

OMH already exposed `omh chat route-hint`, but wrappers still lacked a runnable fixture-backed example showing how a Discord/Slack-style surface can render that hint as an `Open workflow / Route for me / Open omh` card without waiting for plugin load, shell catalog approval, or a transport SDK.

This closes the practical gap behind the user feedback that Hermes may answer without knowing to use OMH. Wrappers now have a deterministic, metadata-only route-hint path they can test and render before falling back to generic chat/tool behavior.

### User / Operator Impact

- A Discord/Slack wrapper can pass a fixture-like event into the shim and get a card that says, for example, `[omh] img-summary looks relevant.`
- If the user reports that OMH was missed, the Slack example routes to `workflow-learning` instead of treating the report as ordinary prose.
- The card stays preview-only: it does not claim workflow selection, image generation, execution, verification, review, CI, merge, or delivery.
- Operators can inspect the rendered JSON without exposing raw chat text in the output contract.

### How It Works

- `examples/wrapper_shim_common.py` now accepts `--route-hint`.
- The shim extracts message text and canonical metadata from the fixture, builds `chat_route_hint/v1`, and renders it as the existing `wrapper_adapter_shim/v1` envelope.
- Route-hint shim output includes `messenger_route_hint_rendering/v1`, route actions, native command registration metadata, `omh_usage_trace/v1`, and explicit not-evidence boundaries.
- The route-hint path intentionally sets `native_render` to `null` because this is not the `/omh` command-preview fallback card; it is a workflow hint card.

### Files And Contracts Touched

- `examples/wrapper_shim_common.py`
  - Adds route-hint rendering support.
- `examples/wrapper-events/discord-route-hint-visual.json`
  - Discord fixture for `img-summary` route hints.
- `examples/wrapper-events/slack-route-hint-missed-route.json`
  - Slack fixture for `workflow-learning` missed-route hints.
- `examples/wrapper-golden/route-hints.json`
  - Golden route-hint scenarios.
- `tests/test_wrapper_golden_examples.py`
  - Live contract and executable shim coverage.
- `docs/CHAT_WRAPPER_EXAMPLES.md`
  - Operator-facing route-hint shim commands and rendered-card example.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_wrapper_golden_examples.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_wrapper_contract.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m src.cli docs workflows --check`
- [x] `uv run python -m src.cli harness validate`
- [x] `uv run python -m src.cli release skill-content-smoke --json`
- [x] `uv run python -m src.cli demo grounded-score`
- [x] `git diff --check`
- [x] Relevant dry-run or smoke command: `uv run python examples/discord-adapter-shim.py --route-hint examples/wrapper-events/discord-route-hint-visual.json`
- [x] Manual Hermes/TUI check, or explicit reason it was not run: not run; this PR adds deterministic fixture-backed wrapper shims only, not a live Hermes transport.

## Risk

Low. This is additive example/test/docs work around an existing route-hint contract. The only executable behavior change is an opt-in `--route-hint` flag in example shims.

## Compatibility / Rollout

- Existing shim commands keep their current behavior.
- Existing `/omh` native command preview rendering remains separate from route-hint card rendering.
- No plugin, Hermes core, Discord, Slack, Telegram, network, or executor behavior changes.

## Release / Claims

- [x] Release-channel impact considered (`preview` example/test/docs enhancement; no command package release metadata change in this PR).
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap.

## Follow-Up

- If real wrapper implementations adopt these examples, add adapter-owned snapshot tests for their exact Discord/Slack component payloads.
