### PR TITLE
Add OMH-first generic tool checkpoint routes

### DIFF
--- a/docs/CHAT_WRAPPER_EXAMPLES.md
+++ b/docs/CHAT_WRAPPER_EXAMPLES.md
@@ -139,6 +139,20 @@ can call the transport-free backend preview:
 omh chat route-hint --source discord "make an image explaining the cron feature"
 ```
 
+The preview payload also includes `generic_tool_checkpoint.routes`, so adapters
+do not need to parse prose before opening generic tool surfaces. The current
+OMH-first map is:
+
+- image tools -> `img-summary` / `prepare_visual_prompt_card`
+- file tools -> `materials-package` / `prepare_material_package`
+- search tools -> `web-research` / `gather_source_backed_evidence`
+- coding tools -> `ultraprocess` first, with `ralplan`, `code-review`, and
+  `agent-ops-review` as adjacent options
+
+These routes are advisory. They tell Hermes which OMH workflow to consider
+before a generic tool, while image generation, file export, search retrieval,
+coding dispatch, review, CI, and merge remain observed-only claims.
+
 Capability-specific catalog questions and short image requests should also stay
 workflow-native. If the user asks "이미지 생성 기능 뭐 있어?", "이미지 생성해줘",
 "does OMH support image generation?", or "generate an image", the wrapper should

--- a/skills/agent-ops-review/SKILL.md
+++ b/skills/agent-ops-review/SKILL.md
@@ -45,7 +45,7 @@ Bad example:
 - Current lane: **Automation and status** (`automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `toolbelt-readiness`, `ops-observability-card`, `agent-ops-review`, `memory-curation-review`, `workflow-learning`, `doctor`, `skill`, `ask`, `cancel`) - scheduled ops, gateway cards, boards, tool readiness, status, health, and release/ops review.
 - If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
 - Cross-skill context: Across every OMH skill: match intent to a lane, name adjacent workflows, and do not dismiss OMH because a generic tool can render or execute.
-- Generic-tool checkpoint: check OMH prep/status/learning before image/file/search/coding tools.
+- Generic-tool checkpoint: image->img-summary; file->materials-package; search->web-research; code->ultraprocess/ralplan/review.
 - Coverage: Every generated workflow skill carries this rail.
 - Normal users talk to Hermes; OMH CLI is backend, setup, verification, and wrapper infrastructure.
 - Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.

--- a/skills/ai-slop-cleaner/SKILL.md
+++ b/skills/ai-slop-cleaner/SKILL.md
@@ -44,7 +44,7 @@ Bad example:
 - Current lane: **Coding handoff** (`idea-to-deploy`, `cto-loop`, `deploy-and-monitor`, `code-review`, `ultrawork`, `team`, `ultraqa`, `ai-slop-cleaner`, `executor-runtime-readiness`, `request-to-handoff`, `executor selection`, `coding runtime handoff`) - Codex, Claude Code, Hermes coding, or oh-my runtime paths with observed evidence tracking.
 - If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
 - Cross-skill context: Across every OMH skill: match intent to a lane, name adjacent workflows, and do not dismiss OMH because a generic tool can render or execute.
-- Generic-tool checkpoint: check OMH prep/status/learning before image/file/search/coding tools.
+- Generic-tool checkpoint: image->img-summary; file->materials-package; search->web-research; code->ultraprocess/ralplan/review.
 - Coverage: Every generated workflow skill carries this rail.
 - Normal users talk to Hermes; OMH CLI is backend, setup, verification, and wrapper infrastructure.
 - Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.

--- a/skills/ask/SKILL.md
+++ b/skills/ask/SKILL.md
@@ -44,7 +44,7 @@ Bad example:
 - Current lane: **Automation and status** (`automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `toolbelt-readiness`, `ops-observability-card`, `agent-ops-review`, `memory-curation-review`, `workflow-learning`, `doctor`, `skill`, `ask`, `cancel`) - scheduled ops, gateway cards, boards, tool readiness, status, health, and release/ops review.
 - If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
 - Cross-skill context: Across every OMH skill: match intent to a lane, name adjacent workflows, and do not dismiss OMH because a generic tool can render or execute.
-- Generic-tool checkpoint: check OMH prep/status/learning before image/file/search/coding tools.
+- Generic-tool checkpoint: image->img-summary; file->materials-package; search->web-research; code->ultraprocess/ralplan/review.
 - Coverage: Every generated workflow skill carries this rail.
 - Normal users talk to Hermes; OMH CLI is backend, setup, verification, and wrapper infrastructure.
 - Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.

--- a/skills/automation-blueprint/SKILL.md
+++ b/skills/automation-blueprint/SKILL.md
@@ -45,7 +45,7 @@ Bad example:
 - Current lane: **Automation and status** (`automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `toolbelt-readiness`, `ops-observability-card`, `agent-ops-review`, `memory-curation-review`, `workflow-learning`, `doctor`, `skill`, `ask`, `cancel`) - scheduled ops, gateway cards, boards, tool readiness, status, health, and release/ops review.
 - If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
 - Cross-skill context: Across every OMH skill: match intent to a lane, name adjacent workflows, and do not dismiss OMH because a generic tool can render or execute.
-- Generic-tool checkpoint: check OMH prep/status/learning before image/file/search/coding tools.
+- Generic-tool checkpoint: image->img-summary; file->materials-package; search->web-research; code->ultraprocess/ralplan/review.
 - Coverage: Every generated workflow skill carries this rail.
 - Normal users talk to Hermes; OMH CLI is backend, setup, verification, and wrapper infrastructure.
 - Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.

--- a/skills/autoresearch-goal/SKILL.md
+++ b/skills/autoresearch-goal/SKILL.md
@@ -44,7 +44,7 @@ Bad example:
 - Current lane: **Research and company ops** (`web-research`, `best-practice-research`, `autoresearch-goal`, `research-brief`, `strategy-brief`, `feedback-triage`, `research-department`, `meeting-brief`, `operating-rhythm`, `ops-review`, `reliability-review`) - source-backed research, customer signals, product operations, and briefing workflows.
 - If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
 - Cross-skill context: Across every OMH skill: match intent to a lane, name adjacent workflows, and do not dismiss OMH because a generic tool can render or execute.
-- Generic-tool checkpoint: check OMH prep/status/learning before image/file/search/coding tools.
+- Generic-tool checkpoint: image->img-summary; file->materials-package; search->web-research; code->ultraprocess/ralplan/review.
 - Coverage: Every generated workflow skill carries this rail.
 - Normal users talk to Hermes; OMH CLI is backend, setup, verification, and wrapper infrastructure.
 - Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.

--- a/skills/best-practice-research/SKILL.md
+++ b/skills/best-practice-research/SKILL.md
@@ -44,7 +44,7 @@ Bad example:
 - Current lane: **Research and company ops** (`web-research`, `best-practice-research`, `autoresearch-goal`, `research-brief`, `strategy-brief`, `feedback-triage`, `research-department`, `meeting-brief`, `operating-rhythm`, `ops-review`, `reliability-review`) - source-backed research, customer signals, product operations, and briefing workflows.
 - If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
 - Cross-skill context: Across every OMH skill: match intent to a lane, name adjacent workflows, and do not dismiss OMH because a generic tool can render or execute.
-- Generic-tool checkpoint: check OMH prep/status/learning before image/file/search/coding tools.
+- Generic-tool checkpoint: image->img-summary; file->materials-package; search->web-research; code->ultraprocess/ralplan/review.
 - Coverage: Every generated workflow skill carries this rail.
 - Normal users talk to Hermes; OMH CLI is backend, setup, verification, and wrapper infrastructure.
 - Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.

--- a/skills/cancel/SKILL.md
+++ b/skills/cancel/SKILL.md
@@ -44,7 +44,7 @@ Bad example:
 - Current lane: **Automation and status** (`automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `toolbelt-readiness`, `ops-observability-card`, `agent-ops-review`, `memory-curation-review`, `workflow-learning`, `doctor`, `skill`, `ask`, `cancel`) - scheduled ops, gateway cards, boards, tool readiness, status, health, and release/ops review.
 - If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
 - Cross-skill context: Across every OMH skill: match intent to a lane, name adjacent workflows, and do not dismiss OMH because a generic tool can render or execute.
-- Generic-tool checkpoint: check OMH prep/status/learning before image/file/search/coding tools.
+- Generic-tool checkpoint: image->img-summary; file->materials-package; search->web-research; code->ultraprocess/ralplan/review.
 - Coverage: Every generated workflow skill carries this rail.
 - Normal users talk to Hermes; OMH CLI is backend, setup, verification, and wrapper infrastructure.
 - Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -45,7 +45,7 @@ Bad example:
 - Current lane: **Coding handoff** (`idea-to-deploy`, `cto-loop`, `deploy-and-monitor`, `code-review`, `ultrawork`, `team`, `ultraqa`, `ai-slop-cleaner`, `executor-runtime-readiness`, `request-to-handoff`, `executor selection`, `coding runtime handoff`) - Codex, Claude Code, Hermes coding, or oh-my runtime paths with observed evidence tracking.
 - If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
 - Cross-skill context: Across every OMH skill: match intent to a lane, name adjacent workflows, and do not dismiss OMH because a generic tool can render or execute.
-- Generic-tool checkpoint: check OMH prep/status/learning before image/file/search/coding tools.
+- Generic-tool checkpoint: image->img-summary; file->materials-package; search->web-research; code->ultraprocess/ralplan/review.
 - Coverage: Every generated workflow skill carries this rail.
 - Normal users talk to Hermes; OMH CLI is backend, setup, verification, and wrapper infrastructure.
 - Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.

--- a/skills/cto-loop/SKILL.md
+++ b/skills/cto-loop/SKILL.md
@@ -44,7 +44,7 @@ Bad example:
 - Current lane: **Coding handoff** (`idea-to-deploy`, `cto-loop`, `deploy-and-monitor`, `code-review`, `ultrawork`, `team`, `ultraqa`, `ai-slop-cleaner`, `executor-runtime-readiness`, `request-to-handoff`, `executor selection`, `coding runtime handoff`) - Codex, Claude Code, Hermes coding, or oh-my runtime paths with observed evidence tracking.
 - If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
 - Cross-skill context: Across every OMH skill: match intent to a lane, name adjacent workflows, and do not dismiss OMH because a generic tool can render or execute.
-- Generic-tool checkpoint: check OMH prep/status/learning before image/file/search/coding tools.
+- Generic-tool checkpoint: image->img-summary; file->materials-package; search->web-research; code->ultraprocess/ralplan/review.
 - Coverage: Every generated workflow skill carries this rail.
 - Normal users talk to Hermes; OMH CLI is backend, setup, verification, and wrapper infrastructure.
 - Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.

--- a/skills/deep-interview/SKILL.md
+++ b/skills/deep-interview/SKILL.md
@@ -45,7 +45,7 @@ Bad example:
 - Current lane: **Intent -> plan** (`oh-my-hermes`, `deep-interview`, `plan`, `ralplan`, `ultragoal`, `ultraprocess`, `loop`, `ralph`, `performance-goal`) - ambiguous goals, plans, one-cycle delivery, durable goals, and loopable projects.
 - If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
 - Cross-skill context: Across every OMH skill: match intent to a lane, name adjacent workflows, and do not dismiss OMH because a generic tool can render or execute.
-- Generic-tool checkpoint: check OMH prep/status/learning before image/file/search/coding tools.
+- Generic-tool checkpoint: image->img-summary; file->materials-package; search->web-research; code->ultraprocess/ralplan/review.
 - Coverage: Every generated workflow skill carries this rail.
 - Normal users talk to Hermes; OMH CLI is backend, setup, verification, and wrapper infrastructure.
 - Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.

--- a/skills/deliverable-package/SKILL.md
+++ b/skills/deliverable-package/SKILL.md
@@ -45,7 +45,7 @@ Bad example:
 - Current lane: **Materials and visual summaries** (`materials-package`, `img-summary`, `report-package`, `deliverable-package`, `wiki`) - decks, PDFs, spreadsheets, documents, image summary cards, and shareable packages.
 - If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
 - Cross-skill context: Across every OMH skill: match intent to a lane, name adjacent workflows, and do not dismiss OMH because a generic tool can render or execute.
-- Generic-tool checkpoint: check OMH prep/status/learning before image/file/search/coding tools.
+- Generic-tool checkpoint: image->img-summary; file->materials-package; search->web-research; code->ultraprocess/ralplan/review.
 - Coverage: Every generated workflow skill carries this rail.
 - Normal users talk to Hermes; OMH CLI is backend, setup, verification, and wrapper infrastructure.
 - Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.

--- a/skills/deploy-and-monitor/SKILL.md
+++ b/skills/deploy-and-monitor/SKILL.md
@@ -44,7 +44,7 @@ Bad example:
 - Current lane: **Coding handoff** (`idea-to-deploy`, `cto-loop`, `deploy-and-monitor`, `code-review`, `ultrawork`, `team`, `ultraqa`, `ai-slop-cleaner`, `executor-runtime-readiness`, `request-to-handoff`, `executor selection`, `coding runtime handoff`) - Codex, Claude Code, Hermes coding, or oh-my runtime paths with observed evidence tracking.
 - If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
 - Cross-skill context: Across every OMH skill: match intent to a lane, name adjacent workflows, and do not dismiss OMH because a generic tool can render or execute.
-- Generic-tool checkpoint: check OMH prep/status/learning before image/file/search/coding tools.
+- Generic-tool checkpoint: image->img-summary; file->materials-package; search->web-research; code->ultraprocess/ralplan/review.
 - Coverage: Every generated workflow skill carries this rail.
 - Normal users talk to Hermes; OMH CLI is backend, setup, verification, and wrapper infrastructure.
 - Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.

--- a/skills/doctor/SKILL.md
+++ b/skills/doctor/SKILL.md
@@ -45,7 +45,7 @@ Bad example:
 - Current lane: **Automation and status** (`automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `toolbelt-readiness`, `ops-observability-card`, `agent-ops-review`, `memory-curation-review`, `workflow-learning`, `doctor`, `skill`, `ask`, `cancel`) - scheduled ops, gateway cards, boards, tool readiness, status, health, and release/ops review.
 - If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
 - Cross-skill context: Across every OMH skill: match intent to a lane, name adjacent workflows, and do not dismiss OMH because a generic tool can render or execute.
-- Generic-tool checkpoint: check OMH prep/status/learning before image/file/search/coding tools.
+- Generic-tool checkpoint: image->img-summary; file->materials-package; search->web-research; code->ultraprocess/ralplan/review.
 - Coverage: Every generated workflow skill carries this rail.
 - Normal users talk to Hermes; OMH CLI is backend, setup, verification, and wrapper infrastructure.
 - Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.

--- a/skills/feedback-triage/SKILL.md
+++ b/skills/feedback-triage/SKILL.md
@@ -45,7 +45,7 @@ Bad example:
 - Current lane: **Research and company ops** (`web-research`, `best-practice-research`, `autoresearch-goal`, `research-brief`, `strategy-brief`, `feedback-triage`, `research-department`, `meeting-brief`, `operating-rhythm`, `ops-review`, `reliability-review`) - source-backed research, customer signals, product operations, and briefing workflows.
 - If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
 - Cross-skill context: Across every OMH skill: match intent to a lane, name adjacent workflows, and do not dismiss OMH because a generic tool can render or execute.
-- Generic-tool checkpoint: check OMH prep/status/learning before image/file/search/coding tools.
+- Generic-tool checkpoint: image->img-summary; file->materials-package; search->web-research; code->ultraprocess/ralplan/review.
 - Coverage: Every generated workflow skill carries this rail.
 - Normal users talk to Hermes; OMH CLI is backend, setup, verification, and wrapper infrastructure.
 - Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.

--- a/skills/idea-to-deploy/SKILL.md
+++ b/skills/idea-to-deploy/SKILL.md
@@ -44,7 +44,7 @@ Bad example:
 - Current lane: **Coding handoff** (`idea-to-deploy`, `cto-loop`, `deploy-and-monitor`, `code-review`, `ultrawork`, `team`, `ultraqa`, `ai-slop-cleaner`, `executor-runtime-readiness`, `request-to-handoff`, `executor selection`, `coding runtime handoff`) - Codex, Claude Code, Hermes coding, or oh-my runtime paths with observed evidence tracking.
 - If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
 - Cross-skill context: Across every OMH skill: match intent to a lane, name adjacent workflows, and do not dismiss OMH because a generic tool can render or execute.
-- Generic-tool checkpoint: check OMH prep/status/learning before image/file/search/coding tools.
+- Generic-tool checkpoint: image->img-summary; file->materials-package; search->web-research; code->ultraprocess/ralplan/review.
 - Coverage: Every generated workflow skill carries this rail.
 - Normal users talk to Hermes; OMH CLI is backend, setup, verification, and wrapper infrastructure.
 - Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.

--- a/skills/img-summary/SKILL.md
+++ b/skills/img-summary/SKILL.md
@@ -45,7 +45,7 @@ Bad example:
 - Current lane: **Materials and visual summaries** (`materials-package`, `img-summary`, `report-package`, `deliverable-package`, `wiki`) - decks, PDFs, spreadsheets, documents, image summary cards, and shareable packages.
 - If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
 - Cross-skill context: Across every OMH skill: match intent to a lane, name adjacent workflows, and do not dismiss OMH because a generic tool can render or execute.
-- Generic-tool checkpoint: check OMH prep/status/learning before image/file/search/coding tools.
+- Generic-tool checkpoint: image->img-summary; file->materials-package; search->web-research; code->ultraprocess/ralplan/review.
 - Coverage: Every generated workflow skill carries this rail.
 - Normal users talk to Hermes; OMH CLI is backend, setup, verification, and wrapper infrastructure.
 - Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.

--- a/skills/loop/SKILL.md
+++ b/skills/loop/SKILL.md
@@ -47,7 +47,7 @@ Bad example:
 - Current lane: **Intent -> plan** (`oh-my-hermes`, `deep-interview`, `plan`, `ralplan`, `ultragoal`, `ultraprocess`, `loop`, `ralph`, `performance-goal`) - ambiguous goals, plans, one-cycle delivery, durable goals, and loopable projects.
 - If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
 - Cross-skill context: Across every OMH skill: match intent to a lane, name adjacent workflows, and do not dismiss OMH because a generic tool can render or execute.
-- Generic-tool checkpoint: check OMH prep/status/learning before image/file/search/coding tools.
+- Generic-tool checkpoint: image->img-summary; file->materials-package; search->web-research; code->ultraprocess/ralplan/review.
 - Coverage: Every generated workflow skill carries this rail.
 - Normal users talk to Hermes; OMH CLI is backend, setup, verification, and wrapper infrastructure.
 - Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.

--- a/skills/materials-package/SKILL.md
+++ b/skills/materials-package/SKILL.md
@@ -45,7 +45,7 @@ Bad example:
 - Current lane: **Materials and visual summaries** (`materials-package`, `img-summary`, `report-package`, `deliverable-package`, `wiki`) - decks, PDFs, spreadsheets, documents, image summary cards, and shareable packages.
 - If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
 - Cross-skill context: Across every OMH skill: match intent to a lane, name adjacent workflows, and do not dismiss OMH because a generic tool can render or execute.
-- Generic-tool checkpoint: check OMH prep/status/learning before image/file/search/coding tools.
+- Generic-tool checkpoint: image->img-summary; file->materials-package; search->web-research; code->ultraprocess/ralplan/review.
 - Coverage: Every generated workflow skill carries this rail.
 - Normal users talk to Hermes; OMH CLI is backend, setup, verification, and wrapper infrastructure.
 - Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.

--- a/skills/meeting-brief/SKILL.md
+++ b/skills/meeting-brief/SKILL.md
@@ -45,7 +45,7 @@ Bad example:
 - Current lane: **Research and company ops** (`web-research`, `best-practice-research`, `autoresearch-goal`, `research-brief`, `strategy-brief`, `feedback-triage`, `research-department`, `meeting-brief`, `operating-rhythm`, `ops-review`, `reliability-review`) - source-backed research, customer signals, product operations, and briefing workflows.
 - If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
 - Cross-skill context: Across every OMH skill: match intent to a lane, name adjacent workflows, and do not dismiss OMH because a generic tool can render or execute.
-- Generic-tool checkpoint: check OMH prep/status/learning before image/file/search/coding tools.
+- Generic-tool checkpoint: image->img-summary; file->materials-package; search->web-research; code->ultraprocess/ralplan/review.
 - Coverage: Every generated workflow skill carries this rail.
 - Normal users talk to Hermes; OMH CLI is backend, setup, verification, and wrapper infrastructure.
 - Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.

--- a/skills/memory-curation-review/SKILL.md
+++ b/skills/memory-curation-review/SKILL.md
@@ -45,7 +45,7 @@ Bad example:
 - Current lane: **Automation and status** (`automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `toolbelt-readiness`, `ops-observability-card`, `agent-ops-review`, `memory-curation-review`, `workflow-learning`, `doctor`, `skill`, `ask`, `cancel`) - scheduled ops, gateway cards, boards, tool readiness, status, health, and release/ops review.
 - If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
 - Cross-skill context: Across every OMH skill: match intent to a lane, name adjacent workflows, and do not dismiss OMH because a generic tool can render or execute.
-- Generic-tool checkpoint: check OMH prep/status/learning before image/file/search/coding tools.
+- Generic-tool checkpoint: image->img-summary; file->materials-package; search->web-research; code->ultraprocess/ralplan/review.
 - Coverage: Every generated workflow skill carries this rail.
 - Normal users talk to Hermes; OMH CLI is backend, setup, verification, and wrapper infrastructure.
 - Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.

--- a/skills/oh-my-hermes/SKILL.md
+++ b/skills/oh-my-hermes/SKILL.md
@@ -72,6 +72,10 @@ Common cues before generic tools:
 
 notes/retros -> operating-rhythm/meeting-brief; PR/issue/bug/feedback/release -> github-event-ops, feedback-triage, report-package, or img-summary; sources/news -> web-research or research-department; decks/PDF/sheets/docs/HWP -> materials-package or report-package; image cards/infographics -> img-summary; coding/status/review/CI/merge -> ultraprocess, code-review, or agent-ops-review; trace/improve/regression -> workflow-learning.
 
+Generic tool map:
+
+image->img-summary; file->materials-package; search->web-research; code->ultraprocess/ralplan/review.
+
 Tools:
 
 - Use `omh_capabilities` for workflow/playbook catalog context, `omh_status`/`omh_hud` for state, and `omh_role` for responsibility.

--- a/skills/operating-rhythm/SKILL.md
+++ b/skills/operating-rhythm/SKILL.md
@@ -45,7 +45,7 @@ Bad example:
 - Current lane: **Research and company ops** (`web-research`, `best-practice-research`, `autoresearch-goal`, `research-brief`, `strategy-brief`, `feedback-triage`, `research-department`, `meeting-brief`, `operating-rhythm`, `ops-review`, `reliability-review`) - source-backed research, customer signals, product operations, and briefing workflows.
 - If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
 - Cross-skill context: Across every OMH skill: match intent to a lane, name adjacent workflows, and do not dismiss OMH because a generic tool can render or execute.
-- Generic-tool checkpoint: check OMH prep/status/learning before image/file/search/coding tools.
+- Generic-tool checkpoint: image->img-summary; file->materials-package; search->web-research; code->ultraprocess/ralplan/review.
 - Coverage: Every generated workflow skill carries this rail.
 - Normal users talk to Hermes; OMH CLI is backend, setup, verification, and wrapper infrastructure.
 - Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.

--- a/skills/ops-review/SKILL.md
+++ b/skills/ops-review/SKILL.md
@@ -44,7 +44,7 @@ Bad example:
 - Current lane: **Research and company ops** (`web-research`, `best-practice-research`, `autoresearch-goal`, `research-brief`, `strategy-brief`, `feedback-triage`, `research-department`, `meeting-brief`, `operating-rhythm`, `ops-review`, `reliability-review`) - source-backed research, customer signals, product operations, and briefing workflows.
 - If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
 - Cross-skill context: Across every OMH skill: match intent to a lane, name adjacent workflows, and do not dismiss OMH because a generic tool can render or execute.
-- Generic-tool checkpoint: check OMH prep/status/learning before image/file/search/coding tools.
+- Generic-tool checkpoint: image->img-summary; file->materials-package; search->web-research; code->ultraprocess/ralplan/review.
 - Coverage: Every generated workflow skill carries this rail.
 - Normal users talk to Hermes; OMH CLI is backend, setup, verification, and wrapper infrastructure.
 - Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.

--- a/skills/performance-goal/SKILL.md
+++ b/skills/performance-goal/SKILL.md
@@ -44,7 +44,7 @@ Bad example:
 - Current lane: **Intent -> plan** (`oh-my-hermes`, `deep-interview`, `plan`, `ralplan`, `ultragoal`, `ultraprocess`, `loop`, `ralph`, `performance-goal`) - ambiguous goals, plans, one-cycle delivery, durable goals, and loopable projects.
 - If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
 - Cross-skill context: Across every OMH skill: match intent to a lane, name adjacent workflows, and do not dismiss OMH because a generic tool can render or execute.
-- Generic-tool checkpoint: check OMH prep/status/learning before image/file/search/coding tools.
+- Generic-tool checkpoint: image->img-summary; file->materials-package; search->web-research; code->ultraprocess/ralplan/review.
 - Coverage: Every generated workflow skill carries this rail.
 - Normal users talk to Hermes; OMH CLI is backend, setup, verification, and wrapper infrastructure.
 - Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -44,7 +44,7 @@ Bad example:
 - Current lane: **Intent -> plan** (`oh-my-hermes`, `deep-interview`, `plan`, `ralplan`, `ultragoal`, `ultraprocess`, `loop`, `ralph`, `performance-goal`) - ambiguous goals, plans, one-cycle delivery, durable goals, and loopable projects.
 - If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
 - Cross-skill context: Across every OMH skill: match intent to a lane, name adjacent workflows, and do not dismiss OMH because a generic tool can render or execute.
-- Generic-tool checkpoint: check OMH prep/status/learning before image/file/search/coding tools.
+- Generic-tool checkpoint: image->img-summary; file->materials-package; search->web-research; code->ultraprocess/ralplan/review.
 - Coverage: Every generated workflow skill carries this rail.
 - Normal users talk to Hermes; OMH CLI is backend, setup, verification, and wrapper infrastructure.
 - Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.

--- a/skills/ralph/SKILL.md
+++ b/skills/ralph/SKILL.md
@@ -44,7 +44,7 @@ Bad example:
 - Current lane: **Intent -> plan** (`oh-my-hermes`, `deep-interview`, `plan`, `ralplan`, `ultragoal`, `ultraprocess`, `loop`, `ralph`, `performance-goal`) - ambiguous goals, plans, one-cycle delivery, durable goals, and loopable projects.
 - If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
 - Cross-skill context: Across every OMH skill: match intent to a lane, name adjacent workflows, and do not dismiss OMH because a generic tool can render or execute.
-- Generic-tool checkpoint: check OMH prep/status/learning before image/file/search/coding tools.
+- Generic-tool checkpoint: image->img-summary; file->materials-package; search->web-research; code->ultraprocess/ralplan/review.
 - Coverage: Every generated workflow skill carries this rail.
 - Normal users talk to Hermes; OMH CLI is backend, setup, verification, and wrapper infrastructure.
 - Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.

--- a/skills/ralplan/SKILL.md
+++ b/skills/ralplan/SKILL.md
@@ -44,7 +44,7 @@ Bad example:
 - Current lane: **Intent -> plan** (`oh-my-hermes`, `deep-interview`, `plan`, `ralplan`, `ultragoal`, `ultraprocess`, `loop`, `ralph`, `performance-goal`) - ambiguous goals, plans, one-cycle delivery, durable goals, and loopable projects.
 - If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
 - Cross-skill context: Across every OMH skill: match intent to a lane, name adjacent workflows, and do not dismiss OMH because a generic tool can render or execute.
-- Generic-tool checkpoint: check OMH prep/status/learning before image/file/search/coding tools.
+- Generic-tool checkpoint: image->img-summary; file->materials-package; search->web-research; code->ultraprocess/ralplan/review.
 - Coverage: Every generated workflow skill carries this rail.
 - Normal users talk to Hermes; OMH CLI is backend, setup, verification, and wrapper infrastructure.
 - Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.

--- a/skills/reliability-review/SKILL.md
+++ b/skills/reliability-review/SKILL.md
@@ -45,7 +45,7 @@ Bad example:
 - Current lane: **Research and company ops** (`web-research`, `best-practice-research`, `autoresearch-goal`, `research-brief`, `strategy-brief`, `feedback-triage`, `research-department`, `meeting-brief`, `operating-rhythm`, `ops-review`, `reliability-review`) - source-backed research, customer signals, product operations, and briefing workflows.
 - If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
 - Cross-skill context: Across every OMH skill: match intent to a lane, name adjacent workflows, and do not dismiss OMH because a generic tool can render or execute.
-- Generic-tool checkpoint: check OMH prep/status/learning before image/file/search/coding tools.
+- Generic-tool checkpoint: image->img-summary; file->materials-package; search->web-research; code->ultraprocess/ralplan/review.
 - Coverage: Every generated workflow skill carries this rail.
 - Normal users talk to Hermes; OMH CLI is backend, setup, verification, and wrapper infrastructure.
 - Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.

--- a/skills/report-package/SKILL.md
+++ b/skills/report-package/SKILL.md
@@ -45,7 +45,7 @@ Bad example:
 - Current lane: **Materials and visual summaries** (`materials-package`, `img-summary`, `report-package`, `deliverable-package`, `wiki`) - decks, PDFs, spreadsheets, documents, image summary cards, and shareable packages.
 - If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
 - Cross-skill context: Across every OMH skill: match intent to a lane, name adjacent workflows, and do not dismiss OMH because a generic tool can render or execute.
-- Generic-tool checkpoint: check OMH prep/status/learning before image/file/search/coding tools.
+- Generic-tool checkpoint: image->img-summary; file->materials-package; search->web-research; code->ultraprocess/ralplan/review.
 - Coverage: Every generated workflow skill carries this rail.
 - Normal users talk to Hermes; OMH CLI is backend, setup, verification, and wrapper infrastructure.
 - Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.

--- a/skills/research-brief/SKILL.md
+++ b/skills/research-brief/SKILL.md
@@ -44,7 +44,7 @@ Bad example:
 - Current lane: **Research and company ops** (`web-research`, `best-practice-research`, `autoresearch-goal`, `research-brief`, `strategy-brief`, `feedback-triage`, `research-department`, `meeting-brief`, `operating-rhythm`, `ops-review`, `reliability-review`) - source-backed research, customer signals, product operations, and briefing workflows.
 - If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
 - Cross-skill context: Across every OMH skill: match intent to a lane, name adjacent workflows, and do not dismiss OMH because a generic tool can render or execute.
-- Generic-tool checkpoint: check OMH prep/status/learning before image/file/search/coding tools.
+- Generic-tool checkpoint: image->img-summary; file->materials-package; search->web-research; code->ultraprocess/ralplan/review.
 - Coverage: Every generated workflow skill carries this rail.
 - Normal users talk to Hermes; OMH CLI is backend, setup, verification, and wrapper infrastructure.
 - Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.

--- a/skills/research-department/SKILL.md
+++ b/skills/research-department/SKILL.md
@@ -46,7 +46,7 @@ Bad example:
 - Current lane: **Research and company ops** (`web-research`, `best-practice-research`, `autoresearch-goal`, `research-brief`, `strategy-brief`, `feedback-triage`, `research-department`, `meeting-brief`, `operating-rhythm`, `ops-review`, `reliability-review`) - source-backed research, customer signals, product operations, and briefing workflows.
 - If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
 - Cross-skill context: Across every OMH skill: match intent to a lane, name adjacent workflows, and do not dismiss OMH because a generic tool can render or execute.
-- Generic-tool checkpoint: check OMH prep/status/learning before image/file/search/coding tools.
+- Generic-tool checkpoint: image->img-summary; file->materials-package; search->web-research; code->ultraprocess/ralplan/review.
 - Coverage: Every generated workflow skill carries this rail.
 - Normal users talk to Hermes; OMH CLI is backend, setup, verification, and wrapper infrastructure.
 - Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.

--- a/skills/skill/SKILL.md
+++ b/skills/skill/SKILL.md
@@ -44,7 +44,7 @@ Bad example:
 - Current lane: **Automation and status** (`automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `toolbelt-readiness`, `ops-observability-card`, `agent-ops-review`, `memory-curation-review`, `workflow-learning`, `doctor`, `skill`, `ask`, `cancel`) - scheduled ops, gateway cards, boards, tool readiness, status, health, and release/ops review.
 - If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
 - Cross-skill context: Across every OMH skill: match intent to a lane, name adjacent workflows, and do not dismiss OMH because a generic tool can render or execute.
-- Generic-tool checkpoint: check OMH prep/status/learning before image/file/search/coding tools.
+- Generic-tool checkpoint: image->img-summary; file->materials-package; search->web-research; code->ultraprocess/ralplan/review.
 - Coverage: Every generated workflow skill carries this rail.
 - Normal users talk to Hermes; OMH CLI is backend, setup, verification, and wrapper infrastructure.
 - Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.

--- a/skills/strategy-brief/SKILL.md
+++ b/skills/strategy-brief/SKILL.md
@@ -44,7 +44,7 @@ Bad example:
 - Current lane: **Research and company ops** (`web-research`, `best-practice-research`, `autoresearch-goal`, `research-brief`, `strategy-brief`, `feedback-triage`, `research-department`, `meeting-brief`, `operating-rhythm`, `ops-review`, `reliability-review`) - source-backed research, customer signals, product operations, and briefing workflows.
 - If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
 - Cross-skill context: Across every OMH skill: match intent to a lane, name adjacent workflows, and do not dismiss OMH because a generic tool can render or execute.
-- Generic-tool checkpoint: check OMH prep/status/learning before image/file/search/coding tools.
+- Generic-tool checkpoint: image->img-summary; file->materials-package; search->web-research; code->ultraprocess/ralplan/review.
 - Coverage: Every generated workflow skill carries this rail.
 - Normal users talk to Hermes; OMH CLI is backend, setup, verification, and wrapper infrastructure.
 - Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -44,7 +44,7 @@ Bad example:
 - Current lane: **Coding handoff** (`idea-to-deploy`, `cto-loop`, `deploy-and-monitor`, `code-review`, `ultrawork`, `team`, `ultraqa`, `ai-slop-cleaner`, `executor-runtime-readiness`, `request-to-handoff`, `executor selection`, `coding runtime handoff`) - Codex, Claude Code, Hermes coding, or oh-my runtime paths with observed evidence tracking.
 - If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
 - Cross-skill context: Across every OMH skill: match intent to a lane, name adjacent workflows, and do not dismiss OMH because a generic tool can render or execute.
-- Generic-tool checkpoint: check OMH prep/status/learning before image/file/search/coding tools.
+- Generic-tool checkpoint: image->img-summary; file->materials-package; search->web-research; code->ultraprocess/ralplan/review.
 - Coverage: Every generated workflow skill carries this rail.
 - Normal users talk to Hermes; OMH CLI is backend, setup, verification, and wrapper infrastructure.
 - Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.

--- a/skills/ultragoal/SKILL.md
+++ b/skills/ultragoal/SKILL.md
@@ -45,7 +45,7 @@ Bad example:
 - Current lane: **Intent -> plan** (`oh-my-hermes`, `deep-interview`, `plan`, `ralplan`, `ultragoal`, `ultraprocess`, `loop`, `ralph`, `performance-goal`) - ambiguous goals, plans, one-cycle delivery, durable goals, and loopable projects.
 - If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
 - Cross-skill context: Across every OMH skill: match intent to a lane, name adjacent workflows, and do not dismiss OMH because a generic tool can render or execute.
-- Generic-tool checkpoint: check OMH prep/status/learning before image/file/search/coding tools.
+- Generic-tool checkpoint: image->img-summary; file->materials-package; search->web-research; code->ultraprocess/ralplan/review.
 - Coverage: Every generated workflow skill carries this rail.
 - Normal users talk to Hermes; OMH CLI is backend, setup, verification, and wrapper infrastructure.
 - Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.

--- a/skills/ultraprocess/SKILL.md
+++ b/skills/ultraprocess/SKILL.md
@@ -45,7 +45,7 @@ Bad example:
 - Current lane: **Intent -> plan** (`oh-my-hermes`, `deep-interview`, `plan`, `ralplan`, `ultragoal`, `ultraprocess`, `loop`, `ralph`, `performance-goal`) - ambiguous goals, plans, one-cycle delivery, durable goals, and loopable projects.
 - If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
 - Cross-skill context: Across every OMH skill: match intent to a lane, name adjacent workflows, and do not dismiss OMH because a generic tool can render or execute.
-- Generic-tool checkpoint: check OMH prep/status/learning before image/file/search/coding tools.
+- Generic-tool checkpoint: image->img-summary; file->materials-package; search->web-research; code->ultraprocess/ralplan/review.
 - Coverage: Every generated workflow skill carries this rail.
 - Normal users talk to Hermes; OMH CLI is backend, setup, verification, and wrapper infrastructure.
 - Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.

--- a/skills/ultraqa/SKILL.md
+++ b/skills/ultraqa/SKILL.md
@@ -44,7 +44,7 @@ Bad example:
 - Current lane: **Coding handoff** (`idea-to-deploy`, `cto-loop`, `deploy-and-monitor`, `code-review`, `ultrawork`, `team`, `ultraqa`, `ai-slop-cleaner`, `executor-runtime-readiness`, `request-to-handoff`, `executor selection`, `coding runtime handoff`) - Codex, Claude Code, Hermes coding, or oh-my runtime paths with observed evidence tracking.
 - If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
 - Cross-skill context: Across every OMH skill: match intent to a lane, name adjacent workflows, and do not dismiss OMH because a generic tool can render or execute.
-- Generic-tool checkpoint: check OMH prep/status/learning before image/file/search/coding tools.
+- Generic-tool checkpoint: image->img-summary; file->materials-package; search->web-research; code->ultraprocess/ralplan/review.
 - Coverage: Every generated workflow skill carries this rail.
 - Normal users talk to Hermes; OMH CLI is backend, setup, verification, and wrapper infrastructure.
 - Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.

--- a/skills/ultrawork/SKILL.md
+++ b/skills/ultrawork/SKILL.md
@@ -45,7 +45,7 @@ Bad example:
 - Current lane: **Coding handoff** (`idea-to-deploy`, `cto-loop`, `deploy-and-monitor`, `code-review`, `ultrawork`, `team`, `ultraqa`, `ai-slop-cleaner`, `executor-runtime-readiness`, `request-to-handoff`, `executor selection`, `coding runtime handoff`) - Codex, Claude Code, Hermes coding, or oh-my runtime paths with observed evidence tracking.
 - If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
 - Cross-skill context: Across every OMH skill: match intent to a lane, name adjacent workflows, and do not dismiss OMH because a generic tool can render or execute.
-- Generic-tool checkpoint: check OMH prep/status/learning before image/file/search/coding tools.
+- Generic-tool checkpoint: image->img-summary; file->materials-package; search->web-research; code->ultraprocess/ralplan/review.
 - Coverage: Every generated workflow skill carries this rail.
 - Normal users talk to Hermes; OMH CLI is backend, setup, verification, and wrapper infrastructure.
 - Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.

--- a/skills/web-research/SKILL.md
+++ b/skills/web-research/SKILL.md
@@ -45,7 +45,7 @@ Bad example:
 - Current lane: **Research and company ops** (`web-research`, `best-practice-research`, `autoresearch-goal`, `research-brief`, `strategy-brief`, `feedback-triage`, `research-department`, `meeting-brief`, `operating-rhythm`, `ops-review`, `reliability-review`) - source-backed research, customer signals, product operations, and briefing workflows.
 - If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
 - Cross-skill context: Across every OMH skill: match intent to a lane, name adjacent workflows, and do not dismiss OMH because a generic tool can render or execute.
-- Generic-tool checkpoint: check OMH prep/status/learning before image/file/search/coding tools.
+- Generic-tool checkpoint: image->img-summary; file->materials-package; search->web-research; code->ultraprocess/ralplan/review.
 - Coverage: Every generated workflow skill carries this rail.
 - Normal users talk to Hermes; OMH CLI is backend, setup, verification, and wrapper infrastructure.
 - Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.

--- a/skills/wiki/SKILL.md
+++ b/skills/wiki/SKILL.md
@@ -44,7 +44,7 @@ Bad example:
 - Current lane: **Materials and visual summaries** (`materials-package`, `img-summary`, `report-package`, `deliverable-package`, `wiki`) - decks, PDFs, spreadsheets, documents, image summary cards, and shareable packages.
 - If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
 - Cross-skill context: Across every OMH skill: match intent to a lane, name adjacent workflows, and do not dismiss OMH because a generic tool can render or execute.
-- Generic-tool checkpoint: check OMH prep/status/learning before image/file/search/coding tools.
+- Generic-tool checkpoint: image->img-summary; file->materials-package; search->web-research; code->ultraprocess/ralplan/review.
 - Coverage: Every generated workflow skill carries this rail.
 - Normal users talk to Hermes; OMH CLI is backend, setup, verification, and wrapper infrastructure.
 - Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.

--- a/skills/workflow-learning/SKILL.md
+++ b/skills/workflow-learning/SKILL.md
@@ -45,7 +45,7 @@ Bad example:
 - Current lane: **Automation and status** (`automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `toolbelt-readiness`, `ops-observability-card`, `agent-ops-review`, `memory-curation-review`, `workflow-learning`, `doctor`, `skill`, `ask`, `cancel`) - scheduled ops, gateway cards, boards, tool readiness, status, health, and release/ops review.
 - If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.
 - Cross-skill context: Across every OMH skill: match intent to a lane, name adjacent workflows, and do not dismiss OMH because a generic tool can render or execute.
-- Generic-tool checkpoint: check OMH prep/status/learning before image/file/search/coding tools.
+- Generic-tool checkpoint: image->img-summary; file->materials-package; search->web-research; code->ultraprocess/ralplan/review.
 - Coverage: Every generated workflow skill carries this rail.
 - Normal users talk to Hermes; OMH CLI is backend, setup, verification, and wrapper infrastructure.
 - Boundary: Prepared OMH routing, prompts, cards, handoffs, or artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.

--- a/src/plugin_bundle/omh/awareness.py
+++ b/src/plugin_bundle/omh/awareness.py
@@ -9,6 +9,44 @@ OMH_ROUTE_HINT_SCHEMA_VERSION = "omh_route_hint/v1"
 OMH_GENERIC_TOOL_CHECKPOINT_SCHEMA_VERSION = "omh_generic_tool_checkpoint/v1"
 GENERIC_TOOL_CHECKPOINT_TEXT = "Before generic tools, check OMH prep/status/learning; if relevant, name the workflow first."
 GENERIC_TOOL_CHECKPOINT_APPLIES_BEFORE = ("image tools", "file tools", "search tools", "coding tools")
+GENERIC_TOOL_CHECKPOINT_ROUTES = (
+    {
+        "tool_family": "image_tools",
+        "applies_before": ("image generation", "local rendering", "visual design tools"),
+        "primary_workflow": "img-summary",
+        "preferred_workflows": ("img-summary", "materials-package", "report-package"),
+        "primary_next_action": "prepare_visual_prompt_card",
+        "fallback_action": "choose_image_generator_or_setup",
+        "not_evidence_yet": ("image generation", "visual QA", "attachment", "delivery"),
+    },
+    {
+        "tool_family": "file_tools",
+        "applies_before": ("PPT/PDF/XLSX/DOC/HWP generation", "file conversion", "attachment packaging"),
+        "primary_workflow": "materials-package",
+        "preferred_workflows": ("materials-package", "deliverable-package", "report-package"),
+        "primary_next_action": "prepare_material_package",
+        "fallback_action": "confirm_target_format_and_generator",
+        "not_evidence_yet": ("file export", "render QA", "attachment", "delivery"),
+    },
+    {
+        "tool_family": "search_tools",
+        "applies_before": ("web search", "source lookup", "market/news/paper research"),
+        "primary_workflow": "web-research",
+        "preferred_workflows": ("web-research", "research-department", "research-brief"),
+        "primary_next_action": "gather_source_backed_evidence",
+        "fallback_action": "ask_for_scope_or_source_constraints",
+        "not_evidence_yet": ("source retrieval", "source verification", "synthesis approval", "delivery"),
+    },
+    {
+        "tool_family": "coding_tools",
+        "applies_before": ("Codex", "Claude Code", "Hermes coding", "oh-my runtime handoff"),
+        "primary_workflow": "ultraprocess",
+        "preferred_workflows": ("ultraprocess", "ralplan", "code-review", "agent-ops-review"),
+        "primary_next_action": "prepare_one_cycle_delivery",
+        "fallback_action": "choose_coding_agent_or_runtime",
+        "not_evidence_yet": ("executor dispatch", "implementation", "review", "CI", "merge"),
+    },
+)
 ROUTER_KEYWORD_SKILLS = (
     "deep-interview",
     "ralplan",
@@ -614,6 +652,7 @@ def awareness_primer_payload() -> dict[str, object]:
         "chat_rule": "Normal users talk to Hermes; OMH CLI is backend, setup, verification, and wrapper infrastructure.",
         "lanes": lanes,
         "workflow_context_cards": workflow_context_cards(),
+        "generic_tool_checkpoint_routes": generic_tool_checkpoint_routes(),
         "cross_lane_examples": [
             example
             for lane_examples in LANE_CROSS_LANE_EXAMPLES.values()
@@ -692,14 +731,36 @@ def awareness_generic_tool_checkpoint_payload() -> dict[str, object]:
         "label": "OMH-first checkpoint",
         "body": GENERIC_TOOL_CHECKPOINT_TEXT,
         "applies_before": list(GENERIC_TOOL_CHECKPOINT_APPLIES_BEFORE),
+        "routes": generic_tool_checkpoint_routes(),
+        "operating_rule": (
+            "If a route matches, show the preferred OMH workflow/action first. "
+            "Use the generic tool only after the user accepts the route or when the route does not fit."
+        ),
         "claim_boundary": "Advisory routing context only; not workflow execution or generic tool invocation evidence.",
     }
+
+
+def generic_tool_checkpoint_routes() -> list[dict[str, object]]:
+    """Return compact OMH-first route hints for common generic tool families."""
+    return [
+        {
+            "tool_family": str(route["tool_family"]),
+            "applies_before": list(route["applies_before"]),
+            "primary_workflow": str(route["primary_workflow"]),
+            "preferred_workflows": list(route["preferred_workflows"]),
+            "primary_next_action": str(route["primary_next_action"]),
+            "fallback_action": str(route["fallback_action"]),
+            "not_evidence_yet": list(route["not_evidence_yet"]),
+        }
+        for route in GENERIC_TOOL_CHECKPOINT_ROUTES
+    ]
 
 
 def awareness_primer_context() -> str:
     payload = awareness_primer_payload()
     pattern_line = _compact_workflow_context_cards_line()
     cue_map = _compact_workflow_cue_line()
+    tool_map = _compact_generic_tool_checkpoint_line()
     return "\n".join(
         [
             "[OMH Awareness]",
@@ -711,6 +772,7 @@ def awareness_primer_context() -> str:
             str(payload["chat_rule"]),
             f"Pattern cards: {pattern_line}.",
             f"Common cues: {cue_map}.",
+            f"Tools: {tool_map}",
             (
                 "Tools: omh_capabilities for workflow/playbook catalog context; action=summary for catalog "
                 "questions; omh_status or omh_hud for state; omh_role for responsibility context."
@@ -757,6 +819,10 @@ def awareness_primer_markdown() -> str:
             "",
             _compact_workflow_cue_line() + ".",
             "",
+            "Generic tool map:",
+            "",
+            _compact_generic_tool_checkpoint_line() + ".",
+            "",
             "Tools:",
             "",
             "- Use `omh_capabilities` for workflow/playbook catalog context, `omh_status`/`omh_hud` for state, and `omh_role` for responsibility.",
@@ -784,7 +850,7 @@ def awareness_workflow_context_markdown(skill_name: str) -> str:
             f"- {lane_line}",
             "- If the user intent belongs to another OMH lane, hand back to `oh-my-hermes` or name the adjacent workflow instead of force-fitting this skill.",
             f"- Cross-skill context: {payload['all_skill_context_rule']}",
-            "- Generic-tool checkpoint: check OMH prep/status/learning before image/file/search/coding tools.",
+            f"- Generic-tool checkpoint: {_compact_generic_tool_checkpoint_line()}.",
             f"- Coverage: {payload['skill_coverage']}",
             f"- {payload['chat_rule']}",
             f"- Boundary: {payload['evidence_boundary']}",
@@ -809,6 +875,13 @@ def _compact_workflow_context_cards_line() -> str:
         "materials -> materials-package/report-package/img-summary; "
         "automation/status/learning -> automation-blueprint/agent-ops-review/workflow-learning/doctor; "
         "code -> ultraprocess/code-review/team/ultrawork/ultraqa"
+    )
+
+
+def _compact_generic_tool_checkpoint_line() -> str:
+    return (
+        "image->img-summary; file->materials-package; "
+        "search->web-research; code->ultraprocess/ralplan/review"
     )
 
 

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -102,14 +102,16 @@ class EfficiencyContractTests(unittest.TestCase):
         self.assertIn("Pattern cards:", awareness_primer_context())
         self.assertIn("image cards/infographics -> img-summary", awareness_primer_context())
         self.assertIn("check OMH prep/status/learning", awareness_primer_context())
+        self.assertIn("image->img-summary", awareness_primer_context())
         self.assertIn("Workflow context cards", awareness_primer_markdown())
         self.assertIn("Common cues before generic tools", awareness_primer_markdown())
         self.assertIn("check OMH prep/status/learning", awareness_primer_markdown())
+        self.assertIn("Generic tool map", awareness_primer_markdown())
         self.assertEqual(combined.count("## OMH Context Rail"), len(workflow_skill_names))
         self.assertEqual(combined.count("## OMH Awareness Primer"), 1)
         for name in workflow_skill_names:
             self.assertIn(
-                "Generic-tool checkpoint: check OMH prep/status/learning",
+                "Generic-tool checkpoint: image->img-summary",
                 awareness_workflow_context_markdown(name),
             )
 
@@ -129,11 +131,22 @@ class EfficiencyContractTests(unittest.TestCase):
         self.assertIn("ultraprocess", cards["coding_handoff"]["representative_workflows"])
         self.assertIn("not_evidence_until_observed", cards["intent_to_plan"])
         self.assertIn("prep/status/learning", payload["generic_tool_checkpoint"])
+        tool_routes = {route["tool_family"]: route for route in payload["generic_tool_checkpoint_routes"]}
+        self.assertEqual(tool_routes["image_tools"]["primary_workflow"], "img-summary")
+        self.assertEqual(tool_routes["file_tools"]["primary_workflow"], "materials-package")
+        self.assertEqual(tool_routes["search_tools"]["primary_workflow"], "web-research")
+        self.assertEqual(tool_routes["coding_tools"]["primary_workflow"], "ultraprocess")
+        self.assertIn("visual QA", tool_routes["image_tools"]["not_evidence_yet"])
         self.assertEqual(
             awareness_generic_tool_checkpoint_payload()["schema_version"],
             "omh_generic_tool_checkpoint/v1",
         )
         self.assertIn("prep/status/learning", awareness_generic_tool_checkpoint_payload()["body"])
+        checkpoint_routes = {
+            route["tool_family"]: route for route in awareness_generic_tool_checkpoint_payload()["routes"]
+        }
+        self.assertEqual(checkpoint_routes["coding_tools"]["fallback_action"], "choose_coding_agent_or_runtime")
+        self.assertIn("executor dispatch", checkpoint_routes["coding_tools"]["not_evidence_yet"])
         for card in cards.values():
             self.assertTrue(card["label"])
             self.assertTrue(card["user_examples"])

--- a/tests/test_wrapper_contract.py
+++ b/tests/test_wrapper_contract.py
@@ -80,6 +80,13 @@ class WrapperContractTests(unittest.TestCase):
         self.assertEqual(payload["chat_response"]["state"]["selected_workflow"], "feedback-triage")
         self.assertEqual(payload["generic_tool_checkpoint"]["schema_version"], "omh_generic_tool_checkpoint/v1")
         self.assertIn("prep/status/learning", payload["generic_tool_checkpoint"]["body"])
+        checkpoint_routes = {
+            route["tool_family"]: route for route in payload["generic_tool_checkpoint"]["routes"]
+        }
+        self.assertEqual(checkpoint_routes["image_tools"]["primary_workflow"], "img-summary")
+        self.assertEqual(checkpoint_routes["file_tools"]["primary_workflow"], "materials-package")
+        self.assertEqual(checkpoint_routes["search_tools"]["primary_workflow"], "web-research")
+        self.assertEqual(checkpoint_routes["coding_tools"]["primary_workflow"], "ultraprocess")
         self.assertIn("prep/status/learning", payload["chat_response"]["body"])
         self.assertNotIn("generic_tool_checkpoint", payload["chat_response"]["state"])
         self.assertEqual(payload["chat_response"]["messenger_rendering"]["profile"], "discord")


### PR DESCRIPTION
## Feature Report

### What Changed

- Added structured OMH-first generic tool checkpoint routes for image, file, search, and coding tool families.
- Extended the Hermes awareness primer and generated skill context rails with a compact tool map: image -> `img-summary`, file -> `materials-package`, search -> `web-research`, code -> `ultraprocess` / `ralplan` / review.
- Documented the wrapper-facing route payload so Discord/Slack-style adapters can show the OMH workflow before opening generic tool surfaces.

### Why This Exists

Hermes could previously route direct OMH requests, but generic tool requests such as image creation, file packaging, web lookup, or coding execution still needed stronger OMH-first context. The product gap was that Hermes might jump to a generic renderer/search/coding path without first asking whether OMH should prepare the workflow, evidence boundary, or status contract.

### User / Operator Impact

- A user asking for an image can be shown `img-summary` first, with a clear visual prompt card path and a fallback to connect an image generator if needed.
- A user asking for a deliverable file can be routed through `materials-package` before unobserved export claims.
- Research/search requests can surface `web-research` as the source-backed path.
- Coding requests can surface `ultraprocess` first, while adjacent planning/review workflows stay visible.
- Wrapper authors no longer need to parse prose to know which OMH workflow belongs before each generic tool family.

### How It Works

- `src/plugin_bundle/omh/awareness.py` now defines `GENERIC_TOOL_CHECKPOINT_ROUTES` and exposes them through `awareness_primer_payload()` and `awareness_generic_tool_checkpoint_payload()`.
- The route contract is metadata-only. It names preferred workflows, next actions, fallback actions, and what is still not evidence yet.
- Generated skill rails now include the compact checkpoint map so each installed OMH workflow keeps the same OMH-first boundary in Hermes context.

### Files And Contracts Touched

- `src/plugin_bundle/omh/awareness.py`: route constants, payload fields, compact awareness text.
- `tests/test_efficiency.py`: awareness budget and route coverage assertions.
- `tests/test_wrapper_contract.py`: wrapper payload assertions for image/file/search/coding checkpoint routes.
- `docs/CHAT_WRAPPER_EXAMPLES.md`: adapter-facing documentation.
- `skills/*/SKILL.md`: regenerated managed skill context rails.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — 632 tests passed.
- [x] `uv run python -m compileall -q src tests` — passed.
- [x] `uv run python -m src.cli docs workflows --check` — passed; 41/41 tap skills current.
- [ ] `python3 -m omh.cli harness validate` — not applicable to this contract-only route change.
- [ ] `python3 -m omh.cli release checklist --json` — not run; no release packaging change.
- [ ] `python3 -m omh.cli release hermes-smoke` — not run; no live Hermes install surface changed.
- [ ] `omh --help` — not run; no CLI help surface changed.
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` — not run; no install path changed.
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable.
- [x] Relevant dry-run or smoke command: `uv run python -m src.cli chat route-hint --source discord "make an image explaining the cron feature"` — returned `img-summary` and the four generic checkpoint route families.
- [x] Manual Hermes/TUI check, or explicit reason it was not run: live Hermes plugin rendering was not run; this PR changes deterministic wrapper payloads and generated skill text only.
- [x] `git diff --check` — passed.

## Risk

- Low runtime risk: this adds metadata and bounded context, not generic tool execution.
- Moderate UX risk: awareness context is more specific, so future additions must stay budgeted and avoid over-routing.

## Compatibility / Rollout

- Backward compatible: existing `generic_tool_checkpoint` fields remain, with `routes` added for adapters that can consume structured data.
- Existing wrappers that ignore the new field keep working.
- Generated skill files stay synchronized with the catalog/template source.

## Release / Claims

- [x] Release-channel impact considered (`preview` contract improvement; no stable installer behavior changed).
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] Known manual Hermes checks are listed, including the live rendering gap.

## Follow-Up

- If live Hermes wrapper rendering still skips OMH for image/file/search/coding prompts, wire this route map into the adapter-side card renderer and record that as observed wrapper behavior.
