### PR TITLE
Add use-case artifact bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,8 +149,8 @@ registration contracts live in the [installation guide](docs/INSTALLATION.md).
   reports, automation blueprints, material packages, and loop work all have
   Hermes-facing workflow paths.
 - **Application-case ready** - the G1-G10 use-case map can be exported as
-  wrapper-ready demo cards so operators see the route, next action, and
-  evidence boundary before wiring a chat surface.
+  wrapper-ready demo cards or local runbook artifacts so operators see the
+  route, next action, and evidence boundary before wiring a chat surface.
 - **Local and inspectable** - skills, manifests, plans, sessions, and status
   records stay in user-owned local directories.
 

--- a/docs/APPLICATION_CASES.md
+++ b/docs/APPLICATION_CASES.md
@@ -38,6 +38,9 @@ omh cases list --json
 omh cases inspect G10 --json
 omh cases demo G10 --json
 omh cases demo --all --json
+omh cases artifact G10 --json
+omh cases artifact --all --write
+omh cases artifact-validate --json
 omh cases recommend "PR opened with failing CI" --json
 omh cases validate --json
 ```
@@ -61,6 +64,30 @@ cron, connectors, file generation, memory mutation, executor work, review, CI,
 or merge happened. The checked-in fixture lives at
 `examples/use-cases/g1-g10-demo-cards.json` and is tested against the live
 command output.
+
+Use-case artifacts are the local, reusable runbook form of the same map. A
+single artifact uses `omh_use_case_artifact/v1`; the full bundle uses
+`omh_use_case_artifact_collection/v1`. These artifacts include:
+
+- the same route, playbook, harness, wrapper card, and Hermes prompt as the
+  demo card
+- operator steps for inspect, playbook/harness review, Hermes start, and later
+  observed-evidence recording
+- proof surfaces that release checks can replay
+- an explicit `prepared_not_observed` evidence boundary
+
+To write the full bundle locally:
+
+```sh
+omh cases artifact --all --write
+omh cases artifact-validate
+```
+
+This writes JSON under `.omh/use-cases/artifacts/` plus a cache-only index at
+`.omh/use-cases/index.json`. It is useful for wrapper QA, release review, demos,
+and onboarding. It is still not evidence that Hermes ran cron, called a
+connector, generated a file, changed memory, dispatched an executor, reviewed
+code, passed CI, merged, delivered a message, or spent real provider budget.
 
 ## Case 1: Coding Request Handling
 
@@ -537,6 +564,10 @@ Before using these cases as public release evidence, verify:
   for wrapper rendering and status decisions.
 - `omh cases demo --all --json` exposes `omh_use_case_demo_collection/v1` for
   every G1-G10 wrapper card and preserves `prepared_not_observed`.
+- `omh cases artifact --all --json` exposes
+  `omh_use_case_artifact_collection/v1`, and `omh cases artifact --all --write`
+  can create `.omh/use-cases/artifacts/*.json` without turning prepared
+  runbooks into observed runtime claims.
 - `omh playbook recommend` returns situation-level pipelines for safe coding,
   source-backed research, research-to-strategy briefs, meeting prep, feedback
   triage, ops review, operating rhythm history, report packages, reliability

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -61,6 +61,7 @@ python3 -m omh.cli harness validate
 python3 -m omh.cli release checklist --json
 python3 -m omh.cli release skill-content-smoke --json
 python3 -m omh.cli cases demo --all --json
+python3 -m omh.cli cases artifact --all --json
 python3 -m omh.cli --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke learning review --all
 python3 -m omh.cli --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke install --dry-run --channel stable --version 1.0.1
 python3 -m omh.cli --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke setup --dry-run --channel stable --version 1.0.1
@@ -98,6 +99,12 @@ The checklist also gates the G1-G10 use-case demo cards through
 use-case projections with route, action, status-card, and evidence-boundary
 metadata. It is not evidence that cron, connectors, files, memory updates,
 executors, reviews, CI, merges, or delivery actually ran.
+
+It also gates the G1-G10 use-case artifact bundle through
+`omh cases artifact --all --json`. That proves OMH can render local prepared
+runbooks with operator steps and proof surfaces for each use case. It is not
+evidence that those runbooks were accepted, executed, delivered, reviewed,
+verified, merged, or billed by any runtime.
 
 ## Hermes CLI Install Smoke
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -9,8 +9,8 @@
 - Richer routing catalog fields
 - More playbook-backed situation pipelines for wrapper UX, research, planning,
   and release flows
-- More artifact-backed application case fixtures beyond the G1-G10 demo-card
-  collection
+- More artifact-backed application case fixtures beyond the prepared G1-G10
+  runbook bundle
 - More public-site examples that mirror wrapper contracts without becoming a
   separate documentation source
 - Optional `~/.hermes/plugins/omh` bridge hardening after v1 install smoke
@@ -46,6 +46,9 @@
   `omh_use_case_demo_collection/v1` fixture for wrapper rendering
 - Release and skill-content smoke now gate those G1-G10 demo cards so route,
   action, wrapper-card, and evidence-boundary drift fails before release
+- G1-G10 use-case artifact bundles through `omh cases artifact`, including
+  local `.omh/use-cases/artifacts/` writes, cache-only validation, and release
+  smoke coverage
 - Codex lifecycle helper commands over existing local runtime artifacts
 - Wrapper session plan decisions and restart recovery for accepted handoffs
 - Review, CI, merge-readiness, and merge observation records for delegated

--- a/src/commands/main.py
+++ b/src/commands/main.py
@@ -169,6 +169,7 @@ def build_parser() -> argparse.ArgumentParser:
             "  omh recommend \"risky refactor\"\n"
             "  omh cases recommend \"daily competitor digest\"\n"
             "  omh cases demo --all\n"
+            "  omh cases artifact --all --write\n"
             "  omh playbook recommend \"turn this issue into a PR\"\n"
             "  omh chat interact \"turn this issue into a PR-ready plan\"\n"
             "  omh hud\n"
@@ -256,6 +257,8 @@ Useful operator commands:
   omh recommend "risky refactor"
   omh cases recommend "daily competitor digest"
   omh cases demo --all  Show wrapper-ready G1-G10 use-case cards
+  omh cases artifact --all --write
+                          Write local G1-G10 runbook artifacts
   omh playbook recommend "turn this issue into a PR"
   omh chat interact "turn this issue into a PR-ready plan"
   omh hud                Show the compact OMH status line

--- a/src/commands/release.py
+++ b/src/commands/release.py
@@ -308,6 +308,7 @@ def _print_skill_content_smoke_summary(payload: dict[str, object]) -> None:
     role_context_budget_failures = payload.get("role_context_budget_failures", [])
     capability_budget_failures = payload.get("capability_budget_failures", [])
     use_case_demo_failures = payload.get("use_case_demo_failures", [])
+    use_case_artifact_failures = payload.get("use_case_artifact_failures", [])
     print(
         "Full capability manifest: "
         f"{payload.get('full_capability_skill_count')} skill surface(s); "
@@ -331,6 +332,11 @@ def _print_skill_content_smoke_summary(payload: dict[str, object]) -> None:
         "Use-case demo cards: "
         f"{payload.get('use_case_demo_card_count')}/{payload.get('expected_use_case_demo_card_count')} card(s); "
         f"failures {len(use_case_demo_failures) if isinstance(use_case_demo_failures, list) else 0}"
+    )
+    print(
+        "Use-case artifacts: "
+        f"{payload.get('use_case_artifact_count')}/{payload.get('expected_use_case_artifact_count')} artifact(s); "
+        f"failures {len(use_case_artifact_failures) if isinstance(use_case_artifact_failures, list) else 0}"
     )
     if missing:
         print("Missing representative skills: " + ", ".join(str(item) for item in missing))
@@ -385,6 +391,8 @@ def _print_skill_content_smoke_summary(payload: dict[str, object]) -> None:
         print("Capability budget failures: " + ", ".join(str(item) for item in capability_budget_failures))
     if use_case_demo_failures:
         print("Use-case demo card failures: " + ", ".join(str(item) for item in use_case_demo_failures))
+    if use_case_artifact_failures:
+        print("Use-case artifact failures: " + ", ".join(str(item) for item in use_case_artifact_failures))
     if isinstance(failed, list) and failed:
         print("Failed markers:")
         for check in failed[:12]:

--- a/src/commands/use_cases.py
+++ b/src/commands/use_cases.py
@@ -3,8 +3,20 @@ from __future__ import annotations
 import argparse
 
 from ..installer import OmhError
-from ..use_cases import demo_all_use_cases, demo_use_case, inspect_use_case, list_use_cases, recommend_use_cases, validate_use_cases
-from .common import _print_json, _wants_json
+from ..use_cases import (
+    build_all_use_case_artifacts,
+    build_use_case_artifact,
+    demo_all_use_cases,
+    demo_use_case,
+    inspect_use_case,
+    list_use_cases,
+    recommend_use_cases,
+    validate_use_case_artifact_store,
+    validate_use_cases,
+    write_all_use_case_artifacts,
+    write_use_case_artifact,
+)
+from .common import _paths, _print_json, _wants_json
 
 
 def cmd_cases_list(args: argparse.Namespace) -> int:
@@ -60,6 +72,41 @@ def cmd_cases_recommend(args: argparse.Namespace) -> int:
     else:
         _print_cases_recommend_summary(payload)
     return 0
+
+
+def cmd_cases_artifact(args: argparse.Namespace) -> int:
+    try:
+        if args.all:
+            if args.id:
+                raise OmhError("use either `omh cases artifact <id>` or `omh cases artifact --all`, not both")
+            payload = (
+                write_all_use_case_artifacts(_paths(args), force=args.force)
+                if args.write
+                else build_all_use_case_artifacts()
+            )
+        else:
+            if not args.id:
+                raise OmhError("use-case id required unless --all is passed")
+            artifact = build_use_case_artifact(args.id)
+            payload = write_use_case_artifact(_paths(args), artifact, force=args.force) if args.write else artifact
+    except KeyError as exc:
+        raise OmhError(f"unknown use case: {args.id}") from exc
+    except ValueError as exc:
+        raise OmhError(str(exc)) from exc
+    if _wants_json(args):
+        _print_json(payload)
+    else:
+        _print_cases_artifact_summary(payload)
+    return 0
+
+
+def cmd_cases_artifact_validate(args: argparse.Namespace) -> int:
+    payload = validate_use_case_artifact_store(_paths(args))
+    if _wants_json(args):
+        _print_json(payload)
+    else:
+        _print_cases_artifact_validate_summary(payload)
+    return 0 if payload["ok"] else 1
 
 
 def cmd_cases_validate(args: argparse.Namespace) -> int:
@@ -176,6 +223,94 @@ def _print_cases_demo_collection_summary(payload: dict[str, object]) -> None:
     print("  For machine-readable output, rerun with `--json`.")
 
 
+def _print_cases_artifact_summary(payload: dict[str, object]) -> None:
+    schema = payload.get("schema_version")
+    if schema == "omh_use_case_artifact_write/v1":
+        mode = str(payload.get("mode", ""))
+        print("OMH use-case artifact write")
+        print("Summary")
+        if mode == "write_all":
+            artifacts = payload.get("artifacts", [])
+            if not isinstance(artifacts, list):
+                artifacts = []
+            print(f"  Written artifacts: {len(artifacts)}")
+            for artifact in artifacts:
+                if not isinstance(artifact, dict):
+                    continue
+                marker = "replaced" if artifact.get("replaced") else "written"
+                print(f"  - {artifact.get('goal')}: {artifact.get('title')} [{marker}]")
+            print(f"  Index: {payload.get('index_path')}")
+        else:
+            artifact = payload.get("artifact", {})
+            if not isinstance(artifact, dict):
+                artifact = {}
+            marker = "replaced" if payload.get("replaced") else "written"
+            print(f"  Artifact: {artifact.get('goal')} - {artifact.get('title')} [{marker}]")
+            print(f"  Path: {payload.get('artifact_path')}")
+            print(f"  Index: {payload.get('index_path')}")
+        print("Boundary")
+        print(f"  {payload.get('boundary')}")
+        print("  For machine-readable output, rerun with `--json`.")
+        return
+    if schema == "omh_use_case_artifact_collection/v1":
+        artifacts = payload.get("artifacts", [])
+        if not isinstance(artifacts, list):
+            artifacts = []
+        print("OMH G1-G10 use-case artifacts")
+        print("Summary")
+        print(f"  Prepared artifacts: {len(artifacts)}")
+        for artifact in artifacts:
+            if not isinstance(artifact, dict):
+                continue
+            route = artifact.get("route", {})
+            if not isinstance(route, dict):
+                route = {}
+            print(f"  - {artifact.get('goal')}: {artifact.get('title')} ({route.get('primary_skill')} -> {route.get('next_action')})")
+        print("Boundary")
+        print(f"  {payload.get('boundary')}")
+        print("Next")
+        print("  Write them with `omh cases artifact --all --write`.")
+        print("  For machine-readable output, rerun with `--json`.")
+        return
+    route = payload.get("route", {})
+    evidence = payload.get("evidence", {})
+    if not isinstance(route, dict):
+        route = {}
+    if not isinstance(evidence, dict):
+        evidence = {}
+    print(f"OMH use-case artifact: {payload.get('goal')} - {payload.get('title')}")
+    print("Route")
+    print(f"  {route.get('primary_skill')} -> {route.get('next_action')}")
+    print("Artifact")
+    print(f"  ID: {payload.get('artifact_id')}")
+    print(f"  Status: {payload.get('observation_status')}")
+    print("Boundary")
+    print(f"  {evidence.get('claim_boundary')}")
+    print("Next")
+    print(f"  Write it with `omh cases artifact {payload.get('goal')} --write`.")
+    print("  For machine-readable output, rerun with `--json`.")
+
+
+def _print_cases_artifact_validate_summary(payload: dict[str, object]) -> None:
+    print("OMH use-case artifact validation")
+    print("Summary")
+    print(f"  OK: {payload.get('ok')}")
+    print(f"  Artifacts: {payload.get('artifact_count')}/{payload.get('expected_count')}")
+    missing = payload.get("missing_goals", [])
+    errors = payload.get("errors", [])
+    if missing:
+        print("  Missing goals: " + ", ".join(str(item) for item in missing))
+    if errors:
+        print("Errors")
+        for error in (errors[:12] if isinstance(errors, list) else []):
+            print(f"  - {error}")
+        if isinstance(errors, list) and len(errors) > 12:
+            print(f"  ... {len(errors) - 12} more")
+    print("Boundary")
+    print(f"  {payload.get('boundary')}")
+    print("  For machine-readable output, rerun with `--json`.")
+
+
 def _print_cases_recommend_summary(payload: dict[str, object]) -> None:
     recommendations = payload.get("recommendations", [])
     if not isinstance(recommendations, list):
@@ -244,6 +379,18 @@ def _add_cases_commands(sub) -> None:
     recommend_cmd.add_argument("--limit", type=int, default=3, help="Maximum use cases to return.")
     recommend_cmd.add_argument("--json", action="store_true", help="Print the full machine-readable recommendation payload.")
     recommend_cmd.set_defaults(func=cmd_cases_recommend)
+
+    artifact_cmd = cases_sub.add_parser("artifact")
+    artifact_cmd.add_argument("id", nargs="?", default="", help="Use-case id such as G10 or ops-observability-card.")
+    artifact_cmd.add_argument("--all", action="store_true", help="Build artifacts for all G1-G10 use cases.")
+    artifact_cmd.add_argument("--write", action="store_true", help="Write prepared use-case artifacts under the OMH home.")
+    artifact_cmd.add_argument("--force", action="store_true", help="Replace an existing managed use-case artifact.")
+    artifact_cmd.add_argument("--json", action="store_true", help="Print the full machine-readable artifact payload.")
+    artifact_cmd.set_defaults(func=cmd_cases_artifact)
+
+    artifact_validate_cmd = cases_sub.add_parser("artifact-validate")
+    artifact_validate_cmd.add_argument("--json", action="store_true", help="Print machine-readable validation for local use-case artifacts.")
+    artifact_validate_cmd.set_defaults(func=cmd_cases_artifact_validate)
 
     validate_cmd = cases_sub.add_parser("validate")
     validate_cmd.add_argument("--json", action="store_true", help="Print machine-readable validation for all G1-G10 feature surfaces.")

--- a/src/paths.py
+++ b/src/paths.py
@@ -175,6 +175,18 @@ class OmhPaths:
         return self.learning_dir / "index.json"
 
     @property
+    def use_cases_dir(self) -> Path:
+        return self.omh_home / "use-cases"
+
+    @property
+    def use_case_artifacts_dir(self) -> Path:
+        return self.use_cases_dir / "artifacts"
+
+    @property
+    def use_case_artifacts_index_path(self) -> Path:
+        return self.use_cases_dir / "index.json"
+
+    @property
     def hermes_config_path(self) -> Path:
         return self.hermes_home / "config.yaml"
 

--- a/src/release.py
+++ b/src/release.py
@@ -32,7 +32,7 @@ from .plugin_bundle.omh.tools.capability_tool import (
 from .release_smoke_core import CommandResult, Runner, bounded_text, expand_home, subprocess_runner
 from .skill_pack import builtin_skill_templates
 from .skills.catalog import builtin_definitions
-from .use_cases import USE_CASES, demo_all_use_cases
+from .use_cases import USE_CASES, build_all_use_case_artifacts, demo_all_use_cases, validate_use_case_artifact
 
 REPOSITORY_ARCHIVE_ROOT = "https://github.com/rlaope/oh-my-hermes/archive/refs"
 RELEASE_CHANNELS = ("stable", "preview", "local")
@@ -192,6 +192,16 @@ def release_readiness_checklist(
             "Use-case demo cards prove wrapper-renderable projections only; they do not prove cron, connector, file, memory, executor, review, CI, merge, or delivery work happened.",
         ),
         ReleaseChecklistItem(
+            "use_case_artifact_bundle",
+            "Check G1-G10 use-case artifact bundle",
+            "uv run python -m src.cli cases artifact --all --json",
+            "contract-quality",
+            True,
+            False,
+            "Use-case artifact bundle renders all ten G1-G10 prepared artifacts with route, operator-step, proof-surface, wrapper-card, and evidence-boundary metadata.",
+            "Use-case artifacts prove prepared runbook projection only; they do not prove runtime execution, connector invocation, delivery, file generation, memory mutation, executor dispatch, review, CI, merge, or billing evidence.",
+        ),
+        ReleaseChecklistItem(
             "stable_install_dry_run",
             "Dry-run stable install metadata",
             (
@@ -264,7 +274,7 @@ def release_readiness_checklist(
             "installed-command",
             True,
             False,
-            "Skill content smoke reports ok=true for router awareness, generated workflow context rails, bundled role context, all-skill awareness lane coverage, full capability manifest context, playbook capability context, standalone plugin capability fallback coverage, bounded prompt context budgets, and bounded capability payload budgets.",
+            "Skill content smoke reports ok=true for router awareness, generated workflow context rails, bundled role context, all-skill awareness lane coverage, full capability manifest context, playbook capability context, standalone plugin capability fallback coverage, G1-G10 use-case demo cards, G1-G10 use-case artifact bundles, bounded prompt context budgets, and bounded capability payload budgets.",
             "This proves the installed OMH command package can render expected skill guidance; it does not prove Hermes loaded or selected it in chat.",
         ),
         ReleaseChecklistItem(
@@ -715,6 +725,8 @@ def skill_content_smoke() -> dict[str, object]:
     )
     use_case_demo_cards = demo_all_use_cases()
     use_case_demo_failures = _use_case_demo_card_failures(use_case_demo_cards)
+    use_case_artifact_bundle = build_all_use_case_artifacts()
+    use_case_artifact_failures = _use_case_artifact_failures(use_case_artifact_bundle)
     max_full_capability_skill_chars = max(
         (len(json.dumps(item, sort_keys=True, ensure_ascii=False)) for item in full_capability_items),
         default=0,
@@ -823,6 +835,7 @@ def skill_content_smoke() -> dict[str, object]:
         and not role_context_budget_failures
         and not capability_budget_failures
         and not use_case_demo_failures
+        and not use_case_artifact_failures
     )
     return {
         "schema_version": SKILL_CONTENT_SMOKE_SCHEMA,
@@ -882,6 +895,12 @@ def skill_content_smoke() -> dict[str, object]:
         else 0,
         "expected_use_case_demo_card_count": len(USE_CASES),
         "use_case_demo_failures": use_case_demo_failures,
+        "use_case_artifact_collection_schema": use_case_artifact_bundle.get("schema_version"),
+        "use_case_artifact_count": len(use_case_artifact_bundle.get("artifacts", []))
+        if isinstance(use_case_artifact_bundle.get("artifacts"), list)
+        else 0,
+        "expected_use_case_artifact_count": len(USE_CASES),
+        "use_case_artifact_failures": use_case_artifact_failures,
         "awareness_context_char_limits": {
             "primer_context": AWARENESS_PRIMER_CONTEXT_CHAR_LIMIT,
             "primer_markdown": AWARENESS_PRIMER_MARKDOWN_CHAR_LIMIT,
@@ -946,6 +965,40 @@ def _use_case_demo_card_failures(payload: Mapping[str, object]) -> list[str]:
             failures.append(f"{goal or index}_primary_action")
         if not isinstance(chat_surface, Mapping) or not str(chat_surface.get("headline") or "").startswith("[omh] "):
             failures.append(f"{goal or index}_chat_surface")
+    if observed_goals != expected_goals:
+        failures.append("goal_order")
+    return failures
+
+
+def _use_case_artifact_failures(payload: Mapping[str, object]) -> list[str]:
+    failures: list[str] = []
+    if payload.get("schema_version") != "omh_use_case_artifact_collection/v1":
+        failures.append("collection_schema")
+    artifacts = payload.get("artifacts", [])
+    if not isinstance(artifacts, Sequence) or isinstance(artifacts, (str, bytes)):
+        return failures + ["artifacts_not_sequence"]
+    if len(artifacts) != len(USE_CASES):
+        failures.append("artifact_count")
+    expected_goals = [case.goal for case in USE_CASES]
+    observed_goals: list[str] = []
+    for index, artifact in enumerate(artifacts):
+        if not isinstance(artifact, dict):
+            failures.append(f"artifact_{index}_not_mapping")
+            continue
+        goal = str(artifact.get("goal") or "")
+        observed_goals.append(goal)
+        for error in validate_use_case_artifact(artifact):
+            failures.append(f"{goal or index}: {error}")
+        steps = artifact.get("operator_steps", [])
+        if not isinstance(steps, Sequence) or isinstance(steps, (str, bytes)):
+            failures.append(f"{goal or index}_operator_steps")
+        elif not any(isinstance(step, Mapping) and step.get("kind") == "hermes_prompt" for step in steps):
+            failures.append(f"{goal or index}_missing_hermes_prompt_step")
+        proof_surfaces = artifact.get("proof_surfaces", [])
+        if not isinstance(proof_surfaces, Sequence) or isinstance(proof_surfaces, (str, bytes)):
+            failures.append(f"{goal or index}_proof_surfaces")
+        elif "omh cases validate --json" not in proof_surfaces:
+            failures.append(f"{goal or index}_missing_validate_surface")
     if observed_goals != expected_goals:
         failures.append("goal_order")
     return failures

--- a/src/use_cases.py
+++ b/src/use_cases.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 from dataclasses import asdict, dataclass
 import re
+from pathlib import Path
 from typing import Any
+
+from .local_store import atomic_write_json, ensure_dir, read_json_object, read_json_object_result, utc_now
+from .paths import OmhPaths
 
 
 USE_CASE_CATALOG_SCHEMA_VERSION = "omh_use_case_catalog/v1"
@@ -10,6 +14,11 @@ USE_CASE_DEMO_CARD_SCHEMA_VERSION = "omh_use_case_demo_card/v1"
 USE_CASE_DEMO_COLLECTION_SCHEMA_VERSION = "omh_use_case_demo_collection/v1"
 USE_CASE_RECOMMENDATION_SCHEMA_VERSION = "omh_use_case_recommendation/v1"
 USE_CASE_VALIDATION_SCHEMA_VERSION = "omh_use_case_validation/v1"
+USE_CASE_ARTIFACT_SCHEMA_VERSION = "omh_use_case_artifact/v1"
+USE_CASE_ARTIFACT_COLLECTION_SCHEMA_VERSION = "omh_use_case_artifact_collection/v1"
+USE_CASE_ARTIFACT_WRITE_SCHEMA_VERSION = "omh_use_case_artifact_write/v1"
+USE_CASE_ARTIFACT_INDEX_SCHEMA_VERSION = "omh_use_case_artifact_index/v1"
+_ARTIFACT_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9-]{0,159}$")
 
 
 @dataclass(frozen=True)
@@ -265,6 +274,241 @@ def demo_all_use_cases() -> dict[str, Any]:
     }
 
 
+def build_use_case_artifact(case_id: str) -> dict[str, Any]:
+    case = _find_case(case_id)
+    if case is None:
+        raise KeyError(case_id)
+    card = _demo_card(case)
+    artifact = {
+        "schema_version": USE_CASE_ARTIFACT_SCHEMA_VERSION,
+        "artifact_id": _artifact_id(case),
+        "goal": case.goal,
+        "id": case.id,
+        "title": case.title,
+        "status": "prepared",
+        "observation_status": "prepared_not_observed",
+        "source": "omh_use_case_catalog",
+        "summary": case.user_value,
+        "route": card["route"],
+        "chat_surface": card["chat_surface"],
+        "wrapper_card": card["wrapper_card"],
+        "workflow_contract": {
+            "primary_skill": case.primary_skill,
+            "playbook": case.playbook,
+            "harness": case.harness,
+            "next_action": case.next_action,
+            "direct_skill_invocation": case.direct_skill_invocation,
+            "hermes_chat_prompt": case.hermes_chat_prompt,
+        },
+        "operator_steps": _artifact_operator_steps(case),
+        "proof_surfaces": [
+            *case.proof_surfaces,
+            f"omh cases demo {case.goal} --json",
+            f"omh cases artifact {case.goal} --json",
+            "omh cases validate --json",
+        ],
+        "evidence": {
+            "state": "prepared_not_observed",
+            "claim_boundary": case.evidence_boundary,
+            "not_evidence_until_observed": card["evidence"]["not_evidence_until_observed"],
+            "observed_evidence_required": [
+                "wrapper or Hermes record that the user accepted this case route",
+                "runtime, connector, file, memory, executor, review, CI, merge, or delivery record matching the claimed action",
+                "human approval record before treating suggested skill, memory, or workflow changes as applied",
+            ],
+        },
+        "release_quality": {
+            "fixture_safe": True,
+            "contains_raw_user_prompt": False,
+            "eligible_for_release_smoke": True,
+            "recommended_gate": "omh cases artifact --all --json",
+        },
+        "boundary": (
+            "Use-case artifacts are prepared runbook metadata for Hermes and wrapper tests. "
+            "They are not observed runtime execution, connector, delivery, file, memory, executor, review, CI, merge, or billing evidence."
+        ),
+    }
+    errors = validate_use_case_artifact(artifact)
+    if errors:
+        raise ValueError("; ".join(errors))
+    return artifact
+
+
+def build_all_use_case_artifacts() -> dict[str, Any]:
+    return {
+        "schema_version": USE_CASE_ARTIFACT_COLLECTION_SCHEMA_VERSION,
+        "count": len(USE_CASES),
+        "artifacts": [build_use_case_artifact(case.goal) for case in USE_CASES],
+        "boundary": (
+            "This collection is a prepared application-case artifact bundle. "
+            "It proves catalog-to-artifact projection only, not runtime execution."
+        ),
+    }
+
+
+def write_use_case_artifact(paths: OmhPaths, artifact: dict[str, Any], *, force: bool = False) -> dict[str, Any]:
+    errors = validate_use_case_artifact(artifact)
+    if errors:
+        raise ValueError("; ".join(errors))
+    artifact_id = str(artifact["artifact_id"])
+    path = _use_case_artifact_path(paths, artifact_id)
+    existed = path.exists()
+    if existed and not force:
+        raise ValueError(f"use-case artifact already exists: {artifact_id}; pass --force to replace it")
+    atomic_write_json(path, artifact, private=True)
+    _write_use_case_artifact_index(paths)
+    return {
+        "schema_version": USE_CASE_ARTIFACT_WRITE_SCHEMA_VERSION,
+        "ok": True,
+        "mode": "write",
+        "artifact": artifact,
+        "artifact_path": str(path),
+        "index_path": str(paths.use_case_artifacts_index_path),
+        "replaced": existed and force,
+        "boundary": artifact["boundary"],
+    }
+
+
+def write_all_use_case_artifacts(paths: OmhPaths, *, force: bool = False) -> dict[str, Any]:
+    written = []
+    for artifact in build_all_use_case_artifacts()["artifacts"]:
+        if not isinstance(artifact, dict):
+            continue
+        written.append(write_use_case_artifact(paths, artifact, force=force))
+    return {
+        "schema_version": USE_CASE_ARTIFACT_WRITE_SCHEMA_VERSION,
+        "ok": True,
+        "mode": "write_all",
+        "count": len(written),
+        "artifacts": [
+            {
+                "artifact_id": item["artifact"]["artifact_id"],
+                "goal": item["artifact"]["goal"],
+                "title": item["artifact"]["title"],
+                "artifact_path": item["artifact_path"],
+                "replaced": item["replaced"],
+            }
+            for item in written
+        ],
+        "index_path": str(paths.use_case_artifacts_index_path),
+        "boundary": (
+            "Writing all use-case artifacts records prepared metadata only. "
+            "It is not evidence that any runtime, connector, delivery, file, memory, executor, review, CI, or merge action happened."
+        ),
+    }
+
+
+def list_use_case_artifacts(paths: OmhPaths, *, limit: int | None = None) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for artifact_path in sorted(paths.use_case_artifacts_dir.glob("*.json")):
+        record, error = read_json_object_result(artifact_path)
+        if error or not record:
+            continue
+        records.append(record)
+    records.sort(key=lambda item: str(item.get("goal", "")))
+    if limit is not None:
+        if limit < 1:
+            return []
+        records = records[-limit:]
+    return records
+
+
+def show_use_case_artifact(paths: OmhPaths, artifact_id: str) -> dict[str, Any]:
+    if not _valid_artifact_id(artifact_id):
+        raise FileNotFoundError(artifact_id)
+    record = read_json_object(_use_case_artifact_path(paths, artifact_id))
+    if record is None:
+        raise FileNotFoundError(artifact_id)
+    return record
+
+
+def validate_use_case_artifact(record: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if record.get("schema_version") != USE_CASE_ARTIFACT_SCHEMA_VERSION:
+        errors.append("schema_version must be omh_use_case_artifact/v1")
+    artifact_id = str(record.get("artifact_id", ""))
+    if not artifact_id:
+        errors.append("artifact_id is required")
+    elif not _valid_artifact_id(artifact_id):
+        errors.append("artifact_id must contain only letters, digits, and hyphens, and must not contain path separators")
+    goal = str(record.get("goal", ""))
+    case = _find_case(goal)
+    if case is None:
+        errors.append("goal must reference a known G1-G10 use case")
+    elif artifact_id != _artifact_id(case):
+        errors.append("artifact_id must match the canonical use-case artifact id")
+    if record.get("status") != "prepared":
+        errors.append("status must be prepared")
+    if record.get("observation_status") != "prepared_not_observed":
+        errors.append("observation_status must be prepared_not_observed")
+    for key in ("route", "chat_surface", "wrapper_card", "workflow_contract", "evidence", "release_quality"):
+        if not isinstance(record.get(key), dict):
+            errors.append(f"{key} must be an object")
+    for key in ("operator_steps", "proof_surfaces"):
+        if not isinstance(record.get(key), list) or not record.get(key):
+            errors.append(f"{key} must be a non-empty list")
+    route = record.get("route") if isinstance(record.get("route"), dict) else {}
+    workflow = record.get("workflow_contract") if isinstance(record.get("workflow_contract"), dict) else {}
+    wrapper = record.get("wrapper_card") if isinstance(record.get("wrapper_card"), dict) else {}
+    evidence = record.get("evidence") if isinstance(record.get("evidence"), dict) else {}
+    if case is not None:
+        if route.get("primary_skill") != case.primary_skill:
+            errors.append("route.primary_skill must match use-case primary skill")
+        if route.get("next_action") != case.next_action:
+            errors.append("route.next_action must match use-case next action")
+        if workflow.get("hermes_chat_prompt") != case.hermes_chat_prompt:
+            errors.append("workflow_contract.hermes_chat_prompt must match catalog prompt")
+    if wrapper.get("component") != "omh_use_case_card":
+        errors.append("wrapper_card.component must be omh_use_case_card")
+    if wrapper.get("status") != "prepared_not_observed":
+        errors.append("wrapper_card.status must be prepared_not_observed")
+    if evidence.get("state") != "prepared_not_observed":
+        errors.append("evidence.state must be prepared_not_observed")
+    boundary = str(evidence.get("claim_boundary", ""))
+    if "not " not in boundary.casefold() or "evidence" not in boundary.casefold():
+        errors.append("evidence.claim_boundary must preserve a not-evidence guard")
+    if not isinstance(evidence.get("not_evidence_until_observed"), list) or "executor_dispatch" not in evidence.get("not_evidence_until_observed", []):
+        errors.append("evidence.not_evidence_until_observed must include executor_dispatch")
+    release_quality = record.get("release_quality") if isinstance(record.get("release_quality"), dict) else {}
+    if release_quality.get("contains_raw_user_prompt") is not False:
+        errors.append("release_quality.contains_raw_user_prompt must be false")
+    return errors
+
+
+def validate_use_case_artifact_store(paths: OmhPaths) -> dict[str, Any]:
+    records: list[dict[str, Any]] = []
+    errors: list[str] = []
+    seen: set[str] = set()
+    for artifact_path in sorted(paths.use_case_artifacts_dir.glob("*.json")):
+        record, error = read_json_object_result(artifact_path)
+        if error:
+            errors.append(f"{artifact_path}: {error}")
+            continue
+        if not record:
+            continue
+        records.append(record)
+        artifact_id = str(record.get("artifact_id", ""))
+        if artifact_id in seen:
+            errors.append(f"duplicate artifact_id: {artifact_id}")
+        seen.add(artifact_id)
+        for item_error in validate_use_case_artifact(record):
+            errors.append(f"{artifact_id or '<unknown>'}: {item_error}")
+    missing_goals = sorted({case.goal for case in USE_CASES} - {str(record.get("goal", "")) for record in records})
+    index = read_json_object(paths.use_case_artifacts_index_path)
+    if index and index.get("schema_version") != USE_CASE_ARTIFACT_INDEX_SCHEMA_VERSION:
+        errors.append("use-case artifact index cache has unsupported schema_version")
+    return {
+        "schema_version": "omh_use_case_artifact_validation/v1",
+        "ok": not errors,
+        "artifact_count": len(records),
+        "expected_count": len(USE_CASES),
+        "missing_goals": missing_goals,
+        "errors": errors,
+        "index_authority": "cache_only",
+        "boundary": "Validation proves local prepared artifact shape only, not runtime execution.",
+    }
+
+
 def recommend_use_cases(query: str, *, limit: int = 3) -> dict[str, Any]:
     clean_query = " ".join(query.split())
     if limit < 1:
@@ -506,6 +750,93 @@ def _demo_card(case: UseCase) -> dict[str, Any]:
 
 def _action_label(action: str) -> str:
     return action.replace("_", " ").capitalize()
+
+
+def _artifact_operator_steps(case: UseCase) -> list[dict[str, str]]:
+    return [
+        {
+            "id": "inspect_case",
+            "kind": "operator_command",
+            "label": "Inspect use case",
+            "value": f"omh cases inspect {case.goal} --json",
+        },
+        {
+            "id": "render_demo_card",
+            "kind": "operator_command",
+            "label": "Render wrapper card",
+            "value": f"omh cases demo {case.goal} --json",
+        },
+        {
+            "id": "inspect_playbook",
+            "kind": "operator_command",
+            "label": "Inspect playbook",
+            "value": f"omh playbook inspect {case.playbook} --json",
+        },
+        {
+            "id": "inspect_harness",
+            "kind": "operator_command",
+            "label": "Inspect harness",
+            "value": f"omh harness inspect {case.harness} --json",
+        },
+        {
+            "id": "start_in_hermes",
+            "kind": "hermes_prompt",
+            "label": "Start in Hermes",
+            "value": case.hermes_chat_prompt,
+        },
+        {
+            "id": "record_observed_evidence",
+            "kind": "boundary",
+            "label": "Record observed evidence only after host/runtime action",
+            "value": case.evidence_boundary,
+        },
+    ]
+
+
+def _artifact_id(case: UseCase) -> str:
+    return f"{case.goal.lower()}-{case.id}"
+
+
+def _use_case_artifact_path(paths: OmhPaths, artifact_id: str) -> Path:
+    if not _valid_artifact_id(artifact_id):
+        raise ValueError("artifact_id must contain only letters, digits, and hyphens, and must not contain path separators")
+    path = paths.use_case_artifacts_dir / f"{artifact_id}.json"
+    root = paths.use_case_artifacts_dir.resolve()
+    resolved = path.resolve()
+    if resolved.parent != root:
+        raise ValueError("artifact_id escapes use-case artifact storage")
+    return path
+
+
+def _write_use_case_artifact_index(paths: OmhPaths) -> None:
+    records = list_use_case_artifacts(paths)
+    ensure_dir(paths.use_cases_dir, private=True)
+    atomic_write_json(
+        paths.use_case_artifacts_index_path,
+        {
+            "schema_version": USE_CASE_ARTIFACT_INDEX_SCHEMA_VERSION,
+            "updated_at": utc_now(),
+            "authority": "cache_only",
+            "artifacts": [
+                {
+                    "artifact_id": record.get("artifact_id", ""),
+                    "goal": record.get("goal", ""),
+                    "id": record.get("id", ""),
+                    "title": record.get("title", ""),
+                    "primary_skill": (record.get("route") or {}).get("primary_skill", "")
+                    if isinstance(record.get("route"), dict)
+                    else "",
+                    "observation_status": record.get("observation_status", ""),
+                }
+                for record in records
+            ],
+        },
+        private=True,
+    )
+
+
+def _valid_artifact_id(value: str) -> bool:
+    return bool(_ARTIFACT_ID_RE.fullmatch(str(value)))
 
 
 def _find_case(case_id: str) -> UseCase | None:

--- a/tests/test_application_cases.py
+++ b/tests/test_application_cases.py
@@ -58,6 +58,8 @@ class ApplicationCaseArtifactTests(unittest.TestCase):
 
         self.assertIn("Artifact-backed verification", cases)
         self.assertIn("omh runtime show", cases)
+        self.assertIn("omh cases artifact --all --write", cases)
+        self.assertIn(".omh/use-cases/artifacts/", cases)
         self.assertIn("Chat Wrapper Backend Flow", install)
         self.assertIn("Codex lifecycle calls", install)
         self.assertIn("What Gets Recorded", install)
@@ -82,6 +84,49 @@ class ApplicationCaseArtifactTests(unittest.TestCase):
                 self.assertEqual(card["actions"][0]["id"], card["route"]["next_action"])
                 self.assertIn("not", card["evidence"]["claim_boundary"].lower())
                 self.assertIn("executor_dispatch", card["evidence"]["not_evidence_until_observed"])
+
+    def test_g1_to_g10_use_case_artifacts_are_local_runbooks(self) -> None:
+        code, stdout, stderr = run_cli(["cases", "artifact", "--all", "--json"], output_json=False)
+
+        self.assertEqual(code, 0, stderr)
+        self.assertEqual(stderr, "")
+        collection = json.loads(stdout)
+        self.assertEqual(collection["schema_version"], "omh_use_case_artifact_collection/v1")
+        self.assertEqual(collection["count"], 10)
+        self.assertEqual([artifact["goal"] for artifact in collection["artifacts"]], [f"G{index}" for index in range(1, 11)])
+        for artifact in collection["artifacts"]:
+            with self.subTest(artifact=artifact["goal"]):
+                self.assertEqual(artifact["schema_version"], "omh_use_case_artifact/v1")
+                self.assertEqual(artifact["status"], "prepared")
+                self.assertEqual(artifact["observation_status"], "prepared_not_observed")
+                self.assertEqual(artifact["wrapper_card"]["status"], "prepared_not_observed")
+                self.assertEqual(artifact["evidence"]["state"], "prepared_not_observed")
+                self.assertFalse(artifact["release_quality"]["contains_raw_user_prompt"])
+                self.assertIn("omh cases validate --json", artifact["proof_surfaces"])
+                self.assertTrue(any(step["kind"] == "hermes_prompt" for step in artifact["operator_steps"]))
+
+    def test_use_case_artifacts_can_be_written_and_validated(self) -> None:
+        with TemporaryDirectory() as tmp:
+            omh_home = Path(tmp) / ".omh"
+
+            code, stdout, stderr = run_cli(["--omh-home", str(omh_home), "cases", "artifact", "--all", "--write", "--json"], output_json=False)
+
+            self.assertEqual(code, 0, stderr)
+            self.assertEqual(stderr, "")
+            write_payload = json.loads(stdout)
+            self.assertEqual(write_payload["schema_version"], "omh_use_case_artifact_write/v1")
+            self.assertEqual(write_payload["count"], 10)
+            self.assertTrue((omh_home / "use-cases" / "index.json").exists())
+            self.assertEqual(len(list((omh_home / "use-cases" / "artifacts").glob("*.json"))), 10)
+
+            code, stdout, stderr = run_cli(["--omh-home", str(omh_home), "cases", "artifact-validate", "--json"], output_json=False)
+
+            self.assertEqual(code, 0, stderr)
+            self.assertEqual(stderr, "")
+            validation = json.loads(stdout)
+            self.assertTrue(validation["ok"])
+            self.assertEqual(validation["artifact_count"], 10)
+            self.assertEqual(validation["missing_goals"], [])
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -655,6 +655,8 @@ class CliTests(unittest.TestCase):
             (["cases", "inspect", "G10"], "OMH use case:", "use_case"),
             (["cases", "demo", "G10"], "OMH use-case demo card:", "wrapper_card"),
             (["cases", "demo", "--all"], "OMH G1-G10 use-case demo cards", "cards"),
+            (["cases", "artifact", "G10"], "OMH use-case artifact:", "artifact_id"),
+            (["cases", "artifact", "--all"], "OMH G1-G10 use-case artifacts", "artifacts"),
             (["cases", "validate"], "OMH G1-G10 feature surface validation", "validated"),
             (["playbook", "list"], "OMH playbooks", "playbooks"),
             (["playbook", "inspect", "safe-feature-change"], "OMH playbook:", "playbook"),
@@ -773,6 +775,69 @@ class CliTests(unittest.TestCase):
                 self.assertIn("not", card["evidence"]["claim_boundary"].lower())
                 self.assertEqual(card["actions"][0]["id"], card["route"]["next_action"])
                 self.assertTrue(card["chat_surface"]["headline"].startswith("[omh] "))
+
+        status, stdout, stderr = run_cli(["cases", "artifact", "G1", "--json"], output_json=False)
+
+        self.assertEqual(status, 0, stderr)
+        self.assertEqual(stderr, "")
+        artifact = json.loads(stdout)
+        self.assertEqual(artifact["schema_version"], "omh_use_case_artifact/v1")
+        self.assertEqual(artifact["artifact_id"], "g1-natural-automation-blueprint")
+        self.assertEqual(artifact["goal"], "G1")
+        self.assertEqual(artifact["route"]["primary_skill"], "automation-blueprint")
+        self.assertEqual(artifact["workflow_contract"]["next_action"], "prepare_scheduled_ops_blueprint")
+        self.assertEqual(artifact["wrapper_card"]["status"], "prepared_not_observed")
+        self.assertEqual(artifact["evidence"]["state"], "prepared_not_observed")
+        self.assertFalse(artifact["release_quality"]["contains_raw_user_prompt"])
+        self.assertIn("omh cases validate --json", artifact["proof_surfaces"])
+        self.assertIn("executor_dispatch", artifact["evidence"]["not_evidence_until_observed"])
+        self.assertTrue(any(step["kind"] == "hermes_prompt" for step in artifact["operator_steps"]))
+
+        status, stdout, stderr = run_cli(["cases", "artifact", "--all", "--json"], output_json=False)
+
+        self.assertEqual(status, 0, stderr)
+        self.assertEqual(stderr, "")
+        artifact_collection = json.loads(stdout)
+        self.assertEqual(artifact_collection["schema_version"], "omh_use_case_artifact_collection/v1")
+        self.assertEqual(artifact_collection["count"], 10)
+        self.assertEqual(
+            [artifact["goal"] for artifact in artifact_collection["artifacts"]],
+            [f"G{index}" for index in range(1, 11)],
+        )
+
+        with TemporaryDirectory() as tmp:
+            base = ["--omh-home", str(Path(tmp) / ".omh")]
+
+            status, stdout, stderr = run_cli(base + ["cases", "artifact", "--all", "--write", "--json"], output_json=False)
+
+            self.assertEqual(status, 0, stderr)
+            self.assertEqual(stderr, "")
+            write_payload = json.loads(stdout)
+            self.assertEqual(write_payload["schema_version"], "omh_use_case_artifact_write/v1")
+            self.assertEqual(write_payload["count"], 10)
+            self.assertTrue(Path(write_payload["index_path"]).exists())
+            self.assertEqual(len(list((Path(tmp) / ".omh" / "use-cases" / "artifacts").glob("*.json"))), 10)
+
+            status, stdout, stderr = run_cli(base + ["cases", "artifact-validate", "--json"], output_json=False)
+
+            self.assertEqual(status, 0, stderr)
+            self.assertEqual(stderr, "")
+            validation_payload = json.loads(stdout)
+            self.assertTrue(validation_payload["ok"])
+            self.assertEqual(validation_payload["artifact_count"], 10)
+            self.assertEqual(validation_payload["missing_goals"], [])
+
+            status, stdout, stderr = run_cli(base + ["cases", "artifact", "G1", "--write", "--json"], output_json=False)
+
+            self.assertEqual(status, 2)
+            self.assertEqual(stdout, "")
+            self.assertIn("already exists", stderr)
+
+            status, stdout, stderr = run_cli(base + ["cases", "artifact", "G1", "--write", "--force", "--json"], output_json=False)
+
+            self.assertEqual(status, 0, stderr)
+            self.assertEqual(stderr, "")
+            self.assertTrue(json.loads(stdout)["replaced"])
 
         examples = (
             ("Every morning send a competitor digest to Slack only if changed", "G1", "automation-blueprint"),
@@ -1475,6 +1540,7 @@ class CliTests(unittest.TestCase):
         self.assertIn("Required gates:", stdout)
         self.assertIn("installed_command_smoke", stdout)
         self.assertIn("use_case_demo_cards", stdout)
+        self.assertIn("use_case_artifact_bundle", stdout)
         self.assertIn("/tmp/omh --help", stdout)
         self.assertIn("live_tap_smoke", stdout)
         self.assertIn("profile-mutating", stdout)
@@ -1495,6 +1561,7 @@ class CliTests(unittest.TestCase):
         items = {item["id"]: item for item in payload["items"]}
         self.assertIn("uv build", items["build_artifacts"]["command"])
         self.assertIn("cases demo --all --json", items["use_case_demo_cards"]["command"])
+        self.assertIn("cases artifact --all --json", items["use_case_artifact_bundle"]["command"])
         self.assertIn("skill-content-smoke", items["skill_content_smoke"]["command"])
         self.assertIn("setup --dry-run --channel stable --version 1.0.0", items["wheel_setup_dry_run"]["command"])
         self.assertTrue(items["live_tap_smoke"]["requires_release_authority"])
@@ -1528,6 +1595,10 @@ class CliTests(unittest.TestCase):
         self.assertEqual(payload["use_case_demo_card_count"], 10)
         self.assertEqual(payload["expected_use_case_demo_card_count"], 10)
         self.assertEqual(payload["use_case_demo_failures"], [])
+        self.assertEqual(payload["use_case_artifact_collection_schema"], "omh_use_case_artifact_collection/v1")
+        self.assertEqual(payload["use_case_artifact_count"], 10)
+        self.assertEqual(payload["expected_use_case_artifact_count"], 10)
+        self.assertEqual(payload["use_case_artifact_failures"], [])
         self.assertLessEqual(
             payload["full_capability_skill_section_chars"],
             payload["capability_context_char_limits"]["full_skill_section"],
@@ -1556,6 +1627,7 @@ class CliTests(unittest.TestCase):
         self.assertIn("Playbook capabilities:", stdout)
         self.assertIn("Plugin fallback capabilities:", stdout)
         self.assertIn("Use-case demo cards: 10/10 card(s); failures 0", stdout)
+        self.assertIn("Use-case artifacts: 10/10 artifact(s); failures 0", stdout)
         self.assertIn("context missing 0", stdout)
         self.assertIn("For machine-readable output", stdout)
         with self.assertRaises(json.JSONDecodeError):

--- a/tests/test_release_smoke.py
+++ b/tests/test_release_smoke.py
@@ -32,6 +32,7 @@ class ReleaseSmokeTests(unittest.TestCase):
         self.assertIn("installed_command_smoke", items)
         self.assertIn("installed_command_path", items)
         self.assertIn("use_case_demo_cards", items)
+        self.assertIn("use_case_artifact_bundle", items)
         self.assertIn("live_tap_smoke", items)
         self.assertIn("tag_and_publish", items)
         self.assertEqual(items["installed_command_path"]["command"], "command -v /tmp/omh")
@@ -43,6 +44,8 @@ class ReleaseSmokeTests(unittest.TestCase):
         self.assertIn("full capability manifest context", items["skill_content_smoke"]["evidence_required"])
         self.assertIn("playbook capability context", items["skill_content_smoke"]["evidence_required"])
         self.assertIn("standalone plugin capability fallback coverage", items["skill_content_smoke"]["evidence_required"])
+        self.assertIn("G1-G10 use-case demo cards", items["skill_content_smoke"]["evidence_required"])
+        self.assertIn("G1-G10 use-case artifact bundles", items["skill_content_smoke"]["evidence_required"])
         self.assertIn("bounded prompt context budgets", items["skill_content_smoke"]["evidence_required"])
         self.assertIn("bounded capability payload budgets", items["skill_content_smoke"]["evidence_required"])
         self.assertIn("--include-command-smoke", items["installed_command_smoke"]["command"])
@@ -54,6 +57,10 @@ class ReleaseSmokeTests(unittest.TestCase):
         self.assertIn("G1-G10", items["use_case_demo_cards"]["evidence_required"])
         self.assertIn("wrapper-renderable projections", items["use_case_demo_cards"]["proof_boundary"])
         self.assertIn("not prove", items["use_case_demo_cards"]["proof_boundary"])
+        self.assertEqual(items["use_case_artifact_bundle"]["command"], "uv run python -m src.cli cases artifact --all --json")
+        self.assertIn("prepared artifacts", items["use_case_artifact_bundle"]["evidence_required"])
+        self.assertIn("prepared runbook projection", items["use_case_artifact_bundle"]["proof_boundary"])
+        self.assertIn("not prove", items["use_case_artifact_bundle"]["proof_boundary"])
         self.assertTrue(items["live_tap_smoke"]["mutates_profile"])
         self.assertTrue(items["live_tap_smoke"]["requires_release_authority"])
         self.assertFalse(items["tag_and_publish"]["required"])
@@ -140,6 +147,10 @@ class ReleaseSmokeTests(unittest.TestCase):
         self.assertEqual(payload["use_case_demo_card_count"], 10)
         self.assertEqual(payload["expected_use_case_demo_card_count"], 10)
         self.assertEqual(payload["use_case_demo_failures"], [])
+        self.assertEqual(payload["use_case_artifact_collection_schema"], "omh_use_case_artifact_collection/v1")
+        self.assertEqual(payload["use_case_artifact_count"], 10)
+        self.assertEqual(payload["expected_use_case_artifact_count"], 10)
+        self.assertEqual(payload["use_case_artifact_failures"], [])
         self.assertLessEqual(
             payload["awareness_primer_context_chars"],
             payload["awareness_context_char_limits"]["primer_context"],


### PR DESCRIPTION
## Summary

Adds a local, deterministic G1-G10 use-case artifact bundle so OMH can prove more than demo-card rendering during release checks. Operators can now export prepared runbook artifacts for every application case, write them under `.omh/use-cases/artifacts/`, validate the local store, and use those artifacts for wrapper QA, demos, onboarding, and release review.

## Why

OMH already had G1-G10 use-case demo cards, but the product story still stopped at renderable examples. The gap was a reusable local artifact shape that says: this is the prepared route, operator step list, proof surface, wrapper card, and evidence boundary for a real application case. This PR closes that gap without claiming Hermes, a connector, a coding executor, CI, delivery, or billing actually ran.

## What Changed

- Adds `omh_use_case_artifact/v1`, `omh_use_case_artifact_collection/v1`, `omh_use_case_artifact_write/v1`, and a cache-only index schema for local use-case runbooks.
- Adds `omh cases artifact <id|--all>` for rendering prepared artifacts and `omh cases artifact --all --write` for writing the full G1-G10 bundle under `.omh/use-cases/artifacts/`.
- Adds `omh cases artifact-validate` to validate local use-case artifact stores without treating them as observed runtime evidence.
- Extends release readiness with a `use_case_artifact_bundle` gate and extends skill-content smoke with use-case artifact validation.
- Updates README and docs so application-case readiness covers both wrapper demo cards and local prepared runbook artifacts.

## User/Operator Impact

After this change, an operator can run:

```sh
omh cases artifact --all --write
omh cases artifact-validate
```

That gives them local, inspectable JSON runbooks for the ten representative OMH use cases. Each artifact contains the route, next action, Hermes prompt, operator commands, proof surfaces, wrapper-card metadata, and a strict `prepared_not_observed` boundary. It is useful when checking whether OMH really supports the advertised operating scenarios before wiring a chat wrapper.

## Implementation Notes

- `src/use_cases.py` owns artifact construction, write, list/show, and validation logic.
- `src/commands/use_cases.py` exposes the new CLI surfaces and human summaries.
- `src/paths.py` defines `.omh/use-cases/` and `.omh/use-cases/artifacts/` paths.
- `src/release.py` and `src/commands/release.py` include artifact-bundle release smoke checks.
- Tests cover JSON shape, local writes, duplicate write refusal, `--force` replacement, local validation, release checklist wiring, and smoke summary output.

## Evidence Observed

```sh
PYTHONPATH=tests uv run python -m unittest discover -s tests -v
# Ran 648 tests in 14.237s - OK

uv run python -m compileall -q src tests examples
uv run python -m src.cli docs workflows --check
uv run python -m src.cli release skill-content-smoke
git diff --check
```

`release skill-content-smoke` reported `Use-case artifacts: 10/10 artifact(s); failures 0`.

## Boundaries And Risks

- These artifacts are prepared runbook metadata only.
- They do not prove live Hermes profile reload, live messenger rendering, connector execution, file generation, memory mutation, executor dispatch, review, CI, merge, delivery, or provider billing.
- Existing unrelated untracked local files were left untouched.
