### PR TITLE
Make omh list catalog-aware

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ tool, an existing Hermes connector, a generic image tool, or prompt-only mode.
 | Skill pack | Hermes gets workflows like `loop`, `ralplan`, `web-research`, `materials-package`, `img-summary`, and `ultraprocess`. |
 | Setup and repair | `omh setup`, `omh doctor`, `omh update`, and `omh uninstall` keep the local install understandable. |
 | Chat workflow picker | Hermes can answer "what can OMH do?" without making the user approve shell commands. |
+| Catalog-aware list | `omh list` groups installed workflows by lane, and `omh list --json` includes descriptions, routing hints, examples, and evidence boundaries for wrappers or operators. |
 | Route hint cards | Wrappers can preview the nearest OMH workflow with `chat_route_hint/v1`, even before plugin load is observed. |
 | Plugin runtime evidence | Hosts or wrappers can record plugin load/use with `omh plugin observe-host`, and plugin tools/hooks can self-record the same metadata when the host passes observation context; active-ready and historical events stay separate from install smoke. |
 | Coding agent paths | Hermes can prepare work for Codex, Claude Code, Hermes itself, or another runtime without pretending the work already ran. |

--- a/docs/CHAT_WRAPPER_EXAMPLES.md
+++ b/docs/CHAT_WRAPPER_EXAMPLES.md
@@ -108,7 +108,11 @@ catalog. `omh_skill_picker/v1` carries the workflow labels, direct invocation
 text, harness names, and routing-only claim boundary. Catalog-question
 responses also include `omh_capability_summary/v1`, so Hermes can summarize the
 larger lanes, representative playbooks, and evidence boundary before or beside
-the picker.
+the picker. When an operator or trusted backend already has permission to query
+the local install, `omh list --json` also includes
+`omh_installed_skill_catalog_context/v1` plus per-skill descriptions, routing
+hints, and evidence boundaries, so a catalog answer does not degrade into a flat
+name list.
 
 ## Plugin-Native Chat Interaction
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -412,7 +412,9 @@ runtime state, Hermes registration, target topology, optional surfaces, command
 availability, issue counts, recommended next action, and the `last_doctor`
 state-log entry when the runtime directory is writable. `omh doctor --json`
 returns the full check payload plus `doctor_summary/v1`. `omh list` should show
-a concise managed skill summary by default and the full manifest with `--json`.
+a concise managed skill summary plus workflow lanes by default. `omh list
+--json` returns the managed manifest plus `omh_installed_skill_catalog_context/v1`
+and per-skill descriptions, routing hints, examples, and evidence boundaries.
 Human-facing maintenance and catalog commands print readable terminal summaries
 by default: `omh install`, `omh update`, `omh uninstall`, `omh apply`,
 `omh list`, `omh recommend`, `omh playbook ...`, `omh profile ...`,

--- a/src/commands/setup.py
+++ b/src/commands/setup.py
@@ -19,6 +19,8 @@ except ImportError:  # pragma: no cover - Windows compatibility guard.
 
 from .. import __version__
 from ..command_path import inspect_omh_command_path
+from ..capabilities.registry import capability_summary
+from ..capabilities.skills import skill_capabilities
 from ..config_adapter import ensure_external_dir, external_dirs, read_config, remove_external_dir, write_config
 from ..doctor import doctor_ok, recommended_next_action, run_doctor
 from ..executors import CODING_EXECUTOR_TARGETS
@@ -725,7 +727,7 @@ def cmd_uninstall(args: argparse.Namespace) -> int:
 def cmd_list(args: argparse.Namespace) -> int:
     paths = _paths(args)
     manifest = read_manifest(paths.manifest_path)
-    payload = manifest or {"skills": [], "message": "not installed"}
+    payload = _catalog_aware_list_payload(manifest)
     if _wants_json(args):
         _print_json(payload)
     else:
@@ -741,6 +743,95 @@ def cmd_doctor(args: argparse.Namespace) -> int:
     else:
         _print_doctor_summary(payload, language=language)
     return 0 if payload["ok"] else 1
+
+
+def _catalog_aware_list_payload(manifest: dict[str, object] | None) -> dict[str, object]:
+    payload = dict(manifest or {"schema_version": 1, "skills": [], "message": "not installed"})
+    raw_skills = payload.get("skills", [])
+    if not isinstance(raw_skills, list):
+        raw_skills = []
+    capabilities = {
+        str(item.get("id")): item
+        for item in skill_capabilities()
+        if isinstance(item, dict) and item.get("id")
+    }
+    enriched_skills: list[dict[str, object]] = []
+    for raw_skill in raw_skills:
+        if not isinstance(raw_skill, dict):
+            continue
+        record = dict(raw_skill)
+        capability = capabilities.get(str(record.get("name") or ""))
+        if capability:
+            record.update(_list_skill_catalog_fields(capability))
+        enriched_skills.append(record)
+    payload["skills"] = enriched_skills
+    payload["catalog_context"] = _list_catalog_context(enriched_skills)
+    return payload
+
+
+def _list_skill_catalog_fields(capability: dict[str, object]) -> dict[str, object]:
+    fields = {
+        "description": capability.get("description", ""),
+        "category": capability.get("category", ""),
+        "phase": capability.get("phase", ""),
+        "hermes_role": capability.get("hermes_role", ""),
+        "use_for": capability.get("use_for", ""),
+        "preferred_usage": capability.get("preferred_usage", ""),
+        "awareness_lane": capability.get("awareness_lane", ""),
+        "awareness_lane_label": capability.get("awareness_lane_label", ""),
+        "workflow_routing_hint": capability.get("workflow_routing_hint", ""),
+        "handoff_policy": capability.get("handoff_policy", ""),
+        "evidence_boundary": capability.get("evidence_boundary", ""),
+    }
+    triggers = capability.get("triggers", [])
+    if isinstance(triggers, list):
+        fields["triggers"] = [str(item) for item in triggers[:10] if str(item)]
+    required_inputs = capability.get("required_inputs", [])
+    if isinstance(required_inputs, list):
+        fields["required_inputs"] = [str(item) for item in required_inputs[:8] if str(item)]
+    expected_outputs = capability.get("expected_outputs", [])
+    if isinstance(expected_outputs, list):
+        fields["expected_outputs"] = [str(item) for item in expected_outputs[:8] if str(item)]
+    return fields
+
+
+def _list_catalog_context(skills: list[dict[str, object]]) -> dict[str, object]:
+    names = {str(skill.get("name") or "") for skill in skills}
+    described_count = sum(1 for skill in skills if skill.get("description"))
+    summary = capability_summary()
+    lanes = []
+    for lane in summary.get("lanes", []):
+        if not isinstance(lane, dict):
+            continue
+        lane_skills = [str(skill) for skill in lane.get("primary_skills", []) if str(skill) in names]
+        if not lane_skills:
+            continue
+        lanes.append(
+            {
+                "id": lane.get("id", ""),
+                "label": lane.get("label", ""),
+                "owner_role": lane.get("owner_role", ""),
+                "use_for": lane.get("use_for", ""),
+                "primary_skills": lane_skills,
+                "examples": lane.get("examples", []),
+            }
+        )
+    return {
+        "schema_version": "omh_installed_skill_catalog_context/v1",
+        "purpose": (
+            "Hermes-facing context for answering what installed OMH workflows are available "
+            "without asking the user to approve extra shell catalog commands."
+        ),
+        "skill_count": len(skills),
+        "described_skill_count": described_count,
+        "lanes": lanes,
+        "direct_response_guidance": [
+            "Summarize workflow lanes before listing every skill.",
+            "Offer `./omh` or the matching clean skill name when the user wants to choose manually.",
+            "Use workflow_routing_hint and evidence_boundary before claiming execution or runtime evidence.",
+        ],
+        "evidence_boundary": summary.get("evidence_boundary", ""),
+    }
 
 
 def _doctor_result(args: argparse.Namespace) -> dict[str, object]:
@@ -1741,8 +1832,28 @@ def _print_list_summary(payload: dict[str, object], *, manifest_path: Path, skil
     shown = names[:12]
     if shown:
         print("  Names: " + ", ".join(shown) + (" ..." if len(names) > len(shown) else ""))
+    catalog = payload.get("catalog_context")
+    if isinstance(catalog, dict):
+        lanes = catalog.get("lanes", [])
+        if isinstance(lanes, list) and lanes:
+            print(_color("Workflow lanes", "1;32", use_color))
+            for lane in lanes[:5]:
+                if not isinstance(lane, dict):
+                    continue
+                lane_skills = lane.get("primary_skills", [])
+                if not isinstance(lane_skills, list):
+                    lane_skills = []
+                skill_names = ", ".join(str(skill) for skill in lane_skills[:5])
+                overflow = f" +{len(lane_skills) - 5}" if len(lane_skills) > 5 else ""
+                label = str(lane.get("label") or lane.get("id") or "workflow lane")
+                use_for = _short_summary(str(lane.get("use_for", "")), limit=96)
+                print(f"  - {label}: {skill_names}{overflow}")
+                if use_for:
+                    print(f"    Use for: {use_for}")
     print(_color("Next", "1;32", use_color))
     print("  Run `omh doctor` to verify Hermes registration.")
+    if skills:
+        print("  In chat, ask Hermes what OMH can do or type `./omh` to open the workflow picker.")
     print(f"  {tr('en', 'machine_readable')}")
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -958,6 +958,39 @@ class CliTests(unittest.TestCase):
             self.assertEqual(status, 0)
             self.assertEqual(json.loads(stdout)["written"], str(output.resolve()))
 
+    def test_list_exposes_catalog_context_for_chat_answers(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+
+            status, stdout, stderr = run_cli(base + ["install"], output_json=False)
+            self.assertEqual(status, 0, stderr)
+
+            status, stdout, stderr = run_cli(base + ["list"], output_json=False)
+
+            self.assertEqual(status, 0, stderr)
+            self.assertEqual(stderr, "")
+            self.assertIn("Workflow lanes", stdout)
+            self.assertIn("Intent -> plan", stdout)
+            self.assertIn("Coding handoff", stdout)
+            self.assertIn("In chat, ask Hermes what OMH can do", stdout)
+
+            status, stdout, stderr = run_cli(base + ["list", "--json"], output_json=False)
+
+            self.assertEqual(status, 0, stderr)
+            self.assertEqual(stderr, "")
+            payload = json.loads(stdout)
+            self.assertEqual(payload["catalog_context"]["schema_version"], "omh_installed_skill_catalog_context/v1")
+            self.assertGreaterEqual(payload["catalog_context"]["described_skill_count"], 40)
+            lane_ids = {lane["id"] for lane in payload["catalog_context"]["lanes"]}
+            self.assertIn("intent_to_plan", lane_ids)
+            self.assertIn("coding_handoff", lane_ids)
+            skills = {skill["name"]: skill for skill in payload["skills"]}
+            self.assertIn("description", skills["loop"])
+            self.assertIn("workflow_routing_hint", skills["loop"])
+            self.assertIn("evidence_boundary", skills["loop"])
+            self.assertEqual(skills["loop"]["awareness_lane"], "intent_to_plan")
+
     def test_probe_parity_matrix_maps_common_agent_runtime_gaps(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## Feature Report

### What Changed

- Made `omh list` catalog-aware instead of only printing a flat managed-skill manifest summary.
- Human output now groups installed OMH workflows into workflow lanes such as intent-to-plan, research/ops, materials/visuals, automation/status, and coding handoff.
- `omh list --json` now preserves the existing managed manifest shape and adds `catalog_context` with `omh_installed_skill_catalog_context/v1`.
- Each installed skill record is enriched with catalog metadata: description, category, phase, Hermes role, use-for copy, routing hint, triggers, expected outputs, handoff policy, and evidence boundary.
- README, installation docs, and chat-wrapper examples now describe the richer list output.

### Why This Exists

- Users often ask Hermes what OMH can do, and a flat list of 40+ skill names is not enough for a useful answer.
- OMH already had rich catalog and capability data, but the most obvious local command, `omh list`, did not expose that context.
- This closes a practical usability gap: Hermes, trusted wrappers, and operators can answer catalog questions from one installed-command payload without making the user approve extra shell commands or parse skill files.

### User / Operator Impact

- `omh list` now gives a readable first-glance map of installed workflows by lane.
- `omh list --json` gives wrappers/operators enough metadata to render better catalog answers, picker fallback text, or skill summaries.
- The output still keeps routing context separate from execution evidence; it does not claim that Hermes selected, loaded, or ran any workflow.

### How It Works

- `src/commands/setup.py` now builds a catalog-aware list payload by combining the installed manifest with deterministic skill capability metadata.
- The raw manifest file remains the install integrity source for sha/path/source tracking; only the command output is enriched.
- The human renderer prints a short lane summary after the installed skill names.
- The JSON payload adds `catalog_context` plus per-skill fields while keeping existing top-level manifest fields such as `skills`, `skills_dir`, `source`, and `version`.

### Files And Contracts Touched

- `src/commands/setup.py`: catalog-aware list payload and human lane rendering.
- `tests/test_cli.py`: locks the new human and JSON list contracts.
- `README.md`: adds catalog-aware list to the public value table.
- `docs/INSTALLATION.md`: updates the CLI behavior contract for `omh list`.
- `docs/CHAT_WRAPPER_EXAMPLES.md`: documents the trusted-backend fallback for enriched catalog answers.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests examples`
- [x] `uv run python -m src.cli docs workflows --check`
- [ ] `python3 -m omh.cli harness validate` (not rerun; no harness catalog data changed)
- [ ] `python3 -m omh.cli release checklist --json` (not rerun; release gate shape unchanged)
- [ ] `python3 -m omh.cli release hermes-smoke` (not rerun; no Hermes install/smoke behavior changed)
- [ ] `omh --help` (not rerun; source CLI tests covered command behavior)
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` (not rerun; installed command smoke behavior unchanged)
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable
- [x] Relevant dry-run or smoke command: `uv run python -m src.cli list` and `uv run python -m src.cli list --json`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; this PR changes deterministic CLI/catalog output, not live Hermes rendering

Additional targeted validation:

- [x] `PYTHONPATH=tests uv run python -m unittest tests.test_cli.CliTests.test_list_exposes_catalog_context_for_chat_answers -v`
- [x] `PYTHONPATH=tests uv run python -m unittest tests.test_cli.CliTests.test_local_operator_commands_default_to_human_summary_with_json_escape_hatch -v`
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_router_content.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_cli.py -v`
- [x] `git diff --check`

## Risk

- Low compatibility risk: existing top-level manifest fields remain present, and existing list tests continue to pass.
- The JSON payload is larger because each skill now includes catalog metadata, but this is intentional for wrapper/operator catalog answers.
- Catalog-aware list output is routing/help context only; docs and payload boundaries avoid treating it as execution evidence.

## Compatibility / Rollout

- Existing `omh list` and `omh list --json` invocations still work.
- Wrappers that only read `skills[].name`, `path`, `sha256`, or `source` remain compatible.
- New wrappers can use `catalog_context.lanes[]` and per-skill routing fields for better catalog cards.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- Live Hermes/chat surfaces can choose whether to render this enriched list payload directly or continue using the existing picker/capability-summary contracts.
