### PR TITLE
Improve capability workflow card actions

### DIFF
--- a/docs/CHAT_WRAPPER_EXAMPLES.md
+++ b/docs/CHAT_WRAPPER_EXAMPLES.md
@@ -139,9 +139,13 @@ such as "OMH 기능 뭐 있어?" still opens `omh_skill_picker/v1`, but "does OM
 support scheduled automation?", "can OMH help with MCP setup?", "does OMH
 support memory cleanup?", "does OMH support voice commands?", or "OMH로 GitHub
 issue webhook 처리 가능해?" should open the matching workflow card directly.
-Selection remains routing intent only; host automation, credentials, memory
-updates, platform actions, and webhook effects stay unobserved until separate
-evidence is recorded.
+The first visible action should be the matching workflow action, such as
+`prepare_scheduled_ops_blueprint`, `prepare_toolbelt_readiness`,
+`prepare_memory_curation_review`, `prepare_voice_operator_card`, or
+`prepare_github_event_ops_card`, followed by a status action. Selection remains
+routing intent only; host automation, credentials, memory updates, platform
+actions, and webhook effects stay unobserved until separate evidence is
+recorded.
 
 That returns `chat_route_hint/v1` with a `chat_response` card the adapter can
 render immediately:

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -102,6 +102,16 @@ VISIBLE_ACTIONS = (
     "record_visual_qa",
     "record_visual_delivery",
     "show_visual_status",
+    "prepare_scheduled_ops_blueprint",
+    "prepare_research_department_plan",
+    "prepare_material_package",
+    "prepare_deliverable_package",
+    "prepare_github_event_ops_card",
+    "prepare_agent_board_card",
+    "prepare_executor_runtime_readiness",
+    "prepare_memory_curation_review",
+    "prepare_voice_operator_card",
+    "prepare_toolbelt_readiness",
     "show_agent_ops_review",
     "choose_ops_lane",
     "prepare_research_lane",
@@ -306,7 +316,47 @@ _HUMAN_ACK_BODY_BY_SKILL = {
         "I will prepare the deliverable path: which files are needed, who generates them, what QA must pass, "
         "and how attachment or delivery status should be recorded."
     ),
+    "github-event-ops": (
+        "I will classify the GitHub PR, issue, review, or CI event into triage, review, label, or fix-handoff "
+        "actions. Webhook delivery and GitHub mutations stay unobserved until a wrapper records them."
+    ),
+    "memory-curation-review": (
+        "I will surface stale, duplicate, or conflicting memory and context candidates for approve, reject, or "
+        "update choices. Nothing is written until approval is observed."
+    ),
+    "voice-operator": (
+        "I will turn the short voice or mobile request into a concise clarify, plan, status, handoff, or "
+        "confirmation card, and require confirmation before risky actions."
+    ),
+    "toolbelt-readiness": (
+        "I will map the MCP, CLI, API, credential, and connector pieces this workflow needs, show what is "
+        "observed versus missing, and suggest the safest setup or handoff next step."
+    ),
 }
+
+_ACK_PRIMARY_ACTIONS_BY_NEXT_ACTION = {
+    "prepare_scheduled_ops_blueprint": ("prepare_scheduled_ops_blueprint", "Prepare automation"),
+    "prepare_research_department_plan": ("prepare_research_department_plan", "Prepare research flow"),
+    "prepare_material_package": ("prepare_material_package", "Prepare package"),
+    "prepare_deliverable_package": ("prepare_deliverable_package", "Prepare deliverable"),
+    "prepare_github_event_ops_card": ("prepare_github_event_ops_card", "Open event card"),
+    "prepare_agent_board_card": ("prepare_agent_board_card", "Open agent board"),
+    "prepare_executor_runtime_readiness": ("prepare_executor_runtime_readiness", "Check runtime"),
+    "prepare_memory_curation_review": ("prepare_memory_curation_review", "Review memory"),
+    "prepare_voice_operator_card": ("prepare_voice_operator_card", "Open voice card"),
+    "prepare_toolbelt_readiness": ("prepare_toolbelt_readiness", "Check toolbelt"),
+}
+
+
+def _ack_actions_for_next_action(next_action: str) -> list[dict[str, object]]:
+    actions: list[dict[str, object]] = []
+    primary = _ACK_PRIMARY_ACTIONS_BY_NEXT_ACTION.get(next_action)
+    if primary:
+        actions.append(_action(primary[0], primary[1], "primary"))
+    status_action = "show_memory_status" if next_action == "prepare_memory_curation_review" else "show_status"
+    status_label = "Show memory status" if status_action == "show_memory_status" else "Show status"
+    actions.append(_action(status_action, status_label, "secondary"))
+    return actions
 
 
 def build_chat_interaction_payload(
@@ -806,7 +856,7 @@ def build_chat_response_from_route(
             phase="routed",
             next_action=next_action,
             thread_key=thread_key,
-            actions=[_action("show_status", "Show status", "secondary")],
+            actions=_ack_actions_for_next_action(next_action),
             claim_boundary=evidence_boundary,
             extra_state={
                 "route_action": action,

--- a/tests/test_wrapper_contract.py
+++ b/tests/test_wrapper_contract.py
@@ -970,6 +970,11 @@ class WrapperContractTests(unittest.TestCase):
                 self.assertEqual(payload["route"]["selected_skill"], selected_workflow)
                 self.assertEqual(payload["next_action"], next_action)
                 self.assertNotEqual(payload["chat_response"]["kind"], "skill_picker")
+                actions = payload["chat_response"]["actions"]
+                action_ids = [str(action["id"]) for action in actions]
+                self.assertEqual(action_ids[0], next_action)
+                self.assertIn("show_status" if selected_workflow != "memory-curation-review" else "show_memory_status", action_ids)
+                self.assertEqual(actions[0]["style"], "primary")
                 self.assertEqual(
                     payload["chat_response"]["state"]["workflow_explanation"]["selected_workflow"],
                     selected_workflow,
@@ -1089,6 +1094,30 @@ class WrapperContractTests(unittest.TestCase):
                 "prepare_deliverable_package",
                 "deliverable path",
             ),
+            (
+                "can OMH help with MCP setup?",
+                "toolbelt-readiness",
+                "prepare_toolbelt_readiness",
+                "MCP, CLI, API",
+            ),
+            (
+                "does OMH support memory cleanup?",
+                "memory-curation-review",
+                "prepare_memory_curation_review",
+                "approve, reject, or update",
+            ),
+            (
+                "does OMH support voice commands?",
+                "voice-operator",
+                "prepare_voice_operator_card",
+                "confirmation before risky actions",
+            ),
+            (
+                "OMH로 GitHub issue webhook 처리 가능해?",
+                "github-event-ops",
+                "prepare_github_event_ops_card",
+                "triage, review, label",
+            ),
         )
 
         for message, selected_workflow, next_action, body_marker in cases:
@@ -1100,6 +1129,8 @@ class WrapperContractTests(unittest.TestCase):
                 self.assertEqual(payload["next_action"], next_action)
                 self.assertEqual(payload["chat_response"]["kind"], "ack")
                 self.assertIn(body_marker, payload["chat_response"]["body"])
+                action_ids = [str(action["id"]) for action in payload["chat_response"]["actions"]]
+                self.assertEqual(action_ids[0], next_action)
                 self.assertIn("workflow_context_id", payload["chat_response"]["usage_trace"])
                 self.assertNotIn("/v1", payload["chat_response"]["body"])
                 self.assertNotIn("schema", payload["chat_response"]["body"].lower())


### PR DESCRIPTION
## Feature Report

### What Changed

- Capability-specific OMH chat questions now render a primary workflow action before the status action.
- Added human-facing ack copy for toolbelt readiness, memory curation, voice/mobile operator, and GitHub event operations cards.
- Documented that specific capability questions should open the matching workflow card instead of only showing a generic picker or status button.

### Why This Exists

- Recent routing work correctly selected workflows for questions like MCP setup, scheduled automation, memory cleanup, voice commands, and GitHub event handling.
- The remaining UX gap was that the chat card only exposed `show_status`, so Hermes could say it knew the workflow but did not give the user an obvious next action.

### User / Operator Impact

- In Discord/Slack/Hermes-style wrappers, a user asking whether OMH supports a specific capability now gets a concrete primary action such as `prepare_toolbelt_readiness`, `prepare_scheduled_ops_blueprint`, or `prepare_github_event_ops_card`.
- Broad catalog questions still open the workflow picker.
- Prepared-vs-observed boundaries stay visible: buttons prepare cards or guidance, but do not claim cron creation, credentials, memory writes, webhooks, or platform mutations happened.

### How It Works

- `src/wrapper/contract.py` now includes the relevant `prepare_*` action ids in `VISIBLE_ACTIONS`.
- Generic ack responses use a small next-action-to-primary-button map, falling back to status-only when no primary action is defined.
- Memory curation uses `show_memory_status` as its secondary status action; other capability cards keep `show_status`.

### Files And Contracts Touched

- `src/wrapper/contract.py`: visible action contract, ack card copy, and primary action selection.
- `tests/test_wrapper_contract.py`: regression coverage for primary capability actions and human-readable copy.
- `docs/CHAT_WRAPPER_EXAMPLES.md`: wrapper guidance for capability cards.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_wrapper_contract.py -v`
- [x] `uvx pyright src/wrapper/contract.py`
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_cli.py tests/test_chat_router.py -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m src.cli docs workflows --check`
- [x] `git diff --check`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] Relevant dry-run or smoke command: `uv run python -m src.cli chat interact --source discord "can OMH help with MCP setup?"`
- [x] Relevant dry-run or smoke command: `uv run python -m src.cli chat interact --source discord "does OMH support scheduled automation?"`
- [x] Relevant dry-run or smoke command: `uv run python -m src.cli chat interact --source discord "does OMH support memory cleanup?"`
- [x] Manual Hermes/TUI check, or explicit reason it was not run: live Hermes/Discord rendering was not run; deterministic wrapper payloads were verified locally.

## Risk

- Narrow contract expansion: new visible action ids are metadata-only wrapper actions and do not trigger execution by themselves.
- Existing status-only ack behavior remains the fallback for workflows without an explicit primary action mapping.

## Compatibility / Rollout

- Backward compatible for existing consumers: `show_status` remains present, and broad catalog questions still use the picker.
- Wrappers can start rendering the first action as the primary button for these capability cards.

## Release / Claims

- [x] Release-channel impact considered (`preview` workflow/card contract improvement; no installer or package channel change).
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] Known manual Hermes checks are listed, including any live rendering gap.

## Follow-Up

- Consider adding richer primary actions for any future ack-only workflow cards that prove useful in real chat usage.
