### PR TITLE
Add G1-G10 use-case demo cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,9 @@ registration contracts live in the [installation guide](docs/INSTALLATION.md).
 - **Useful beyond coding** - research, planning, feedback triage, meeting prep,
   reports, automation blueprints, material packages, and loop work all have
   Hermes-facing workflow paths.
+- **Application-case ready** - the G1-G10 use-case map can be exported as
+  wrapper-ready demo cards so operators see the route, next action, and
+  evidence boundary before wiring a chat surface.
 - **Local and inspectable** - skills, manifests, plans, sessions, and status
   records stay in user-owned local directories.
 

--- a/docs/APPLICATION_CASES.md
+++ b/docs/APPLICATION_CASES.md
@@ -36,6 +36,8 @@ Machine-readable operator checks:
 ```sh
 omh cases list --json
 omh cases inspect G10 --json
+omh cases demo G10 --json
+omh cases demo --all --json
 omh cases recommend "PR opened with failing CI" --json
 omh cases validate --json
 ```
@@ -43,6 +45,22 @@ omh cases validate --json
 Normal users should not need those commands. They exist so Hermes wrappers,
 tests, and release checks can verify that the chat-first story has deterministic
 local backing.
+
+Use-case demo cards are the wrapper-facing projection of this catalog. A card
+uses `omh_use_case_demo_card/v1` and contains:
+
+- the selected skill, playbook, harness, exposure, and next action
+- a Hermes-facing headline, body lines, and status line
+- primary and secondary wrapper actions
+- the exact evidence boundary and `prepared_not_observed` state
+
+`omh cases demo --all --json` exports all ten cards as
+`omh_use_case_demo_collection/v1`. This gives wrapper authors and release checks
+one deterministic artifact for the full G1-G10 product story without claiming
+cron, connectors, file generation, memory mutation, executor work, review, CI,
+or merge happened. The checked-in fixture lives at
+`examples/use-cases/g1-g10-demo-cards.json` and is tested against the live
+command output.
 
 ## Case 1: Coding Request Handling
 
@@ -517,6 +535,8 @@ Before using these cases as public release evidence, verify:
 - The generated router includes the representative harness registry.
 - `omh docs workflows --json` exposes `harness_quality/v1` style quality data
   for wrapper rendering and status decisions.
+- `omh cases demo --all --json` exposes `omh_use_case_demo_collection/v1` for
+  every G1-G10 wrapper card and preserves `prepared_not_observed`.
 - `omh playbook recommend` returns situation-level pipelines for safe coding,
   source-backed research, research-to-strategy briefs, meeting prep, feedback
   triage, ops review, operating rhythm history, report packages, reliability

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,7 @@ repo-local contract for Codex agents working here.
 | Render workflow quality gates in wrappers | [Harness Quality Contract](HARNESS_QUALITY.md) |
 | Install Hermes-native skills or bootstrap managed skills | [Installation](INSTALLATION.md) |
 | Run deterministic backend demos | [Chat Wrapper Examples](CHAT_WRAPPER_EXAMPLES.md#commands-used) and [fixture shims](../examples) |
-| See the G1-G10 implemented feature surfaces | [Application Cases](APPLICATION_CASES.md) |
+| See the G1-G10 implemented feature surfaces and demo cards | [Application Cases](APPLICATION_CASES.md) |
 | Check generated skill and harness metadata | [Workflow Reference](WORKFLOWS.md) |
 | Prepare or verify a release | [Release](RELEASE.md) |
 | Track public sequencing | [Roadmap](ROADMAP.md) |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -9,7 +9,8 @@
 - Richer routing catalog fields
 - More playbook-backed situation pipelines for wrapper UX, research, planning,
   and release flows
-- More artifact-backed application cases for Hermes-hosted chat surfaces
+- More artifact-backed application case fixtures beyond the G1-G10 demo-card
+  collection
 - More public-site examples that mirror wrapper contracts without becoming a
   separate documentation source
 - Optional `~/.hermes/plugins/omh` bridge hardening after v1 install smoke
@@ -41,6 +42,8 @@
 - Fixture-backed Hermes Agent wrapper examples that consume plugin
   `omh_interact` and render the resulting `chat_interaction/v1` without
   touching real user state
+- G1-G10 use-case demo cards through `omh cases demo`, including a checked-in
+  `omh_use_case_demo_collection/v1` fixture for wrapper rendering
 - Codex lifecycle helper commands over existing local runtime artifacts
 - Wrapper session plan decisions and restart recovery for accepted handoffs
 - Review, CI, merge-readiness, and merge observation records for delegated

--- a/examples/use-cases/g1-g10-demo-cards.json
+++ b/examples/use-cases/g1-g10-demo-cards.json
@@ -1,0 +1,1562 @@
+{
+  "boundary": "Use-case demo cards are wrapper rendering artifacts. They prove OMH can shape a Hermes-facing card for the scenario; they are not runtime, connector, delivery, file, memory, or execution evidence.",
+  "cards": [
+    {
+      "actions": [
+        {
+          "id": "prepare_scheduled_ops_blueprint",
+          "kind": "hermes_prompt",
+          "label": "Prepare scheduled ops blueprint",
+          "style": "primary",
+          "value": "Use OMH automation-blueprint for: Every morning, research competitor updates and send a digest only if something changed."
+        },
+        {
+          "id": "inspect_playbook",
+          "kind": "operator_command",
+          "label": "Inspect playbook",
+          "style": "secondary",
+          "value": "omh playbook inspect scheduled-ops-blueprint --json"
+        },
+        {
+          "id": "inspect_harness",
+          "kind": "operator_command",
+          "label": "Inspect harness",
+          "style": "secondary",
+          "value": "omh harness inspect scheduled-ops-blueprint --json"
+        },
+        {
+          "id": "show_boundary",
+          "kind": "static_boundary",
+          "label": "Show evidence boundary",
+          "style": "secondary",
+          "value": "A scheduled ops blueprint is not host cron creation, Hermes automation enablement, gateway delivery, source retrieval, or no-agent execution evidence."
+        }
+      ],
+      "case": {
+        "compatibility_alias": false,
+        "current_gap": "Loop had automation metadata, but the Hermes cron-ready blueprint surface was the only partially implemented member of this pack.",
+        "direct_skill_invocation": "$automation-blueprint Every morning, research competitor updates and send a digest only if something changed.",
+        "docs_visibility": "primary_workflow_skill",
+        "evidence_boundary": "A scheduled ops blueprint is not host cron creation, Hermes automation enablement, gateway delivery, source retrieval, or no-agent execution evidence.",
+        "exposure": "workflow_skill",
+        "feature_surface": "automation-blueprint skill: schedule intent, skill list, delivery target, silence policy, and confirmation/status card.",
+        "goal": "G1",
+        "harness": "scheduled-ops-blueprint",
+        "hermes_chat_prompt": "Use OMH automation-blueprint for: Every morning, research competitor updates and send a digest only if something changed.",
+        "hermes_use_case": "Turn a plain recurring request into a Hermes cron/automation blueprint with delivery target and confirmation card.",
+        "id": "natural-automation-blueprint",
+        "install_visibility": true,
+        "keywords": [
+          "cron",
+          "automation",
+          "every morning",
+          "daily",
+          "digest",
+          "slack",
+          "discord",
+          "telegram",
+          "\ub9e4\uc77c",
+          "\uc815\uae30",
+          "\uc790\ub3d9\ud654"
+        ],
+        "next_action": "prepare_scheduled_ops_blueprint",
+        "playbook": "scheduled-ops-blueprint",
+        "preferred_usage": "Use as an installed Hermes workflow skill when the user asks for recurring automation or scheduled ops planning.",
+        "primary_skill": "automation-blueprint",
+        "priority": 1,
+        "projections": [
+          "routable",
+          "installable",
+          "playbook",
+          "harness",
+          "workflow_reference",
+          "capability"
+        ],
+        "proof_surfaces": [
+          "omh ops blueprint",
+          "omh playbook inspect scheduled-ops-blueprint",
+          "omh harness inspect scheduled-ops-blueprint"
+        ],
+        "title": "Natural-language scheduled automation",
+        "user_value": "Hermes can shape recurring work without pretending cron, source retrieval, or delivery already happened."
+      },
+      "chat_surface": {
+        "body_lines": [
+          "Turn a plain recurring request into a Hermes cron/automation blueprint with delivery target and confirmation card.",
+          "Route: automation-blueprint -> prepare_scheduled_ops_blueprint.",
+          "Hermes can shape recurring work without pretending cron, source retrieval, or delivery already happened."
+        ],
+        "direct_skill_invocation": "$automation-blueprint Every morning, research competitor updates and send a digest only if something changed.",
+        "headline": "[omh] Natural-language scheduled automation",
+        "source": "hermes_agent_chat",
+        "status_line": "prepared_not_observed | automation-blueprint | prepare_scheduled_ops_blueprint",
+        "suggested_user_prompt": "Use OMH automation-blueprint for: Every morning, research competitor updates and send a digest only if something changed."
+      },
+      "evidence": {
+        "claim_boundary": "A scheduled ops blueprint is not host cron creation, Hermes automation enablement, gateway delivery, source retrieval, or no-agent execution evidence.",
+        "not_evidence_until_observed": [
+          "runtime_execution",
+          "connector_invocation",
+          "delivery_or_attachment",
+          "file_generation",
+          "memory_mutation",
+          "executor_dispatch",
+          "executor_result",
+          "verification",
+          "review",
+          "ci",
+          "merge"
+        ],
+        "state": "prepared_not_observed"
+      },
+      "goal": "G1",
+      "id": "natural-automation-blueprint",
+      "operator_commands": [
+        "omh cases inspect G1 --json",
+        "omh playbook inspect scheduled-ops-blueprint --json",
+        "omh harness inspect scheduled-ops-blueprint --json"
+      ],
+      "route": {
+        "compatibility_alias": false,
+        "exposure": "workflow_skill",
+        "harness": "scheduled-ops-blueprint",
+        "install_visibility": true,
+        "next_action": "prepare_scheduled_ops_blueprint",
+        "playbook": "scheduled-ops-blueprint",
+        "primary_skill": "automation-blueprint"
+      },
+      "schema_version": "omh_use_case_demo_card/v1",
+      "title": "Natural-language scheduled automation",
+      "wrapper_card": {
+        "chips": [
+          "G1",
+          "automation-blueprint",
+          "workflow_skill",
+          "prepare_scheduled_ops_blueprint"
+        ],
+        "component": "omh_use_case_card",
+        "headline": "[omh] Natural-language scheduled automation",
+        "render_profile": "chat_first",
+        "sections": [
+          {
+            "body": "Turn a plain recurring request into a Hermes cron/automation blueprint with delivery target and confirmation card.",
+            "id": "why_this_route",
+            "title": "Why this workflow"
+          },
+          {
+            "body": "automation-blueprint skill: schedule intent, skill list, delivery target, silence policy, and confirmation/status card.",
+            "id": "what_omh_prepares",
+            "title": "What OMH prepares"
+          },
+          {
+            "body": "A scheduled ops blueprint is not host cron creation, Hermes automation enablement, gateway delivery, source retrieval, or no-agent execution evidence.",
+            "id": "evidence_boundary",
+            "title": "What is not evidence yet"
+          }
+        ],
+        "status": "prepared_not_observed",
+        "summary": "Hermes can shape recurring work without pretending cron, source retrieval, or delivery already happened."
+      }
+    },
+    {
+      "actions": [
+        {
+          "id": "prepare_github_event_ops_card",
+          "kind": "hermes_prompt",
+          "label": "Prepare github event ops card",
+          "style": "primary",
+          "value": "Use OMH github-event-ops for: PR opened with failing CI; decide whether to review, label, or prepare a fix handoff."
+        },
+        {
+          "id": "inspect_playbook",
+          "kind": "operator_command",
+          "label": "Inspect playbook",
+          "style": "secondary",
+          "value": "omh playbook inspect github-event-ops --json"
+        },
+        {
+          "id": "inspect_harness",
+          "kind": "operator_command",
+          "label": "Inspect harness",
+          "style": "secondary",
+          "value": "omh harness inspect github-event-ops --json"
+        },
+        {
+          "id": "show_boundary",
+          "kind": "static_boundary",
+          "label": "Show evidence boundary",
+          "style": "secondary",
+          "value": "A GitHub event ops card is not webhook delivery, GitHub API mutation, label application, review completion, CI rerun, or fix execution evidence."
+        }
+      ],
+      "case": {
+        "compatibility_alias": true,
+        "current_gap": "OMH had handoff/status strength, but GitHub event recipes were not first-class.",
+        "direct_skill_invocation": "$github-event-ops PR opened with failing CI; decide whether to review, label, or prepare a fix handoff.",
+        "docs_visibility": "compatibility_reference",
+        "evidence_boundary": "A GitHub event ops card is not webhook delivery, GitHub API mutation, label application, review completion, CI rerun, or fix execution evidence.",
+        "exposure": "router_only",
+        "feature_surface": "github-event-ops router surface: PR/issue/CI event classification with label/review/fix-handoff actions.",
+        "goal": "G2",
+        "harness": "github-event-ops",
+        "hermes_chat_prompt": "Use OMH github-event-ops for: PR opened with failing CI; decide whether to review, label, or prepare a fix handoff.",
+        "hermes_use_case": "Route PR opened, CI failed, issue opened, and review events into review, triage, labeling, or fix-handoff cards.",
+        "id": "github-event-ops",
+        "install_visibility": false,
+        "keywords": [
+          "github",
+          "webhook",
+          "pr opened",
+          "ci failed",
+          "issue opened",
+          "label",
+          "review",
+          "\uae43\ud5c8\ube0c",
+          "\uc774\uc288",
+          "ci"
+        ],
+        "next_action": "prepare_github_event_ops_card",
+        "playbook": "github-event-ops",
+        "preferred_usage": "Prefer natural-language Hermes routing into the GitHub event ops playbook/harness instead of showing this as a primary skill picker item.",
+        "primary_skill": "github-event-ops",
+        "priority": 2,
+        "projections": [
+          "routable",
+          "playbook",
+          "harness",
+          "workflow_reference",
+          "capability"
+        ],
+        "proof_surfaces": [
+          "omh recommend",
+          "omh playbook inspect github-event-ops",
+          "omh harness inspect github-event-ops"
+        ],
+        "title": "GitHub PR/Issue event operations",
+        "user_value": "Maintainers can paste or receive GitHub events and get a safe next action without claiming a bot mutated GitHub."
+      },
+      "chat_surface": {
+        "body_lines": [
+          "Route PR opened, CI failed, issue opened, and review events into review, triage, labeling, or fix-handoff cards.",
+          "Route: github-event-ops -> prepare_github_event_ops_card.",
+          "Maintainers can paste or receive GitHub events and get a safe next action without claiming a bot mutated GitHub."
+        ],
+        "direct_skill_invocation": "$github-event-ops PR opened with failing CI; decide whether to review, label, or prepare a fix handoff.",
+        "headline": "[omh] GitHub PR/Issue event operations",
+        "source": "hermes_agent_chat",
+        "status_line": "prepared_not_observed | github-event-ops | prepare_github_event_ops_card",
+        "suggested_user_prompt": "Use OMH github-event-ops for: PR opened with failing CI; decide whether to review, label, or prepare a fix handoff."
+      },
+      "evidence": {
+        "claim_boundary": "A GitHub event ops card is not webhook delivery, GitHub API mutation, label application, review completion, CI rerun, or fix execution evidence.",
+        "not_evidence_until_observed": [
+          "runtime_execution",
+          "connector_invocation",
+          "delivery_or_attachment",
+          "file_generation",
+          "memory_mutation",
+          "executor_dispatch",
+          "executor_result",
+          "verification",
+          "review",
+          "ci",
+          "merge"
+        ],
+        "state": "prepared_not_observed"
+      },
+      "goal": "G2",
+      "id": "github-event-ops",
+      "operator_commands": [
+        "omh cases inspect G2 --json",
+        "omh playbook inspect github-event-ops --json",
+        "omh harness inspect github-event-ops --json"
+      ],
+      "route": {
+        "compatibility_alias": true,
+        "exposure": "router_only",
+        "harness": "github-event-ops",
+        "install_visibility": false,
+        "next_action": "prepare_github_event_ops_card",
+        "playbook": "github-event-ops",
+        "primary_skill": "github-event-ops"
+      },
+      "schema_version": "omh_use_case_demo_card/v1",
+      "title": "GitHub PR/Issue event operations",
+      "wrapper_card": {
+        "chips": [
+          "G2",
+          "github-event-ops",
+          "router_only",
+          "prepare_github_event_ops_card"
+        ],
+        "component": "omh_use_case_card",
+        "headline": "[omh] GitHub PR/Issue event operations",
+        "render_profile": "chat_first",
+        "sections": [
+          {
+            "body": "Route PR opened, CI failed, issue opened, and review events into review, triage, labeling, or fix-handoff cards.",
+            "id": "why_this_route",
+            "title": "Why this workflow"
+          },
+          {
+            "body": "github-event-ops router surface: PR/issue/CI event classification with label/review/fix-handoff actions.",
+            "id": "what_omh_prepares",
+            "title": "What OMH prepares"
+          },
+          {
+            "body": "A GitHub event ops card is not webhook delivery, GitHub API mutation, label application, review completion, CI rerun, or fix execution evidence.",
+            "id": "evidence_boundary",
+            "title": "What is not evidence yet"
+          }
+        ],
+        "status": "prepared_not_observed",
+        "summary": "Maintainers can paste or receive GitHub events and get a safe next action without claiming a bot mutated GitHub."
+      }
+    },
+    {
+      "actions": [
+        {
+          "id": "prepare_agent_board_card",
+          "kind": "hermes_prompt",
+          "label": "Prepare agent board card",
+          "style": "primary",
+          "value": "Use OMH agent-board for: Coordinate CTO, PM, QA, and release agents on this launch checklist."
+        },
+        {
+          "id": "inspect_playbook",
+          "kind": "operator_command",
+          "label": "Inspect playbook",
+          "style": "secondary",
+          "value": "omh playbook inspect agent-board --json"
+        },
+        {
+          "id": "inspect_harness",
+          "kind": "operator_command",
+          "label": "Inspect harness",
+          "style": "secondary",
+          "value": "omh harness inspect agent-board --json"
+        },
+        {
+          "id": "show_boundary",
+          "kind": "static_boundary",
+          "label": "Show evidence boundary",
+          "style": "secondary",
+          "value": "An agent board card is not proof that another Hermes target accepted, worked, heartbeat-ed, or completed unless target-specific evidence exists."
+        }
+      ],
+      "case": {
+        "compatibility_alias": true,
+        "current_gap": "OMH had target topology and team profiles, but not a Hermes board contract.",
+        "direct_skill_invocation": "$agent-board Coordinate CTO, PM, QA, and release agents on this launch checklist.",
+        "docs_visibility": "agent_context_reference",
+        "evidence_boundary": "An agent board card is not proof that another Hermes target accepted, worked, heartbeat-ed, or completed unless target-specific evidence exists.",
+        "exposure": "agent_context",
+        "feature_surface": "agent-board agent context: task/handoff/heartbeat/block/complete cards connected to OMH status.",
+        "goal": "G3",
+        "harness": "agent-board",
+        "hermes_chat_prompt": "Use OMH agent-board for: Coordinate CTO, PM, QA, and release agents on this launch checklist.",
+        "hermes_use_case": "Let multiple Hermes profiles or agents collaborate through task, handoff, heartbeat, blocker, and completion states.",
+        "id": "agent-board",
+        "install_visibility": false,
+        "keywords": [
+          "agent board",
+          "kanban",
+          "multi agent",
+          "heartbeat",
+          "blocker",
+          "handoff",
+          "profile",
+          "\uce78\ubc18",
+          "\uc5ec\ub7ec \uc5d0\uc774\uc804\ud2b8"
+        ],
+        "next_action": "prepare_agent_board_card",
+        "playbook": "agent-board",
+        "preferred_usage": "Use as Hermes agent/context guidance for board-shaped collaboration; keep direct invocation compatibility only for existing references.",
+        "primary_skill": "agent-board",
+        "priority": 3,
+        "projections": [
+          "routable",
+          "playbook",
+          "harness",
+          "workflow_reference",
+          "capability"
+        ],
+        "proof_surfaces": [
+          "omh recommend",
+          "omh playbook inspect agent-board",
+          "omh harness inspect agent-board"
+        ],
+        "title": "Multi-agent Kanban board",
+        "user_value": "Teams see who owns each lane and which states are only prepared versus observed."
+      },
+      "chat_surface": {
+        "body_lines": [
+          "Let multiple Hermes profiles or agents collaborate through task, handoff, heartbeat, blocker, and completion states.",
+          "Route: agent-board -> prepare_agent_board_card.",
+          "Teams see who owns each lane and which states are only prepared versus observed."
+        ],
+        "direct_skill_invocation": "$agent-board Coordinate CTO, PM, QA, and release agents on this launch checklist.",
+        "headline": "[omh] Multi-agent Kanban board",
+        "source": "hermes_agent_chat",
+        "status_line": "prepared_not_observed | agent-board | prepare_agent_board_card",
+        "suggested_user_prompt": "Use OMH agent-board for: Coordinate CTO, PM, QA, and release agents on this launch checklist."
+      },
+      "evidence": {
+        "claim_boundary": "An agent board card is not proof that another Hermes target accepted, worked, heartbeat-ed, or completed unless target-specific evidence exists.",
+        "not_evidence_until_observed": [
+          "runtime_execution",
+          "connector_invocation",
+          "delivery_or_attachment",
+          "file_generation",
+          "memory_mutation",
+          "executor_dispatch",
+          "executor_result",
+          "verification",
+          "review",
+          "ci",
+          "merge"
+        ],
+        "state": "prepared_not_observed"
+      },
+      "goal": "G3",
+      "id": "agent-board",
+      "operator_commands": [
+        "omh cases inspect G3 --json",
+        "omh playbook inspect agent-board --json",
+        "omh harness inspect agent-board --json"
+      ],
+      "route": {
+        "compatibility_alias": true,
+        "exposure": "agent_context",
+        "harness": "agent-board",
+        "install_visibility": false,
+        "next_action": "prepare_agent_board_card",
+        "playbook": "agent-board",
+        "primary_skill": "agent-board"
+      },
+      "schema_version": "omh_use_case_demo_card/v1",
+      "title": "Multi-agent Kanban board",
+      "wrapper_card": {
+        "chips": [
+          "G3",
+          "agent-board",
+          "agent_context",
+          "prepare_agent_board_card"
+        ],
+        "component": "omh_use_case_card",
+        "headline": "[omh] Multi-agent Kanban board",
+        "render_profile": "chat_first",
+        "sections": [
+          {
+            "body": "Let multiple Hermes profiles or agents collaborate through task, handoff, heartbeat, blocker, and completion states.",
+            "id": "why_this_route",
+            "title": "Why this workflow"
+          },
+          {
+            "body": "agent-board agent context: task/handoff/heartbeat/block/complete cards connected to OMH status.",
+            "id": "what_omh_prepares",
+            "title": "What OMH prepares"
+          },
+          {
+            "body": "An agent board card is not proof that another Hermes target accepted, worked, heartbeat-ed, or completed unless target-specific evidence exists.",
+            "id": "evidence_boundary",
+            "title": "What is not evidence yet"
+          }
+        ],
+        "status": "prepared_not_observed",
+        "summary": "Teams see who owns each lane and which states are only prepared versus observed."
+      }
+    },
+    {
+      "actions": [
+        {
+          "id": "prepare_memory_curation_review",
+          "kind": "hermes_prompt",
+          "label": "Prepare memory curation review",
+          "style": "primary",
+          "value": "Use OMH memory-curation-review for: Inspect stale project memories and ask me what to keep."
+        },
+        {
+          "id": "inspect_playbook",
+          "kind": "operator_command",
+          "label": "Inspect playbook",
+          "style": "secondary",
+          "value": "omh playbook inspect memory-curation-review --json"
+        },
+        {
+          "id": "inspect_harness",
+          "kind": "operator_command",
+          "label": "Inspect harness",
+          "style": "secondary",
+          "value": "omh harness inspect memory-curation-review --json"
+        },
+        {
+          "id": "show_boundary",
+          "kind": "static_boundary",
+          "label": "Show evidence boundary",
+          "style": "secondary",
+          "value": "A memory curation review is not Hermes internal memory, MEMORY.md, USER.md, or skill-file modification evidence."
+        }
+      ],
+      "case": {
+        "compatibility_alias": false,
+        "current_gap": "OMH had memory inspect, but not a deep Hermes MEMORY.md/USER.md/curator flow.",
+        "direct_skill_invocation": "$memory-curation-review Inspect stale project memories and ask me what to keep.",
+        "docs_visibility": "primary_workflow_skill",
+        "evidence_boundary": "A memory curation review is not Hermes internal memory, MEMORY.md, USER.md, or skill-file modification evidence.",
+        "exposure": "workflow_skill",
+        "feature_surface": "memory-curation-review skill: candidate cleanup list, conflict detection, and human approval gates.",
+        "goal": "G4",
+        "harness": "memory-curation-review",
+        "hermes_chat_prompt": "Use OMH memory-curation-review for: Inspect stale project memories and ask me what to keep.",
+        "hermes_use_case": "Review stale memories, conflicting facts, and duplicate skills with approve/reject/update actions.",
+        "id": "memory-curation-review",
+        "install_visibility": true,
+        "keywords": [
+          "memory",
+          "curation",
+          "stale",
+          "conflict",
+          "duplicate",
+          "MEMORY.md",
+          "USER.md",
+          "\uae30\uc5b5",
+          "\uba54\ubaa8\ub9ac",
+          "\uc911\ubcf5"
+        ],
+        "next_action": "prepare_memory_curation_review",
+        "playbook": "memory-curation-review",
+        "preferred_usage": "Use as an installed Hermes workflow skill when the user asks to review stale, duplicate, or conflicting memory and skill context.",
+        "primary_skill": "memory-curation-review",
+        "priority": 4,
+        "projections": [
+          "routable",
+          "installable",
+          "playbook",
+          "harness",
+          "workflow_reference",
+          "capability"
+        ],
+        "proof_surfaces": [
+          "omh recommend",
+          "omh playbook inspect memory-curation-review",
+          "omh harness inspect memory-curation-review"
+        ],
+        "title": "Memory and skill curation review",
+        "user_value": "Users can clean memory and skill drift without a silent destructive edit."
+      },
+      "chat_surface": {
+        "body_lines": [
+          "Review stale memories, conflicting facts, and duplicate skills with approve/reject/update actions.",
+          "Route: memory-curation-review -> prepare_memory_curation_review.",
+          "Users can clean memory and skill drift without a silent destructive edit."
+        ],
+        "direct_skill_invocation": "$memory-curation-review Inspect stale project memories and ask me what to keep.",
+        "headline": "[omh] Memory and skill curation review",
+        "source": "hermes_agent_chat",
+        "status_line": "prepared_not_observed | memory-curation-review | prepare_memory_curation_review",
+        "suggested_user_prompt": "Use OMH memory-curation-review for: Inspect stale project memories and ask me what to keep."
+      },
+      "evidence": {
+        "claim_boundary": "A memory curation review is not Hermes internal memory, MEMORY.md, USER.md, or skill-file modification evidence.",
+        "not_evidence_until_observed": [
+          "runtime_execution",
+          "connector_invocation",
+          "delivery_or_attachment",
+          "file_generation",
+          "memory_mutation",
+          "executor_dispatch",
+          "executor_result",
+          "verification",
+          "review",
+          "ci",
+          "merge"
+        ],
+        "state": "prepared_not_observed"
+      },
+      "goal": "G4",
+      "id": "memory-curation-review",
+      "operator_commands": [
+        "omh cases inspect G4 --json",
+        "omh playbook inspect memory-curation-review --json",
+        "omh harness inspect memory-curation-review --json"
+      ],
+      "route": {
+        "compatibility_alias": false,
+        "exposure": "workflow_skill",
+        "harness": "memory-curation-review",
+        "install_visibility": true,
+        "next_action": "prepare_memory_curation_review",
+        "playbook": "memory-curation-review",
+        "primary_skill": "memory-curation-review"
+      },
+      "schema_version": "omh_use_case_demo_card/v1",
+      "title": "Memory and skill curation review",
+      "wrapper_card": {
+        "chips": [
+          "G4",
+          "memory-curation-review",
+          "workflow_skill",
+          "prepare_memory_curation_review"
+        ],
+        "component": "omh_use_case_card",
+        "headline": "[omh] Memory and skill curation review",
+        "render_profile": "chat_first",
+        "sections": [
+          {
+            "body": "Review stale memories, conflicting facts, and duplicate skills with approve/reject/update actions.",
+            "id": "why_this_route",
+            "title": "Why this workflow"
+          },
+          {
+            "body": "memory-curation-review skill: candidate cleanup list, conflict detection, and human approval gates.",
+            "id": "what_omh_prepares",
+            "title": "What OMH prepares"
+          },
+          {
+            "body": "A memory curation review is not Hermes internal memory, MEMORY.md, USER.md, or skill-file modification evidence.",
+            "id": "evidence_boundary",
+            "title": "What is not evidence yet"
+          }
+        ],
+        "status": "prepared_not_observed",
+        "summary": "Users can clean memory and skill drift without a silent destructive edit."
+      }
+    },
+    {
+      "actions": [
+        {
+          "id": "prepare_gateway_intent_card",
+          "kind": "hermes_prompt",
+          "label": "Prepare gateway intent card",
+          "style": "primary",
+          "value": "Use OMH gateway-intent-card for: Route this Discord thread update silently unless action is needed."
+        },
+        {
+          "id": "inspect_playbook",
+          "kind": "operator_command",
+          "label": "Inspect playbook",
+          "style": "secondary",
+          "value": "omh playbook inspect gateway-intent-card --json"
+        },
+        {
+          "id": "inspect_harness",
+          "kind": "operator_command",
+          "label": "Inspect harness",
+          "style": "secondary",
+          "value": "omh harness inspect gateway-intent-card --json"
+        },
+        {
+          "id": "show_boundary",
+          "kind": "static_boundary",
+          "label": "Show evidence boundary",
+          "style": "secondary",
+          "value": "A gateway intent card is not platform login, message send, thread mutation, attachment upload, or delivery evidence."
+        }
+      ],
+      "case": {
+        "compatibility_alias": true,
+        "current_gap": "OMH had wrapper contracts, but gateway-native target and delivery models were shallow.",
+        "direct_skill_invocation": "$gateway-intent-card Route this Discord thread update silently unless action is needed.",
+        "docs_visibility": "compatibility_reference",
+        "evidence_boundary": "A gateway intent card is not platform login, message send, thread mutation, attachment upload, or delivery evidence.",
+        "exposure": "router_only",
+        "feature_surface": "gateway-intent-card router surface: origin, thread, delivery, silence, attachment, and status-update policy.",
+        "goal": "G5",
+        "harness": "gateway-intent-card",
+        "hermes_chat_prompt": "Use OMH gateway-intent-card for: Route this Discord thread update silently unless action is needed.",
+        "hermes_use_case": "Normalize Discord, Slack, Telegram, and other gateway sessions into origin/thread/delivery/silent/attachment/status-update policy.",
+        "id": "gateway-intent-card",
+        "install_visibility": false,
+        "keywords": [
+          "gateway",
+          "discord",
+          "slack",
+          "telegram",
+          "thread",
+          "delivery",
+          "attachment",
+          "silent",
+          "\uac8c\uc774\ud2b8\uc6e8\uc774",
+          "\ub514\uc2a4\ucf54\ub4dc",
+          "\uc2ac\ub799"
+        ],
+        "next_action": "prepare_gateway_intent_card",
+        "playbook": "gateway-intent-card",
+        "preferred_usage": "Prefer wrapper or Hermes natural-language routing into gateway intent policy instead of exposing this as a primary user skill.",
+        "primary_skill": "gateway-intent-card",
+        "priority": 5,
+        "projections": [
+          "routable",
+          "playbook",
+          "harness",
+          "workflow_reference",
+          "capability"
+        ],
+        "proof_surfaces": [
+          "omh recommend",
+          "omh playbook inspect gateway-intent-card",
+          "omh harness inspect gateway-intent-card"
+        ],
+        "title": "Gateway-native intent card",
+        "user_value": "Gateway builders get a platform-neutral card Hermes can use without hardcoding a bot SDK into OMH."
+      },
+      "chat_surface": {
+        "body_lines": [
+          "Normalize Discord, Slack, Telegram, and other gateway sessions into origin/thread/delivery/silent/attachment/status-update policy.",
+          "Route: gateway-intent-card -> prepare_gateway_intent_card.",
+          "Gateway builders get a platform-neutral card Hermes can use without hardcoding a bot SDK into OMH."
+        ],
+        "direct_skill_invocation": "$gateway-intent-card Route this Discord thread update silently unless action is needed.",
+        "headline": "[omh] Gateway-native intent card",
+        "source": "hermes_agent_chat",
+        "status_line": "prepared_not_observed | gateway-intent-card | prepare_gateway_intent_card",
+        "suggested_user_prompt": "Use OMH gateway-intent-card for: Route this Discord thread update silently unless action is needed."
+      },
+      "evidence": {
+        "claim_boundary": "A gateway intent card is not platform login, message send, thread mutation, attachment upload, or delivery evidence.",
+        "not_evidence_until_observed": [
+          "runtime_execution",
+          "connector_invocation",
+          "delivery_or_attachment",
+          "file_generation",
+          "memory_mutation",
+          "executor_dispatch",
+          "executor_result",
+          "verification",
+          "review",
+          "ci",
+          "merge"
+        ],
+        "state": "prepared_not_observed"
+      },
+      "goal": "G5",
+      "id": "gateway-intent-card",
+      "operator_commands": [
+        "omh cases inspect G5 --json",
+        "omh playbook inspect gateway-intent-card --json",
+        "omh harness inspect gateway-intent-card --json"
+      ],
+      "route": {
+        "compatibility_alias": true,
+        "exposure": "router_only",
+        "harness": "gateway-intent-card",
+        "install_visibility": false,
+        "next_action": "prepare_gateway_intent_card",
+        "playbook": "gateway-intent-card",
+        "primary_skill": "gateway-intent-card"
+      },
+      "schema_version": "omh_use_case_demo_card/v1",
+      "title": "Gateway-native intent card",
+      "wrapper_card": {
+        "chips": [
+          "G5",
+          "gateway-intent-card",
+          "router_only",
+          "prepare_gateway_intent_card"
+        ],
+        "component": "omh_use_case_card",
+        "headline": "[omh] Gateway-native intent card",
+        "render_profile": "chat_first",
+        "sections": [
+          {
+            "body": "Normalize Discord, Slack, Telegram, and other gateway sessions into origin/thread/delivery/silent/attachment/status-update policy.",
+            "id": "why_this_route",
+            "title": "Why this workflow"
+          },
+          {
+            "body": "gateway-intent-card router surface: origin, thread, delivery, silence, attachment, and status-update policy.",
+            "id": "what_omh_prepares",
+            "title": "What OMH prepares"
+          },
+          {
+            "body": "A gateway intent card is not platform login, message send, thread mutation, attachment upload, or delivery evidence.",
+            "id": "evidence_boundary",
+            "title": "What is not evidence yet"
+          }
+        ],
+        "status": "prepared_not_observed",
+        "summary": "Gateway builders get a platform-neutral card Hermes can use without hardcoding a bot SDK into OMH."
+      }
+    },
+    {
+      "actions": [
+        {
+          "id": "prepare_executor_runtime_readiness",
+          "kind": "hermes_prompt",
+          "label": "Prepare executor runtime readiness",
+          "style": "primary",
+          "value": "Use OMH executor-runtime-readiness for: Can this task run in Codex, Claude Code, or Hermes coding?"
+        },
+        {
+          "id": "inspect_playbook",
+          "kind": "operator_command",
+          "label": "Inspect playbook",
+          "style": "secondary",
+          "value": "omh playbook inspect executor-runtime-readiness --json"
+        },
+        {
+          "id": "inspect_harness",
+          "kind": "operator_command",
+          "label": "Inspect harness",
+          "style": "secondary",
+          "value": "omh harness inspect executor-runtime-readiness --json"
+        },
+        {
+          "id": "show_boundary",
+          "kind": "static_boundary",
+          "label": "Show evidence boundary",
+          "style": "secondary",
+          "value": "Runtime readiness is not executor dispatch, plugin load, tool invocation, code execution, review, CI, or merge evidence."
+        }
+      ],
+      "case": {
+        "compatibility_alias": true,
+        "current_gap": "OMH had executor-neutral handoff, but runtime migration readiness was weak.",
+        "direct_skill_invocation": "$executor-runtime-readiness Can this task run in Codex, Claude Code, or Hermes coding?",
+        "docs_visibility": "harness_reference",
+        "evidence_boundary": "Runtime readiness is not executor dispatch, plugin load, tool invocation, code execution, review, CI, or merge evidence.",
+        "exposure": "harness_only",
+        "feature_surface": "executor-runtime-readiness harness surface: runtime matrix, missing tools, and handoff mode.",
+        "goal": "G6",
+        "harness": "executor-runtime-readiness",
+        "hermes_chat_prompt": "Use OMH executor-runtime-readiness for: Can this task run in Codex, Claude Code, or Hermes coding?",
+        "hermes_use_case": "Show whether Codex, Claude Code, Hermes coding, or an oh-my runtime has the tools, credentials, and handoff mode needed.",
+        "id": "executor-runtime-readiness",
+        "install_visibility": false,
+        "keywords": [
+          "codex",
+          "claude code",
+          "runtime",
+          "executor",
+          "missing tools",
+          "handoff mode",
+          "omx",
+          "omc",
+          "omo",
+          "\ucf54\ub371\uc2a4",
+          "\ud074\ub85c\ub4dc"
+        ],
+        "next_action": "prepare_executor_runtime_readiness",
+        "playbook": "executor-runtime-readiness",
+        "preferred_usage": "Use as a readiness harness/status surface when Hermes needs to compare executor/runtime options before handoff.",
+        "primary_skill": "executor-runtime-readiness",
+        "priority": 6,
+        "projections": [
+          "routable",
+          "playbook",
+          "harness",
+          "workflow_reference",
+          "capability"
+        ],
+        "proof_surfaces": [
+          "omh recommend",
+          "omh playbook inspect executor-runtime-readiness",
+          "omh harness inspect executor-runtime-readiness"
+        ],
+        "title": "Executor runtime readiness",
+        "user_value": "Users can choose Codex, Claude Code, Hermes, or plugin runtimes without guessing hidden capabilities."
+      },
+      "chat_surface": {
+        "body_lines": [
+          "Show whether Codex, Claude Code, Hermes coding, or an oh-my runtime has the tools, credentials, and handoff mode needed.",
+          "Route: executor-runtime-readiness -> prepare_executor_runtime_readiness.",
+          "Users can choose Codex, Claude Code, Hermes, or plugin runtimes without guessing hidden capabilities."
+        ],
+        "direct_skill_invocation": "$executor-runtime-readiness Can this task run in Codex, Claude Code, or Hermes coding?",
+        "headline": "[omh] Executor runtime readiness",
+        "source": "hermes_agent_chat",
+        "status_line": "prepared_not_observed | executor-runtime-readiness | prepare_executor_runtime_readiness",
+        "suggested_user_prompt": "Use OMH executor-runtime-readiness for: Can this task run in Codex, Claude Code, or Hermes coding?"
+      },
+      "evidence": {
+        "claim_boundary": "Runtime readiness is not executor dispatch, plugin load, tool invocation, code execution, review, CI, or merge evidence.",
+        "not_evidence_until_observed": [
+          "runtime_execution",
+          "connector_invocation",
+          "delivery_or_attachment",
+          "file_generation",
+          "memory_mutation",
+          "executor_dispatch",
+          "executor_result",
+          "verification",
+          "review",
+          "ci",
+          "merge"
+        ],
+        "state": "prepared_not_observed"
+      },
+      "goal": "G6",
+      "id": "executor-runtime-readiness",
+      "operator_commands": [
+        "omh cases inspect G6 --json",
+        "omh playbook inspect executor-runtime-readiness --json",
+        "omh harness inspect executor-runtime-readiness --json"
+      ],
+      "route": {
+        "compatibility_alias": true,
+        "exposure": "harness_only",
+        "harness": "executor-runtime-readiness",
+        "install_visibility": false,
+        "next_action": "prepare_executor_runtime_readiness",
+        "playbook": "executor-runtime-readiness",
+        "primary_skill": "executor-runtime-readiness"
+      },
+      "schema_version": "omh_use_case_demo_card/v1",
+      "title": "Executor runtime readiness",
+      "wrapper_card": {
+        "chips": [
+          "G6",
+          "executor-runtime-readiness",
+          "harness_only",
+          "prepare_executor_runtime_readiness"
+        ],
+        "component": "omh_use_case_card",
+        "headline": "[omh] Executor runtime readiness",
+        "render_profile": "chat_first",
+        "sections": [
+          {
+            "body": "Show whether Codex, Claude Code, Hermes coding, or an oh-my runtime has the tools, credentials, and handoff mode needed.",
+            "id": "why_this_route",
+            "title": "Why this workflow"
+          },
+          {
+            "body": "executor-runtime-readiness harness surface: runtime matrix, missing tools, and handoff mode.",
+            "id": "what_omh_prepares",
+            "title": "What OMH prepares"
+          },
+          {
+            "body": "Runtime readiness is not executor dispatch, plugin load, tool invocation, code execution, review, CI, or merge evidence.",
+            "id": "evidence_boundary",
+            "title": "What is not evidence yet"
+          }
+        ],
+        "status": "prepared_not_observed",
+        "summary": "Users can choose Codex, Claude Code, Hermes, or plugin runtimes without guessing hidden capabilities."
+      }
+    },
+    {
+      "actions": [
+        {
+          "id": "prepare_deliverable_package",
+          "kind": "hermes_prompt",
+          "label": "Prepare deliverable package",
+          "style": "primary",
+          "value": "Use OMH deliverable-package for: Turn this research into PPT and PDF with attachment status."
+        },
+        {
+          "id": "inspect_playbook",
+          "kind": "operator_command",
+          "label": "Inspect playbook",
+          "style": "secondary",
+          "value": "omh playbook inspect deliverable-package --json"
+        },
+        {
+          "id": "inspect_harness",
+          "kind": "operator_command",
+          "label": "Inspect harness",
+          "style": "secondary",
+          "value": "omh harness inspect deliverable-package --json"
+        },
+        {
+          "id": "show_boundary",
+          "kind": "static_boundary",
+          "label": "Show evidence boundary",
+          "style": "secondary",
+          "value": "A deliverable package card is not binary generation, render QA, formula recalculation, approval, upload, attachment, or delivery evidence."
+        }
+      ],
+      "case": {
+        "compatibility_alias": false,
+        "current_gap": "OMH had materials-package, but not a Hermes deliverable attachment UX lane.",
+        "direct_skill_invocation": "$deliverable-package Turn this research into PPT and PDF with attachment status.",
+        "docs_visibility": "primary_workflow_skill",
+        "evidence_boundary": "A deliverable package card is not binary generation, render QA, formula recalculation, approval, upload, attachment, or delivery evidence.",
+        "exposure": "workflow_skill",
+        "feature_surface": "deliverable-package skill: file deliverable plan and prepared/generated/attached status card.",
+        "goal": "G7",
+        "harness": "deliverable-package",
+        "hermes_chat_prompt": "Use OMH deliverable-package for: Turn this research into PPT and PDF with attachment status.",
+        "hermes_use_case": "Track PPT, PDF, XLSX, DOCX, HWP, Markdown, and attachments through prepared/generated/QA/attached states.",
+        "id": "deliverable-package",
+        "install_visibility": true,
+        "keywords": [
+          "deliverable",
+          "file",
+          "attachment",
+          "ppt",
+          "pdf",
+          "xlsx",
+          "docx",
+          "hwp",
+          "keynote",
+          "\uc790\ub8cc",
+          "\ucca8\ubd80",
+          "\ud30c\uc77c"
+        ],
+        "next_action": "prepare_deliverable_package",
+        "playbook": "deliverable-package",
+        "preferred_usage": "Use as an installed Hermes workflow skill when the user asks for file deliverable packaging and attachment lifecycle status.",
+        "primary_skill": "deliverable-package",
+        "priority": 7,
+        "projections": [
+          "routable",
+          "installable",
+          "playbook",
+          "harness",
+          "workflow_reference",
+          "capability"
+        ],
+        "proof_surfaces": [
+          "omh recommend",
+          "omh playbook inspect deliverable-package",
+          "omh harness inspect deliverable-package"
+        ],
+        "title": "Deliverable file package",
+        "user_value": "Users can ask for files in chat and see exactly whether they are planned, generated, QAed, approved, or attached."
+      },
+      "chat_surface": {
+        "body_lines": [
+          "Track PPT, PDF, XLSX, DOCX, HWP, Markdown, and attachments through prepared/generated/QA/attached states.",
+          "Route: deliverable-package -> prepare_deliverable_package.",
+          "Users can ask for files in chat and see exactly whether they are planned, generated, QAed, approved, or attached."
+        ],
+        "direct_skill_invocation": "$deliverable-package Turn this research into PPT and PDF with attachment status.",
+        "headline": "[omh] Deliverable file package",
+        "source": "hermes_agent_chat",
+        "status_line": "prepared_not_observed | deliverable-package | prepare_deliverable_package",
+        "suggested_user_prompt": "Use OMH deliverable-package for: Turn this research into PPT and PDF with attachment status."
+      },
+      "evidence": {
+        "claim_boundary": "A deliverable package card is not binary generation, render QA, formula recalculation, approval, upload, attachment, or delivery evidence.",
+        "not_evidence_until_observed": [
+          "runtime_execution",
+          "connector_invocation",
+          "delivery_or_attachment",
+          "file_generation",
+          "memory_mutation",
+          "executor_dispatch",
+          "executor_result",
+          "verification",
+          "review",
+          "ci",
+          "merge"
+        ],
+        "state": "prepared_not_observed"
+      },
+      "goal": "G7",
+      "id": "deliverable-package",
+      "operator_commands": [
+        "omh cases inspect G7 --json",
+        "omh playbook inspect deliverable-package --json",
+        "omh harness inspect deliverable-package --json"
+      ],
+      "route": {
+        "compatibility_alias": false,
+        "exposure": "workflow_skill",
+        "harness": "deliverable-package",
+        "install_visibility": true,
+        "next_action": "prepare_deliverable_package",
+        "playbook": "deliverable-package",
+        "primary_skill": "deliverable-package"
+      },
+      "schema_version": "omh_use_case_demo_card/v1",
+      "title": "Deliverable file package",
+      "wrapper_card": {
+        "chips": [
+          "G7",
+          "deliverable-package",
+          "workflow_skill",
+          "prepare_deliverable_package"
+        ],
+        "component": "omh_use_case_card",
+        "headline": "[omh] Deliverable file package",
+        "render_profile": "chat_first",
+        "sections": [
+          {
+            "body": "Track PPT, PDF, XLSX, DOCX, HWP, Markdown, and attachments through prepared/generated/QA/attached states.",
+            "id": "why_this_route",
+            "title": "Why this workflow"
+          },
+          {
+            "body": "deliverable-package skill: file deliverable plan and prepared/generated/attached status card.",
+            "id": "what_omh_prepares",
+            "title": "What OMH prepares"
+          },
+          {
+            "body": "A deliverable package card is not binary generation, render QA, formula recalculation, approval, upload, attachment, or delivery evidence.",
+            "id": "evidence_boundary",
+            "title": "What is not evidence yet"
+          }
+        ],
+        "status": "prepared_not_observed",
+        "summary": "Users can ask for files in chat and see exactly whether they are planned, generated, QAed, approved, or attached."
+      }
+    },
+    {
+      "actions": [
+        {
+          "id": "prepare_voice_operator_card",
+          "kind": "hermes_prompt",
+          "label": "Prepare voice operator card",
+          "style": "primary",
+          "value": "Use OMH voice-operator for: 'release before lunch, check risky parts' from mobile."
+        },
+        {
+          "id": "inspect_playbook",
+          "kind": "operator_command",
+          "label": "Inspect playbook",
+          "style": "secondary",
+          "value": "omh playbook inspect voice-operator --json"
+        },
+        {
+          "id": "inspect_harness",
+          "kind": "operator_command",
+          "label": "Inspect harness",
+          "style": "secondary",
+          "value": "omh harness inspect voice-operator --json"
+        },
+        {
+          "id": "show_boundary",
+          "kind": "static_boundary",
+          "label": "Show evidence boundary",
+          "style": "secondary",
+          "value": "A voice operator card is not speech recognition proof, mobile notification delivery, platform action, or accepted execution evidence."
+        }
+      ],
+      "case": {
+        "compatibility_alias": true,
+        "current_gap": "OMH had setup language UX, but no voice-first workflow guidance.",
+        "direct_skill_invocation": "$voice-operator 'release before lunch, check risky parts' from mobile.",
+        "docs_visibility": "agent_context_reference",
+        "evidence_boundary": "A voice operator card is not speech recognition proof, mobile notification delivery, platform action, or accepted execution evidence.",
+        "exposure": "agent_context",
+        "feature_surface": "voice-operator agent context: short command normalization, ambiguity check, and safe confirmation card.",
+        "goal": "G8",
+        "harness": "voice-operator",
+        "hermes_chat_prompt": "Use OMH voice-operator for: 'release before lunch, check risky parts' from mobile.",
+        "hermes_use_case": "Convert terse voice/mobile commands into clarify, plan, status, handoff, or confirmation actions.",
+        "id": "voice-operator",
+        "install_visibility": false,
+        "keywords": [
+          "voice",
+          "mobile",
+          "accessibility",
+          "short command",
+          "spoken",
+          "hands free",
+          "\uc74c\uc131",
+          "\ubaa8\ubc14\uc77c",
+          "\uc811\uadfc\uc131"
+        ],
+        "next_action": "prepare_voice_operator_card",
+        "playbook": "voice-operator",
+        "preferred_usage": "Use as Hermes voice/mobile context guidance that normalizes short commands before choosing a concrete workflow.",
+        "primary_skill": "voice-operator",
+        "priority": 8,
+        "projections": [
+          "routable",
+          "harness",
+          "workflow_reference",
+          "capability"
+        ],
+        "proof_surfaces": [
+          "omh recommend",
+          "omh playbook inspect voice-operator",
+          "omh harness inspect voice-operator"
+        ],
+        "title": "Voice and mobile operator",
+        "user_value": "Voice and mobile users get concise, safe routing instead of long CLI-like responses."
+      },
+      "chat_surface": {
+        "body_lines": [
+          "Convert terse voice/mobile commands into clarify, plan, status, handoff, or confirmation actions.",
+          "Route: voice-operator -> prepare_voice_operator_card.",
+          "Voice and mobile users get concise, safe routing instead of long CLI-like responses."
+        ],
+        "direct_skill_invocation": "$voice-operator 'release before lunch, check risky parts' from mobile.",
+        "headline": "[omh] Voice and mobile operator",
+        "source": "hermes_agent_chat",
+        "status_line": "prepared_not_observed | voice-operator | prepare_voice_operator_card",
+        "suggested_user_prompt": "Use OMH voice-operator for: 'release before lunch, check risky parts' from mobile."
+      },
+      "evidence": {
+        "claim_boundary": "A voice operator card is not speech recognition proof, mobile notification delivery, platform action, or accepted execution evidence.",
+        "not_evidence_until_observed": [
+          "runtime_execution",
+          "connector_invocation",
+          "delivery_or_attachment",
+          "file_generation",
+          "memory_mutation",
+          "executor_dispatch",
+          "executor_result",
+          "verification",
+          "review",
+          "ci",
+          "merge"
+        ],
+        "state": "prepared_not_observed"
+      },
+      "goal": "G8",
+      "id": "voice-operator",
+      "operator_commands": [
+        "omh cases inspect G8 --json",
+        "omh playbook inspect voice-operator --json",
+        "omh harness inspect voice-operator --json"
+      ],
+      "route": {
+        "compatibility_alias": true,
+        "exposure": "agent_context",
+        "harness": "voice-operator",
+        "install_visibility": false,
+        "next_action": "prepare_voice_operator_card",
+        "playbook": "voice-operator",
+        "primary_skill": "voice-operator"
+      },
+      "schema_version": "omh_use_case_demo_card/v1",
+      "title": "Voice and mobile operator",
+      "wrapper_card": {
+        "chips": [
+          "G8",
+          "voice-operator",
+          "agent_context",
+          "prepare_voice_operator_card"
+        ],
+        "component": "omh_use_case_card",
+        "headline": "[omh] Voice and mobile operator",
+        "render_profile": "chat_first",
+        "sections": [
+          {
+            "body": "Convert terse voice/mobile commands into clarify, plan, status, handoff, or confirmation actions.",
+            "id": "why_this_route",
+            "title": "Why this workflow"
+          },
+          {
+            "body": "voice-operator agent context: short command normalization, ambiguity check, and safe confirmation card.",
+            "id": "what_omh_prepares",
+            "title": "What OMH prepares"
+          },
+          {
+            "body": "A voice operator card is not speech recognition proof, mobile notification delivery, platform action, or accepted execution evidence.",
+            "id": "evidence_boundary",
+            "title": "What is not evidence yet"
+          }
+        ],
+        "status": "prepared_not_observed",
+        "summary": "Voice and mobile users get concise, safe routing instead of long CLI-like responses."
+      }
+    },
+    {
+      "actions": [
+        {
+          "id": "prepare_toolbelt_readiness",
+          "kind": "hermes_prompt",
+          "label": "Prepare toolbelt readiness",
+          "style": "primary",
+          "value": "Use OMH toolbelt-readiness for: What MCP or CLI tools do I need for weekly Linear and GitHub triage?"
+        },
+        {
+          "id": "inspect_playbook",
+          "kind": "operator_command",
+          "label": "Inspect playbook",
+          "style": "secondary",
+          "value": "omh playbook inspect toolbelt-readiness --json"
+        },
+        {
+          "id": "inspect_harness",
+          "kind": "operator_command",
+          "label": "Inspect harness",
+          "style": "secondary",
+          "value": "omh harness inspect toolbelt-readiness --json"
+        },
+        {
+          "id": "show_boundary",
+          "kind": "static_boundary",
+          "label": "Show evidence boundary",
+          "style": "secondary",
+          "value": "A toolbelt readiness card is not MCP server installation, credential validation, API access, connector invocation, or successful workflow execution evidence."
+        }
+      ],
+      "case": {
+        "compatibility_alias": true,
+        "current_gap": "OMH setup had MCP preference, but workflow-specific MCP/tool recommendation and verification was weak.",
+        "direct_skill_invocation": "$toolbelt-readiness What MCP or CLI tools do I need for weekly Linear and GitHub triage?",
+        "docs_visibility": "harness_reference",
+        "evidence_boundary": "A toolbelt readiness card is not MCP server installation, credential validation, API access, connector invocation, or successful workflow execution evidence.",
+        "exposure": "harness_only",
+        "feature_surface": "toolbelt-readiness harness surface: workflow tool requirements, installed/missing/credential matrix, and next setup action.",
+        "goal": "G9",
+        "harness": "toolbelt-readiness",
+        "hermes_chat_prompt": "Use OMH toolbelt-readiness for: What MCP or CLI tools do I need for weekly Linear and GitHub triage?",
+        "hermes_use_case": "Check which MCP servers, CLIs, APIs, credentials, and connectors a workflow needs before claiming it can run.",
+        "id": "toolbelt-readiness",
+        "install_visibility": false,
+        "keywords": [
+          "mcp",
+          "toolbelt",
+          "tools",
+          "connector",
+          "credential",
+          "cli",
+          "api",
+          "missing tool",
+          "\ucee4\ub125\ud130",
+          "\uc678\ubd80 \ub3c4\uad6c"
+        ],
+        "next_action": "prepare_toolbelt_readiness",
+        "playbook": "toolbelt-readiness",
+        "preferred_usage": "Use as a readiness harness when Hermes needs to show missing MCP, CLI, API, credential, or connector requirements.",
+        "primary_skill": "toolbelt-readiness",
+        "priority": 9,
+        "projections": [
+          "routable",
+          "playbook",
+          "harness",
+          "workflow_reference",
+          "capability"
+        ],
+        "proof_surfaces": [
+          "omh recommend",
+          "omh playbook inspect toolbelt-readiness",
+          "omh harness inspect toolbelt-readiness"
+        ],
+        "title": "MCP and external toolbelt readiness",
+        "user_value": "Users see missing MCP/CLI/API pieces before an automation or handoff overclaims readiness."
+      },
+      "chat_surface": {
+        "body_lines": [
+          "Check which MCP servers, CLIs, APIs, credentials, and connectors a workflow needs before claiming it can run.",
+          "Route: toolbelt-readiness -> prepare_toolbelt_readiness.",
+          "Users see missing MCP/CLI/API pieces before an automation or handoff overclaims readiness."
+        ],
+        "direct_skill_invocation": "$toolbelt-readiness What MCP or CLI tools do I need for weekly Linear and GitHub triage?",
+        "headline": "[omh] MCP and external toolbelt readiness",
+        "source": "hermes_agent_chat",
+        "status_line": "prepared_not_observed | toolbelt-readiness | prepare_toolbelt_readiness",
+        "suggested_user_prompt": "Use OMH toolbelt-readiness for: What MCP or CLI tools do I need for weekly Linear and GitHub triage?"
+      },
+      "evidence": {
+        "claim_boundary": "A toolbelt readiness card is not MCP server installation, credential validation, API access, connector invocation, or successful workflow execution evidence.",
+        "not_evidence_until_observed": [
+          "runtime_execution",
+          "connector_invocation",
+          "delivery_or_attachment",
+          "file_generation",
+          "memory_mutation",
+          "executor_dispatch",
+          "executor_result",
+          "verification",
+          "review",
+          "ci",
+          "merge"
+        ],
+        "state": "prepared_not_observed"
+      },
+      "goal": "G9",
+      "id": "toolbelt-readiness",
+      "operator_commands": [
+        "omh cases inspect G9 --json",
+        "omh playbook inspect toolbelt-readiness --json",
+        "omh harness inspect toolbelt-readiness --json"
+      ],
+      "route": {
+        "compatibility_alias": true,
+        "exposure": "harness_only",
+        "harness": "toolbelt-readiness",
+        "install_visibility": false,
+        "next_action": "prepare_toolbelt_readiness",
+        "playbook": "toolbelt-readiness",
+        "primary_skill": "toolbelt-readiness"
+      },
+      "schema_version": "omh_use_case_demo_card/v1",
+      "title": "MCP and external toolbelt readiness",
+      "wrapper_card": {
+        "chips": [
+          "G9",
+          "toolbelt-readiness",
+          "harness_only",
+          "prepare_toolbelt_readiness"
+        ],
+        "component": "omh_use_case_card",
+        "headline": "[omh] MCP and external toolbelt readiness",
+        "render_profile": "chat_first",
+        "sections": [
+          {
+            "body": "Check which MCP servers, CLIs, APIs, credentials, and connectors a workflow needs before claiming it can run.",
+            "id": "why_this_route",
+            "title": "Why this workflow"
+          },
+          {
+            "body": "toolbelt-readiness harness surface: workflow tool requirements, installed/missing/credential matrix, and next setup action.",
+            "id": "what_omh_prepares",
+            "title": "What OMH prepares"
+          },
+          {
+            "body": "A toolbelt readiness card is not MCP server installation, credential validation, API access, connector invocation, or successful workflow execution evidence.",
+            "id": "evidence_boundary",
+            "title": "What is not evidence yet"
+          }
+        ],
+        "status": "prepared_not_observed",
+        "summary": "Users see missing MCP/CLI/API pieces before an automation or handoff overclaims readiness."
+      }
+    },
+    {
+      "actions": [
+        {
+          "id": "prepare_ops_observability_card",
+          "kind": "hermes_prompt",
+          "label": "Prepare ops observability card",
+          "style": "primary",
+          "value": "Use OMH ops-observability-card for: Show token, cost, latency, and last run status for this loop."
+        },
+        {
+          "id": "inspect_playbook",
+          "kind": "operator_command",
+          "label": "Inspect playbook",
+          "style": "secondary",
+          "value": "omh playbook inspect ops-observability-card --json"
+        },
+        {
+          "id": "inspect_harness",
+          "kind": "operator_command",
+          "label": "Inspect harness",
+          "style": "secondary",
+          "value": "omh harness inspect ops-observability-card --json"
+        },
+        {
+          "id": "show_boundary",
+          "kind": "static_boundary",
+          "label": "Show evidence boundary",
+          "style": "secondary",
+          "value": "An ops observability card is not billing truth, provider quota truth, complete tracing, performance proof, or workflow completion evidence."
+        }
+      ],
+      "case": {
+        "compatibility_alias": true,
+        "current_gap": "OMH evidence boundaries were strong, but runtime cost/latency telemetry contract was weak.",
+        "direct_skill_invocation": "$ops-observability-card Show token, cost, latency, and last run status for this loop.",
+        "docs_visibility": "harness_reference",
+        "evidence_boundary": "An ops observability card is not billing truth, provider quota truth, complete tracing, performance proof, or workflow completion evidence.",
+        "exposure": "harness_only",
+        "feature_surface": "ops-observability-card harness surface: wrapper-safe token, cost, latency, run history, queue, and failure-mode status card.",
+        "goal": "G10",
+        "harness": "ops-observability-card",
+        "hermes_chat_prompt": "Use OMH ops-observability-card for: Show token, cost, latency, and last run status for this loop.",
+        "hermes_use_case": "Keep automation and loop work from failing silently by showing token/cost/latency/run-history/failure-mode telemetry boundaries.",
+        "id": "ops-observability-card",
+        "install_visibility": false,
+        "keywords": [
+          "observability",
+          "cost",
+          "latency",
+          "token",
+          "run history",
+          "telemetry",
+          "failure mode",
+          "\ube44\uc6a9",
+          "\ud1a0\ud070",
+          "\uad00\uce21\uc131"
+        ],
+        "next_action": "prepare_ops_observability_card",
+        "playbook": "ops-observability-card",
+        "preferred_usage": "Use as a telemetry/status harness for token, cost, latency, run history, and failure-mode boundaries.",
+        "primary_skill": "ops-observability-card",
+        "priority": 10,
+        "projections": [
+          "routable",
+          "playbook",
+          "harness",
+          "workflow_reference",
+          "capability"
+        ],
+        "proof_surfaces": [
+          "omh recommend",
+          "omh playbook inspect ops-observability-card",
+          "omh harness inspect ops-observability-card"
+        ],
+        "title": "Ops observability and cost card",
+        "user_value": "Operators can see health/cost signals without confusing estimates with provider truth or completion evidence."
+      },
+      "chat_surface": {
+        "body_lines": [
+          "Keep automation and loop work from failing silently by showing token/cost/latency/run-history/failure-mode telemetry boundaries.",
+          "Route: ops-observability-card -> prepare_ops_observability_card.",
+          "Operators can see health/cost signals without confusing estimates with provider truth or completion evidence."
+        ],
+        "direct_skill_invocation": "$ops-observability-card Show token, cost, latency, and last run status for this loop.",
+        "headline": "[omh] Ops observability and cost card",
+        "source": "hermes_agent_chat",
+        "status_line": "prepared_not_observed | ops-observability-card | prepare_ops_observability_card",
+        "suggested_user_prompt": "Use OMH ops-observability-card for: Show token, cost, latency, and last run status for this loop."
+      },
+      "evidence": {
+        "claim_boundary": "An ops observability card is not billing truth, provider quota truth, complete tracing, performance proof, or workflow completion evidence.",
+        "not_evidence_until_observed": [
+          "runtime_execution",
+          "connector_invocation",
+          "delivery_or_attachment",
+          "file_generation",
+          "memory_mutation",
+          "executor_dispatch",
+          "executor_result",
+          "verification",
+          "review",
+          "ci",
+          "merge"
+        ],
+        "state": "prepared_not_observed"
+      },
+      "goal": "G10",
+      "id": "ops-observability-card",
+      "operator_commands": [
+        "omh cases inspect G10 --json",
+        "omh playbook inspect ops-observability-card --json",
+        "omh harness inspect ops-observability-card --json"
+      ],
+      "route": {
+        "compatibility_alias": true,
+        "exposure": "harness_only",
+        "harness": "ops-observability-card",
+        "install_visibility": false,
+        "next_action": "prepare_ops_observability_card",
+        "playbook": "ops-observability-card",
+        "primary_skill": "ops-observability-card"
+      },
+      "schema_version": "omh_use_case_demo_card/v1",
+      "title": "Ops observability and cost card",
+      "wrapper_card": {
+        "chips": [
+          "G10",
+          "ops-observability-card",
+          "harness_only",
+          "prepare_ops_observability_card"
+        ],
+        "component": "omh_use_case_card",
+        "headline": "[omh] Ops observability and cost card",
+        "render_profile": "chat_first",
+        "sections": [
+          {
+            "body": "Keep automation and loop work from failing silently by showing token/cost/latency/run-history/failure-mode telemetry boundaries.",
+            "id": "why_this_route",
+            "title": "Why this workflow"
+          },
+          {
+            "body": "ops-observability-card harness surface: wrapper-safe token, cost, latency, run history, queue, and failure-mode status card.",
+            "id": "what_omh_prepares",
+            "title": "What OMH prepares"
+          },
+          {
+            "body": "An ops observability card is not billing truth, provider quota truth, complete tracing, performance proof, or workflow completion evidence.",
+            "id": "evidence_boundary",
+            "title": "What is not evidence yet"
+          }
+        ],
+        "status": "prepared_not_observed",
+        "summary": "Operators can see health/cost signals without confusing estimates with provider truth or completion evidence."
+      }
+    }
+  ],
+  "count": 10,
+  "schema_version": "omh_use_case_demo_collection/v1"
+}

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -595,6 +595,12 @@ omh playbook recommend "every morning check competitor news and send a Slack dig
             playbook confidence, and evidence boundary all match; execution,
             review, CI, and merge never count unless observed.
           </p>
+          <p>
+            Export the wrapper-facing G1-G10 card set with
+            <code>omh cases demo --all --json</code>. Each card uses
+            <code>omh_use_case_demo_card/v1</code> and keeps route, action,
+            and evidence state in one deterministic payload.
+          </p>
           <div class="case-grid case-grid--docs" aria-label="Grounded operator case summary">
             <article class="case-card">
               <span>10/10 contract</span>

--- a/site/index.html
+++ b/site/index.html
@@ -617,6 +617,11 @@ omh setup</code>
             how Hermes can classify natural messages without making users pick a command
             or pretending coding already happened.
           </p>
+          <p>
+            The full G1-G10 map also exports <code>omh_use_case_demo_card/v1</code>
+            cards, so wrappers can render the route, next action, and evidence boundary
+            from one local artifact.
+          </p>
         </div>
         <div class="case-grid" aria-label="Grounded OMH operator cases">
           <article class="case-card">

--- a/src/commands/main.py
+++ b/src/commands/main.py
@@ -168,6 +168,7 @@ def build_parser() -> argparse.ArgumentParser:
             "Operator examples:\n"
             "  omh recommend \"risky refactor\"\n"
             "  omh cases recommend \"daily competitor digest\"\n"
+            "  omh cases demo --all\n"
             "  omh playbook recommend \"turn this issue into a PR\"\n"
             "  omh chat interact \"turn this issue into a PR-ready plan\"\n"
             "  omh hud\n"
@@ -254,6 +255,7 @@ First five minutes:
 Useful operator commands:
   omh recommend "risky refactor"
   omh cases recommend "daily competitor digest"
+  omh cases demo --all  Show wrapper-ready G1-G10 use-case cards
   omh playbook recommend "turn this issue into a PR"
   omh chat interact "turn this issue into a PR-ready plan"
   omh hud                Show the compact OMH status line

--- a/src/commands/use_cases.py
+++ b/src/commands/use_cases.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import argparse
 
 from ..installer import OmhError
-from ..use_cases import inspect_use_case, list_use_cases, recommend_use_cases, validate_use_cases
+from ..use_cases import demo_all_use_cases, demo_use_case, inspect_use_case, list_use_cases, recommend_use_cases, validate_use_cases
 from .common import _print_json, _wants_json
 
 
@@ -25,6 +25,27 @@ def cmd_cases_inspect(args: argparse.Namespace) -> int:
         _print_json(payload)
     else:
         _print_case_summary(payload["use_case"])
+    return 0
+
+
+def cmd_cases_demo(args: argparse.Namespace) -> int:
+    try:
+        if args.all:
+            if args.id:
+                raise OmhError("use either `omh cases demo <id>` or `omh cases demo --all`, not both")
+            payload = demo_all_use_cases()
+        else:
+            if not args.id:
+                raise OmhError("use-case id required unless --all is passed")
+            payload = demo_use_case(args.id)
+    except KeyError as exc:
+        raise OmhError(f"unknown use case: {args.id}") from exc
+    if _wants_json(args):
+        _print_json(payload)
+    elif args.all:
+        _print_cases_demo_collection_summary(payload)
+    else:
+        _print_case_demo_summary(payload)
     return 0
 
 
@@ -99,6 +120,62 @@ def _print_case_summary(case: dict[str, object]) -> None:
     print("  For machine-readable output, rerun with `--json`.")
 
 
+def _print_case_demo_summary(card: dict[str, object]) -> None:
+    route = card.get("route", {})
+    chat_surface = card.get("chat_surface", {})
+    evidence = card.get("evidence", {})
+    actions = card.get("actions", [])
+    if not isinstance(route, dict):
+        route = {}
+    if not isinstance(chat_surface, dict):
+        chat_surface = {}
+    if not isinstance(evidence, dict):
+        evidence = {}
+    if not isinstance(actions, list):
+        actions = []
+    print(f"OMH use-case demo card: {card.get('goal')} - {card.get('title')}")
+    print("Route")
+    print(
+        f"  {route.get('primary_skill')} -> {route.get('next_action')} "
+        f"({route.get('exposure')}; playbook {route.get('playbook')}; harness {route.get('harness')})"
+    )
+    print("Hermes card")
+    print(f"  {chat_surface.get('headline')}")
+    for line in chat_surface.get("body_lines", []):
+        print(f"  - {line}")
+    print(f"  Status: {chat_surface.get('status_line')}")
+    print("Actions")
+    for action in actions[:4]:
+        if not isinstance(action, dict):
+            continue
+        print(f"  - {action.get('label')}: {action.get('value')}")
+    print("Boundary")
+    print(f"  {evidence.get('claim_boundary')}")
+    print("  For machine-readable output, rerun with `--json`.")
+
+
+def _print_cases_demo_collection_summary(payload: dict[str, object]) -> None:
+    cards = payload.get("cards", [])
+    if not isinstance(cards, list):
+        cards = []
+    print("OMH G1-G10 use-case demo cards")
+    print("Summary")
+    print(f"  Demo cards: {len(cards)}")
+    for card in cards:
+        if not isinstance(card, dict):
+            continue
+        route = card.get("route", {})
+        if not isinstance(route, dict):
+            route = {}
+        print(f"  - {card.get('goal')}: {card.get('title')} ({route.get('primary_skill')} -> {route.get('next_action')})")
+    print("Boundary")
+    print(f"  {payload.get('boundary')}")
+    print("Next")
+    print("  Inspect one with `omh cases demo G10`.")
+    print("  Export all cards with `omh cases demo --all --json`.")
+    print("  For machine-readable output, rerun with `--json`.")
+
+
 def _print_cases_recommend_summary(payload: dict[str, object]) -> None:
     recommendations = payload.get("recommendations", [])
     if not isinstance(recommendations, list):
@@ -155,6 +232,12 @@ def _add_cases_commands(sub) -> None:
     inspect_cmd.add_argument("id", help="Use-case id such as G10, ops-observability-card, or natural-automation-blueprint.")
     inspect_cmd.add_argument("--json", action="store_true", help="Print the full machine-readable use-case payload.")
     inspect_cmd.set_defaults(func=cmd_cases_inspect)
+
+    demo_cmd = cases_sub.add_parser("demo")
+    demo_cmd.add_argument("id", nargs="?", default="", help="Use-case id such as G10 or ops-observability-card.")
+    demo_cmd.add_argument("--all", action="store_true", help="Print demo cards for all G1-G10 use cases.")
+    demo_cmd.add_argument("--json", action="store_true", help="Print the full machine-readable demo card payload.")
+    demo_cmd.set_defaults(func=cmd_cases_demo)
 
     recommend_cmd = cases_sub.add_parser("recommend")
     recommend_cmd.add_argument("task", nargs="+", help="Natural-language request to map to a representative OMH use case.")

--- a/src/use_cases.py
+++ b/src/use_cases.py
@@ -6,6 +6,8 @@ from typing import Any
 
 
 USE_CASE_CATALOG_SCHEMA_VERSION = "omh_use_case_catalog/v1"
+USE_CASE_DEMO_CARD_SCHEMA_VERSION = "omh_use_case_demo_card/v1"
+USE_CASE_DEMO_COLLECTION_SCHEMA_VERSION = "omh_use_case_demo_collection/v1"
 USE_CASE_RECOMMENDATION_SCHEMA_VERSION = "omh_use_case_recommendation/v1"
 USE_CASE_VALIDATION_SCHEMA_VERSION = "omh_use_case_validation/v1"
 
@@ -243,6 +245,26 @@ def inspect_use_case(case_id: str) -> dict[str, Any]:
     }
 
 
+def demo_use_case(case_id: str) -> dict[str, Any]:
+    case = _find_case(case_id)
+    if case is None:
+        raise KeyError(case_id)
+    return _demo_card(case)
+
+
+def demo_all_use_cases() -> dict[str, Any]:
+    return {
+        "schema_version": USE_CASE_DEMO_COLLECTION_SCHEMA_VERSION,
+        "count": len(USE_CASES),
+        "cards": [_demo_card(case) for case in USE_CASES],
+        "boundary": (
+            "Use-case demo cards are wrapper rendering artifacts. They prove OMH "
+            "can shape a Hermes-facing card for the scenario; they are not runtime, "
+            "connector, delivery, file, memory, or execution evidence."
+        ),
+    }
+
+
 def recommend_use_cases(query: str, *, limit: int = 3) -> dict[str, Any]:
     clean_query = " ".join(query.split())
     if limit < 1:
@@ -371,6 +393,119 @@ def _public_case(case: UseCase) -> dict[str, Any]:
     payload["proof_surfaces"] = list(case.proof_surfaces)
     payload["keywords"] = list(case.keywords)
     return payload
+
+
+def _demo_card(case: UseCase) -> dict[str, Any]:
+    exposure = _public_case(case)
+    return {
+        "schema_version": USE_CASE_DEMO_CARD_SCHEMA_VERSION,
+        "goal": case.goal,
+        "id": case.id,
+        "title": case.title,
+        "route": {
+            "primary_skill": case.primary_skill,
+            "playbook": case.playbook,
+            "harness": case.harness,
+            "exposure": exposure["exposure"],
+            "install_visibility": exposure["install_visibility"],
+            "compatibility_alias": exposure["compatibility_alias"],
+            "next_action": case.next_action,
+        },
+        "chat_surface": {
+            "source": "hermes_agent_chat",
+            "suggested_user_prompt": case.hermes_chat_prompt,
+            "direct_skill_invocation": case.direct_skill_invocation,
+            "headline": f"[omh] {case.title}",
+            "body_lines": [
+                case.hermes_use_case,
+                f"Route: {case.primary_skill} -> {case.next_action}.",
+                case.user_value,
+            ],
+            "status_line": f"prepared_not_observed | {case.primary_skill} | {case.next_action}",
+        },
+        "wrapper_card": {
+            "component": "omh_use_case_card",
+            "render_profile": "chat_first",
+            "status": "prepared_not_observed",
+            "headline": f"[omh] {case.title}",
+            "summary": case.user_value,
+            "sections": [
+                {
+                    "id": "why_this_route",
+                    "title": "Why this workflow",
+                    "body": case.hermes_use_case,
+                },
+                {
+                    "id": "what_omh_prepares",
+                    "title": "What OMH prepares",
+                    "body": case.feature_surface,
+                },
+                {
+                    "id": "evidence_boundary",
+                    "title": "What is not evidence yet",
+                    "body": case.evidence_boundary,
+                },
+            ],
+            "chips": [case.goal, case.primary_skill, exposure["exposure"], case.next_action],
+        },
+        "actions": [
+            {
+                "id": case.next_action,
+                "label": _action_label(case.next_action),
+                "kind": "hermes_prompt",
+                "style": "primary",
+                "value": case.hermes_chat_prompt,
+            },
+            {
+                "id": "inspect_playbook",
+                "label": "Inspect playbook",
+                "kind": "operator_command",
+                "style": "secondary",
+                "value": f"omh playbook inspect {case.playbook} --json",
+            },
+            {
+                "id": "inspect_harness",
+                "label": "Inspect harness",
+                "kind": "operator_command",
+                "style": "secondary",
+                "value": f"omh harness inspect {case.harness} --json",
+            },
+            {
+                "id": "show_boundary",
+                "label": "Show evidence boundary",
+                "kind": "static_boundary",
+                "style": "secondary",
+                "value": case.evidence_boundary,
+            },
+        ],
+        "operator_commands": [
+            f"omh cases inspect {case.goal} --json",
+            f"omh playbook inspect {case.playbook} --json",
+            f"omh harness inspect {case.harness} --json",
+        ],
+        "evidence": {
+            "state": "prepared_not_observed",
+            "claim_boundary": case.evidence_boundary,
+            "not_evidence_until_observed": [
+                "runtime_execution",
+                "connector_invocation",
+                "delivery_or_attachment",
+                "file_generation",
+                "memory_mutation",
+                "executor_dispatch",
+                "executor_result",
+                "verification",
+                "review",
+                "ci",
+                "merge",
+            ],
+        },
+        "case": exposure,
+    }
+
+
+def _action_label(action: str) -> str:
+    return action.replace("_", " ").capitalize()
 
 
 def _find_case(case_id: str) -> UseCase | None:

--- a/tests/test_application_cases.py
+++ b/tests/test_application_cases.py
@@ -63,6 +63,26 @@ class ApplicationCaseArtifactTests(unittest.TestCase):
         self.assertIn("What Gets Recorded", install)
         self.assertNotIn("What Gets Recorded", readme)
 
+    def test_g1_to_g10_demo_fixture_is_wrapper_renderable(self) -> None:
+        code, stdout, stderr = run_cli(["cases", "demo", "--all", "--json"], output_json=False)
+
+        self.assertEqual(code, 0, stderr)
+        self.assertEqual(stderr, "")
+        generated = json.loads(stdout)
+        fixture = json.loads(Path("examples/use-cases/g1-g10-demo-cards.json").read_text(encoding="utf-8"))
+        self.assertEqual(fixture, generated)
+        self.assertEqual(fixture["schema_version"], "omh_use_case_demo_collection/v1")
+        self.assertEqual(fixture["count"], 10)
+        for card in fixture["cards"]:
+            with self.subTest(card=card["goal"]):
+                self.assertEqual(card["schema_version"], "omh_use_case_demo_card/v1")
+                self.assertEqual(card["wrapper_card"]["component"], "omh_use_case_card")
+                self.assertEqual(card["wrapper_card"]["status"], "prepared_not_observed")
+                self.assertEqual(card["evidence"]["state"], "prepared_not_observed")
+                self.assertEqual(card["actions"][0]["id"], card["route"]["next_action"])
+                self.assertIn("not", card["evidence"]["claim_boundary"].lower())
+                self.assertIn("executor_dispatch", card["evidence"]["not_evidence_until_observed"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -653,6 +653,8 @@ class CliTests(unittest.TestCase):
             (["cases", "recommend", "daily", "competitor", "digest"], "OMH use-case recommendation", "recommendations"),
             (["cases", "list"], "OMH Hermes use cases", "use_cases"),
             (["cases", "inspect", "G10"], "OMH use case:", "use_case"),
+            (["cases", "demo", "G10"], "OMH use-case demo card:", "wrapper_card"),
+            (["cases", "demo", "--all"], "OMH G1-G10 use-case demo cards", "cards"),
             (["cases", "validate"], "OMH G1-G10 feature surface validation", "validated"),
             (["playbook", "list"], "OMH playbooks", "playbooks"),
             (["playbook", "inspect", "safe-feature-change"], "OMH playbook:", "playbook"),
@@ -735,6 +737,42 @@ class CliTests(unittest.TestCase):
                 self.assertTrue(item["checks"]["boundary_has_evidence_guard"])
                 self.assertGreaterEqual(len(item["proof_surfaces"]), 3)
                 self.assertIn("not", item["evidence_boundary"].lower())
+
+        status, stdout, stderr = run_cli(["cases", "demo", "G1", "--json"], output_json=False)
+
+        self.assertEqual(status, 0, stderr)
+        self.assertEqual(stderr, "")
+        demo = json.loads(stdout)
+        self.assertEqual(demo["schema_version"], "omh_use_case_demo_card/v1")
+        self.assertEqual(demo["goal"], "G1")
+        self.assertEqual(demo["route"]["primary_skill"], "automation-blueprint")
+        self.assertEqual(demo["route"]["next_action"], "prepare_scheduled_ops_blueprint")
+        self.assertEqual(demo["wrapper_card"]["component"], "omh_use_case_card")
+        self.assertEqual(demo["wrapper_card"]["status"], "prepared_not_observed")
+        self.assertIn("prepared_not_observed", demo["chat_surface"]["status_line"])
+        self.assertEqual(demo["actions"][0]["id"], "prepare_scheduled_ops_blueprint")
+        self.assertEqual(demo["actions"][0]["kind"], "hermes_prompt")
+        self.assertIn("omh playbook inspect scheduled-ops-blueprint", demo["operator_commands"][1])
+        self.assertIn("connector_invocation", demo["evidence"]["not_evidence_until_observed"])
+        self.assertIn("executor_dispatch", demo["evidence"]["not_evidence_until_observed"])
+        self.assertIn("not host cron creation", demo["evidence"]["claim_boundary"])
+
+        status, stdout, stderr = run_cli(["cases", "demo", "--all", "--json"], output_json=False)
+
+        self.assertEqual(status, 0, stderr)
+        self.assertEqual(stderr, "")
+        demo_collection = json.loads(stdout)
+        self.assertEqual(demo_collection["schema_version"], "omh_use_case_demo_collection/v1")
+        self.assertEqual(demo_collection["count"], 10)
+        self.assertEqual([card["goal"] for card in demo_collection["cards"]], [f"G{index}" for index in range(1, 11)])
+        for card in demo_collection["cards"]:
+            with self.subTest(demo_card=card["goal"]):
+                self.assertEqual(card["schema_version"], "omh_use_case_demo_card/v1")
+                self.assertEqual(card["wrapper_card"]["status"], "prepared_not_observed")
+                self.assertEqual(card["evidence"]["state"], "prepared_not_observed")
+                self.assertIn("not", card["evidence"]["claim_boundary"].lower())
+                self.assertEqual(card["actions"][0]["id"], card["route"]["next_action"])
+                self.assertTrue(card["chat_surface"]["headline"].startswith("[omh] "))
 
         examples = (
             ("Every morning send a competitor digest to Slack only if changed", "G1", "automation-blueprint"),

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -1335,6 +1335,9 @@ class RouterContentTests(unittest.TestCase):
         self.assertIn("safe-feature-change", text)
         self.assertIn("결제 실패 피드백을 모아서 회의 주제와 다음 전략을 정리해줘", text)
         self.assertIn("omh demo grounded-score", text)
+        self.assertIn("omh cases demo --all --json", text)
+        self.assertIn("omh_use_case_demo_card/v1", text)
+        self.assertIn("examples/use-cases/g1-g10-demo-cards.json", text)
         self.assertIn("10/10", text)
         self.assertIn("$ultraprocess research the repo", text)
         self.assertIn("feedback-triage", text)
@@ -1401,6 +1404,8 @@ class RouterContentTests(unittest.TestCase):
         self.assertIn('id="operator-cases"', site_docs)
         self.assertIn("Grounded operator cases", site_docs)
         self.assertIn("omh demo grounded-score", site_docs)
+        self.assertIn("omh cases demo --all --json", site_docs)
+        self.assertIn("omh_use_case_demo_card/v1", site_docs)
         self.assertIn("10/10", site_docs)
 
     def test_architecture_docs_include_visual_system_view(self) -> None:


### PR DESCRIPTION
## Feature Report

### What Changed

- Added `omh cases demo <id>` and `omh cases demo --all`.
- Added `omh_use_case_demo_card/v1` for individual G1-G10 use cases and `omh_use_case_demo_collection/v1` for the full set.
- Added a checked-in fixture at `examples/use-cases/g1-g10-demo-cards.json` generated from `omh cases demo --all --json`.
- Updated README, docs, roadmap, and site copy so the G1-G10 use-case map is described as wrapper-renderable, not prose-only.
- Added regression tests that lock schema, actions, route metadata, and prepared-vs-observed evidence boundaries for every demo card.

### Why This Exists

- OMH already had a G1-G10 Hermes use-case catalog, but it was strongest as documentation and catalog metadata.
- To feel more mature in Hermes-hosted chat surfaces, the catalog needs a deterministic card projection that wrapper authors can render directly.
- This moves the application-case story from “we have a table of situations” to “we can export a local artifact showing route, next action, card copy, and evidence boundary for every case.”

### User / Operator Impact

- Operators can run `omh cases demo --all --json` and get a complete wrapper-ready card set for scheduled ops, GitHub events, agent boards, memory curation, gateways, executor readiness, deliverables, voice/mobile, toolbelt readiness, and observability.
- Wrapper authors can render a consistent Hermes card with headline, body lines, chips, primary action, inspect commands, and `prepared_not_observed` state.
- Normal Hermes users still do not need to know the command; this is backend/wrapper infrastructure that makes the chat-first story easier to verify.

### How It Works

- `src/use_cases.py` now projects each `UseCase` into a demo card with route metadata, Hermes-facing copy, wrapper sections, actions, operator commands, and explicit evidence boundaries.
- `src/commands/use_cases.py` exposes the projection through the `cases demo` CLI with human summaries by default and JSON output for wrappers.
- The checked-in fixture is compared against live CLI output in tests to prevent drift.
- Docs and site copy point operators to the demo-card collection without implying that a card proves cron, connector, file generation, memory mutation, executor work, review, CI, or merge happened.

### Files And Contracts Touched

- `src/use_cases.py`
- `src/commands/use_cases.py`
- `src/commands/main.py`
- `examples/use-cases/g1-g10-demo-cards.json`
- `tests/test_cli.py`
- `tests/test_application_cases.py`
- `tests/test_router_content.py`
- `docs/APPLICATION_CASES.md`
- `docs/README.md`
- `docs/ROADMAP.md`
- `README.md`
- `site/index.html`
- `site/docs/index.html`
- New contracts: `omh_use_case_demo_card/v1`, `omh_use_case_demo_collection/v1`

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_cli.py -v` — 186 tests passed.
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_application_cases.py tests/test_router_content.py -v` — 38 tests passed.
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — 646 tests passed.
- [x] `uv run python -m src.cli docs workflows --check` — docs/workflows in sync, 41/41 tap skills checked.
- [x] `uv run python -m compileall -q src tests examples` — passed.
- [x] `uv run python -m src.cli cases demo --all --json` — produced valid JSON.
- [x] Live `cases demo --all --json` output compared against `examples/use-cases/g1-g10-demo-cards.json` — matched.
- [x] `git diff --check` — passed.
- [ ] Manual Hermes/TUI check — not run; this PR adds deterministic backend/wrapper artifacts, not live host rendering.

## Risk

- Low. This is an additive CLI/catalog projection and docs/test update.
- The largest diff is the generated JSON fixture; tests keep it synchronized with live CLI output.
- The evidence language is intentionally conservative so demo cards are not mistaken for observed runtime action.

## Compatibility / Rollout

- Existing `omh cases list`, `inspect`, `recommend`, and `validate` behavior is unchanged.
- Existing chat, playbook, and runtime contracts remain compatible.
- No network/API calls, Hermes core patching, or hidden execution behavior were added.

## Release / Claims

- [x] Release-channel impact considered: additive backend/wrapper CLI projection.
- [x] Runtime/native capability claims are backed by deterministic fixture evidence or marked as not observed.
- [x] Known manual Hermes checks are listed: live Hermes host rendering was not run.

## Follow-Up

- Add richer visual examples for selected cards if a future wrapper/site design pass needs screenshot-like assets.
