### PR TITLE
Add release gate for use-case demo cards

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -60,6 +60,7 @@ python3 -m omh.cli docs workflows --check
 python3 -m omh.cli harness validate
 python3 -m omh.cli release checklist --json
 python3 -m omh.cli release skill-content-smoke --json
+python3 -m omh.cli cases demo --all --json
 python3 -m omh.cli --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke learning review --all
 python3 -m omh.cli --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke install --dry-run --channel stable --version 1.0.1
 python3 -m omh.cli --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke setup --dry-run --channel stable --version 1.0.1
@@ -91,6 +92,12 @@ omh release checklist --version 1.0.1 --json
 It is plan-only: it does not run checks, mutate Hermes, create tags, or publish
 GitHub releases. Treat it as the operator-facing index of the evidence that must
 be attached before a stable tag.
+
+The checklist also gates the G1-G10 use-case demo cards through
+`omh cases demo --all --json`. That proves OMH can render wrapper-safe
+use-case projections with route, action, status-card, and evidence-boundary
+metadata. It is not evidence that cron, connectors, files, memory updates,
+executors, reviews, CI, merges, or delivery actually ran.
 
 ## Hermes CLI Install Smoke
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -44,6 +44,8 @@
   touching real user state
 - G1-G10 use-case demo cards through `omh cases demo`, including a checked-in
   `omh_use_case_demo_collection/v1` fixture for wrapper rendering
+- Release and skill-content smoke now gate those G1-G10 demo cards so route,
+  action, wrapper-card, and evidence-boundary drift fails before release
 - Codex lifecycle helper commands over existing local runtime artifacts
 - Wrapper session plan decisions and restart recovery for accepted handoffs
 - Review, CI, merge-readiness, and merge observation records for delegated

--- a/src/commands/release.py
+++ b/src/commands/release.py
@@ -307,6 +307,7 @@ def _print_skill_content_smoke_summary(payload: dict[str, object]) -> None:
     oversized_role_contexts = payload.get("oversized_role_contexts", [])
     role_context_budget_failures = payload.get("role_context_budget_failures", [])
     capability_budget_failures = payload.get("capability_budget_failures", [])
+    use_case_demo_failures = payload.get("use_case_demo_failures", [])
     print(
         "Full capability manifest: "
         f"{payload.get('full_capability_skill_count')} skill surface(s); "
@@ -325,6 +326,11 @@ def _print_skill_content_smoke_summary(payload: dict[str, object]) -> None:
         f"{payload.get('standalone_capability_skill_count')} workflow skill(s); "
         f"missing {len(missing_standalone) if isinstance(missing_standalone, list) else 0}; "
         f"context missing {len(missing_standalone_context) if isinstance(missing_standalone_context, list) else 0}"
+    )
+    print(
+        "Use-case demo cards: "
+        f"{payload.get('use_case_demo_card_count')}/{payload.get('expected_use_case_demo_card_count')} card(s); "
+        f"failures {len(use_case_demo_failures) if isinstance(use_case_demo_failures, list) else 0}"
     )
     if missing:
         print("Missing representative skills: " + ", ".join(str(item) for item in missing))
@@ -377,6 +383,8 @@ def _print_skill_content_smoke_summary(payload: dict[str, object]) -> None:
         print("Role context budget failures: " + ", ".join(str(item) for item in role_context_budget_failures))
     if capability_budget_failures:
         print("Capability budget failures: " + ", ".join(str(item) for item in capability_budget_failures))
+    if use_case_demo_failures:
+        print("Use-case demo card failures: " + ", ".join(str(item) for item in use_case_demo_failures))
     if isinstance(failed, list) and failed:
         print("Failed markers:")
         for check in failed[:12]:

--- a/src/release.py
+++ b/src/release.py
@@ -32,6 +32,7 @@ from .plugin_bundle.omh.tools.capability_tool import (
 from .release_smoke_core import CommandResult, Runner, bounded_text, expand_home, subprocess_runner
 from .skill_pack import builtin_skill_templates
 from .skills.catalog import builtin_definitions
+from .use_cases import USE_CASES, demo_all_use_cases
 
 REPOSITORY_ARCHIVE_ROOT = "https://github.com/rlaope/oh-my-hermes/archive/refs"
 RELEASE_CHANNELS = ("stable", "preview", "local")
@@ -179,6 +180,16 @@ def release_readiness_checklist(
             False,
             "Harness catalog validation exits successfully.",
             "Harness validation proves local schemas and metadata, not runtime execution.",
+        ),
+        ReleaseChecklistItem(
+            "use_case_demo_cards",
+            "Check G1-G10 use-case demo cards",
+            "uv run python -m src.cli cases demo --all --json",
+            "contract-quality",
+            True,
+            False,
+            "Use-case demo card collection renders all ten G1-G10 cards with route, action, wrapper card, and evidence boundary metadata.",
+            "Use-case demo cards prove wrapper-renderable projections only; they do not prove cron, connector, file, memory, executor, review, CI, merge, or delivery work happened.",
         ),
         ReleaseChecklistItem(
             "stable_install_dry_run",
@@ -702,6 +713,8 @@ def skill_content_smoke() -> dict[str, object]:
     standalone_capability_skill_section_chars = len(
         json.dumps(standalone_capability_items, sort_keys=True, ensure_ascii=False)
     )
+    use_case_demo_cards = demo_all_use_cases()
+    use_case_demo_failures = _use_case_demo_card_failures(use_case_demo_cards)
     max_full_capability_skill_chars = max(
         (len(json.dumps(item, sort_keys=True, ensure_ascii=False)) for item in full_capability_items),
         default=0,
@@ -809,6 +822,7 @@ def skill_content_smoke() -> dict[str, object]:
         and not awareness_budget_failures
         and not role_context_budget_failures
         and not capability_budget_failures
+        and not use_case_demo_failures
     )
     return {
         "schema_version": SKILL_CONTENT_SMOKE_SCHEMA,
@@ -862,6 +876,12 @@ def skill_content_smoke() -> dict[str, object]:
         "standalone_capability_skill_section_chars": standalone_capability_skill_section_chars,
         "max_standalone_capability_skill_chars": max_standalone_capability_skill_chars,
         "capability_budget_failures": capability_budget_failures,
+        "use_case_demo_collection_schema": use_case_demo_cards.get("schema_version"),
+        "use_case_demo_card_count": len(use_case_demo_cards.get("cards", []))
+        if isinstance(use_case_demo_cards.get("cards"), list)
+        else 0,
+        "expected_use_case_demo_card_count": len(USE_CASES),
+        "use_case_demo_failures": use_case_demo_failures,
         "awareness_context_char_limits": {
             "primer_context": AWARENESS_PRIMER_CONTEXT_CHAR_LIMIT,
             "primer_markdown": AWARENESS_PRIMER_MARKDOWN_CHAR_LIMIT,
@@ -883,6 +903,52 @@ def skill_content_smoke() -> dict[str, object]:
             "It does not prove the target Hermes profile installed, loaded, selected, or used those skills in chat."
         ),
     }
+
+
+def _use_case_demo_card_failures(payload: Mapping[str, object]) -> list[str]:
+    failures: list[str] = []
+    if payload.get("schema_version") != "omh_use_case_demo_collection/v1":
+        failures.append("collection_schema")
+    cards = payload.get("cards", [])
+    if not isinstance(cards, Sequence) or isinstance(cards, (str, bytes)):
+        return failures + ["cards_not_sequence"]
+    if len(cards) != len(USE_CASES):
+        failures.append("card_count")
+    expected_goals = [case.goal for case in USE_CASES]
+    observed_goals: list[str] = []
+    for index, card in enumerate(cards):
+        if not isinstance(card, Mapping):
+            failures.append(f"card_{index}_not_mapping")
+            continue
+        goal = str(card.get("goal") or "")
+        observed_goals.append(goal)
+        if card.get("schema_version") != "omh_use_case_demo_card/v1":
+            failures.append(f"{goal or index}_schema")
+        route = card.get("route")
+        wrapper_card = card.get("wrapper_card")
+        evidence = card.get("evidence")
+        actions = card.get("actions")
+        chat_surface = card.get("chat_surface")
+        if not isinstance(route, Mapping) or not route.get("primary_skill") or not route.get("next_action"):
+            failures.append(f"{goal or index}_route")
+        if not isinstance(wrapper_card, Mapping) or wrapper_card.get("component") != "omh_use_case_card":
+            failures.append(f"{goal or index}_wrapper_card")
+        if isinstance(wrapper_card, Mapping) and wrapper_card.get("status") != "prepared_not_observed":
+            failures.append(f"{goal or index}_wrapper_status")
+        if not isinstance(evidence, Mapping) or evidence.get("state") != "prepared_not_observed":
+            failures.append(f"{goal or index}_evidence_state")
+        boundary = str(evidence.get("claim_boundary") if isinstance(evidence, Mapping) else "")
+        if "not " not in boundary.casefold() or "evidence" not in boundary.casefold():
+            failures.append(f"{goal or index}_boundary")
+        if not isinstance(actions, Sequence) or isinstance(actions, (str, bytes)) or not actions:
+            failures.append(f"{goal or index}_actions")
+        elif isinstance(route, Mapping) and isinstance(actions[0], Mapping) and actions[0].get("id") != route.get("next_action"):
+            failures.append(f"{goal or index}_primary_action")
+        if not isinstance(chat_surface, Mapping) or not str(chat_surface.get("headline") or "").startswith("[omh] "):
+            failures.append(f"{goal or index}_chat_surface")
+    if observed_goals != expected_goals:
+        failures.append("goal_order")
+    return failures
 
 
 def _bundled_role_contexts() -> dict[str, str]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1474,6 +1474,7 @@ class CliTests(unittest.TestCase):
         self.assertIn("OMH release checklist for 1.0.0 (v1.0.0)", stdout)
         self.assertIn("Required gates:", stdout)
         self.assertIn("installed_command_smoke", stdout)
+        self.assertIn("use_case_demo_cards", stdout)
         self.assertIn("/tmp/omh --help", stdout)
         self.assertIn("live_tap_smoke", stdout)
         self.assertIn("profile-mutating", stdout)
@@ -1493,6 +1494,7 @@ class CliTests(unittest.TestCase):
         self.assertFalse(payload["observed"])
         items = {item["id"]: item for item in payload["items"]}
         self.assertIn("uv build", items["build_artifacts"]["command"])
+        self.assertIn("cases demo --all --json", items["use_case_demo_cards"]["command"])
         self.assertIn("skill-content-smoke", items["skill_content_smoke"]["command"])
         self.assertIn("setup --dry-run --channel stable --version 1.0.0", items["wheel_setup_dry_run"]["command"])
         self.assertTrue(items["live_tap_smoke"]["requires_release_authority"])
@@ -1522,6 +1524,10 @@ class CliTests(unittest.TestCase):
         self.assertEqual(payload["unexpected_standalone_capability_skills"], [])
         self.assertEqual(payload["missing_standalone_capability_context_skills"], [])
         self.assertEqual(payload["capability_budget_failures"], [])
+        self.assertEqual(payload["use_case_demo_collection_schema"], "omh_use_case_demo_collection/v1")
+        self.assertEqual(payload["use_case_demo_card_count"], 10)
+        self.assertEqual(payload["expected_use_case_demo_card_count"], 10)
+        self.assertEqual(payload["use_case_demo_failures"], [])
         self.assertLessEqual(
             payload["full_capability_skill_section_chars"],
             payload["capability_context_char_limits"]["full_skill_section"],
@@ -1549,6 +1555,7 @@ class CliTests(unittest.TestCase):
         self.assertIn("Full capability manifest:", stdout)
         self.assertIn("Playbook capabilities:", stdout)
         self.assertIn("Plugin fallback capabilities:", stdout)
+        self.assertIn("Use-case demo cards: 10/10 card(s); failures 0", stdout)
         self.assertIn("context missing 0", stdout)
         self.assertIn("For machine-readable output", stdout)
         with self.assertRaises(json.JSONDecodeError):

--- a/tests/test_release_smoke.py
+++ b/tests/test_release_smoke.py
@@ -31,6 +31,7 @@ class ReleaseSmokeTests(unittest.TestCase):
         self.assertIn("skill_content_smoke", items)
         self.assertIn("installed_command_smoke", items)
         self.assertIn("installed_command_path", items)
+        self.assertIn("use_case_demo_cards", items)
         self.assertIn("live_tap_smoke", items)
         self.assertIn("tag_and_publish", items)
         self.assertEqual(items["installed_command_path"]["command"], "command -v /tmp/omh")
@@ -49,12 +50,16 @@ class ReleaseSmokeTests(unittest.TestCase):
         self.assertIn("wheel_setup_dry_run", items)
         self.assertIn("setup --dry-run --channel stable --version 1.0.0", items["wheel_setup_dry_run"]["command"])
         self.assertIn("release install-smoke --live", items["installer_smoke"]["command"])
+        self.assertEqual(items["use_case_demo_cards"]["command"], "uv run python -m src.cli cases demo --all --json")
+        self.assertIn("G1-G10", items["use_case_demo_cards"]["evidence_required"])
+        self.assertIn("wrapper-renderable projections", items["use_case_demo_cards"]["proof_boundary"])
+        self.assertIn("not prove", items["use_case_demo_cards"]["proof_boundary"])
         self.assertTrue(items["live_tap_smoke"]["mutates_profile"])
         self.assertTrue(items["live_tap_smoke"]["requires_release_authority"])
         self.assertFalse(items["tag_and_publish"]["required"])
         self.assertIn('git tag -a v1.0.0 -m "Release v1.0.0"', items["tag_and_publish"]["command"])
         self.assertTrue(items["tag_and_publish"]["requires_release_authority"])
-        self.assertGreaterEqual(payload["required_item_count"], 16)
+        self.assertGreaterEqual(payload["required_item_count"], 17)
 
     def test_release_readiness_checklist_rejects_unsafe_versions_and_quotes_command_paths(self) -> None:
         with self.assertRaises(ValueError):
@@ -131,6 +136,10 @@ class ReleaseSmokeTests(unittest.TestCase):
             payload["capability_context_char_limits"]["standalone_skill_item"],
         )
         self.assertEqual(payload["capability_budget_failures"], [])
+        self.assertEqual(payload["use_case_demo_collection_schema"], "omh_use_case_demo_collection/v1")
+        self.assertEqual(payload["use_case_demo_card_count"], 10)
+        self.assertEqual(payload["expected_use_case_demo_card_count"], 10)
+        self.assertEqual(payload["use_case_demo_failures"], [])
         self.assertLessEqual(
             payload["awareness_primer_context_chars"],
             payload["awareness_context_char_limits"]["primer_context"],


### PR DESCRIPTION
## Feature Report

### What Changed

- Added a required `use_case_demo_cards` item to the deterministic `release_readiness_checklist/v1` contract.
- Extended `skill_content_smoke/v1` so it renders the G1-G10 use-case demo collection and fails when card schema, order, route/action linkage, wrapper-card status, chat headline, or evidence boundary drift.
- Added human CLI summary output for `omh release skill-content-smoke` showing the G1-G10 card count and failure count.
- Updated release docs and roadmap notes so maintainers know `omh cases demo --all --json` is a release quality gate.

### Why This Exists

- OMH now has a strong G1-G10 use-case story, but that story should not live only as docs and examples.
- Release readiness needs to catch wrapper-facing drift before publishing, especially around route metadata, visible next actions, and prepared-vs-observed status boundaries.
- The goal is to make product-facing examples behave like contracts without pretending they are runtime execution evidence.

### User / Operator Impact

- Maintainers can see `use_case_demo_cards` in `omh release checklist` before tagging.
- `omh release skill-content-smoke` now reports `Use-case demo cards: 10/10 card(s); failures 0` when the installed command package can still render all representative use-case cards correctly.
- Wrapper/demo regressions become release blockers instead of silent documentation drift.

### How It Works

- `src/release.py` imports the use-case catalog and calls `demo_all_use_cases()` inside `skill_content_smoke()`.
- `_use_case_demo_card_failures()` validates the collection schema, exact G1-G10 count/order, per-card schema, route primary skill/next action, wrapper-card component/status, evidence state/claim boundary, primary action linkage, and `[omh]` chat headline.
- `release_readiness_checklist()` now includes a plan-only command gate: `uv run python -m src.cli cases demo --all --json`.
- `src/commands/release.py` prints the new smoke fields in the human summary.

### Files And Contracts Touched

- `src/release.py`: `release_readiness_checklist/v1`, `skill_content_smoke/v1`, G1-G10 demo-card validator.
- `src/commands/release.py`: human summary line for use-case demo card smoke.
- `tests/test_release_smoke.py`: direct release contract coverage.
- `tests/test_cli.py`: CLI JSON and human summary coverage.
- `docs/RELEASE.md`: required check and proof-boundary wording.
- `docs/ROADMAP.md`: recently-landed release gate note.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_release_smoke.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_cli.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_router_content.py tests/test_application_cases.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests examples`
- [x] `uv run python -m src.cli docs workflows --check`
- [x] `uv run python -m src.cli release skill-content-smoke`
- [x] `uv run python -m src.cli release skill-content-smoke --json`
- [x] `uv run python -m src.cli release checklist --version 1.0.1 --json`
- [x] `uv run python -m src.cli cases demo --all --json`
- [x] `git diff --check`
- [ ] Manual Hermes/TUI check: not run; this PR changes deterministic release contracts and local CLI smoke only.

## Risk

- Low. The new gate is deterministic and metadata-only, but it can fail future releases if the demo-card contract changes without updating the validator.
- The validator intentionally checks projection shape, not live Hermes or messenger runtime behavior.

## Compatibility / Rollout

- Backward compatible for normal `omh` usage.
- Adds new fields to `skill_content_smoke/v1`; existing consumers should ignore unknown fields.
- The new release checklist item is plan-only and does not mutate Hermes profiles.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- If future wrapper cards add new required UI fields, extend `_use_case_demo_card_failures()` at the same time as the card schema.
