### PR TITLE
Add MCP host config recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,8 +249,8 @@ files remain an explicit advanced option.
 | "Are we ready to release?" | Separate prepared claims from observed test, review, CI, and merge-readiness evidence. |
 
 Advanced team presets, plugin status helpers, the optional MCP bridge with
-host-session evidence records, runtime observation, and release smoke commands
-are covered in the documentation below.
+host-specific config recipes, host-session evidence records, runtime
+observation, and release smoke commands are covered in the documentation below.
 
 <br>
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -475,7 +475,9 @@ host load, connector invocation, or coding execution.
 
 The MCP bridge is intentionally narrow. `omh mcp serve` speaks newline-delimited
 stdio JSON-RPC and exposes only `omh_status`, `omh_recommend`, and `omh_probe`.
-It does not expose arbitrary shell commands, mutate host MCP configuration,
+`omh mcp config-recipe --host ...` can print host-shaped config snippets for
+Claude Code, Codex, OpenCode, Cursor, and generic MCP hosts, but it does not
+mutate those host files. The bridge does not expose arbitrary shell commands,
 call external APIs, dispatch coding executors, or prove a specific Hermes host
 loaded the bridge.
 When a host or wrapper does observe bridge load or use, it can record

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -16,7 +16,8 @@ over existing OMH catalogs and contracts:
 - wrapper action ids from `src/wrapper/contract.py`
 - runtime observation events from `src/runtime/records.py`
 - plugin hook/tool metadata from `src/plugin_bundle/omh/*`
-- optional MCP bridge metadata from `omh mcp manifest`
+- optional MCP bridge metadata from `omh mcp manifest` and host recipes from
+  `omh mcp config-recipe`
 
 Use:
 
@@ -73,11 +74,12 @@ session-start guidance only, not executor dispatch, implementation, review, CI,
 or merge.
 
 The optional MCP bridge uses `omh mcp serve` and exposes only `omh_status`,
-`omh_recommend`, and `omh_probe`. Bridge availability is not host-load evidence,
-and a host config file is not proof that any MCP tool was called. A host or
-wrapper that actually observes bridge load or use can record
-`omh_mcp_host_session/v1` with `omh mcp observe-host`; that remains session
-evidence only.
+`omh_recommend`, and `omh_probe`. `omh mcp config-recipe --host
+claude-code|codex|opencode|cursor|generic` can print copy-paste snippets for
+common MCP-capable hosts, but bridge availability and host config text are not
+host-load evidence. A host or wrapper that actually observes bridge load or use
+can record `omh_mcp_host_session/v1` with `omh mcp observe-host`; that remains
+session evidence only.
 
 The optional plugin bridge has the same split. Local install/import/register
 smoke proves the bundle is present and importable. Host or wrapper evidence that

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -152,14 +152,20 @@ MCP bridge setup is also optional and intentionally conservative:
 ```sh
 omh setup --with-mcp
 omh mcp manifest
+omh mcp config-recipe --host claude-code
+omh mcp config-recipe --host codex
+omh mcp config-recipe --host opencode
+omh mcp config-recipe --host cursor
 # wrapper/host adapters can record observed host load when they see it:
 omh mcp observe-host --host hermes-agent --session <session-id> --event host_load --evidence-ref <host-log-ref>
 ```
 
 This records `mcp_mode: bridge_requested` in setup state and keeps
 `observed: false` until a Hermes/MCP host records a concrete load or tool-call
-event. `omh mcp manifest` prints a stdio MCP config snippet for the allowlisted
-`omh mcp serve` bridge. The bridge exposes only local `omh_status`,
+event. `omh mcp manifest` prints the generic stdio MCP bridge contract, and
+`omh mcp config-recipe --host ...` prints host-shaped copy-paste snippets for
+common MCP-capable environments without mutating those host config files. The
+bridge exposes only local `omh_status`,
 `omh_recommend`, and `omh_probe` tools; it is not arbitrary shell access,
 connector execution, coding dispatch, or proof that an MCP runtime is active.
 `omh mcp observe-host` is for host/wrapper adapters that already observed
@@ -402,9 +408,12 @@ call observation, host session observation, and host config separately:
 `mcp_bridge_runtime` means OMH has observed a local MCP bridge tool call, and
 `mcp_host_session` means a host or wrapper recorded load/session evidence with
 `omh mcp observe-host`. `mcp_host_config` only means a Hermes MCP config file
-such as `.mcp.json` or `mcp.json` exists. These fields do not prove connector
-invocation, coding dispatch, implementation, review, CI, merge, or unrecorded
-host-specific MCP load unless separate runtime evidence records that event.
+such as `.mcp.json` or `mcp.json` exists. `omh mcp config-recipe --host
+claude-code|codex|opencode|cursor|generic` can prepare the matching config
+shape, but a pasted config snippet is still not runtime evidence. These fields
+do not prove connector invocation, coding dispatch, implementation, review, CI,
+merge, or unrecorded host-specific MCP load unless separate runtime evidence
+records that event.
 After `omh setup` has run, `omh doctor` also checks the managed plugin manifest
 plus local import/register smoke. `omh probe` reports
 `plugin_distribution_ready` separately from `native_integration_claim_ready` so
@@ -846,6 +855,7 @@ Record the optional MCP bridge preference during setup:
 ```sh
 omh setup --with-mcp
 omh mcp manifest
+omh mcp config-recipe --host codex
 ```
 
 Use project-local OMH/Hermes paths during setup:

--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -41,7 +41,7 @@ implementation or claim runtime behavior it did not observe.
 | Team, swarm, and worker protocol | Partial | `team`, `ultrawork`, runtime handoff payloads, worker-protocol guidance, wrapper sessions, and runtime observations. | OMH does not launch hidden tmux teams, spawn workers, or manage panes by itself. |
 | Worktree and project-session isolation | Available | `worktree_session_isolation/v1` plans in coding handoffs, wrapper Prepare worktree actions, `omh worktree prepare/list/bind`, executor-session status cards, loop queue metadata, and runtime observations for worktree creation. | OMH creates local Git worktrees only through the explicit opt-in backend command; binding recipes show how wrappers can open or attach host sessions but do not auto-launch executors or claim runtime evidence. |
 | HUD, status, and session observability | Available | `omh hud`, plugin `omh_hud`/`omh_status`, wrapper sessions, runtime runs, and status cards. | Live host HUD rendering depends on Hermes/plugin support. |
-| MCP and tool bridge | Available | `omh setup --with-mcp`, `omh mcp manifest`, `omh mcp serve`, `omh mcp observe-host`, and `omh probe` preference/server/runtime/host-session/host-config separation. | OMH does not auto-enable host MCP config or independently inspect live host sessions; the host or wrapper must record load/session evidence. |
+| MCP and tool bridge | Available | `omh setup --with-mcp`, `omh mcp manifest`, `omh mcp config-recipe`, `omh mcp serve`, `omh mcp observe-host`, and `omh probe` preference/server/runtime/host-session/host-config separation. | OMH does not auto-enable host MCP config or independently inspect live host sessions; the host or wrapper must record load/session evidence. |
 | Loop and autopilot workflow | Available | `loop`, `ultraprocess`, `ralplan`, `ultragoal`, loop queue ticks, verification tiers, and failure-mode cards. | Scheduling, connector I/O, worktree creation, and subagent execution remain prepared or delegated until observed. |
 | Doctor, update, uninstall, and release smoke | Available | `omh setup`, `omh doctor`, `omh update`, `omh uninstall`, `omh release checklist`, `omh release install-smoke`, and `omh release hermes-smoke`. | Installer smoke can run live in an isolated temp HOME; live Hermes profile smoke still needs an explicit target Hermes profile or operator confirmation before mutation. |
 
@@ -72,17 +72,14 @@ implementation or claim runtime behavior it did not observe.
   executor or treating a terminal command as evidence.
 - A dependency-free stdio MCP bridge with allowlisted local `omh_status`,
   `omh_recommend`, and `omh_probe` tools plus manifest and probe evidence.
+- `omh mcp config-recipe --host ...`, which prints copy-paste config snippets
+  for Claude Code, Codex, OpenCode, Cursor, and generic MCP hosts without
+  mutating host files or claiming host load.
 - `omh_mcp_host_session/v1` records for host/wrapper-observed MCP bridge load
   or session use, kept separate from local bridge tool-call evidence and host
   config file probes.
 - Unit tests that lock JSON schema shape, human summaries, conservative claim
   boundaries, and wrapper-visible Prepare worktree actions.
-
-Next PR candidates:
-
-| Next PR | Why it matters |
-| --- | --- |
-| Host-specific MCP config recipes | Turns the manifest contract into copy-paste recipes for common MCP-capable host config shapes without auto-mutating them. |
 
 ## Acceptance Criteria
 

--- a/src/commands/main.py
+++ b/src/commands/main.py
@@ -79,7 +79,14 @@ from .materials import (
 )
 from .menubar import _add_menubar_commands, cmd_menubar_status
 from .memory import _add_memory_commands, cmd_memory_apply, cmd_memory_inspect, cmd_memory_pack
-from .mcp import cmd_mcp_manifest, cmd_mcp_observe_host, cmd_mcp_serve, cmd_mcp_sessions, _add_mcp_commands
+from .mcp import (
+    _add_mcp_commands,
+    cmd_mcp_config_recipe,
+    cmd_mcp_manifest,
+    cmd_mcp_observe_host,
+    cmd_mcp_serve,
+    cmd_mcp_sessions,
+)
 from .plugin import _add_plugin_commands, cmd_plugin_observations, cmd_plugin_observe_host
 from .ops import (
     _add_ops_commands,
@@ -165,6 +172,7 @@ def build_parser() -> argparse.ArgumentParser:
             "  omh hud\n"
             "  omh menubar status\n"
             "  omh mcp manifest\n"
+            "  omh mcp config-recipe --host codex\n"
             "  omh plugin observe-host --host hermes-agent --session <session-id> --event plugin_load --evidence-ref <host-log>\n"
             "  omh loop status\n"
             "  omh ops list\n"

--- a/src/commands/mcp.py
+++ b/src/commands/mcp.py
@@ -4,8 +4,10 @@ import argparse
 
 from ..installer import OmhError
 from ..mcp_bridge import (
+    MCP_HOST_CONFIG_RECIPE_HOSTS,
     MCP_HOST_SESSION_EVENTS,
     MCP_HOST_SESSION_STATUSES,
+    build_mcp_host_config_recipe,
     build_mcp_manifest,
     read_mcp_host_sessions,
     record_mcp_host_session,
@@ -20,6 +22,20 @@ def cmd_mcp_manifest(args: argparse.Namespace) -> int:
         command=args.command,
         include_absolute_homes=not args.portable,
     )
+    _print_json(payload)
+    return 0
+
+
+def cmd_mcp_config_recipe(args: argparse.Namespace) -> int:
+    try:
+        payload = build_mcp_host_config_recipe(
+            _paths(args),
+            host=args.host,
+            command=args.command,
+            include_absolute_homes=not args.portable,
+        )
+    except ValueError as exc:
+        raise OmhError(str(exc)) from exc
     _print_json(payload)
     return 0
 
@@ -88,6 +104,27 @@ def _add_mcp_commands(sub) -> None:
         help="Omit absolute --omh-home/--hermes-home args so the host inherits its environment.",
     )
     manifest.set_defaults(func=cmd_mcp_manifest)
+
+    config_recipe = mcp_sub.add_parser(
+        "config-recipe",
+        help="Print a host-specific copy-paste MCP config recipe without mutating host files.",
+    )
+    config_recipe.add_argument(
+        "--host",
+        default="generic",
+        help=f"Target host recipe ({', '.join(MCP_HOST_CONFIG_RECIPE_HOSTS)}). Common aliases are accepted.",
+    )
+    config_recipe.add_argument(
+        "--command",
+        default="omh",
+        help="Command path the MCP host should launch. Use an absolute installed omh path when needed.",
+    )
+    config_recipe.add_argument(
+        "--portable",
+        action="store_true",
+        help="Omit absolute --omh-home/--hermes-home args so the host inherits its environment.",
+    )
+    config_recipe.set_defaults(func=cmd_mcp_config_recipe)
 
     serve = mcp_sub.add_parser(
         "serve",

--- a/src/commands/setup.py
+++ b/src/commands/setup.py
@@ -2151,6 +2151,8 @@ def _mcp_setup_result(args: argparse.Namespace, paths) -> dict[str, object]:
         },
         "bridge": {
             "manifest_command": "omh mcp manifest",
+            "host_config_recipes_command": "omh mcp config-recipe --host <host>",
+            "known_recipe_hosts": ["generic", "claude-code", "codex", "opencode", "cursor"],
             "server_command": "omh mcp serve",
             "host_observation_command": (
                 "omh mcp observe-host --host <host> --session <session-id> "
@@ -2164,8 +2166,8 @@ def _mcp_setup_result(args: argparse.Namespace, paths) -> dict[str, object]:
             "loaded OMH, called a tool, or observed runtime evidence."
         ),
         "next_action": (
-            "Use Hermes skills as the normal surface. If the host supports MCP, export `omh mcp manifest` and "
-            "wire the stdio `omh mcp serve` bridge. Treat host load as unobserved until a Hermes/MCP host "
+            "Use Hermes skills as the normal surface. If the host supports MCP, export `omh mcp manifest` or "
+            "`omh mcp config-recipe --host <host>` and wire the stdio `omh mcp serve` bridge. Treat host load as unobserved until a Hermes/MCP host "
             "records a concrete load or tool-call event with `omh mcp observe-host`."
         ),
     }

--- a/src/mcp_bridge.py
+++ b/src/mcp_bridge.py
@@ -18,8 +18,26 @@ MCP_BRIDGE_SCHEMA_VERSION = "omh_mcp_bridge/v1"
 MCP_TOOL_RESULT_SCHEMA_VERSION = "omh_mcp_tool_result/v1"
 MCP_OBSERVATION_SCHEMA_VERSION = "omh_mcp_observation/v1"
 MCP_HOST_SESSION_SCHEMA_VERSION = "omh_mcp_host_session/v1"
+MCP_HOST_CONFIG_RECIPE_SCHEMA_VERSION = "omh_mcp_host_config_recipe/v1"
 MCP_HOST_SESSION_EVENTS = ("host_load", "session_start", "tool_call", "session_end", "host_unload")
 MCP_HOST_SESSION_STATUSES = ("observed", "not_observed", "blocked")
+MCP_HOST_CONFIG_RECIPE_HOSTS = ("generic", "claude-code", "codex", "opencode", "cursor")
+_MCP_HOST_CONFIG_RECIPE_ALIASES = {
+    "generic": "generic",
+    "mcp": "generic",
+    "claude": "claude-code",
+    "claude-code": "claude-code",
+    "claude_code": "claude-code",
+    "claude code": "claude-code",
+    "codex": "codex",
+    "openai-codex": "codex",
+    "openai_codex": "codex",
+    "opencode": "opencode",
+    "open-code": "opencode",
+    "open_code": "opencode",
+    "open code": "opencode",
+    "cursor": "cursor",
+}
 
 MCP_BRIDGE_CLAIM_BOUNDARY = (
     "The OMH MCP bridge exposes allowlisted local status, recommendation, and probe tools only. "
@@ -95,11 +113,23 @@ def mcp_tool_definitions() -> list[dict[str, Any]]:
     ]
 
 
-def build_mcp_manifest(paths: OmhPaths, *, command: str = "omh", include_absolute_homes: bool = True) -> dict[str, Any]:
+def _mcp_server_args(paths: OmhPaths, *, include_absolute_homes: bool) -> list[str]:
     args = []
     if include_absolute_homes:
         args.extend(["--omh-home", str(paths.omh_home), "--hermes-home", str(paths.hermes_home)])
     args.extend(["mcp", "serve"])
+    return args
+
+
+def _mcp_stdio_server(command: str, args: list[str], *, include_type: bool = False) -> dict[str, Any]:
+    server: dict[str, Any] = {"command": command, "args": args}
+    if include_type:
+        server["type"] = "stdio"
+    return server
+
+
+def build_mcp_manifest(paths: OmhPaths, *, command: str = "omh", include_absolute_homes: bool = True) -> dict[str, Any]:
+    args = _mcp_server_args(paths, include_absolute_homes=include_absolute_homes)
     return {
         "schema_version": MCP_BRIDGE_SCHEMA_VERSION,
         "name": "omh",
@@ -124,6 +154,7 @@ def build_mcp_manifest(paths: OmhPaths, *, command: str = "omh", include_absolut
         "setup": {
             "operator_command": f"{command} mcp manifest",
             "server_command": " ".join([command, *args]),
+            "host_config_recipes_command": f"{command} mcp config-recipe --host <host>",
             "host_observation_command": (
                 f"{command} mcp observe-host --host <host> --session <session-id> "
                 "--event host_load --status observed --evidence-ref <host-log-or-session-ref>"
@@ -132,6 +163,152 @@ def build_mcp_manifest(paths: OmhPaths, *, command: str = "omh", include_absolut
         },
         "claim_boundary": MCP_BRIDGE_CLAIM_BOUNDARY,
     }
+
+
+def build_mcp_host_config_recipe(
+    paths: OmhPaths,
+    *,
+    host: str = "generic",
+    command: str = "omh",
+    include_absolute_homes: bool = True,
+) -> dict[str, Any]:
+    host = _normalize_recipe_host(host)
+    args = _mcp_server_args(paths, include_absolute_homes=include_absolute_homes)
+    generic_server = _mcp_stdio_server(command, args)
+    typed_stdio_server = _mcp_stdio_server(command, args, include_type=True)
+    if host == "generic":
+        snippet: dict[str, Any] | str = {"mcpServers": {"omh": generic_server}}
+        snippet_text = _pretty_json(snippet)
+        config_format = "json"
+        target_paths = ["mcp.json", ".mcp.json"]
+        target_notes = ["Some MCP hosts use a host-specific MCP config file or settings panel."]
+        apply_steps = [
+            "Open the MCP-capable host configuration file.",
+            "Merge the mcpServers.omh entry into the existing config.",
+            "Restart or reload the host, then record observed load with omh mcp observe-host.",
+        ]
+        source_urls = ["https://modelcontextprotocol.io"]
+    elif host == "claude-code":
+        snippet = {"mcpServers": {"omh": typed_stdio_server}}
+        snippet_text = _pretty_json(snippet)
+        config_format = "json"
+        target_paths = [".mcp.json", "~/.claude.json"]
+        target_notes = ["Claude Code can also add the same stdio command through `claude mcp add`."]
+        apply_steps = [
+            "For project scope, merge this into .mcp.json at the project root.",
+            "Alternatively use Claude Code's MCP CLI to add the same stdio command.",
+            "Open Claude Code and approve the project MCP server if prompted, then record observed load with omh mcp observe-host.",
+        ]
+        source_urls = ["https://code.claude.com/docs/en/mcp", "https://docs.anthropic.com/en/docs/claude-code/settings"]
+    elif host == "codex":
+        snippet = _codex_mcp_toml(command, args)
+        snippet_text = snippet
+        config_format = "toml"
+        target_paths = ["~/.codex/config.toml", ".codex/config.toml"]
+        target_notes = ["Use the user config for global availability or project config for one repository."]
+        apply_steps = [
+            "Merge the [mcp_servers.omh] table into the target Codex config.toml.",
+            "Restart or reload Codex so it can start the stdio MCP server.",
+            "Record observed load or tool use with omh mcp observe-host after the host actually uses the bridge.",
+        ]
+        source_urls = [
+            "https://developers.openai.com/codex/config-basic",
+            "https://developers.openai.com/codex/config-reference",
+        ]
+    elif host == "opencode":
+        snippet = {
+            "$schema": "https://opencode.ai/config.json",
+            "mcp": {
+                "omh": {
+                    "type": "local",
+                    "command": [command, *args],
+                    "enabled": True,
+                }
+            },
+        }
+        snippet_text = _pretty_json(snippet)
+        config_format = "json"
+        target_paths = ["opencode.json", "opencode.jsonc"]
+        target_notes = ["OpenCode supports local MCP servers under the mcp config object."]
+        apply_steps = [
+            "Merge the mcp.omh entry into the OpenCode config.",
+            "Restart or reload OpenCode so it can start the local MCP server.",
+            "Record observed load or tool use with omh mcp observe-host after OpenCode actually connects.",
+        ]
+        source_urls = ["https://opencode.ai/docs/mcp-servers/", "https://opencode.ai/docs/config/"]
+    else:
+        snippet = {"mcpServers": {"omh": typed_stdio_server}}
+        snippet_text = _pretty_json(snippet)
+        config_format = "json"
+        target_paths = [".cursor/mcp.json", "~/.cursor/mcp.json"]
+        target_notes = ["Cursor MCP settings can create or open the active MCP JSON config for the current version."]
+        apply_steps = [
+            "Open Cursor MCP settings or the project/user MCP JSON file supported by the current Cursor version.",
+            "Merge the mcpServers.omh entry into the existing config.",
+            "Reload Cursor and record observed load or tool use with omh mcp observe-host after it actually connects.",
+        ]
+        source_urls = ["https://cursor.com/docs/mcp"]
+    return {
+        "schema_version": MCP_HOST_CONFIG_RECIPE_SCHEMA_VERSION,
+        "host": host,
+        "known_hosts": list(MCP_HOST_CONFIG_RECIPE_HOSTS),
+        "config_format": config_format,
+        "target_paths": target_paths,
+        "target_notes": target_notes,
+        "server": {
+            "name": "omh",
+            "transport": "stdio",
+            "command": command,
+            "args": args,
+            "tools": [tool["name"] for tool in mcp_tool_definitions()],
+        },
+        "snippet": snippet,
+        "snippet_text": snippet_text,
+        "apply_steps": apply_steps,
+        "verify": {
+            "local_command": f"{command} mcp manifest",
+            "host_observation_command": (
+                f"{command} mcp observe-host --host {host} --session <session-id> "
+                "--event host_load --status observed --evidence-ref <host-log-or-session-ref>"
+            ),
+            "boundary": "A pasted host config is not evidence that the host loaded OMH; record a host observation only after the host actually loads or uses the bridge.",
+        },
+        "source_urls": source_urls,
+        "claim_boundary": MCP_BRIDGE_CLAIM_BOUNDARY,
+    }
+
+
+def _normalize_recipe_host(host: str) -> str:
+    normalized = " ".join(str(host or "generic").strip().lower().replace("_", " ").split())
+    normalized = normalized.replace(" ", "-") if normalized in {"claude code", "openai codex", "open code"} else normalized
+    normalized = _MCP_HOST_CONFIG_RECIPE_ALIASES.get(normalized, normalized)
+    if normalized not in MCP_HOST_CONFIG_RECIPE_HOSTS:
+        raise ValueError(f"mcp config recipe host must be one of: {', '.join(MCP_HOST_CONFIG_RECIPE_HOSTS)}")
+    return normalized
+
+
+def _pretty_json(value: Any) -> str:
+    return json.dumps(value, indent=2, sort_keys=True)
+
+
+def _toml_string(value: str) -> str:
+    return json.dumps(value)
+
+
+def _toml_array(values: list[str]) -> str:
+    return "[" + ", ".join(_toml_string(value) for value in values) + "]"
+
+
+def _codex_mcp_toml(command: str, args: list[str]) -> str:
+    return "\n".join(
+        [
+            "[mcp_servers.omh]",
+            f"command = {_toml_string(command)}",
+            f"args = {_toml_array(args)}",
+            "enabled = true",
+            'enabled_tools = ["omh_status", "omh_recommend", "omh_probe"]',
+        ]
+    ) + "\n"
 
 
 def record_mcp_host_session(

--- a/src/parity.py
+++ b/src/parity.py
@@ -124,12 +124,12 @@ PARITY_CAPABILITIES: tuple[ParityCapability, ...] = (
         id="mcp_tool_bridge",
         title="MCP and tool bridge",
         common_pattern="Offer tool/MCP bridge configuration so the host agent can reach external capabilities through a controlled surface.",
-        omh_surface="`omh setup --with-mcp`, `omh mcp manifest`, `omh mcp serve`, `omh probe`, and MCP preference/host-config/runtime-call separation.",
+        omh_surface="`omh setup --with-mcp`, `omh mcp manifest`, `omh mcp config-recipe`, `omh mcp serve`, `omh probe`, and MCP preference/host-config/runtime-call separation.",
         status="available",
         evidence=("src/mcp_bridge.py", "src/commands/mcp.py", "src/probe.py", "tests/test_mcp_bridge.py"),
         missing_piece="OMH does not auto-enable a host MCP config or independently inspect live host sessions; the host or wrapper must record load/session evidence.",
         v1_decision="Ship a dependency-free stdio bridge with only allowlisted local status, recommendation, and probe tools.",
-        user_value="Operators can connect OMH to MCP-capable hosts without exposing arbitrary shell or hidden execution.",
+        user_value="Operators can connect OMH to MCP-capable hosts with copy-paste host recipes without exposing arbitrary shell or hidden execution.",
         claim_boundary="MCP bridge availability and host config are not connector invocation, coding dispatch, implementation, review, CI, merge, or host-load proof.",
     ),
     ParityCapability(
@@ -177,13 +177,7 @@ def build_parity_matrix(probe_payload: dict[str, object] | None = None) -> dict[
         },
         "capabilities": capabilities,
         "probe_alignment": _probe_alignment(probe_payload or {}),
-        "recommended_next_prs": [
-            {
-                "id": "mcp-host-config-guides",
-                "title": "Add host-specific MCP config recipes",
-                "why": "Turns the manifest contract into copy-paste recipes for common MCP-capable host config shapes without auto-mutating them.",
-            },
-        ],
+        "recommended_next_prs": [],
         "claim_boundary": (
             "The parity matrix is a product and operator contract. It does not claim hidden worker launch, "
             "automatic worktree creation, host-observed MCP load, plugin runtime load, executor execution, review, CI, or merge evidence."

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -932,6 +932,11 @@ class CliTests(unittest.TestCase):
             self.assertTrue(mcp["requested"])
             self.assertFalse(mcp["observed"])
             self.assertEqual(mcp["bridge"]["manifest_command"], "omh mcp manifest")
+            self.assertEqual(mcp["bridge"]["host_config_recipes_command"], "omh mcp config-recipe --host <host>")
+            self.assertEqual(
+                mcp["bridge"]["known_recipe_hosts"],
+                ["generic", "claude-code", "codex", "opencode", "cursor"],
+            )
             self.assertEqual(mcp["bridge"]["server_command"], "omh mcp serve")
             self.assertIn("observe-host", mcp["bridge"]["host_observation_command"])
             self.assertIn("omh_probe", mcp["bridge"]["tools"])

--- a/tests/test_mcp_bridge.py
+++ b/tests/test_mcp_bridge.py
@@ -26,7 +26,75 @@ class McpBridgeTests(unittest.TestCase):
             tools = {tool["name"] for tool in payload["tools"]}
             self.assertEqual(tools, {"omh_status", "omh_recommend", "omh_probe"})
             self.assertIn("observe-host", payload["setup"]["host_observation_command"])
+            self.assertEqual(payload["setup"]["host_config_recipes_command"], "/tmp/omh mcp config-recipe --host <host>")
             self.assertIn("allowlisted local status", payload["claim_boundary"])
+
+    def test_mcp_config_recipe_outputs_host_specific_snippets(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+
+            status, stdout, stderr = run_cli(
+                base + ["mcp", "config-recipe", "--host", "claude_code", "--command", "/tmp/omh"]
+            )
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            claude = json.loads(stdout)
+            self.assertEqual(claude["schema_version"], "omh_mcp_host_config_recipe/v1")
+            self.assertEqual(claude["host"], "claude-code")
+            self.assertEqual(claude["config_format"], "json")
+            self.assertIn(".mcp.json", claude["target_paths"])
+            self.assertIn("~/.claude.json", claude["target_paths"])
+            self.assertEqual(claude["snippet"]["mcpServers"]["omh"]["command"], "/tmp/omh")
+            self.assertEqual(claude["snippet"]["mcpServers"]["omh"]["type"], "stdio")
+            self.assertEqual(claude["snippet"]["mcpServers"]["omh"]["args"][-2:], ["mcp", "serve"])
+            self.assertTrue(claude["target_notes"])
+            self.assertIn("https://code.claude.com/docs/en/mcp", claude["source_urls"])
+            self.assertIn("not evidence that the host loaded OMH", claude["verify"]["boundary"])
+
+            status, stdout, stderr = run_cli(
+                base + ["mcp", "config-recipe", "--host", "codex", "--portable"],
+            )
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            codex = json.loads(stdout)
+            self.assertEqual(codex["config_format"], "toml")
+            self.assertEqual(codex["server"]["args"], ["mcp", "serve"])
+            self.assertIn("[mcp_servers.omh]", codex["snippet_text"])
+            self.assertIn('command = "omh"', codex["snippet_text"])
+            self.assertIn('args = ["mcp", "serve"]', codex["snippet_text"])
+            self.assertIn('enabled_tools = ["omh_status", "omh_recommend", "omh_probe"]', codex["snippet_text"])
+            self.assertIn("https://developers.openai.com/codex/config-reference", codex["source_urls"])
+
+            status, stdout, stderr = run_cli(base + ["mcp", "config-recipe", "--host", "opencode"])
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            opencode = json.loads(stdout)
+            self.assertEqual(opencode["snippet"]["mcp"]["omh"]["type"], "local")
+            self.assertEqual(opencode["snippet"]["mcp"]["omh"]["command"][0], "omh")
+            self.assertIn("https://opencode.ai/docs/mcp-servers/", opencode["source_urls"])
+
+            status, stdout, stderr = run_cli(base + ["mcp", "config-recipe", "--host", "cursor"])
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            cursor = json.loads(stdout)
+            self.assertEqual(cursor["snippet"]["mcpServers"]["omh"]["command"], "omh")
+            self.assertEqual(cursor["snippet"]["mcpServers"]["omh"]["type"], "stdio")
+            self.assertIn(".cursor/mcp.json", cursor["target_paths"])
+            self.assertIn("~/.cursor/mcp.json", cursor["target_paths"])
+            self.assertTrue(cursor["target_notes"])
+
+    def test_mcp_config_recipe_rejects_unknown_host(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+
+            status, stdout, stderr = run_cli(base + ["mcp", "config-recipe", "--host", "not-a-host"])
+
+            self.assertEqual(status, 2)
+            self.assertEqual(stdout, "")
+            self.assertIn("mcp config recipe host must be one of", stderr)
 
     def test_mcp_stdio_server_lists_and_calls_tools_without_stdout_noise(self) -> None:
         with TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Feature Report

### What Changed

- Added `omh mcp config-recipe --host <host>` to emit host-specific, copy-paste MCP config recipes for `generic`, `claude-code`, `codex`, `opencode`, and `cursor`.
- Extended the MCP manifest/setup payloads so operators and wrappers can discover the new recipe command without guessing host config shape.
- Updated README, installation, capabilities, architecture, and parity docs to describe MCP recipes as prepared guidance, not host runtime evidence.
- Added tests that lock host snippets, host aliases, setup host list, `type: "stdio"` for Claude Code/Cursor JSON recipes, Codex TOML output, OpenCode local MCP config shape, and invalid-host rejection.

### Why This Exists

OMH already had an allowlisted stdio MCP bridge and host observation ledger, but operators still had to translate the generic manifest into each MCP-capable host's config format. That made the MCP bridge feel less native and raised avoidable setup friction.

This change closes that gap while preserving OMH's product boundary: OMH can prepare the config recipe, but it does not mutate host files or claim the host loaded the bridge until a host/wrapper records concrete evidence with `omh mcp observe-host`.

### User / Operator Impact

- A user can run `omh mcp config-recipe --host codex` and get a Codex `config.toml` snippet with the OMH MCP server and allowlisted tools.
- A wrapper or operator can run `omh mcp config-recipe --host claude-code|opencode|cursor` and receive the matching JSON shape plus target paths, target notes, apply steps, source URLs, and the host observation command.
- Setup payloads now advertise `host_config_recipes_command`, so Hermes/wrapper UIs can show the next action without forcing the user to read internal docs.
- The recipe payload keeps `target_paths` machine-oriented and moves prose to `target_notes`, reducing contract ambiguity for future wrappers.

### How It Works

- `src/mcp_bridge.py` now centralizes MCP server args, host aliases, JSON/TOML snippet formatting, and `omh_mcp_host_config_recipe/v1` payload construction.
- `src/commands/mcp.py` adds the `config-recipe` subcommand with `--host`, `--command`, and `--portable` options.
- `src/commands/setup.py` adds the recipe command and known host list to the MCP setup payload.
- `src/parity.py` and docs move MCP host config recipes from a parity gap into the implemented surface.
- Runtime boundaries remain unchanged: config recipes are prepared guidance; observed host load/tool-use still requires `omh_mcp_host_session/v1` via `omh mcp observe-host`.

### Files And Contracts Touched

- `src/mcp_bridge.py`: `omh_mcp_host_config_recipe/v1`, host aliases, host snippets, Codex TOML, JSON stdio helper.
- `src/commands/mcp.py`: `omh mcp config-recipe` CLI entrypoint.
- `src/commands/setup.py`: MCP setup payload recipe discovery fields.
- `src/parity.py`: parity surface and recommended-next-PR cleanup.
- `tests/test_mcp_bridge.py`, `tests/test_cli.py`: recipe shape, host aliases, setup host list, and rejection coverage.
- `README.md`, `docs/INSTALLATION.md`, `docs/CAPABILITIES.md`, `docs/ARCHITECTURE.md`, `docs/PARITY.md`: operator-facing docs sync.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` (611 tests passed)
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m src.cli docs workflows --check`
- [x] `uv run python -m src.cli harness validate`
- [x] `uv run python -m src.cli release skill-content-smoke --json`
- [ ] `python3 -m omh.cli release checklist --json` (not run; this PR targets MCP recipe contracts and used the repo's current `uv run python -m src.cli ...` gates instead)
- [ ] `uv run python -m src.cli release hermes-smoke` (not run; no live Hermes profile mutation in this PR)
- [x] Relevant dry-run or smoke command: `uv run python -m src.cli mcp config-recipe --host claude-code --portable`
- [x] Relevant dry-run or smoke command: `uv run python -m src.cli mcp config-recipe --host cursor --portable`
- [x] Relevant dry-run or smoke command: `uv run python -m src.cli mcp config-recipe --host codex --portable`
- [x] Relevant dry-run or smoke command: `uv run python -m src.cli mcp config-recipe --host opencode --portable`
- [x] `git diff --check`
- [x] Independent code review: initial HIGH about missing `type: "stdio"` fixed; re-review found 0 blocking issues.
- [x] Independent architecture review: initial WATCH about mixed path/prose contract fixed; re-review status `CLEAR`.
- [ ] Manual live host MCP load check: not run. Host load remains not observed unless recorded by a host/wrapper.

## Risk

- Host MCP config schemas can change over time. The command includes source URLs and keeps recipes as prepared guidance rather than claiming the host accepted the config.
- Cursor official docs are JS-rendered in browser output, so the Cursor recipe stays conservative with settings guidance and `.cursor`/user MCP paths.
- Future host additions can still drift across docs/setup/parity if this grows; tests now lock the current setup host list, and a shared recipe registry can be considered later.

## Compatibility / Rollout

- Backward compatible: existing `omh mcp manifest`, `omh mcp serve`, `omh mcp observe-host`, and `omh probe` behavior is unchanged.
- No host files are mutated.
- No new dependencies.
- No network or external runtime calls inside OMH.

## Release / Claims

- [x] Release-channel impact considered: local command/package behavior only; no channel metadata change.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] Known manual Hermes checks are listed: live MCP host load was not run, and config recipe output is not host-load evidence.

## Follow-Up

- Consider a single shared MCP recipe registry if host coverage expands beyond the current five host recipes.