### PR TITLE
Align plugin bridge setup roadmap

### DIFF
--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -82,7 +82,7 @@ host-load evidence. A host or wrapper that actually observes bridge load or use
 can record `omh_mcp_host_session/v1` with `omh mcp observe-host`; that remains
 session evidence only.
 
-The optional plugin bridge has the same split. Local install/import/register
+The managed plugin bridge has the same split. Local install/import/register
 smoke proves the bundle is present and importable. Host or wrapper evidence that
 Hermes actually loaded or used the plugin is recorded separately with
 `omh plugin observe-host` as `omh_plugin_host_observation/v1`. Active readiness

--- a/docs/CHAT_WRAPPER_EXAMPLES.md
+++ b/docs/CHAT_WRAPPER_EXAMPLES.md
@@ -110,7 +110,7 @@ the picker.
 
 ## Plugin Route Hints
 
-When the optional OMH plugin bridge is loaded, `pre_llm_call` can add a bounded
+When the managed OMH plugin bridge is loaded, `pre_llm_call` can add a bounded
 `omh_route_hint/v1` context block for messages that look like workflow-shaped
 work. The hint does not include the raw user message. It carries only message
 hash/length metadata, matched cue labels, a candidate workflow, adjacent
@@ -153,7 +153,7 @@ These routes are advisory. They tell Hermes which OMH workflow to consider
 before a generic tool, while image generation, file export, search retrieval,
 coding dispatch, review, CI, and merge remain observed-only claims.
 
-When the optional OMH plugin is loaded, its `pre_tool_call` hook can emit the
+When the managed OMH plugin is loaded, its `pre_tool_call` hook can emit the
 same checkpoint before image, file, search, or coding tool calls. The hook uses
 tool metadata such as `tool_name` or `tool_family`; it does not copy the raw
 image prompt, file body, search query, or coding task into the context.

--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -39,7 +39,7 @@ implementation or claim runtime behavior it did not observe.
 
 | Capability axis | OMH status | OMH surface | Missing or intentionally delegated |
 | --- | --- | --- | --- |
-| Skill and plugin distribution | Available | Tap-compatible `skills/*/SKILL.md`, `omh setup`, optional `~/.hermes/plugins/omh` bridge, and `omh plugin observe-host` for host-observed plugin load/use. | Live plugin load/use must still be recorded by the host or wrapper; local install smoke is not runtime evidence. |
+| Skill and plugin distribution | Available | Tap-compatible `skills/*/SKILL.md`, `omh setup`, managed `~/.hermes/plugins/omh` bridge, and `omh plugin observe-host` for host-observed plugin load/use. | Live plugin load/use must still be recorded by the host or wrapper; local install smoke is not runtime evidence. |
 | Specialist role/profile system | Available | Skill catalog metadata, operating models, optional visible profile packs, wrapper role narration, plugin `omh_role`, and `[omh-role:name]` context injection. | Observed role execution still requires wrapper or runtime evidence; role context is not a hidden live agent. |
 | Bounded evidence probe | Available | Plugin `omh_gather_evidence` runs shell-free allowlisted local probes such as doctor, harness validation, docs checks, unittest, compileall, and whitespace checks. | It is not a general shell, executor dispatch, PR review, CI, merge, or live Hermes plugin-load signal. |
 | Team, swarm, and worker protocol | Available | `team`, `ultrawork`, `omh runtime team-readiness`, runtime handoff payloads, worker-protocol guidance, wrapper sessions, and runtime observations. | Live worker launch and pane/session management still require the selected host runtime to act and record observations. |
@@ -55,7 +55,7 @@ implementation or claim runtime behavior it did not observe.
 - `omh probe --parity` so operators and wrappers can inspect the matrix beside
   the current local capability probe.
 - `omh probe --roadmap`, and the roadmap section inside `omh probe --parity`,
-  so operators can see whether the next step is setup, optional plugin/MCP
+  so operators can see whether the next step is setup or repair, optional MCP
   configuration, wrapper usage evidence, or host runtime observation.
 - A plugin bridge with native role context lookup, role marker injection,
   delegate marker validation, session-end checkpoints, and bounded

--- a/src/capability_roadmap.py
+++ b/src/capability_roadmap.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 
 CAPABILITY_GAP_ROADMAP_SCHEMA_VERSION = "omh_capability_gap_roadmap/v1"
-BASELINE_PRODUCT_CAPABILITIES = ("managed_skills", "external_skill_dirs", "target_registry")
+BASELINE_PRODUCT_CAPABILITIES = ("managed_skills", "external_skill_dirs", "target_registry", "omh_plugin_bundle")
 PLUGIN_SMOKE_CAPABILITIES = ("plugin_import_smoke", "plugin_register_smoke")
 OPTIONAL_HOST_CAPABILITIES = ("native_hooks", "apps", "native_skill_metadata", "mcp_host_config")
 
@@ -24,36 +24,15 @@ def build_capability_gap_roadmap(probe_payload: dict[str, object]) -> dict[str, 
                 "kind": "product_gap",
                 "priority": 10,
                 "label": "Run OMH setup",
-                "why": "Managed skills, Hermes registration, or target registry evidence is missing.",
+                "why": "Managed skills, Hermes registration, target registry, or plugin bridge evidence is missing.",
                 "command": "omh setup",
                 "boundary": "Setup prepares and registers local OMH workflow surfaces; it is not workflow execution evidence.",
                 "capabilities": [item["capability"] for item in baseline_gaps],
             }
         )
 
-    optional_plugin_gap = None
-    if _status(capabilities, "omh_plugin_bundle") in {"missing", "unknown"}:
-        optional_plugin_gap = _gap_item(
-            capabilities,
-            "omh_plugin_bundle",
-            category="optional_surface",
-            severity="optional",
-        )
-        actions.append(
-            {
-                "id": "install_optional_plugin",
-                "kind": "optional_surface",
-                "priority": 60,
-                "label": "Install the optional OMH plugin bridge",
-                "why": "The skill-first path works without the plugin, but plugin tools can expose compact status and role context inside Hermes when the host loads them.",
-                "command": "omh setup --with-plugin",
-                "boundary": "Local plugin install/import/register smoke is still not proof that Hermes loaded or used the plugin.",
-                "capabilities": ["omh_plugin_bundle"],
-            }
-        )
-
     plugin_smoke_gaps = [
-        _gap_item(capabilities, name, category="optional_surface", severity="repair")
+        _gap_item(capabilities, name, category="product_gap", severity="repair")
         for name in PLUGIN_SMOKE_CAPABILITIES
         if _status(capabilities, name) == "missing"
     ]
@@ -61,12 +40,12 @@ def build_capability_gap_roadmap(probe_payload: dict[str, object]) -> dict[str, 
     if plugin_smoke_gaps:
         actions.append(
             {
-                "id": "repair_optional_plugin",
-                "kind": "optional_surface",
+                "id": "repair_plugin_bridge",
+                "kind": "product_gap",
                 "priority": 25,
-                "label": "Repair the optional OMH plugin bridge",
-                "why": "The optional plugin bundle exists, but its local import/register smoke check is failing.",
-                "command": "omh setup --with-plugin --force",
+                "label": "Repair the managed OMH plugin bridge",
+                "why": "The managed plugin bundle exists, but its local import/register smoke check is failing.",
+                "command": "omh setup --force",
                 "boundary": "Repairing the local plugin bridge is not proof that Hermes loaded it or that any workflow executed.",
                 "capabilities": [item["capability"] for item in plugin_smoke_gaps],
             }
@@ -156,12 +135,10 @@ def build_capability_gap_roadmap(probe_payload: dict[str, object]) -> dict[str, 
             }
         )
 
-    if optional_plugin_gap:
-        optional_unknowns.append(optional_plugin_gap)
-    optional_unknowns.extend(plugin_smoke_gaps)
+    baseline_gaps.extend(plugin_smoke_gaps)
 
     actions.sort(key=_action_priority)
-    product_gap_count = len(baseline_gaps)
+    product_gap_count = len({str(item["capability"]) for item in baseline_gaps if item})
     evidence_gap_count = len({str(item["capability"]) for item in evidence_gaps if item})
     optional_count = len({str(item["capability"]) for item in optional_unknowns if item})
 

--- a/src/parity.py
+++ b/src/parity.py
@@ -39,7 +39,7 @@ PARITY_CAPABILITIES: tuple[ParityCapability, ...] = (
         id="skill_plugin_distribution",
         title="Skill and plugin distribution",
         common_pattern="Install a native skill/plugin payload, then let the host agent surface workflows without making users memorize backend commands.",
-        omh_surface="`hermes skills ...` compatible skill pack, `omh setup`, and the optional `~/.hermes/plugins/omh` bridge.",
+        omh_surface="`hermes skills ...` compatible skill pack, `omh setup`, and the managed `~/.hermes/plugins/omh` bridge.",
         status="available",
         evidence=(
             "skills/*/SKILL.md",

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -45,6 +45,7 @@ class ProbeCliTests(unittest.TestCase):
             self.assertGreaterEqual(roadmap["summary"]["baseline_product_gaps"], 2)
             self.assertFalse(roadmap["summary"]["baseline_ready"])
             self.assertEqual(roadmap["next_actions"][0]["id"], "run_setup")
+            self.assertIn("omh_plugin_bundle", roadmap["next_actions"][0]["capabilities"])
             self.assertIn("not workflow execution evidence", roadmap["next_actions"][0]["boundary"])
 
             self.assertEqual(run_cli(base + ["setup", "--with-plugin"])[0], 0)
@@ -169,7 +170,7 @@ class ProbeCliTests(unittest.TestCase):
             self.assertTrue(payload["plugin_distribution_ready"])
             self.assertFalse(payload["native_integration_claim_ready"])
 
-    def test_probe_roadmap_points_to_repair_for_broken_optional_plugin(self) -> None:
+    def test_probe_roadmap_points_to_repair_for_broken_plugin_bridge(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)
             omh_home = root / ".omh"
@@ -190,11 +191,11 @@ class ProbeCliTests(unittest.TestCase):
             self.assertEqual(caps["plugin_register_smoke"]["status"], "missing")
             self.assertFalse(payload["plugin_distribution_ready"])
             roadmap = payload["capability_gap_roadmap"]
-            self.assertEqual(roadmap["summary"]["baseline_product_gaps"], 0)
+            self.assertEqual(roadmap["summary"]["baseline_product_gaps"], 2)
             actions = {action["id"]: action for action in roadmap["next_actions"]}
-            self.assertIn("repair_optional_plugin", actions)
-            self.assertEqual(actions["repair_optional_plugin"]["command"], "omh setup --with-plugin --force")
-            self.assertIn("not proof that Hermes loaded", actions["repair_optional_plugin"]["boundary"])
+            self.assertIn("repair_plugin_bridge", actions)
+            self.assertEqual(actions["repair_plugin_bridge"]["command"], "omh setup --force")
+            self.assertIn("not proof that Hermes loaded", actions["repair_plugin_bridge"]["boundary"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Feature Report

### What Changed

- Updated the capability roadmap so the OMH plugin bridge is treated as a managed setup-installed bridge, not an optional plugin install path.
- Changed broken plugin import/register smoke from an optional-surface warning into a product repair gap with `omh setup --force` as the recovery command.
- Synced parity and wrapper docs from optional plugin language to managed plugin bridge language while preserving the live host-observation boundary.

### Why This Exists

- Current `omh setup` installs `~/.hermes/plugins/omh` by default, but roadmap/docs still carried older optional-plugin wording.
- That mismatch could make operators think the plugin bridge needs a hidden `--with-plugin` path even though normal setup already owns it.
- OMH should stay simple for setup while still being strict that local plugin smoke is not proof Hermes loaded or used the plugin.

### User / Operator Impact

- `omh probe --roadmap` now points missing plugin bridge evidence through `omh setup`.
- If the managed plugin bundle is present but broken, the roadmap points to `omh setup --force`.
- Users see one setup story: run `omh setup`; use host/plugin observation only when claiming live Hermes plugin usage.

### How It Works

- `omh_plugin_bundle` is now part of baseline product setup readiness in `src/capability_roadmap.py`.
- `plugin_import_smoke` and `plugin_register_smoke` failures now count as product repair gaps instead of optional unknowns.
- The docs/parity copy names the installed bridge as managed while keeping `omh plugin observe-host` as the only live host-runtime evidence path.

### Files And Contracts Touched

- `src/capability_roadmap.py`: roadmap gap categorization and recovery commands.
- `src/parity.py`, `docs/PARITY.md`: parity wording.
- `docs/CHAT_WRAPPER_EXAMPLES.md`, `docs/CAPABILITIES.md`: plugin bridge wording.
- `tests/test_probe.py`: locked roadmap expectations for setup and repair paths.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` - 637 tests passed.
- [x] `uv run python -m compileall -q src tests` - passed.
- [x] `uv run python -m src.cli docs workflows --check` - passed.
- [ ] `python3 -m omh.cli harness validate` - not run; full unittest and docs workflow check cover the touched roadmap/docs contracts.
- [ ] `python3 -m omh.cli release checklist --json` - not run; no release packaging surface changed.
- [ ] `python3 -m omh.cli release hermes-smoke` - not run; no live Hermes profile mutation in this PR.
- [x] `uv run python -m src.cli setup --help | rg -n -- '--with-plugin|Plugin|plugin|with-plugin' || true` - confirmed hidden legacy flag is not user-facing.
- [x] Relevant dry-run or smoke command: temp-home `omh probe --roadmap --json` showed `run_setup -> omh setup` with `omh_plugin_bundle` included.
- [ ] Manual Hermes/TUI check: not run; live plugin load/use remains host-observed and outside this local roadmap copy change.

## Risk

- Low. The change is copy and deterministic roadmap classification only.
- Wrappers reading the previous `repair_optional_plugin` action id should move to `repair_plugin_bridge`; the user-facing command is simpler and matches current setup behavior.

## Compatibility / Rollout

- `omh setup --with-plugin` remains accepted as a hidden compatibility flag in existing tests and scripts.
- Normal users should continue running plain `omh setup`.

## Release / Claims

- [x] Release-channel impact considered: no channel behavior changed.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] Known manual Hermes checks are listed: live plugin load observation still requires host/wrapper evidence.

## Follow-Up

- None required for this slice.
