### PR TITLE
Add G1-G10 use-case readiness rollup

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,9 +149,9 @@ registration contracts live in the [installation guide](docs/INSTALLATION.md).
   reports, automation blueprints, material packages, and loop work all have
   Hermes-facing workflow paths.
 - **Application-case ready** - the G1-G10 use-case map can be exported as
-  wrapper-ready demo cards, local runbook artifacts, and deterministic replay
-  fixtures so operators see the route, next action, and evidence boundary
-  before wiring a chat surface.
+  wrapper-ready demo cards, local runbook artifacts, deterministic replay
+  fixtures, and a readiness rollup so operators see the route, next action,
+  and evidence boundary before wiring a chat surface.
 - **Local and inspectable** - skills, manifests, plans, sessions, and status
   records stay in user-owned local directories.
 

--- a/docs/APPLICATION_CASES.md
+++ b/docs/APPLICATION_CASES.md
@@ -41,6 +41,7 @@ omh cases demo --all --json
 omh cases artifact G10 --json
 omh cases artifact --all --write
 omh cases artifact-validate --json
+omh cases readiness --json
 omh cases replay --json
 omh cases recommend "PR opened with failing CI" --json
 omh cases validate --json
@@ -103,6 +104,20 @@ consult. The replay passes only when each fixture returns the expected goal and
 primary skill. It proves deterministic product-fit routing for those fixtures;
 it is not evidence of live Hermes chat behavior, connector execution, file
 generation, memory mutation, executor dispatch, review, CI, merge, or delivery.
+
+Use-case readiness is the operator-facing rollup for the full G1-G10 story:
+
+```sh
+omh cases readiness
+omh cases readiness --json
+```
+
+It checks the catalog, wrapper demo cards, prepared artifact bundle, and replay
+fixtures as required gates, then reports the local artifact store as an optional
+state. A missing local store is a warning, not a release blocker, because the
+bundle can still be rendered deterministically. This command is useful when a
+release reviewer, wrapper author, or Hermes operator wants one answer to: "are
+the application cases ready to show?"
 
 ## Case 1: Coding Request Handling
 
@@ -586,6 +601,9 @@ Before using these cases as public release evidence, verify:
 - `omh cases replay --json` exposes `omh_use_case_replay/v1` and must pass the
   English/Korean G1-G10 synthetic operator fixture set before the use-case map is
   treated as release-ready.
+- `omh cases readiness --json` exposes `omh_use_case_readiness/v1` and rolls the
+  catalog, card, artifact, replay, and optional local-store states into a single
+  operator-readable readiness card.
 - `omh playbook recommend` returns situation-level pipelines for safe coding,
   source-backed research, research-to-strategy briefs, meeting prep, feedback
   triage, ops review, operating rhythm history, report packages, reliability

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -63,6 +63,7 @@ python3 -m omh.cli release skill-content-smoke --json
 python3 -m omh.cli cases demo --all --json
 python3 -m omh.cli cases artifact --all --json
 python3 -m omh.cli cases replay --json
+python3 -m omh.cli cases readiness --json
 python3 -m omh.cli --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke learning review --all
 python3 -m omh.cli --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke install --dry-run --channel stable --version 1.0.1
 python3 -m omh.cli --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke setup --dry-run --channel stable --version 1.0.1
@@ -112,6 +113,12 @@ The same gate replays G1-G10 natural-language use-case fixtures through
 synthetic English/Korean operator corpus. It is not evidence that a live Hermes
 profile selected the route in chat or that any connector, executor, review, CI,
 merge, delivery, or billing event happened.
+
+The readiness rollup, `omh cases readiness --json`, combines the catalog,
+demo-card, artifact-bundle, replay, and optional local artifact-store states
+into one operator-readable card. It should be ready before a release, but it
+still proves only local deterministic contracts, not live Hermes selection or
+runtime execution.
 
 ## Hermes CLI Install Smoke
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -54,6 +54,9 @@
 - G1-G10 use-case replay through `omh cases replay`, including English/Korean
   synthetic operator fixtures and release smoke coverage for deterministic
   recommendation routing
+- G1-G10 use-case readiness through `omh cases readiness`, rolling catalog,
+  demo-card, artifact-bundle, replay, and optional local artifact-store states
+  into one operator-facing release card
 - Codex lifecycle helper commands over existing local runtime artifacts
 - Wrapper session plan decisions and restart recovery for accepted handoffs
 - Review, CI, merge-readiness, and merge observation records for delegated

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -601,6 +601,11 @@ omh playbook recommend "every morning check competitor news and send a Slack dig
             <code>omh_use_case_demo_card/v1</code> and keeps route, action,
             and evidence state in one deterministic payload.
           </p>
+          <p>
+            Check the full public story with <code>omh cases readiness --json</code>.
+            It rolls catalog, demo cards, prepared artifacts, replay fixtures,
+            and optional local artifact-store state into one readiness card.
+          </p>
           <div class="case-grid case-grid--docs" aria-label="Grounded operator case summary">
             <article class="case-card">
               <span>10/10 contract</span>

--- a/site/index.html
+++ b/site/index.html
@@ -619,8 +619,9 @@ omh setup</code>
           </p>
           <p>
             The full G1-G10 map also exports <code>omh_use_case_demo_card/v1</code>
-            cards, so wrappers can render the route, next action, and evidence boundary
-            from one local artifact.
+            cards plus a <code>omh_use_case_readiness/v1</code> rollup, so wrappers
+            can render the route, next action, evidence boundary, and release-ready
+            gate state from local artifacts.
           </p>
         </div>
         <div class="case-grid" aria-label="Grounded OMH operator cases">

--- a/src/commands/main.py
+++ b/src/commands/main.py
@@ -168,6 +168,7 @@ def build_parser() -> argparse.ArgumentParser:
             "Operator examples:\n"
             "  omh recommend \"risky refactor\"\n"
             "  omh cases recommend \"daily competitor digest\"\n"
+            "  omh cases readiness\n"
             "  omh cases demo --all\n"
             "  omh cases artifact --all --write\n"
             "  omh cases replay\n"
@@ -257,6 +258,7 @@ First five minutes:
 Useful operator commands:
   omh recommend "risky refactor"
   omh cases recommend "daily competitor digest"
+  omh cases readiness   Check the G1-G10 readiness rollup
   omh cases demo --all  Show wrapper-ready G1-G10 use-case cards
   omh cases artifact --all --write
                           Write local G1-G10 runbook artifacts

--- a/src/commands/use_cases.py
+++ b/src/commands/use_cases.py
@@ -12,6 +12,7 @@ from ..use_cases import (
     list_use_cases,
     recommend_use_cases,
     replay_use_case_fixtures,
+    use_case_readiness,
     validate_use_case_artifact_store,
     validate_use_cases,
     write_all_use_case_artifacts,
@@ -108,6 +109,15 @@ def cmd_cases_artifact_validate(args: argparse.Namespace) -> int:
     else:
         _print_cases_artifact_validate_summary(payload)
     return 0 if payload["ok"] else 1
+
+
+def cmd_cases_readiness(args: argparse.Namespace) -> int:
+    payload = use_case_readiness(_paths(args))
+    if _wants_json(args):
+        _print_json(payload)
+    else:
+        _print_cases_readiness_summary(payload)
+    return 0 if payload["blocking_failures"] == 0 else 1
 
 
 def cmd_cases_replay(args: argparse.Namespace) -> int:
@@ -324,6 +334,39 @@ def _print_cases_artifact_validate_summary(payload: dict[str, object]) -> None:
     print("  For machine-readable output, rerun with `--json`.")
 
 
+def _print_cases_readiness_summary(payload: dict[str, object]) -> None:
+    print("OMH G1-G10 use-case readiness")
+    print("Summary")
+    print(f"  Status: {payload.get('status')}")
+    print(f"  Score: {payload.get('score')}/100")
+    print(f"  Blocking failures: {payload.get('blocking_failures')}")
+    print(f"  Warnings: {payload.get('warning_count')}")
+    gates = payload.get("gates", [])
+    if not isinstance(gates, list):
+        gates = []
+    print("Gates")
+    for gate in gates:
+        if not isinstance(gate, dict):
+            continue
+        marker = "required" if gate.get("blocking") else "optional"
+        print(f"  - {gate.get('id')}: {gate.get('status')} [{marker}]")
+        print(f"    {gate.get('summary')}")
+        errors = gate.get("errors", [])
+        if isinstance(errors, list) and errors:
+            for error in errors[:5]:
+                print(f"    error: {error}")
+            if len(errors) > 5:
+                print(f"    ... {len(errors) - 5} more")
+    next_actions = payload.get("next_actions", [])
+    if isinstance(next_actions, list) and next_actions:
+        print("Next")
+        for action in next_actions:
+            print(f"  - {action}")
+    print("Boundary")
+    print(f"  {payload.get('boundary')}")
+    print("  For machine-readable output, rerun with `--json`.")
+
+
 def _print_cases_replay_summary(payload: dict[str, object]) -> None:
     print("OMH G1-G10 use-case replay")
     print("Summary")
@@ -440,6 +483,10 @@ def _add_cases_commands(sub) -> None:
     artifact_validate_cmd = cases_sub.add_parser("artifact-validate")
     artifact_validate_cmd.add_argument("--json", action="store_true", help="Print machine-readable validation for local use-case artifacts.")
     artifact_validate_cmd.set_defaults(func=cmd_cases_artifact_validate)
+
+    readiness_cmd = cases_sub.add_parser("readiness")
+    readiness_cmd.add_argument("--json", action="store_true", help="Print the full machine-readable G1-G10 readiness rollup.")
+    readiness_cmd.set_defaults(func=cmd_cases_readiness)
 
     replay_cmd = cases_sub.add_parser("replay")
     replay_cmd.add_argument("--limit", type=int, default=None, help="Replay only the first N deterministic use-case fixtures.")

--- a/src/release.py
+++ b/src/release.py
@@ -218,6 +218,16 @@ def release_readiness_checklist(
             "Use-case replay proves deterministic recommendation routing for synthetic fixtures only; it does not prove live Hermes chat behavior or any runtime execution.",
         ),
         ReleaseChecklistItem(
+            "use_case_readiness",
+            "Check G1-G10 use-case readiness rollup",
+            "uv run python -m src.cli cases readiness --json",
+            "contract-quality",
+            True,
+            False,
+            "Use-case readiness reports catalog, demo-card, artifact-bundle, and replay gates as passing while separating optional local artifact-store state.",
+            "Use-case readiness proves deterministic local use-case contracts only; it does not prove live Hermes chat behavior, connector work, executor work, review, CI, merge, delivery, or billing evidence.",
+        ),
+        ReleaseChecklistItem(
             "stable_install_dry_run",
             "Dry-run stable install metadata",
             (

--- a/src/use_cases.py
+++ b/src/use_cases.py
@@ -19,6 +19,7 @@ USE_CASE_ARTIFACT_COLLECTION_SCHEMA_VERSION = "omh_use_case_artifact_collection/
 USE_CASE_ARTIFACT_WRITE_SCHEMA_VERSION = "omh_use_case_artifact_write/v1"
 USE_CASE_ARTIFACT_INDEX_SCHEMA_VERSION = "omh_use_case_artifact_index/v1"
 USE_CASE_REPLAY_SCHEMA_VERSION = "omh_use_case_replay/v1"
+USE_CASE_READINESS_SCHEMA_VERSION = "omh_use_case_readiness/v1"
 _ARTIFACT_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9-]{0,159}$")
 
 
@@ -644,6 +645,79 @@ def replay_use_case_fixtures(*, limit: int | None = None) -> dict[str, Any]:
     }
 
 
+def use_case_readiness(paths: OmhPaths | None = None) -> dict[str, Any]:
+    catalog = validate_use_cases()
+    demo_collection = demo_all_use_cases()
+    demo_errors = _validate_demo_collection(demo_collection)
+    artifact_bundle = build_all_use_case_artifacts()
+    artifact_errors = _validate_artifact_collection(artifact_bundle)
+    replay = replay_use_case_fixtures()
+    replay_errors = _validate_replay_result(replay)
+
+    gates = [
+        _readiness_gate(
+            "catalog",
+            "Catalog registration",
+            "passed" if catalog.get("ok") else "failed",
+            True,
+            f"{len(catalog.get('validated', []))}/{len(USE_CASES)} use-case surface(s) registered",
+            "omh cases validate --json",
+            catalog.get("errors", []),
+        ),
+        _readiness_gate(
+            "demo_cards",
+            "Wrapper demo cards",
+            "passed" if not demo_errors else "failed",
+            True,
+            f"{len(demo_collection.get('cards', []))}/{len(USE_CASES)} wrapper card(s) render",
+            "omh cases demo --all --json",
+            demo_errors,
+        ),
+        _readiness_gate(
+            "artifact_bundle",
+            "Prepared artifact bundle",
+            "passed" if not artifact_errors else "failed",
+            True,
+            f"{len(artifact_bundle.get('artifacts', []))}/{len(USE_CASES)} prepared artifact(s) render",
+            "omh cases artifact --all --json",
+            artifact_errors,
+        ),
+        _readiness_gate(
+            "replay",
+            "Natural-language replay fixtures",
+            "passed" if not replay_errors else "failed",
+            True,
+            f"{replay.get('passed')}/{replay.get('total')} deterministic fixture(s) pass",
+            "omh cases replay --json",
+            replay_errors,
+        ),
+        _local_artifact_store_gate(paths),
+    ]
+    blocking_failures = [gate for gate in gates if gate["blocking"] and gate["status"] != "passed"]
+    warnings = [gate for gate in gates if not gate["blocking"] and gate["status"] != "passed"]
+    next_actions = []
+    if blocking_failures:
+        next_actions.append("Fix blocking gates, then rerun `omh cases readiness`.")
+    if any(gate["id"] == "local_artifact_store" and gate["status"] != "passed" for gate in gates):
+        next_actions.append("Optional: write local runbook artifacts with `omh cases artifact --all --write`.")
+    next_actions.append("Use `omh cases readiness --json` when a wrapper or release check needs the full payload.")
+    return {
+        "schema_version": USE_CASE_READINESS_SCHEMA_VERSION,
+        "status": "ready" if not blocking_failures else "needs_attention",
+        "score": 100 if not blocking_failures else round(((len(gates) - len(warnings) - len(blocking_failures)) / max(1, len(gates) - len(warnings))) * 100),
+        "blocking_failures": len(blocking_failures),
+        "warning_count": len(warnings),
+        "expected_goals": [case.goal for case in USE_CASES],
+        "gates": gates,
+        "next_actions": next_actions,
+        "boundary": (
+            "Use-case readiness proves deterministic local catalog, card, artifact, and replay contracts only. "
+            "It is not evidence that Hermes selected a workflow in live chat, ran connectors, generated files, "
+            "changed memory, dispatched an executor, reviewed code, passed CI, merged, delivered messages, or spent real provider budget."
+        ),
+    }
+
+
 def validate_use_cases() -> dict[str, Any]:
     from .playbooks import list_playbooks
     from .skill_pack import (
@@ -715,6 +789,160 @@ def validate_use_cases() -> dict[str, Any]:
         "errors": errors,
         "boundary": "Validation proves the 10 OMH feature surfaces are routable and registered with the right exposure, playbook, harness, and invocation metadata; it is not proof that any external runtime action happened.",
     }
+
+
+def _readiness_gate(
+    gate_id: str,
+    label: str,
+    status: str,
+    blocking: bool,
+    summary: str,
+    command: str,
+    errors: object | None = None,
+    *,
+    details: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "id": gate_id,
+        "label": label,
+        "status": status,
+        "blocking": blocking,
+        "summary": summary,
+        "command": command,
+        "errors": errors if isinstance(errors, list) else ([] if errors is None else [errors]),
+        "details": details or {},
+    }
+
+
+def _validate_demo_collection(payload: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if payload.get("schema_version") != USE_CASE_DEMO_COLLECTION_SCHEMA_VERSION:
+        errors.append("schema_version must be omh_use_case_demo_collection/v1")
+    cards = payload.get("cards", [])
+    if not isinstance(cards, list):
+        return errors + ["cards must be a list"]
+    if len(cards) != len(USE_CASES):
+        errors.append(f"expected {len(USE_CASES)} cards, observed {len(cards)}")
+    expected_goals = [case.goal for case in USE_CASES]
+    observed_goals = [str(card.get("goal", "")) for card in cards if isinstance(card, dict)]
+    if observed_goals != expected_goals:
+        errors.append("cards must be ordered G1-G10")
+    for card in cards:
+        if not isinstance(card, dict):
+            errors.append("card must be an object")
+            continue
+        goal = str(card.get("goal", ""))
+        case = _find_case(goal)
+        prefix = goal or "<unknown>"
+        if card.get("schema_version") != USE_CASE_DEMO_CARD_SCHEMA_VERSION:
+            errors.append(f"{prefix}: schema_version must be omh_use_case_demo_card/v1")
+        route = card.get("route") if isinstance(card.get("route"), dict) else {}
+        wrapper = card.get("wrapper_card") if isinstance(card.get("wrapper_card"), dict) else {}
+        evidence = card.get("evidence") if isinstance(card.get("evidence"), dict) else {}
+        actions = card.get("actions") if isinstance(card.get("actions"), list) else []
+        if case is None:
+            errors.append(f"{prefix}: goal must reference a known G1-G10 use case")
+            continue
+        if route.get("primary_skill") != case.primary_skill:
+            errors.append(f"{prefix}: route.primary_skill must match catalog")
+        if route.get("next_action") != case.next_action:
+            errors.append(f"{prefix}: route.next_action must match catalog")
+        if wrapper.get("component") != "omh_use_case_card":
+            errors.append(f"{prefix}: wrapper_card.component must be omh_use_case_card")
+        if wrapper.get("status") != "prepared_not_observed":
+            errors.append(f"{prefix}: wrapper_card.status must be prepared_not_observed")
+        if evidence.get("state") != "prepared_not_observed":
+            errors.append(f"{prefix}: evidence.state must be prepared_not_observed")
+        if "not" not in str(evidence.get("claim_boundary", "")).casefold():
+            errors.append(f"{prefix}: evidence.claim_boundary must keep a not-evidence guard")
+        if not actions or not isinstance(actions[0], dict) or actions[0].get("id") != case.next_action:
+            errors.append(f"{prefix}: first action must match the next action")
+    return errors
+
+
+def _validate_artifact_collection(payload: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if payload.get("schema_version") != USE_CASE_ARTIFACT_COLLECTION_SCHEMA_VERSION:
+        errors.append("schema_version must be omh_use_case_artifact_collection/v1")
+    artifacts = payload.get("artifacts", [])
+    if not isinstance(artifacts, list):
+        return errors + ["artifacts must be a list"]
+    if len(artifacts) != len(USE_CASES):
+        errors.append(f"expected {len(USE_CASES)} artifacts, observed {len(artifacts)}")
+    expected_goals = [case.goal for case in USE_CASES]
+    observed_goals = [str(artifact.get("goal", "")) for artifact in artifacts if isinstance(artifact, dict)]
+    if observed_goals != expected_goals:
+        errors.append("artifacts must be ordered G1-G10")
+    for artifact in artifacts:
+        if not isinstance(artifact, dict):
+            errors.append("artifact must be an object")
+            continue
+        for error in validate_use_case_artifact(artifact):
+            errors.append(f"{artifact.get('goal', '<unknown>')}: {error}")
+    return errors
+
+
+def _validate_replay_result(payload: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if payload.get("schema_version") != USE_CASE_REPLAY_SCHEMA_VERSION:
+        errors.append("schema_version must be omh_use_case_replay/v1")
+    if payload.get("status") != "passed":
+        errors.append(f"status must be passed, observed {payload.get('status')}")
+    if payload.get("passed") != payload.get("expected_total"):
+        errors.append(f"expected {payload.get('expected_total')} passing fixture(s), observed {payload.get('passed')}")
+    if payload.get("covered_goals") != [case.goal for case in USE_CASES]:
+        errors.append("covered_goals must include G1-G10")
+    results = payload.get("results", [])
+    if not isinstance(results, list):
+        return errors + ["results must be a list"]
+    for result in results:
+        if isinstance(result, dict) and result.get("status") != "passed":
+            errors.append(f"{result.get('fixture_id', '<unknown>')}: {result.get('errors', [])}")
+    return errors
+
+
+def _local_artifact_store_gate(paths: OmhPaths | None) -> dict[str, Any]:
+    if paths is None:
+        return _readiness_gate(
+            "local_artifact_store",
+            "Local artifact store",
+            "not_checked",
+            False,
+            "Local artifact store was not checked because no OMH paths were supplied",
+            "omh cases artifact-validate --json",
+        )
+    validation = validate_use_case_artifact_store(paths)
+    artifact_count = int(validation.get("artifact_count", 0))
+    expected_count = int(validation.get("expected_count", len(USE_CASES)))
+    errors = validation.get("errors", [])
+    missing = validation.get("missing_goals", [])
+    if errors:
+        status = "warning"
+        summary = f"{artifact_count}/{expected_count} local artifact(s) readable; repair warnings before relying on the local cache"
+    elif artifact_count == 0:
+        status = "not_written"
+        summary = f"0/{expected_count} local artifact(s) written; optional for wrapper QA and demos"
+    elif missing:
+        status = "partial"
+        summary = f"{artifact_count}/{expected_count} local artifact(s) written; {len(missing)} goal(s) missing"
+    else:
+        status = "passed"
+        summary = f"{artifact_count}/{expected_count} local artifact(s) written and valid"
+    return _readiness_gate(
+        "local_artifact_store",
+        "Local artifact store",
+        status,
+        False,
+        summary,
+        "omh cases artifact-validate --json",
+        errors,
+        details={
+            "artifact_count": artifact_count,
+            "expected_count": expected_count,
+            "missing_goals": missing,
+            "index_authority": validation.get("index_authority", ""),
+        },
+    )
 
 
 def _proof_surface_supported(surface: str, *, playbook_ids: set[str], harness_names: set[str]) -> bool:

--- a/tests/test_application_cases.py
+++ b/tests/test_application_cases.py
@@ -61,6 +61,7 @@ class ApplicationCaseArtifactTests(unittest.TestCase):
         self.assertIn("omh cases artifact --all --write", cases)
         self.assertIn(".omh/use-cases/artifacts/", cases)
         self.assertIn("omh cases replay --json", cases)
+        self.assertIn("omh cases readiness --json", cases)
         self.assertIn("Chat Wrapper Backend Flow", install)
         self.assertIn("Codex lifecycle calls", install)
         self.assertIn("What Gets Recorded", install)
@@ -147,6 +148,41 @@ class ApplicationCaseArtifactTests(unittest.TestCase):
                 self.assertEqual(result["status"], "passed")
                 self.assertEqual(result["expected"]["goal"], result["observed"]["goal"])
                 self.assertEqual(result["expected"]["primary_skill"], result["observed"]["primary_skill"])
+
+    def test_g1_to_g10_use_case_readiness_rollup_separates_optional_store(self) -> None:
+        with TemporaryDirectory() as tmp:
+            omh_home = Path(tmp) / ".omh"
+
+            code, stdout, stderr = run_cli(["--omh-home", str(omh_home), "cases", "readiness", "--json"], output_json=False)
+
+            self.assertEqual(code, 0, stderr)
+            self.assertEqual(stderr, "")
+            readiness = json.loads(stdout)
+            self.assertEqual(readiness["schema_version"], "omh_use_case_readiness/v1")
+            self.assertEqual(readiness["status"], "ready")
+            self.assertEqual(readiness["score"], 100)
+            self.assertEqual(readiness["blocking_failures"], 0)
+            self.assertEqual(readiness["expected_goals"], [f"G{index}" for index in range(1, 11)])
+            gates = {gate["id"]: gate for gate in readiness["gates"]}
+            self.assertEqual(gates["catalog"]["status"], "passed")
+            self.assertEqual(gates["demo_cards"]["status"], "passed")
+            self.assertEqual(gates["artifact_bundle"]["status"], "passed")
+            self.assertEqual(gates["replay"]["status"], "passed")
+            self.assertFalse(gates["local_artifact_store"]["blocking"])
+            self.assertEqual(gates["local_artifact_store"]["status"], "not_written")
+            self.assertIn("not evidence", readiness["boundary"])
+
+            code, _, stderr = run_cli(["--omh-home", str(omh_home), "cases", "artifact", "--all", "--write", "--json"], output_json=False)
+            self.assertEqual(code, 0, stderr)
+
+            code, stdout, stderr = run_cli(["--omh-home", str(omh_home), "cases", "readiness", "--json"], output_json=False)
+
+            self.assertEqual(code, 0, stderr)
+            self.assertEqual(stderr, "")
+            readiness = json.loads(stdout)
+            gates = {gate["id"]: gate for gate in readiness["gates"]}
+            self.assertEqual(gates["local_artifact_store"]["status"], "passed")
+            self.assertEqual(gates["local_artifact_store"]["details"]["artifact_count"], 10)
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -657,6 +657,7 @@ class CliTests(unittest.TestCase):
             (["cases", "demo", "--all"], "OMH G1-G10 use-case demo cards", "cards"),
             (["cases", "artifact", "G10"], "OMH use-case artifact:", "artifact_id"),
             (["cases", "artifact", "--all"], "OMH G1-G10 use-case artifacts", "artifacts"),
+            (["cases", "readiness"], "OMH G1-G10 use-case readiness", "gates"),
             (["cases", "replay"], "OMH G1-G10 use-case replay", "results"),
             (["cases", "validate"], "OMH G1-G10 feature surface validation", "validated"),
             (["playbook", "list"], "OMH playbooks", "playbooks"),
@@ -858,6 +859,27 @@ class CliTests(unittest.TestCase):
         self.assertEqual(status, 2)
         self.assertEqual(stdout, "")
         self.assertIn("limit must be at least 1", stderr)
+
+        with TemporaryDirectory() as tmp:
+            base = ["--omh-home", str(Path(tmp) / ".omh")]
+
+            status, stdout, stderr = run_cli(base + ["cases", "readiness", "--json"], output_json=False)
+
+            self.assertEqual(status, 0, stderr)
+            self.assertEqual(stderr, "")
+            readiness = json.loads(stdout)
+            self.assertEqual(readiness["schema_version"], "omh_use_case_readiness/v1")
+            self.assertEqual(readiness["status"], "ready")
+            self.assertEqual(readiness["score"], 100)
+            self.assertEqual(readiness["blocking_failures"], 0)
+            gates = {gate["id"]: gate for gate in readiness["gates"]}
+            self.assertEqual(gates["catalog"]["status"], "passed")
+            self.assertEqual(gates["demo_cards"]["command"], "omh cases demo --all --json")
+            self.assertEqual(gates["artifact_bundle"]["status"], "passed")
+            self.assertEqual(gates["replay"]["status"], "passed")
+            self.assertEqual(gates["local_artifact_store"]["status"], "not_written")
+            self.assertFalse(gates["local_artifact_store"]["blocking"])
+            self.assertIn("artifact --all --write", " ".join(readiness["next_actions"]))
 
         examples = (
             ("Every morning send a competitor digest to Slack only if changed", "G1", "automation-blueprint"),
@@ -1562,6 +1584,7 @@ class CliTests(unittest.TestCase):
         self.assertIn("use_case_demo_cards", stdout)
         self.assertIn("use_case_artifact_bundle", stdout)
         self.assertIn("use_case_replay", stdout)
+        self.assertIn("use_case_readiness", stdout)
         self.assertIn("/tmp/omh --help", stdout)
         self.assertIn("live_tap_smoke", stdout)
         self.assertIn("profile-mutating", stdout)
@@ -1584,6 +1607,7 @@ class CliTests(unittest.TestCase):
         self.assertIn("cases demo --all --json", items["use_case_demo_cards"]["command"])
         self.assertIn("cases artifact --all --json", items["use_case_artifact_bundle"]["command"])
         self.assertIn("cases replay --json", items["use_case_replay"]["command"])
+        self.assertIn("cases readiness --json", items["use_case_readiness"]["command"])
         self.assertIn("skill-content-smoke", items["skill_content_smoke"]["command"])
         self.assertIn("setup --dry-run --channel stable --version 1.0.0", items["wheel_setup_dry_run"]["command"])
         self.assertTrue(items["live_tap_smoke"]["requires_release_authority"])

--- a/tests/test_release_smoke.py
+++ b/tests/test_release_smoke.py
@@ -34,6 +34,7 @@ class ReleaseSmokeTests(unittest.TestCase):
         self.assertIn("use_case_demo_cards", items)
         self.assertIn("use_case_artifact_bundle", items)
         self.assertIn("use_case_replay", items)
+        self.assertIn("use_case_readiness", items)
         self.assertIn("live_tap_smoke", items)
         self.assertIn("tag_and_publish", items)
         self.assertEqual(items["installed_command_path"]["command"], "command -v /tmp/omh")
@@ -67,12 +68,15 @@ class ReleaseSmokeTests(unittest.TestCase):
         self.assertIn("English and Korean operator fixtures", items["use_case_replay"]["evidence_required"])
         self.assertIn("synthetic fixtures", items["use_case_replay"]["proof_boundary"])
         self.assertIn("does not prove live Hermes chat behavior", items["use_case_replay"]["proof_boundary"])
+        self.assertEqual(items["use_case_readiness"]["command"], "uv run python -m src.cli cases readiness --json")
+        self.assertIn("readiness", items["use_case_readiness"]["evidence_required"])
+        self.assertIn("deterministic local use-case contracts", items["use_case_readiness"]["proof_boundary"])
         self.assertTrue(items["live_tap_smoke"]["mutates_profile"])
         self.assertTrue(items["live_tap_smoke"]["requires_release_authority"])
         self.assertFalse(items["tag_and_publish"]["required"])
         self.assertIn('git tag -a v1.0.0 -m "Release v1.0.0"', items["tag_and_publish"]["command"])
         self.assertTrue(items["tag_and_publish"]["requires_release_authority"])
-        self.assertGreaterEqual(payload["required_item_count"], 17)
+        self.assertGreaterEqual(payload["required_item_count"], 18)
 
     def test_release_readiness_checklist_rejects_unsafe_versions_and_quotes_command_paths(self) -> None:
         with self.assertRaises(ValueError):


### PR DESCRIPTION
## Summary

Adds a deterministic G1-G10 use-case readiness rollup so operators, wrapper authors, and release reviewers can answer one question: is the full public application-case story ready to show?

The new `omh cases readiness` command does not introduce runtime execution. It aggregates existing local proof surfaces and keeps optional local artifact materialization separate from required release gates.

## Why

G1-G10 now has several strong surfaces: catalog validation, wrapper demo cards, prepared runbook artifacts, and natural-language replay fixtures. The gap was that a reviewer still had to know and run several commands to understand the overall state.

This PR adds a single conservative readiness card that makes the story easier to inspect without weakening OMH's prepared-vs-observed boundary.

## What Changed

- Adds `omh_use_case_readiness/v1` in `src/use_cases.py`.
- Adds `use_case_readiness()` with gates for:
  - catalog registration
  - wrapper demo cards
  - prepared artifact bundle
  - natural-language replay fixtures
  - optional local artifact store
- Adds `omh cases readiness` and `omh cases readiness --json`.
- Adds a release checklist item: `use_case_readiness`.
- Updates README, application-case docs, release docs, roadmap, and site copy.
- Adds tests for CLI behavior, local artifact-store warning/pass states, and release checklist coverage.

## How It Works

The readiness payload treats deterministic generated surfaces as required gates and the user's local `.omh/use-cases/artifacts/` store as optional state:

- Missing local artifacts report `not_written` as a warning, not a blocking failure.
- Invalid core catalog/card/artifact/replay contracts report blocking failures.
- The status remains `ready` when all required gates pass, even if optional local artifacts have not been written.

This keeps the release story clean while avoiding a false claim that local wrapper/demo artifacts have already been materialized for a specific operator.

## Verification

Observed locally:

```sh
uv run python -m src.cli cases readiness
uv run python -m src.cli cases readiness --json
PYTHONPATH=tests uv run python -m unittest tests/test_application_cases.py -v
PYTHONPATH=tests uv run python -m unittest tests/test_release_smoke.py -v
PYTHONPATH=tests uv run python -m unittest tests/test_cli.py -v
PYTHONPATH=tests uv run python -m unittest discover -s tests -v
uv run python -m src.cli release checklist --version 1.0.1 --json
uv run python -m src.cli docs workflows --check
uv run python -m compileall -q src tests examples
git diff --check
```

Full unittest result: 650 tests passed.

## Boundary And Risk

- This is local deterministic readiness evidence only.
- It does not prove live Hermes chat selection, connector execution, file generation, memory mutation, executor dispatch, review, CI, merge, delivery, or billing events.
- Optional local artifact-store warnings should remain non-blocking unless a future release explicitly requires materialized local artifacts.
