### PR TITLE
Add plugin host observation evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ tool, an existing Hermes connector, a generic image tool, or prompt-only mode.
 | Setup and repair | `omh setup`, `omh doctor`, `omh update`, and `omh uninstall` keep the local install understandable. |
 | Chat workflow picker | Hermes can answer "what can OMH do?" without making the user approve shell commands. |
 | Route hint cards | Wrappers can preview the nearest OMH workflow with `chat_route_hint/v1`, even before plugin load is observed. |
+| Plugin runtime evidence | Hosts or wrappers can record `omh plugin observe-host` when Hermes actually loads or uses the OMH plugin; active-ready and historical events stay separate from install smoke. |
 | Coding agent paths | Hermes can prepare work for Codex, Claude Code, Hermes itself, or another runtime without pretending the work already ran. |
 | Workspace isolation | Hermes can show whether the current workspace is ok, recommend or require a worktree, use `omh worktree prepare` to create one, and use `omh worktree bind` to render open/attach/record actions for the selected coding agent. |
 | Agent ops review | Hermes can explain quality gates, blockers, next actions, and throughput levers for AI-agent work without turning a prepared handoff into evidence. |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -482,6 +482,17 @@ When a host or wrapper does observe bridge load or use, it can record
 `omh_mcp_host_session/v1` through `omh mcp observe-host`; observed records
 require an evidence reference and remain host-load/session evidence only.
 
+Plugin runtime load uses a parallel contract. Local plugin install and
+import/register smoke prove only the copied bundle. A Hermes host or wrapper can
+record `omh_plugin_host_observation/v1` with `omh plugin observe-host` after it
+actually sees plugin load, tool use, hook use, status query, session end, or
+unload. That observation can make `plugin_runtime_observed` available in
+`omh probe`, but it still proves only the recorded plugin event. Active native
+readiness is narrower: only `plugin_load`, `tool_call`, `hook_call`, and
+`status_query` observations keep `native_integration_claim_ready` true. `blocked`
+is descriptive host metadata and `session_end`/`plugin_unload` are historical
+runtime evidence, not active readiness.
+
 For terminal operators, `omh probe` prints a compact status summary by default.
 Wrappers and automation should request the full capability payload with
 `omh probe --json` or `OMH_OUTPUT=json`.

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -79,6 +79,14 @@ wrapper that actually observes bridge load or use can record
 `omh_mcp_host_session/v1` with `omh mcp observe-host`; that remains session
 evidence only.
 
+The optional plugin bridge has the same split. Local install/import/register
+smoke proves the bundle is present and importable. Host or wrapper evidence that
+Hermes actually loaded or used the plugin is recorded separately with
+`omh plugin observe-host` as `omh_plugin_host_observation/v1`. Active readiness
+requires the latest observed event to be `plugin_load`, `tool_call`, `hook_call`,
+or `status_query`; `blocked`, `session_end`, and `plugin_unload` do not make the
+native bridge active.
+
 ## Why This Exists
 
 Hermes and wrapper surfaces should not need to scrape README prose to know which

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -166,6 +166,24 @@ connector execution, coding dispatch, or proof that an MCP runtime is active.
 bridge load or use and can attach a stable evidence reference. It records
 `omh_mcp_host_session/v1` metadata; it does not discover or force host loading.
 
+The OMH plugin follows the same evidence split. `omh setup` installs the plugin
+bundle and `omh doctor` can prove local import/register smoke. A Hermes host or
+wrapper that actually sees the plugin load or one of its tools/hooks run can
+record that runtime event:
+
+```sh
+omh plugin observe-host --host hermes-agent --session <session-id> --event plugin_load --evidence-ref <host-log-ref>
+omh plugin observations
+```
+
+This writes `omh_plugin_host_observation/v1`. It is plugin load/use evidence
+only; it is not coding dispatch, implementation, review, CI, merge, or proof of
+unrecorded plugin calls. Observed `plugin_load`, `tool_call`, `hook_call`, or
+`status_query` records count as active runtime observations. Observed
+`session_end` or `plugin_unload` records are historical runtime evidence only.
+`blocked` means the host or wrapper could not inspect the plugin state; it does
+not preserve an older active-ready claim.
+
 ## Install Path A: Hermes-Native Skill Tap
 
 Use this path when the target Hermes environment supports skill taps:
@@ -391,7 +409,11 @@ After `omh setup` has run, `omh doctor` also checks the managed plugin manifest
 plus local import/register smoke. `omh probe` reports
 `plugin_distribution_ready` separately from `native_integration_claim_ready` so
 operators do not mistake local install readiness for observed Hermes runtime
-use.
+use. When a host or wrapper records `omh plugin observe-host`,
+`plugin_runtime_observed` can become available. `native_integration_claim_ready`
+can become true only when the latest observed plugin event is active
+(`plugin_load`, `tool_call`, `hook_call`, or `status_query`); observed
+`session_end` and `plugin_unload` remain historical evidence only.
 Use `omh probe --parity` when an operator wants the broader comparison against
 common oh-my runtime capability axes. It returns `omh_parity_matrix/v1` with
 available and partial rows for skills/plugins, roles, team/swarm workers,

--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -35,7 +35,7 @@ implementation or claim runtime behavior it did not observe.
 
 | Capability axis | OMH status | OMH surface | Missing or intentionally delegated |
 | --- | --- | --- | --- |
-| Skill and plugin distribution | Available | Tap-compatible `skills/*/SKILL.md`, `omh setup`, and optional `~/.hermes/plugins/omh` bridge. | Observed Hermes plugin load still needs host runtime evidence. |
+| Skill and plugin distribution | Available | Tap-compatible `skills/*/SKILL.md`, `omh setup`, optional `~/.hermes/plugins/omh` bridge, and `omh plugin observe-host` for host-observed plugin load/use. | Live plugin load/use must still be recorded by the host or wrapper; local install smoke is not runtime evidence. |
 | Specialist role/profile system | Available | Skill catalog metadata, operating models, optional visible profile packs, wrapper role narration, plugin `omh_role`, and `[omh-role:name]` context injection. | Observed role execution still requires wrapper or runtime evidence; role context is not a hidden live agent. |
 | Bounded evidence probe | Available | Plugin `omh_gather_evidence` runs shell-free allowlisted local probes such as doctor, harness validation, docs checks, unittest, compileall, and whitespace checks. | It is not a general shell, executor dispatch, PR review, CI, merge, or live Hermes plugin-load signal. |
 | Team, swarm, and worker protocol | Partial | `team`, `ultrawork`, runtime handoff payloads, worker-protocol guidance, wrapper sessions, and runtime observations. | OMH does not launch hidden tmux teams, spawn workers, or manage panes by itself. |
@@ -53,6 +53,11 @@ implementation or claim runtime behavior it did not observe.
 - A plugin bridge with native role context lookup, role marker injection,
   delegate marker validation, session-end checkpoints, and bounded
   `omh_gather_evidence` probes.
+- `omh_plugin_host_observation/v1` records through `omh plugin observe-host`, so
+  operators can distinguish local plugin install/import/register smoke from
+  host-observed Hermes plugin load or use. Active native readiness requires the
+  latest observed event to be `plugin_load`, `tool_call`, `hook_call`, or
+  `status_query`; `session_end` and `plugin_unload` remain historical evidence.
 - `worktree_session_isolation/v1`, which gives coding handoffs and wrapper
   status cards a concrete same-workspace/worktree-recommended/worktree-required
   contract before any executor is opened.
@@ -78,7 +83,6 @@ Next PR candidates:
 | Next PR | Why it matters |
 | --- | --- |
 | Host-specific MCP config recipes | Turns the manifest contract into copy-paste recipes for common MCP-capable host config shapes without auto-mutating them. |
-| Live Hermes plugin-load smoke evidence | Separates installed/importable plugin payloads from host-observed plugin runtime use. |
 
 ## Acceptance Criteria
 
@@ -96,6 +100,11 @@ Next PR candidates:
   before it is claimed.
 - Specialist roles are `available` only as prompt context, marker validation,
   and profile guidance. They are not hidden runtime agents.
+- Plugin runtime observation is `available` only when a host or wrapper records
+  `omh_plugin_host_observation/v1` with an evidence reference. It is not coding
+  dispatch, implementation, review, CI, merge, or proof of unrecorded tool/hook
+  calls. `native_integration_claim_ready` is narrower than historical runtime
+  observation and requires an active plugin event.
 - Bounded evidence probes are `available` only as explicit allowlisted local
   command results. They are not executor dispatch, implementation, review, CI,
   merge, or plugin-load evidence.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -228,4 +228,5 @@ Use explicit proof-boundary language:
 Do not claim native Hermes runtime use from plugin installation alone.
 `plugin_distribution_ready` means the local bundle exists and passed local
 import/register smoke; `native_integration_claim_ready` still requires observed
-Hermes runtime-load or hook/tool-use evidence.
+Hermes active runtime-load, hook/tool-use, or status-query evidence. Session-end
+and plugin-unload observations are historical evidence only.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -28,7 +28,8 @@
 
 - Hermes plugin enablement automation when the runtime contract is stable
 - Deeper workflow telemetry that remains local and inspectable
-- Richer plugin hooks and tools after observed runtime-load evidence exists
+- Richer plugin hooks and tools after enough host-observed plugin load/use
+  evidence exists across real Hermes environments
 
 ## Recently Landed
 
@@ -48,3 +49,5 @@
   `recommend`
 - Default plugin distribution path through `omh setup`, with local
   import/register smoke and conservative runtime-claim boundaries
+- Host-observed plugin load/use records through `omh plugin observe-host`, kept
+  separate from local install smoke and from execution/review/CI evidence

--- a/src/commands/main.py
+++ b/src/commands/main.py
@@ -80,6 +80,7 @@ from .materials import (
 from .menubar import _add_menubar_commands, cmd_menubar_status
 from .memory import _add_memory_commands, cmd_memory_apply, cmd_memory_inspect, cmd_memory_pack
 from .mcp import cmd_mcp_manifest, cmd_mcp_observe_host, cmd_mcp_serve, cmd_mcp_sessions, _add_mcp_commands
+from .plugin import _add_plugin_commands, cmd_plugin_observations, cmd_plugin_observe_host
 from .ops import (
     _add_ops_commands,
     cmd_ops_agent_review,
@@ -164,6 +165,7 @@ def build_parser() -> argparse.ArgumentParser:
             "  omh hud\n"
             "  omh menubar status\n"
             "  omh mcp manifest\n"
+            "  omh plugin observe-host --host hermes-agent --session <session-id> --event plugin_load --evidence-ref <host-log>\n"
             "  omh loop status\n"
             "  omh ops list\n"
             "  omh materials list\n"
@@ -206,6 +208,7 @@ def build_parser() -> argparse.ArgumentParser:
     _add_memory_commands(sub)
     _add_menubar_commands(sub)
     _add_mcp_commands(sub)
+    _add_plugin_commands(sub)
     _add_ops_commands(sub)
     _add_materials_commands(sub)
     _add_visual_commands(sub)
@@ -246,6 +249,7 @@ Useful operator commands:
   omh hud                Show the compact OMH status line
   omh menubar status     Show the menu bar app status view model
   omh mcp manifest       Print the optional stdio MCP bridge manifest
+  omh plugin observe-host --host hermes-agent --session <session-id> --event plugin_load --evidence-ref <host-log>
   omh loop status        Show loopable goal cycle state
   omh ops list           List local operations artifacts
   omh materials list     List material-processing artifacts

--- a/src/commands/plugin.py
+++ b/src/commands/plugin.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import argparse
+
+from ..installer import OmhError
+from ..plugin_observations import (
+    PLUGIN_HOST_OBSERVATION_EVENTS,
+    PLUGIN_HOST_OBSERVATION_STATUSES,
+    read_plugin_host_observations,
+    record_plugin_host_observation,
+)
+from .common import _paths, _print_json
+
+
+def cmd_plugin_observe_host(args: argparse.Namespace) -> int:
+    try:
+        observation = record_plugin_host_observation(
+            _paths(args),
+            host=args.host,
+            session_id=args.session_id,
+            event=args.event,
+            status=args.status,
+            evidence_refs=args.evidence_ref or [],
+            message=args.message or "",
+            source=args.source or "wrapper",
+            tool=args.tool or "",
+            hook=args.hook or "",
+        )
+    except ValueError as exc:
+        raise OmhError(str(exc)) from exc
+    _print_json({"observation": observation})
+    return 0
+
+
+def cmd_plugin_observations(args: argparse.Namespace) -> int:
+    limit = int(args.limit)
+    if limit < 1:
+        raise OmhError("--limit must be at least 1")
+    observations, errors = read_plugin_host_observations(_paths(args), limit=limit)
+    _print_json(
+        {
+            "schema_version": "omh_plugin_host_observations/v1",
+            "observations": observations,
+            "errors": errors,
+            "claim_boundary": (
+                "Plugin host observations are host/wrapper-supplied metadata. They prove only observed "
+                "plugin load/use events, not coding dispatch, implementation, review, CI, merge, or "
+                "unrecorded tool/hook calls."
+            ),
+        }
+    )
+    return 0
+
+
+def _add_plugin_commands(sub) -> None:
+    plugin = sub.add_parser(
+        "plugin",
+        help="Record host-observed OMH plugin load/use evidence without claiming execution.",
+    )
+    plugin_sub = plugin.add_subparsers(dest="plugin_command", required=True)
+
+    observe_host = plugin_sub.add_parser(
+        "observe-host",
+        help="Record Hermes host or wrapper evidence that the OMH plugin was loaded or used.",
+    )
+    observe_host.add_argument("--host", required=True, help="Hermes host or wrapper name that observed the plugin.")
+    observe_host.add_argument("--session", dest="session_id", required=True, help="Host session id or stable session reference.")
+    observe_host.add_argument("--event", choices=PLUGIN_HOST_OBSERVATION_EVENTS, required=True)
+    observe_host.add_argument("--status", choices=PLUGIN_HOST_OBSERVATION_STATUSES, default="observed")
+    observe_host.add_argument("--source", default="wrapper", help="Observation source, such as wrapper, host, operator, or test.")
+    observe_host.add_argument("--tool", default="", help="Tool name for tool_call observations.")
+    observe_host.add_argument("--hook", default="", help="Hook name for hook_call observations.")
+    observe_host.add_argument("--evidence-ref", action="append", help="Required for observed records; use host log/session/tool refs.")
+    observe_host.add_argument("--message", default="", help="Short metadata-only summary. Do not pass raw prompts.")
+    observe_host.set_defaults(func=cmd_plugin_observe_host)
+
+    observations = plugin_sub.add_parser("observations", help="List recent plugin host observation records.")
+    observations.add_argument("--limit", type=int, default=20)
+    observations.set_defaults(func=cmd_plugin_observations)

--- a/src/doctor.py
+++ b/src/doctor.py
@@ -9,6 +9,11 @@ from .hashutil import sha256_file
 from .local_store import can_write_dir
 from .manifest import local_modifications, read_manifest
 from .paths import OmhPaths
+from .plugin_observations import (
+    PLUGIN_HOST_ACTIVE_OBSERVATION_EVENTS,
+    latest_plugin_host_observation,
+    plugin_host_runtime_readiness,
+)
 from .plugin_pack import inspect_plugin_bundle
 from .runtime.artifacts import read_state, read_state_error
 from .skill_pack import CORE_SKILLS
@@ -164,6 +169,17 @@ def run_doctor(paths: OmhPaths) -> list[Check]:
         )
     )
     plugin = inspect_plugin_bundle(paths)
+    latest_plugin_observation, plugin_observation_errors = latest_plugin_host_observation(paths)
+    latest_plugin_readiness = ""
+    if latest_plugin_observation:
+        latest_plugin_readiness = str(
+            latest_plugin_observation.get("runtime_readiness")
+            or plugin_host_runtime_readiness(
+                event=str(latest_plugin_observation.get("event", "")),
+                status=str(latest_plugin_observation.get("status", "")),
+            )
+        )
+    latest_plugin_active = latest_plugin_readiness == "active_runtime_observed"
     plugin_expected = bool(plugin["plugin_dir_installed"]) or bool(state and state.get("last_plugin_distribution"))
     if not plugin_expected:
         checks.append(Check("plugin_bundle", True, f"managed OMH plugin bridge is not installed yet at {paths.hermes_plugin_dir}"))
@@ -189,10 +205,32 @@ def run_doctor(paths: OmhPaths) -> list[Check]:
                 Check(
                     "plugin_runtime_observed",
                     True,
-                    "not required for doctor; Hermes runtime load/use must be observed separately before claiming native runtime readiness",
-                    severity="warning",
-                    next_action="Observe Hermes plugin load/use in the target Hermes runtime before claiming native runtime readiness.",
-                    observed=False,
+                    (
+                        f"{latest_plugin_readiness} by {latest_plugin_observation.get('host', 'unknown')} "
+                        f"({latest_plugin_observation.get('event', 'unknown')}, "
+                        f"session={latest_plugin_observation.get('session_id', 'unknown')})"
+                        if latest_plugin_observation and latest_plugin_observation.get("observed")
+                        else (
+                            f"plugin observation ledger unreadable: {'; '.join(plugin_observation_errors[:3])}"
+                            if plugin_observation_errors
+                            else (
+                                f"latest plugin host observation is {latest_plugin_observation.get('status', 'unknown')}; "
+                                "Hermes runtime load/use is not currently observed"
+                                if latest_plugin_observation
+                                else "not required for doctor; Hermes runtime load/use must be observed separately before claiming native runtime readiness"
+                            )
+                        )
+                    ),
+                    severity="ok" if latest_plugin_active else "warning",
+                    next_action=(
+                        ""
+                        if latest_plugin_active
+                        else (
+                            "Record an active Hermes plugin event "
+                            f"({', '.join(PLUGIN_HOST_ACTIVE_OBSERVATION_EVENTS)}) before claiming native runtime readiness."
+                        )
+                    ),
+                    observed=bool(latest_plugin_observation and latest_plugin_observation.get("observed")),
                 ),
             ]
         )

--- a/src/parity.py
+++ b/src/parity.py
@@ -41,11 +41,20 @@ PARITY_CAPABILITIES: tuple[ParityCapability, ...] = (
         common_pattern="Install a native skill/plugin payload, then let the host agent surface workflows without making users memorize backend commands.",
         omh_surface="`hermes skills ...` compatible skill pack, `omh setup`, and the optional `~/.hermes/plugins/omh` bridge.",
         status="available",
-        evidence=("skills/*/SKILL.md", "src/plugin_bundle/omh/plugin.yaml", "src/plugin_pack.py", "src/commands/setup.py"),
-        missing_piece="Observed Hermes plugin load/use still requires runtime evidence from the host.",
+        evidence=(
+            "skills/*/SKILL.md",
+            "src/plugin_bundle/omh/plugin.yaml",
+            "src/plugin_pack.py",
+            "src/plugin_observations.py",
+            "src/commands/plugin.py",
+        ),
+        missing_piece="Live Hermes plugin load/use is now recordable, but it still requires host or wrapper-supplied evidence.",
         v1_decision="Keep skills as the default surface and plugin as a thin metadata bridge.",
         user_value="Users install OMH once and then talk to Hermes; operators can still verify the local payload.",
-        claim_boundary="Plugin install/import/register smoke is not proof that Hermes loaded or used the plugin.",
+        claim_boundary=(
+            "Plugin install/import/register smoke is not proof that Hermes loaded or used the plugin; "
+            "omh_plugin_host_observation/v1 proves only the recorded host plugin event."
+        ),
     ),
     ParityCapability(
         id="specialist_roles",
@@ -170,11 +179,6 @@ def build_parity_matrix(probe_payload: dict[str, object] | None = None) -> dict[
         "probe_alignment": _probe_alignment(probe_payload or {}),
         "recommended_next_prs": [
             {
-                "id": "observed-plugin-load",
-                "title": "Add live Hermes plugin load smoke evidence",
-                "why": "Separates installed/importable plugin payloads from host-observed plugin runtime use.",
-            },
-            {
                 "id": "mcp-host-config-guides",
                 "title": "Add host-specific MCP config recipes",
                 "why": "Turns the manifest contract into copy-paste recipes for common MCP-capable host config shapes without auto-mutating them.",
@@ -199,6 +203,8 @@ def _probe_alignment(probe_payload: dict[str, object]) -> dict[str, object]:
         "external_skill_dirs": by_name.get("external_skill_dirs", "unknown"),
         "omh_plugin_bundle": by_name.get("omh_plugin_bundle", "unknown"),
         "plugin_register_smoke": by_name.get("plugin_register_smoke", "unknown"),
+        "plugin_runtime_observed": by_name.get("plugin_runtime_observed", "unknown"),
+        "plugin_runtime_active": "available" if probe_payload.get("plugin_runtime_active") else "unverified",
         "mcp_preference": by_name.get("mcp_preference", "unknown"),
         "mcp_bridge_server": by_name.get("mcp_bridge_server", "unknown"),
         "mcp_bridge_runtime": by_name.get("mcp_bridge_runtime", "unknown"),

--- a/src/paths.py
+++ b/src/paths.py
@@ -39,6 +39,10 @@ class OmhPaths:
         return self.runtime_dir / "mcp_host_sessions.jsonl"
 
     @property
+    def runtime_plugin_host_observations_path(self) -> Path:
+        return self.runtime_dir / "plugin_host_observations.jsonl"
+
+    @property
     def runtime_worktrees_path(self) -> Path:
         return self.runtime_dir / "worktrees.jsonl"
 

--- a/src/plugin_observations.py
+++ b/src/plugin_observations.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from .local_store import ensure_dir, ensure_file, read_jsonl_objects, utc_now
+from .paths import OmhPaths
+from .runtime.artifacts import update_state
+
+PLUGIN_HOST_OBSERVATION_SCHEMA_VERSION = "omh_plugin_host_observation/v1"
+PLUGIN_HOST_OBSERVATION_EVENTS = (
+    "plugin_load",
+    "tool_call",
+    "hook_call",
+    "status_query",
+    "session_end",
+    "plugin_unload",
+)
+PLUGIN_HOST_OBSERVATION_STATUSES = ("observed", "not_observed", "blocked")
+PLUGIN_HOST_ACTIVE_OBSERVATION_EVENTS = ("plugin_load", "tool_call", "hook_call", "status_query")
+PLUGIN_HOST_HISTORICAL_OBSERVATION_EVENTS = ("session_end", "plugin_unload")
+PLUGIN_HOST_TEXT_LIMITS = {
+    "host": 96,
+    "session": 160,
+    "source": 64,
+    "tool": 96,
+    "hook": 96,
+    "evidence_ref": 180,
+    "message": 280,
+}
+PLUGIN_HOST_SENSITIVE_PATTERNS = (
+    "api_key",
+    "apikey",
+    "authorization:",
+    "bearer ",
+    "ghp_",
+    "password",
+    "private-token",
+    "raw prompt",
+    "secret",
+    "token",
+    "xoxb-",
+    "xoxp-",
+)
+
+PLUGIN_HOST_OBSERVATION_CLAIM_BOUNDARY = (
+    "An OMH plugin host observation is metadata supplied by a Hermes host or wrapper "
+    "that observed plugin load or use. It proves only that host plugin event, not coding "
+    "dispatch, implementation, verification, review, CI, merge, or unrecorded tool/hook calls."
+)
+
+
+def record_plugin_host_observation(
+    paths: OmhPaths,
+    *,
+    host: str,
+    session_id: str,
+    event: str,
+    status: str,
+    evidence_refs: list[str] | None = None,
+    message: str = "",
+    source: str = "wrapper",
+    tool: str = "",
+    hook: str = "",
+) -> dict[str, Any]:
+    host = _bounded_metadata_text(host, field="host")
+    session_id = _bounded_metadata_text(session_id, field="session")
+    event = event.strip()
+    status = status.strip()
+    source = _bounded_metadata_text(source, field="source") or "wrapper"
+    tool = _bounded_metadata_text(tool, field="tool")
+    hook = _bounded_metadata_text(hook, field="hook")
+    message = _bounded_metadata_text(message, field="message")
+    evidence_refs = [
+        _bounded_metadata_text(item, field="evidence_ref") for item in (evidence_refs or []) if item and item.strip()
+    ]
+
+    if not host:
+        raise ValueError("plugin host observation requires --host")
+    if not session_id:
+        raise ValueError("plugin host observation requires --session")
+    if event not in PLUGIN_HOST_OBSERVATION_EVENTS:
+        raise ValueError(f"plugin host observation event must be one of: {', '.join(PLUGIN_HOST_OBSERVATION_EVENTS)}")
+    if status not in PLUGIN_HOST_OBSERVATION_STATUSES:
+        raise ValueError(
+            f"plugin host observation status must be one of: {', '.join(PLUGIN_HOST_OBSERVATION_STATUSES)}"
+        )
+    if status == "observed" and not evidence_refs:
+        raise ValueError("observed plugin host events require at least one --evidence-ref")
+    if event == "tool_call" and not tool:
+        raise ValueError("plugin host tool_call observation requires --tool")
+    if event == "hook_call" and not hook:
+        raise ValueError("plugin host hook_call observation requires --hook")
+
+    recorded_at = utc_now()
+    runtime_readiness = plugin_host_runtime_readiness(event=event, status=status)
+    record: dict[str, Any] = {
+        "schema_version": PLUGIN_HOST_OBSERVATION_SCHEMA_VERSION,
+        "host": host,
+        "session_id": session_id,
+        "event": event,
+        "status": status,
+        "observed": status == "observed",
+        "runtime_readiness": runtime_readiness,
+        "native_integration_active": runtime_readiness == "active_runtime_observed",
+        "source": source,
+        "tool": tool,
+        "hook": hook,
+        "evidence_refs": evidence_refs,
+        "message": message,
+        "redaction_policy": "metadata_only_bounded",
+        "recorded_at": recorded_at,
+        "claim_boundary": PLUGIN_HOST_OBSERVATION_CLAIM_BOUNDARY,
+    }
+    if status == "observed":
+        record["observed_at"] = recorded_at
+    _append_plugin_host_observation(paths, record)
+    patch: dict[str, Any] = {"last_plugin_host_observation": record}
+    patch["last_plugin_runtime_observed"] = record if record["native_integration_active"] else None
+    patch["last_plugin_runtime_readiness"] = runtime_readiness
+    update_state(paths, patch)
+    return record
+
+
+def read_plugin_host_observations(paths: OmhPaths, *, limit: int | None = 20) -> tuple[list[dict[str, Any]], list[str]]:
+    records, errors = read_jsonl_objects(paths.runtime_plugin_host_observations_path)
+    records = list(reversed(records))
+    if limit is not None:
+        records = records[:limit]
+    return records, errors
+
+
+def latest_plugin_host_observation(paths: OmhPaths) -> tuple[dict[str, Any] | None, list[str]]:
+    records, errors = read_jsonl_objects(paths.runtime_plugin_host_observations_path)
+    for record in reversed(records):
+        if record.get("schema_version") == PLUGIN_HOST_OBSERVATION_SCHEMA_VERSION:
+            return record, errors
+    return None, errors
+
+
+def plugin_host_runtime_readiness(*, event: str, status: str) -> str:
+    if status == "blocked":
+        return "blocked"
+    if status != "observed":
+        return "not_observed"
+    if event in PLUGIN_HOST_ACTIVE_OBSERVATION_EVENTS:
+        return "active_runtime_observed"
+    if event in PLUGIN_HOST_HISTORICAL_OBSERVATION_EVENTS:
+        return "historical_runtime_observed"
+    return "observed_unknown_event"
+
+
+def _append_plugin_host_observation(paths: OmhPaths, record: dict[str, Any]) -> None:
+    ensure_dir(paths.runtime_dir, private=True)
+    ensure_file(paths.runtime_plugin_host_observations_path, private=True)
+    with paths.runtime_plugin_host_observations_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record, sort_keys=True) + "\n")
+
+
+def _bounded_metadata_text(value: str, *, field: str) -> str:
+    text = str(value or "").strip()
+    limit = PLUGIN_HOST_TEXT_LIMITS[field]
+    if len(text) > limit:
+        raise ValueError(f"plugin host observation --{field.replace('_', '-')} must be {limit} characters or fewer")
+    if _looks_sensitive_metadata(text):
+        raise ValueError(
+            f"plugin host observation --{field.replace('_', '-')} must be metadata-only and must not include secrets, tokens, passwords, or raw prompts"
+        )
+    return text
+
+
+def _looks_sensitive_metadata(text: str) -> bool:
+    lowered = text.lower()
+    if any(pattern in lowered for pattern in PLUGIN_HOST_SENSITIVE_PATTERNS):
+        return True
+    words = lowered.replace("=", " ").replace(":", " ").replace(",", " ").split()
+    return any(word.startswith("sk-") for word in words)

--- a/src/probe.py
+++ b/src/probe.py
@@ -7,6 +7,12 @@ from .config_adapter import external_dirs, read_config
 from .local_store import read_jsonl_objects
 from .parity import build_parity_matrix
 from .paths import OmhPaths
+from .plugin_observations import (
+    PLUGIN_HOST_ACTIVE_OBSERVATION_EVENTS,
+    PLUGIN_HOST_OBSERVATION_SCHEMA_VERSION,
+    plugin_host_runtime_readiness,
+    read_plugin_host_observations,
+)
 from .plugin_pack import inspect_plugin_bundle
 from .runtime.artifacts import read_state_result
 from .targets import summarize_target_registry
@@ -203,6 +209,74 @@ def _mcp_host_session_capability(paths: OmhPaths) -> Capability:
     )
 
 
+def _plugin_runtime_observed_capability(paths: OmhPaths) -> tuple[Capability, bool, bool]:
+    records, errors = read_plugin_host_observations(paths, limit=None)
+    evidence = str(paths.runtime_plugin_host_observations_path)
+    if errors:
+        return (
+            Capability(
+                "plugin_runtime_observed",
+                "unknown",
+                evidence,
+                f"Could not read OMH plugin host observations: {'; '.join(errors[:3])}",
+            ),
+            False,
+            False,
+        )
+    latest = next(
+        (
+            record
+            for record in records
+            if record.get("schema_version") == PLUGIN_HOST_OBSERVATION_SCHEMA_VERSION
+        ),
+        None,
+    )
+    if latest and latest.get("observed"):
+        host = str(latest.get("host", "unknown"))
+        event = str(latest.get("event", "unknown"))
+        session_id = str(latest.get("session_id", "unknown"))
+        readiness = str(latest.get("runtime_readiness") or plugin_host_runtime_readiness(event=event, status="observed"))
+        active = readiness == "active_runtime_observed"
+        return (
+            Capability(
+                "plugin_runtime_observed",
+                "available",
+                evidence,
+                (
+                    f"OMH plugin active runtime observed by {host} ({event}, session={session_id})"
+                    if active
+                    else f"OMH plugin historical runtime event observed by {host} ({event}, session={session_id}); active readiness requires one of {', '.join(PLUGIN_HOST_ACTIVE_OBSERVATION_EVENTS)}"
+                ),
+            ),
+            True,
+            active,
+        )
+    if latest:
+        host = str(latest.get("host", "unknown"))
+        status = str(latest.get("status", "unknown"))
+        event = str(latest.get("event", "unknown"))
+        return (
+            Capability(
+                "plugin_runtime_observed",
+                "unverified",
+                evidence,
+                f"Latest plugin host observation from {host} is {status} ({event}); Hermes plugin runtime is not currently observed",
+            ),
+            False,
+            False,
+        )
+    return (
+        Capability(
+            "plugin_runtime_observed",
+            "unverified",
+            evidence,
+            "No Hermes runtime load/use observation is recorded; local install smoke is not native runtime evidence",
+        ),
+        False,
+        False,
+    )
+
+
 def _dir_capability(name: str, path: Path, found_message: str, missing_message: str) -> Capability:
     found = _has_dir(path)
     return Capability(
@@ -286,6 +360,7 @@ def probe_capabilities(paths: OmhPaths, *, include_parity: bool = False) -> dict
     )
     wrappers = _wrapper_artifacts(paths)
     plugin = inspect_plugin_bundle(paths)
+    plugin_runtime_capability, plugin_runtime_observed, plugin_runtime_active = _plugin_runtime_observed_capability(paths)
     plugins_dir_exists = _has_dir(paths.hermes_plugins_dir)
     capabilities.extend(
         [
@@ -317,12 +392,7 @@ def probe_capabilities(paths: OmhPaths, *, include_parity: bool = False) -> dict
                     else "Installed OMH plugin has not passed fake Hermes register smoke"
                 ),
             ),
-            Capability(
-                "plugin_runtime_observed",
-                "unverified",
-                str(paths.hermes_plugin_dir),
-                "No Hermes runtime load/use observation is recorded; local install smoke is not native runtime evidence",
-            ),
+            plugin_runtime_capability,
         ]
     )
     capabilities.append(
@@ -362,9 +432,15 @@ def probe_capabilities(paths: OmhPaths, *, include_parity: bool = False) -> dict
         "capabilities": [capability.to_dict() for capability in capabilities],
         "target_topology": target_topology,
         "plugin_distribution_ready": bool(plugin["plugin_distribution_ready"]),
+        "plugin_runtime_observed": plugin_runtime_observed,
+        "plugin_runtime_active": plugin_runtime_active,
         "mcp_host_session_observed": mcp_host_session.status == "available",
-        "native_integration_claim_ready": False,
-        "claim_boundary": "Prompt-level routing is the default unless a future stable Hermes extension surface and runtime evidence prove deeper integration.",
+        "native_integration_claim_ready": bool(plugin["plugin_distribution_ready"]) and plugin_runtime_active,
+        "claim_boundary": (
+            "Prompt-level routing is the default unless a stable Hermes extension surface and host-supplied "
+            "runtime evidence prove deeper integration. Plugin host observations prove plugin load/use only, "
+            "not coding execution, review, CI, or merge."
+        ),
     }
     if include_parity:
         payload["parity_matrix"] = build_parity_matrix(payload)

--- a/tests/test_plugin_observations.py
+++ b/tests/test_plugin_observations.py
@@ -1,0 +1,430 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from _cli_harness import run_cli
+
+
+class PluginHostObservationTests(unittest.TestCase):
+    def test_plugin_host_observation_records_runtime_load_without_execution_claims(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+            self.assertEqual(run_cli(base + ["setup", "--with-plugin"])[0], 0)
+
+            status, stdout, stderr = run_cli(
+                base
+                + [
+                    "plugin",
+                    "observe-host",
+                    "--host",
+                    "hermes-agent",
+                    "--session",
+                    "session-123",
+                    "--event",
+                    "plugin_load",
+                ]
+            )
+
+            self.assertEqual(status, 2)
+            self.assertEqual(stdout, "")
+            self.assertIn("require at least one --evidence-ref", stderr)
+
+            status, stdout, stderr = run_cli(
+                base
+                + [
+                    "plugin",
+                    "observe-host",
+                    "--host",
+                    "hermes-agent",
+                    "--session",
+                    "session-123",
+                    "--event",
+                    "plugin_load",
+                    "--status",
+                    "observed",
+                    "--evidence-ref",
+                    "host-log:plugin-loaded",
+                    "--message",
+                    "Hermes host reported OMH plugin loaded.",
+                ]
+            )
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            observation = json.loads(stdout)["observation"]
+            self.assertEqual(observation["schema_version"], "omh_plugin_host_observation/v1")
+            self.assertTrue(observation["observed"])
+            self.assertEqual(observation["host"], "hermes-agent")
+            self.assertEqual(observation["session_id"], "session-123")
+            self.assertEqual(observation["event"], "plugin_load")
+            self.assertEqual(observation["evidence_refs"], ["host-log:plugin-loaded"])
+            self.assertEqual(observation["runtime_readiness"], "active_runtime_observed")
+            self.assertTrue(observation["native_integration_active"])
+            self.assertEqual(observation["redaction_policy"], "metadata_only_bounded")
+            self.assertIn("plugin event", observation["claim_boundary"])
+            self.assertIn("not coding dispatch", observation["claim_boundary"])
+            state = json.loads((root / ".omh" / "runtime" / "state.json").read_text(encoding="utf-8"))
+            self.assertEqual(state["last_plugin_runtime_observed"]["session_id"], "session-123")
+            self.assertEqual(state["last_plugin_runtime_readiness"], "active_runtime_observed")
+
+            status, stdout, stderr = run_cli(base + ["plugin", "observations", "--limit", "1"])
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            observations = json.loads(stdout)["observations"]
+            self.assertEqual(len(observations), 1)
+            self.assertEqual(observations[0]["session_id"], "session-123")
+
+            status, stdout, stderr = run_cli(base + ["probe", "--parity", "--json"], output_json=False)
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            payload = json.loads(stdout)
+            caps = {capability["name"]: capability for capability in payload["capabilities"]}
+            self.assertTrue(payload["plugin_distribution_ready"])
+            self.assertTrue(payload["plugin_runtime_observed"])
+            self.assertTrue(payload["plugin_runtime_active"])
+            self.assertTrue(payload["native_integration_claim_ready"])
+            self.assertEqual(caps["plugin_runtime_observed"]["status"], "available")
+            self.assertIn("session-123", caps["plugin_runtime_observed"]["message"])
+            self.assertEqual(payload["parity_matrix"]["probe_alignment"]["plugin_runtime_observed"], "available")
+            self.assertEqual(payload["parity_matrix"]["probe_alignment"]["plugin_runtime_active"], "available")
+            self.assertNotIn(
+                "observed-plugin-load",
+                {item["id"] for item in payload["parity_matrix"]["recommended_next_prs"]},
+            )
+
+            status, stdout, stderr = run_cli(base + ["doctor", "--json"], output_json=False)
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            checks = {check["name"]: check for check in json.loads(stdout)["checks"]}
+            self.assertTrue(checks["plugin_runtime_observed"]["ok"])
+            self.assertTrue(checks["plugin_runtime_observed"]["observed"])
+            self.assertEqual(checks["plugin_runtime_observed"]["severity"], "ok")
+            self.assertIn("session-123", checks["plugin_runtime_observed"]["message"])
+
+    def test_plugin_host_not_observed_records_do_not_claim_native_ready(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+            self.assertEqual(run_cli(base + ["setup", "--with-plugin"])[0], 0)
+
+            status, stdout, stderr = run_cli(
+                base
+                + [
+                    "plugin",
+                    "observe-host",
+                    "--host",
+                    "hermes-agent",
+                    "--session",
+                    "session-124",
+                    "--event",
+                    "plugin_load",
+                    "--status",
+                    "not_observed",
+                    "--message",
+                    "Host checked but did not see the plugin loaded.",
+                ]
+            )
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            self.assertFalse(json.loads(stdout)["observation"]["observed"])
+
+            status, stdout, stderr = run_cli(base + ["probe", "--json"], output_json=False)
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            payload = json.loads(stdout)
+            caps = {capability["name"]: capability for capability in payload["capabilities"]}
+            self.assertTrue(payload["plugin_distribution_ready"])
+            self.assertFalse(payload["plugin_runtime_observed"])
+            self.assertFalse(payload["plugin_runtime_active"])
+            self.assertFalse(payload["native_integration_claim_ready"])
+            self.assertEqual(caps["plugin_runtime_observed"]["status"], "unverified")
+            self.assertIn("not_observed", caps["plugin_runtime_observed"]["message"])
+            state = json.loads((root / ".omh" / "runtime" / "state.json").read_text(encoding="utf-8"))
+            self.assertIsNone(state["last_plugin_runtime_observed"])
+            self.assertEqual(state["last_plugin_runtime_readiness"], "not_observed")
+
+    def test_latest_not_observed_record_stops_stale_plugin_ready_claim(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+            self.assertEqual(run_cli(base + ["setup", "--with-plugin"])[0], 0)
+            self.assertEqual(
+                run_cli(
+                    base
+                    + [
+                        "plugin",
+                        "observe-host",
+                        "--host",
+                        "hermes-agent",
+                        "--session",
+                        "session-128",
+                        "--event",
+                        "plugin_load",
+                        "--evidence-ref",
+                        "host-log:plugin-loaded",
+                    ]
+                )[0],
+                0,
+            )
+            self.assertEqual(
+                run_cli(
+                    base
+                    + [
+                        "plugin",
+                        "observe-host",
+                        "--host",
+                        "hermes-agent",
+                        "--session",
+                        "session-128",
+                        "--event",
+                        "status_query",
+                        "--status",
+                        "not_observed",
+                        "--message",
+                        "Host checked the session and did not see OMH plugin status.",
+                    ]
+                )[0],
+                0,
+            )
+
+            status, stdout, stderr = run_cli(base + ["probe", "--json"], output_json=False)
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            payload = json.loads(stdout)
+            caps = {capability["name"]: capability for capability in payload["capabilities"]}
+            self.assertFalse(payload["plugin_runtime_observed"])
+            self.assertFalse(payload["plugin_runtime_active"])
+            self.assertFalse(payload["native_integration_claim_ready"])
+            self.assertEqual(caps["plugin_runtime_observed"]["status"], "unverified")
+            self.assertIn("not_observed", caps["plugin_runtime_observed"]["message"])
+
+            status, stdout, stderr = run_cli(base + ["doctor", "--json"], output_json=False)
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            checks = {check["name"]: check for check in json.loads(stdout)["checks"]}
+            self.assertTrue(checks["plugin_runtime_observed"]["ok"])
+            self.assertFalse(checks["plugin_runtime_observed"]["observed"])
+            self.assertEqual(checks["plugin_runtime_observed"]["severity"], "warning")
+            self.assertIn("not_observed", checks["plugin_runtime_observed"]["message"])
+            state = json.loads((root / ".omh" / "runtime" / "state.json").read_text(encoding="utf-8"))
+            self.assertIsNone(state["last_plugin_runtime_observed"])
+            self.assertEqual(state["last_plugin_runtime_readiness"], "not_observed")
+
+    def test_latest_blocked_record_stops_stale_plugin_ready_claim(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+            self.assertEqual(run_cli(base + ["setup", "--with-plugin"])[0], 0)
+            self.assertEqual(
+                run_cli(
+                    base
+                    + [
+                        "plugin",
+                        "observe-host",
+                        "--host",
+                        "hermes-agent",
+                        "--session",
+                        "session-129",
+                        "--event",
+                        "plugin_load",
+                        "--evidence-ref",
+                        "host-log:plugin-loaded",
+                    ]
+                )[0],
+                0,
+            )
+            self.assertEqual(
+                run_cli(
+                    base
+                    + [
+                        "plugin",
+                        "observe-host",
+                        "--host",
+                        "hermes-agent",
+                        "--session",
+                        "session-129",
+                        "--event",
+                        "status_query",
+                        "--status",
+                        "blocked",
+                        "--message",
+                        "Host could not inspect the current plugin session.",
+                    ]
+                )[0],
+                0,
+            )
+
+            status, stdout, stderr = run_cli(base + ["probe", "--json"], output_json=False)
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            payload = json.loads(stdout)
+            caps = {capability["name"]: capability for capability in payload["capabilities"]}
+            self.assertFalse(payload["plugin_runtime_observed"])
+            self.assertFalse(payload["plugin_runtime_active"])
+            self.assertFalse(payload["native_integration_claim_ready"])
+            self.assertEqual(caps["plugin_runtime_observed"]["status"], "unverified")
+            self.assertIn("blocked", caps["plugin_runtime_observed"]["message"])
+            state = json.loads((root / ".omh" / "runtime" / "state.json").read_text(encoding="utf-8"))
+            self.assertIsNone(state["last_plugin_runtime_observed"])
+            self.assertEqual(state["last_plugin_runtime_readiness"], "blocked")
+
+    def test_plugin_host_observation_rejects_sensitive_or_unbounded_metadata(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+
+            status, stdout, stderr = run_cli(
+                base
+                + [
+                    "plugin",
+                    "observe-host",
+                    "--host",
+                    "hermes-agent",
+                    "--session",
+                    "session-130",
+                    "--event",
+                    "plugin_load",
+                    "--evidence-ref",
+                    "host-log:plugin-loaded",
+                    "--message",
+                    "raw prompt included private-token-123",
+                ]
+            )
+            self.assertEqual(status, 2)
+            self.assertEqual(stdout, "")
+            self.assertIn("metadata-only", stderr)
+
+            status, stdout, stderr = run_cli(
+                base
+                + [
+                    "plugin",
+                    "observe-host",
+                    "--host",
+                    "hermes-agent",
+                    "--session",
+                    "session-131",
+                    "--event",
+                    "plugin_load",
+                    "--evidence-ref",
+                    "secret:abc",
+                ]
+            )
+            self.assertEqual(status, 2)
+            self.assertEqual(stdout, "")
+            self.assertIn("metadata-only", stderr)
+
+            status, stdout, stderr = run_cli(
+                base
+                + [
+                    "plugin",
+                    "observe-host",
+                    "--host",
+                    "hermes-agent",
+                    "--session",
+                    "session-132",
+                    "--event",
+                    "plugin_load",
+                    "--evidence-ref",
+                    "host-log:plugin-loaded",
+                    "--message",
+                    "x" * 281,
+                ]
+            )
+            self.assertEqual(status, 2)
+            self.assertEqual(stdout, "")
+            self.assertIn("280 characters or fewer", stderr)
+
+    def test_plugin_unload_observation_is_runtime_evidence_not_native_ready(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+            self.assertEqual(run_cli(base + ["setup", "--with-plugin"])[0], 0)
+
+            status, stdout, stderr = run_cli(
+                base
+                + [
+                    "plugin",
+                    "observe-host",
+                    "--host",
+                    "hermes-agent",
+                    "--session",
+                    "session-127",
+                    "--event",
+                    "plugin_unload",
+                    "--status",
+                    "observed",
+                    "--evidence-ref",
+                    "host-log:plugin-unloaded",
+                ]
+            )
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            self.assertTrue(json.loads(stdout)["observation"]["observed"])
+
+            status, stdout, stderr = run_cli(base + ["probe", "--json"], output_json=False)
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            payload = json.loads(stdout)
+            caps = {capability["name"]: capability for capability in payload["capabilities"]}
+            self.assertTrue(payload["plugin_runtime_observed"])
+            self.assertFalse(payload["plugin_runtime_active"])
+            self.assertFalse(payload["native_integration_claim_ready"])
+            self.assertEqual(caps["plugin_runtime_observed"]["status"], "available")
+            self.assertIn("plugin_unload", caps["plugin_runtime_observed"]["message"])
+            self.assertIn("historical", caps["plugin_runtime_observed"]["message"])
+            state = json.loads((root / ".omh" / "runtime" / "state.json").read_text(encoding="utf-8"))
+            self.assertIsNone(state["last_plugin_runtime_observed"])
+            self.assertEqual(state["last_plugin_runtime_readiness"], "historical_runtime_observed")
+
+    def test_plugin_host_tool_and_hook_observations_require_names(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+
+            status, stdout, stderr = run_cli(
+                base
+                + [
+                    "plugin",
+                    "observe-host",
+                    "--host",
+                    "hermes-agent",
+                    "--session",
+                    "session-125",
+                    "--event",
+                    "tool_call",
+                    "--evidence-ref",
+                    "host-log:tool",
+                ]
+            )
+            self.assertEqual(status, 2)
+            self.assertEqual(stdout, "")
+            self.assertIn("requires --tool", stderr)
+
+            status, stdout, stderr = run_cli(
+                base
+                + [
+                    "plugin",
+                    "observe-host",
+                    "--host",
+                    "hermes-agent",
+                    "--session",
+                    "session-126",
+                    "--event",
+                    "hook_call",
+                    "--evidence-ref",
+                    "host-log:hook",
+                ]
+            )
+            self.assertEqual(status, 2)
+            self.assertEqual(stdout, "")
+            self.assertIn("requires --hook", stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- Added `omh plugin observe-host` for recording host- or wrapper-supplied OMH plugin load/use observations as `omh_plugin_host_observation/v1`.
- Added `omh plugin observations` for listing recent plugin observation records.
- Updated `omh probe`, `omh doctor`, and parity output to distinguish local plugin install smoke, historical runtime evidence, active runtime readiness, and native integration claims.
- Added bounded metadata validation so observation messages and evidence references stay short and reject obvious secret/token/raw-prompt content.
- Synced README, installation, architecture, capabilities, parity, roadmap, release docs, and focused tests.

### Why This Exists

OMH already had a plugin bundle and local import/register smoke, but it still had no explicit way for a Hermes host or wrapper to say: "I actually saw the OMH plugin load or use a tool/hook in this session." That made `plugin_runtime_observed` permanently unobserved and left a product gap between install readiness and native-runtime evidence.

This change closes that gap without turning OMH into a hidden Hermes runtime patch, transport bot, network service, or plugin loader.

### User / Operator Impact

- Operators can now record concrete plugin host evidence after a Hermes wrapper observes plugin load or plugin use.
- `omh probe --parity` can show plugin runtime evidence as available when it was actually recorded.
- `native_integration_claim_ready` is stricter than "some runtime event existed": it requires active events such as `plugin_load`, `tool_call`, `hook_call`, or `status_query`.
- `session_end` and `plugin_unload` remain historical runtime evidence only.
- `not_observed` and `blocked` records clear stale active-ready state instead of preserving old successful observations.

### How It Works

- `src/plugin_observations.py` owns the schema, event/status validation, bounded metadata guard, JSONL ledger writes, and readiness classification.
- `src/commands/plugin.py` exposes `observe-host` and `observations` CLI commands.
- `src/probe.py` reads the latest ledger record and exposes:
  - `plugin_runtime_observed` for historical plugin runtime evidence.
  - `plugin_runtime_active` for active plugin runtime readiness.
  - `native_integration_claim_ready` only when plugin distribution is ready and the latest observed event is active.
- `src/doctor.py` mirrors the same active/historical/not_observed/blocked distinction in human and JSON health output.
- State cache writes are conservative: `last_plugin_runtime_observed` is set only for active observations and becomes `null` for non-active outcomes.

### Files And Contracts Touched

- `src/plugin_observations.py`: new `omh_plugin_host_observation/v1` contract.
- `src/commands/plugin.py`: new plugin observation CLI surface.
- `src/probe.py`: plugin runtime observed/active/native-ready separation.
- `src/doctor.py`: plugin runtime observation health check.
- `src/parity.py`, `docs/PARITY.md`: parity gap closed and next-PR candidate removed.
- `README.md`, `docs/INSTALLATION.md`, `docs/ARCHITECTURE.md`, `docs/CAPABILITIES.md`, `docs/ROADMAP.md`, `docs/RELEASE.md`: boundary and rollout docs.
- `tests/test_plugin_observations.py`: regression coverage for active, historical, blocked, not observed, stale state clearing, and metadata validation.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` (609 tests passed)
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m src.cli docs workflows --check`
- [x] `uv run python -m src.cli harness validate`
- [x] `uv run python -m src.cli release skill-content-smoke --json`
- [x] `git diff --check`
- [x] Relevant dry-run or smoke command: `PYTHONPATH=tests uv run python -m unittest tests/test_plugin_observations.py tests/test_probe.py tests/test_plugin_distribution.py -v`
- [x] Code review: independent `code-reviewer` re-review found no blockers; architecture re-review returned `CLEAR`.
- [ ] `python3 -m unittest discover -s tests` (repo validation uses `uv`/`PYTHONPATH=tests`)
- [ ] `python3 -m compileall src` (repo validation uses `uv run python -m compileall -q src tests`)
- [ ] `python3 -m omh.cli docs workflows --check` (repo validation uses `uv run python -m src.cli docs workflows --check`)
- [ ] `python3 -m omh.cli harness validate` (repo validation uses `uv run python -m src.cli harness validate`)
- [ ] `python3 -m omh.cli release checklist --json` (not run; this PR does not change release checklist behavior)
- [ ] `python3 -m omh.cli release hermes-smoke` (not run; this PR adds host-supplied observation records, not a live Hermes profile smoke)
- [ ] `omh --help` (not run against installed global command; local parser help was exercised through tests)
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` (not run; no installed-command release smoke in this PR)
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; live host/plugin loading requires a target Hermes runtime and this PR records host/wrapper-supplied observations only.

## Risk

- Host/wrapper operators must provide truthful evidence references; OMH does not independently load Hermes plugins.
- The metadata guard is intentionally conservative and may reject evidence refs containing obvious secret/token words.
- `plugin_runtime_observed` and `plugin_runtime_active` are separate to avoid overclaiming, but consumers must use the active flag for readiness claims.

## Compatibility / Rollout

- Backward compatible with existing `omh setup`, plugin bundle, `omh doctor`, and `omh probe` behavior.
- Adds new CLI subcommands under `omh plugin`; no existing command is removed.
- Existing local plugin install/import/register smoke remains separate from runtime evidence.

## Release / Claims

- [x] Release-channel impact considered (`preview` feature surface; no stable release metadata changed)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Known manual Hermes checks are listed, including the live Hermes plugin-load gap

## Follow-Up

- Add host-specific plugin observation recipes if real Hermes wrappers need copy-paste examples.
- Consider richer plugin hooks/tools only after enough host-observed plugin load/use evidence exists across real environments.
