### PR TITLE
Improve routed workflow card actions

### DIFF
--- a/docs/CHAT_WRAPPER_EXAMPLES.md
+++ b/docs/CHAT_WRAPPER_EXAMPLES.md
@@ -150,6 +150,16 @@ recorded.
 That returns `chat_route_hint/v1` with a `chat_response` card the adapter can
 render immediately:
 
+The same primary-action rule applies to normal routed workflow cards, not only
+catalog capability questions. For example, `web-research`,
+`strategy-brief`, `code-review`, `gateway-intent-card`,
+`ops-observability-card`, and `report-package` responses should place the
+workflow `next_action` first, then a status action. A route such as
+`run_hermes_research`, `prepare_strategy_brief`,
+`prepare_review_or_followup_handoff`, `prepare_gateway_intent_card`,
+`prepare_ops_observability_card`, or `prepare_report_package` is still only a
+prepared wrapper action until observed work or evidence is recorded.
+
 ```text
 Hermes Agent  BOT
 [omh] img-summary looks relevant.

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -45,6 +45,7 @@ VISIBLE_ACTIONS = (
     "search_skills",
     "accept_plan",
     "revise_plan",
+    "present_plan",
     "prepare_handoff",
     "choose_executor",
     "show_prompt_handoff",
@@ -91,6 +92,7 @@ VISIBLE_ACTIONS = (
     "revise_research_sources",
     "confirm_cadence_delivery_tooling",
     "record_source_observation",
+    "prepare_visual_prompt_card",
     "show_visual_prompt_card",
     "copy_visual_prompt",
     "revise_visual_card",
@@ -102,6 +104,23 @@ VISIBLE_ACTIONS = (
     "record_visual_qa",
     "record_visual_delivery",
     "show_visual_status",
+    "run_hermes_research",
+    "prepare_strategy_brief",
+    "prepare_meeting_brief",
+    "triage_feedback",
+    "prepare_ops_review",
+    "present_app_delivery_loop",
+    "run_cto_loop",
+    "prepare_deploy_monitor_plan",
+    "prepare_review_or_followup_handoff",
+    "run_local_operator_check",
+    "prepare_operating_workflow",
+    "prepare_memory_review",
+    "prepare_coding_handoff",
+    "prepare_coding_runtime_handoff",
+    "prepare_operating_record",
+    "prepare_report_package",
+    "prepare_reliability_review",
     "prepare_scheduled_ops_blueprint",
     "prepare_research_department_plan",
     "prepare_material_package",
@@ -110,8 +129,12 @@ VISIBLE_ACTIONS = (
     "prepare_agent_board_card",
     "prepare_executor_runtime_readiness",
     "prepare_memory_curation_review",
+    "prepare_gateway_intent_card",
     "prepare_voice_operator_card",
     "prepare_toolbelt_readiness",
+    "prepare_ops_observability_card",
+    "refresh_status",
+    "prepare_agent_ops_review",
     "show_agent_ops_review",
     "choose_ops_lane",
     "prepare_research_lane",
@@ -332,9 +355,72 @@ _HUMAN_ACK_BODY_BY_SKILL = {
         "I will map the MCP, CLI, API, credential, and connector pieces this workflow needs, show what is "
         "observed versus missing, and suggest the safest setup or handoff next step."
     ),
+    "web-research": (
+        "I will keep this in Hermes as a source-backed research lane: define source boundaries, freshness, "
+        "version or jurisdiction scope, citation confidence, and retrieval gaps before any later plan or handoff."
+    ),
+    "strategy-brief": (
+        "I will prepare strategy options, tradeoffs, decision notes, and open questions in Hermes. Implementation "
+        "handoff stays disabled until an accepted decision creates explicit work."
+    ),
+    "meeting-brief": (
+        "I will prepare the agenda, context prompts, decision slots, and follow-up template. Prepared meeting "
+        "material is not evidence that the meeting happened."
+    ),
+    "feedback-triage": (
+        "I will cluster the signal, separate bug reports, requests, and questions, and recommend the next investigation, "
+        "plan, or handoff path without treating triage as implementation."
+    ),
+    "code-review": (
+        "I will prepare the review path: what needs checking, which claims need evidence, and what follow-up handoff "
+        "is needed if fixes are found. Review preparation is not a completed review."
+    ),
+    "report-package": (
+        "I will prepare the report package: source inputs, outline, missing numbers, approval points, and export or "
+        "delivery checks. The package is not delivered until observed evidence exists."
+    ),
+    "reliability-review": (
+        "I will prepare a reliability review with service boundaries, SLO or incident context, risk areas, and "
+        "remediation handoff options. Healthy status or incident closure still needs observed evidence."
+    ),
+    "gateway-intent-card": (
+        "I will normalize the gateway intent: origin, thread, delivery policy, silent updates, attachments, and "
+        "status-update behavior before any platform action is claimed."
+    ),
+    "ops-observability-card": (
+        "I will prepare a wrapper-safe observability card for token, cost, latency, run history, and failure-mode "
+        "signals while keeping local estimates separate from provider-observed truth."
+    ),
+    "operating-rhythm": (
+        "I will prepare the operating rhythm: cadence, meeting topics, decision records, owners, and follow-up "
+        "slots. Prepared operations notes are not evidence that the work happened."
+    ),
 }
 
 _ACK_PRIMARY_ACTIONS_BY_NEXT_ACTION = {
+    "present_plan": ("present_plan", "Show plan"),
+    "assess_loopability": ("assess_loopability", "Assess loopability"),
+    "prepare_visual_prompt_card": ("prepare_visual_prompt_card", "Prepare image card"),
+    "prepare_agent_ops_review": ("prepare_agent_ops_review", "Open ops review"),
+    "start_ultraprocess": ("start_ultraprocess", "Start ultraprocess"),
+    "audit_learning_readiness": ("audit_learning_readiness", "Audit learning"),
+    "run_hermes_research": ("run_hermes_research", "Start research"),
+    "prepare_strategy_brief": ("prepare_strategy_brief", "Prepare strategy"),
+    "prepare_meeting_brief": ("prepare_meeting_brief", "Prepare brief"),
+    "triage_feedback": ("triage_feedback", "Triage feedback"),
+    "prepare_ops_review": ("prepare_ops_review", "Prepare ops review"),
+    "present_app_delivery_loop": ("present_app_delivery_loop", "Show delivery loop"),
+    "run_cto_loop": ("run_cto_loop", "Open team loop"),
+    "prepare_deploy_monitor_plan": ("prepare_deploy_monitor_plan", "Prepare deploy plan"),
+    "prepare_review_or_followup_handoff": ("prepare_review_or_followup_handoff", "Prepare review"),
+    "run_local_operator_check": ("run_local_operator_check", "Show local check"),
+    "prepare_operating_workflow": ("prepare_operating_workflow", "Prepare workflow"),
+    "prepare_memory_review": ("prepare_memory_review", "Review memory"),
+    "prepare_coding_handoff": ("prepare_coding_handoff", "Prepare coding handoff"),
+    "prepare_coding_runtime_handoff": ("prepare_coding_runtime_handoff", "Prepare runtime handoff"),
+    "prepare_operating_record": ("prepare_operating_record", "Prepare rhythm"),
+    "prepare_report_package": ("prepare_report_package", "Prepare report"),
+    "prepare_reliability_review": ("prepare_reliability_review", "Review reliability"),
     "prepare_scheduled_ops_blueprint": ("prepare_scheduled_ops_blueprint", "Prepare automation"),
     "prepare_research_department_plan": ("prepare_research_department_plan", "Prepare research flow"),
     "prepare_material_package": ("prepare_material_package", "Prepare package"),
@@ -343,8 +429,11 @@ _ACK_PRIMARY_ACTIONS_BY_NEXT_ACTION = {
     "prepare_agent_board_card": ("prepare_agent_board_card", "Open agent board"),
     "prepare_executor_runtime_readiness": ("prepare_executor_runtime_readiness", "Check runtime"),
     "prepare_memory_curation_review": ("prepare_memory_curation_review", "Review memory"),
+    "prepare_gateway_intent_card": ("prepare_gateway_intent_card", "Open gateway card"),
     "prepare_voice_operator_card": ("prepare_voice_operator_card", "Open voice card"),
     "prepare_toolbelt_readiness": ("prepare_toolbelt_readiness", "Check toolbelt"),
+    "prepare_ops_observability_card": ("prepare_ops_observability_card", "Open observability"),
+    "refresh_status": ("refresh_status", "Refresh status"),
 }
 
 

--- a/tests/test_wrapper_contract.py
+++ b/tests/test_wrapper_contract.py
@@ -1118,6 +1118,42 @@ class WrapperContractTests(unittest.TestCase):
                 "prepare_github_event_ops_card",
                 "triage, review, label",
             ),
+            (
+                "we need a competitor market scan and strategy memo for next week's leadership meeting",
+                "strategy-brief",
+                "prepare_strategy_brief",
+                "strategy options",
+            ),
+            (
+                "AI가 했다고 했는데 실제로 뭐 했는지 모르겠다",
+                "code-review",
+                "prepare_review_or_followup_handoff",
+                "review path",
+            ),
+            (
+                "web search latest secure login UX evidence",
+                "web-research",
+                "run_hermes_research",
+                "source-backed research lane",
+            ),
+            (
+                "route Discord Slack Telegram threads with delivery policy",
+                "gateway-intent-card",
+                "prepare_gateway_intent_card",
+                "gateway intent",
+            ),
+            (
+                "show token cost latency run history for this automation loop",
+                "ops-observability-card",
+                "prepare_ops_observability_card",
+                "observability card",
+            ),
+            (
+                "turn this sprint retro into a report package with decisions and actions",
+                "report-package",
+                "prepare_report_package",
+                "report package",
+            ),
         )
 
         for message, selected_workflow, next_action, body_marker in cases:
@@ -1135,6 +1171,36 @@ class WrapperContractTests(unittest.TestCase):
                 self.assertNotIn("/v1", payload["chat_response"]["body"])
                 self.assertNotIn("schema", payload["chat_response"]["body"].lower())
                 self.assertNotIn("artifact", payload["chat_response"]["body"].lower())
+
+    def test_recommendation_policy_next_actions_are_visible_ack_actions(self) -> None:
+        from omh.routing import recommend
+        from omh.wrapper import contract
+
+        policies = {
+            **recommend._SKILL_POLICIES,
+            **recommend._CATEGORY_POLICIES,
+            **recommend._HERMES_ROLE_POLICIES,
+        }
+        control_actions = {
+            "answer_clarification",
+            "ask_clarification",
+            "cancel",
+            "clarify_or_route",
+            "dispatch_to_workflow",
+            "show_workflow_guidance",
+        }
+
+        missing: list[str] = []
+        for name, policy in sorted(policies.items()):
+            next_action = policy.next_action
+            if not next_action or next_action in control_actions:
+                continue
+            if next_action not in contract.VISIBLE_ACTIONS:
+                missing.append(f"{name}:{next_action}:not-visible")
+            if next_action not in contract._ACK_PRIMARY_ACTIONS_BY_NEXT_ACTION:
+                missing.append(f"{name}:{next_action}:no-ack-primary")
+
+        self.assertEqual(missing, [])
 
     def test_cancel_routes_to_control_action_without_plan_ui(self) -> None:
         payload = build_chat_interaction_payload("cancel", source="discord")


### PR DESCRIPTION
## Feature Report

### What Changed

- Expanded chat wrapper ack actions so normal routed workflows surface their concrete workflow `next_action` as the primary button/action.
- Added human-friendly ack copy for high-value workflows that previously felt status-only in chat: `web-research`, `strategy-brief`, `meeting-brief`, `feedback-triage`, `code-review`, `report-package`, `reliability-review`, `gateway-intent-card`, `ops-observability-card`, and `operating-rhythm`.
- Added a policy-level regression test that fails whenever a recommendation policy exposes a non-control `next_action` that is not also visible and renderable in the wrapper ack contract.
- Documented that routed workflow cards follow the same primary-action rule as catalog capability cards while preserving prepared-vs-observed boundaries.

### Why This Exists

- After the capability-card action work, capability questions produced useful primary actions, but many ordinary routed workflow requests still degraded to `show_status` as the only visible action.
- In Hermes/Discord/Slack-style chat, that makes OMH feel like it recognized the workflow but did not know what the operator should do next.
- This closes that UX gap without adding transport code, hidden execution, or any observed-evidence claim.

### User / Operator Impact

- A user asking for research gets a `Start research` action instead of only `Show status`.
- A user asking for report packaging gets a `Prepare report` action.
- Gateway, observability, strategy, review, reliability, feedback, meeting, and operating-rhythm requests now get workflow-specific first actions and plain-language body copy.
- Wrapper operators still see conservative claim boundaries: these actions are prepared wrapper choices, not proof that research, review, report delivery, platform work, or runtime evidence happened.

### How It Works

- `src/wrapper/contract.py` now treats policy `next_action` values as first-class visible actions and maps each to a primary ack button label.
- `_HUMAN_ACK_BODY_BY_SKILL` now has concise, operator-facing text for the affected workflows.
- `tests/test_wrapper_contract.py` locks both representative routed messages and the broader policy/action map, so future recommendation policies cannot silently ship status-only cards.
- `docs/CHAT_WRAPPER_EXAMPLES.md` states the wrapper contract rule for normal routed workflow cards.

### Files And Contracts Touched

- `src/wrapper/contract.py`
  - `VISIBLE_ACTIONS`
  - `_HUMAN_ACK_BODY_BY_SKILL`
  - `_ACK_PRIMARY_ACTIONS_BY_NEXT_ACTION`
- `tests/test_wrapper_contract.py`
  - routed workflow ack cases
  - recommendation policy next-action visibility regression test
- `docs/CHAT_WRAPPER_EXAMPLES.md`
  - wrapper primary-action contract note

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_cli.py tests/test_chat_router.py tests/test_wrapper_contract.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_wrapper_sessions.py -v`
- [x] `uvx pyright src/wrapper/contract.py`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m src.cli docs workflows --check`
- [x] `git diff --check`
- [x] Relevant dry-run or smoke command: `uv run python -m src.cli chat interact "web search latest secure login UX evidence"`
- [x] Relevant dry-run or smoke command: `uv run python -m src.cli chat interact "show token cost latency run history for this automation loop"`
- [x] Relevant dry-run or smoke command: `uv run python -m src.cli chat interact "turn this sprint retro into a report package with decisions and actions"`
- [x] Manual Hermes/TUI check, or explicit reason it was not run: live Hermes/TUI was not run; this PR only changes deterministic wrapper payload composition and docs.

## Risk

- Narrow: action vocabulary is expanded, but no new execution path, transport integration, or runtime artifact writer is introduced.
- Main compatibility risk is adapter UI code that hard-codes an older action allowlist. The action ids are deterministic and remain secondary to the existing payload schema.

## Compatibility / Rollout

- Existing `show_status` actions remain present as secondary actions.
- Control actions such as `ask_clarification`, `answer_clarification`, and `cancel` stay outside the primary workflow action regression rule.
- Prepared-vs-observed boundaries are unchanged.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`): no release metadata change.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap.

## Follow-Up

- None required for this PR.
