### PR TITLE
Expose OMH-first route hint checkpoint

### DIFF
--- a/docs/CHAT_WRAPPER_EXAMPLES.md
+++ b/docs/CHAT_WRAPPER_EXAMPLES.md
@@ -165,12 +165,15 @@ Hermes Agent  BOT
 [omh] img-summary looks relevant.
 
 I can open `img-summary` first because this request matches the materials and
-visuals lane. Next action: `prepare_visual_prompt_card`.
+visuals lane. Next action: `prepare_visual_prompt_card`. Checkpoint: Before
+generic tools, check OMH prep/status/learning; if relevant, name the workflow
+first.
 
 [ Open img-summary ] [ Route for me ] [ Open omh ]
 
 State
 - Hint only: no workflow has been selected or executed.
+- OMH-first checkpoint: visible before image/file/search/coding tools.
 - Safe to render without shell approval.
 - Plugin load is not required.
 ```
@@ -194,7 +197,9 @@ Hermes Agent  BOT
 [omh] img-summary looks relevant.
 
 I can open `img-summary` first because this request matches the materials and
-visuals lane. Next action: `prepare_visual_prompt_card`.
+visuals lane. Next action: `prepare_visual_prompt_card`. Checkpoint: Before
+generic tools, check OMH prep/status/learning; if relevant, name the workflow
+first.
 
 [ Open img-summary ] [ Route for me ] [ Open omh ]
 ```

--- a/examples/wrapper-golden/route-hints.json
+++ b/examples/wrapper-golden/route-hints.json
@@ -16,6 +16,7 @@
           "route_for_me",
           "open_picker"
         ],
+        "generic_tool_checkpoint": "omh_generic_tool_checkpoint/v1",
         "messenger_rendering": "messenger_route_hint_rendering/v1",
         "safe_to_render_without_shell_approval": true
       },
@@ -35,6 +36,7 @@
           "route_for_me",
           "open_picker"
         ],
+        "generic_tool_checkpoint": "omh_generic_tool_checkpoint/v1",
         "messenger_rendering": "messenger_route_hint_rendering/v1",
         "safe_to_render_without_shell_approval": true
       },

--- a/examples/wrapper_shim_common.py
+++ b/examples/wrapper_shim_common.py
@@ -120,6 +120,7 @@ def _render_route_hint(source: str, payload: dict[str, object]) -> dict[str, obj
             "claim_boundary": response.get("claim_boundary", payload.get("claim_boundary", "")),
         },
         "route_hint": payload.get("route_hint", {}),
+        "generic_tool_checkpoint": payload.get("generic_tool_checkpoint", {}),
         "wrapper_contract": payload.get("wrapper_contract", {}),
         "privacy": payload.get("privacy", {}),
         "usage_trace": usage_trace,

--- a/src/plugin_bundle/omh/awareness.py
+++ b/src/plugin_bundle/omh/awareness.py
@@ -6,6 +6,9 @@ import unicodedata
 
 OMH_AWARENESS_SCHEMA_VERSION = "omh_awareness/v1"
 OMH_ROUTE_HINT_SCHEMA_VERSION = "omh_route_hint/v1"
+OMH_GENERIC_TOOL_CHECKPOINT_SCHEMA_VERSION = "omh_generic_tool_checkpoint/v1"
+GENERIC_TOOL_CHECKPOINT_TEXT = "Before generic tools, check OMH prep/status/learning; if relevant, name the workflow first."
+GENERIC_TOOL_CHECKPOINT_APPLIES_BEFORE = ("image tools", "file tools", "search tools", "coding tools")
 ROUTER_KEYWORD_SKILLS = (
     "deep-interview",
     "ralplan",
@@ -606,9 +609,7 @@ def awareness_primer_payload() -> dict[str, object]:
             "Across every OMH skill: match intent to a lane, name adjacent workflows, "
             "and do not dismiss OMH because a generic tool can render or execute."
         ),
-        "generic_tool_checkpoint": (
-            "Before generic tools, check OMH prep/status/learning; if relevant, name the workflow first."
-        ),
+        "generic_tool_checkpoint": GENERIC_TOOL_CHECKPOINT_TEXT,
         "skill_coverage": "Every generated workflow skill carries this rail.",
         "chat_rule": "Normal users talk to Hermes; OMH CLI is backend, setup, verification, and wrapper infrastructure.",
         "lanes": lanes,
@@ -682,6 +683,16 @@ def awareness_primer_payload() -> dict[str, object]:
             "src/skills/render.py",
             "src/capabilities/registry.py",
         ],
+    }
+
+
+def awareness_generic_tool_checkpoint_payload() -> dict[str, object]:
+    return {
+        "schema_version": OMH_GENERIC_TOOL_CHECKPOINT_SCHEMA_VERSION,
+        "label": "OMH-first checkpoint",
+        "body": GENERIC_TOOL_CHECKPOINT_TEXT,
+        "applies_before": list(GENERIC_TOOL_CHECKPOINT_APPLIES_BEFORE),
+        "claim_boundary": "Advisory routing context only; not workflow execution or generic tool invocation evidence.",
     }
 
 

--- a/src/wrapper/route_hints.py
+++ b/src/wrapper/route_hints.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
-from ..plugin_bundle.omh.awareness import awareness_route_hint, awareness_route_hint_context
+from ..plugin_bundle.omh.awareness import (
+    awareness_generic_tool_checkpoint_payload,
+    awareness_route_hint,
+    awareness_route_hint_context,
+)
 
 CHAT_ROUTE_HINT_SCHEMA_VERSION = "chat_route_hint/v1"
 CHAT_ROUTE_HINT_RESPONSE_SCHEMA_VERSION = "chat_route_hint_response/v1"
@@ -16,21 +20,24 @@ def build_chat_route_hint_payload(
 ) -> dict[str, object]:
     """Return a wrapper-facing route hint without storing or echoing raw prompt text."""
     route_hint = awareness_route_hint(message, max_hints=max_hints)
+    generic_tool_checkpoint = _generic_tool_checkpoint()
     hints = [hint for hint in route_hint.get("hints", []) if isinstance(hint, dict)]
     primary_hint = hints[0] if hints else {}
-    response = _response_for_hint(primary_hint, hints, source=source)
+    response = _response_for_hint(primary_hint, hints, source=source, generic_tool_checkpoint=generic_tool_checkpoint)
     payload: dict[str, object] = {
         "schema_version": CHAT_ROUTE_HINT_SCHEMA_VERSION,
         "source": source,
         "message_length": len(message),
         "source_metadata": dict(source_metadata or {}),
         "route_hint": route_hint,
+        "generic_tool_checkpoint": generic_tool_checkpoint,
         "chat_response": response,
         "wrapper_contract": {
             "schema_version": "omh_route_hint_wrapper_contract/v1",
             "purpose": "Render a lightweight OMH hint before generic chat/tools when plugin context is unavailable or a wrapper wants an explicit preview.",
             "read_path": "chat_response",
             "state_path": "chat_response.state.route_hint",
+            "generic_tool_checkpoint_path": "generic_tool_checkpoint",
             "safe_to_render_without_shell_approval": True,
             "does_not_require_plugin_load": True,
             "next_backend_commands": _next_backend_commands(primary_hint),
@@ -51,7 +58,25 @@ def build_chat_route_hint_payload(
     return payload
 
 
-def _response_for_hint(primary_hint: dict[str, object], hints: list[dict[str, object]], *, source: str) -> dict[str, object]:
+def _generic_tool_checkpoint() -> dict[str, object]:
+    return awareness_generic_tool_checkpoint_payload()
+
+
+def _checkpoint_body_text(generic_tool_checkpoint: dict[str, object]) -> str:
+    body = str(generic_tool_checkpoint.get("body") or "").strip()
+    if not body:
+        return ""
+    return f"Checkpoint: {body}"
+
+
+def _response_for_hint(
+    primary_hint: dict[str, object],
+    hints: list[dict[str, object]],
+    *,
+    source: str,
+    generic_tool_checkpoint: dict[str, object],
+) -> dict[str, object]:
+    checkpoint_body = _checkpoint_body_text(generic_tool_checkpoint)
     if primary_hint:
         workflow = str(primary_hint.get("workflow") or "")
         next_action = str(primary_hint.get("next_action") or "")
@@ -61,6 +86,8 @@ def _response_for_hint(primary_hint: dict[str, object], hints: list[dict[str, ob
             f"I can open `{workflow}` first because this request matches the {lane.replace('_', ' ')} lane. "
             f"Next action: `{next_action}`. This is only a route hint until a workflow is selected and observed."
         )
+        if checkpoint_body:
+            body = f"{body} {checkpoint_body}"
         actions = [
             {
                 "id": "open_workflow",
@@ -92,6 +119,8 @@ def _response_for_hint(primary_hint: dict[str, object], hints: list[dict[str, ob
             "I do not have a strong OMH workflow hint from this message alone. "
             "Open the workflow picker or ask Hermes to clarify before choosing a workflow."
         )
+        if checkpoint_body:
+            body = f"{body} {checkpoint_body}"
         actions = [
             {
                 "id": "open_picker",
@@ -120,6 +149,7 @@ def _response_for_hint(primary_hint: dict[str, object], hints: list[dict[str, ob
             "profile": source,
             "title": headline,
             "body_text": body,
+            "checkpoint_text": checkpoint_body,
             "primary_action": actions[0],
             "secondary_actions": actions[1:],
         },

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3282,6 +3282,11 @@ class CliTests(unittest.TestCase):
         self.assertEqual(payload["route_hint"]["primary_workflow"], "img-summary")
         self.assertEqual(payload["chat_response"]["kind"], "workflow_route_hint")
         self.assertEqual(payload["chat_response"]["state"]["selected_workflow"], "img-summary")
+        self.assertEqual(payload["generic_tool_checkpoint"]["schema_version"], "omh_generic_tool_checkpoint/v1")
+        self.assertIn("prep/status/learning", payload["generic_tool_checkpoint"]["body"])
+        self.assertIn("prep/status/learning", payload["chat_response"]["body"])
+        self.assertNotIn("generic_tool_checkpoint", payload["chat_response"]["state"])
+        self.assertIn("prep/status/learning", payload["chat_response"]["messenger_rendering"]["checkpoint_text"])
         actions = {action["id"]: action for action in payload["chat_response"]["actions"]}
         self.assertIn("open_workflow", actions)
         self.assertIn("route_for_me", actions)

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -23,6 +23,7 @@ from omh.capabilities.skills import skill_capabilities
 from omh.plugin_bundle.omh.tools.capability_tool import standalone_skill_capability_items
 from omh.plugin_bundle.omh.awareness import (
     awareness_context_matches_message,
+    awareness_generic_tool_checkpoint_payload,
     awareness_primer_payload,
     awareness_primer_context,
     awareness_primer_markdown,
@@ -128,6 +129,11 @@ class EfficiencyContractTests(unittest.TestCase):
         self.assertIn("ultraprocess", cards["coding_handoff"]["representative_workflows"])
         self.assertIn("not_evidence_until_observed", cards["intent_to_plan"])
         self.assertIn("prep/status/learning", payload["generic_tool_checkpoint"])
+        self.assertEqual(
+            awareness_generic_tool_checkpoint_payload()["schema_version"],
+            "omh_generic_tool_checkpoint/v1",
+        )
+        self.assertIn("prep/status/learning", awareness_generic_tool_checkpoint_payload()["body"])
         for card in cards.values():
             self.assertTrue(card["label"])
             self.assertTrue(card["user_examples"])

--- a/tests/test_wrapper_contract.py
+++ b/tests/test_wrapper_contract.py
@@ -78,7 +78,16 @@ class WrapperContractTests(unittest.TestCase):
         self.assertEqual(payload["route_hint"]["schema_version"], "omh_route_hint/v1")
         self.assertEqual(payload["route_hint"]["primary_workflow"], "feedback-triage")
         self.assertEqual(payload["chat_response"]["state"]["selected_workflow"], "feedback-triage")
+        self.assertEqual(payload["generic_tool_checkpoint"]["schema_version"], "omh_generic_tool_checkpoint/v1")
+        self.assertIn("prep/status/learning", payload["generic_tool_checkpoint"]["body"])
+        self.assertIn("prep/status/learning", payload["chat_response"]["body"])
+        self.assertNotIn("generic_tool_checkpoint", payload["chat_response"]["state"])
         self.assertEqual(payload["chat_response"]["messenger_rendering"]["profile"], "discord")
+        self.assertIn("prep/status/learning", payload["chat_response"]["messenger_rendering"]["checkpoint_text"])
+        self.assertIn(
+            "generic_tool_checkpoint_path",
+            payload["wrapper_contract"],
+        )
         self.assertTrue(payload["wrapper_contract"]["safe_to_render_without_shell_approval"])
         action_ids = {action["id"] for action in payload["chat_response"]["actions"]}
         self.assertIn("open_workflow", action_ids)
@@ -92,6 +101,9 @@ class WrapperContractTests(unittest.TestCase):
         self.assertEqual(payload["route_hint"]["status"], "no_hint")
         self.assertEqual(payload["chat_response"]["kind"], "no_route_hint")
         self.assertEqual(payload["chat_response"]["state"]["selected_workflow"], "")
+        self.assertEqual(payload["generic_tool_checkpoint"]["schema_version"], "omh_generic_tool_checkpoint/v1")
+        self.assertIn("Before generic tools", payload["generic_tool_checkpoint"]["body"])
+        self.assertIn("Before generic tools", payload["chat_response"]["body"])
         actions = {action["id"]: action for action in payload["chat_response"]["actions"]}
         self.assertIn("open_picker", actions)
         self.assertIn("clarify", actions)

--- a/tests/test_wrapper_golden_examples.py
+++ b/tests/test_wrapper_golden_examples.py
@@ -306,6 +306,11 @@ class WrapperGoldenExampleTests(unittest.TestCase):
                 self.assertEqual(response["kind"], expected["kind"])
                 self.assertEqual(live["route_hint"]["primary_workflow"], expected["primary_workflow"])
                 self.assertEqual(response["state"]["next_action"], expected["next_action"])
+                self.assertEqual(
+                    live["generic_tool_checkpoint"]["schema_version"],
+                    expected["generic_tool_checkpoint"],
+                )
+                self.assertIn("prep/status/learning", live["generic_tool_checkpoint"]["body"])
                 self.assertEqual(response["messenger_rendering"]["schema_version"], expected["messenger_rendering"])
                 self.assertEqual(
                     [action["id"] for action in response["actions"]],
@@ -359,6 +364,8 @@ class WrapperGoldenExampleTests(unittest.TestCase):
                 self.assertEqual(payload["redaction_policy"], "metadata_only")
                 self.assertEqual(payload["response"]["kind"], "workflow_route_hint")
                 self.assertEqual(payload["route_hint"]["primary_workflow"], workflow)
+                self.assertEqual(payload["generic_tool_checkpoint"]["schema_version"], "omh_generic_tool_checkpoint/v1")
+                self.assertIn("prep/status/learning", payload["generic_tool_checkpoint"]["body"])
                 self.assertEqual(payload["next_action"], next_action)
                 self.assertEqual(payload["usage_trace"]["schema_version"], "omh_usage_trace/v1")
                 self.assertEqual(payload["usage_trace"]["visible_prefix"], f"[omh] {workflow}")


### PR DESCRIPTION
## Feature Report

### What Changed

- Exposed a wrapper-visible `omh_generic_tool_checkpoint/v1` advisory payload on `chat_route_hint/v1` responses.
- Added `messenger_rendering.checkpoint_text` so Discord/Slack/Telegram-style wrappers can show that OMH prep/status/learning should be checked before generic image, file, search, or coding tools.
- Kept the checkpoint out of `chat_response.state` after architecture review so advisory copy cannot be confused with runtime state or observed evidence.
- Updated route-hint golden examples, transport-free shim output, docs, and tests to lock the new contract.

### Why This Exists

- Hermes can use generic tools directly, but OMH should remain visible when a request is workflow-shaped: image summaries, files, search-backed research, coding handoffs, status, and learning all benefit from OMH's prep/status/evidence boundaries.
- Recent user feedback showed that a Hermes agent could answer "I did not use OMH" for image work because the generic tool path looked more direct. This PR makes the wrapper card itself carry the reminder before the agent or adapter falls through to generic tooling.

### User / Operator Impact

- When a wrapper asks for a lightweight route hint, the card can now say: `Checkpoint: Before generic tools, check OMH prep/status/learning; if relevant, name the workflow first.`
- Users still see the same primary actions such as `Open img-summary`, `Route for me`, and `Open omh`.
- Operators get a stable path, `generic_tool_checkpoint`, for rendering this advisory without shell approval or plugin-load assumptions.
- No route ranking, workflow selection, execution, delivery, CI, or merge claim behavior changes.

### How It Works

- `src/plugin_bundle/omh/awareness.py` now owns a dedicated `awareness_generic_tool_checkpoint_payload()` helper and schema constant.
- `src/wrapper/route_hints.py` adds the checkpoint to the route-hint envelope and messenger rendering text while keeping `chat_response.state` limited to route facts.
- `examples/wrapper_shim_common.py` forwards the top-level checkpoint into transport-free shim output.
- The route-hint wrapper contract declares `generic_tool_checkpoint_path` so adapters know where to read it.

### Files And Contracts Touched

- `src/plugin_bundle/omh/awareness.py`: dedicated checkpoint payload owner.
- `src/wrapper/route_hints.py`: `chat_route_hint/v1` envelope and `messenger_route_hint_rendering/v1` rendering field.
- `examples/wrapper_shim_common.py`: route-hint shim output.
- `examples/wrapper-golden/route-hints.json`: golden contract expectations.
- `docs/CHAT_WRAPPER_EXAMPLES.md`: human-readable wrapper card examples.
- `tests/test_cli.py`, `tests/test_wrapper_contract.py`, `tests/test_wrapper_golden_examples.py`, `tests/test_efficiency.py`: contract, CLI, shim, and budget coverage.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` - 630 tests passed.
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_wrapper_contract.py tests/test_cli.py tests/test_wrapper_golden_examples.py tests/test_efficiency.py -v` - 257 tests passed.
- [x] `uv run python -m compileall -q src tests` - passed.
- [x] `uv run python -m src.cli docs workflows --check` - passed; 41/41 tap skills checked.
- [ ] `python3 -m omh.cli harness validate` - not run; this PR does not change harness definitions.
- [ ] `python3 -m omh.cli release checklist --json` - not run; this PR does not change release packaging or channel metadata.
- [ ] `python3 -m omh.cli release hermes-smoke` - not run; this PR changes route-hint wrapper metadata, not install smoke.
- [x] Relevant dry-run or smoke command: `uv run python -m src.cli chat route-hint --source discord "make an image explaining the cron feature"` - returned `generic_tool_checkpoint` plus `messenger_rendering.checkpoint_text`, with no checkpoint in `chat_response.state`.
- [x] Code review: independent `code-reviewer` found no issues; independent `architect` initially raised WATCH about state/coupling, the PR was revised, and the architect re-review returned CLEAR.
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; live messenger adapters are outside this repository, so this was verified through deterministic CLI/shim/golden fixtures.

## Risk

- Low. The change is additive to wrapper metadata and rendering text, and it does not alter routing scores, selected workflows, execution, or persisted runtime evidence.
- Strict consumers that reject unknown top-level fields could need to ignore `generic_tool_checkpoint`; this follows the existing additive wrapper-contract pattern.

## Compatibility / Rollout

- Backward-compatible for existing route-hint consumers that read `chat_response`, `route_hint`, or existing action fields.
- New consumers should read `wrapper_contract.generic_tool_checkpoint_path` and render the top-level advisory as copy, not as runtime state.

## Release / Claims

- [x] Release-channel impact considered: no release channel behavior changes.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] Known manual Hermes checks are listed: live messenger rendering was not run; fixture/shim/CLI contracts were verified instead.

## Follow-Up

- If a real wrapper wants richer UI, it can render the checkpoint as a compact card badge or footer without changing OMH runtime state.
