### PR TITLE
Add worktree executor binding recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ registration contracts live in the [installation guide](docs/INSTALLATION.md).
 - **Workspace-aware starts** - risky, parallel, or runtime-owned coding requests
   can show Prepare worktree before Hermes starts Codex, Claude Code, Hermes, or
   another configured coding-agent session; the backend can explicitly create the
-  local Git worktree when that button is used.
+  local Git worktree, then return a separate wrapper recipe for opening or
+  attaching the selected coding agent from that worktree.
 - **Useful beyond coding** - research, planning, feedback triage, meeting prep,
   reports, automation blueprints, material packages, and loop work all have
   Hermes-facing workflow paths.
@@ -214,7 +215,7 @@ tool, an existing Hermes connector, a generic image tool, or prompt-only mode.
 | Chat workflow picker | Hermes can answer "what can OMH do?" without making the user approve shell commands. |
 | Route hint cards | Wrappers can preview the nearest OMH workflow with `chat_route_hint/v1`, even before plugin load is observed. |
 | Coding agent paths | Hermes can prepare work for Codex, Claude Code, Hermes itself, or another runtime without pretending the work already ran. |
-| Workspace isolation | Hermes can show whether the current workspace is ok, recommend or require a worktree, and use `omh worktree prepare` to create the local Git worktree only when explicitly chosen. |
+| Workspace isolation | Hermes can show whether the current workspace is ok, recommend or require a worktree, use `omh worktree prepare` to create one, and use `omh worktree bind` to render open/attach/record actions for the selected coding agent. |
 | Agent ops review | Hermes can explain quality gates, blockers, next actions, and throughput levers for AI-agent work without turning a prepared handoff into evidence. |
 | Evidence-aware status | Plans, handoffs, dispatch, results, verification, review, CI, and merge readiness stay visibly separate. |
 | Workflow learning | Hermes can show learning-readiness and improvement-review cards for workflow attempts, including missed OMH routes: metadata-only trace, deterministic eval, human review queue, non-applying patch proposal, regression case, audit, and export bundle. |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -382,11 +382,14 @@ worktree is required before opening an executor. That record stores a compact
 snapshot of the generated workspace policy. When a wrapper or operator chooses
 the explicit workspace action, `omh worktree prepare` creates a local Git
 worktree and records `omh_worktree_observation/v1`; that observation is
-workspace-isolation evidence only. Runtime ladders still need a separate
-`runtime_observation/v1` `worktree_creation` event when the created worktree is
-attached to a prepared runtime handoff. The coding handoff also stores
-acceptance criteria, verification expectations, report contract, and evidence
-contract, runtime-specific invocation templates, and the
+workspace-isolation evidence only. `omh worktree bind` can then return a
+wrapper recipe for opening or attaching Codex, Claude Code, Hermes, or another
+runtime from that worktree; the recipe is still not executor dispatch or result
+evidence. Runtime ladders still need a separate `runtime_observation/v1`
+`worktree_creation` event when the created worktree is attached to a prepared
+runtime handoff. The coding handoff also stores acceptance criteria,
+verification expectations, report contract, and evidence contract,
+runtime-specific invocation templates, and the
 `runtime_observation/v1` recording contract, but not the raw prompt body. With
 `--record`,
 the companion `run.json` is marked as
@@ -492,8 +495,9 @@ claim. A `partial` row means OMH has deterministic guidance, handoff metadata,
 or observation records for that axis, while the live worker, executor session,
 MCP host load, or plugin runtime event still belongs to Hermes, the selected
 executor, or a future observed integration. Worktree isolation is available only
-for the explicit `omh worktree prepare/list` backend and its local
-`omh_worktree_observation/v1` ledger; it does not auto-launch an executor.
+for the explicit `omh worktree prepare/list/bind` backend and its local
+`omh_worktree_observation/v1` ledger plus wrapper binding recipes; it does not
+auto-launch an executor.
 
 ## Harness Contract
 

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -66,8 +66,11 @@ wrapper to keep the same workspace, recommend a worktree, or require a worktree
 before opening a coding agent. It is still prepared guidance until a wrapper or
 operator invokes or observes the workspace action. `omh worktree prepare` is the
 explicit opt-in backend that can create a local Git worktree and record
-`omh_worktree_observation/v1`; that record proves workspace isolation only, not
-executor dispatch, implementation, review, CI, or merge.
+`omh_worktree_observation/v1`. `omh worktree bind` can then return
+`worktree_executor_binding/v1` so a wrapper can show open/attach/record actions
+for the selected coding agent. Those records prove workspace isolation and
+session-start guidance only, not executor dispatch, implementation, review, CI,
+or merge.
 
 The optional MCP bridge uses `omh mcp serve` and exposes only `omh_status`,
 `omh_recommend`, and `omh_probe`. Bridge availability is not host-load evidence,

--- a/docs/CHAT_WRAPPER_EXAMPLES.md
+++ b/docs/CHAT_WRAPPER_EXAMPLES.md
@@ -321,6 +321,15 @@ User-facing effect:
   render `Prepare worktree` before the open button. The action prepares wrapper
   UX and operator guidance; only `runtime_observation/v1` worktree evidence can
   mark the worktree as observed.
+- After a worktree is prepared, the wrapper can call
+  `omh worktree bind --path <worktree> --executor codex --session <session-id>`
+  to get `worktree_executor_binding/v1`. That payload contains resolved launch
+  command templates and messenger actions such as `Open in Codex`,
+  `Attach existing session`, and `Record opened`. For `claude-code`, it returns
+  Claude Code launch templates. For `hermes`, `omx-runtime`, `omo-runtime`, and
+  `omc-runtime`, it returns prompt/runtime guidance plus a separate runtime
+  observation recipe. The bind payload is still not executor dispatch or result
+  evidence.
 - Execution, verification, CI, merge-readiness, and merge stay separate.
 - The wrapper can keep editing the same thread as evidence arrives.
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -712,8 +712,10 @@ Before calling the bot integration ready, verify these points:
   isolation. The plan remains `prepared_not_observed` until a wrapper invokes
   or observes the workspace action. `omh worktree prepare --repo <repo> --task
   "<task>"` is the explicit local backend action for creating the Git worktree;
-  linked runtime ladders still require separate `runtime_observation/v1`
-  records.
+  `omh worktree bind --path <worktree> --executor codex --session <session-id>`
+  returns the safe wrapper recipe for opening or attaching the selected coding
+  agent from that worktree. Linked runtime ladders still require separate
+  `runtime_observation/v1` records.
 - Executor-choice, runtime-handoff, clarify, fallback, and prompt-only handoffs
   return `runtime.recorded=false`; wrappers should not expect
   `runtime.run.run_id` for those paths.

--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -39,7 +39,7 @@ implementation or claim runtime behavior it did not observe.
 | Specialist role/profile system | Available | Skill catalog metadata, operating models, optional visible profile packs, wrapper role narration, plugin `omh_role`, and `[omh-role:name]` context injection. | Observed role execution still requires wrapper or runtime evidence; role context is not a hidden live agent. |
 | Bounded evidence probe | Available | Plugin `omh_gather_evidence` runs shell-free allowlisted local probes such as doctor, harness validation, docs checks, unittest, compileall, and whitespace checks. | It is not a general shell, executor dispatch, PR review, CI, merge, or live Hermes plugin-load signal. |
 | Team, swarm, and worker protocol | Partial | `team`, `ultrawork`, runtime handoff payloads, worker-protocol guidance, wrapper sessions, and runtime observations. | OMH does not launch hidden tmux teams, spawn workers, or manage panes by itself. |
-| Worktree and project-session isolation | Available | `worktree_session_isolation/v1` plans in coding handoffs, wrapper Prepare worktree actions, `omh worktree prepare/list`, executor-session status cards, loop queue metadata, and runtime observations for worktree creation. | OMH creates local Git worktrees only through the explicit opt-in backend command; it does not auto-launch executors or bind host sessions without wrapper/runtime evidence. |
+| Worktree and project-session isolation | Available | `worktree_session_isolation/v1` plans in coding handoffs, wrapper Prepare worktree actions, `omh worktree prepare/list/bind`, executor-session status cards, loop queue metadata, and runtime observations for worktree creation. | OMH creates local Git worktrees only through the explicit opt-in backend command; binding recipes show how wrappers can open or attach host sessions but do not auto-launch executors or claim runtime evidence. |
 | HUD, status, and session observability | Available | `omh hud`, plugin `omh_hud`/`omh_status`, wrapper sessions, runtime runs, and status cards. | Live host HUD rendering depends on Hermes/plugin support. |
 | MCP and tool bridge | Available | `omh setup --with-mcp`, `omh mcp manifest`, `omh mcp serve`, `omh mcp observe-host`, and `omh probe` preference/server/runtime/host-session/host-config separation. | OMH does not auto-enable host MCP config or independently inspect live host sessions; the host or wrapper must record load/session evidence. |
 | Loop and autopilot workflow | Available | `loop`, `ultraprocess`, `ralplan`, `ultragoal`, loop queue ticks, verification tiers, and failure-mode cards. | Scheduling, connector I/O, worktree creation, and subagent execution remain prepared or delegated until observed. |
@@ -61,6 +61,10 @@ implementation or claim runtime behavior it did not observe.
   `omh_worktree_observation/v1` workspace-isolation evidence. That evidence is
   still not executor dispatch, implementation, review, CI, merge-readiness, or
   merge evidence.
+- `omh worktree bind`, which returns `worktree_executor_binding/v1` so wrappers
+  can render Open in Codex, Open in Claude Code, Attach session, and runtime
+  observation record actions for a prepared worktree without launching the
+  executor or treating a terminal command as evidence.
 - A dependency-free stdio MCP bridge with allowlisted local `omh_status`,
   `omh_recommend`, and `omh_probe` tools plus manifest and probe evidence.
 - `omh_mcp_host_session/v1` records for host/wrapper-observed MCP bridge load
@@ -73,7 +77,6 @@ Next PR candidates:
 
 | Next PR | Why it matters |
 | --- | --- |
-| Worktree-to-executor session binding recipes | Shows wrappers how to connect an observed worktree to Codex, Claude Code, Hermes, or an oh-my runtime without auto-launching them. |
 | Host-specific MCP config recipes | Turns the manifest contract into copy-paste recipes for common MCP-capable host config shapes without auto-mutating them. |
 | Live Hermes plugin-load smoke evidence | Separates installed/importable plugin payloads from host-observed plugin runtime use. |
 
@@ -85,8 +88,9 @@ Next PR candidates:
   `omh_parity_matrix/v1`.
 - Team/swarm worker launch remains `partial` until observed runtime support
   exists. Worktree isolation is `available` only for explicit local Git
-  worktree creation and `omh_worktree_observation/v1` records; executor/session
-  use still needs separate runtime evidence. The MCP bridge axis is `available`
+  worktree creation, `omh_worktree_observation/v1` records, and
+  `worktree_executor_binding/v1` wrapper recipes; executor/session dispatch
+  still needs separate runtime evidence. The MCP bridge axis is `available`
   only for the local stdio server and allowlisted tools; host-specific
   load/session use must still be recorded through `omh_mcp_host_session/v1`
   before it is claimed.
@@ -103,7 +107,7 @@ Next PR candidates:
 
 - No hidden tmux team launcher.
 - No automatic Git worktree creator.
-- No executor launch or host-session binding from the worktree creator.
+- No executor launch from the worktree creator or binder.
 - No arbitrary MCP shell, connector runner, or auto-enabled host config.
 - No Discord/Slack transport implementation.
 - No Hermes core patch.

--- a/docs/README.md
+++ b/docs/README.md
@@ -134,7 +134,8 @@ separate profile pack is explicitly selected.
 - Worktree/session isolation docs should describe `worktree_session_isolation/v1`
   as prepared workspace guidance and wrapper UX, and `omh worktree prepare` as
   explicit opt-in Git worktree creation that records workspace-isolation
-  evidence only.
+  evidence only. `omh worktree bind` may describe wrapper launch/attach recipes
+  for a prepared worktree, but must not claim executor dispatch or results.
 - Workflow learning docs should state that `workflow_learning_trace/v1` records
   are metadata-only process evidence. They can feed evals, readiness audits,
   review-only improvement candidates, human-review queues, regression cases,

--- a/src/commands/main.py
+++ b/src/commands/main.py
@@ -133,7 +133,7 @@ from .setup import (
 from .state import _add_state_commands, cmd_state_clear, cmd_state_finish, cmd_state_start, cmd_state_status
 from .use_cases import _add_cases_commands, cmd_cases_inspect, cmd_cases_list, cmd_cases_recommend
 from .visual import _add_visual_commands, cmd_visual_observe, cmd_visual_prompt_card
-from .worktree import cmd_worktree_list, cmd_worktree_prepare, _add_worktree_commands
+from .worktree import cmd_worktree_bind, cmd_worktree_list, cmd_worktree_prepare, _add_worktree_commands
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -170,6 +170,7 @@ def build_parser() -> argparse.ArgumentParser:
             "  omh img-summary prompt-card --kind github_pr --visual-format auto --section summary:What_changed:Safer_setup_copy\n"
             "  omh img-summary prompt-card --kind report --aspect-ratio long_scroll --section summary:Executive_summary:Weekly_metrics_changed\n"
             "  omh worktree prepare --repo . --task \"risky refactor\" --dry-run\n"
+            "  omh worktree bind --path .worktrees/risky-refactor --executor codex --session <session-id>\n"
             "  omh runtime status\n\n"
             "Human-facing maintenance, catalog, and operator checklist commands print summaries by default;\n"
             "pass --json or set OMH_OUTPUT=json when a wrapper needs full payloads.\n"
@@ -250,6 +251,7 @@ Useful operator commands:
   omh materials list     List material-processing artifacts
   omh img-summary prompt-card Prepare image-generation-ready summary cards
   omh worktree prepare --repo . --task "risky refactor" --dry-run
+  omh worktree bind --path .worktrees/risky-refactor --executor codex --session <session-id>
   omh runtime status     Show local evidence artifacts
 
 After setup, restart or reload Hermes Agent and try:

--- a/src/commands/worktree.py
+++ b/src/commands/worktree.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import argparse
 
+from ..executors import CODING_EXECUTOR_TARGETS
 from ..installer import OmhError
 from ..worktree_creator import list_worktree_records, prepare_git_worktree
+from ..wrapper.worktree_binding import build_worktree_executor_binding
 from .common import _paths, _print_json
 
 
@@ -44,6 +46,23 @@ def cmd_worktree_list(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_worktree_bind(args: argparse.Namespace) -> int:
+    try:
+        payload = build_worktree_executor_binding(
+            _paths(args),
+            worktree_path=args.path,
+            executor=args.executor,
+            session_id=args.session_id or "",
+            run_id=args.run_id or "",
+            runtime_profile=args.runtime_profile or "",
+            prompt_ref=args.prompt_ref or "",
+        )
+    except ValueError as exc:
+        raise OmhError(str(exc)) from exc
+    _print_json({"binding": payload})
+    return 1 if payload["status"] == "blocked_missing_worktree" else 0
+
+
 def _add_worktree_commands(sub) -> None:
     worktree = sub.add_parser("worktree", help="Prepare opt-in Git worktrees for isolated coding handoffs.")
     worktree_sub = worktree.add_subparsers(dest="worktree_command", required=True)
@@ -69,3 +88,21 @@ def _add_worktree_commands(sub) -> None:
     listing = worktree_sub.add_parser("list", help="List recent OMH worktree preparation records.")
     listing.add_argument("--limit", type=int, default=20)
     listing.set_defaults(func=cmd_worktree_list)
+
+    bind = worktree_sub.add_parser(
+        "bind",
+        help="Build wrapper launch and observation recipes for an isolated coding-agent worktree.",
+    )
+    bind.add_argument("--path", required=True, help="Existing or intended Git worktree path.")
+    bind.add_argument(
+        "--executor",
+        choices=tuple(target for target in CODING_EXECUTOR_TARGETS if target != "choose"),
+        required=True,
+        help="Coding agent or runtime profile that should open in this worktree.",
+    )
+    bind_target = bind.add_mutually_exclusive_group()
+    bind_target.add_argument("--session", dest="session_id", default="", help="Wrapper executor-session id to bind.")
+    bind_target.add_argument("--run", dest="run_id", default="", help="Runtime run id to bind.")
+    bind.add_argument("--runtime-profile", default="", help="Override the runtime profile for runtime observation recipes.")
+    bind.add_argument("--prompt-ref", default="", help="Opaque prompt/handoff reference held by the wrapper.")
+    bind.set_defaults(func=cmd_worktree_bind)

--- a/src/parity.py
+++ b/src/parity.py
@@ -87,13 +87,17 @@ PARITY_CAPABILITIES: tuple[ParityCapability, ...] = (
         id="worktree_isolation",
         title="Worktree and project-session isolation",
         common_pattern="Use isolated workspaces so parallel agents can work without stepping on each other's files.",
-        omh_surface="`worktree_session_isolation/v1` plans inside coding handoffs, wrapper Prepare worktree actions, `omh worktree prepare/list`, executor-session status cards, loop queue metadata, and runtime observations for worktree creation.",
+        omh_surface="`worktree_session_isolation/v1` plans inside coding handoffs, wrapper Prepare worktree actions, `omh worktree prepare/list/bind`, executor-session status cards, loop queue metadata, and runtime observations for worktree creation.",
         status="available",
         evidence=("src/isolation.py", "src/worktree_creator.py", "src/commands/worktree.py", "src/wrapper/executor_sessions.py", "tests/test_worktree_creator.py"),
-        missing_piece="OMH can explicitly create a local Git worktree, but it does not auto-launch executors or bind host agent sessions without wrapper/runtime evidence.",
-        v1_decision="Make worktree mutation explicit and opt-in: the wrapper may show Prepare worktree, and the backend can create the Git worktree only when invoked.",
-        user_value="Teams see when same workspace is acceptable, when an isolated worktree is recommended, and when it is required before opening a coding agent.",
-        claim_boundary="A worktree plan is not a created worktree; an OMH-created worktree is workspace-isolation evidence only, not executor dispatch or implementation evidence.",
+        missing_piece="OMH can explicitly create a local Git worktree and return binding recipes, but it does not auto-launch executors or claim host agent sessions without wrapper/runtime evidence.",
+        v1_decision="Make worktree mutation explicit and opt-in: the wrapper may show Prepare worktree, create it through the backend, then bind the selected coding agent with a recipe.",
+        user_value="Teams see when same workspace is acceptable, when an isolated worktree is recommended, and how to open or attach the chosen coding agent from that worktree.",
+        claim_boundary=(
+            "A worktree plan is not a created worktree; an OMH-created worktree is "
+            "workspace-isolation evidence only, and a binding recipe is session-start guidance only, "
+            "not executor dispatch or implementation evidence."
+        ),
     ),
     ParityCapability(
         id="hud_session_observability",
@@ -169,11 +173,6 @@ def build_parity_matrix(probe_payload: dict[str, object] | None = None) -> dict[
                 "id": "observed-plugin-load",
                 "title": "Add live Hermes plugin load smoke evidence",
                 "why": "Separates installed/importable plugin payloads from host-observed plugin runtime use.",
-            },
-            {
-                "id": "worktree-session-binding-guides",
-                "title": "Add worktree-to-executor session binding recipes",
-                "why": "Shows wrappers how to connect an observed worktree to Codex, Claude Code, Hermes, or an oh-my runtime without auto-launching them.",
             },
             {
                 "id": "mcp-host-config-guides",

--- a/src/probe.py
+++ b/src/probe.py
@@ -124,8 +124,12 @@ def _worktree_creator_capability() -> Capability:
     return Capability(
         "worktree_creator",
         "available",
-        "omh worktree prepare; omh worktree list",
-        "OMH can explicitly create local Git worktrees and record omh_worktree_observation/v1 workspace-isolation evidence",
+        "omh worktree prepare; omh worktree list; omh worktree bind",
+        (
+            "OMH can explicitly create local Git worktrees, record omh_worktree_observation/v1 "
+            "workspace-isolation evidence, and return wrapper binding recipes for opening or attaching "
+            "the selected coding agent without launching it"
+        ),
     )
 
 

--- a/src/worktree_creator.py
+++ b/src/worktree_creator.py
@@ -130,6 +130,21 @@ def list_worktree_records(paths: OmhPaths, *, limit: int = 20) -> tuple[list[dic
     return list(reversed(records))[:limit], errors
 
 
+def latest_observed_worktree_record(paths: OmhPaths, worktree_path: str | Path) -> dict[str, Any]:
+    records, _errors = read_jsonl_objects(paths.runtime_worktrees_path)
+    target = str(expand_path(worktree_path))
+    for record in reversed(records):
+        if not isinstance(record, dict):
+            continue
+        if (
+            str(record.get("worktree_path", "")) == target
+            and record.get("observed")
+            and record.get("created")
+        ):
+            return record
+    return {}
+
+
 def _blocked_result(
     paths: OmhPaths,
     *,

--- a/src/wrapper/executor_sessions.py
+++ b/src/wrapper/executor_sessions.py
@@ -263,6 +263,25 @@ def build_executor_session_actions(
     ]
 
 
+def build_executor_launch_contract(
+    executor: str,
+    *,
+    session_id: str = "worktree-binding",
+    handoff_state: str = "prepared",
+    isolation_status: dict[str, object] | None = None,
+) -> dict[str, object]:
+    """Build a wrapper-facing launch contract without creating a session record."""
+    return _executor_launch_contract(
+        executor,
+        {
+            "session_id": session_id,
+            "status": handoff_state,
+            "selected_executor_profile": executor,
+        },
+        isolation_status=isolation_status,
+    )
+
+
 def read_executor_session(paths: OmhPaths, session_id: str) -> dict[str, Any] | None:
     record, error = read_executor_session_result(_session_dir(paths, session_id))
     return None if error else record

--- a/src/wrapper/worktree_binding.py
+++ b/src/wrapper/worktree_binding.py
@@ -1,0 +1,282 @@
+from __future__ import annotations
+
+import shlex
+from pathlib import Path
+from typing import Any
+
+from ..executors import CODING_EXECUTOR_TARGETS, CODING_RUNTIME_HANDOFF_TARGETS, executor_label
+from ..isolation import build_isolation_plan
+from ..paths import OmhPaths, expand_path
+from ..worktree_creator import latest_observed_worktree_record
+from .executor_sessions import build_executor_launch_contract
+
+WORKTREE_BINDING_SCHEMA_VERSION = "worktree_executor_binding/v1"
+
+
+def build_worktree_executor_binding(
+    paths: OmhPaths,
+    *,
+    worktree_path: str | Path,
+    executor: str,
+    session_id: str = "",
+    run_id: str = "",
+    runtime_profile: str = "",
+    prompt_ref: str = "",
+) -> dict[str, Any]:
+    if executor == "choose" or executor not in CODING_EXECUTOR_TARGETS:
+        raise ValueError(f"unsupported executor for worktree binding: {executor}")
+    resolved_path = expand_path(worktree_path)
+    observed_record = latest_observed_worktree_record(paths, resolved_path)
+    path_exists = resolved_path.exists()
+    status = _binding_status(path_exists=path_exists, observed_record=observed_record)
+    isolation_status = _binding_isolation_status(
+        executor=executor,
+        status=status,
+        worktree_path=resolved_path,
+        observed_record=observed_record,
+    )
+    launch = build_executor_launch_contract(
+        executor,
+        session_id=session_id or "worktree-binding",
+        isolation_status=isolation_status,
+    )
+    launch["resolved_workspace_path"] = str(resolved_path)
+    launch["resolved_command_templates"] = _resolve_workspace_templates(launch, resolved_path)
+    launch["preferred_command_template_id"] = _preferred_workspace_template_id(
+        launch["resolved_command_templates"]
+    )
+    preferred_command_template_id = str(launch["preferred_command_template_id"])
+    return {
+        "schema_version": WORKTREE_BINDING_SCHEMA_VERSION,
+        "status": status,
+        "executor": {
+            "profile": executor,
+            "label": executor_label(executor),
+            "terminal_launch_available": bool(launch.get("terminal_launch_available")),
+        },
+        "worktree": {
+            "path": str(resolved_path),
+            "exists": path_exists,
+            "observed_in_omh_ledger": bool(observed_record),
+            "evidence_refs": list(observed_record.get("evidence_refs", [])) if observed_record else [],
+            "record": observed_record or None,
+        },
+        "session_binding": {
+            "session_id": session_id,
+            "run_id": run_id,
+            "runtime_profile": runtime_profile
+            or (executor if executor in CODING_RUNTIME_HANDOFF_TARGETS else ""),
+            "prompt_ref": prompt_ref,
+        },
+        "launch": launch,
+        "wrapper_actions": _binding_actions(
+            executor=executor,
+            status=status,
+            worktree_path=resolved_path,
+            session_id=session_id,
+            run_id=run_id,
+            runtime_profile=runtime_profile,
+            prompt_ref=prompt_ref,
+            preferred_command_template_id=preferred_command_template_id,
+        ),
+        "next_action": _binding_next_action(status, executor=executor, session_id=session_id, run_id=run_id),
+        "claim_boundary": (
+            "A worktree binding recipe is wrapper guidance only. It can show how to open or attach a "
+            "coding-agent session in an isolated workspace, but OMH does not launch the executor or claim "
+            "coding progress until matching observed session or runtime evidence is recorded."
+        ),
+        "not_evidence_until_observed": [
+            "executor_dispatch",
+            "executor_result",
+            "verification",
+            "review",
+            "ci",
+            "merge_readiness",
+            "merge",
+        ],
+    }
+
+
+def _binding_isolation_status(
+    *,
+    executor: str,
+    status: str,
+    worktree_path: Path,
+    observed_record: dict[str, Any],
+) -> dict[str, object]:
+    plan = build_isolation_plan(
+        "isolated coding-agent session",
+        intent="implementation",
+        workflow="ultrawork",
+        work_owner_mode=(
+            "runtime_handoff" if executor in CODING_RUNTIME_HANDOFF_TARGETS else "external_executor"
+        ),
+        selected_executor_profile=executor,
+    )
+    plan = {**plan, "worktree_path": str(worktree_path)}
+    return {
+        "schema_version": "worktree_session_isolation_status/v1",
+        "status": "observed"
+        if observed_record
+        else ("filesystem_only" if status != "blocked_missing_worktree" else "missing"),
+        "strategy": str(plan.get("strategy", "worktree_recommended")),
+        "risk_level": str(plan.get("risk_level", "high")),
+        "next_action": (
+            "open_executor_session" if status != "blocked_missing_worktree" else "prepare_worktree"
+        ),
+        "observed": bool(observed_record),
+        "worktree_path": str(worktree_path),
+        "plan": plan,
+        "claim_boundary": (
+            "This binding uses an isolated workspace path for a future coding-agent session. "
+            "It is not executor dispatch, implementation, verification, review, CI, merge-readiness, or merge evidence."
+        ),
+    }
+
+
+def _binding_status(*, path_exists: bool, observed_record: dict[str, Any]) -> str:
+    if observed_record:
+        return "ready_observed_worktree"
+    if path_exists:
+        return "ready_filesystem_only"
+    return "blocked_missing_worktree"
+
+
+def _binding_next_action(status: str, *, executor: str, session_id: str, run_id: str) -> str:
+    if status == "blocked_missing_worktree":
+        return "prepare_worktree_before_opening_executor"
+    if executor in CODING_RUNTIME_HANDOFF_TARGETS and (session_id or run_id):
+        return "open_runtime_session_then_record_runtime_observation"
+    if session_id:
+        return "open_executor_session_then_record_observed_session"
+    return "open_executor_in_worktree_then_attach_session_ref"
+
+
+def _resolve_workspace_templates(launch: dict[str, Any], worktree_path: Path) -> list[dict[str, Any]]:
+    workspace = str(worktree_path)
+    workspace_shell = shlex.quote(workspace)
+    resolved: list[dict[str, Any]] = []
+    for template in launch.get("command_templates", []):
+        if not isinstance(template, dict):
+            continue
+        rendered = dict(template)
+        argv_template = template.get("argv_template")
+        if isinstance(argv_template, list):
+            rendered["argv_template"] = [
+                _replace_workspace_placeholders(str(item), workspace, workspace_shell)
+                for item in argv_template
+            ]
+        shell_template = template.get("shell_command_template")
+        if isinstance(shell_template, str):
+            rendered["shell_command_template"] = _replace_workspace_placeholders(
+                shell_template, workspace, workspace_shell
+            )
+        resolved.append(rendered)
+    return resolved
+
+
+def _preferred_workspace_template_id(templates: list[dict[str, Any]]) -> str:
+    for template in templates:
+        if (
+            "{workspace_path}" in str(template)
+            or " --cd " in str(template)
+            or "--add-dir" in str(template)
+        ):
+            return str(template.get("id", ""))
+    return str(templates[0].get("id", "")) if templates else ""
+
+
+def _replace_workspace_placeholders(value: str, workspace: str, workspace_shell: str) -> str:
+    return value.replace("{workspace_path}", workspace).replace("{workspace_path_shell_quoted}", workspace_shell)
+
+
+def _binding_actions(
+    *,
+    executor: str,
+    status: str,
+    worktree_path: Path,
+    session_id: str,
+    run_id: str,
+    runtime_profile: str,
+    prompt_ref: str,
+    preferred_command_template_id: str,
+) -> list[dict[str, Any]]:
+    disabled_reason = (
+        "Worktree path is missing; run omh worktree prepare first."
+        if status == "blocked_missing_worktree"
+        else ""
+    )
+    worktree_ref = str(worktree_path)
+    worktree_evidence_ref = f"worktree:{worktree_ref}"
+    worktree_evidence_arg = shlex.quote(worktree_evidence_ref)
+    actions: list[dict[str, Any]] = [
+        {
+            "id": "open_executor_session",
+            "label": f"Open in {executor_label(executor)}",
+            "enabled": not disabled_reason,
+            "style": "primary",
+            "disabled_reason": disabled_reason,
+            "worktree_path": worktree_ref,
+            "prompt_ref": prompt_ref,
+            "backend_action_owner": "wrapper",
+            "launch_command_template_id": preferred_command_template_id,
+            "claim_boundary": (
+                "Opening the executor is observed only after Hermes or the wrapper actually starts "
+                "or attaches the session."
+            ),
+        },
+        {
+            "id": "attach_executor_session",
+            "label": "Attach existing session",
+            "enabled": not disabled_reason,
+            "style": "secondary",
+            "disabled_reason": disabled_reason,
+            "backend_action_owner": "wrapper",
+            "input_schema": {
+                "type": "object",
+                "required": ["external_session_ref"],
+                "properties": {
+                    "external_session_ref": {"type": "string", "title": "Coding session reference"},
+                    "evidence_ref": {"type": "array", "items": {"type": "string"}},
+                },
+            },
+        },
+    ]
+    if session_id and executor not in CODING_RUNTIME_HANDOFF_TARGETS:
+        actions.append(
+            {
+                "id": "record_executor_opened",
+                "label": "Record opened",
+                "enabled": not disabled_reason,
+                "style": "secondary",
+                "backend_command": (
+                    f"omh chat session open-executor {shlex.quote(session_id)} --observed "
+                    f"--evidence-ref {worktree_evidence_arg}"
+                ),
+                "claim_boundary": (
+                    "This records that a wrapper observed session open/dispatch; it is not executor "
+                    "result evidence."
+                ),
+            }
+        )
+    runtime = runtime_profile or (executor if executor in CODING_RUNTIME_HANDOFF_TARGETS else "")
+    if runtime and (session_id or run_id):
+        target = f"--session {shlex.quote(session_id)}" if session_id else f"--run {shlex.quote(run_id)}"
+        actions.append(
+            {
+                "id": "record_worktree_runtime_observation",
+                "label": "Record worktree observation",
+                "enabled": not disabled_reason,
+                "style": "secondary",
+                "backend_command": (
+                    f"omh runtime observe {target} --runtime-profile {shlex.quote(runtime)} "
+                    f"--event worktree_creation --status observed --worktree-ref {shlex.quote(worktree_ref)} "
+                    f"--evidence-ref {worktree_evidence_arg}"
+                ),
+                "claim_boundary": (
+                    "This records workspace-isolation evidence only; runtime start and worker/result "
+                    "events remain separate."
+                ),
+            }
+        )
+    return actions

--- a/tests/test_worktree_creator.py
+++ b/tests/test_worktree_creator.py
@@ -114,6 +114,154 @@ class WorktreeCreatorTests(unittest.TestCase):
             self.assertEqual(payload["reason"], "source_dirty")
             self.assertFalse(payload["created"])
 
+    def test_worktree_bind_builds_codex_launch_recipe_for_observed_worktree(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo = _init_repo(root / "repo")
+            target = root / "worktrees" / "codex-bind"
+            home = root / ".omh"
+
+            prepare_status, _, prepare_stderr = run_cli(
+                [
+                    "--omh-home",
+                    str(home),
+                    "worktree",
+                    "prepare",
+                    "--repo",
+                    str(repo),
+                    "--task",
+                    "codex binding",
+                    "--branch",
+                    "omh/codex-binding-test",
+                    "--path",
+                    str(target),
+                ]
+            )
+            self.assertEqual(prepare_stderr, "")
+            self.assertEqual(prepare_status, 0)
+
+            status, stdout, stderr = run_cli(
+                [
+                    "--omh-home",
+                    str(home),
+                    "worktree",
+                    "bind",
+                    "--path",
+                    str(target),
+                    "--executor",
+                    "codex",
+                    "--session",
+                    "session-1",
+                    "--prompt-ref",
+                    "handoff:abc",
+                ]
+            )
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            payload = json.loads(stdout)["binding"]
+            self.assertEqual(payload["schema_version"], "worktree_executor_binding/v1")
+            self.assertEqual(payload["status"], "ready_observed_worktree")
+            self.assertEqual(payload["executor"]["profile"], "codex")
+            self.assertTrue(payload["worktree"]["observed_in_omh_ledger"])
+            self.assertEqual(payload["launch"]["resolved_workspace_path"], str(target.resolve()))
+            self.assertEqual(payload["launch"]["preferred_command_template_id"], "codex_interactive_workspace")
+            isolation_plan = payload["launch"]["workspace_isolation"]["plan"]
+            self.assertEqual(isolation_plan["schema_version"], "worktree_session_isolation/v1")
+            self.assertIn("workspace_policy", isolation_plan)
+            commands = payload["launch"]["resolved_command_templates"]
+            self.assertTrue(any(command.get("argv_template", [None, None])[1] == "--cd" for command in commands))
+            self.assertTrue(any(str(target.resolve()) in str(command) for command in commands))
+            actions = {action["id"]: action for action in payload["wrapper_actions"]}
+            self.assertTrue(actions["open_executor_session"]["enabled"])
+            self.assertEqual(actions["open_executor_session"]["launch_command_template_id"], "codex_interactive_workspace")
+            self.assertTrue(actions["attach_executor_session"]["enabled"])
+            self.assertIn("omh chat session open-executor session-1 --observed", actions["record_executor_opened"]["backend_command"])
+            self.assertEqual(actions["open_executor_session"]["prompt_ref"], "handoff:abc")
+            self.assertIn("executor_dispatch", payload["not_evidence_until_observed"])
+
+    def test_worktree_bind_blocks_missing_path_without_claiming_evidence(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            target = root / "missing" / "worktree"
+
+            status, stdout, stderr = run_cli(
+                [
+                    "--omh-home",
+                    str(root / ".omh"),
+                    "worktree",
+                    "bind",
+                    "--path",
+                    str(target),
+                    "--executor",
+                    "claude-code",
+                    "--session",
+                    "session-2",
+                ]
+            )
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 1)
+            payload = json.loads(stdout)["binding"]
+            self.assertEqual(payload["status"], "blocked_missing_worktree")
+            self.assertFalse(payload["worktree"]["exists"])
+            self.assertFalse(payload["wrapper_actions"][0]["enabled"])
+            self.assertEqual(payload["next_action"], "prepare_worktree_before_opening_executor")
+            self.assertIn("not proof of execution", payload["launch"]["claim_boundary"])
+
+    def test_worktree_bind_runtime_profile_adds_runtime_observation_recipe(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo = _init_repo(root / "repo")
+            target = root / "worktrees" / "runtime-bind"
+            home = root / ".omh"
+
+            prepare_status, _, prepare_stderr = run_cli(
+                [
+                    "--omh-home",
+                    str(home),
+                    "worktree",
+                    "prepare",
+                    "--repo",
+                    str(repo),
+                    "--task",
+                    "runtime binding",
+                    "--branch",
+                    "omh/runtime-binding-test",
+                    "--path",
+                    str(target),
+                ]
+            )
+            self.assertEqual(prepare_stderr, "")
+            self.assertEqual(prepare_status, 0)
+
+            status, stdout, stderr = run_cli(
+                [
+                    "--omh-home",
+                    str(home),
+                    "worktree",
+                    "bind",
+                    "--path",
+                    str(target),
+                    "--executor",
+                    "omx-runtime",
+                    "--session",
+                    "session-3",
+                ]
+            )
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            payload = json.loads(stdout)["binding"]
+            self.assertEqual(payload["executor"]["profile"], "omx-runtime")
+            self.assertFalse(payload["executor"]["terminal_launch_available"])
+            self.assertEqual(payload["session_binding"]["runtime_profile"], "omx-runtime")
+            actions = {action["id"]: action for action in payload["wrapper_actions"]}
+            self.assertIn("record_worktree_runtime_observation", actions)
+            self.assertIn("omh runtime observe --session session-3", actions["record_worktree_runtime_observation"]["backend_command"])
+            self.assertIn("--event worktree_creation", actions["record_worktree_runtime_observation"]["backend_command"])
+            self.assertIn("prompt_only", str(payload["launch"]["resolved_command_templates"]))
+
 
 def _init_repo(path: Path) -> Path:
     path.mkdir(parents=True)


### PR DESCRIPTION
## Summary

Adds a wrapper-facing worktree executor binding contract so OMH can turn an observed prepared worktree into a safe executor launch or attach recipe without starting the executor itself.

## Why

Hermes can already prepare isolated worktrees and coding sessions, but wrappers still needed a deterministic bridge between an observed worktree and an executor-specific session start. This PR adds that bridge while preserving the key OMH boundary: a prepared worktree is isolation evidence only, and a binding recipe is session-start guidance only.

## What changed

- Adds `omh worktree bind --path <worktree> --executor <executor>`.
- Introduces `worktree_executor_binding/v1` from `src/wrapper/worktree_binding.py`.
- Reuses the canonical worktree isolation planner instead of duplicating isolation policy.
- Keeps `src/worktree_creator.py` focused on prepare/list/ledger behavior.
- Exposes resolved launch templates for Codex, Claude Code, Hermes, and oh-my runtime profiles without launching anything.
- Adds wrapper actions for open, attach, and record-observed-runtime steps.
- Syncs README, architecture, capabilities, installation, chat wrapper examples, parity, and probe output.

## Boundary behavior

- Does not launch Codex, Claude Code, Hermes, or runtime profiles.
- Does not claim implementation, review, CI, merge, or live executor evidence.
- Missing worktree paths block with `blocked_missing_worktree`.
- Existing filesystem paths without an OMH ledger are labeled `ready_filesystem_only` rather than overclaimed as observed OMH worktrees.

## Verification

Observed locally:

```sh
PYTHONPATH=tests uv run python -m unittest tests/test_worktree_creator.py tests/test_wrapper_sessions.py -v
PYTHONPATH=tests uv run python -m unittest discover -s tests -v
uv run python -m src.cli docs workflows --check
uv run python -m src.cli harness validate
uv run python -m src.cli release skill-content-smoke --json
uv run python -m compileall -q src tests
git diff --check
```

All passed.

## Review notes

- Code review found no must-fix issues; LSP/Pyright was unavailable to that reviewer.
- Architecture review initially flagged cross-layer coupling and duplicated isolation policy.
- Follow-up changes moved binding assembly into the wrapper layer and reused the canonical isolation plan.
- Final architecture review status: CLEAR.

## Risks and rollout

- Live Hermes chat rendering and real executor process launch were not tested; this PR intentionally stops at deterministic local binding recipes.
- Future launcher/rendering behavior should stay in wrapper/session modules, not worktree ledger modules.