### PR TITLE
Add release evidence bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,8 +291,9 @@ documentation below.
 
 ## Development
 
-Development and release smoke details live in [Release](docs/RELEASE.md). For a
-quick local sanity check from a source checkout:
+Development, release smoke, product readiness, and evidence-bundle details live
+in [Release](docs/RELEASE.md). For a quick local sanity check from a source
+checkout:
 
 ```sh
 python3 -m unittest discover -s tests

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -276,6 +276,7 @@ command -v omh
 omh --help
 omh release skill-content-smoke --json
 omh release product-readiness --version 1.0.1 --json
+omh release evidence-bundle --version 1.0.1 --write --json
 omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke
 ```
 
@@ -294,6 +295,11 @@ Use `omh release product-readiness --version 1.0.1 --json` when you want a
 single release-candidate card that combines skill content, G1-G10 use-case
 readiness, parity contracts, and release checklist shape. It is still local
 contract evidence, not live Hermes chat or executor evidence.
+
+Use `omh release evidence-bundle --version 1.0.1 --write --json` when you want
+that local release-candidate evidence written under
+`.omh/runtime/release-evidence/` for a release PR or release note. The bundle is
+not CI, live Hermes smoke, executor, delivery, merge, or GitHub release evidence.
 
 ```sh
 omh release hermes-smoke --live --install-path tap --target-confirmed

--- a/docs/README.md
+++ b/docs/README.md
@@ -126,6 +126,7 @@ separate profile pack is explicitly selected.
 - Release checks should include `omh release checklist --json`,
   `omh release skill-content-smoke --json`,
   `omh release product-readiness --version 1.0.1 --json`,
+  `omh release evidence-bundle --version 1.0.1 --write --json`,
   `omh release hermes-smoke`, `omh release install-smoke`, and installed command
   smoke (`omh --help`). Use `release install-smoke --live` for an isolated
   first-time downloader check, and use `hermes-smoke --live` only from the

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -61,6 +61,7 @@ python3 -m omh.cli harness validate
 python3 -m omh.cli release checklist --json
 python3 -m omh.cli release skill-content-smoke --json
 python3 -m omh.cli release product-readiness --version 1.0.1 --json
+python3 -m omh.cli release evidence-bundle --version 1.0.1 --write --json
 python3 -m omh.cli cases demo --all --json
 python3 -m omh.cli cases artifact --all --json
 python3 -m omh.cli cases replay --json
@@ -133,6 +134,19 @@ notes and maintainer handoff, but it is still local deterministic evidence only:
 it does not run the checklist, mutate Hermes, dispatch executors, review code,
 pass CI, merge, deliver messages, or spend provider budget.
 
+When the local release story is ready, write an attachable evidence bundle:
+
+```sh
+omh release evidence-bundle --version 1.0.1 --write --json
+```
+
+The bundle writes `omh_release_evidence_bundle/v1` under
+`.omh/runtime/release-evidence/` with the checklist, product readiness,
+skill-content smoke, use-case readiness, and parity snapshots. It is useful for
+release PRs and notes, but it is still local deterministic evidence only; live
+Hermes smoke, CI, review, merge, delivery, and GitHub release publication must
+be observed separately.
+
 ## Hermes CLI Install Smoke
 
 The release gate includes a deterministic smoke plan for the real Hermes CLI
@@ -177,6 +191,7 @@ command -v omh
 omh --help
 omh release skill-content-smoke --json
 omh release product-readiness --version 1.0.1 --json
+omh release evidence-bundle --version 1.0.1 --write --json
 omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke
 ```
 

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -611,6 +611,12 @@ omh playbook recommend "every morning check competitor news and send a Slack dig
             It combines skill content, G1-G10 readiness, parity contracts, and release
             checklist shape without claiming live Hermes chat or executor evidence.
           </p>
+          <p>
+            To attach local deterministic proof to a release PR or note, run
+            <code>omh release evidence-bundle --version 1.0.1 --write --json</code>.
+            The bundle records local package evidence while CI, live Hermes smoke,
+            review, merge, and publication remain separately observed gates.
+          </p>
           <div class="case-grid case-grid--docs" aria-label="Grounded operator case summary">
             <article class="case-card">
               <span>10/10 contract</span>

--- a/src/commands/main.py
+++ b/src/commands/main.py
@@ -178,6 +178,7 @@ def build_parser() -> argparse.ArgumentParser:
             "  omh menubar status\n"
             "  omh mcp manifest\n"
             "  omh mcp config-recipe --host codex\n"
+            "  omh release evidence-bundle --version 1.0.1 --write\n"
             "  omh plugin observe-host --host hermes-agent --session <session-id> --event plugin_load --evidence-ref <host-log>\n"
             "  omh loop status\n"
             "  omh ops list\n"
@@ -268,6 +269,8 @@ Useful operator commands:
   omh hud                Show the compact OMH status line
   omh menubar status     Show the menu bar app status view model
   omh mcp manifest       Print the optional stdio MCP bridge manifest
+  omh release evidence-bundle --version 1.0.1 --write
+                          Write local deterministic release evidence
   omh plugin observe-host --host hermes-agent --session <session-id> --event plugin_load --evidence-ref <host-log>
   omh loop status        Show loopable goal cycle state
   omh ops list           List local operations artifacts

--- a/src/commands/release.py
+++ b/src/commands/release.py
@@ -9,6 +9,7 @@ from ..release import (
     DEFAULT_HERMES_TAP,
     INSTALL_PATHS,
     hermes_release_smoke_plan,
+    release_evidence_bundle,
     product_readiness_report,
     release_readiness_checklist,
     run_hermes_release_smoke,
@@ -16,7 +17,7 @@ from ..release import (
     skill_content_smoke,
 )
 from ..release_install_smoke import install_script_smoke_plan, run_install_script_smoke
-from .common import _print_json, _wants_json
+from .common import _paths, _print_json, _wants_json
 
 
 def cmd_release_checklist(args: argparse.Namespace) -> int:
@@ -132,6 +133,23 @@ def cmd_release_product_readiness(args: argparse.Namespace) -> int:
     return 0 if payload["status"] == "ready" else 1
 
 
+def cmd_release_evidence_bundle(args: argparse.Namespace) -> int:
+    try:
+        payload = release_evidence_bundle(
+            version=args.version or __version__,
+            omh_command=args.omh_command,
+            paths=_paths(args),
+            write=args.write,
+        )
+    except ValueError as exc:
+        raise OmhError(str(exc)) from exc
+    if _wants_json(args):
+        _print_json(payload)
+    else:
+        _print_release_evidence_bundle_summary(payload)
+    return 0 if payload["status"] == "ready" else 1
+
+
 def _add_release_commands(sub) -> None:
     release = sub.add_parser("release", help="Plan or run release smoke checks for real Hermes installation paths.")
     release_sub = release.add_subparsers(dest="release_command", required=True)
@@ -219,6 +237,16 @@ def _add_release_commands(sub) -> None:
     product_readiness.add_argument("--json", action="store_true", help="Print the machine-readable product readiness payload.")
     product_readiness.set_defaults(func=cmd_release_product_readiness)
 
+    evidence_bundle = release_sub.add_parser(
+        "evidence-bundle",
+        help="Package local deterministic release evidence into one optional artifact.",
+    )
+    evidence_bundle.add_argument("--version", default="", help="Release version to bundle, such as 1.0.1 or v1.0.1.")
+    evidence_bundle.add_argument("--omh-command", default="omh", help="Installed OMH executable name/path shown in release gate commands.")
+    evidence_bundle.add_argument("--write", action="store_true", help="Write the bundle under .omh/runtime/release-evidence/.")
+    evidence_bundle.add_argument("--json", action="store_true", help="Print the machine-readable release evidence bundle payload.")
+    evidence_bundle.set_defaults(func=cmd_release_evidence_bundle)
+
 
 def _print_release_checklist_summary(payload: dict[str, object]) -> None:
     print(f"OMH release checklist for {payload['version']} ({payload['tag']})")
@@ -299,6 +327,38 @@ def _print_product_readiness_summary(payload: dict[str, object]) -> None:
         if isinstance(warnings, list) and warnings:
             print(f"    Warnings: {', '.join(str(warning) for warning in warnings)}")
     print("")
+    print("Next")
+    for action in payload.get("next_actions", []):
+        print(f"  - {action}")
+    print("")
+    print(f"Boundary: {payload.get('boundary')}")
+    print("For machine-readable output, rerun with `--json`.")
+
+
+def _print_release_evidence_bundle_summary(payload: dict[str, object]) -> None:
+    summary = payload.get("summary", {})
+    summary = summary if isinstance(summary, dict) else {}
+    print(f"OMH release evidence bundle for {payload.get('version')}")
+    print("Summary")
+    print(f"  Status: {payload.get('status')}")
+    print(f"  Written: {'yes' if payload.get('written') else 'no'}")
+    print(f"  Artifact: {payload.get('artifact_path')}")
+    print(f"  Product readiness: {summary.get('product_readiness_status')} ({summary.get('product_readiness_score')}/100)")
+    print(f"  Use-case readiness: {summary.get('use_case_readiness_status')} ({summary.get('use_case_readiness_score')}/100)")
+    print(f"  Local artifact store: {summary.get('local_artifact_store')}")
+    print("")
+    blocking = payload.get("blocking_failures", [])
+    if isinstance(blocking, list) and blocking:
+        print("Blocking")
+        for item in blocking:
+            print(f"  - {item}")
+        print("")
+    warnings = payload.get("warnings", [])
+    if isinstance(warnings, list) and warnings:
+        print("Warnings")
+        for item in warnings:
+            print(f"  - {item}")
+        print("")
     print("Next")
     for action in payload.get("next_actions", []):
         print(f"  - {action}")

--- a/src/paths.py
+++ b/src/paths.py
@@ -47,6 +47,14 @@ class OmhPaths:
         return self.runtime_dir / "worktrees.jsonl"
 
     @property
+    def release_evidence_dir(self) -> Path:
+        return self.runtime_dir / "release-evidence"
+
+    @property
+    def release_evidence_index_path(self) -> Path:
+        return self.release_evidence_dir / "index.json"
+
+    @property
     def operations_dir(self) -> Path:
         return self.omh_home / "operations"
 

--- a/src/plugin_bundle/omh/config.yaml
+++ b/src/plugin_bundle/omh/config.yaml
@@ -15,6 +15,7 @@ evidence:
     - "omh docs workflows --check"
     - "omh release checklist"
     - "omh release product-readiness"
+    - "omh release evidence-bundle"
     - "python -m unittest"
     - "python3 -m unittest"
     - "python -m compileall"

--- a/src/plugin_bundle/omh/tools/evidence_tool.py
+++ b/src/plugin_bundle/omh/tools/evidence_tool.py
@@ -62,6 +62,7 @@ _DEFAULT_ALLOWLIST = (
     "omh docs workflows --check",
     "omh release checklist",
     "omh release product-readiness",
+    "omh release evidence-bundle",
     "python -m unittest",
     "python3 -m unittest",
     "python -m compileall",

--- a/src/release.py
+++ b/src/release.py
@@ -18,6 +18,7 @@ from .command_path import (
     inspect_installed_command_path,
     path_check_kind,
 )
+from .local_store import atomic_write_json, read_json_object_result, utc_now
 from .plugin_bundle.omh.awareness import (
     awareness_primer_context,
     awareness_primer_markdown,
@@ -50,6 +51,7 @@ INSTALLED_COMMAND_SMOKE_SCHEMA = "installed_omh_command_smoke/v1"
 FIRST_USE_STATUS_SMOKE_SCHEMA = "first_use_status_smoke/v1"
 SKILL_CONTENT_SMOKE_SCHEMA = "skill_content_smoke/v1"
 PRODUCT_READINESS_SCHEMA = "omh_product_readiness/v1"
+RELEASE_EVIDENCE_BUNDLE_SCHEMA = "omh_release_evidence_bundle/v1"
 RELEASE_VERSION_RE = re.compile(r"^[0-9]+(?:\.[0-9]+)*(?:[-_+.]?[A-Za-z0-9][A-Za-z0-9._+-]*)?$")
 DEFAULT_HERMES_TAP = "rlaope/oh-my-hermes"
 DEFAULT_HERMES_SKILL = "oh-my-hermes"
@@ -239,6 +241,16 @@ def release_readiness_checklist(
             False,
             "Product readiness reports skill-content, G1-G10 use-case, parity, and release checklist gates as passing.",
             "Product readiness proves deterministic local package and product contracts only; it does not prove live Hermes chat behavior, connector work, executor work, review, CI, merge, delivery, or billing evidence.",
+        ),
+        ReleaseChecklistItem(
+            "release_evidence_bundle",
+            "Write the local release evidence bundle",
+            f"{omh_display} release evidence-bundle --version {release_version} --write --json",
+            "evidence-packaging",
+            True,
+            False,
+            "A local `omh_release_evidence_bundle/v1` artifact is written with checklist, product readiness, skill content, use-case readiness, and parity snapshots.",
+            "The evidence bundle packages local deterministic evidence only; it is not live Hermes runtime use, connector execution, executor dispatch, review, CI, merge, delivery, or release publication evidence.",
         ),
         ReleaseChecklistItem(
             "stable_install_dry_run",
@@ -456,6 +468,7 @@ def product_readiness_report(
         "skill_content_smoke",
         "use_case_readiness",
         "product_readiness",
+        "release_evidence_bundle",
         "installed_command_smoke",
         "installer_smoke",
         "live_tap_smoke",
@@ -1201,6 +1214,7 @@ def _product_readiness_next_actions(blocking_failures: Sequence[Mapping[str, obj
             "Use the per-gate command to inspect the failing contract before tagging.",
         ]
     actions = [
+        "Write `omh release evidence-bundle --version <version> --write --json` and attach it to the release notes or PR.",
         "Attach observed evidence for each required release checklist item before tagging or publishing.",
         "Run one live Hermes tap smoke from the target profile before treating Hermes runtime visibility as observed.",
         "Use `omh release product-readiness --json` when a wrapper or release note needs the full machine-readable payload.",
@@ -1208,6 +1222,170 @@ def _product_readiness_next_actions(blocking_failures: Sequence[Mapping[str, obj
     if warning_count:
         actions.insert(0, "Review non-blocking warnings; they should be acknowledged but do not block local product readiness.")
     return actions
+
+
+def release_evidence_bundle(
+    *,
+    version: str = __version__,
+    omh_command: str = "omh",
+    paths: OmhPaths | None = None,
+    write: bool = False,
+) -> dict[str, object]:
+    release_version = _normalize_release_version(version)
+    resolved_paths = paths or OmhPaths(omh_home=Path("~/.omh").expanduser(), hermes_home=Path("~/.hermes").expanduser())
+    checklist = release_readiness_checklist(version=release_version, omh_command=omh_command)
+    product = product_readiness_report(version=release_version, omh_command=omh_command)
+    skill_content = skill_content_smoke()
+    use_cases = use_case_readiness(resolved_paths)
+    parity = build_parity_matrix()
+    local_store_status = _release_local_store_status(use_cases)
+    required_status = {
+        "release_checklist": "passed" if checklist.get("ok") else "failed",
+        "product_readiness": "passed" if product.get("status") == "ready" else "failed",
+        "skill_content": "passed" if skill_content.get("ok") else "failed",
+        "use_case_readiness": "passed" if use_cases.get("blocking_failures") == 0 else "failed",
+        "parity_contracts": "passed" if _parity_contracts_ready(parity) else "failed",
+    }
+    blocking_failures = [
+        f"{gate_id}: {status}"
+        for gate_id, status in required_status.items()
+        if status != "passed"
+    ]
+    warnings = []
+    if local_store_status != "passed":
+        warnings.append(f"local_artifact_store: {local_store_status}")
+    payload: dict[str, object] = {
+        "schema_version": RELEASE_EVIDENCE_BUNDLE_SCHEMA,
+        "mode": "live",
+        "observed": True,
+        "written": False,
+        "version": release_version,
+        "tag": f"v{release_version}",
+        "created_at": utc_now(),
+        "status": "ready" if not blocking_failures else "needs_attention",
+        "blocking_failures": blocking_failures,
+        "warnings": warnings,
+        "summary": {
+            "release_checklist_required_items": checklist.get("required_item_count"),
+            "product_readiness_status": product.get("status"),
+            "product_readiness_score": product.get("score"),
+            "skill_content_ok": skill_content.get("ok"),
+            "use_case_readiness_status": use_cases.get("status"),
+            "use_case_readiness_score": use_cases.get("score"),
+            "local_artifact_store": local_store_status,
+            "parity_available": (parity.get("summary") or {}).get("available")
+            if isinstance(parity.get("summary"), Mapping)
+            else None,
+            "parity_capability_count": (parity.get("summary") or {}).get("capability_count")
+            if isinstance(parity.get("summary"), Mapping)
+            else None,
+        },
+        "evidence": {
+            "release_checklist": checklist,
+            "product_readiness": product,
+            "skill_content": skill_content,
+            "use_case_readiness": use_cases,
+            "parity_contracts": parity,
+        },
+        "claims": [
+            "deterministic_local_package_contracts_checked",
+            "release_checklist_indexed",
+            "product_readiness_rollup_ready",
+            "skill_content_smoke_ready",
+            "g1_to_g10_use_case_readiness_ready",
+            "parity_contract_matrix_ready",
+        ],
+        "not_evidence_for": [
+            "live_hermes_chat_selection",
+            "connector_execution",
+            "executor_dispatch",
+            "implementation",
+            "review",
+            "ci",
+            "merge",
+            "delivery",
+            "billing_or_provider_budget",
+            "github_release_publication",
+        ],
+        "next_actions": _release_evidence_next_actions(blocking_failures, local_store_status),
+        "boundary": (
+            "A release evidence bundle packages deterministic local OMH evidence and optional local artifact-store state. "
+            "It does not mutate Hermes, run live profile smoke, call connectors, dispatch executors, review code, pass CI, "
+            "merge, deliver messages, publish GitHub releases, or prove provider billing/quota truth."
+        ),
+    }
+    if write:
+        artifact_path = resolved_paths.release_evidence_dir / f"omh-release-evidence-{release_version}.json"
+        payload["written"] = True
+        payload["artifact_path"] = str(artifact_path)
+        atomic_write_json(artifact_path, payload, private=True)
+        _write_release_evidence_index(resolved_paths, payload)
+    else:
+        payload["artifact_path"] = str(resolved_paths.release_evidence_dir / f"omh-release-evidence-{release_version}.json")
+    return payload
+
+
+def _release_evidence_next_actions(blocking_failures: Sequence[str], local_store_status: str) -> list[str]:
+    if blocking_failures:
+        return [
+            "Fix blocking bundle gates, then rerun `omh release evidence-bundle --write --json`.",
+            "Inspect the nested evidence payload for the failing gate before tagging.",
+        ]
+    actions = [
+        "Attach this bundle to the release PR or release notes as local deterministic evidence.",
+        "Run the required CI and live Hermes smoke separately; this bundle does not observe those remote/runtime gates.",
+    ]
+    if local_store_status != "passed":
+        actions.insert(0, "Run `omh cases artifact --all --write --json` if you want the optional local use-case artifact store populated.")
+    return actions
+
+
+def _release_local_store_status(use_case_payload: Mapping[str, object]) -> str:
+    gates = use_case_payload.get("gates", [])
+    if not isinstance(gates, Sequence) or isinstance(gates, (str, bytes)):
+        return "unknown"
+    for gate in gates:
+        if isinstance(gate, Mapping) and gate.get("id") == "local_artifact_store":
+            return str(gate.get("status") or "unknown")
+    return "missing"
+
+
+def _parity_contracts_ready(payload: Mapping[str, object]) -> bool:
+    summary = payload.get("summary")
+    if not isinstance(summary, Mapping):
+        return False
+    for key in ("partial", "planned", "deferred"):
+        if int(summary.get(key, 0) or 0) != 0:
+            return False
+    return int(summary.get("available", 0) or 0) == int(summary.get("capability_count", 0) or 0)
+
+
+def _write_release_evidence_index(paths: OmhPaths, payload: Mapping[str, object]) -> None:
+    version = str(payload.get("version") or "")
+    artifact_path = str(payload.get("artifact_path") or "")
+    existing, _ = read_json_object_result(paths.release_evidence_index_path)
+    entries = []
+    if existing and isinstance(existing.get("entries"), list):
+        entries = [entry for entry in existing["entries"] if isinstance(entry, dict) and entry.get("version") != version]
+    entries.append(
+        {
+            "version": version,
+            "tag": payload.get("tag"),
+            "status": payload.get("status"),
+            "created_at": payload.get("created_at"),
+            "artifact_path": artifact_path,
+            "schema_version": payload.get("schema_version"),
+        }
+    )
+    entries.sort(key=lambda entry: str(entry.get("created_at") or ""))
+    index = {
+        "schema_version": "omh_release_evidence_index/v1",
+        "latest_version": version,
+        "latest_artifact_path": artifact_path,
+        "count": len(entries),
+        "entries": entries,
+    }
+    atomic_write_json(paths.release_evidence_index_path, index, private=True)
 
 
 def _use_case_demo_card_failures(payload: Mapping[str, object]) -> list[str]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1610,6 +1610,7 @@ class CliTests(unittest.TestCase):
         self.assertIn("cases replay --json", items["use_case_replay"]["command"])
         self.assertIn("cases readiness --json", items["use_case_readiness"]["command"])
         self.assertIn("release product-readiness --version 1.0.0 --json", items["product_readiness"]["command"])
+        self.assertIn("release evidence-bundle --version 1.0.0 --write --json", items["release_evidence_bundle"]["command"])
         self.assertIn("skill-content-smoke", items["skill_content_smoke"]["command"])
         self.assertIn("setup --dry-run --channel stable --version 1.0.0", items["wheel_setup_dry_run"]["command"])
         self.assertTrue(items["live_tap_smoke"]["requires_release_authority"])
@@ -1723,14 +1724,41 @@ class CliTests(unittest.TestCase):
         self.assertIn("Capability payload:", stdout)
         self.assertIn("Full capability manifest:", stdout)
         self.assertIn("Playbook capabilities:", stdout)
-        self.assertIn("Plugin fallback capabilities:", stdout)
-        self.assertIn("Use-case demo cards: 10/10 card(s); failures 0", stdout)
-        self.assertIn("Use-case artifacts: 10/10 artifact(s); failures 0", stdout)
-        self.assertIn("Use-case replay: 20/20 fixture(s); status passed; failures 0", stdout)
-        self.assertIn("context missing 0", stdout)
-        self.assertIn("For machine-readable output", stdout)
-        with self.assertRaises(json.JSONDecodeError):
-            json.loads(stdout)
+
+    def test_release_evidence_bundle_cli_packages_optional_write_artifact(self) -> None:
+        with TemporaryDirectory() as tmp:
+            omh_home = Path(tmp) / ".omh"
+            hermes_home = Path(tmp) / ".hermes"
+            base = ["--omh-home", str(omh_home), "--hermes-home", str(hermes_home)]
+
+            status, stdout, stderr = run_cli(
+                base + ["release", "evidence-bundle", "--version", "v1.0.1", "--omh-command", "/tmp/omh"],
+                output_json=False,
+            )
+
+            self.assertEqual(status, 0, stderr)
+            self.assertEqual(stderr, "")
+            self.assertIn("OMH release evidence bundle for 1.0.1", stdout)
+            self.assertIn("Status: ready", stdout)
+            self.assertIn("Written: no", stdout)
+            self.assertIn("Local artifact store: not_written", stdout)
+            self.assertFalse((omh_home / "runtime" / "release-evidence" / "index.json").exists())
+
+            status, stdout, stderr = run_cli(
+                base + ["release", "evidence-bundle", "--version", "1.0.1", "--write", "--json"],
+                output_json=False,
+            )
+
+            self.assertEqual(status, 0, stderr)
+            self.assertEqual(stderr, "")
+            payload = json.loads(stdout)
+            self.assertEqual(payload["schema_version"], "omh_release_evidence_bundle/v1")
+            self.assertEqual(payload["status"], "ready")
+            self.assertTrue(payload["written"])
+            self.assertEqual(payload["summary"]["product_readiness_status"], "ready")
+            self.assertIn("local_artifact_store: not_written", payload["warnings"])
+            self.assertTrue(Path(payload["artifact_path"]).exists())
+            self.assertTrue((omh_home / "runtime" / "release-evidence" / "index.json").exists())
 
     def test_release_install_smoke_defaults_to_human_plan_with_json_escape_hatch(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_release_smoke.py
+++ b/tests/test_release_smoke.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
+import json
 import sys
 import subprocess
 import unittest
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
+from omh.paths import OmhPaths
 from omh.release import (
     hermes_release_smoke_plan,
     product_readiness_report,
+    release_evidence_bundle,
     release_readiness_checklist,
     run_hermes_release_smoke,
     skill_content_smoke,
@@ -37,6 +41,7 @@ class ReleaseSmokeTests(unittest.TestCase):
         self.assertIn("use_case_replay", items)
         self.assertIn("use_case_readiness", items)
         self.assertIn("product_readiness", items)
+        self.assertIn("release_evidence_bundle", items)
         self.assertIn("live_tap_smoke", items)
         self.assertIn("tag_and_publish", items)
         self.assertEqual(items["installed_command_path"]["command"], "command -v /tmp/omh")
@@ -76,6 +81,9 @@ class ReleaseSmokeTests(unittest.TestCase):
         self.assertEqual(items["product_readiness"]["command"], "/tmp/omh release product-readiness --version 1.0.0 --json")
         self.assertIn("skill-content", items["product_readiness"]["evidence_required"])
         self.assertIn("product contracts", items["product_readiness"]["proof_boundary"])
+        self.assertEqual(items["release_evidence_bundle"]["command"], "/tmp/omh release evidence-bundle --version 1.0.0 --write --json")
+        self.assertIn("omh_release_evidence_bundle/v1", items["release_evidence_bundle"]["evidence_required"])
+        self.assertIn("local deterministic evidence", items["release_evidence_bundle"]["proof_boundary"])
         self.assertTrue(items["live_tap_smoke"]["mutates_profile"])
         self.assertTrue(items["live_tap_smoke"]["requires_release_authority"])
         self.assertFalse(items["tag_and_publish"]["required"])
@@ -96,6 +104,10 @@ class ReleaseSmokeTests(unittest.TestCase):
         self.assertEqual(
             items["product_readiness"]["command"],
             "'/tmp/omh command' release product-readiness --version 1.0.0 --json",
+        )
+        self.assertEqual(
+            items["release_evidence_bundle"]["command"],
+            "'/tmp/omh command' release evidence-bundle --version 1.0.0 --write --json",
         )
         self.assertIn("--omh-command '/tmp/omh command'", items["installed_command_smoke"]["command"])
         self.assertIn("'/tmp/omh command' release hermes-smoke --live", items["live_tap_smoke"]["command"])
@@ -231,6 +243,36 @@ class ReleaseSmokeTests(unittest.TestCase):
         )
         self.assertIn("deterministic local OMH package", payload["boundary"])
         self.assertIn("Attach observed evidence", " ".join(payload["next_actions"]))
+        self.assertIn("evidence-bundle", " ".join(payload["next_actions"]))
+
+    def test_release_evidence_bundle_packages_and_writes_local_evidence(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = OmhPaths(omh_home=Path(tmp) / ".omh", hermes_home=Path(tmp) / ".hermes")
+
+            payload = release_evidence_bundle(version="v1.0.1", omh_command="/tmp/omh command", paths=paths)
+
+            self.assertEqual(payload["schema_version"], "omh_release_evidence_bundle/v1")
+            self.assertEqual(payload["status"], "ready")
+            self.assertFalse(payload["written"])
+            self.assertFalse(paths.release_evidence_index_path.exists())
+            self.assertIn("local_artifact_store: not_written", payload["warnings"])
+            self.assertEqual(payload["summary"]["product_readiness_status"], "ready")
+            self.assertEqual(payload["evidence"]["product_readiness"]["schema_version"], "omh_product_readiness/v1")
+            self.assertEqual(payload["evidence"]["release_checklist"]["schema_version"], "release_readiness_checklist/v1")
+            self.assertIn("executor_dispatch", payload["not_evidence_for"])
+
+            written = release_evidence_bundle(version="v1.0.1", omh_command="/tmp/omh command", paths=paths, write=True)
+
+            self.assertTrue(written["written"])
+            artifact_path = Path(str(written["artifact_path"]))
+            self.assertTrue(artifact_path.exists())
+            self.assertTrue(paths.release_evidence_index_path.exists())
+            stored = json.loads(artifact_path.read_text(encoding="utf-8"))
+            index = json.loads(paths.release_evidence_index_path.read_text(encoding="utf-8"))
+            self.assertEqual(stored["schema_version"], "omh_release_evidence_bundle/v1")
+            self.assertEqual(index["schema_version"], "omh_release_evidence_index/v1")
+            self.assertEqual(index["latest_version"], "1.0.1")
+            self.assertEqual(index["latest_artifact_path"], str(artifact_path))
 
     def test_release_readiness_checklist_rejects_empty_version(self) -> None:
         with self.assertRaises(ValueError):


### PR DESCRIPTION
## Feature Report

### What Changed

- Added `omh release evidence-bundle` as a deterministic local release evidence packaging command.
- Extended the release checklist and product-readiness next actions so release operators explicitly write and attach an `omh_release_evidence_bundle/v1` artifact.
- Added `.omh/runtime/release-evidence/` path helpers and an `index.json` ledger for the latest written bundle.
- Allowed the optional OMH plugin evidence tool to run the new release evidence-bundle command.
- Updated README, release docs, installation docs, and site docs with the new release evidence flow.

### Why This Exists

- OMH already had release checklist and product-readiness rollups, but reviewers/operators still had to mentally connect multiple local evidence payloads.
- Release PRs and notes need one attachable, machine-readable artifact that says what local evidence was packaged and what remains outside that claim.
- The change strengthens release trust without pretending that local checks prove live Hermes runtime behavior, CI, executor work, delivery, merge, or GitHub release publication.

### User / Operator Impact

- Operators can run `omh release evidence-bundle --version 1.0.1 --write --json` to write a single local release evidence artifact under `.omh/runtime/release-evidence/`.
- The payload includes release checklist shape, product readiness, skill-content smoke, G1-G10 use-case readiness, and parity-contract snapshots.
- Human output summarizes status, artifact path, local artifact-store state, warnings, next actions, and the boundary.
- The command stays optional and local; it does not mutate Hermes or run hidden release/runtime work.

### How It Works

- `src/release.py` builds `omh_release_evidence_bundle/v1` from existing deterministic release/product/use-case/parity functions.
- `src/commands/release.py` exposes the new subcommand with `--version`, `--omh-command`, `--write`, and `--json`.
- `src/paths.py` centralizes release evidence paths.
- When `--write` is passed, OMH writes the artifact and updates `.omh/runtime/release-evidence/index.json` with the latest version/path.
- Plugin evidence allowlists now include `omh release evidence-bundle` so Hermes/plugin contexts can gather this local release evidence through the bounded evidence surface.

### Files And Contracts Touched

- `src/release.py`: new release evidence bundle schema, payload builder, next actions, and index writer.
- `src/commands/release.py`: new CLI subcommand and human summary renderer.
- `src/paths.py`: release evidence runtime path helpers.
- `src/plugin_bundle/omh/config.yaml` and `src/plugin_bundle/omh/tools/evidence_tool.py`: bounded evidence allowlist update.
- `tests/test_release_smoke.py` and `tests/test_cli.py`: direct bundle and CLI coverage.
- `README.md`, `docs/RELEASE.md`, `docs/INSTALLATION.md`, `docs/README.md`, `site/docs/index.html`: release documentation sync.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests examples`
- [x] `uv run python -m src.cli docs workflows --check`
- [x] `uv run python -m src.cli harness validate`
- [x] `uv run python -m src.cli release checklist --version 1.0.1 --json`
- [x] `uv run python -m src.cli release hermes-smoke`
- [ ] `omh --help` (not rerun for this source-branch PR; source CLI and full tests were used instead)
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` (not rerun; this PR adds a local evidence packaging command, not installed command smoke behavior)
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable
- [x] Relevant dry-run or smoke command: `uv run python -m src.cli release evidence-bundle --version 1.0.1 --json`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; no live Hermes profile, TUI, transport, or plugin runtime behavior changed

Additional targeted validation:

- [x] `PYTHONPATH=tests uv run python -m unittest tests.test_release_smoke.ReleaseSmokeTests.test_release_evidence_bundle_packages_and_writes_local_evidence -v`
- [x] `PYTHONPATH=tests uv run python -m unittest tests.test_cli.CliTests.test_release_evidence_bundle_cli_packages_optional_write_artifact -v`
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_release_smoke.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_cli.py -v`
- [x] `git diff --check`

## Risk

- Low runtime risk: the new command reuses existing deterministic local evidence builders and writes only when `--write` is explicitly passed.
- Moderate product-surface risk: release evidence could be misread as live runtime proof, so the payload and docs repeat the not-evidence boundary.
- The optional local use-case artifact store can remain `not_written`; this is intentionally a warning, not a blocker.

## Compatibility / Rollout

- Backward compatible: existing release commands and schemas remain available.
- The new command is additive and opt-in.
- Written artifacts live under the user-controlled OMH runtime directory and are safe to delete/regenerate.
- Release docs now recommend attaching this bundle before tagging or publishing.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- Run the existing live Hermes tap/install smoke separately before publishing a tagged release.
- Attach the written `omh_release_evidence_bundle/v1` artifact to the release PR or release notes when preparing 1.0.1.
