### PR TITLE
Tighten workflow learning feedback routing

### DIFF
--- a/src/routing/policy.py
+++ b/src/routing/policy.py
@@ -503,6 +503,10 @@ _WORKFLOW_LEARNING_PHRASES = (
     "learn from this workflow",
     "learn from this workflow run",
     "learn from this run",
+    "record this as workflow learning",
+    "record this workflow learning",
+    "record this as a workflow learning trace",
+    "record this workflow learning trace",
     "improve the skill next time",
     "improve this skill next time",
     "improve routing next time",
@@ -524,6 +528,38 @@ _WORKFLOW_LEARNING_PHRASES = (
     "omh 안 썼",
     "워크플로 누락",
     "라우팅 누락",
+)
+_WORKFLOW_LEARNING_ACTION_TOKENS = _normalized_token_set(
+    {
+        "add",
+        "audit",
+        "case",
+        "candidate",
+        "eval",
+        "evaluate",
+        "export",
+        "fix",
+        "future",
+        "improve",
+        "improvement",
+        "missed",
+        "missing",
+        "next",
+        "propose",
+        "record",
+        "recorded",
+        "regression",
+        "replay",
+        "review",
+        "trace",
+        "why",
+        "개선",
+        "기록",
+        "누락",
+        "리뷰",
+        "왜",
+        "회귀",
+    }
 )
 _WORKFLOW_LEARNING_CONTEXT_TOKENS = _normalized_token_set(
     {
@@ -1465,7 +1501,8 @@ def _workflow_learning_guard_applies(normalized_query: str, query_tokens: set[st
     learning = bool({"learn", "learning", "학습"} & query_tokens)
     workflow_or_skill = bool({"workflow", "run", "trace", "skill", "routing", "route", "워크플로우", "스킬", "라우팅"} & query_tokens)
     future_improvement = bool({"improve", "improvement", "next", "future", "regression", "개선", "회귀"} & query_tokens)
-    if learning and workflow_or_skill:
+    feedback_action = bool(_WORKFLOW_LEARNING_ACTION_TOKENS & query_tokens)
+    if learning and workflow_or_skill and feedback_action:
         return True
     if future_improvement and workflow_or_skill and bool(_WORKFLOW_LEARNING_CONTEXT_TOKENS & query_tokens):
         return True

--- a/tests/test_chat_router.py
+++ b/tests/test_chat_router.py
@@ -97,7 +97,7 @@ class ChatRouterTests(unittest.TestCase):
                 self.assertEqual(decision["action"], "dispatch")
                 self.assertEqual(decision["selected_skill"], skill)
                 self.assertEqual(decision["selected_harness"], harness)
-        self.assertEqual(decision["confidence"], "high")
+                self.assertEqual(decision["confidence"], "high")
 
     def test_visual_summary_chat_dispatches_to_img_summary(self) -> None:
         cases = (
@@ -116,6 +116,7 @@ class ChatRouterTests(unittest.TestCase):
             "生成一张发布说明海报",
             "프리렌이 OMH 안 쓰고 일반 도구로 이미지 만들었어",
             "The Hermes agent did not use OMH for this summary image.",
+            "make a workflow learning image card",
         )
 
         for message in cases:
@@ -126,6 +127,22 @@ class ChatRouterTests(unittest.TestCase):
                 self.assertEqual(decision["selected_skill"], "img-summary")
                 self.assertEqual(decision["selected_harness"], "img-summary")
                 self.assertEqual(decision["confidence"], "high")
+
+    def test_explicit_workflow_learning_feedback_wins_over_domain_terms(self) -> None:
+        cases = (
+            "Hermes did not use OMH for my image request; record this as workflow learning",
+            "이미지 생성 요청에서 OMH 안 썼어. workflow-learning으로 기록해줘",
+        )
+
+        for message in cases:
+            with self.subTest(message=message):
+                decision = route_chat_message(message, source="discord")
+
+                self.assertEqual(decision["action"], "dispatch")
+                self.assertEqual(decision["selected_skill"], "workflow-learning")
+                self.assertEqual(decision["selected_harness"], "workflow-learning")
+                self.assertEqual(decision["confidence"], "high")
+                self.assertIn("guard:workflow_learning", decision["recommendations"][0]["matched"])
 
     def test_catalog_question_dispatches_to_router_without_shell_approval(self) -> None:
         for message in (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -79,7 +79,12 @@ class CliTests(unittest.TestCase):
             <= action_ids
         )
 
-        for message in ("missed route: OMH was not used", "OMH 안 썼어"):
+        for message in (
+            "missed route: OMH was not used",
+            "OMH 안 썼어",
+            "Hermes did not use OMH for my image request; record this as workflow learning",
+            "이미지 생성 요청에서 OMH 안 썼어. workflow-learning으로 기록해줘",
+        ):
             status, stdout, stderr = run_cli(["chat", "interact", "--source", "discord", message], output_json=False)
 
             self.assertEqual(status, 0, stderr)


### PR DESCRIPTION
## Feature Report

### What Changed

- Tightened chat routing so explicit missed-workflow learning feedback routes to `workflow-learning` even when the message contains domain terms such as `image`.
- Preserved normal image-card behavior: plain image-card or poster requests still route to `img-summary`, including `make a workflow learning image card`.
- Added CLI and router regression coverage for both sides of that boundary.
- Fixed a nearby chat-router test assertion so each operating-surface case checks confidence inside its own `subTest`.

### Why This Exists

Users can tell Hermes that OMH was missed, for example: `Hermes did not use OMH for my image request; record this as workflow learning`. Before this change, the visual-summary guard could win because the message contained `image`, so the feedback was treated as another image-card request instead of learning material.

OMH's workflow-learning direction depends on capturing missed routing as reviewable process evidence. The router now distinguishes explicit learning feedback from domain work without claiming that future behavior has already been fixed.

### User / Operator Impact

- Hermes wrappers can respond to missed-route feedback with the workflow-learning audit card, including actions such as record trace, record missed route, add regression, audit readiness, and export bundle.
- Image summary requests still feel natural and do not get stolen by incidental mentions of `workflow learning`.
- Operators get deterministic regression tests around a real chat-first failure mode instead of relying on manual prompt memory.

### How It Works

- `src/routing/policy.py` adds explicit record-as-workflow-learning phrases and a small feedback-action token set.
- The workflow-learning guard still accepts direct learning phrases, but token-only routing now requires both workflow-learning context and a feedback/action intent such as record, regression, improve, audit, or missed.
- Router tests assert that missed image feedback routes to `workflow-learning` while `make a workflow learning image card` remains `img-summary`.
- CLI tests assert the same behavior through `omh chat interact`.

### Files And Contracts Touched

- `src/routing/policy.py`: workflow-learning trigger policy and action-token gate.
- `tests/test_chat_router.py`: direct router regressions and per-case confidence assertion fix.
- `tests/test_cli.py`: `omh chat interact` regressions for explicit missed-workflow learning feedback.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_chat_router.py tests/test_cli.py -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m src.cli docs workflows --check`
- [x] `uvx pyright src/routing/policy.py`
- [x] `git diff --check`
- [x] Relevant workflow-learning review queue smoke, when learning contracts changed: `uv run python -m src.cli chat interact "Hermes did not use OMH for my image request; record this as workflow learning"`
- [x] Relevant dry-run or smoke command: `uv run python -m src.cli chat interact "make a workflow learning image card"`
- [x] Manual Hermes/TUI check, or explicit reason it was not run: live Hermes wrapper was not run; this PR changes deterministic local routing only.

## Risk

- Narrow routing-policy change. Main risk is phrase drift, mitigated with both positive and negative routing regressions.
- No new network calls, LLM calls, runtime execution, plugin behavior, or persisted artifact schema changes.

## Compatibility / Rollout

- Backward compatible for existing `workflow-learning` and `img-summary` commands.
- Does not change generated skill files or Hermes setup/update behavior.
- Existing wrappers reading `chat_interaction/v1` continue to receive the same schema with different selected workflow for the explicit missed-route feedback case.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`): code-only routing fix for next normal release/update.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed: no runtime/native execution claims added.
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap: live Hermes wrapper was not run because deterministic local routing is the touched surface.

## Follow-Up

- Consider centralizing catalog and policy workflow-learning trigger vocabulary if future routing changes expand this surface again.
