### PR TITLE
Sync probe and ops surface status

### DIFF
--- a/examples/hermes-ops/scheduled-competitor-digest.json
+++ b/examples/hermes-ops/scheduled-competitor-digest.json
@@ -128,6 +128,11 @@
     }
   ],
   "source": "example fixture",
+  "staged_gap_map_stage_contract": {
+    "implemented": "The OMH feature surface exists in local skill, playbook, CLI, or artifact guidance; this is not observed host/runtime execution evidence.",
+    "prepared_only": "This blueprint can prepare policy or intent, but observed host/gateway evidence is still required before claiming execution.",
+    "supported_elsewhere": "The capability is covered by a different OMH surface and is not claimed by this scheduled ops blueprint."
+  },
   "staged_gap_map": [
     {
       "gap": "automation_blueprints",
@@ -136,18 +141,18 @@
     },
     {
       "gap": "github_pr_issue_event_ops",
-      "scope": "future projection over issue/PR event intake and review status",
-      "stage": "planned"
+      "scope": "github-event-ops playbook routes issue, PR, CI, and review events into review, triage, label, or fix-handoff cards",
+      "stage": "implemented"
     },
     {
       "gap": "durable_agent_board",
-      "scope": "future board projection over multi-agent ownership and work lanes",
-      "stage": "planned"
+      "scope": "agent-board playbook provides task, handoff, heartbeat, blocker, and completion card contracts",
+      "stage": "implemented"
     },
     {
       "gap": "memory_curation",
-      "scope": "future memory/skill curation review projection",
-      "stage": "planned"
+      "scope": "memory-curation-review playbook and memory inspect/apply flows support approve/reject/update cleanup",
+      "stage": "implemented"
     },
     {
       "gap": "gateway_delivery_intent",
@@ -166,8 +171,8 @@
     },
     {
       "gap": "voice_operator_guidance",
-      "scope": "future chat/voice concise status card copy",
-      "stage": "planned"
+      "scope": "voice-operator playbook turns terse voice/mobile requests into clarify, plan, status, handoff, or confirmation actions",
+      "stage": "implemented"
     },
     {
       "gap": "toolbelt_mcp_readiness",
@@ -176,8 +181,8 @@
     },
     {
       "gap": "observability_cost_latency_evidence",
-      "scope": "status card lists missing evidence; full run/cost telemetry remains runtime-owned",
-      "stage": "partial"
+      "scope": "ops-observability-card playbook standardizes wrapper-safe token, cost, latency, run-history, and failure-mode boundaries",
+      "stage": "implemented"
     }
   ],
   "status": "prepared",

--- a/src/hermes_ops.py
+++ b/src/hermes_ops.py
@@ -36,6 +36,11 @@ PREPARED_IS_NOT_OBSERVED = (
     "A Hermes ops blueprint is projection metadata only. It is not host cron creation, gateway delivery, "
     "source retrieval, no-agent execution, plugin load, review, CI, merge-readiness, or merge evidence."
 )
+STAGED_GAP_MAP_STAGE_CONTRACT = {
+    "implemented": "The OMH feature surface exists in local skill, playbook, CLI, or artifact guidance; this is not observed host/runtime execution evidence.",
+    "prepared_only": "This blueprint can prepare policy or intent, but observed host/gateway evidence is still required before claiming execution.",
+    "supported_elsewhere": "The capability is covered by a different OMH surface and is not claimed by this scheduled ops blueprint.",
+}
 DEFAULT_NOT_EVIDENCE = (
     "host_cron_created",
     "hermes_automation_enabled",
@@ -217,6 +222,7 @@ def build_scheduled_ops_blueprint(
         "not_evidence_until_observed": list(DEFAULT_NOT_EVIDENCE),
         "observed_evidence_required": list(OBSERVED_EVIDENCE_REQUIRED),
         "prepared_is_not": PREPARED_IS_NOT_OBSERVED,
+        "staged_gap_map_stage_contract": dict(STAGED_GAP_MAP_STAGE_CONTRACT),
         "staged_gap_map": staged_gap_map(),
         "next_action": "Present the blueprint in Hermes, ask for schedule/delivery confirmation, then create host automation only outside this prepared artifact.",
         "status_card": _status_card(schedule_intent, delivery_intent, silence_policy, no_agent_suitability),
@@ -259,6 +265,14 @@ def validate_hermes_ops_blueprint(record: dict[str, Any]) -> list[str]:
         source_refs = projection.get("source_refs")
         if not isinstance(source_refs, list) or not source_refs:
             errors.append("projection.source_refs must be a non-empty list")
+    stage_contract = record.get("staged_gap_map_stage_contract")
+    if stage_contract is not None:
+        if not isinstance(stage_contract, dict):
+            errors.append("staged_gap_map_stage_contract must be an object")
+        elif "observed" in str(stage_contract.get("implemented", "")).lower() and "not observed" not in str(
+            stage_contract.get("implemented", "")
+        ).lower():
+            errors.append("staged_gap_map_stage_contract.implemented must not imply observed runtime evidence")
     for key in (
         "schedule_intent",
         "delivery_intent",
@@ -393,18 +407,18 @@ def staged_gap_map() -> list[dict[str, str]]:
         },
         {
             "gap": "github_pr_issue_event_ops",
-            "stage": "planned",
-            "scope": "future projection over issue/PR event intake and review status",
+            "stage": "implemented",
+            "scope": "github-event-ops playbook routes issue, PR, CI, and review events into review, triage, label, or fix-handoff cards",
         },
         {
             "gap": "durable_agent_board",
-            "stage": "planned",
-            "scope": "future board projection over multi-agent ownership and work lanes",
+            "stage": "implemented",
+            "scope": "agent-board playbook provides task, handoff, heartbeat, blocker, and completion card contracts",
         },
         {
             "gap": "memory_curation",
-            "stage": "planned",
-            "scope": "future memory/skill curation review projection",
+            "stage": "implemented",
+            "scope": "memory-curation-review playbook and memory inspect/apply flows support approve/reject/update cleanup",
         },
         {
             "gap": "gateway_delivery_intent",
@@ -423,8 +437,8 @@ def staged_gap_map() -> list[dict[str, str]]:
         },
         {
             "gap": "voice_operator_guidance",
-            "stage": "planned",
-            "scope": "future chat/voice concise status card copy",
+            "stage": "implemented",
+            "scope": "voice-operator playbook turns terse voice/mobile requests into clarify, plan, status, handoff, or confirmation actions",
         },
         {
             "gap": "toolbelt_mcp_readiness",
@@ -433,8 +447,8 @@ def staged_gap_map() -> list[dict[str, str]]:
         },
         {
             "gap": "observability_cost_latency_evidence",
-            "stage": "partial",
-            "scope": "status card lists missing evidence; full run/cost telemetry remains runtime-owned",
+            "stage": "implemented",
+            "scope": "ops-observability-card playbook standardizes wrapper-safe token, cost, latency, run-history, and failure-mode boundaries",
         },
     ]
 
@@ -567,12 +581,13 @@ def _prompt_outline(
     silence_policy: dict[str, object],
 ) -> dict[str, object]:
     skills = ", ".join(str(item["skill"]) for item in skill_suggestions) or "automation-blueprint"
+    delivery_surfaces = _string_list(delivery_intent.get("surfaces"))
     return {
         "system_intent": "Hermes should prepare a scheduled operation blueprint, not execute the schedule.",
         "operator_prompt": (
             f"Prepare scheduled ops for: {_preview(text, limit=160)}. "
             f"Use skills: {skills}. Cadence: {schedule_intent['cadence']}. "
-            f"Delivery: {', '.join(str(item) for item in delivery_intent['surfaces'])}. "
+            f"Delivery: {', '.join(delivery_surfaces)}. "
             f"Silence mode: {silence_policy['mode']}. Keep prepared-vs-observed boundaries explicit."
         ),
         "missing_decisions": _missing_decisions(schedule_intent, delivery_intent, silence_policy),

--- a/src/probe.py
+++ b/src/probe.py
@@ -355,7 +355,10 @@ def probe_capabilities(paths: OmhPaths, *, include_parity: bool = False) -> dict
         _dir_capability(
             "plugin_bundles",
             paths.hermes_home / "plugins",
-            "Plugin directory exists, but omh has no stable Hermes plugin bundle contract",
+            (
+                "Hermes plugin directory exists; managed OMH bundle install, import/register smoke, "
+                "and host-observed runtime load are reported by the dedicated plugin capabilities"
+            ),
             "No Hermes plugin directory detected by file probe",
         )
     )

--- a/tests/test_operations_artifacts.py
+++ b/tests/test_operations_artifacts.py
@@ -22,6 +22,7 @@ from omh.hermes_ops import (
     build_scheduled_ops_blueprint,
     list_hermes_ops_blueprints,
     show_hermes_ops_blueprint,
+    staged_gap_map,
     validate_hermes_ops_blueprint,
     validate_hermes_ops_store,
     write_hermes_ops_blueprint,
@@ -61,7 +62,20 @@ class OperationsArtifactTests(unittest.TestCase):
         self.assertIn("merge", blueprint["not_evidence_until_observed"])
         self.assertEqual(blueprint["status_card"]["not_observed"], blueprint["not_evidence_until_observed"])
         self.assertIn("not host cron creation", blueprint["prepared_is_not"])
+        self.assertIn("not observed host/runtime execution evidence", blueprint["staged_gap_map_stage_contract"]["implemented"])
         self.assertEqual(validate_hermes_ops_blueprint(blueprint), [])
+
+    def test_staged_gap_map_tracks_implemented_operator_playbooks(self) -> None:
+        stages = {item["gap"]: item["stage"] for item in staged_gap_map()}
+
+        self.assertEqual(stages["automation_blueprints"], "implemented")
+        self.assertEqual(stages["github_pr_issue_event_ops"], "implemented")
+        self.assertEqual(stages["durable_agent_board"], "implemented")
+        self.assertEqual(stages["memory_curation"], "implemented")
+        self.assertEqual(stages["voice_operator_guidance"], "implemented")
+        self.assertEqual(stages["observability_cost_latency_evidence"], "implemented")
+        self.assertNotIn("planned", stages.values())
+        self.assertNotIn("partial", stages.values())
 
     def test_scheduled_ops_blueprint_does_not_treat_content_numbers_as_time(self) -> None:
         for request in (

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -126,6 +126,8 @@ class ProbeCliTests(unittest.TestCase):
             self.assertEqual(status, 0)
             payload = json.loads(stdout)
             caps = {capability["name"]: capability for capability in payload["capabilities"]}
+            self.assertIn("dedicated plugin capabilities", caps["plugin_bundles"]["message"])
+            self.assertNotIn("no stable Hermes plugin bundle contract", caps["plugin_bundles"]["message"])
             self.assertEqual(caps["omh_plugin_bundle"]["status"], "available")
             self.assertEqual(caps["plugin_import_smoke"]["status"], "available")
             self.assertEqual(caps["plugin_register_smoke"]["status"], "available")


### PR DESCRIPTION
## Summary

This PR syncs OMH's probe and scheduled-ops status surfaces with the feature surfaces that now exist in the project.

The user-facing problem was that OMH could report stale or confusing status:

- the generic plugin directory probe still said OMH had no stable Hermes plugin bundle contract, even though dedicated plugin distribution/import/register/runtime-observation probes now exist;
- the scheduled ops blueprint `staged_gap_map` still marked several operator workflow surfaces as `planned` or `partial`, even though OMH now ships corresponding playbooks and artifact flows.

## What changed

- Updated `plugin_bundles` probe copy so the generic directory check points reviewers to the dedicated plugin capabilities instead of contradicting them.
- Refreshed scheduled ops staged gap rows for implemented OMH surfaces:
  - `github-event-ops`
  - `agent-board`
  - `memory-curation-review`
  - `voice-operator`
  - `ops-observability-card`
- Added `staged_gap_map_stage_contract` to scheduled ops blueprints so `implemented` is explicitly defined as local skill/playbook/CLI/artifact surface availability, not observed host/runtime execution evidence.
- Kept `gateway_delivery_intent` as `prepared_only` and executor/deliverable/toolbelt capabilities as `supported_elsewhere` to preserve prepared-vs-observed boundaries.
- Updated the scheduled competitor digest example fixture and tests to lock the refreshed contract.

## User/operator impact

After this change, `omh probe --parity` and scheduled ops blueprints read more consistently with the current OMH product surface. Operators should no longer see a stale "no stable plugin bundle contract" message beside successful plugin bundle smoke checks, and generated ops blueprints now describe the implemented workflow/playbook surfaces without implying cron, gateway delivery, plugin runtime load, coding execution, review, CI, or merge evidence.

## Boundary notes

This PR does not add hidden runtime execution. The new `implemented` stage means the OMH feature surface exists locally. It does not mean Hermes has executed a schedule, delivered a message, loaded the plugin at runtime, invoked a connector, reviewed code, passed CI, or merged a PR.

## Verification

Observed locally:

```sh
PYTHONPATH=tests uv run python -m unittest tests/test_probe.py tests/test_operations_artifacts.py -v
PYTHONPATH=tests uv run python -m unittest discover -s tests -v
uv run python -m src.cli docs workflows --check
uv run python -m compileall -q src tests
uv run python -m src.cli harness validate
uv run python -m src.cli release skill-content-smoke --json
uv run python -m src.cli probe --parity
uv run python -m src.cli ops blueprint "every morning check competitor news and send a Slack digest only if something changed"
uvx pyright src/probe.py src/hermes_ops.py
git diff --check
```

Independent review was also run:

- code-reviewer: APPROVE
- architect: CLEAR

## Risks and follow-up

- The scheduled ops example fixture intentionally mirrors the generated payload; future changes to public stage wording should continue to update the fixture and tests together.
- Live Hermes host plugin load, gateway delivery, cron execution, wrapper runtime observations, review, CI, and merge evidence remain outside this PR and still require observed runtime records.
