### PR TITLE
Add OMH pre-tool generic checkpoints

### DIFF
--- a/docs/CHAT_WRAPPER_EXAMPLES.md
+++ b/docs/CHAT_WRAPPER_EXAMPLES.md
@@ -153,6 +153,11 @@ These routes are advisory. They tell Hermes which OMH workflow to consider
 before a generic tool, while image generation, file export, search retrieval,
 coding dispatch, review, CI, and merge remain observed-only claims.
 
+When the optional OMH plugin is loaded, its `pre_tool_call` hook can emit the
+same checkpoint before image, file, search, or coding tool calls. The hook uses
+tool metadata such as `tool_name` or `tool_family`; it does not copy the raw
+image prompt, file body, search query, or coding task into the context.
+
 Capability-specific catalog questions and short image requests should also stay
 workflow-native. If the user asks "이미지 생성 기능 뭐 있어?", "이미지 생성해줘",
 "does OMH support image generation?", or "generate an image", the wrapper should

--- a/src/capabilities/hooks.py
+++ b/src/capabilities/hooks.py
@@ -67,7 +67,7 @@ def _hook_payload_fields(name: str) -> list[str]:
     if name == "pre_llm_call":
         return ["omh_awareness_primer", "omh_route_hint", "bounded_status_context", "redacted"]
     if name == "pre_tool_call":
-        return ["tool_name", "claim_boundary"]
+        return ["tool_name", "tool_family_hint", "omh_generic_tool_checkpoint", "claim_boundary", "redacted"]
     if name == "on_session_end":
         return ["session_summary", "metadata_only"]
     return []

--- a/src/plugin_bundle/omh/hooks/tool_hooks.py
+++ b/src/plugin_bundle/omh/hooks/tool_hooks.py
@@ -2,34 +2,178 @@ from __future__ import annotations
 
 import json
 
+from ..awareness import generic_tool_checkpoint_routes
 from ..omh_roles import extract_role_marker, resolve_role_name, role_aliases, role_names
 
 
 def pre_tool_call(**kwargs) -> dict[str, str] | None:
-    """Warn when a delegate_task goal uses an unknown OMH role marker."""
-    if str(kwargs.get("tool_name", "") or "") != "delegate_task":
+    """Inject bounded OMH context before tool calls without exposing tool input."""
+    context_parts: list[str] = []
+    role_warning = _delegate_role_warning(kwargs)
+    if role_warning:
+        context_parts.append(role_warning)
+
+    checkpoint = _generic_tool_checkpoint_context(kwargs)
+    if checkpoint:
+        context_parts.append(checkpoint)
+
+    if not context_parts:
         return None
+    return {"context": "\n\n".join(context_parts)}
+
+
+def _delegate_role_warning(kwargs: dict) -> str:
+    if str(kwargs.get("tool_name", "") or "") != "delegate_task":
+        return ""
     tool_input = kwargs.get("tool_input") or {}
     if isinstance(tool_input, str):
         try:
             parsed = json.loads(tool_input)
         except json.JSONDecodeError:
-            return None
+            return ""
         tool_input = parsed if isinstance(parsed, dict) else {}
     if not isinstance(tool_input, dict):
-        return None
+        return ""
     marker = extract_role_marker(str(tool_input.get("goal", "") or ""))
     if not marker:
-        return None
+        return ""
     available = role_names()
     aliases = role_aliases()
     if marker in available or resolve_role_name(marker) in available:
-        return None
-    return {
-        "context": (
-            f"[OMH Role Warning] Unknown role '{marker}' in delegate_task goal. "
-            f"Available roles: {', '.join(available) or '(none)'}. "
-            f"Legacy aliases: {', '.join(sorted(aliases)) or '(none)'}. "
-            "No OMH role context will be injected for that subagent."
-        )
+        return ""
+    return (
+        f"[OMH Role Warning] Unknown role '{marker}' in delegate_task goal. "
+        f"Available roles: {', '.join(available) or '(none)'}. "
+        f"Legacy aliases: {', '.join(sorted(aliases)) or '(none)'}. "
+        "No OMH role context will be injected for that subagent."
+    )
+
+
+def _generic_tool_checkpoint_context(kwargs: dict) -> str:
+    if kwargs.get("include_omh_tool_checkpoint", True) is False:
+        return ""
+    route = _generic_tool_route(kwargs)
+    if not route:
+        return ""
+    tool_name = str(kwargs.get("tool_name", "") or "").strip() or "unknown"
+    preferred = ", ".join(str(item) for item in route.get("preferred_workflows", []))
+    applies_before = ", ".join(str(item) for item in route.get("applies_before", []))
+    not_evidence = ", ".join(str(item) for item in route.get("not_evidence_yet", []))
+    return "\n".join(
+        [
+            "[OMH Tool Checkpoint]",
+            "schema=omh_generic_tool_checkpoint/v1",
+            f"tool_name={_redacted_label(tool_name)}; tool_family={route.get('tool_family')}.",
+            f"Before this generic tool ({applies_before}), consider OMH workflow={route.get('primary_workflow')} first.",
+            f"preferred_workflows={preferred}.",
+            f"next_action={route.get('primary_next_action')}; fallback_action={route.get('fallback_action')}.",
+            f"not_evidence_yet={not_evidence}.",
+            "Boundary: advisory tool-use context only; not workflow selection, tool invocation, generated output, dispatch, verification, review, CI, merge, or delivery evidence.",
+        ]
+    )
+
+
+def _generic_tool_route(kwargs: dict) -> dict[str, object]:
+    family = _canonical_tool_family(str(kwargs.get("tool_family", "") or ""))
+    tool_name = str(kwargs.get("tool_name", "") or "")
+    if not family:
+        family = _canonical_tool_family_from_name(tool_name)
+    if not family:
+        return {}
+    for route in generic_tool_checkpoint_routes():
+        if route.get("tool_family") == family:
+            return route
+    return {}
+
+
+def _canonical_tool_family(value: str) -> str:
+    normalized = value.strip().lower().replace("-", "_").replace(" ", "_")
+    aliases = {
+        "image": "image_tools",
+        "images": "image_tools",
+        "image_generation": "image_tools",
+        "visual": "image_tools",
+        "file": "file_tools",
+        "files": "file_tools",
+        "document": "file_tools",
+        "documents": "file_tools",
+        "materials": "file_tools",
+        "search": "search_tools",
+        "web": "search_tools",
+        "browser": "search_tools",
+        "research": "search_tools",
+        "code": "coding_tools",
+        "coding": "coding_tools",
+        "executor": "coding_tools",
+        "terminal": "coding_tools",
+        "shell": "coding_tools",
     }
+    if normalized in {"image_tools", "file_tools", "search_tools", "coding_tools"}:
+        return normalized
+    return aliases.get(normalized, "")
+
+
+def _canonical_tool_family_from_name(tool_name: str) -> str:
+    normalized = tool_name.strip().lower().replace("-", "_")
+    families = (
+        (
+            "image_tools",
+            (
+                "image",
+                "img",
+                "visual",
+                "render",
+                "screenshot",
+                "canvas",
+            ),
+        ),
+        (
+            "file_tools",
+            (
+                "file",
+                "document",
+                "docx",
+                "pdf",
+                "ppt",
+                "slides",
+                "sheet",
+                "xlsx",
+                "spreadsheet",
+                "hwp",
+                "materials",
+            ),
+        ),
+        (
+            "search_tools",
+            (
+                "web",
+                "search",
+                "browser",
+                "crawl",
+                "fetch",
+                "open_url",
+                "research",
+            ),
+        ),
+        (
+            "coding_tools",
+            (
+                "codex",
+                "claude",
+                "opencode",
+                "coding",
+                "executor",
+                "apply_patch",
+                "git",
+            ),
+        ),
+    )
+    for family, markers in families:
+        if any(marker in normalized for marker in markers):
+            return family
+    return ""
+
+
+def _redacted_label(value: str) -> str:
+    safe = "".join(char if char.isalnum() or char in {"_", "-", "."} else "_" for char in value)
+    return safe[:80] or "unknown"

--- a/src/plugin_bundle/omh/tools/capability_tool.py
+++ b/src/plugin_bundle/omh/tools/capability_tool.py
@@ -483,7 +483,7 @@ def _standalone_hook_payload_fields(name: str) -> list[str]:
     if name == "pre_llm_call":
         return ["omh_awareness_primer", "bounded_status_context", "redacted"]
     if name == "pre_tool_call":
-        return ["tool_name", "claim_boundary"]
+        return ["tool_name", "tool_family_hint", "omh_generic_tool_checkpoint", "claim_boundary", "redacted"]
     if name == "on_session_end":
         return ["session_summary", "metadata_only"]
     return []

--- a/tests/test_hook_manifest.py
+++ b/tests/test_hook_manifest.py
@@ -9,6 +9,7 @@ load_local_package()
 from omh.capabilities.hooks import hook_manifest
 from omh.plugin_bundle.omh.awareness import awareness_route_hint
 from omh.plugin_bundle.omh.hooks.llm_hooks import pre_llm_call
+from omh.plugin_bundle.omh.hooks.tool_hooks import pre_tool_call
 
 
 class HookManifestTests(unittest.TestCase):
@@ -28,6 +29,9 @@ class HookManifestTests(unittest.TestCase):
         self.assertIn("omh_awareness_primer", hooks["pre_llm_call"]["payload_fields"])
         self.assertIn("omh_route_hint", hooks["pre_llm_call"]["payload_fields"])
         self.assertIn("bounded_status_context", hooks["pre_llm_call"]["payload_fields"])
+        self.assertIn("omh_generic_tool_checkpoint", hooks["pre_tool_call"]["payload_fields"])
+        self.assertIn("tool_family_hint", hooks["pre_tool_call"]["payload_fields"])
+        self.assertIn("redacted", hooks["pre_tool_call"]["payload_fields"])
         self.assertIn("executor_opened", events)
         self.assertIn("selected_executor_profile", events["executor_opened"]["payload_fields"])
         self.assertIn("native_command_registered", events)
@@ -101,3 +105,39 @@ class HookManifestTests(unittest.TestCase):
         self.assertNotIn("[OMH Awareness]", context)
         self.assertNotIn("[OMH Route Hint]", context)
         self.assertNotIn("workflow=img-summary", context)
+
+    def test_pre_tool_call_injects_generic_tool_checkpoint_without_raw_input(self) -> None:
+        cases = (
+            ("image_generate", {}, "image_tools", "img-summary", "prepare_visual_prompt_card"),
+            ("write_file", {}, "file_tools", "materials-package", "prepare_material_package"),
+            ("web_search", {}, "search_tools", "web-research", "gather_source_backed_evidence"),
+            ("codex_session_open", {}, "coding_tools", "ultraprocess", "prepare_one_cycle_delivery"),
+            ("python_runner", {"tool_family": "search"}, "search_tools", "web-research", "gather_source_backed_evidence"),
+        )
+
+        for tool_name, extra_kwargs, tool_family, workflow, next_action in cases:
+            with self.subTest(tool_name=tool_name):
+                result = pre_tool_call(
+                    tool_name=tool_name,
+                    tool_input={"prompt": "secret-token-123 should never appear"},
+                    **extra_kwargs,
+                )
+                context = result["context"] if result else ""
+
+                self.assertIn("[OMH Tool Checkpoint]", context)
+                self.assertIn("schema=omh_generic_tool_checkpoint/v1", context)
+                self.assertIn(f"tool_family={tool_family}", context)
+                self.assertIn(f"workflow={workflow}", context)
+                self.assertIn(f"next_action={next_action}", context)
+                self.assertIn("advisory tool-use context only", context)
+                self.assertNotIn("secret-token-123", context)
+                self.assertNotIn("should never appear", context)
+
+    def test_pre_tool_call_checkpoint_can_be_disabled(self) -> None:
+        result = pre_tool_call(
+            tool_name="image_generate",
+            tool_input={"prompt": "secret-token-123"},
+            include_omh_tool_checkpoint=False,
+        )
+
+        self.assertIsNone(result)

--- a/tests/test_plugin_distribution.py
+++ b/tests/test_plugin_distribution.py
@@ -322,6 +322,18 @@ class PluginDistributionTests(unittest.TestCase):
             self.assertIn("Unknown role 'nope'", tool_warning["context"])
             self.assertIn("planner", tool_warning["context"])
 
+            tool_checkpoint = ctx.hooks["pre_tool_call"](
+                tool_name="image_generate",
+                tool_input={"prompt": "secret-token-123 should not leak"},
+            )
+            self.assertIsNotNone(tool_checkpoint)
+            self.assertIn("[OMH Tool Checkpoint]", tool_checkpoint["context"])
+            self.assertIn("schema=omh_generic_tool_checkpoint/v1", tool_checkpoint["context"])
+            self.assertIn("workflow=img-summary", tool_checkpoint["context"])
+            self.assertIn("next_action=prepare_visual_prompt_card", tool_checkpoint["context"])
+            self.assertNotIn("secret-token-123", tool_checkpoint["context"])
+            self.assertNotIn("should not leak", tool_checkpoint["context"])
+
             session_checkpoint = ctx.hooks["on_session_end"](omh_home=str(omh_home))
             self.assertEqual(session_checkpoint["status"], "checkpoint_written")
             checkpoint = json.loads((omh_home / "runtime" / "plugin-session-end.json").read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary
- Add metadata-only OMH-first checkpoints to the optional plugin `pre_tool_call` hook.
- Detect image, file/material, search/research, and coding tool families from `tool_name` or host-provided `tool_family` metadata.
- Keep existing delegate-task role marker warnings while allowing multiple bounded hook context blocks.
- Document that plugin-loaded Hermes sessions can receive the same generic tool checkpoint already exposed through wrapper route-hint payloads.

## Why
OMH already exposes `generic_tool_checkpoint.routes` in wrapper route-hint payloads, but plugin-loaded Hermes sessions could still go directly to generic tools without seeing the same OMH-first reminder. That is exactly the kind of gap that makes Hermes forget OMH exists during normal work: image generation skips `img-summary`, file generation skips `materials-package`, search skips `web-research`, or coding skips `ultraprocess`/planning.

This PR moves that reminder closer to the Hermes runtime surface. When a relevant tool call is about to happen, the plugin can say: consider the OMH workflow first, name the next action, and preserve what is not evidence yet.

## User Impact
When Hermes is about to use a generic tool such as an image generator, file writer, search/browser tool, or coding executor surface, OMH can inject a small context block like:

```text
[OMH Tool Checkpoint]
schema=omh_generic_tool_checkpoint/v1
tool_family=image_tools
workflow=img-summary
next_action=prepare_visual_prompt_card
```

The practical effect is that Hermes is less likely to skip the OMH workflow layer for tasks where OMH should shape the work first.

## Implementation Notes
- `src/plugin_bundle/omh/hooks/tool_hooks.py` now builds combined hook context from:
  - unknown role marker warnings for `delegate_task`
  - generic OMH-first tool checkpoints for image/file/search/coding families
- The hook relies on metadata only:
  - `tool_name`
  - optional `tool_family`
  - static checkpoint routes from `awareness.py`
- Raw `tool_input` content is never copied into the hook context.
- Hook capability manifests now advertise `omh_generic_tool_checkpoint`, `tool_family_hint`, and `redacted` fields.

## Boundaries
- This is advisory prompt context only.
- It is not workflow selection, tool invocation, image/file/search/coding execution, dispatch, verification, review, CI, merge, or delivery evidence.
- It does not call external tools, execute providers, install connectors, or patch Hermes core.

## Verification
Observed locally:

```sh
PYTHONPATH=tests uv run python -m unittest tests.test_hook_manifest -v
PYTHONPATH=tests uv run python -m unittest tests.test_plugin_distribution.PluginDistributionTests.test_installed_plugin_status_tool_and_hook_keep_evidence_boundary -v
PYTHONPATH=tests uv run python -m unittest tests.test_capabilities tests.test_plugin_capabilities -v
PYTHONPATH=tests uv run python -m unittest discover -s tests -v
uv run python -m compileall -q src tests
uv run python -m src.cli docs workflows --check
git diff --check
```

Results:
- Focused hook/plugin/capability tests passed.
- Full unittest passed: `Ran 637 tests ... OK`.
- compileall passed.
- docs/workflows check passed with 41/41 tap skills fresh.
- diff check passed.

## Risks / Follow-up
- Live Hermes plugin invocation inside an external Hermes TUI session was not exercised here.
- Tool-family detection is intentionally conservative and metadata-based; hosts can pass `tool_family` when a tool name is too generic.