### PR TITLE
Route OMH status questions to roadmap status

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -508,7 +508,14 @@ The backend flow is:
    `omh_capability_summary/v1`, which lets Hermes explain the larger
    capability lanes and representative playbooks without a second catalog
    command.
-8. The wrapper renders `chat_response.headline`, `body`, `state`, `actions`, and
+8. If the user asks whether OMH is installed correctly, what OMH's current
+   status is, or what to do next after setup, the wrapper returns
+   `chat_response.kind == status` with `[omh] status`, a compact human summary,
+   and `chat_response.state.capability_gap_roadmap`. This is the chat-first
+   form of `omh probe --roadmap`: it separates missing product setup from
+   missing host/runtime evidence without making the user approve shell commands
+   just to understand OMH health.
+9. The wrapper renders `chat_response.headline`, `body`, `state`, `actions`, and
    `status_card` when present in the original channel or thread. The headline
    already starts with the visible OMH marker, such as `[omh] web-research`;
    adapters can read `chat_response.usage_trace` for the selected workflow,
@@ -517,7 +524,7 @@ The backend flow is:
    why/next/not-evidence card so Hermes can explain why OMH selected this
    workflow, what the user or wrapper should do next, and which claims are
    still not observed evidence.
-9. Adapters apply `chat_response.messenger_rendering` for the selected surface:
+10. Adapters apply `chat_response.messenger_rendering` for the selected surface:
    Discord, Slack, and Telegram default to `limited_markdown`, while Hermes TUI,
    web, and generic rich Markdown surfaces default to `rich_markdown`. Render
    `chat_response.messenger_rendering.body_text` for that profile. Limited
@@ -528,35 +535,35 @@ The backend flow is:
    `omh chat interact --render-profile limited_markdown`. The prefix appears
    once per response; repeat it only if the adapter splits a long answer into
    separate posted chunks.
-10. If the interaction asks for clarification, the wrapper keeps the answer in
+11. If the interaction asks for clarification, the wrapper keeps the answer in
    the same thread and calls `omh chat interact` again with the updated message.
-11. If the interaction presents a plan, the wrapper waits for the user to accept
+12. If the interaction presents a plan, the wrapper waits for the user to accept
    or revise it before preparing any coding handoff.
-12. If the accepted interaction exposes executor or runtime selection, the
+13. If the accepted interaction exposes executor or runtime selection, the
    wrapper uses the chosen profile. Codex can use the run-backed lifecycle path;
    Claude Code and generic agents use prompt-only handoffs; Hermes, OMX, OMO,
    and OMC use runtime handoffs with team/swarm, worker-protocol, and worktree
    guidance. The wrapper records only what it actually observes.
-13. For a coding profile that has not been observed before, the wrapper can run
+14. For a coding profile that has not been observed before, the wrapper can run
    `omh coding executor-readiness --executor <profile>` once and cache
    `executor_readiness/v1`. If the probe reports `missing` or `blocked`, ask the
    user to choose another coding agent, configure PATH, continue in Hermes, or
    keep a prompt/runtime handoff. Retry only after that state changes. Readiness
    is not dispatch, implementation, review, CI, or merge evidence.
-14. If the wrapper observes Hermes target metadata such as `agent_ref`,
+15. If the wrapper observes Hermes target metadata such as `agent_ref`,
    `agent_count`, or `hermes_home`, `chat_interaction/v1` may include
    `target_notice` and `target_topology`. Render the concise notice or
    `apply_target_change` action before treating single-to-multi or
    multi-to-single target changes as persistent setup state. When target
    identity metadata is present, `thread_key` is scoped by that target so two
    Hermes agents in the same channel do not share wrapper session state.
-15. If the wrapper has local memory-like context candidates, it can run
+16. If the wrapper has local memory-like context candidates, it can run
    `omh memory inspect` and attach a conflict-free `handoff_context_pack/v1` to
    the later handoff. Conflicting or stale assumptions must be shown as memory
    review, not silently reused.
-16. Status updates use `omh coding lifecycle report` or
+17. Status updates use `omh coding lifecycle report` or
    `omh chat interact --run <run-id>` and stay in the same thread.
-17. Hermes still starts with its normal config and reads `skills.external_dirs`;
+18. Hermes still starts with its normal config and reads `skills.external_dirs`;
    `omh apply` makes sure `~/.omh/skills` is included in that discovery list.
 
 `omh` provides deterministic local contracts for command registration, fallback

--- a/src/commands/chat.py
+++ b/src/commands/chat.py
@@ -112,6 +112,7 @@ def cmd_chat_interact(args: argparse.Namespace) -> int:
                 executor_target=_resolved_executor(args, default="choose"),
                 source_metadata=source_metadata,
                 target_notice=_target_notice(args, source_metadata),
+                paths=_paths(args),
             )
     except FileNotFoundError as exc:
         raise OmhError(f"runtime run not found: {args.run_id}") from exc

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -11,7 +11,9 @@ from ..executors import executor_label
 from ..goal_loop import build_loop_start_card
 from ..hermes_planning import build_hermes_plan_payload
 from ..operator_productivity import build_agent_operator_productivity_card
+from ..paths import OmhPaths, resolve_paths
 from ..plugin_bundle.omh.awareness import workflow_context_card_for_workflow, workflow_context_cards
+from ..probe import probe_capabilities
 from ..skills.catalog import installable_skill_definitions, primary_harness_for_skill, retained_delegation_skill_names
 from ..visual_summary import image_generation_setup_fallback
 from .hermes_runtime import (
@@ -318,6 +320,7 @@ def build_chat_interaction_payload(
     executor_target: str = "choose",
     source_metadata: dict[str, str] | None = None,
     target_notice: dict[str, object] | None = None,
+    paths: OmhPaths | None = None,
 ) -> dict[str, object]:
     if source not in CHAT_SOURCES:
         raise ValueError(f"unsupported chat interaction source: {source}")
@@ -335,6 +338,16 @@ def build_chat_interaction_payload(
     if _is_skill_catalog_question(message):
         route_payload = _catalog_question_route_payload(route_payload)
     base["route"] = route_payload
+
+    if _is_omh_status_question(message) and resolved_mode in {"route", "plan", "clarify"}:
+        base["mode"] = "status"
+        base["route"] = _omh_status_route_payload(route_payload)
+        base["chat_response"] = build_chat_response_from_omh_status_roadmap(
+            paths or resolve_paths(),
+            thread_key=str(base["thread_key"]),
+        )
+        base["next_action"] = str(_nested(base["chat_response"], "state").get("next_action", "show_status"))
+        return _finish_interaction(base, target_notice)
 
     if resolved_mode == "route" and _is_command_preview_invocation(message):
         base["chat_response"] = build_chat_response_from_route(
@@ -1107,6 +1120,56 @@ def build_chat_response_from_status(status_payload: dict[str, Any], *, thread_ke
     )
 
 
+def build_chat_response_from_omh_status_roadmap(paths: OmhPaths, *, thread_key: str = "") -> dict[str, object]:
+    probe = probe_capabilities(paths, include_roadmap=True)
+    roadmap = _nested(probe, "capability_gap_roadmap")
+    summary = _nested(roadmap, "summary")
+    next_actions = _roadmap_next_actions(roadmap, limit=3)
+    setup_gaps = _intish(summary.get("baseline_product_gaps", 0))
+    evidence_gaps = _intish(summary.get("evidence_gaps", 0))
+    optional_unknowns = _intish(summary.get("optional_or_host_unknowns", 0))
+    body_lines = [
+        (
+            f"OMH setup gaps: {setup_gaps}; evidence gaps: {evidence_gaps}; "
+            f"optional/host unknowns: {optional_unknowns}."
+        ),
+        _roadmap_next_action_sentence(next_actions),
+        "Boundary: local setup, plugin install, or smoke checks are not proof that Hermes loaded the plugin, ran an executor, reviewed code, passed CI, or merged anything.",
+    ]
+    return _chat_response(
+        kind="status",
+        headline="Here is the current OMH status and next action.",
+        body=" ".join(line for line in body_lines if line),
+        phase="status",
+        next_action="show_status",
+        thread_key=thread_key,
+        actions=[
+            _action("show_status", "Show status", "primary"),
+            _action("show_target_status", "Show target status", "secondary"),
+        ],
+        claim_boundary=str(roadmap.get("claim_boundary") or probe.get("claim_boundary") or _default_overclaim_guard()),
+        extra_state={
+            "status_source": "omh_probe",
+            "probe_summary": {
+                "plugin_distribution_ready": bool(probe.get("plugin_distribution_ready")),
+                "plugin_runtime_active": bool(probe.get("plugin_runtime_active")),
+                "native_integration_claim_ready": bool(probe.get("native_integration_claim_ready")),
+                "team_worker_readiness_ready": bool(probe.get("team_worker_readiness_ready")),
+                "mcp_host_session_observed": bool(probe.get("mcp_host_session_observed")),
+            },
+            "capability_gap_roadmap": roadmap,
+            "roadmap_next_actions": next_actions,
+            "workflow_explanation_reason": "The user asked for OMH status or the next operational action, so the wrapper shows local probe and roadmap evidence instead of drafting a new plan.",
+            "evidence_not_observed": [
+                "Hermes plugin runtime load",
+                "wrapper-visible workflow use",
+                "executor work",
+                "review, CI, or merge",
+            ],
+        },
+    )
+
+
 def build_status_card_from_status(status_payload: dict[str, Any]) -> dict[str, object]:
     next_action = str(status_payload.get("next_action", "show_status"))
     kind, headline, body, claim_boundary = _status_copy(status_payload, next_action)
@@ -1229,7 +1292,8 @@ def _chat_response_with_target_notice(response: dict[str, object], target_notice
     notice_body = str(target_notice.get("body", ""))
     if notice_body and notice_body not in body:
         updated["body"] = f"{body} {notice_body}".strip()
-    actions = list(updated.get("actions", []))
+    raw_actions = updated.get("actions", [])
+    actions = [action for action in raw_actions if isinstance(action, dict)] if isinstance(raw_actions, list) else []
     action_ids = {str(action.get("id", "")) for action in actions if isinstance(action, dict)}
     if "show_target_status" not in action_ids:
         actions.append(_action("show_target_status", "Show target status", "secondary"))
@@ -1347,20 +1411,166 @@ def _catalog_question_route_payload(route_payload: dict[str, object]) -> dict[st
                     "evidence_boundary": "Skill picker routing is not plan acceptance, dispatch, execution, review, CI, or verification evidence.",
                     "matched": ["catalog_question"],
                     "next_action": "choose_skill",
-                    "score": max(10, int(updated.get("score", 0) or 0)),
+                    "score": max(10, _intish(updated.get("score", 0))),
                     "skill": _ROUTER_SKILL,
                     "wrapper_guidance": "Render the OMH workflow picker in chat; do not ask the user to approve `omh list` for catalog discovery.",
                 }
             ],
             "routing_instruction": "Show the OMH workflow picker for this catalog question.",
             "routing_prompt_template": "Show the OMH workflow picker for this catalog question.\n\nUser message:\n{message}",
-            "score": max(10, int(updated.get("score", 0) or 0)),
+            "score": max(10, _intish(updated.get("score", 0))),
             "selected_harness": harness,
             "selected_skill": _ROUTER_SKILL,
             "threshold": "high",
         }
     )
     return updated
+
+
+def _omh_status_route_payload(route_payload: dict[str, object]) -> dict[str, object]:
+    updated = dict(route_payload)
+    harness = primary_harness_for_skill(_ROUTER_SKILL)
+    updated.update(
+        {
+            "action": "dispatch",
+            "ambiguous": False,
+            "candidate_harness": harness,
+            "candidate_skill": _ROUTER_SKILL,
+            "confidence": "high",
+            "reason": "OMH status or next-action question; show probe-backed status instead of drafting a plan.",
+            "recommendations": [
+                {
+                    "confidence": "high",
+                    "evidence_boundary": "Status and roadmap output is local probe evidence only; it is not host plugin load, executor work, review, CI, or merge evidence.",
+                    "matched": ["omh_status_question"],
+                    "next_action": "show_status",
+                    "score": max(10, _intish(updated.get("score", 0))),
+                    "skill": _ROUTER_SKILL,
+                    "wrapper_guidance": "Render the OMH status and capability roadmap in chat; do not ask for shell approval just to answer status.",
+                }
+            ],
+            "routing_instruction": "Show OMH status and next actions from the local probe roadmap.",
+            "routing_prompt_template": "Show OMH status and next actions from the local probe roadmap.\n\nUser message:\n{message}",
+            "score": max(10, _intish(updated.get("score", 0))),
+            "selected_harness": harness,
+            "selected_skill": _ROUTER_SKILL,
+            "threshold": "high",
+        }
+    )
+    return updated
+
+
+def _is_omh_status_question(message: str) -> bool:
+    text = message.strip().lower()
+    if not text:
+        return False
+    omh_markers = ("omh", "oh-my-hermes", "oh my hermes", "오마이헤르메스")
+    if not any(marker in text for marker in omh_markers):
+        return False
+    catalog_markers = (
+        "what can",
+        "what does",
+        "available",
+        "workflows",
+        "skills",
+        "commands",
+        "뭐 할",
+        "뭘 도와",
+        "명령어",
+        "스킬",
+        "워크플로",
+    )
+    if any(marker in text for marker in catalog_markers) and not any(
+        marker in text
+        for marker in ("status", "health", "doctor", "setup", "install", "installed", "next", "상태", "다음", "설치", "셋업", "세팅", "정상", "진단")
+    ):
+        return False
+    status_markers = (
+        "status",
+        "health",
+        "doctor",
+        "diagnose",
+        "installed",
+        "installation",
+        "setup",
+        "set up",
+        "next action",
+        "what next",
+        "what should i do next",
+        "what do i do next",
+        "상태",
+        "다음",
+        "액션",
+        "설치",
+        "셋업",
+        "세팅",
+        "정상",
+        "확인",
+        "헬스",
+        "진단",
+    )
+    return any(marker in text for marker in status_markers)
+
+
+def _roadmap_next_actions(roadmap: dict[str, Any], *, limit: int) -> list[dict[str, object]]:
+    actions = roadmap.get("next_actions", [])
+    if not isinstance(actions, list):
+        return []
+    compact: list[dict[str, object]] = []
+    for action in actions:
+        if not isinstance(action, dict):
+            continue
+        item = {
+            "id": str(action.get("id", "")),
+            "kind": str(action.get("kind", "")),
+            "label": str(action.get("label", "")),
+            "why": str(action.get("why", "")),
+            "boundary": str(action.get("boundary", "")),
+            "capabilities": _as_string_list(action.get("capabilities", [])),
+        }
+        command = str(action.get("command", "")).strip()
+        operator_instruction = str(action.get("operator_instruction", "")).strip()
+        if command:
+            item["command"] = command
+        if operator_instruction:
+            item["operator_instruction"] = operator_instruction
+        compact.append(item)
+        if len(compact) >= limit:
+            break
+    return compact
+
+
+def _roadmap_next_action_sentence(actions: list[dict[str, object]]) -> str:
+    if not actions:
+        return "Next: no blocking OMH setup action is currently required."
+    first = actions[0]
+    label = str(first.get("label", "Check OMH status")).strip() or "Check OMH status"
+    kind = str(first.get("kind", "")).strip()
+    command = str(first.get("command", "")).strip()
+    operator_instruction = str(first.get("operator_instruction", "")).strip()
+    why = str(first.get("why", "")).strip()
+    if command and kind == "product_gap" and "<" not in command:
+        return f"Next: {label} with `{command}`."
+    if operator_instruction:
+        return f"Next: {label}: {operator_instruction}"
+    if why:
+        return f"Next: {label}. {why}"
+    return f"Next: {label}."
+
+
+def _intish(value: object, default: int = 0) -> int:
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return default
+    return default
 
 
 def _is_skill_picker_invocation(message: str) -> bool:
@@ -1394,6 +1604,8 @@ def _is_command_preview_invocation(message: str) -> bool:
 
 def _command_preview_response(decision: dict[str, object], *, thread_key: str = "", message: str = "") -> dict[str, object]:
     preview = _command_preview_state(message, source=str(decision.get("source", "generic")))
+    suggestions = _as_dict_list(preview.get("suggestions", []))
+    insert_text = str(suggestions[0].get("insert_text", "./omh")) if suggestions else "./omh"
     return _chat_response(
         kind="command_preview",
         headline="Open OMH.",
@@ -1408,7 +1620,7 @@ def _command_preview_response(decision: dict[str, object], *, thread_key: str = 
                 "primary",
                 payload={
                     "schema_version": COMMAND_PREVIEW_SCHEMA_VERSION,
-                    "suggestions": preview["suggestions"],
+                    "suggestions": suggestions,
                 },
             ),
             _action(
@@ -1416,7 +1628,7 @@ def _command_preview_response(decision: dict[str, object], *, thread_key: str = 
                 "Open picker",
                 "secondary",
                 payload={
-                    "insert_text": preview["suggestions"][0]["insert_text"] if preview["suggestions"] else "./omh",
+                    "insert_text": insert_text,
                     "opens_schema": SKILL_PICKER_SCHEMA_VERSION,
                 },
             ),
@@ -1585,16 +1797,14 @@ def _catalog_capability_summary() -> dict[str, object]:
 
     summary = capability_summary()
     compact_lanes = []
-    for lane in summary.get("lanes", []):
-        if not isinstance(lane, dict):
-            continue
+    for lane in _as_dict_list(summary.get("lanes", [])):
         compact_lanes.append(
             {
                 "id": lane.get("id", ""),
                 "label": lane.get("label", ""),
                 "owner_role": lane.get("owner_role", ""),
                 "use_for": lane.get("use_for", ""),
-                "primary_skills": list(lane.get("primary_skills", [])),
+                "primary_skills": _as_string_list(lane.get("primary_skills", [])),
                 "representative_playbooks": [
                     {
                         "id": playbook.get("id", ""),
@@ -1602,21 +1812,26 @@ def _catalog_capability_summary() -> dict[str, object]:
                         "owner_role": playbook.get("owner_role", ""),
                         "first_stage": playbook.get("first_stage", {}),
                     }
-                    for playbook in lane.get("representative_playbooks", [])[:3]
-                    if isinstance(playbook, dict)
+                    for playbook in _as_dict_list(lane.get("representative_playbooks", []))[:3]
                 ],
-                "wrapper_actions": list(lane.get("wrapper_actions", []))[:6],
-                "examples": list(lane.get("examples", []))[:3],
+                "wrapper_actions": _as_string_list(lane.get("wrapper_actions", []))[:6],
+                "examples": _as_string_list(lane.get("examples", []))[:3],
             }
         )
     return {
         "schema_version": summary.get("schema_version", "omh_capability_summary/v1"),
         "purpose": summary.get("purpose", ""),
         "lanes": compact_lanes,
-        "workflow_context_cards": list(summary.get("workflow_context_cards", [])),
+        "workflow_context_cards": _as_dict_list(summary.get("workflow_context_cards", [])),
         "direct_response_guidance": _as_string_list(summary.get("direct_response_guidance", [])),
         "evidence_boundary": _as_string_list(summary.get("evidence_boundary", [])),
     }
+
+
+def _as_dict_list(value: object) -> list[dict[str, object]]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, dict)]
 
 
 def _as_string_list(value: object) -> list[str]:
@@ -2231,12 +2446,14 @@ def _action(action_id: str, label: str, style: str, *, enabled: bool = True, pay
 
 
 def _action_from_spec(spec: dict[str, object]) -> dict[str, object]:
+    payload_value = spec.get("payload")
+    payload = {str(key): value for key, value in payload_value.items()} if isinstance(payload_value, dict) else None
     return _action(
         str(spec.get("id", "")),
         str(spec.get("label", "")),
         str(spec.get("style", "")),
         enabled=bool(spec.get("enabled", True)),
-        payload=spec.get("payload") if isinstance(spec.get("payload"), dict) else None,
+        payload=payload,
     )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -89,6 +89,27 @@ class CliTests(unittest.TestCase):
             self.assertEqual(payload["next_action"], "audit_learning_readiness")
             self.assertIn("guard:workflow_learning", payload["route"]["recommendations"][0]["matched"])
 
+    def test_chat_interact_omh_status_question_uses_probe_roadmap(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+            status, stdout, stderr = run_cli(
+                base + ["chat", "interact", "--source", "discord", "omh 상태랑 다음 액션 알려줘"],
+                output_json=False,
+            )
+
+            self.assertEqual(status, 0, stderr)
+            self.assertEqual(stderr, "")
+            payload = json.loads(stdout)
+            self.assertEqual(payload["mode"], "status")
+            self.assertEqual(payload["next_action"], "show_status")
+            self.assertEqual(payload["chat_response"]["kind"], "status")
+            self.assertTrue(payload["chat_response"]["headline"].startswith("[omh] status - "))
+            state = payload["chat_response"]["state"]
+            self.assertEqual(state["capability_gap_roadmap"]["schema_version"], "omh_capability_gap_roadmap/v1")
+            self.assertEqual(state["roadmap_next_actions"][0]["id"], "run_setup")
+            self.assertIn("omh setup", state["roadmap_next_actions"][0]["command"])
+
     def test_learning_record_eval_and_regression_replay(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/test_wrapper_contract.py
+++ b/tests/test_wrapper_contract.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
 import unittest
 
 from _local_package import load_local_package
 
 load_local_package()
+from omh.paths import OmhPaths
 from omh.wrapper_contract import (
     build_chat_interaction_payload,
     build_chat_response_from_status,
@@ -600,6 +603,34 @@ class WrapperContractTests(unittest.TestCase):
         self.assertTrue(response["headline"].startswith("[omh] status - "))
         self.assertEqual(response["usage_trace"]["visible_prefix"], "[omh] status")
         self.assertEqual(response["usage_trace"]["evidence_state"], "observed_partial")
+
+    def test_omh_status_questions_render_probe_roadmap_instead_of_plan(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = OmhPaths(omh_home=Path(tmp) / ".omh", hermes_home=Path(tmp) / ".hermes")
+            for message in (
+                "what should I do next with OMH setup?",
+                "omh 상태랑 다음 액션 알려줘",
+                "is OMH installed correctly?",
+                "show OMH status",
+            ):
+                with self.subTest(message=message):
+                    payload = build_chat_interaction_payload(message, source="discord", paths=paths)
+
+                    self.assertEqual(payload["mode"], "status")
+                    self.assertEqual(payload["next_action"], "show_status")
+                    self.assertEqual(payload["route"]["selected_skill"], "oh-my-hermes")
+                    self.assertEqual(payload["chat_response"]["kind"], "status")
+                    self.assertTrue(payload["chat_response"]["headline"].startswith("[omh] status - "))
+                    self.assertIn("OMH setup gaps:", payload["chat_response"]["body"])
+                    self.assertIn("Boundary:", payload["chat_response"]["body"])
+                    state = payload["chat_response"]["state"]
+                    self.assertEqual(state["status_source"], "omh_probe")
+                    roadmap = state["capability_gap_roadmap"]
+                    self.assertEqual(roadmap["schema_version"], "omh_capability_gap_roadmap/v1")
+                    self.assertGreaterEqual(roadmap["summary"]["baseline_product_gaps"], 1)
+                    self.assertEqual(state["roadmap_next_actions"][0]["id"], "run_setup")
+                    self.assertEqual(state["workflow_explanation"]["label"], "status")
+                    self.assertNotIn(message, json.dumps(payload))
 
     def test_direct_omh_invocation_exposes_skill_picker(self) -> None:
         payload = build_chat_interaction_payload("./omh", source="discord")


### PR DESCRIPTION
## Feature Report

### What Changed

- Added a chat-first OMH status response for messages such as `what should I do next with OMH setup?`, `is OMH installed correctly?`, `show OMH status`, and `omh 상태랑 다음 액션 알려줘`.
- `omh chat interact` now returns `chat_response.kind == status`, `[omh] status`, and `chat_response.state.capability_gap_roadmap` for those questions instead of falling into generic plan mode.
- Passed CLI-resolved `OmhPaths` into the wrapper interaction builder so `--omh-home` / `--hermes-home` status checks use the same local state as the CLI invocation.
- Tightened a few loose object/list conversions in `src/wrapper/contract.py` while keeping behavior compatible.
- Documented the wrapper behavior in the chat backend flow.

### Why This Exists

- Hermes users often ask status and next-action questions in Discord, Slack, Telegram, or Hermes TUI rather than running backend commands manually.
- Before this change, status-like OMH questions could route to `plan`, producing "accept or revise the plan" copy instead of answering whether OMH setup/runtime evidence is healthy.
- The product boundary from the previous roadmap work is useful only if Hermes can surface it naturally in chat.

### User / Operator Impact

- A user can ask Hermes "what should I do next with OMH setup?" and get a compact status answer instead of a draft plan.
- Wrappers can render the top-level `show_status` / `show_target_status` actions plus the machine-readable `omh_capability_gap_roadmap/v1` state.
- The response separates setup gaps, evidence gaps, and optional host unknowns while keeping host plugin load, wrapper usage, executor work, review, CI, and merge as not observed unless matching evidence exists.
- Catalog questions such as "what can OMH do?" still open the skill picker and do not become status responses.

### How It Works

- `build_chat_interaction_payload(...)` now accepts an optional `paths: OmhPaths` argument.
- `cmd_chat_interact` passes `_paths(args)` into the wrapper builder.
- A narrow `_is_omh_status_question(...)` guard recognizes explicit OMH status/setup/health/next-action phrasing.
- Status questions use `probe_capabilities(paths, include_roadmap=True)` and build a `chat_response/v1` status envelope with compact body copy, roadmap state, and conservative evidence boundaries.
- Route metadata is rewritten to `oh-my-hermes` with `next_action == show_status` so the envelope does not claim one workflow while rendering another.

### Files And Contracts Touched

- `src/wrapper/contract.py`: status question guard, status roadmap response builder, route payload rewrite, typed helper cleanup.
- `src/commands/chat.py`: passes CLI paths into the interaction builder.
- `tests/test_wrapper_contract.py`: locks English/Korean status questions as status responses instead of plans.
- `tests/test_cli.py`: locks `omh chat interact` status behavior with isolated OMH/Hermes homes.
- `docs/INSTALLATION.md`: documents wrapper-native OMH status/next-action questions.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` -> 623 tests OK.
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_wrapper_contract.py tests/test_cli.py -v` -> 229 tests OK.
- [x] `uvx pyright src/wrapper/contract.py src/commands/chat.py` -> 0 errors, 0 warnings.
- [x] `uv run python -m compileall -q src tests` -> OK.
- [x] `uv run python -m src.cli docs workflows --check` -> OK; 41/41 tap skills checked.
- [x] `git diff --check` -> OK.
- [x] Relevant dry-run or smoke command: `uv run python -m src.cli chat interact "what should I do next with OMH setup?" | uv run python -m json.tool` -> `mode: status`, `chat_response.kind: status`, roadmap state included.
- [x] Relevant dry-run or smoke command: `uv run python -m src.cli chat interact "omh 상태랑 다음 액션 알려줘" | uv run python -m json.tool` -> `mode: status`, `[omh] status`, roadmap state included.
- [x] Manual Hermes/TUI check, or explicit reason it was not run: live Hermes host/plugin observation was not run; this PR intentionally only adds deterministic local wrapper status behavior.

## Risk

- Moderate routing risk: the new guard could catch an OMH setup/status phrase that the user intended as a broader plan request. It requires explicit OMH wording plus status/setup/health/next-action wording to keep the match narrow.
- The status body exposes only a compact summary; detailed commands and operator instructions remain in state payloads so chat copy stays less CLI-heavy.

## Compatibility / Rollout

- Existing `chat_interaction/v1` and `chat_response/v1` envelopes remain compatible.
- Existing catalog picker behavior is preserved for OMH catalog questions.
- Existing `build_chat_interaction_payload(...)` callers remain source-compatible because `paths` is optional.
- Wrappers that do not inspect the new roadmap state still receive a normal status response with visible body copy and actions.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`): preview/stable workflow behavior improves without requiring migration.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed: status copy explicitly separates local setup/probe evidence from host/plugin/executor/review/CI/merge evidence.
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap: live host/plugin observation was not run for this deterministic wrapper contract PR.

## Follow-Up

- Consider a richer visual status card renderer for `capability_gap_roadmap` if wrapper operators want more than the current compact body plus state payload.
