### PR TITLE
Add capability gap roadmap probe

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -474,7 +474,9 @@ requested bridge preference or config file from being mistaken for observed MCP
 host load, connector invocation, or coding execution.
 
 The MCP bridge is intentionally narrow. `omh mcp serve` speaks newline-delimited
-stdio JSON-RPC and exposes only `omh_status`, `omh_recommend`, and `omh_probe`.
+stdio JSON-RPC and exposes only `omh_status`, `omh_recommend`, and `omh_probe`;
+`omh_probe` can include parity and capability-roadmap projections when a host
+requests those advisory views.
 `omh mcp config-recipe --host ...` can print host-shaped config snippets for
 Claude Code, Codex, OpenCode, Cursor, and generic MCP hosts, but it does not
 mutate those host files. The bridge does not expose arbitrary shell commands,

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -74,7 +74,8 @@ session-start guidance only, not executor dispatch, implementation, review, CI,
 or merge.
 
 The optional MCP bridge uses `omh mcp serve` and exposes only `omh_status`,
-`omh_recommend`, and `omh_probe`. `omh mcp config-recipe --host
+`omh_recommend`, and `omh_probe`. `omh_probe` can include the parity matrix and
+capability roadmap when the host asks for them. `omh mcp config-recipe --host
 claude-code|codex|opencode|cursor|generic` can print copy-paste snippets for
 common MCP-capable hosts, but bridge availability and host config text are not
 host-load evidence. A host or wrapper that actually observes bridge load or use

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -367,6 +367,7 @@ omh runtime status
 omh runtime team-readiness
 omh probe
 omh probe --parity
+omh probe --roadmap
 ```
 
 `omh setup` should report a human-readable setup summary by default, including
@@ -447,6 +448,18 @@ coding agent. If a wrapper or operator chooses the explicit backend action,
 `omh worktree prepare` can create the local Git worktree and record
 `omh_worktree_observation/v1`; that still proves workspace isolation only, not
 executor dispatch or implementation.
+
+Use `omh probe --roadmap` when the question is "what should I do next?" rather
+than "what does OMH support?" It returns
+`omh_capability_gap_roadmap/v1` and separates baseline product/setup gaps from
+host or wrapper evidence gaps. For example, missing managed skills or Hermes
+registration points to `omh setup`; missing plugin runtime, MCP host-session,
+or wrapper-session observations points to the host or wrapper evidence that
+must be recorded before OMH can claim those runtime states. `omh probe
+--parity` includes the same roadmap so a wrapper can render capability parity
+and next actions in one status card. Roadmap actions separate executable
+backend commands from `operator_instruction` text so chat wrappers can render
+human/Hermes guidance without treating it as a shell command.
 
 For concrete examples that show how the installed skills should affect coding,
 planning, and specialist review flows, see

--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -11,9 +11,13 @@ Use the live verifier for the current local install:
 ```sh
 omh probe --parity
 omh probe --parity --json
+omh probe --roadmap
 ```
 
-The JSON payload includes `omh_parity_matrix/v1`.
+The JSON payload includes `omh_parity_matrix/v1`. `--parity` also includes
+`omh_capability_gap_roadmap/v1`, which separates real product/setup gaps from
+host or wrapper evidence gaps. This matters because a missing runtime
+observation is usually not a missing OMH feature.
 
 ## Search Basis
 
@@ -50,6 +54,9 @@ implementation or claim runtime behavior it did not observe.
 - A deterministic parity catalog in `src/parity.py`.
 - `omh probe --parity` so operators and wrappers can inspect the matrix beside
   the current local capability probe.
+- `omh probe --roadmap`, and the roadmap section inside `omh probe --parity`,
+  so operators can see whether the next step is setup, optional plugin/MCP
+  configuration, wrapper usage evidence, or host runtime observation.
 - A plugin bridge with native role context lookup, role marker injection,
   delegate marker validation, session-end checkpoints, and bounded
   `omh_gather_evidence` probes.
@@ -93,6 +100,15 @@ implementation or claim runtime behavior it did not observe.
 - `omh probe --parity` prints a human-readable parity section.
 - `omh probe --parity --json` includes `parity_matrix.schema_version` equal to
   `omh_parity_matrix/v1`.
+- `omh probe --roadmap --json` includes
+  `capability_gap_roadmap.schema_version` equal to
+  `omh_capability_gap_roadmap/v1`.
+- The roadmap distinguishes baseline product setup gaps from evidence gaps
+  such as missing wrapper metadata, MCP host-session observations, or plugin
+  runtime observations.
+- Roadmap `next_actions` keeps executable backend commands in `command` and
+  Hermes/operator guidance in `operator_instruction`, so wrappers do not treat
+  prose instructions as shell commands.
 - Team/swarm worker protocol is `available` as a readiness contract, wrapper
   action set, runtime template set, and `runtime_observation/v1` ledger. Worker
   launch, pane/session management, worker results, review, CI, and merge still

--- a/src/capability_roadmap.py
+++ b/src/capability_roadmap.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+
+CAPABILITY_GAP_ROADMAP_SCHEMA_VERSION = "omh_capability_gap_roadmap/v1"
+BASELINE_PRODUCT_CAPABILITIES = ("managed_skills", "external_skill_dirs", "target_registry")
+PLUGIN_SMOKE_CAPABILITIES = ("plugin_import_smoke", "plugin_register_smoke")
+OPTIONAL_HOST_CAPABILITIES = ("native_hooks", "apps", "native_skill_metadata", "mcp_host_config")
+
+
+def build_capability_gap_roadmap(probe_payload: dict[str, object]) -> dict[str, object]:
+    capabilities = _capability_map(probe_payload)
+    actions: list[dict[str, object]] = []
+
+    baseline_gaps = [
+        _gap_item(capabilities, name, category="product_gap", severity="blocking")
+        for name in BASELINE_PRODUCT_CAPABILITIES
+        if _status(capabilities, name) not in {"available"}
+    ]
+    baseline_gaps = [item for item in baseline_gaps if item]
+    if baseline_gaps:
+        actions.append(
+            {
+                "id": "run_setup",
+                "kind": "product_gap",
+                "priority": 10,
+                "label": "Run OMH setup",
+                "why": "Managed skills, Hermes registration, or target registry evidence is missing.",
+                "command": "omh setup",
+                "boundary": "Setup prepares and registers local OMH workflow surfaces; it is not workflow execution evidence.",
+                "capabilities": [item["capability"] for item in baseline_gaps],
+            }
+        )
+
+    optional_plugin_gap = None
+    if _status(capabilities, "omh_plugin_bundle") in {"missing", "unknown"}:
+        optional_plugin_gap = _gap_item(
+            capabilities,
+            "omh_plugin_bundle",
+            category="optional_surface",
+            severity="optional",
+        )
+        actions.append(
+            {
+                "id": "install_optional_plugin",
+                "kind": "optional_surface",
+                "priority": 60,
+                "label": "Install the optional OMH plugin bridge",
+                "why": "The skill-first path works without the plugin, but plugin tools can expose compact status and role context inside Hermes when the host loads them.",
+                "command": "omh setup --with-plugin",
+                "boundary": "Local plugin install/import/register smoke is still not proof that Hermes loaded or used the plugin.",
+                "capabilities": ["omh_plugin_bundle"],
+            }
+        )
+
+    plugin_smoke_gaps = [
+        _gap_item(capabilities, name, category="optional_surface", severity="repair")
+        for name in PLUGIN_SMOKE_CAPABILITIES
+        if _status(capabilities, name) == "missing"
+    ]
+    plugin_smoke_gaps = [item for item in plugin_smoke_gaps if item]
+    if plugin_smoke_gaps:
+        actions.append(
+            {
+                "id": "repair_optional_plugin",
+                "kind": "optional_surface",
+                "priority": 25,
+                "label": "Repair the optional OMH plugin bridge",
+                "why": "The optional plugin bundle exists, but its local import/register smoke check is failing.",
+                "command": "omh setup --with-plugin --force",
+                "boundary": "Repairing the local plugin bridge is not proof that Hermes loaded it or that any workflow executed.",
+                "capabilities": [item["capability"] for item in plugin_smoke_gaps],
+            }
+        )
+
+    evidence_gaps: list[dict[str, object]] = []
+    if probe_payload.get("plugin_distribution_ready") and not probe_payload.get("plugin_runtime_active"):
+        evidence_gaps.append(
+            _gap_item(
+                capabilities,
+                "plugin_runtime_observed",
+                category="evidence_gap",
+                severity="non_blocking",
+            )
+        )
+        actions.append(
+            {
+                "id": "observe_plugin_runtime",
+                "kind": "evidence_gap",
+                "priority": 20,
+                "label": "Record Hermes plugin runtime observation",
+                "why": "The OMH plugin bundle is locally installed, but no host-supplied active Hermes plugin event is recorded yet.",
+                "command": "omh plugin observe-host --event plugin_load --host hermes --evidence-ref <host-log-or-wrapper-event>",
+                "boundary": "A plugin observation proves only that host plugin event, not coding execution, review, CI, or merge.",
+                "capabilities": ["plugin_runtime_observed"],
+            }
+        )
+
+    if _status(capabilities, "wrapper_metadata") != "available":
+        evidence_gaps.append(
+            _gap_item(
+                capabilities,
+                "wrapper_metadata",
+                category="evidence_gap",
+                severity="non_blocking",
+            )
+        )
+        actions.append(
+            {
+                "id": "record_wrapper_usage",
+                "kind": "evidence_gap",
+                "priority": 30,
+                "label": "Record a wrapper-visible OMH workflow run",
+                "why": "OMH can prepare chat-first workflows, but no wrapper/session artifact has been observed in this OMH home yet.",
+                "operator_instruction": "Ask Hermes to use an OMH workflow, then let the wrapper record the route/session status.",
+                "boundary": "A wrapper route/session record is chat orchestration evidence; it is not executor implementation evidence.",
+                "capabilities": ["wrapper_metadata"],
+            }
+        )
+
+    mcp_preference_status = _status(capabilities, "mcp_preference")
+    if mcp_preference_status in {"unverified", "available"}:
+        for name in ("mcp_bridge_runtime", "mcp_host_session"):
+            if _status(capabilities, name) != "available":
+                evidence_gaps.append(_gap_item(capabilities, name, category="evidence_gap", severity="non_blocking"))
+        if _status(capabilities, "mcp_bridge_runtime") != "available" or _status(capabilities, "mcp_host_session") != "available":
+            actions.append(
+                {
+                    "id": "verify_mcp_bridge",
+                    "kind": "evidence_gap",
+                    "priority": 40,
+                    "label": "Verify the optional MCP bridge in the host",
+                    "why": "The MCP bridge was requested or configured, but host load/session evidence is not complete.",
+                    "command": "omh mcp config-recipe --host <host> && omh mcp serve",
+                    "boundary": "MCP config or bridge availability is not connector invocation, coding dispatch, review, CI, or merge evidence.",
+                    "capabilities": ["mcp_bridge_runtime", "mcp_host_session"],
+                }
+            )
+
+    optional_unknowns = [
+        _gap_item(capabilities, name, category="host_unknown", severity="informational")
+        for name in OPTIONAL_HOST_CAPABILITIES
+        if _status(capabilities, name) in {"unknown", "unverified"}
+    ]
+    optional_unknowns = [item for item in optional_unknowns if item]
+    if mcp_preference_status == "unknown":
+        actions.append(
+            {
+                "id": "optional_mcp_setup",
+                "kind": "optional_surface",
+                "priority": 70,
+                "label": "Optionally configure OMH as an MCP bridge",
+                "why": "Normal Hermes chat workflows do not require MCP, but MCP-capable hosts can use it for local OMH status/recommend/probe tools.",
+                "command": "omh setup --with-mcp",
+                "boundary": "MCP setup records preference and recipes; host load/use still needs observed host evidence.",
+                "capabilities": ["mcp_preference", "mcp_host_config"],
+            }
+        )
+
+    if optional_plugin_gap:
+        optional_unknowns.append(optional_plugin_gap)
+    optional_unknowns.extend(plugin_smoke_gaps)
+
+    actions.sort(key=_action_priority)
+    product_gap_count = len(baseline_gaps)
+    evidence_gap_count = len({str(item["capability"]) for item in evidence_gaps if item})
+    optional_count = len({str(item["capability"]) for item in optional_unknowns if item})
+
+    return {
+        "schema_version": CAPABILITY_GAP_ROADMAP_SCHEMA_VERSION,
+        "summary": {
+            "baseline_product_gaps": product_gap_count,
+            "evidence_gaps": evidence_gap_count,
+            "optional_or_host_unknowns": optional_count,
+            "baseline_ready": product_gap_count == 0,
+            "native_runtime_observed": bool(probe_payload.get("plugin_runtime_active")),
+            "wrapper_usage_observed": _status(capabilities, "wrapper_metadata") == "available",
+        },
+        "product_gaps": baseline_gaps,
+        "evidence_gaps": [item for item in evidence_gaps if item],
+        "optional_or_host_unknowns": optional_unknowns,
+        "next_actions": actions,
+        "claim_boundary": (
+            "This roadmap separates missing OMH product setup from missing host/runtime evidence. "
+            "It does not turn unknown or unverified host surfaces into product defects, and it does not "
+            "claim plugin load, MCP host use, wrapper routing, executor work, review, CI, or merge without matching observations."
+        ),
+    }
+
+
+def _capability_map(probe_payload: dict[str, object]) -> dict[str, dict[str, object]]:
+    capabilities = probe_payload.get("capabilities", [])
+    if not isinstance(capabilities, list):
+        return {}
+    return {
+        str(capability.get("name", "")): capability
+        for capability in capabilities
+        if isinstance(capability, dict) and str(capability.get("name", "")).strip()
+    }
+
+
+def _status(capabilities: dict[str, dict[str, object]], name: str) -> str:
+    capability = capabilities.get(name)
+    if not capability:
+        return "unknown"
+    return str(capability.get("status", "unknown"))
+
+
+def _gap_item(
+    capabilities: dict[str, dict[str, object]],
+    name: str,
+    *,
+    category: str,
+    severity: str,
+) -> dict[str, object]:
+    capability = capabilities.get(name, {})
+    return {
+        "capability": name,
+        "category": category,
+        "severity": severity,
+        "status": str(capability.get("status", "unknown")),
+        "message": str(capability.get("message", "")),
+        "evidence": str(capability.get("evidence", "")),
+    }
+
+
+def _action_priority(item: dict[str, object]) -> int:
+    priority = item.get("priority", 100)
+    if isinstance(priority, int):
+        return priority
+    if isinstance(priority, str) and priority.isdigit():
+        return int(priority)
+    return 100

--- a/src/commands/setup.py
+++ b/src/commands/setup.py
@@ -1931,6 +1931,9 @@ def _print_probe_summary(payload: dict[str, object]) -> None:
     parity = payload.get("parity_matrix")
     if isinstance(parity, dict):
         _print_probe_parity_summary(parity, use_color=use_color)
+    roadmap = payload.get("capability_gap_roadmap")
+    if isinstance(roadmap, dict):
+        _print_probe_roadmap_summary(roadmap, use_color=use_color)
     print(f"  {tr('en', 'machine_readable')}")
 
 
@@ -1962,6 +1965,41 @@ def _print_probe_parity_summary(payload: dict[str, object], *, use_color: bool) 
     if boundary:
         print(_color("Parity boundary", "1;32", use_color))
         print(f"  {_short_summary(boundary, limit=132)}")
+
+
+def _print_probe_roadmap_summary(payload: dict[str, object], *, use_color: bool) -> None:
+    summary = payload.get("summary", {})
+    if not isinstance(summary, dict):
+        summary = {}
+    print(_color("Capability roadmap", "1;32", use_color))
+    print(
+        "  Gaps: "
+        f"{summary.get('baseline_product_gaps', 0)} product setup, "
+        f"{summary.get('evidence_gaps', 0)} evidence, "
+        f"{summary.get('optional_or_host_unknowns', 0)} optional/host unknown"
+    )
+    actions = payload.get("next_actions", [])
+    if not isinstance(actions, list):
+        actions = []
+    for action in actions[:3]:
+        if not isinstance(action, dict):
+            continue
+        label = str(action.get("label", "Next action"))
+        kind = str(action.get("kind", "unknown"))
+        next_step = _short_summary(_roadmap_next_step(action), limit=100)
+        print(f"  - {label} ({kind})")
+        if next_step:
+            print(f"    Next: {next_step}")
+    boundary = str(payload.get("claim_boundary", "")).strip()
+    if boundary:
+        print(f"  Boundary: {_short_summary(boundary, limit=132)}")
+
+
+def _roadmap_next_step(action: dict[str, object]) -> str:
+    command = str(action.get("command", "")).strip()
+    if command:
+        return command
+    return str(action.get("operator_instruction", "")).strip()
 
 
 def _short_summary(value: str, *, limit: int) -> str:
@@ -2250,7 +2288,11 @@ def cmd_snippet(args: argparse.Namespace) -> int:
 
 
 def cmd_probe(args: argparse.Namespace) -> int:
-    payload = probe_capabilities(_paths(args), include_parity=bool(getattr(args, "parity", False)))
+    payload = probe_capabilities(
+        _paths(args),
+        include_parity=bool(getattr(args, "parity", False)),
+        include_roadmap=bool(getattr(args, "roadmap", False)),
+    )
     if _wants_json(args):
         _print_json(payload)
     else:
@@ -2391,6 +2433,11 @@ def _add_top_level_commands(sub) -> None:
         "--parity",
         action="store_true",
         help="Include the OMH parity matrix for common oh-my agent runtime capability axes.",
+    )
+    probe.add_argument(
+        "--roadmap",
+        action="store_true",
+        help="Include next actions that separate product setup gaps from missing host/runtime evidence.",
     )
     probe.add_argument("--json", action="store_true", help="Print the full machine-readable capability payload.")
     probe.set_defaults(func=cmd_probe)

--- a/src/mcp_bridge.py
+++ b/src/mcp_bridge.py
@@ -100,11 +100,12 @@ def mcp_tool_definitions() -> list[dict[str, Any]]:
         {
             "name": "omh_probe",
             "title": "OMH Capability Probe",
-            "description": "Return local OMH capability probe data, optionally with the parity matrix.",
+            "description": "Return local OMH capability probe data, optionally with the parity matrix and capability roadmap.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
                     "include_parity": {"type": "boolean", "default": False},
+                    "include_roadmap": {"type": "boolean", "default": False},
                 },
                 "additionalProperties": False,
             },
@@ -451,7 +452,8 @@ def handle_mcp_message(paths: OmhPaths, message: Any) -> dict[str, Any] | None:
 
 def _handle_tool_call(paths: OmhPaths, request_id: Any, params: dict[str, Any]) -> dict[str, Any]:
     name = str(params.get("name", ""))
-    arguments = params.get("arguments") if isinstance(params.get("arguments"), dict) else {}
+    raw_arguments = params.get("arguments")
+    arguments: dict[str, Any] = raw_arguments if isinstance(raw_arguments, dict) else {}
     try:
         structured = _call_tool(paths, name, arguments)
     except ValueError as exc:
@@ -491,7 +493,8 @@ def _call_tool(paths: OmhPaths, name: str, arguments: dict[str, Any]) -> dict[st
         )
     if name == "omh_probe":
         include_parity = bool(arguments.get("include_parity", False))
-        probe = probe_capabilities(paths, include_parity=include_parity)
+        include_roadmap = bool(arguments.get("include_roadmap", False))
+        probe = probe_capabilities(paths, include_parity=include_parity, include_roadmap=include_roadmap)
         return _tool_result("omh_probe_result/v1", "omh_probe", {"probe": probe})
     raise ValueError(f"Unknown tool: {name}")
 

--- a/src/probe.py
+++ b/src/probe.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 
+from .capability_roadmap import build_capability_gap_roadmap
 from .config_adapter import external_dirs, read_config
 from .local_store import read_jsonl_objects
 from .parity import build_parity_matrix
@@ -319,7 +320,7 @@ def _dir_capability(name: str, path: Path, found_message: str, missing_message: 
     )
 
 
-def probe_capabilities(paths: OmhPaths, *, include_parity: bool = False) -> dict:
+def probe_capabilities(paths: OmhPaths, *, include_parity: bool = False, include_roadmap: bool = False) -> dict:
     config_text = read_config(paths.hermes_config_path)
     configured_dirs = external_dirs(config_text)
     skills_registered = str(paths.skills_dir) in configured_dirs
@@ -484,4 +485,6 @@ def probe_capabilities(paths: OmhPaths, *, include_parity: bool = False) -> dict
     }
     if include_parity:
         payload["parity_matrix"] = build_parity_matrix(payload)
+    if include_roadmap or include_parity:
+        payload["capability_gap_roadmap"] = build_capability_gap_roadmap(payload)
     return payload

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -822,6 +822,9 @@ class CliTests(unittest.TestCase):
             self.assertIn("Parity matrix", stdout)
             self.assertIn("Team, swarm, and worker protocol: available", stdout)
             self.assertIn("Worktree and project-session isolation: available", stdout)
+            self.assertIn("Capability roadmap", stdout)
+            self.assertIn("Gaps: 0 product setup", stdout)
+            self.assertIn("Record Hermes plugin runtime observation", stdout)
             self.assertIn("For machine-readable output, rerun with `--json`.", stdout)
             with self.assertRaises(json.JSONDecodeError):
                 json.loads(stdout)

--- a/tests/test_mcp_bridge.py
+++ b/tests/test_mcp_bridge.py
@@ -118,6 +118,12 @@ class McpBridgeTests(unittest.TestCase):
                     "method": "tools/call",
                     "params": {"name": "omh_probe", "arguments": {"include_parity": True}},
                 },
+                {
+                    "jsonrpc": "2.0",
+                    "id": 5,
+                    "method": "tools/call",
+                    "params": {"name": "omh_probe", "arguments": {"include_roadmap": True}},
+                },
             ]
             stdin_text = "\n".join(json.dumps(request) for request in requests) + "\n"
 
@@ -126,17 +132,25 @@ class McpBridgeTests(unittest.TestCase):
             self.assertEqual(stderr, "")
             self.assertEqual(status, 0)
             lines = [json.loads(line) for line in stdout.splitlines()]
-            self.assertEqual([line["id"] for line in lines], [1, 2, 3, 4])
+            self.assertEqual([line["id"] for line in lines], [1, 2, 3, 4, 5])
             self.assertEqual(lines[0]["result"]["protocolVersion"], "2025-06-18")
-            tools = {tool["name"] for tool in lines[1]["result"]["tools"]}
+            listed_tools = lines[1]["result"]["tools"]
+            tools = {tool["name"] for tool in listed_tools}
             self.assertEqual(tools, {"omh_status", "omh_recommend", "omh_probe"})
+            probe_tool = next(tool for tool in listed_tools if tool["name"] == "omh_probe")
+            self.assertIn("capability roadmap", probe_tool["description"])
+            self.assertIn("include_roadmap", probe_tool["inputSchema"]["properties"])
             recommend = lines[2]["result"]["structuredContent"]
             self.assertEqual(recommend["schema_version"], "omh_mcp_tool_result/v1")
             self.assertEqual(recommend["tool"], "omh_recommend")
             self.assertIn("recommendations", recommend["payload"])
             probe = lines[3]["result"]["structuredContent"]["payload"]["probe"]
             self.assertIn("parity_matrix", probe)
+            self.assertIn("capability_gap_roadmap", probe)
             self.assertEqual(probe["parity_matrix"]["probe_alignment"]["mcp_bridge_server"], "available")
+            roadmap_probe = lines[4]["result"]["structuredContent"]["payload"]["probe"]
+            self.assertIn("capability_gap_roadmap", roadmap_probe)
+            self.assertNotIn("parity_matrix", roadmap_probe)
 
             status, stdout, stderr = run_cli(base + ["probe"])
             self.assertEqual(stderr, "")

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -31,6 +31,40 @@ class ProbeCliTests(unittest.TestCase):
             self.assertFalse(payload["plugin_distribution_ready"])
             self.assertFalse(payload["native_integration_claim_ready"])
 
+    def test_probe_roadmap_separates_product_setup_from_runtime_evidence(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+
+            status, stdout, stderr = run_cli(base + ["probe", "--roadmap", "--json"])
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            roadmap = json.loads(stdout)["capability_gap_roadmap"]
+            self.assertEqual(roadmap["schema_version"], "omh_capability_gap_roadmap/v1")
+            self.assertGreaterEqual(roadmap["summary"]["baseline_product_gaps"], 2)
+            self.assertFalse(roadmap["summary"]["baseline_ready"])
+            self.assertEqual(roadmap["next_actions"][0]["id"], "run_setup")
+            self.assertIn("not workflow execution evidence", roadmap["next_actions"][0]["boundary"])
+
+            self.assertEqual(run_cli(base + ["setup", "--with-plugin"])[0], 0)
+            status, stdout, stderr = run_cli(base + ["probe", "--parity", "--json"])
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            payload = json.loads(stdout)
+            roadmap = payload["capability_gap_roadmap"]
+            self.assertTrue(roadmap["summary"]["baseline_ready"])
+            self.assertEqual(roadmap["summary"]["baseline_product_gaps"], 0)
+            self.assertGreaterEqual(roadmap["summary"]["evidence_gaps"], 1)
+            self.assertIn("parity_matrix", payload)
+            actions = {action["id"]: action for action in roadmap["next_actions"]}
+            self.assertIn("observe_plugin_runtime", actions)
+            self.assertIn("record_wrapper_usage", actions)
+            self.assertIn("not coding execution", actions["observe_plugin_runtime"]["boundary"])
+            self.assertNotIn("command", actions["record_wrapper_usage"])
+            self.assertIn("operator_instruction", actions["record_wrapper_usage"])
+
     def test_probe_reports_available_local_evidence_after_install_and_wrapper_record(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -134,6 +168,33 @@ class ProbeCliTests(unittest.TestCase):
             self.assertEqual(caps["plugin_runtime_observed"]["status"], "unverified")
             self.assertTrue(payload["plugin_distribution_ready"])
             self.assertFalse(payload["native_integration_claim_ready"])
+
+    def test_probe_roadmap_points_to_repair_for_broken_optional_plugin(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / ".omh"
+            hermes_home = root / ".hermes"
+            base = ["--omh-home", str(omh_home), "--hermes-home", str(hermes_home)]
+
+            self.assertEqual(run_cli(base + ["setup", "--with-plugin"])[0], 0)
+            (hermes_home / "plugins" / "omh" / "__init__.py").write_text("definitely not python: nope\n", encoding="utf-8")
+
+            status, stdout, stderr = run_cli(base + ["probe", "--roadmap", "--json"])
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            payload = json.loads(stdout)
+            caps = {capability["name"]: capability for capability in payload["capabilities"]}
+            self.assertEqual(caps["omh_plugin_bundle"]["status"], "available")
+            self.assertEqual(caps["plugin_import_smoke"]["status"], "missing")
+            self.assertEqual(caps["plugin_register_smoke"]["status"], "missing")
+            self.assertFalse(payload["plugin_distribution_ready"])
+            roadmap = payload["capability_gap_roadmap"]
+            self.assertEqual(roadmap["summary"]["baseline_product_gaps"], 0)
+            actions = {action["id"]: action for action in roadmap["next_actions"]}
+            self.assertIn("repair_optional_plugin", actions)
+            self.assertEqual(actions["repair_optional_plugin"]["command"], "omh setup --with-plugin --force")
+            self.assertIn("not proof that Hermes loaded", actions["repair_optional_plugin"]["boundary"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Feature Report

### What Changed

- Added `omh_capability_gap_roadmap/v1`, an advisory projection produced by `omh probe --roadmap` and included inside `omh probe --parity`.
- Split capability findings into baseline product/setup gaps, missing evidence gaps, and optional/host unknowns.
- Added next-action guidance for setup repair, optional plugin install/repair, plugin runtime observation, wrapper usage evidence, and optional MCP bridge verification.
- Updated the MCP `omh_probe` bridge tool so hosts can request `include_roadmap` explicitly.

### Why This Exists

- `omh probe --parity` could show broad parity as available while raw probe data still contained unobserved host/runtime evidence such as wrapper metadata, plugin runtime load, or MCP host sessions.
- Operators needed a clearer answer to “what should I do next?” without treating missing host evidence as missing OMH product capability.
- Review also found a broken optional plugin install could fail import/register smoke without a repair action, so the roadmap now points to `omh setup --with-plugin --force` for that case.

### User / Operator Impact

- Users can run `omh probe --roadmap` to see whether the next step is setup, optional bridge configuration, wrapper usage observation, or host runtime evidence collection.
- Chat wrappers and MCP hosts can render the same roadmap without inventing runtime claims.
- Machine consumers no longer need to interpret prose in `command`; executable commands stay in `command`, while Hermes/operator guidance uses `operator_instruction`.

### How It Works

- `src/capability_roadmap.py` derives a schema-versioned roadmap from the existing probe payload.
- `src/probe.py` attaches the roadmap when `include_roadmap` is requested, and also when parity is requested so a wrapper can render capability parity and next actions in one payload.
- `src/commands/setup.py` adds `omh probe --roadmap` and renders the top roadmap actions in human output.
- `src/mcp_bridge.py` exposes `include_roadmap` on `omh_probe` and keeps parity/roadmap projections explicit.

### Files And Contracts Touched

- `src/capability_roadmap.py`: new `omh_capability_gap_roadmap/v1` projection.
- `src/probe.py`: `include_roadmap` support and parity-inclusive roadmap output.
- `src/commands/setup.py`: CLI flag and human roadmap summary.
- `src/mcp_bridge.py`: MCP `omh_probe` schema and call behavior.
- `tests/test_probe.py`, `tests/test_mcp_bridge.py`, `tests/test_cli.py`: roadmap classification, broken plugin repair, MCP roadmap, and human rendering coverage.
- `docs/PARITY.md`, `docs/INSTALLATION.md`, `docs/CAPABILITIES.md`, `docs/ARCHITECTURE.md`: operator docs and bridge contract copy.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` - 621 tests passed.
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_probe.py tests/test_mcp_bridge.py tests/test_cli.py -v` - 195 tests passed.
- [x] `uvx pyright src/capability_roadmap.py src/probe.py src/mcp_bridge.py` - 0 errors.
- [x] `uv run python -m compileall -q src tests` - passed.
- [x] `uv run python -m src.cli docs workflows --check` - passed.
- [x] `uv run python -m src.cli harness validate` - passed.
- [x] `uv run python -m src.cli release skill-content-smoke --json` - passed.
- [x] `uv run python -m src.cli probe --roadmap` - rendered roadmap summary.
- [x] `uv run python -m src.cli probe --roadmap --json | uv run python -m json.tool` - rendered `capability_gap_roadmap` JSON.
- [x] `git diff --check` - passed.
- [ ] `python3 -m unittest discover -s tests` - not run; project verification uses `uv run` and `PYTHONPATH=tests`.
- [ ] `python3 -m compileall src` - not run; equivalent `uv run python -m compileall -q src tests` passed.
- [ ] `python3 -m omh.cli docs workflows --check` - not run; equivalent `uv run python -m src.cli docs workflows --check` passed.
- [ ] `python3 -m omh.cli harness validate` - not run; equivalent `uv run python -m src.cli harness validate` passed.
- [ ] `python3 -m omh.cli release checklist --json` - not run; release checklist was not changed.
- [ ] `python3 -m omh.cli release hermes-smoke` - not run; live Hermes mutation was not required.
- [ ] `omh --help` - not run; command package entrypoint was not changed.
- [ ] Manual Hermes/TUI check: not run; this PR changes local deterministic probe/MCP contracts, and live host observations remain explicitly not observed.

## Risk

- Moderate: this adds a new machine-readable projection that wrappers may consume. The schema is versioned and intentionally advisory.
- The roadmap must stay aligned with probe capability IDs; capability groups are centralized in `src/capability_roadmap.py` to reduce drift.
- The roadmap does not infer host/plugin/MCP runtime evidence from local install smoke.

## Compatibility / Rollout

- Existing `omh probe` output stays compact unless `--roadmap`, `--parity`, or JSON consumers request the additional projection.
- `omh probe --parity` now includes roadmap data by design, preserving parity while adding next-action guidance.
- MCP hosts can opt into `include_roadmap`; `include_parity` still works and carries the roadmap for parity status cards.

## Release / Claims

- [x] Release-channel impact considered: preview/local behavior only; no release metadata changed.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] Known manual Hermes checks are listed; live Hermes/plugin/MCP host checks were not run and remain not observed.

## Follow-Up

- Consider moving roadmap action metadata to a more declarative catalog if capability axes grow further.
- Add live wrapper/Hermes-host smoke once a stable external host test surface is available.
