### PR TITLE
Record plugin tool and hook host observations

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ tool, an existing Hermes connector, a generic image tool, or prompt-only mode.
 | Setup and repair | `omh setup`, `omh doctor`, `omh update`, and `omh uninstall` keep the local install understandable. |
 | Chat workflow picker | Hermes can answer "what can OMH do?" without making the user approve shell commands. |
 | Route hint cards | Wrappers can preview the nearest OMH workflow with `chat_route_hint/v1`, even before plugin load is observed. |
-| Plugin runtime evidence | Hosts or wrappers can record `omh plugin observe-host` when Hermes actually loads or uses the OMH plugin; active-ready and historical events stay separate from install smoke. |
+| Plugin runtime evidence | Hosts or wrappers can record plugin load/use with `omh plugin observe-host`, and plugin tools/hooks can self-record the same metadata when the host passes observation context; active-ready and historical events stay separate from install smoke. |
 | Coding agent paths | Hermes can prepare work for Codex, Claude Code, Hermes itself, or another runtime without pretending the work already ran. |
 | Workspace isolation | Hermes can show whether the current workspace is ok, recommend or require a worktree, use `omh worktree prepare` to create one, and use `omh worktree bind` to render open/attach/record actions for the selected coding agent. |
 | Agent ops review | Hermes can explain quality gates, blockers, next actions, and throughput levers for AI-agent work without turning a prepared handoff into evidence. |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -492,12 +492,14 @@ require an evidence reference and remain host-load/session evidence only.
 Plugin runtime load uses a parallel contract. Local plugin install and
 import/register smoke prove only the copied bundle. A Hermes host or wrapper can
 record `omh_plugin_host_observation/v1` with `omh plugin observe-host` after it
-actually sees plugin load, tool use, hook use, status query, session end, or
-unload. That observation can make `plugin_runtime_observed` available in
-`omh probe`, but it still proves only the recorded plugin event. Active native
-readiness is narrower: only `plugin_load`, `tool_call`, `hook_call`, and
-`status_query` observations keep `native_integration_claim_ready` true. `blocked`
-is descriptive host metadata and `session_end`/`plugin_unload` are historical
+actually sees plugin load, status query, session end, or unload. Invoked OMH
+plugin tools/hooks can also self-record the same observation schema when the
+host supplies bounded `observation` metadata. That observation can make
+`plugin_runtime_observed` available in `omh probe`, but it still proves only the
+recorded plugin event. Active native readiness is narrower: only `plugin_load`,
+`tool_call`, `hook_call`, and `status_query` observations keep
+`native_integration_claim_ready` true. `blocked` is descriptive host metadata
+and `session_end`/`plugin_unload` are historical
 runtime evidence, not active readiness.
 
 For terminal operators, `omh probe` prints a compact status summary by default.

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -92,10 +92,12 @@ smoke proves the bundle is present and importable, including tools such as
 --roadmap`; in standalone plugin-bundle mode it returns a degraded roadmap that
 only uses local files and metadata. Host or wrapper evidence that Hermes
 actually loaded or used the plugin is recorded separately with
-`omh plugin observe-host` as `omh_plugin_host_observation/v1`. Active readiness
-requires the latest observed event to be `plugin_load`, `tool_call`, `hook_call`,
-or `status_query`; `blocked`, `session_end`, and `plugin_unload` do not make the
-native bridge active.
+`omh plugin observe-host`, or self-recorded by an invoked plugin tool/hook when
+the host passes bounded `observation` metadata, as
+`omh_plugin_host_observation/v1`. Active readiness requires the latest observed
+event to be `plugin_load`, `tool_call`, `hook_call`, or `status_query`;
+`blocked`, `session_end`, and `plugin_unload` do not make the native bridge
+active.
 
 ## Why This Exists
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -177,8 +177,7 @@ bridge load or use and can attach a stable evidence reference. It records
 
 The OMH plugin follows the same evidence split. `omh setup` installs the plugin
 bundle and `omh doctor` can prove local import/register smoke. A Hermes host or
-wrapper that actually sees the plugin load or one of its tools/hooks run can
-record that runtime event:
+wrapper that actually sees the plugin load can record that runtime event:
 
 ```sh
 omh plugin observe-host --host hermes-agent --session <session-id> --event plugin_load --evidence-ref <host-log-ref>
@@ -192,6 +191,11 @@ unrecorded plugin calls. Observed `plugin_load`, `tool_call`, `hook_call`, or
 `session_end` or `plugin_unload` records are historical runtime evidence only.
 `blocked` means the host or wrapper could not inspect the plugin state; it does
 not preserve an older active-ready claim.
+
+When the managed plugin is actually invoked, hosts can also pass bounded
+`observation` metadata to OMH plugin tools/hooks. The plugin then records the
+same `omh_plugin_host_observation/v1` event automatically, without storing raw
+prompts or tool bodies. This proves only the recorded plugin tool/hook use.
 
 ## Install Path A: Hermes-Native Skill Tap
 
@@ -423,11 +427,12 @@ After `omh setup` has run, `omh doctor` also checks the managed plugin manifest
 plus local import/register smoke. `omh probe` reports
 `plugin_distribution_ready` separately from `native_integration_claim_ready` so
 operators do not mistake local install readiness for observed Hermes runtime
-use. When a host or wrapper records `omh plugin observe-host`,
-`plugin_runtime_observed` can become available. `native_integration_claim_ready`
-can become true only when the latest observed plugin event is active
-(`plugin_load`, `tool_call`, `hook_call`, or `status_query`); observed
-`session_end` and `plugin_unload` remain historical evidence only.
+use. When a host or wrapper records `omh plugin observe-host`, or invokes an OMH
+plugin tool/hook with bounded `observation` metadata, `plugin_runtime_observed`
+can become available. `native_integration_claim_ready` can become true only when
+the latest observed plugin event is active (`plugin_load`, `tool_call`,
+`hook_call`, or `status_query`); observed `session_end` and `plugin_unload`
+remain historical evidence only.
 Use `omh runtime team-readiness` when an operator or wrapper wants to know
 whether Hermes/team/swarm coding paths are ready to present. It returns
 `omh_team_worker_readiness/v1` with the installed skill visibility, runtime

--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -39,7 +39,7 @@ implementation or claim runtime behavior it did not observe.
 
 | Capability axis | OMH status | OMH surface | Missing or intentionally delegated |
 | --- | --- | --- | --- |
-| Skill and plugin distribution | Available | Tap-compatible `skills/*/SKILL.md`, `omh setup`, managed `~/.hermes/plugins/omh` bridge, and `omh plugin observe-host` for host-observed plugin load/use. | Live plugin load/use must still be recorded by the host or wrapper; local install smoke is not runtime evidence. |
+| Skill and plugin distribution | Available | Tap-compatible `skills/*/SKILL.md`, `omh setup`, managed `~/.hermes/plugins/omh` bridge, `omh plugin observe-host`, and plugin tool/hook self-observation when a host supplies bounded observation metadata. | Live plugin load/use must still be recorded or host-supplied; local install smoke is not runtime evidence. |
 | Specialist role/profile system | Available | Skill catalog metadata, operating models, optional visible profile packs, wrapper role narration, plugin `omh_role`, and `[omh-role:name]` context injection. | Observed role execution still requires wrapper or runtime evidence; role context is not a hidden live agent. |
 | Bounded evidence probe | Available | Plugin `omh_gather_evidence` runs shell-free allowlisted local probes such as doctor, harness validation, docs checks, unittest, compileall, and whitespace checks. | It is not a general shell, executor dispatch, PR review, CI, merge, or live Hermes plugin-load signal. |
 | Team, swarm, and worker protocol | Available | `team`, `ultrawork`, `omh runtime team-readiness`, runtime handoff payloads, worker-protocol guidance, wrapper sessions, and runtime observations. | Live worker launch and pane/session management still require the selected host runtime to act and record observations. |
@@ -60,11 +60,13 @@ implementation or claim runtime behavior it did not observe.
 - A plugin bridge with native role context lookup, role marker injection,
   delegate marker validation, `omh_probe` capability-roadmap status, session-end
   checkpoints, and bounded `omh_gather_evidence` probes.
-- `omh_plugin_host_observation/v1` records through `omh plugin observe-host`, so
-  operators can distinguish local plugin install/import/register smoke from
-  host-observed Hermes plugin load or use. Active native readiness requires the
-  latest observed event to be `plugin_load`, `tool_call`, `hook_call`, or
-  `status_query`; `session_end` and `plugin_unload` remain historical evidence.
+- `omh_plugin_host_observation/v1` records through `omh plugin observe-host`, or
+  through plugin tool/hook self-observation when a host supplies bounded
+  observation metadata, so operators can distinguish local plugin
+  install/import/register smoke from host-observed Hermes plugin load or use.
+  Active native readiness requires the latest observed event to be
+  `plugin_load`, `tool_call`, `hook_call`, or `status_query`; `session_end` and
+  `plugin_unload` remain historical evidence.
 - `worktree_session_isolation/v1`, which gives coding handoffs and wrapper
   status cards a concrete same-workspace/worktree-recommended/worktree-required
   contract before any executor is opened.
@@ -121,7 +123,8 @@ implementation or claim runtime behavior it did not observe.
   through `omh_mcp_host_session/v1` before it is claimed.
 - Specialist roles are `available` only as prompt context, marker validation,
   and profile guidance. They are not hidden runtime agents.
-- Plugin runtime observation is `available` only when a host or wrapper records
+- Plugin runtime observation is `available` only when a host or wrapper records,
+  or an invoked plugin tool/hook self-records,
   `omh_plugin_host_observation/v1` with an evidence reference. It is not coding
   dispatch, implementation, review, CI, merge, or proof of unrecorded tool/hook
   calls. `native_integration_claim_ready` is narrower than historical runtime

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -51,3 +51,5 @@
   import/register smoke and conservative runtime-claim boundaries
 - Host-observed plugin load/use records through `omh plugin observe-host`, kept
   separate from local install smoke and from execution/review/CI evidence
+- Plugin tool/hook self-observation when a Hermes host supplies bounded
+  observation metadata, using the same runtime evidence boundary

--- a/src/plugin_bundle/omh/hooks/llm_hooks.py
+++ b/src/plugin_bundle/omh/hooks/llm_hooks.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from ..awareness import awareness_context_matches_message, awareness_primer_context, awareness_route_hint_context
+from ..host_observation import observe_plugin_hook_call
 from ..omh_roles import extract_role_marker, role_context_payload
 from ..runtime_reader import read_omh_hud, read_omh_status
 
@@ -18,6 +19,7 @@ def _token_metadata_from_kwargs(kwargs: dict) -> dict[str, object]:
 
 def pre_llm_call(**kwargs) -> dict[str, str] | None:
     """Inject bounded OMH role/status context without storing prompts."""
+    observe_plugin_hook_call("pre_llm_call", kwargs)
     context_parts: list[str] = []
     user_message = str(kwargs.get("user_message", "") or "")
     is_first_turn = bool(kwargs.get("is_first_turn", False))

--- a/src/plugin_bundle/omh/hooks/session_hooks.py
+++ b/src/plugin_bundle/omh/hooks/session_hooks.py
@@ -6,9 +6,12 @@ import os
 from pathlib import Path
 import uuid
 
+from ..host_observation import observe_plugin_hook_call
+
 
 def on_session_end(**kwargs) -> dict[str, str] | None:
     """Record a metadata-only plugin checkpoint when OMH runtime state exists."""
+    observe_plugin_hook_call("on_session_end", kwargs)
     home = _expand_path(str(kwargs.get("omh_home", "") or "") or os.environ.get("OMH_HOME", "~/.omh"))
     runtime_dir = home / "runtime"
     if not runtime_dir.exists():

--- a/src/plugin_bundle/omh/hooks/tool_hooks.py
+++ b/src/plugin_bundle/omh/hooks/tool_hooks.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 import json
 
 from ..awareness import generic_tool_checkpoint_routes
+from ..host_observation import observe_plugin_hook_call
 from ..omh_roles import extract_role_marker, resolve_role_name, role_aliases, role_names
 
 
 def pre_tool_call(**kwargs) -> dict[str, str] | None:
     """Inject bounded OMH context before tool calls without exposing tool input."""
+    observe_plugin_hook_call("pre_tool_call", kwargs)
     context_parts: list[str] = []
     role_warning = _delegate_role_warning(kwargs)
     if role_warning:

--- a/src/plugin_bundle/omh/host_observation.py
+++ b/src/plugin_bundle/omh/host_observation.py
@@ -1,0 +1,372 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+
+PLUGIN_HOST_OBSERVATION_SCHEMA_VERSION = "omh_plugin_host_observation/v1"
+PLUGIN_HOST_ACTIVE_OBSERVATION_EVENTS = ("plugin_load", "tool_call", "hook_call", "status_query")
+PLUGIN_HOST_HISTORICAL_OBSERVATION_EVENTS = ("session_end", "plugin_unload")
+PLUGIN_HOST_TEXT_LIMITS = {
+    "host": 96,
+    "session": 160,
+    "source": 64,
+    "tool": 96,
+    "hook": 96,
+    "evidence_ref": 180,
+    "message": 280,
+}
+PLUGIN_HOST_SENSITIVE_PATTERNS = (
+    "api_key",
+    "apikey",
+    "authorization:",
+    "bearer ",
+    "ghp_",
+    "password",
+    "private-token",
+    "raw prompt",
+    "secret",
+    "token",
+    "xoxb-",
+    "xoxp-",
+)
+PLUGIN_HOST_OBSERVATION_CLAIM_BOUNDARY = (
+    "An OMH plugin host observation is metadata supplied by a Hermes host or wrapper "
+    "that observed plugin load or use. It proves only that host plugin event, not coding "
+    "dispatch, implementation, verification, review, CI, merge, or unrecorded tool/hook calls."
+)
+
+OBSERVATION_SCHEMA: dict[str, object] = {
+    "type": "object",
+    "description": (
+        "Optional host-supplied metadata for recording that Hermes actually invoked this OMH plugin "
+        "tool or hook. This records plugin load/use only; it is not workflow execution evidence."
+    ),
+    "properties": {
+        "host": {"type": "string", "description": "Host or wrapper name, such as hermes-agent."},
+        "session_id": {"type": "string", "description": "Stable host session/thread id."},
+        "evidence_ref": {"type": "string", "description": "Host log, tool-call, or wrapper event reference."},
+        "evidence_refs": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Optional host log, tool-call, or wrapper event references.",
+        },
+        "source": {"type": "string", "description": "Observation source, such as plugin, host, or wrapper."},
+        "message": {"type": "string", "description": "Short metadata-only summary. Do not pass raw prompts."},
+    },
+}
+
+
+def observe_plugin_tool_call(tool_name: str, args: dict[str, Any], kwargs: dict[str, Any]) -> dict[str, Any] | None:
+    metadata = _observation_metadata(args, kwargs)
+    return _record_observation(metadata, event="tool_call", tool=tool_name, hook="")
+
+
+def observe_plugin_hook_call(hook_name: str, kwargs: dict[str, Any]) -> dict[str, Any] | None:
+    metadata = _observation_metadata({}, kwargs)
+    return _record_observation(metadata, event="hook_call", tool="", hook=hook_name)
+
+
+def public_observation(record: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not record:
+        return None
+    return {
+        "schema_version": str(record.get("schema_version", "")),
+        "event": str(record.get("event", "")),
+        "status": str(record.get("status", "")),
+        "host": str(record.get("host", "")),
+        "session_id": str(record.get("session_id", "")),
+        "tool": str(record.get("tool", "")),
+        "hook": str(record.get("hook", "")),
+        "runtime_readiness": str(record.get("runtime_readiness", "")),
+        "claim_boundary": str(record.get("claim_boundary", "")),
+    }
+
+
+def attach_public_observation(payload: dict[str, Any], record: dict[str, Any] | None) -> dict[str, Any]:
+    public = public_observation(record)
+    if public:
+        payload["plugin_host_observation"] = public
+    return payload
+
+
+def _observation_metadata(args: dict[str, Any], kwargs: dict[str, Any]) -> dict[str, Any]:
+    metadata: dict[str, Any] = {}
+    for source in (args.get("observation"), kwargs.get("observation"), kwargs.get("omh_observation")):
+        if isinstance(source, dict):
+            metadata.update(source)
+    for key in ("host", "session_id", "source", "message", "omh_home", "hermes_home"):
+        if args.get(key) is not None:
+            metadata.setdefault(key, args.get(key))
+        if kwargs.get(key) is not None:
+            metadata.setdefault(key, kwargs.get(key))
+    if args.get("evidence_ref") is not None:
+        metadata.setdefault("evidence_ref", args.get("evidence_ref"))
+    if kwargs.get("evidence_ref") is not None:
+        metadata.setdefault("evidence_ref", kwargs.get("evidence_ref"))
+    if args.get("evidence_refs") is not None:
+        metadata.setdefault("evidence_refs", args.get("evidence_refs"))
+    if kwargs.get("evidence_refs") is not None:
+        metadata.setdefault("evidence_refs", kwargs.get("evidence_refs"))
+    return metadata
+
+
+def _record_observation(metadata: dict[str, Any], *, event: str, tool: str, hook: str) -> dict[str, Any] | None:
+    raw_host = str(metadata.get("host", "") or "").strip()
+    raw_session_id = str(metadata.get("session_id", "") or "").strip()
+    if not raw_host or not raw_session_id:
+        return None
+
+    try:
+        host = _bounded_metadata_text(raw_host, field="host")
+        session_id = _bounded_metadata_text(raw_session_id, field="session")
+        source = _bounded_metadata_text(str(metadata.get("source", "") or "plugin"), field="source") or "plugin"
+        clean_tool = _bounded_metadata_text(tool, field="tool")
+        clean_hook = _bounded_metadata_text(hook, field="hook")
+        message = _bounded_metadata_text(
+            str(metadata.get("message", "") or _default_message(event=event, tool=clean_tool, hook=clean_hook)),
+            field="message",
+        )
+        evidence_refs = _evidence_refs(
+            metadata,
+            event=event,
+            tool=clean_tool,
+            hook=clean_hook,
+            host=host,
+            session_id=session_id,
+        )
+    except ValueError as exc:
+        return _observation_error(
+            event=event,
+            tool=tool,
+            hook=hook,
+            error=str(exc),
+        )
+
+    try:
+        from omh.paths import resolve_paths
+        from omh.plugin_observations import record_plugin_host_observation
+
+        paths = resolve_paths(
+            omh_home=str(metadata.get("omh_home", "") or "") or None,
+            hermes_home=str(metadata.get("hermes_home", "") or "") or None,
+        )
+        return record_plugin_host_observation(
+            paths,
+            host=host,
+            session_id=session_id,
+            event=event,
+            status="observed",
+            source=source,
+            tool=clean_tool,
+            hook=clean_hook,
+            evidence_refs=evidence_refs,
+            message=message,
+        )
+    except (ImportError, ModuleNotFoundError):
+        return _record_standalone_observation(
+            metadata,
+            host=host,
+            session_id=session_id,
+            event=event,
+            source=source,
+            tool=clean_tool,
+            hook=clean_hook,
+            evidence_refs=evidence_refs,
+            message=message,
+        )
+    except Exception as exc:
+        return _observation_error(
+            event=event,
+            tool=clean_tool,
+            hook=clean_hook,
+            host=host,
+            session_id=session_id,
+            error=str(exc),
+        )
+
+
+def _evidence_refs(
+    metadata: dict[str, Any],
+    *,
+    event: str,
+    tool: str,
+    hook: str,
+    host: str,
+    session_id: str,
+) -> list[str]:
+    refs: list[str] = []
+    raw_refs = metadata.get("evidence_refs")
+    if isinstance(raw_refs, list):
+        refs.extend(
+            _bounded_metadata_text(str(item or ""), field="evidence_ref")
+            for item in raw_refs
+            if str(item or "").strip()
+        )
+    raw_ref = str(metadata.get("evidence_ref", "") or "").strip()
+    if raw_ref:
+        refs.append(_bounded_metadata_text(raw_ref, field="evidence_ref"))
+    if refs:
+        return refs
+    target = tool or hook or "unknown"
+    return [f"plugin:{event}:{target}:host={host}:session={session_id}"]
+
+
+def _default_message(*, event: str, tool: str, hook: str) -> str:
+    if event == "tool_call":
+        return f"OMH plugin tool {tool} observed with host/session metadata."
+    if event == "hook_call":
+        return f"OMH plugin hook {hook} observed with host/session metadata."
+    return "OMH plugin host observation recorded with metadata-only context."
+
+
+def _record_standalone_observation(
+    metadata: dict[str, Any],
+    *,
+    host: str,
+    session_id: str,
+    event: str,
+    source: str,
+    tool: str,
+    hook: str,
+    evidence_refs: list[str],
+    message: str,
+) -> dict[str, Any]:
+    omh_home = _expand_path(str(metadata.get("omh_home", "") or "") or os.environ.get("OMH_HOME", "~/.omh"))
+    runtime_dir = omh_home / "runtime"
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        runtime_dir.chmod(0o700)
+    except OSError:
+        pass
+    recorded_at = _utc_now()
+    runtime_readiness = _plugin_host_runtime_readiness(event=event, status="observed")
+    record: dict[str, Any] = {
+        "schema_version": PLUGIN_HOST_OBSERVATION_SCHEMA_VERSION,
+        "host": host,
+        "session_id": session_id,
+        "event": event,
+        "status": "observed",
+        "observed": True,
+        "runtime_readiness": runtime_readiness,
+        "native_integration_active": runtime_readiness == "active_runtime_observed",
+        "source": source,
+        "tool": tool,
+        "hook": hook,
+        "evidence_refs": evidence_refs,
+        "message": message,
+        "redaction_policy": "metadata_only_bounded",
+        "recorded_at": recorded_at,
+        "observed_at": recorded_at,
+        "claim_boundary": PLUGIN_HOST_OBSERVATION_CLAIM_BOUNDARY,
+    }
+    _append_jsonl(runtime_dir / "plugin_host_observations.jsonl", record)
+    _update_standalone_state(runtime_dir / "state.json", record, runtime_readiness)
+    return record
+
+
+def _append_jsonl(path: Path, record: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record, sort_keys=True) + "\n")
+    try:
+        path.chmod(0o600)
+    except OSError:
+        pass
+
+
+def _update_standalone_state(path: Path, record: dict[str, Any], runtime_readiness: str) -> None:
+    current: dict[str, Any] = {"schema_version": 1}
+    if path.exists():
+        try:
+            loaded = json.loads(path.read_text(encoding="utf-8"))
+            if isinstance(loaded, dict):
+                current = loaded
+        except (OSError, json.JSONDecodeError):
+            pass
+    patch: dict[str, Any] = {
+        "last_plugin_host_observation": record,
+        "last_plugin_runtime_observed": record if record["native_integration_active"] else None,
+        "last_plugin_runtime_readiness": runtime_readiness,
+        "schema_version": 1,
+        "updated_at": _utc_now(),
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f".{path.name}.tmp")
+    tmp.write_text(json.dumps({**current, **patch}, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    try:
+        tmp.chmod(0o600)
+    except OSError:
+        pass
+    tmp.replace(path)
+
+
+def _observation_error(
+    *,
+    event: str,
+    tool: str,
+    hook: str,
+    error: str,
+    host: str = "",
+    session_id: str = "",
+) -> dict[str, Any]:
+    return {
+        "schema_version": "omh_plugin_host_observation_error/v1",
+        "event": event,
+        "status": "not_recorded",
+        "host": host,
+        "session_id": session_id,
+        "tool": tool,
+        "hook": hook,
+        "runtime_readiness": "not_observed",
+        "message": _safe_error_message(error),
+        "claim_boundary": "Plugin observation recording failed; no host runtime evidence was persisted.",
+    }
+
+
+def _safe_error_message(error: str) -> str:
+    lowered = str(error or "").lower()
+    if any(pattern in lowered for pattern in PLUGIN_HOST_SENSITIVE_PATTERNS):
+        return "Plugin observation metadata was rejected because it was not metadata-only."
+    return str(error or "Plugin observation recording failed.")[:180]
+
+
+def _plugin_host_runtime_readiness(*, event: str, status: str) -> str:
+    if status != "observed":
+        return "not_observed"
+    if event in PLUGIN_HOST_ACTIVE_OBSERVATION_EVENTS:
+        return "active_runtime_observed"
+    if event in PLUGIN_HOST_HISTORICAL_OBSERVATION_EVENTS:
+        return "historical_runtime_observed"
+    return "observed_unknown_event"
+
+
+def _bounded_metadata_text(value: str, *, field: str) -> str:
+    text = str(value or "").strip()
+    limit = PLUGIN_HOST_TEXT_LIMITS[field]
+    if len(text) > limit:
+        raise ValueError(f"plugin host observation --{field.replace('_', '-')} must be {limit} characters or fewer")
+    if _looks_sensitive_metadata(text):
+        raise ValueError(
+            f"plugin host observation --{field.replace('_', '-')} must be metadata-only and must not include secrets, tokens, passwords, or raw prompts"
+        )
+    return text
+
+
+def _looks_sensitive_metadata(text: str) -> bool:
+    lowered = text.lower()
+    if any(pattern in lowered for pattern in PLUGIN_HOST_SENSITIVE_PATTERNS):
+        return True
+    words = lowered.replace("=", " ").replace(":", " ").replace(",", " ").split()
+    return any(word.startswith("sk-") for word in words)
+
+
+def _expand_path(value: str) -> Path:
+    return Path(os.path.expandvars(value)).expanduser()
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")

--- a/src/plugin_bundle/omh/tools/capability_tool.py
+++ b/src/plugin_bundle/omh/tools/capability_tool.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 
 from ..awareness import awareness_lane_examples, awareness_primer_payload
+from ..host_observation import OBSERVATION_SCHEMA, attach_public_observation, observe_plugin_tool_call
 from ..metadata import PROVIDED_HOOKS, PROVIDED_TOOLS
 
 STANDALONE_CAPABILITY_SECTIONS = (
@@ -93,19 +94,21 @@ OMH_CAPABILITIES_SCHEMA = {
                 "type": "string",
                 "description": "Capability id for action=inspect.",
             },
+            "observation": OBSERVATION_SCHEMA,
         },
     },
 }
 
 
 def omh_capabilities_handler(args: dict, **kwargs) -> str:
+    observation = observe_plugin_tool_call("omh_capabilities", args, kwargs)
     action = str(args.get("action", "export") or "export")
     section = str(args.get("section", "") or "") or None
     try:
         payload = _handle_capability_action(action, section, str(args.get("id", "") or ""))
     except ValueError as exc:
         payload = {"error": str(exc)}
-    return json.dumps(payload, sort_keys=True)
+    return json.dumps(attach_public_observation(payload, observation), sort_keys=True)
 
 
 def _handle_capability_action(action: str, section: str | None, capability_id: str) -> dict[str, object]:

--- a/src/plugin_bundle/omh/tools/evidence_tool.py
+++ b/src/plugin_bundle/omh/tools/evidence_tool.py
@@ -9,6 +9,8 @@ import shlex
 import subprocess
 from typing import Any
 
+from ..host_observation import OBSERVATION_SCHEMA, attach_public_observation, observe_plugin_tool_call
+
 OMH_EVIDENCE_SCHEMA = {
     "name": "omh_gather_evidence",
     "description": (
@@ -39,6 +41,7 @@ OMH_EVIDENCE_SCHEMA = {
                 "type": "integer",
                 "description": "Maximum output characters per command. Keeps the tail. Default 4000, capped at 20000.",
             },
+            "observation": OBSERVATION_SCHEMA,
         },
         "required": ["commands"],
     },
@@ -71,18 +74,24 @@ _DEFAULT_ALLOWLIST = (
 
 
 def omh_evidence_handler(args: dict, **kwargs) -> str:
+    observation = observe_plugin_tool_call("omh_gather_evidence", args, kwargs)
     commands = args.get("commands", [])
     if not isinstance(commands, list) or not commands:
-        return _json({"error": "commands must be a non-empty list"})
+        return _json(_with_observation({"error": "commands must be a non-empty list"}, observation))
     if len(commands) > _MAX_COMMANDS:
-        return _json({"error": f"too many commands: {len(commands)} > {_MAX_COMMANDS}"})
+        return _json(_with_observation({"error": f"too many commands: {len(commands)} > {_MAX_COMMANDS}"}, observation))
 
     project_root = _project_root(args, kwargs)
     if not project_root.is_dir():
-        return _json({"error": "project_root must be an existing directory", "project_root": str(project_root)})
+        return _json(
+            _with_observation(
+                {"error": "project_root must be an existing directory", "project_root": str(project_root)},
+                observation,
+            )
+        )
     workdir = _workdir(args, project_root)
     if isinstance(workdir, dict):
-        return _json(workdir)
+        return _json(_with_observation(workdir, observation))
 
     timeout = min(_positive_int(args.get("timeout"), _DEFAULT_TIMEOUT_SECONDS), _MAX_TIMEOUT_SECONDS)
     truncate = min(_positive_int(args.get("truncate"), _DEFAULT_TRUNCATE_CHARS), _MAX_TRUNCATE_CHARS)
@@ -127,7 +136,11 @@ def omh_evidence_handler(args: dict, **kwargs) -> str:
             "implementation, review, CI, merge, or Hermes runtime-load evidence."
         ),
     }
-    return _json(payload)
+    return _json(_with_observation(payload, observation))
+
+
+def _with_observation(payload: dict[str, Any], observation: dict[str, Any] | None) -> dict[str, Any]:
+    return attach_public_observation(payload, observation)
 
 
 def _project_root(args: dict, kwargs: dict) -> Path:

--- a/src/plugin_bundle/omh/tools/hud_tool.py
+++ b/src/plugin_bundle/omh/tools/hud_tool.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from typing import Any
 
+from ..host_observation import OBSERVATION_SCHEMA, attach_public_observation, observe_plugin_tool_call
 from ..runtime_reader import read_omh_hud
 
 OMH_HUD_SCHEMA = {
@@ -51,12 +52,14 @@ OMH_HUD_SCHEMA = {
                 "type": "number",
                 "description": "Optional host-provided context remaining percentage.",
             },
+            "observation": OBSERVATION_SCHEMA,
         },
     },
 }
 
 
 def omh_hud_handler(args: dict[str, Any], **kwargs) -> str:
+    observation = observe_plugin_tool_call("omh_hud", args, kwargs)
     token_metadata = {
         key: args.get(key)
         for key in (
@@ -75,4 +78,4 @@ def omh_hud_handler(args: dict[str, Any], **kwargs) -> str:
         limit=args.get("limit") or 3,
         token_metadata=token_metadata,
     )
-    return json.dumps(payload, sort_keys=True)
+    return json.dumps(attach_public_observation(payload, observation), sort_keys=True)

--- a/src/plugin_bundle/omh/tools/probe_tool.py
+++ b/src/plugin_bundle/omh/tools/probe_tool.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import json
+from json import JSONDecodeError
 import os
 from pathlib import Path
 from typing import Any
 
+from ..host_observation import PLUGIN_HOST_ACTIVE_OBSERVATION_EVENTS
+from ..host_observation import OBSERVATION_SCHEMA, attach_public_observation, observe_plugin_tool_call
 from ..runtime_reader import read_omh_hud, read_omh_status
 
 OMH_PROBE_SCHEMA = {
@@ -32,6 +35,7 @@ OMH_PROBE_SCHEMA = {
                 "type": "boolean",
                 "description": "Include the capability gap roadmap.",
             },
+            "observation": OBSERVATION_SCHEMA,
         },
     },
 }
@@ -42,6 +46,7 @@ def omh_probe_handler(args: dict, **kwargs) -> str:
     include_roadmap = bool(args.get("include_roadmap", False))
     omh_home = _optional_path_arg(args.get("omh_home"))
     hermes_home = _optional_path_arg(args.get("hermes_home"))
+    observation = observe_plugin_tool_call("omh_probe", args, kwargs)
     try:
         payload = _package_probe(
             omh_home=omh_home,
@@ -58,7 +63,7 @@ def omh_probe_handler(args: dict, **kwargs) -> str:
             include_parity=include_parity,
             include_roadmap=include_roadmap,
         )
-    return json.dumps(payload, sort_keys=True)
+    return json.dumps(attach_public_observation(payload, observation), sort_keys=True)
 
 
 def _package_probe(
@@ -93,7 +98,12 @@ def _standalone_probe(
     hermes = _expand_path(hermes_home or os.environ.get("HERMES_HOME", "~/.hermes"))
     status = read_omh_status(omh_home=home, limit=3)
     hud = read_omh_hud(omh_home=home, hermes_home=hermes, preset="focused", limit=1)
-    capabilities = _standalone_capabilities(home, hermes, status, hud)
+    plugin_observation = _latest_plugin_observation(home)
+    plugin_runtime_observed = bool(plugin_observation and plugin_observation.get("observed"))
+    plugin_runtime_active = (
+        plugin_runtime_observed and str(plugin_observation.get("runtime_readiness", "")) == "active_runtime_observed"
+    )
+    capabilities = _standalone_capabilities(home, hermes, status, hud, plugin_observation=plugin_observation)
     payload: dict[str, Any] = {
         "schema_version": 1,
         "source": "standalone_plugin_bundle_fallback",
@@ -104,9 +114,9 @@ def _standalone_probe(
         "capabilities": capabilities,
         "target_topology": hud.get("target_topology", {}),
         "plugin_distribution_ready": _capability_status(capabilities, "omh_plugin_bundle") == "available",
-        "plugin_runtime_observed": False,
-        "plugin_runtime_active": False,
-        "native_integration_claim_ready": False,
+        "plugin_runtime_observed": plugin_runtime_observed,
+        "plugin_runtime_active": plugin_runtime_active,
+        "native_integration_claim_ready": plugin_runtime_active,
         "privacy": "metadata_only",
         "claim_boundary": (
             "This standalone plugin probe can read local OMH files and the current plugin bundle metadata. "
@@ -129,7 +139,14 @@ def _standalone_probe(
     return payload
 
 
-def _standalone_capabilities(home: Path, hermes: Path, status: dict[str, Any], hud: dict[str, Any]) -> list[dict[str, str]]:
+def _standalone_capabilities(
+    home: Path,
+    hermes: Path,
+    status: dict[str, Any],
+    hud: dict[str, Any],
+    *,
+    plugin_observation: dict[str, Any] | None,
+) -> list[dict[str, str]]:
     skills_dir = home / "skills"
     managed_skill = skills_dir / "oh-my-hermes" / "SKILL.md"
     hermes_config = hermes / "config.yaml"
@@ -172,12 +189,7 @@ def _standalone_capabilities(home: Path, hermes: Path, status: dict[str, Any], h
             "omh_probe",
             "This response was produced by the managed OMH plugin tool; persisted host observation remains separate",
         ),
-        _capability(
-            "plugin_runtime_observed",
-            "unverified",
-            str(home / "runtime" / "plugin_host_observations.jsonl"),
-            "No host-supplied plugin observation is inferred by the standalone probe fallback",
-        ),
+        _standalone_plugin_runtime_capability(home, plugin_observation),
         _capability(
             "wrapper_metadata",
             "available" if wrapper_paths else "missing",
@@ -271,7 +283,7 @@ def _standalone_roadmap(probe_payload: dict[str, Any]) -> dict[str, Any]:
             "evidence_gaps": len(evidence),
             "optional_or_host_unknowns": 1,
             "baseline_ready": len(baseline) == 0,
-            "native_runtime_observed": False,
+            "native_runtime_observed": _status(capabilities, "plugin_runtime_observed") == "available",
             "wrapper_usage_observed": _status(capabilities, "wrapper_metadata") == "available",
         },
         "product_gaps": baseline,
@@ -305,6 +317,59 @@ def _read_text(path: Path) -> str:
         return path.read_text(encoding="utf-8")
     except OSError:
         return ""
+
+
+def _latest_plugin_observation(home: Path) -> dict[str, Any] | None:
+    path = home / "runtime" / "plugin_host_observations.jsonl"
+    if not path.exists():
+        return None
+    latest: dict[str, Any] | None = None
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return None
+    for line in lines:
+        if not line.strip():
+            continue
+        try:
+            record = json.loads(line)
+        except JSONDecodeError:
+            continue
+        if isinstance(record, dict) and record.get("schema_version") == "omh_plugin_host_observation/v1":
+            latest = record
+    return latest
+
+
+def _standalone_plugin_runtime_capability(home: Path, observation: dict[str, Any] | None) -> dict[str, str]:
+    evidence = str(home / "runtime" / "plugin_host_observations.jsonl")
+    if observation and observation.get("observed"):
+        host = str(observation.get("host", "unknown") or "unknown")
+        event = str(observation.get("event", "unknown") or "unknown")
+        session_id = str(observation.get("session_id", "unknown") or "unknown")
+        readiness = str(observation.get("runtime_readiness", "") or "")
+        active = readiness == "active_runtime_observed"
+        message = (
+            f"OMH plugin active runtime observed by {host} ({event}, session={session_id})"
+            if active
+            else f"OMH plugin historical runtime event observed by {host} ({event}, session={session_id}); active readiness requires one of {', '.join(PLUGIN_HOST_ACTIVE_OBSERVATION_EVENTS)}"
+        )
+        return _capability("plugin_runtime_observed", "available", evidence, message)
+    if observation:
+        host = str(observation.get("host", "unknown") or "unknown")
+        status = str(observation.get("status", "unknown") or "unknown")
+        event = str(observation.get("event", "unknown") or "unknown")
+        return _capability(
+            "plugin_runtime_observed",
+            "unverified",
+            evidence,
+            f"Latest plugin host observation from {host} is {status} ({event}); Hermes plugin runtime is not currently observed",
+        )
+    return _capability(
+        "plugin_runtime_observed",
+        "unverified",
+        evidence,
+        "No host-supplied plugin observation is inferred by the standalone probe fallback",
+    )
 
 
 def _capability(name: str, status: str, evidence: str, message: str) -> dict[str, str]:

--- a/src/plugin_bundle/omh/tools/recommend_tool.py
+++ b/src/plugin_bundle/omh/tools/recommend_tool.py
@@ -5,6 +5,7 @@ import json
 from typing import Any
 
 from ..awareness import awareness_primer_payload, awareness_route_hint
+from ..host_observation import OBSERVATION_SCHEMA, attach_public_observation, observe_plugin_tool_call
 
 OMH_RECOMMEND_SCHEMA = {
     "name": "omh_recommend",
@@ -26,6 +27,7 @@ OMH_RECOMMEND_SCHEMA = {
                 "default": 5,
                 "description": "Maximum recommendations to return.",
             },
+            "observation": OBSERVATION_SCHEMA,
         },
         "required": ["message"],
     },
@@ -66,6 +68,7 @@ _FALLBACK_RECOMMENDATIONS = (
 
 
 def omh_recommend_handler(args: dict, **kwargs) -> str:
+    observation = observe_plugin_tool_call("omh_recommend", args, kwargs)
     message = str(args.get("message") or "").strip()
     limit = _bounded_limit(args.get("limit"), default=5)
     if not message:
@@ -76,7 +79,7 @@ def omh_recommend_handler(args: dict, **kwargs) -> str:
             "recommendations": [],
             "claim_boundary": _claim_boundary(),
         }
-        return json.dumps(payload, sort_keys=True)
+        return json.dumps(attach_public_observation(payload, observation), sort_keys=True)
 
     recommendations, source = _recommendations(message, limit)
     payload = {
@@ -96,7 +99,7 @@ def omh_recommend_handler(args: dict, **kwargs) -> str:
         ),
         "claim_boundary": _claim_boundary(),
     }
-    return json.dumps(payload, sort_keys=True)
+    return json.dumps(attach_public_observation(payload, observation), sort_keys=True)
 
 
 def _recommendations(message: str, limit: int) -> tuple[list[dict[str, Any]], str]:

--- a/src/plugin_bundle/omh/tools/role_tool.py
+++ b/src/plugin_bundle/omh/tools/role_tool.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 
+from ..host_observation import OBSERVATION_SCHEMA, attach_public_observation, observe_plugin_tool_call
 from ..omh_roles import role_aliases, role_context_payload, role_names
 
 OMH_ROLE_SCHEMA = {
@@ -22,6 +23,7 @@ OMH_ROLE_SCHEMA = {
                 "type": "string",
                 "description": "Role name for action=read, such as planner, researcher, handoff-guide, or a legacy alias.",
             },
+            "observation": OBSERVATION_SCHEMA,
         },
         "required": ["action"],
     },
@@ -29,17 +31,18 @@ OMH_ROLE_SCHEMA = {
 
 
 def omh_role_handler(args: dict, **kwargs) -> str:
+    observation = observe_plugin_tool_call("omh_role", args, kwargs)
     action = str(args.get("action", "list") or "list")
     if action == "list":
-        return json.dumps(
-            {
-                "schema_version": "omh_role_catalog/v1",
-                "roles": role_names(),
-                "aliases": role_aliases(),
-                "claim_boundary": "OMH role names are prompt guidance only; they are not observed runtime agents.",
-            },
-            sort_keys=True,
-        )
+        payload = {
+            "schema_version": "omh_role_catalog/v1",
+            "roles": role_names(),
+            "aliases": role_aliases(),
+            "claim_boundary": "OMH role names are prompt guidance only; they are not observed runtime agents.",
+        }
+        return json.dumps(attach_public_observation(payload, observation), sort_keys=True)
     if action != "read":
-        return json.dumps({"error": f"unknown action: {action}"}, sort_keys=True)
-    return json.dumps(role_context_payload(str(args.get("role", "") or "")), sort_keys=True)
+        payload = {"error": f"unknown action: {action}"}
+    else:
+        payload = role_context_payload(str(args.get("role", "") or ""))
+    return json.dumps(attach_public_observation(payload, observation), sort_keys=True)

--- a/src/plugin_bundle/omh/tools/status_tool.py
+++ b/src/plugin_bundle/omh/tools/status_tool.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 
+from ..host_observation import OBSERVATION_SCHEMA, attach_public_observation, observe_plugin_tool_call
 from ..runtime_reader import read_omh_status
 
 OMH_STATUS_SCHEMA = {
@@ -21,14 +22,16 @@ OMH_STATUS_SCHEMA = {
                 "type": "integer",
                 "description": "Maximum recent runtime runs to summarize.",
             },
+            "observation": OBSERVATION_SCHEMA,
         },
     },
 }
 
 
 def omh_status_handler(args: dict, **kwargs) -> str:
+    observation = observe_plugin_tool_call("omh_status", args, kwargs)
     payload = read_omh_status(
         omh_home=str(args.get("omh_home", "") or "") or None,
         limit=int(args.get("limit") or 5),
     )
-    return json.dumps(payload, sort_keys=True)
+    return json.dumps(attach_public_observation(payload, observation), sort_keys=True)

--- a/tests/test_plugin_capabilities.py
+++ b/tests/test_plugin_capabilities.py
@@ -79,6 +79,67 @@ class PluginCapabilitiesTests(unittest.TestCase):
             retained = json.loads(handler({"action": "inspect", "id": "retained-cognition", "section": "agent_roles"}))
             self.assertIn("capability not found: retained-cognition", retained["error"])
 
+    def test_plugin_tool_and_hook_can_self_record_host_observation_metadata(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / ".omh"
+            hermes_home = root / ".hermes"
+            base = ["--omh-home", str(omh_home), "--hermes-home", str(hermes_home)]
+            status, _, stderr = run_cli(base + ["setup", "--with-plugin"])
+            self.assertEqual(status, 0, stderr)
+
+            module = load_installed_plugin(hermes_home / "plugins" / "omh")
+            ctx = FakeHermesContext()
+            module.register(ctx)
+
+            probe_handler = ctx.tools["omh_probe"]["args"][2]
+            probe = json.loads(
+                probe_handler(
+                    {
+                        "omh_home": str(omh_home),
+                        "hermes_home": str(hermes_home),
+                        "include_roadmap": True,
+                        "observation": {
+                            "host": "hermes-agent",
+                            "session_id": "session-tool-1",
+                            "evidence_ref": "host-tool-call:omh_probe",
+                        },
+                    }
+                )
+            )
+
+            self.assertTrue(probe["plugin_runtime_observed"])
+            self.assertTrue(probe["native_integration_claim_ready"])
+            self.assertEqual(probe["plugin_host_observation"]["event"], "tool_call")
+            self.assertEqual(probe["plugin_host_observation"]["tool"], "omh_probe")
+            self.assertEqual(probe["plugin_host_observation"]["runtime_readiness"], "active_runtime_observed")
+            roadmap_actions = {item["id"] for item in probe["capability_gap_roadmap"]["next_actions"]}
+            self.assertNotIn("observe_plugin_runtime", roadmap_actions)
+
+            pre_llm = ctx.hooks["pre_llm_call"]
+            pre_llm(
+                omh_home=str(omh_home),
+                hermes_home=str(hermes_home),
+                user_message="summarize this without storing secret-token-123",
+                observation={
+                    "host": "hermes-agent",
+                    "session_id": "session-hook-1",
+                    "evidence_ref": "host-hook-call:pre_llm_call",
+                },
+            )
+
+            status, stdout, stderr = run_cli(base + ["plugin", "observations", "--limit", "5"])
+            self.assertEqual(status, 0, stderr)
+            observations = json.loads(stdout)["observations"]
+            latest = observations[0]
+            self.assertEqual(latest["event"], "hook_call")
+            self.assertEqual(latest["hook"], "pre_llm_call")
+            self.assertEqual(latest["host"], "hermes-agent")
+            serialized = json.dumps(observations, sort_keys=True)
+            self.assertIn("host-tool-call:omh_probe", serialized)
+            self.assertIn("host-hook-call:pre_llm_call", serialized)
+            self.assertNotIn("secret-token-123", serialized)
+
     def test_installed_plugin_capabilities_tool_loads_without_installed_omh_package(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -131,6 +192,34 @@ class PluginCapabilitiesTests(unittest.TestCase):
                         "include_parity": True,
                     }})
                 )
+                observed_probe = json.loads(
+                    probe_handler({{
+                        "omh_home": {str(omh_home)!r},
+                        "hermes_home": {str(hermes_home)!r},
+                        "include_roadmap": True,
+                        "include_parity": True,
+                        "observation": {{
+                            "host": "hermes-agent",
+                            "session_id": "standalone-session-1",
+                            "evidence_ref": "standalone-host-call:omh_probe",
+                        }},
+                    }})
+                )
+                sensitive_probe = json.loads(
+                    probe_handler({{
+                        "omh_home": {str(omh_home)!r},
+                        "hermes_home": {str(hermes_home)!r},
+                        "observation": {{
+                            "host": "secret-token-123",
+                            "session_id": "session-secret-token-123",
+                            "evidence_ref": "standalone-host-call:sensitive",
+                        }},
+                    }})
+                )
+                observation_text = ({str(omh_home / "runtime" / "plugin_host_observations.jsonl")!r})
+                observation_text = open(observation_text, encoding="utf-8").read() if __import__("os").path.exists(observation_text) else ""
+                state_path = {str(omh_home / "runtime" / "state.json")!r}
+                state = json.load(open(state_path, encoding="utf-8")) if __import__("os").path.exists(state_path) else {{}}
                 listed_tools = json.loads(handler({{"action": "list", "section": "tool_requirements"}}))
                 evidence = json.loads(handler({{"action": "export", "section": "evidence_boundaries"}}))
                 inspected = json.loads(handler({{"action": "inspect", "id": "handoff-guide"}}))
@@ -178,6 +267,16 @@ class PluginCapabilitiesTests(unittest.TestCase):
                     "probe_roadmap_schema": probe["capability_gap_roadmap"]["schema_version"],
                     "probe_roadmap_actions": [item["id"] for item in probe["capability_gap_roadmap"]["next_actions"]],
                     "probe_parity_status": probe["parity_matrix"]["status"],
+                    "observed_probe_runtime_observed": observed_probe["plugin_runtime_observed"],
+                    "observed_probe_native_ready": observed_probe["native_integration_claim_ready"],
+                    "observed_probe_public": observed_probe["plugin_host_observation"],
+                    "observed_probe_roadmap_actions": [
+                        item["id"] for item in observed_probe["capability_gap_roadmap"]["next_actions"]
+                    ],
+                    "standalone_observation_text": observation_text,
+                    "standalone_state_readiness": state.get("last_plugin_runtime_readiness"),
+                    "sensitive_probe_serialized": json.dumps(sensitive_probe, sort_keys=True),
+                    "sensitive_probe_public": sensitive_probe.get("plugin_host_observation"),
                     "summary_lanes": [lane["id"] for lane in summary["lanes"]],
                     "summary_visual_skills": [
                         lane["primary_skills"]
@@ -274,6 +373,20 @@ class PluginCapabilitiesTests(unittest.TestCase):
             self.assertEqual(payload["probe_roadmap_schema"], "omh_capability_gap_roadmap/v1")
             self.assertIn("observe_plugin_runtime", payload["probe_roadmap_actions"])
             self.assertEqual(payload["probe_parity_status"], "unavailable_without_package_backend")
+            self.assertTrue(payload["observed_probe_runtime_observed"])
+            self.assertTrue(payload["observed_probe_native_ready"])
+            self.assertEqual(payload["observed_probe_public"]["event"], "tool_call")
+            self.assertEqual(payload["observed_probe_public"]["tool"], "omh_probe")
+            self.assertEqual(payload["observed_probe_public"]["host"], "hermes-agent")
+            self.assertIn("standalone-host-call:omh_probe", payload["standalone_observation_text"])
+            self.assertIn("standalone-session-1", payload["standalone_observation_text"])
+            self.assertEqual(payload["standalone_state_readiness"], "active_runtime_observed")
+            self.assertNotIn("observe_plugin_runtime", payload["observed_probe_roadmap_actions"])
+            self.assertEqual(payload["sensitive_probe_public"]["status"], "not_recorded")
+            self.assertEqual(payload["sensitive_probe_public"]["host"], "")
+            self.assertEqual(payload["sensitive_probe_public"]["session_id"], "")
+            self.assertNotIn("secret-token-123", payload["sensitive_probe_serialized"])
+            self.assertNotIn("secret-token-123", payload["standalone_observation_text"])
             self.assertIn("intent_to_plan", payload["summary_lanes"])
             self.assertIn("img-summary", payload["summary_visual_skills"])
             self.assertIn("request-to-handoff", payload["summary_intent_playbooks"])


### PR DESCRIPTION
## Feature Report

### What Changed

- Added a managed plugin-side `omh_plugin_host_observation/v1` recorder for OMH plugin tool and hook calls.
- Updated plugin tools (`omh_probe`, `omh_status`, `omh_hud`, `omh_recommend`, `omh_capabilities`, `omh_role`, `omh_gather_evidence`) to accept bounded host-supplied `observation` metadata and attach a public observation summary when recording succeeds or safely fails.
- Updated plugin hooks (`pre_llm_call`, `pre_tool_call`, `on_session_end`) to self-record when Hermes or a wrapper supplies the same bounded metadata.
- Extended standalone copied-plugin behavior so the plugin can persist observations to `~/.omh/runtime/plugin_host_observations.jsonl` even when the installed `omh` package backend is unavailable.
- Updated docs and parity language so manual `omh plugin observe-host` and host-supplied plugin self-observation describe the same evidence boundary.

### Why This Exists

OMH already separated local plugin install/import/register smoke from live Hermes runtime evidence. The remaining usability gap was that a Hermes host or wrapper had to call a separate CLI command to record that an OMH plugin tool or hook actually ran. This change lets the plugin record that evidence directly from the tool/hook invocation when the host supplies metadata such as `host`, `session_id`, and an evidence reference.

This improves Hermes-native runtime evidence without turning OMH into a hidden executor or overclaiming workflow execution.

### User / Operator Impact

- Operators can see `plugin_runtime_observed` become available after a real plugin tool/hook invocation with host metadata, instead of relying only on local install smoke.
- Wrapper authors can pass a small `observation` object to OMH plugin calls and get persisted runtime evidence plus a bounded public summary in the tool response.
- If observation metadata is missing, OMH remains conservative and records nothing.
- If metadata looks sensitive, too long, or not metadata-only, OMH returns a safe `not_recorded` summary without echoing the raw value.

### How It Works

- `src/plugin_bundle/omh/host_observation.py` centralizes observation extraction, validation, redaction-safe public summaries, package-backed recording, and standalone fallback recording.
- Package-backed plugin calls use `omh.plugin_observations.record_plugin_host_observation` so `omh probe`, `omh doctor`, and runtime state all see the same ledger.
- Standalone plugin-bundle calls use a minimal local JSONL/state writer so copied plugin bundles can still persist plugin-use evidence without importing the installed package.
- `omh_probe` reads standalone observation records so the degraded probe output can immediately drop the `observe_plugin_runtime` roadmap action once active plugin use is observed.
- The contract remains metadata-only: plugin self-observation proves only the recorded plugin tool/hook event, not coding dispatch, implementation, review, CI, merge, or unrecorded host behavior.

### Files And Contracts Touched

- `src/plugin_bundle/omh/host_observation.py`
- `src/plugin_bundle/omh/tools/*.py`
- `src/plugin_bundle/omh/hooks/*.py`
- `tests/test_plugin_capabilities.py`
- `README.md`
- `docs/ARCHITECTURE.md`
- `docs/CAPABILITIES.md`
- `docs/INSTALLATION.md`
- `docs/PARITY.md`
- `docs/ROADMAP.md`
- Contracts: `omh_plugin_host_observation/v1`, `omh_plugin_host_observation_error/v1`, plugin tool schemas with optional `observation` metadata.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m src.cli docs workflows --check`
- [ ] `python3 -m omh.cli harness validate` (not required for this plugin-only contract change; docs/workflows check covered generated workflow drift)
- [ ] `python3 -m omh.cli release checklist --json` (not run; release packaging was not changed)
- [ ] `python3 -m omh.cli release hermes-smoke` (not run; this PR does not mutate installer/release smoke)
- [ ] `omh --help` (not run; no CLI command surface changed)
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` (not run; live install smoke unchanged)
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable
- [x] Relevant dry-run or smoke command: `PYTHONPATH=tests uv run python -m unittest tests/test_plugin_capabilities.py tests/test_plugin_distribution.py tests/test_plugin_observations.py tests/test_probe.py -v`
- [x] Manual Hermes/TUI check, or explicit reason it was not run: live Hermes host plugin invocation was not run; installed and standalone plugin handlers were simulated with host/session metadata.
- [x] `git diff --check`
- [x] Independent code review lane re-review: APPROVE after fixing sensitive echo and standalone persistence findings.
- [x] Independent architecture lane re-review: CLEAR after standalone persistence and active-event scoping fixes.

## Risk

- The public tool response now includes a `plugin_host_observation` summary when host observation metadata is supplied. It is bounded to schema/event/status/host/session/tool/hook/readiness/boundary and tests cover sensitive metadata rejection.
- Standalone fallback intentionally duplicates only the small observation JSONL/state write path, not the entire package-backed runtime implementation.
- Live Hermes host behavior may differ in the exact metadata shape it can pass; missing metadata remains a no-op rather than an overclaim.

## Compatibility / Rollout

- Backward compatible for existing plugin calls; `observation` is optional.
- Existing `omh plugin observe-host` remains supported.
- Local install/import/register smoke still does not count as runtime evidence.
- Active native readiness still requires an active plugin event: `plugin_load`, `tool_call`, `hook_call`, or `status_query`.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`): local plugin bundle behavior changes and will ship through the normal package/update path.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap: live Hermes host invocation remains unobserved in this PR.

## Follow-Up

- Add live Hermes host smoke once the host exposes a stable plugin-call metadata fixture.
- Consider wrapper examples that pass `observation` metadata to plugin tools/hooks.
