### PR TITLE
Make missed-route learning feedback primary

### DIFF
--- a/docs/CHAT_WRAPPER_EXAMPLES.md
+++ b/docs/CHAT_WRAPPER_EXAMPLES.md
@@ -230,9 +230,15 @@ first.
 [ Open img-summary ] [ Route for me ] [ Open omh ]
 ```
 
-For missed OMH usage feedback, the Slack fixture routes to `workflow-learning`
-instead of treating the message as normal prose. The card still stays
-metadata-only and hint-only until the user or wrapper chooses a workflow.
+For missed OMH usage feedback, the wrapper does not need to teach the user a
+backend command first. Phrases such as "OMH 안 썼어", "missed route: Hermes
+skipped OMH", or "Hermes did not use OMH for my image request; record this as
+workflow learning" route to `workflow-learning` with `record_missed_route` as
+the primary action. Domain-specific recovery phrases can still route to the
+expected workflow, such as `img-summary` or `operating-rhythm`, when the user is
+asking Hermes to do the work now rather than record a learning case. The card
+still stays metadata-only and hint-only until the user or wrapper records the
+missed-route review bundle.
 
 ## Missed OMH Route Capture
 

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -850,24 +850,38 @@ def build_chat_response_from_route(
                 },
             )
         if selected == "workflow-learning":
+            missed_route_feedback = _is_missed_route_feedback(message)
+            primary_learning_action = "record_missed_route" if missed_route_feedback else "audit_learning_readiness"
+            headline = (
+                "I can record this missed OMH route."
+                if missed_route_feedback
+                else "I can inspect this workflow for learning readiness."
+            )
             evidence_boundary = str(policy.get("evidence_boundary", "")) or (
                 "Workflow learning records are process-review evidence only; they are not automatic improvement evidence."
             )
-            body = (
-                "I will turn the workflow attempt into learning material without storing raw prompts: "
-                "record the trace, run deterministic evals, add a regression case, audit readiness, "
-                "and export a redacted review bundle when useful. Any skill or routing improvement still needs human review."
-            )
+            if missed_route_feedback:
+                body = (
+                    "I will treat this as missed-route feedback: record a metadata-only trace, create a reviewable "
+                    "missed-route bundle, add or request a minimized regression fixture, and keep any routing or skill "
+                    "change behind human review."
+                )
+            else:
+                body = (
+                    "I will turn the workflow attempt into learning material without storing raw prompts: "
+                    "record the trace, run deterministic evals, add a regression case, audit readiness, "
+                    "and export a redacted review bundle when useful. Any skill or routing improvement still needs human review."
+                )
             return _chat_response(
                 kind="workflow_learning",
-                headline="I can inspect this workflow for learning readiness.",
+                headline=headline,
                 body=body,
                 phase="workflow_learning_prepared",
-                next_action="audit_learning_readiness",
+                next_action=primary_learning_action,
                 thread_key=thread_key,
                 actions=[
+                    _action("record_missed_route", "Record missed route", "primary" if missed_route_feedback else "secondary"),
                     _action("record_workflow_learning_trace", "Record trace", "secondary"),
-                    _action("record_missed_route", "Record missed route", "secondary"),
                     _action("show_learning_review_queue", "Review queue", "secondary"),
                     _action("show_learning_eval", "Run eval", "secondary"),
                     _action("propose_skill_improvement", "Propose improvement", "secondary"),
@@ -876,7 +890,7 @@ def build_chat_response_from_route(
                     _action("show_patch_proposal", "Show patch proposal", "secondary"),
                     _action("copy_patch_handoff", "Copy patch handoff", "secondary"),
                     _action("add_regression_case", "Add regression", "secondary"),
-                    _action("audit_learning_readiness", "Audit readiness", "primary"),
+                    _action("audit_learning_readiness", "Audit readiness", "secondary" if missed_route_feedback else "primary"),
                     _action("export_learning_bundle", "Export bundle", "secondary"),
                     _action("replay_regression_cases", "Replay cases", "secondary"),
                     _action("check_learning_index", "Check index", "secondary"),
@@ -890,6 +904,8 @@ def build_chat_response_from_route(
                     "selected_workflow": selected,
                     "workflow_explanation_reason": workflow_explanation_reason,
                     "policy_next_action": policy_next_action,
+                    "learning_intent": "missed_route" if missed_route_feedback else "readiness_audit",
+                    "primary_learning_action": primary_learning_action,
                     "artifact_schemas": [
                         "workflow_learning_trace/v1",
                         "workflow_eval_result/v1",
@@ -1521,6 +1537,50 @@ def _selected_recommendation_policy(decision: dict[str, object], selected: str) 
                 "wrapper_guidance": item.get("wrapper_guidance", ""),
             }
     return {}
+
+
+def _is_missed_route_feedback(message: str) -> bool:
+    text = " ".join(message.lower().split())
+    compact = text.replace(" ", "")
+    if not text:
+        return False
+    missed_route_phrases = (
+        "missed route",
+        "missed workflow",
+        "missing route",
+        "wrong route",
+        "wrong workflow",
+        "did not use omh",
+        "didn't use omh",
+        "didnt use omh",
+        "not use omh",
+        "skipped omh",
+        "omh was not used",
+        "omh was skipped",
+        "expected omh",
+        "expected workflow",
+    )
+    if any(phrase in text for phrase in missed_route_phrases):
+        return True
+    missed_route_compact_phrases = (
+        "omh안썼",
+        "omh안썻",
+        "omh안썼어",
+        "omh안썻어",
+        "omh안쓰",
+        "omh를안썼",
+        "omh를안썻",
+        "omh를안쓰",
+        "omh기능안썼",
+        "omh기능안썻",
+        "omh기능안쓰",
+        "omh안씀",
+        "omh누락",
+        "워크플로누락",
+        "라우팅누락",
+        "잘못라우팅",
+    )
+    return any(phrase in compact for phrase in missed_route_compact_phrases)
 
 
 def _workflow_explanation_reason_for_route(

--- a/tests/test_chat_router.py
+++ b/tests/test_chat_router.py
@@ -114,8 +114,6 @@ class ChatRouterTests(unittest.TestCase):
             "make a visual one-pager for this release",
             "作成して、PRの要約画像",
             "生成一张发布说明海报",
-            "프리렌이 OMH 안 쓰고 일반 도구로 이미지 만들었어",
-            "The Hermes agent did not use OMH for this summary image.",
             "make a workflow learning image card",
         )
 
@@ -132,6 +130,8 @@ class ChatRouterTests(unittest.TestCase):
         cases = (
             "Hermes did not use OMH for my image request; record this as workflow learning",
             "이미지 생성 요청에서 OMH 안 썼어. workflow-learning으로 기록해줘",
+            "OMH 안 썼어",
+            "missed route: Hermes skipped OMH for my image request",
         )
 
         for message in cases:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -82,6 +82,7 @@ class CliTests(unittest.TestCase):
         for message in (
             "missed route: OMH was not used",
             "OMH 안 썼어",
+            "missed route: Hermes skipped OMH for my image request",
             "Hermes did not use OMH for my image request; record this as workflow learning",
             "이미지 생성 요청에서 OMH 안 썼어. workflow-learning으로 기록해줘",
         ):
@@ -91,7 +92,12 @@ class CliTests(unittest.TestCase):
             self.assertEqual(stderr, "")
             payload = json.loads(stdout)
             self.assertEqual(payload["route"]["selected_skill"], "workflow-learning")
-            self.assertEqual(payload["next_action"], "audit_learning_readiness")
+            self.assertEqual(payload["next_action"], "record_missed_route")
+            self.assertEqual(payload["chat_response"]["state"]["learning_intent"], "missed_route")
+            self.assertEqual(payload["chat_response"]["state"]["primary_learning_action"], "record_missed_route")
+            actions = {action["id"]: action for action in payload["chat_response"]["actions"]}
+            self.assertEqual(actions["record_missed_route"]["style"], "primary")
+            self.assertEqual(actions["audit_learning_readiness"]["style"], "secondary")
             self.assertIn("guard:workflow_learning", payload["route"]["recommendations"][0]["matched"])
 
     def test_chat_interact_omh_status_question_uses_probe_roadmap(self) -> None:

--- a/tests/test_wrapper_contract.py
+++ b/tests/test_wrapper_contract.py
@@ -304,6 +304,8 @@ class WrapperContractTests(unittest.TestCase):
                 response = payload["chat_response"]
                 self.assertEqual(response["kind"], "workflow_learning")
                 self.assertEqual(response["state"]["learning_audit_card_schema"], "learning_audit_card/v1")
+                self.assertEqual(response["state"]["learning_intent"], "readiness_audit")
+                self.assertEqual(response["state"]["primary_learning_action"], "audit_learning_readiness")
                 self.assertTrue(response["state"]["human_gate_required"])
                 self.assertIn("workflow_learning_trace/v1", response["state"]["artifact_schemas"])
                 self.assertIn("workflow_eval_result/v1", response["state"]["artifact_schemas"])
@@ -346,6 +348,34 @@ class WrapperContractTests(unittest.TestCase):
                 self.assertIn("record_missed_route", response["state"]["learning_flow"])
                 self.assertIn("prepare_patch_proposal", response["state"]["learning_flow"])
                 self.assertIn("human_review_improvement_candidate", response["state"]["learning_flow"])
+                self.assertNotIn(message, serialized)
+
+    def test_missed_route_feedback_makes_record_missed_route_primary(self) -> None:
+        messages = (
+            "OMH 안 썼어",
+            "Hermes did not use OMH for my image request; record this as workflow learning",
+            "missed route: Hermes skipped OMH for my image request",
+            "missed route: OMH was not used",
+        )
+
+        for message in messages:
+            with self.subTest(message=message):
+                payload = build_chat_interaction_payload(message, source="discord")
+
+                serialized = json.dumps(payload)
+                response = payload["chat_response"]
+                actions = {action["id"]: action for action in response["actions"]}
+                self.assertEqual(payload["mode"], "route")
+                self.assertEqual(payload["route"]["selected_skill"], "workflow-learning")
+                self.assertEqual(payload["next_action"], "record_missed_route")
+                self.assertEqual(response["kind"], "workflow_learning")
+                self.assertEqual(response["state"]["learning_intent"], "missed_route")
+                self.assertEqual(response["state"]["primary_learning_action"], "record_missed_route")
+                self.assertEqual(actions["record_missed_route"]["style"], "primary")
+                self.assertEqual(actions["audit_learning_readiness"]["style"], "secondary")
+                self.assertIn("missed-route feedback", response["body"])
+                self.assertIn("human review", response["body"])
+                self.assertIn("automatic skill patch", response["state"]["evidence_not_observed"])
                 self.assertNotIn(message, serialized)
 
     def test_route_mode_exposes_visible_omh_usage_trace_for_web_research(self) -> None:


### PR DESCRIPTION
## Summary
- Make explicit missed OMH routing feedback resolve to `record_missed_route` as the primary wrapper action.
- Keep normal workflow-learning requests on the existing `audit_learning_readiness` primary path.
- Preserve domain recovery routing so messages that are asking Hermes to do the work now can still land on workflows such as `operating-rhythm` instead of being swallowed by learning capture.

## Why
Operators reported cases where Hermes skipped OMH for a task, but the wrapper-facing response still emphasized generic learning readiness. That made the next action less obvious in chat. The product gap is small but important: when the user says OMH missed the route, Hermes should offer to record that miss first, not bury it behind a generic audit.

## User Impact
After this change, a user can say things like:

- `OMH 안 썼어`
- `missed route: Hermes skipped OMH for my image request`
- `Hermes did not use OMH for my image request; record this as workflow learning`

Hermes/OMH can now return a workflow-learning card whose primary action is `record_missed_route`. The card remains conservative: it prepares a metadata-only missed-route review bundle and does not claim automatic skill patching, training, or execution.

## Implementation Notes
- Added missed-route feedback detection inside the workflow-learning wrapper response path.
- Added `learning_intent` and `primary_learning_action` state fields so wrappers can render the right primary action without inferring intent from prose.
- Kept router policy narrow enough that domain-specific recovery phrases can continue to route to the expected workflow.
- Updated chat wrapper docs with the difference between missed-route learning capture and immediate workflow recovery.

## Boundaries
- No raw user prompt is stored in the public wrapper payload.
- No automatic routing patch, skill patch, model training, execution, review, CI, or merge evidence is claimed.
- This is a wrapper contract and deterministic routing/response refinement only.

## Verification
Observed locally:

```sh
uv run python -m src.cli chat interact --source discord "missed route: Hermes skipped OMH for my image request" | python3 -m json.tool | rg -n '"selected_skill"|"next_action"|"learning_intent"|"id": "record_missed_route"|"style": "primary"'
```

Confirmed `workflow-learning`, `record_missed_route`, `learning_intent: missed_route`, and a primary `record_missed_route` action.

```sh
uv run python -m src.cli chat interact --source discord "회의록 요약을 부탁했는데 OMH 안 쓰고 일반 답변했어" | python3 -m json.tool | rg -n '"selected_skill"|"next_action"|operating-rhythm'
```

Confirmed the domain recovery path still routes to `operating-rhythm`.

```sh
PYTHONPATH=tests uv run python -m unittest discover -s tests -v
uv run python -m compileall -q src tests
uv run python -m src.cli docs workflows --check
git diff --check
```

Results:
- `Ran 633 tests ... OK`
- compileall passed
- docs/workflows check passed with 41/41 tap skills fresh
- diff check passed

## Risks / Follow-up
- Live Discord/Slack button rendering is still wrapper-owned and was not exercised here.
- Future additions should keep missed-route learning separate from domain recovery unless the user explicitly asks to record or learn from the miss.