### PR TITLE
Add plugin-native wrapper golden examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,9 @@ action, and keep the prepared handoff separate from observed work. When the
 plugin surface is available, Hermes can use `omh_interact` to build the same
 chat response and record a metadata-only wrapper session without asking for
 shell approval; session records include producer provenance so plugin-authored
-metadata stays distinguishable from wrapper/backend metadata. Normal users do not need to know `omh recommend`,
-`omh chat interact`, or other backend commands.
+metadata stays distinguishable from wrapper/backend metadata. Normal users do
+not need to know `omh recommend`, `omh chat interact`, or other backend
+commands.
 
 OMH's setup footprint is deliberately small: it installs Hermes-visible skills,
 records local status contracts, and can repair managed `skills.external_dirs`
@@ -277,7 +278,7 @@ documentation below.
 | Situation playbooks | [Playbooks](docs/PLAYBOOKS.md) |
 | Role surfaces and profile packs | [Roles](docs/ROLES.md) |
 | Memory/context review and handoff packs | [Memory Context Review](docs/MEMORY_CONTEXT.md) |
-| Discord-style wrapper examples | [Chat Wrapper Examples](docs/CHAT_WRAPPER_EXAMPLES.md) |
+| Discord-style and plugin-native wrapper examples | [Chat Wrapper Examples](docs/CHAT_WRAPPER_EXAMPLES.md) |
 | Harness quality contracts | [Harness Quality Contract](docs/HARNESS_QUALITY.md) |
 | Representative workflows | [Application Cases](docs/APPLICATION_CASES.md) |
 | Public website source | [GitHub Pages site](site/index.html) |

--- a/docs/CHAT_WRAPPER_EXAMPLES.md
+++ b/docs/CHAT_WRAPPER_EXAMPLES.md
@@ -15,6 +15,8 @@ uv run python examples/discord-adapter-shim.py
 uv run python examples/discord-adapter-shim.py examples/wrapper-events/discord-command-preview.json
 uv run python examples/slack-adapter-shim.py examples/wrapper-events/slack-command-preview.json
 uv run python examples/telegram-adapter-shim.py examples/wrapper-events/telegram-command-preview.json
+uv run python examples/discord-adapter-shim.py --plugin-interact examples/wrapper-events/discord-workflow-catalog.json
+uv run python examples/slack-adapter-shim.py --plugin-interact examples/wrapper-events/slack-risky-refactor.json
 uv run python examples/discord-adapter-shim.py --route-hint examples/wrapper-events/discord-route-hint-visual.json
 uv run python examples/slack-adapter-shim.py --route-hint examples/wrapper-events/slack-route-hint-missed-route.json
 uv run python -m src.cli chat route-hint --source discord "make an image explaining the cron feature"
@@ -107,6 +109,57 @@ text, harness names, and routing-only claim boundary. Catalog-question
 responses also include `omh_capability_summary/v1`, so Hermes can summarize the
 larger lanes, representative playbooks, and evidence boundary before or beside
 the picker.
+
+## Plugin-Native Chat Interaction
+
+When the managed OMH plugin is loaded, a Hermes wrapper can call the plugin
+tool `omh_interact` directly. That path returns the same renderable
+`chat_interaction/v1` envelope as `omh chat interact`, and it can also record a
+metadata-only wrapper session with `record_provenance.producer == plugin_tool`.
+
+The transport-free shims can render this without touching your real `~/.omh` or
+`~/.hermes` state:
+
+```sh
+uv run python examples/discord-adapter-shim.py --plugin-interact examples/wrapper-events/discord-workflow-catalog.json
+uv run python examples/slack-adapter-shim.py --plugin-interact examples/wrapper-events/slack-risky-refactor.json
+```
+
+Example catalog effect:
+
+```text
+Hermes Agent  BOT
+[omh] oh-my-hermes - Here are the OMH workflows.
+
+You do not need to run a shell command for this. OMH covers planning, ops,
+deliverables, coding handoffs, loops, and status.
+
+[ Choose workflow ] [ Search workflows ] [ Show status ]
+
+Plugin session
+- tool: omh_interact
+- wrapper_session: recorded
+- producer: plugin_tool
+- state scope: temporary example
+```
+
+Example plan effect:
+
+```text
+Hermes Agent  BOT
+[omh] ralplan - I routed this to `ralplan` because it needs a safe plan first.
+
+Accept or revise the plan first; the handoff button stays disabled until
+acceptance. A draft plan is still only planning evidence.
+
+[ Accept plan ] [ Revise plan ] [ Prepare handoff disabled ]
+```
+
+These examples are locked by
+`examples/wrapper-golden/plugin-interact.json`. The plugin observation and
+wrapper session record prove only that the plugin tool produced metadata for
+the wrapper. They do not prove workflow execution, executor dispatch,
+verification, review, CI, or merge.
 
 ## Plugin Route Hints
 

--- a/docs/DELEGATION_FIRST_COMPLETENESS.md
+++ b/docs/DELEGATION_FIRST_COMPLETENESS.md
@@ -40,7 +40,7 @@ evidence exists.
 | `omh runtime observe` | Records metadata-only `runtime_observation/v1` events for Hermes/OMX/OMO/OMC runtime handoffs: runtime start, worktree creation, worker dispatch/result, verification, review, CI, merge-readiness, and merge. | `src/runtime/artifacts.py`, `src/runtime/records.py`, `tests/test_cli.py`, `tests/test_runtime_artifacts.py` |
 | `omh runtime review`, `omh runtime ci`, `omh runtime merge` | Records observed review, CI, merge-readiness, and merge evidence under the run ledger. | `src/runtime/artifacts.py`, `src/runtime/records.py`, `tests/test_cli.py` |
 | `omh runtime validate/export` | Validates and exports local evidence without storing prompt bodies by default. | `src/runtime/artifacts.py`, `tests/test_runtime_artifacts.py` |
-| `examples/wrapper-golden/` | Provides platform-neutral golden chat responses for wrapper button/thread/status UX. | `examples/wrapper-golden/status-ladder.json`, `tests/test_wrapper_golden_examples.py` |
+| `examples/wrapper-golden/` | Provides platform-neutral golden chat responses for wrapper button/thread/status UX, including plugin-native `omh_interact` examples. | `examples/wrapper-golden/status-ladder.json`, `examples/wrapper-golden/plugin-interact.json`, `tests/test_wrapper_golden_examples.py` |
 
 The strongest existing path is:
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -10,8 +10,6 @@
 - More playbook-backed situation pipelines for wrapper UX, research, planning,
   and release flows
 - More artifact-backed application cases for Hermes-hosted chat surfaces
-- More fixture-backed Hermes Agent wrapper examples that consume plugin
-  `omh_interact` and `chat_interaction/v1`
 - More public-site examples that mirror wrapper contracts without becoming a
   separate documentation source
 - Optional `~/.hermes/plugins/omh` bridge hardening after v1 install smoke
@@ -40,6 +38,9 @@
   hosted chat surfaces
 - Plugin-native `omh_interact` chat/session observation for Hermes-hosted
   surfaces
+- Fixture-backed Hermes Agent wrapper examples that consume plugin
+  `omh_interact` and render the resulting `chat_interaction/v1` without
+  touching real user state
 - Codex lifecycle helper commands over existing local runtime artifacts
 - Wrapper session plan decisions and restart recovery for accepted handoffs
 - Review, CI, merge-readiness, and merge observation records for delegated

--- a/examples/wrapper-events/discord-workflow-catalog.json
+++ b/examples/wrapper-events/discord-workflow-catalog.json
@@ -1,0 +1,13 @@
+{
+  "id": "discord-fixture-omh-catalog",
+  "channel_id": "ops-help",
+  "message": {
+    "id": "discord-message-omh-catalog",
+    "channel": "ops-help",
+    "content": "what OMH workflows are available?",
+    "author": {
+      "id": "maintainer-1"
+    },
+    "timestamp": "2026-06-20T12:00:00Z"
+  }
+}

--- a/examples/wrapper-golden/plugin-interact.json
+++ b/examples/wrapper-golden/plugin-interact.json
@@ -1,0 +1,72 @@
+{
+  "schema_version": "plugin_interact_golden_examples/v1",
+  "purpose": "Transport-free examples for Hermes wrappers that call the managed OMH plugin tool `omh_interact` instead of asking the user to approve backend shell catalog commands.",
+  "examples": [
+    {
+      "scenario": "discord_catalog_question_via_plugin_tool",
+      "source": "discord",
+      "fixture": "examples/wrapper-events/discord-workflow-catalog.json",
+      "expected_response": {
+        "schema_version": "wrapper_adapter_shim/v1",
+        "mode": "plugin_interact",
+        "response_kind": "skill_picker",
+        "response_phase": "skill_selection",
+        "action_ids": [
+          "choose_skill",
+          "search_skills",
+          "show_status"
+        ],
+        "wrapper_session_recorded": true,
+        "wrapper_session_status": "routed",
+        "record_provenance": "plugin_tool",
+        "plugin_observation_status": "observed",
+        "plugin_observation_event": "tool_call",
+        "tool": "omh_interact",
+        "state_scope": "temporary_example",
+        "real_user_state_mutated": false,
+        "not_evidence_until_observed": [
+          "workflow_execution",
+          "executor_dispatch",
+          "executor_result",
+          "verification",
+          "review",
+          "ci",
+          "merge"
+        ]
+      }
+    },
+    {
+      "scenario": "slack_risky_refactor_plan_via_plugin_tool",
+      "source": "slack",
+      "fixture": "examples/wrapper-events/slack-risky-refactor.json",
+      "expected_response": {
+        "schema_version": "wrapper_adapter_shim/v1",
+        "mode": "plugin_interact",
+        "response_kind": "plan",
+        "response_phase": "planning",
+        "action_ids": [
+          "accept_plan",
+          "revise_plan",
+          "prepare_handoff"
+        ],
+        "wrapper_session_recorded": true,
+        "wrapper_session_status": "plan_presented",
+        "record_provenance": "plugin_tool",
+        "plugin_observation_status": "observed",
+        "plugin_observation_event": "tool_call",
+        "tool": "omh_interact",
+        "state_scope": "temporary_example",
+        "real_user_state_mutated": false,
+        "not_evidence_until_observed": [
+          "workflow_execution",
+          "executor_dispatch",
+          "executor_result",
+          "verification",
+          "review",
+          "ci",
+          "merge"
+        ]
+      }
+    }
+  ]
+}

--- a/examples/wrapper_shim_common.py
+++ b/examples/wrapper_shim_common.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -20,6 +21,7 @@ from src.wrapper.contract import (  # noqa: E402
 )
 from src.wrapper.native_commands import build_native_command_surface, render_native_command_response  # noqa: E402
 from src.wrapper.route_hints import build_chat_route_hint_payload  # noqa: E402
+from omh.plugin_bundle.omh.tools.chat_tool import omh_interact_handler  # noqa: E402
 
 
 SCHEMA_VERSION = "wrapper_adapter_shim/v1"
@@ -41,14 +43,38 @@ def run_shim(source: str, argv: list[str] | None = None) -> int:
         help="Render a metadata-only route-hint card from the fixture event instead of a full interaction.",
     )
     parser.add_argument(
+        "--plugin-interact",
+        action="store_true",
+        help=(
+            "Render the fixture through the managed plugin's omh_interact tool. "
+            "By default this uses temporary OMH/Hermes homes so the example does not mutate real user state."
+        ),
+    )
+    parser.add_argument(
         "--status-json",
         default=None,
         help="Optional delegated_coding_status/v1 JSON to render as a status card instead of routing the event.",
     )
+    parser.add_argument(
+        "--omh-home",
+        default=None,
+        help="Optional OMH home for --plugin-interact. Defaults to an isolated temporary directory.",
+    )
+    parser.add_argument(
+        "--hermes-home",
+        default=None,
+        help="Optional Hermes home for --plugin-interact. Defaults to an isolated temporary directory.",
+    )
+    parser.add_argument(
+        "--no-record-session",
+        action="store_true",
+        help="For --plugin-interact, render without recording the metadata-only wrapper session.",
+    )
     args = parser.parse_args(argv)
 
-    if args.route_hint and args.status_json:
-        parser.error("--route-hint cannot be combined with --status-json")
+    selected_modes = sum(bool(flag) for flag in (args.route_hint, args.status_json, args.plugin_interact))
+    if selected_modes > 1:
+        parser.error("--route-hint, --status-json, and --plugin-interact are mutually exclusive")
 
     if args.status_json:
         status_payload = _read_json(Path(args.status_json))
@@ -63,6 +89,20 @@ def run_shim(source: str, argv: list[str] | None = None) -> int:
             source_metadata=extract_source_metadata(event),
         )
         print(json.dumps(_render_route_hint(source, payload), indent=2, sort_keys=True))
+        return 0
+    elif args.plugin_interact:
+        event = _read_json(Path(args.event_json))
+        interaction = _plugin_interaction(
+            source,
+            event,
+            fixture=Path(args.event_json),
+            mode=args.mode,
+            limit=args.limit,
+            omh_home=args.omh_home,
+            hermes_home=args.hermes_home,
+            record_session=not args.no_record_session,
+        )
+        print(json.dumps(_render_plugin_interaction(source, interaction), indent=2, sort_keys=True))
         return 0
     else:
         event = _read_json(Path(args.event_json))
@@ -148,6 +188,129 @@ def _render_route_hint(source: str, payload: dict[str, object]) -> dict[str, obj
             "delivery",
         ],
     }
+
+
+def _plugin_interaction(
+    source: str,
+    event: dict[str, Any],
+    *,
+    fixture: Path,
+    mode: str,
+    limit: int,
+    omh_home: str | None,
+    hermes_home: str | None,
+    record_session: bool,
+) -> dict[str, Any]:
+    message = extract_message_text(event)
+    source_metadata = extract_source_metadata(event)
+    if omh_home and hermes_home:
+        return _plugin_interaction_with_homes(
+            source,
+            message,
+            source_metadata,
+            fixture=fixture,
+            mode=mode,
+            limit=limit,
+            omh_home=omh_home,
+            hermes_home=hermes_home,
+            record_session=record_session,
+            state_scope="caller_supplied",
+        )
+
+    with tempfile.TemporaryDirectory(prefix="omh-plugin-interact.") as temp_root:
+        root = Path(temp_root)
+        return _plugin_interaction_with_homes(
+            source,
+            message,
+            source_metadata,
+            fixture=fixture,
+            mode=mode,
+            limit=limit,
+            omh_home=str(root / ".omh"),
+            hermes_home=str(root / ".hermes"),
+            record_session=record_session,
+            state_scope="temporary_example",
+        )
+
+
+def _plugin_interaction_with_homes(
+    source: str,
+    message: str,
+    source_metadata: dict[str, Any],
+    *,
+    fixture: Path,
+    mode: str,
+    limit: int,
+    omh_home: str,
+    hermes_home: str,
+    record_session: bool,
+    state_scope: str,
+) -> dict[str, Any]:
+    payload = json.loads(
+        omh_interact_handler(
+            {
+                "message": message,
+                "source": source,
+                "mode": mode,
+                "limit": limit,
+                "record_session": record_session,
+                "source_metadata": source_metadata,
+                "omh_home": omh_home,
+                "hermes_home": hermes_home,
+                "observation": {
+                    "host": f"{source}-hermes-wrapper-example",
+                    "session_id": f"{source}-plugin-interact-example",
+                    "event": "tool_call",
+                    "evidence_ref": f"fixture:{fixture.as_posix()}#omh_interact",
+                },
+            }
+        )
+    )
+    payload["example_runtime"] = {
+        "schema_version": "omh_plugin_interact_example_runtime/v1",
+        "state_scope": state_scope,
+        "real_user_state_mutated": state_scope != "temporary_example",
+        "tool": "omh_interact",
+    }
+    return payload
+
+
+def _render_plugin_interaction(source: str, interaction: dict[str, Any]) -> dict[str, object]:
+    rendered = _render(source, interaction)
+    response = _nested(interaction, "chat_response")
+    wrapper_session = interaction.get("wrapper_session") if isinstance(interaction.get("wrapper_session"), dict) else {}
+    provenance = (
+        wrapper_session.get("record_provenance", {})
+        if isinstance(wrapper_session, dict) and isinstance(wrapper_session.get("record_provenance"), dict)
+        else {}
+    )
+    claim_boundary = (
+        str(interaction.get("claim_boundary") or "")
+        or str(wrapper_session.get("claim_boundary") or "")
+        or str(response.get("claim_boundary") or "")
+    )
+    rendered["mode"] = "plugin_interact"
+    rendered["plugin_interact"] = {
+        "schema_version": "omh_plugin_interact_render/v1",
+        "tool": "omh_interact",
+        "source_backend": interaction.get("source_backend", "package_backend"),
+        "wrapper_session_recorded": bool(wrapper_session.get("recorded")) if isinstance(wrapper_session, dict) else False,
+        "wrapper_session_status": wrapper_session.get("session_status", "") if isinstance(wrapper_session, dict) else "",
+        "record_provenance": provenance,
+        "plugin_host_observation": interaction.get("plugin_host_observation", {}),
+        "example_runtime": interaction.get("example_runtime", {}),
+        "claim_boundary": claim_boundary,
+    }
+    rendered["not_evidence_until_observed"] = [
+        "workflow_execution",
+        "executor_dispatch",
+        "executor_result",
+        "verification",
+        "review",
+        "ci",
+        "merge",
+    ]
+    return rendered
 
 
 def _render(source: str, interaction: dict[str, object]) -> dict[str, object]:

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -338,7 +338,8 @@ omh chat interact --source slack "diagnose installation health"</code>
             <code>omh_interact</code> is the plugin-native path: it returns the
             same chat envelope and records a metadata-only wrapper session with
             producer provenance. The CLI examples are adapter backend
-            equivalents. A response can be
+            equivalents. Fixture-backed examples cover both shell-free workflow
+            picker responses and plugin-produced planning cards. A response can be
             an answer, a clarification request, policy-specific workflow
             guidance for research, strategy, feedback triage, meeting prep, a
             plan, a status card, or a prepared handoff. The wrapper should
@@ -363,7 +364,8 @@ omh chat interact --source slack "diagnose installation health"</code>
           <p>
             Read the source runbook at
             <code>docs/HERMES_AGENT_INTEGRATION_RUNBOOK.md</code> and validate the matching
-            golden fixture at <code>examples/wrapper-golden/hermes-agent-integration.json</code>.
+            golden fixtures at <code>examples/wrapper-golden/hermes-agent-integration.json</code>
+            and <code>examples/wrapper-golden/plugin-interact.json</code>.
             Responsibility roles are described in <code>docs/ROLES.md</code>;
             agent-facing installation is described in <code>INSTALL_FOR_AGENTS.md</code>.
           </p>

--- a/tests/test_wrapper_golden_examples.py
+++ b/tests/test_wrapper_golden_examples.py
@@ -380,6 +380,64 @@ class WrapperGoldenExampleTests(unittest.TestCase):
                 self.assertIn(f"Open {workflow}", {action["label"] for action in payload["actions"]})
                 self.assertNotIn(raw_message, result.stdout)
 
+    def test_plugin_interact_golden_examples_render_plugin_tool_sessions(self) -> None:
+        payload = json.loads(Path("examples/wrapper-golden/plugin-interact.json").read_text(encoding="utf-8"))
+        self.assertEqual(payload["schema_version"], "plugin_interact_golden_examples/v1")
+
+        for item in payload["examples"]:
+            source = str(item["source"])
+            fixture = str(item["fixture"])
+            expected = item["expected_response"]
+            script = f"examples/{source}-adapter-shim.py"
+            event = json.loads(Path(fixture).read_text(encoding="utf-8"))
+            raw_message = extract_message_text(event)
+
+            with self.subTest(item["scenario"]):
+                result = subprocess.run(
+                    [sys.executable, script, "--plugin-interact", fixture],
+                    cwd=Path.cwd(),
+                    text=True,
+                    capture_output=True,
+                    check=False,
+                )
+
+                self.assertEqual(result.stderr, "")
+                self.assertEqual(result.returncode, 0)
+                rendered = json.loads(result.stdout)
+                plugin = rendered["plugin_interact"]
+                response = rendered["response"]
+                action_ids = [action["id"] for action in rendered["actions"]]
+
+                self.assertEqual(rendered["schema_version"], expected["schema_version"])
+                self.assertEqual(rendered["source"], source)
+                self.assertEqual(rendered["mode"], expected["mode"])
+                self.assertEqual(rendered["redaction_policy"], "metadata_only")
+                self.assertEqual(response["kind"], expected["response_kind"])
+                self.assertEqual(response["phase"], expected["response_phase"])
+                self.assertEqual(action_ids, expected["action_ids"])
+                self.assertEqual(plugin["schema_version"], "omh_plugin_interact_render/v1")
+                self.assertEqual(plugin["tool"], expected["tool"])
+                self.assertEqual(plugin["source_backend"], "package_backend")
+                self.assertEqual(plugin["wrapper_session_recorded"], expected["wrapper_session_recorded"])
+                self.assertEqual(plugin["wrapper_session_status"], expected["wrapper_session_status"])
+                self.assertEqual(plugin["record_provenance"]["producer"], expected["record_provenance"])
+                self.assertEqual(plugin["record_provenance"]["schema_version"], "wrapper_session_provenance/v1")
+                self.assertEqual(
+                    plugin["plugin_host_observation"]["status"],
+                    expected["plugin_observation_status"],
+                )
+                self.assertEqual(plugin["plugin_host_observation"]["event"], expected["plugin_observation_event"])
+                self.assertEqual(plugin["plugin_host_observation"]["tool"], expected["tool"])
+                self.assertEqual(plugin["example_runtime"]["state_scope"], expected["state_scope"])
+                self.assertEqual(
+                    plugin["example_runtime"]["real_user_state_mutated"],
+                    expected["real_user_state_mutated"],
+                )
+                self.assertEqual(rendered["not_evidence_until_observed"], expected["not_evidence_until_observed"])
+                self.assertTrue(plugin["claim_boundary"])
+                self.assertIn("not executor dispatch", plugin["claim_boundary"])
+                self.assertNotIn(raw_message, result.stdout)
+
     def _source_harness_quality(self, item: dict[str, object]) -> dict[str, object]:
         source = item["source_payload"]
         if source == "coding_delegation/v1.harness_quality":


### PR DESCRIPTION
## Feature Report

### What Changed

- Added a `--plugin-interact` mode to the transport-free Discord, Slack, and Telegram wrapper shims.
- Added fixture-backed golden examples that route a Discord workflow-catalog question and a Slack risky-refactor request through the managed OMH plugin `omh_interact` tool.
- Extended wrapper golden tests so plugin-native chat interaction output is locked for provenance, observation boundaries, redaction, and session-state shape.
- Updated README, wrapper example docs, roadmap, completeness notes, and the docs site to mention the plugin-native wrapper examples.

### Why This Exists

- OMH already had a Hermes plugin tool surface, but operators did not have a reproducible example showing how a wrapper consumes that tool without shelling out to `omh list` or mutating real user state.
- Hermes-facing chat UX should be observable and inspectable: the wrapper should know whether a response came from the plugin tool, whether a wrapper session was recorded, and what is still not execution evidence.
- This closes a practical documentation and verification gap between the plugin payload and the wrapper-native chat contracts.

### User / Operator Impact

- Operators can run one fixture command and see how a Discord/Slack-style wrapper can render OMH workflow catalog and planning responses from the plugin tool.
- Wrapper authors get a concrete JSON shape for `omh_plugin_interact_render/v1`, including plugin provenance, source backend, wrapper-session status, and observed-only evidence boundaries.
- Normal users do not need to approve shell catalog commands just to ask what OMH workflows are available in chat.

### How It Works

- `examples/wrapper_shim_common.py` now accepts `--plugin-interact` and calls `omh.plugin_bundle.omh.tools.chat_tool.omh_interact_handler` directly.
- Plugin example runs use temporary OMH and Hermes homes by default, so fixture demos do not write to the user's real `~/.omh` or `~/.hermes` unless an explicit path is passed.
- Rendered output includes a `plugin_interact` block with tool name, source backend, wrapper-session recording state, record provenance, plugin host observation, example runtime scope, and a conservative claim boundary.
- Tests assert that workflow execution, executor dispatch, verification, review, CI, and merge remain observed-only and that raw prompt/token fields do not leak into shim output.

### Files And Contracts Touched

- `examples/wrapper_shim_common.py`
- `examples/wrapper-events/discord-workflow-catalog.json`
- `examples/wrapper-golden/plugin-interact.json`
- `tests/test_wrapper_golden_examples.py`
- `docs/CHAT_WRAPPER_EXAMPLES.md`
- `docs/DELEGATION_FIRST_COMPLETENESS.md`
- `docs/ROADMAP.md`
- `site/docs/index.html`
- `README.md`
- Contract: `omh_plugin_interact_render/v1`

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — 645 tests passed.
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_wrapper_golden_examples.py -v` — 13 tests passed.
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_plugin_capabilities.py tests/test_plugin_distribution.py tests/test_router_content.py -v` — 49 tests passed.
- [x] `uv run python examples/discord-adapter-shim.py --plugin-interact examples/wrapper-events/discord-workflow-catalog.json` — produced valid JSON.
- [x] `uv run python examples/slack-adapter-shim.py --plugin-interact examples/wrapper-events/slack-risky-refactor.json` — produced valid JSON.
- [x] `uv run python -m src.cli docs workflows --check` — docs/workflows in sync, 41/41 tap skills checked.
- [x] `uv run python -m compileall -q src tests examples` — passed.
- [x] `git diff --check` — passed.
- [x] Raw prompt/token leak checks against plugin-interact Discord and Slack output — no matches.
- [ ] Manual Hermes/TUI check — not run; this PR adds transport-free plugin wrapper fixtures, not a live Hermes host renderer.

## Risk

- Low. The new path is opt-in example/demo behavior and defaults to temporary state directories.
- The main risk is wrapper authors mistaking the fixture output for live platform integration, so the rendered contract explicitly separates plugin tool observation from executor dispatch, verification, review, CI, and merge evidence.

## Compatibility / Rollout

- Existing wrapper shim behavior is unchanged unless `--plugin-interact` is passed.
- Existing plugin and CLI contracts remain compatible.
- No network/API calls, Hermes core patching, or real user OMH state mutation were added.

## Release / Claims

- [x] Release-channel impact considered: local/docs/examples/test-only wrapper surface; no stable command semantics changed.
- [x] Runtime/native capability claims are backed by fixture evidence or marked as not observed.
- [x] Known manual Hermes checks are listed: live Hermes host rendering was not run.

## Follow-Up

- A future live Hermes-host smoke can verify that the same plugin output is rendered by an actual wrapper host, but this PR intentionally keeps the examples deterministic and transport-free.
