### PR TITLE
Route specific capability questions to workflow cards

### DIFF
--- a/docs/CHAT_WRAPPER_EXAMPLES.md
+++ b/docs/CHAT_WRAPPER_EXAMPLES.md
@@ -134,6 +134,15 @@ user asks "이미지 생성 기능 뭐 있어?", "does OMH support image generat
 `image_generation_setup/v1` actions instead of falling back to the generic OMH
 workflow picker.
 
+The same rule applies to other specific capability questions. A broad question
+such as "OMH 기능 뭐 있어?" still opens `omh_skill_picker/v1`, but "does OMH
+support scheduled automation?", "can OMH help with MCP setup?", "does OMH
+support memory cleanup?", "does OMH support voice commands?", or "OMH로 GitHub
+issue webhook 처리 가능해?" should open the matching workflow card directly.
+Selection remains routing intent only; host automation, credentials, memory
+updates, platform actions, and webhook effects stay unobserved until separate
+evidence is recorded.
+
 That returns `chat_route_hint/v1` with a `chat_response` card the adapter can
 render immediately:
 

--- a/src/routing/chat.py
+++ b/src/routing/chat.py
@@ -20,7 +20,61 @@ from ..skills.catalog import SkillDefinition, primary_harness_for_skill, routabl
 FILE_LOOKUP_REASON = (
     "File or text lookup request; answer directly or ask for the target file instead of dispatching to a workflow keyword."
 )
-_SPECIFIC_CAPABILITY_CATALOG_SKILLS = frozenset({"img-summary"})
+_ROUTER_SKILL = "oh-my-hermes"
+_SPECIFIC_CAPABILITY_CATALOG_MIN_SCORE = 6
+_SPECIFIC_CAPABILITY_CATALOG_SKILLS = frozenset(
+    {
+        "agent-board",
+        "agent-ops-review",
+        "automation-blueprint",
+        "deliverable-package",
+        "executor-runtime-readiness",
+        "feedback-triage",
+        "github-event-ops",
+        "img-summary",
+        "loop",
+        "materials-package",
+        "memory-curation-review",
+        "operating-rhythm",
+        "ops-observability-card",
+        "report-package",
+        "research-department",
+        "strategy-brief",
+        "toolbelt-readiness",
+        "ultraprocess",
+        "voice-operator",
+        "web-research",
+        "workflow-learning",
+    }
+)
+_BROAD_CAPABILITY_CATALOG_PHRASES = (
+    "planning, research, and coding",
+    "planning/research/coding",
+    "planning, research, coding",
+    "deep-interview/ralplan/loop",
+    "계획/리서치/코딩",
+    "플랜/리서치/코딩",
+)
+_BROAD_CAPABILITY_TOPIC_TOKENS = frozenset(
+    {
+        "planning",
+        "plan",
+        "research",
+        "coding",
+        "interview",
+        "workflow",
+        "workflows",
+        "skill",
+        "skills",
+        "계획",
+        "플랜",
+        "리서치",
+        "코딩",
+        "워크플로",
+        "워크플로우",
+        "스킬",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -67,6 +121,14 @@ def route_chat_message(
 
     definitions = routable_definitions()
     full_recommendations = recommend_skills(message, limit=len(definitions))
+    catalog_question = is_skill_catalog_question(message)
+    specific_catalog_match = (
+        _specific_capability_catalog_match(full_recommendations)
+        if catalog_question and not _is_broad_capability_catalog_question(message)
+        else None
+    )
+    if specific_catalog_match is not None:
+        full_recommendations = _prioritize_recommendation(full_recommendations, specific_catalog_match)
     recommendations = tuple(full_recommendations[:limit])
     top = full_recommendations[0]
     explicit_skill = explicit_skill_invocation(message, definitions)
@@ -75,7 +137,6 @@ def route_chat_message(
     candidate_score = _int_value(top["score"])
     candidate_confidence = str(top["confidence"])
     ambiguous = _is_ambiguous(full_recommendations)
-    catalog_question = is_skill_catalog_question(message)
     file_or_text_lookup = is_file_or_text_lookup_question(message)
 
     if explicit_skill:
@@ -83,7 +144,7 @@ def route_chat_message(
         action = "dispatch"
         reason = "Explicit workflow invocation wins over heuristic routing."
         ambiguous = False
-    elif catalog_question and _specific_capability_catalog_match(top):
+    elif catalog_question and specific_catalog_match is not None:
         selected_skill = candidate_skill
         action = "dispatch"
         reason = (
@@ -92,7 +153,7 @@ def route_chat_message(
         )
         ambiguous = False
     elif catalog_question:
-        selected_skill = "oh-my-hermes"
+        selected_skill = _ROUTER_SKILL
         candidate_skill = selected_skill
         candidate_harness = primary_harness_for_skill(candidate_skill)
         candidate_score = max(candidate_score, 11)
@@ -101,7 +162,7 @@ def route_chat_message(
         reason = "Catalog question; show the OMH workflow picker instead of asking for shell command approval."
         ambiguous = False
     elif file_or_text_lookup:
-        selected_skill = "oh-my-hermes"
+        selected_skill = _ROUTER_SKILL
         candidate_skill = selected_skill
         candidate_harness = primary_harness_for_skill(candidate_skill)
         candidate_score = 0
@@ -110,13 +171,13 @@ def route_chat_message(
         reason = FILE_LOOKUP_REASON
         ambiguous = False
     elif candidate_score == 0:
-        selected_skill = "oh-my-hermes"
+        selected_skill = _ROUTER_SKILL
         candidate_skill = selected_skill
         candidate_harness = primary_harness_for_skill(candidate_skill)
         action = "fallback"
         reason = "No strong catalog metadata match; use the router to clarify the workflow."
     elif ambiguous:
-        selected_skill = "oh-my-hermes"
+        selected_skill = _ROUTER_SKILL
         action = "clarify"
         reason = "Top catalog matches are tied; ask one concise clarification before dispatch."
     elif _meets_threshold(candidate_confidence, min_confidence):
@@ -124,7 +185,7 @@ def route_chat_message(
         action = "dispatch"
         reason = str(top["why"])
     else:
-        selected_skill = "oh-my-hermes"
+        selected_skill = _ROUTER_SKILL
         action = "clarify"
         reason = f"Best match confidence {candidate_confidence} is below {min_confidence}; clarify before dispatch."
 
@@ -228,18 +289,43 @@ def _meets_threshold(confidence: str, threshold: str) -> bool:
     return meets_confidence_threshold(confidence, threshold)
 
 
-def _specific_capability_catalog_match(top: dict[str, object]) -> bool:
-    skill = str(top.get("skill", ""))
-    if skill not in _SPECIFIC_CAPABILITY_CATALOG_SKILLS:
-        return False
-    if _int_value(top.get("score", 0)) < 30:
-        return False
-    confidence = str(top.get("confidence", "low"))
-    if not _meets_threshold(confidence, "high"):
-        return False
-    matched = _string_list(top.get("matched", []))
-    next_action = str(top.get("next_action", ""))
-    return next_action == "prepare_visual_prompt_card" or any(item.startswith("guard:") for item in matched)
+def _specific_capability_catalog_match(recommendations: list[dict[str, object]]) -> dict[str, object] | None:
+    for recommendation in recommendations:
+        skill = str(recommendation.get("skill", ""))
+        if skill == _ROUTER_SKILL or skill not in _SPECIFIC_CAPABILITY_CATALOG_SKILLS:
+            continue
+        if _int_value(recommendation.get("score", 0)) < _SPECIFIC_CAPABILITY_CATALOG_MIN_SCORE:
+            continue
+        confidence = str(recommendation.get("confidence", "low"))
+        if not _meets_threshold(confidence, "high"):
+            continue
+        matched = _string_list(recommendation.get("matched", []))
+        next_action = str(recommendation.get("next_action", ""))
+        if not next_action or next_action == "clarify_or_route":
+            continue
+        if any(item.startswith("guard:") for item in matched) or any(item.startswith("trigger:") for item in matched):
+            return recommendation
+    return None
+
+
+def _is_broad_capability_catalog_question(message: str) -> bool:
+    text = message.strip().lower()
+    if any(phrase in text for phrase in _BROAD_CAPABILITY_CATALOG_PHRASES):
+        return True
+    if "/" in text or "," in text:
+        topic_hits = sum(1 for token in _BROAD_CAPABILITY_TOPIC_TOKENS if token in text)
+        if topic_hits >= 2:
+            return True
+    named_hits = sum(1 for skill in _SPECIFIC_CAPABILITY_CATALOG_SKILLS if skill in text)
+    return named_hits >= 2
+
+
+def _prioritize_recommendation(
+    recommendations: list[dict[str, object]],
+    selected: dict[str, object],
+) -> list[dict[str, object]]:
+    selected_skill = str(selected.get("skill", ""))
+    return [selected] + [item for item in recommendations if str(item.get("skill", "")) != selected_skill]
 
 
 def _clarification(action: str, candidate_skill: str, candidate_confidence: str, threshold: str, reason: str = "") -> str:

--- a/src/routing/policy.py
+++ b/src/routing/policy.py
@@ -843,6 +843,25 @@ _VOICE_OPERATOR_TOKENS = _normalized_token_set(
         "접근성",
     }
 )
+_CAPABILITY_INTENT_TOKENS = _normalized_token_set(
+    {
+        "support",
+        "supports",
+        "feature",
+        "features",
+        "capability",
+        "capabilities",
+        "available",
+        "help",
+        "helps",
+        "can",
+        "기능",
+        "지원",
+        "가능",
+        "있어",
+        "있나요",
+    }
+)
 _DELIVERABLE_STRONG_TOKENS = _normalized_token_set(
     {
         "attachment",
@@ -1642,9 +1661,11 @@ def _memory_curation_guard_applies(normalized_query: str, query_tokens: set[str]
         return True
     context = bool(_MEMORY_CURATION_CONTEXT_TOKENS & query_tokens)
     hermes_context = _contains_phrase(normalized_query, ("hermes", "헤르메스"))
+    omh_context = _contains_phrase(normalized_query, ("omh", "oh-my-hermes", "oh my hermes"))
     cleanup = _contains_phrase(normalized_query, ("cleanup", "curate", "review", "inspect", "정리", "점검", "검토"))
     stale = _contains_phrase(normalized_query, ("stale", "old", "duplicate", "conflicting", "오래된", "중복", "충돌"))
-    return context and (hermes_context or stale) and cleanup
+    capability_intent = bool(_CAPABILITY_INTENT_TOKENS & query_tokens)
+    return context and (hermes_context or omh_context or stale or capability_intent) and cleanup
 
 
 def _agent_board_guard_applies(normalized_query: str, query_tokens: set[str]) -> bool:
@@ -1705,6 +1726,8 @@ def _executor_runtime_readiness_guard_applies(normalized_query: str, query_token
 
 def _voice_operator_guard_applies(normalized_query: str, query_tokens: set[str]) -> bool:
     if _contains_phrase(normalized_query, _VOICE_OPERATOR_PHRASES):
+        return True
+    if _VOICE_OPERATOR_TOKENS & query_tokens and _CAPABILITY_INTENT_TOKENS & query_tokens:
         return True
     return bool(_VOICE_OPERATOR_TOKENS & query_tokens) and _contains_phrase(
         normalized_query,

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -339,7 +339,11 @@ def build_chat_interaction_payload(
         route_payload = _catalog_question_route_payload(route_payload)
     base["route"] = route_payload
 
-    if _is_omh_status_question(message) and resolved_mode in {"route", "plan", "clarify"}:
+    if (
+        _is_omh_status_question(message)
+        and str(route_payload.get("selected_skill", "")) == _ROUTER_SKILL
+        and resolved_mode in {"route", "plan", "clarify"}
+    ):
         base["mode"] = "status"
         base["route"] = _omh_status_route_payload(route_payload)
         base["chat_response"] = build_chat_response_from_omh_status_roadmap(

--- a/tests/test_chat_router.py
+++ b/tests/test_chat_router.py
@@ -13,6 +13,7 @@ from omh.chat_router import (
     route_chat_message,
     routing_record_payload,
 )
+from omh.skills.catalog import primary_harness_for_skill
 
 
 class ChatRouterTests(unittest.TestCase):
@@ -147,6 +148,26 @@ class ChatRouterTests(unittest.TestCase):
                 self.assertEqual(decision["selected_harness"], "coding-handling")
                 self.assertEqual(decision["confidence"], "high")
                 self.assertIn("Catalog question", decision["reason"])
+
+    def test_specific_capability_catalog_questions_dispatch_to_matching_workflow(self) -> None:
+        cases = (
+            ("does OMH support scheduled automation?", "automation-blueprint"),
+            ("can OMH help with MCP setup?", "toolbelt-readiness"),
+            ("does OMH support memory cleanup?", "memory-curation-review"),
+            ("does OMH support voice commands?", "voice-operator"),
+            ("OMH로 GitHub issue webhook 처리 가능해?", "github-event-ops"),
+        )
+
+        for message, selected_skill in cases:
+            with self.subTest(message=message):
+                decision = route_chat_message(message, source="discord")
+
+                self.assertEqual(decision["action"], "dispatch")
+                self.assertEqual(decision["selected_skill"], selected_skill)
+                self.assertEqual(decision["selected_harness"], primary_harness_for_skill(selected_skill))
+                self.assertEqual(decision["recommendations"][0]["skill"], selected_skill)
+                self.assertEqual(decision["confidence"], "high")
+                self.assertIn("Specific OMH capability question", decision["reason"])
 
     def test_file_lookup_does_not_dispatch_to_workflow_keyword(self) -> None:
         for message in (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3243,6 +3243,28 @@ class CliTests(unittest.TestCase):
                 self.assertEqual(route["recommendations"][0]["next_action"], "prepare_visual_prompt_card")
                 self.assertIn("guard:img_summary", route["recommendations"][0]["matched"])
 
+    def test_chat_route_dispatches_specific_capability_questions_to_cards(self) -> None:
+        cases = (
+            ("does OMH support scheduled automation?", "automation-blueprint", "prepare_scheduled_ops_blueprint"),
+            ("can OMH help with MCP setup?", "toolbelt-readiness", "prepare_toolbelt_readiness"),
+            ("does OMH support memory cleanup?", "memory-curation-review", "prepare_memory_curation_review"),
+            ("does OMH support voice commands?", "voice-operator", "prepare_voice_operator_card"),
+            ("OMH로 GitHub issue webhook 처리 가능해?", "github-event-ops", "prepare_github_event_ops_card"),
+        )
+
+        for message, selected_skill, next_action in cases:
+            with self.subTest(message=message):
+                status, stdout, stderr = run_cli(["chat", "route", "--source", "discord", message])
+
+                self.assertEqual(stderr, "")
+                self.assertEqual(status, 0)
+                route = json.loads(stdout)["route"]
+                self.assertEqual(route["action"], "dispatch")
+                self.assertEqual(route["selected_skill"], selected_skill)
+                self.assertEqual(route["recommendations"][0]["skill"], selected_skill)
+                self.assertEqual(route["recommendations"][0]["next_action"], next_action)
+                self.assertIn("Specific OMH capability question", route["reason"])
+
     def test_chat_route_hint_exposes_wrapper_card_without_recording_route(self) -> None:
         message = "make an image explaining the cron feature"
         status, stdout, stderr = run_cli(["chat", "route-hint", "--source", "discord", message])

--- a/tests/test_wrapper_contract.py
+++ b/tests/test_wrapper_contract.py
@@ -953,6 +953,28 @@ class WrapperContractTests(unittest.TestCase):
         self.assertEqual(payload["next_action"], "choose_skill")
         self.assertIn("skill_picker", payload["chat_response"]["state"])
 
+    def test_specific_capability_catalog_questions_skip_generic_picker(self) -> None:
+        cases = (
+            ("does OMH support scheduled automation?", "automation-blueprint", "prepare_scheduled_ops_blueprint"),
+            ("can OMH help with MCP setup?", "toolbelt-readiness", "prepare_toolbelt_readiness"),
+            ("does OMH support memory cleanup?", "memory-curation-review", "prepare_memory_curation_review"),
+            ("does OMH support voice commands?", "voice-operator", "prepare_voice_operator_card"),
+            ("OMH로 GitHub issue webhook 처리 가능해?", "github-event-ops", "prepare_github_event_ops_card"),
+        )
+
+        for message, selected_workflow, next_action in cases:
+            with self.subTest(message=message):
+                payload = build_chat_interaction_payload(message, source="discord")
+
+                self.assertEqual(payload["mode"], "route")
+                self.assertEqual(payload["route"]["selected_skill"], selected_workflow)
+                self.assertEqual(payload["next_action"], next_action)
+                self.assertNotEqual(payload["chat_response"]["kind"], "skill_picker")
+                self.assertEqual(
+                    payload["chat_response"]["state"]["workflow_explanation"]["selected_workflow"],
+                    selected_workflow,
+                )
+
     def test_complex_operator_patterns_route_to_dedicated_surfaces(self) -> None:
         cases = (
             (


### PR DESCRIPTION
## Feature Report

### What Changed

- Route specific OMH capability questions to the matching workflow card instead of the generic workflow picker.
- Keep broad catalog questions such as "OMH 기능 뭐 있어?" or "Can OMH help with planning, research, and coding?" on the picker.
- Add capability guard coverage for English memory cleanup and voice command support questions.
- Prevent OMH status/setup detection from stealing specific toolbelt/MCP setup capability routes.
- Document the wrapper-facing behavior for specific capability cards.

### Why This Exists

OMH is supposed to feel chat-first in Hermes. Users should be able to ask, "does OMH support scheduled automation?" or "can OMH help with MCP setup?" and get the relevant workflow surface immediately. Before this change, several specific capability questions were treated as broad catalog/status questions, so Hermes could open the generic picker or status card even when a concrete workflow was a better match.

### User / Operator Impact

- "does OMH support scheduled automation?" opens `automation-blueprint`.
- "can OMH help with MCP setup?" opens `toolbelt-readiness`.
- "does OMH support memory cleanup?" opens `memory-curation-review`.
- "does OMH support voice commands?" opens `voice-operator`.
- "OMH로 GitHub issue webhook 처리 가능해?" opens `github-event-ops`.
- Broad workflow discovery still opens `omh_skill_picker/v1` without shell approval.
- All selected cards remain routing intent only; host automation, credentials, memory writes, voice/mobile platform actions, and webhook effects stay unobserved until separate evidence is recorded.

### How It Works

- `src/routing/chat.py` now checks catalog questions for a high-confidence specific workflow candidate before falling back to the generic router picker.
- The same file detects broad multi-topic catalog questions and keeps them picker-first.
- `src/routing/policy.py` extends capability intent tokens and applies them to memory curation and voice operator guards.
- `src/wrapper/contract.py` limits OMH status-roadmap interception to router-selected status questions, so toolbelt/MCP capability questions can render their own card.
- CLI, chat-router, and wrapper contract tests cover both the new specific routes and the preserved generic picker behavior.

### Files And Contracts Touched

- `src/routing/chat.py`
- `src/routing/policy.py`
- `src/wrapper/contract.py`
- `tests/test_chat_router.py`
- `tests/test_cli.py`
- `tests/test_wrapper_contract.py`
- `docs/CHAT_WRAPPER_EXAMPLES.md`

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m src.cli docs workflows --check`
- [ ] `python3 -m omh.cli harness validate`
- [ ] `python3 -m omh.cli release checklist --json`
- [ ] `python3 -m omh.cli release hermes-smoke`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable; no workflow-learning ledger contract changed.
- [x] Relevant dry-run or smoke command: sampled `uv run python -m src.cli chat route` for broad picker and specific capability questions.
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; deterministic local chat route and wrapper contracts cover this PR and no live transport behavior changed.

Additional checks:

- [x] `uvx pyright src/routing/chat.py src/routing/policy.py src/wrapper/contract.py`
- [x] `git diff --check`

## Risk

- Narrow routing risk: specific capability questions now bypass the generic picker when a high-confidence workflow candidate is present.
- Mitigation: broad multi-topic catalog questions are explicitly kept picker-first, and tests cover both sides.

## Compatibility / Rollout

- Backward compatible JSON shape for `chat_route/v1` and wrapper responses.
- No new dependencies, no network calls, no Hermes core patching, and no generated skill drift.
- Existing broad catalog and status questions continue to work.

## Release / Claims

- [x] Release-channel impact considered (`preview` chat routing/docs behavior)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- More language-specific capability phrases can be added as deterministic routing packs if user testing reveals misses in non-English chats.
