### PR TITLE
Expose catalog hints from OMH context brief

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -157,7 +157,9 @@ planning, research, ops, materials, visual summary, automation,
 workflow-learning, or coding-handoff work. That hook payload carries only
 hash/length metadata, matched cue labels, candidate workflow names, next
 actions, generic-tool checkpoint rules, and boundaries; it does not include the
-raw user message or prove a workflow executed. The `pre_tool_call` hook mirrors
+raw user message or prove a workflow executed. For capability/catalog questions,
+the context brief adds `omh_catalog_question_hint/v1` so Hermes can show the
+workflow picker or capability summary without shell approval. The `pre_tool_call` hook mirrors
 the generic-tool checkpoint as structured `omh_generic_tool_checkpoint/v1`
 metadata before image, file, search, or coding tools, while preserving the
 legacy text context for hosts that only consume prompt strings. It uses only

--- a/docs/CHAT_WRAPPER_EXAMPLES.md
+++ b/docs/CHAT_WRAPPER_EXAMPLES.md
@@ -115,8 +115,14 @@ omh context brief --source discord --json "make an image card for this PR"
 
 The plugin-native form is the `omh_context` tool. Both return the same compact
 shape: OMH lanes, common cues, a generic-tool checkpoint, an optional route
-hint, and the response contract. The raw prompt is represented by hash/length
-metadata only.
+hint, catalog-question guidance, and the response contract. The raw prompt is
+represented by hash/length metadata only.
+
+When the message asks what OMH commands, workflows, or skills are available,
+the payload includes `catalog_question.schema_version ==
+omh_catalog_question_hint/v1`. Hermes can then summarize the lanes and offer
+`omh_skill_picker/v1` or call `omh_capabilities` with `{"action":"summary"}`
+without asking the user to approve `omh list`.
 
 For an image request, Hermes can then say:
 

--- a/src/commands/context.py
+++ b/src/commands/context.py
@@ -34,6 +34,12 @@ def _print_context_brief_summary(payload: dict[str, object]) -> None:
             print(f"  Route hint: {primary} -> {action}")
         else:
             print("  Route hint: no strong message-specific hint")
+    catalog_question = payload.get("catalog_question")
+    if isinstance(catalog_question, dict) and catalog_question.get("status") == "matched":
+        print(
+            "  Catalog question: "
+            f"{catalog_question.get('next_action')} via {catalog_question.get('recommended_tool')}"
+        )
     print("Workflow lanes")
     lanes = payload.get("lanes", [])
     if isinstance(lanes, list):

--- a/src/plugin_bundle/omh/context_brief.py
+++ b/src/plugin_bundle/omh/context_brief.py
@@ -75,6 +75,9 @@ def build_context_brief(
         payload["prompt_context_boundary"] = (
             "Prompt context is for Hermes routing guidance only; it is not workflow execution or observed evidence."
         )
+    catalog_hint = _catalog_question_hint(text)
+    if catalog_hint:
+        payload["catalog_question"] = catalog_hint
     return payload
 
 
@@ -84,3 +87,119 @@ def bounded_context_hint_limit(value: object, *, default: int) -> int:
     except (TypeError, ValueError):
         parsed = default
     return max(0, min(parsed, 10))
+
+
+def _catalog_question_hint(message: str) -> dict[str, object]:
+    if not _is_catalog_question(message):
+        return {}
+    return {
+        "schema_version": "omh_catalog_question_hint/v1",
+        "status": "matched",
+        "next_action": "show_workflow_picker",
+        "recommended_tool": "omh_capabilities",
+        "recommended_tool_args": {"action": "summary"},
+        "wrapper_contracts": ["omh_skill_picker/v1", "omh_capability_summary/v1"],
+        "direct_invocation_aliases": ["./omh", "/omh", "./skills", "/skills"],
+        "response_rule": (
+            "Answer in chat by summarizing OMH lanes and offering the workflow picker; "
+            "do not ask the user to approve `omh list` for catalog discovery."
+        ),
+        "claim_boundary": (
+            "A catalog answer or workflow picker is routing/help context only; it is not plan acceptance, dispatch, "
+            "execution, review, CI, or verification evidence."
+        ),
+    }
+
+
+def _is_catalog_question(message: str) -> bool:
+    text = message.strip()
+    if not text:
+        return False
+    try:
+        from omh.routing.catalog_questions import is_skill_catalog_question
+    except Exception:
+        return _standalone_catalog_question(text)
+    try:
+        return bool(is_skill_catalog_question(text))
+    except Exception:
+        return _standalone_catalog_question(text)
+
+
+def _standalone_catalog_question(message: str) -> bool:
+    text = message.strip().lower()
+    if not text:
+        return False
+    if any(marker in text for marker in ("src/", "tests/", "docs/", ".py", ".md", "readme", "section")):
+        return False
+    explicit = (
+        "what commands are available",
+        "what skills are available",
+        "what workflows are available",
+        "available commands",
+        "available skills",
+        "available workflows",
+        "skill menu",
+        "workflow menu",
+        "workflow picker",
+        "what can omh do",
+        "what does omh do",
+        "how can omh help",
+        "omh 기능",
+        "omh로 뭐 할 수",
+        "omh가 뭐 해",
+        "omh는 뭐 해",
+        "使えるスキル",
+        "利用可能なスキル",
+        "利用可能なワークフロー",
+        "有哪些命令",
+        "有哪些技能",
+        "有哪些工作流",
+        "可用命令",
+        "可用技能",
+        "可用工作流",
+    )
+    if any(phrase in text for phrase in explicit):
+        return True
+    has_context = any(marker in text for marker in ("omh", "oh-my-hermes", "oh my hermes", "hermes", "헤르메스"))
+    has_catalog_word = any(
+        word in text
+        for word in (
+            "command",
+            "commands",
+            "skill",
+            "skills",
+            "workflow",
+            "workflows",
+            "스킬",
+            "워크플로",
+            "워크플로우",
+            "명령",
+            "기능",
+            "スキル",
+            "ワークフロー",
+            "技能",
+            "工作流",
+            "命令",
+        )
+    )
+    has_availability = any(
+        word in text
+        for word in (
+            "available",
+            "do you have",
+            "can you do",
+            "menu",
+            "picker",
+            "뭐",
+            "무엇",
+            "어떤",
+            "알려",
+            "보여",
+            "있어",
+            "가능",
+            "一覧",
+            "有哪些",
+            "可用",
+        )
+    )
+    return has_catalog_word and (has_context or has_availability)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -67,6 +67,15 @@ class CliTests(unittest.TestCase):
         self.assertIn("Do not skip OMH merely because a generic tool", stdout)
 
         status, stdout, stderr = run_cli(
+            ["context", "brief", "--source", "discord", "what OMH workflows are available?"],
+            output_json=False,
+        )
+
+        self.assertEqual(status, 0, stderr)
+        self.assertEqual(stderr, "")
+        self.assertIn("Catalog question: show_workflow_picker via omh_capabilities", stdout)
+
+        status, stdout, stderr = run_cli(
             [
                 "context",
                 "brief",
@@ -91,6 +100,49 @@ class CliTests(unittest.TestCase):
         self.assertFalse(payload["message"]["raw_prompt_echoed"])
         self.assertFalse(payload["message"]["raw_prompt_stored"])
         self.assertNotIn("secret-token-123", stdout)
+
+        status, stdout, stderr = run_cli(
+            [
+                "context",
+                "brief",
+                "--source",
+                "discord",
+                "--json",
+                "what OMH workflows are available with secret-token-123?",
+            ],
+            output_json=False,
+        )
+
+        self.assertEqual(status, 0, stderr)
+        self.assertEqual(stderr, "")
+        payload = json.loads(stdout)
+        catalog_question = payload["catalog_question"]
+        self.assertEqual(catalog_question["schema_version"], "omh_catalog_question_hint/v1")
+        self.assertEqual(catalog_question["status"], "matched")
+        self.assertEqual(catalog_question["next_action"], "show_workflow_picker")
+        self.assertEqual(catalog_question["recommended_tool"], "omh_capabilities")
+        self.assertEqual(catalog_question["recommended_tool_args"], {"action": "summary"})
+        self.assertIn("omh_skill_picker/v1", catalog_question["wrapper_contracts"])
+        self.assertIn("omh_capability_summary/v1", catalog_question["wrapper_contracts"])
+        self.assertIn("./omh", catalog_question["direct_invocation_aliases"])
+        self.assertNotIn("secret-token-123", stdout)
+
+        status, stdout, stderr = run_cli(
+            [
+                "context",
+                "brief",
+                "--source",
+                "discord",
+                "--json",
+                "what does OMH do in src/routing/catalog_questions.py?",
+            ],
+            output_json=False,
+        )
+
+        self.assertEqual(status, 0, stderr)
+        self.assertEqual(stderr, "")
+        payload = json.loads(stdout)
+        self.assertNotIn("catalog_question", payload)
 
     def test_chat_interact_routes_workflow_learning_to_audit_actions(self) -> None:
         status, stdout, stderr = run_cli(

--- a/tests/test_hook_manifest.py
+++ b/tests/test_hook_manifest.py
@@ -134,6 +134,23 @@ class HookManifestTests(unittest.TestCase):
         self.assertNotIn("[OMH Route Hint]", context)
         self.assertNotIn("workflow=img-summary", context)
 
+    def test_pre_llm_call_includes_catalog_question_hint_without_raw_message(self) -> None:
+        message = "what OMH workflows are available with secret-token-123?"
+
+        result = pre_llm_call(user_message=message, is_first_turn=False)
+        context_brief = result["omh_context_brief"] if result else {}
+        catalog_question = context_brief["catalog_question"]
+
+        self.assertEqual(catalog_question["schema_version"], "omh_catalog_question_hint/v1")
+        self.assertEqual(catalog_question["status"], "matched")
+        self.assertEqual(catalog_question["next_action"], "show_workflow_picker")
+        self.assertEqual(catalog_question["recommended_tool"], "omh_capabilities")
+        self.assertEqual(catalog_question["recommended_tool_args"], {"action": "summary"})
+        self.assertIn("omh_skill_picker/v1", catalog_question["wrapper_contracts"])
+        self.assertIn("omh_capability_summary/v1", catalog_question["wrapper_contracts"])
+        self.assertNotIn(message, str(context_brief))
+        self.assertNotIn("secret-token-123", str(context_brief))
+
     def test_pre_tool_call_injects_generic_tool_checkpoint_without_raw_input(self) -> None:
         cases = (
             ("image_generate", {}, "image_tools", "img-summary", "prepare_visual_prompt_card"),

--- a/tests/test_plugin_capabilities.py
+++ b/tests/test_plugin_capabilities.py
@@ -262,6 +262,13 @@ class PluginCapabilitiesTests(unittest.TestCase):
                         "include_prompt_context": True,
                     }})
                 )
+                context_catalog = json.loads(
+                    context_handler({{
+                        "message": "what OMH workflows are available with secret-token-123?",
+                        "source": "discord",
+                        "limit": 2,
+                    }})
+                )
                 interaction = json.loads(
                     interact_handler({{
                         "message": "make an image summary for this PR with secret-token-123",
@@ -349,6 +356,10 @@ class PluginCapabilitiesTests(unittest.TestCase):
                     "context_primary_workflow": context_brief["route_hint"]["primary_workflow"],
                     "context_prompt_context": context_brief["prompt_context"],
                     "context_serialized": json.dumps(context_brief, sort_keys=True),
+                    "context_catalog_status": context_catalog["catalog_question"]["status"],
+                    "context_catalog_next_action": context_catalog["catalog_question"]["next_action"],
+                    "context_catalog_tool": context_catalog["catalog_question"]["recommended_tool"],
+                    "context_catalog_serialized": json.dumps(context_catalog, sort_keys=True),
                     "interaction_schema": interaction["schema_version"],
                     "interaction_degraded": interaction["degraded"],
                     "interaction_source": interaction["source_backend"],
@@ -466,6 +477,10 @@ class PluginCapabilitiesTests(unittest.TestCase):
             self.assertIn("workflow=img-summary", payload["context_prompt_context"])
             self.assertIn("generic tool can render", payload["context_serialized"])
             self.assertNotIn("secret-token-123", payload["context_serialized"])
+            self.assertEqual(payload["context_catalog_status"], "matched")
+            self.assertEqual(payload["context_catalog_next_action"], "show_workflow_picker")
+            self.assertEqual(payload["context_catalog_tool"], "omh_capabilities")
+            self.assertNotIn("secret-token-123", payload["context_catalog_serialized"])
             self.assertEqual(payload["interaction_schema"], "chat_interaction/v1")
             self.assertTrue(payload["interaction_degraded"])
             self.assertEqual(payload["interaction_source"], "standalone_plugin_bundle_fallback")


### PR DESCRIPTION
## Feature Report

### What Changed

- Added `omh_catalog_question_hint/v1` to `omh_context_brief/v1` when a user asks what OMH workflows, skills, or commands are available.
- Updated the human `omh context brief` summary to print the catalog-question action in plain text.
- Documented the wrapper behavior so Hermes can show `omh_skill_picker/v1` or call `omh_capabilities {"action":"summary"}` without asking for shell approval.

### Why This Exists

- Hermes users often ask natural questions such as "what OMH workflows are available?" from Discord, Slack, Telegram, or the Hermes TUI.
- `omh chat interact` already knew how to route those questions, but the smaller plugin/context surface only exposed general lanes and generic tool boundaries.
- That meant a wrapper using compact context alone could still fall back to approving `omh list`, which is too CLI-shaped for normal chat discovery.

### User / Operator Impact

- Users can ask Hermes what OMH can do and receive a workflow picker or capability summary instead of a terminal command approval prompt.
- Operators get a deterministic, metadata-only hint that says the next action is `show_workflow_picker` through `omh_capabilities`.
- Secret text in the original message remains excluded from the context payload.

### How It Works

- `src/plugin_bundle/omh/context_brief.py` now calls the packaged catalog-question detector when available.
- Standalone installed plugin bundles use a bounded fallback detector for common English, Korean, Japanese, and Chinese catalog questions.
- False positives are avoided for obvious source/doc/path questions such as `src/...`, `.py`, `.md`, `README`, or `section` references.
- The new block remains routing/help metadata only. It does not claim planning, dispatch, execution, review, CI, or verification evidence.

### Files And Contracts Touched

- `src/plugin_bundle/omh/context_brief.py`: emits `catalog_question` metadata for catalog-style questions.
- `src/commands/context.py`: prints the catalog-question action in human CLI output.
- `docs/CHAT_WRAPPER_EXAMPLES.md`: explains wrapper consumption of `omh_catalog_question_hint/v1`.
- `docs/ARCHITECTURE.md`: records the context-brief discovery boundary.
- `tests/test_cli.py`, `tests/test_hook_manifest.py`, `tests/test_plugin_capabilities.py`: cover CLI JSON, pre-LLM hook, standalone plugin smoke, and no-secret behavior.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests.test_cli.CliTests.test_context_brief_exposes_omh_mental_model_and_route_hint tests.test_hook_manifest.HookManifestTests.test_pre_llm_call_includes_catalog_question_hint_without_raw_message tests.test_plugin_capabilities.PluginCapabilitiesTests -v`
- [x] `PYTHONPATH=tests uv run python -m unittest tests.test_cli tests.test_hook_manifest tests.test_wrapper_contract tests.test_plugin_capabilities -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m src.cli docs workflows --check`
- [x] `uv run python -m src.cli release product-readiness --json`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv build`
- [x] `git diff --check`
- [ ] Manual Hermes/TUI check: not run in this PR; live wrapper rendering remains host-owned and not observed.

## Risk

- Low. The new payload is additive, metadata-only, and only appears for catalog questions.
- The standalone fallback detector is intentionally conservative around file/path/doc questions to reduce false positives.

## Compatibility / Rollout

- Existing `omh_context_brief/v1` consumers can ignore the new `catalog_question` block.
- Existing chat routing and capability summary contracts remain unchanged.
- Plugin bundles installed without the full Python package still get the fallback behavior.

## Release / Claims

- [x] Release-channel impact considered (`preview`/local package behavior only; no installer or version bump).
- [x] Runtime/native capability claims are backed by tests or marked as not observed.
- [x] Known manual Hermes checks are listed; live wrapper rendering is not claimed.

## Follow-Up

- Live Hermes wrapper surfaces can render the hint as an "Open OMH" picker/card and record host observation separately if needed.
