### PR TITLE
Strengthen OMH route hint response guidance

### DIFF
--- a/docs/CHAT_WRAPPER_EXAMPLES.md
+++ b/docs/CHAT_WRAPPER_EXAMPLES.md
@@ -206,7 +206,8 @@ When the managed OMH plugin bridge is loaded, `pre_llm_call` can add a bounded
 messages that look like workflow-shaped work. The payload and hint do not
 include the raw user message. They carry only message hash/length metadata,
 matched cue labels, candidate workflows, adjacent workflows, next actions, the
-generic-tool checkpoint, and the same prepared-vs-observed boundary.
+generic-tool checkpoint, the first response shape, fallback action, and the
+same prepared-vs-observed boundary.
 
 Example effect:
 
@@ -217,7 +218,11 @@ make an image explaining the cron feature
 Hermes Agent
 [OMH Route Hint]
 - workflow=img-summary; lane=materials_and_visuals; next_action=prepare_visual_prompt_card
+  first_response_shape=Separate copy/layout/package prep from generated file or image evidence, then offer revise/copy/generate/record actions.
+  fallback_action=choose_image_generator_or_prompt_only_when_missing.
 - workflow=automation-blueprint; lane=automation_and_status; next_action=prepare_scheduled_ops_blueprint
+  first_response_shape=Show the prepared status, schedule, or learning shape, name the missing evidence, and expose refresh, repair, or review actions.
+  fallback_action=confirm_schedule_delivery_and_tools.
 ```
 
 The wrapper still owns rendering and state recording. The context brief and

--- a/src/plugin_bundle/omh/awareness.py
+++ b/src/plugin_bundle/omh/awareness.py
@@ -278,6 +278,7 @@ _ROUTE_HINT_RULES = (
         "lane": "automation_and_status",
         "next_action": "record_missed_route",
         "reason": "The user is reporting that OMH or the expected workflow was not used.",
+        "fallback_action": "record_learning_trace_or_show_route_review",
         "phrases": (
             "missed route",
             "missed workflow",
@@ -299,6 +300,7 @@ _ROUTE_HINT_RULES = (
         "lane": "materials_and_visuals",
         "next_action": "prepare_visual_prompt_card",
         "reason": "The user is asking for an image card, infographic, poster, or shareable visual summary.",
+        "fallback_action": "choose_image_generator_or_prompt_only_when_missing",
         "phrases": (
             "image card",
             "summary card",
@@ -325,6 +327,7 @@ _ROUTE_HINT_RULES = (
         "lane": "research_and_ops",
         "next_action": "classify_signal_and_prepare_investigation",
         "reason": "The user is describing customer feedback, bugs, issues, or product signals that need triage before implementation.",
+        "fallback_action": "ask_for_examples_or_prepare_repro_plan",
         "phrases": (
             "customer feedback",
             "payment failure",
@@ -347,6 +350,7 @@ _ROUTE_HINT_RULES = (
         "lane": "automation_and_status",
         "next_action": "prepare_scheduled_ops_blueprint",
         "reason": "The user is asking for recurring, scheduled, cron-like, or digest-style work.",
+        "fallback_action": "confirm_schedule_delivery_and_tools",
         "phrases": (
             "every morning",
             "every day",
@@ -369,6 +373,7 @@ _ROUTE_HINT_RULES = (
         "lane": "research_and_ops",
         "next_action": "gather_source_backed_evidence",
         "reason": "The user is asking for current, source-backed, market, competitor, paper, or news research.",
+        "fallback_action": "ask_for_scope_or_source_constraints",
         "phrases": (
             "web search",
             "best practice",
@@ -392,6 +397,7 @@ _ROUTE_HINT_RULES = (
         "lane": "coding_handoff",
         "next_action": "prepare_one_cycle_delivery",
         "reason": "The user is asking for coding delivery, PR preparation, implementation, review, CI, or merge-oriented work.",
+        "fallback_action": "choose_coding_agent_or_runtime",
         "phrases": (
             "pull request",
             "code review",
@@ -490,6 +496,7 @@ def awareness_route_hint(message: str, *, max_hints: int = 2) -> dict[str, objec
                     "lane": str(rule["lane"]),
                     "next_action": str(rule["next_action"]),
                     "reason": str(rule["reason"]),
+                    "fallback_action": str(rule["fallback_action"]),
                     "matched_cues": _bounded_matches(phrase_matches + token_matches),
                     "adjacent_workflows": list(rule["adjacent_workflows"]),
                     "workflow_context_card": context_card,
@@ -537,6 +544,14 @@ def awareness_route_hint_context(message: str, *, max_hints: int = 2) -> str:
             f"- workflow={hint.get('workflow')}; lane={hint.get('lane')}; "
             f"next_action={hint.get('next_action')}; reason={hint.get('reason')}"
         )
+        context_card = hint.get("workflow_context_card")
+        if isinstance(context_card, dict):
+            first_response_shape = str(context_card.get("first_response_shape") or "").strip()
+            if first_response_shape:
+                lines.append(f"  first_response_shape={first_response_shape}")
+        fallback_action = str(hint.get("fallback_action") or "").strip()
+        if fallback_action:
+            lines.append(f"  fallback_action={fallback_action}.")
         if adjacent:
             lines.append(f"  adjacent_workflows={adjacent}.")
         not_evidence = ", ".join(str(item) for item in hint.get("not_evidence_yet", [])[:4])

--- a/tests/test_hook_manifest.py
+++ b/tests/test_hook_manifest.py
@@ -111,11 +111,22 @@ class HookManifestTests(unittest.TestCase):
         self.assertIn("[OMH Route Hint]", context)
         self.assertIn("workflow=img-summary", context)
         self.assertIn("workflow=automation-blueprint", context)
+        self.assertIn("first_response_shape=Separate copy/layout/package prep", context)
+        self.assertIn("fallback_action=choose_image_generator_or_prompt_only_when_missing", context)
+        self.assertIn("fallback_action=confirm_schedule_delivery_and_tools", context)
         self.assertIn("not_evidence_yet=file export, image generation", context)
         self.assertEqual(context_brief["schema_version"], "omh_context_brief/v1")
         self.assertEqual(context_brief["source"], "pre_llm_call")
         self.assertEqual(context_brief["route_hint"]["primary_workflow"], "img-summary")
         self.assertEqual(context_brief["route_hint"]["primary_next_action"], "prepare_visual_prompt_card")
+        self.assertEqual(
+            context_brief["route_hint"]["hints"][0]["fallback_action"],
+            "choose_image_generator_or_prompt_only_when_missing",
+        )
+        self.assertIn(
+            "generated file or image evidence",
+            context_brief["route_hint"]["hints"][0]["workflow_context_card"]["first_response_shape"],
+        )
         self.assertFalse(context_brief["message"]["raw_prompt_stored"])
         self.assertFalse(context_brief["message"]["raw_prompt_echoed"])
         self.assertNotIn(message, context)


### PR DESCRIPTION
## Feature Report

### What Changed

- Extended deterministic `omh_route_hint/v1` entries with `fallback_action` for missed-route, visual summary, customer signal, scheduled ops, source research, and coding delivery cues.
- Added `first_response_shape` and `fallback_action` lines to the plugin `pre_llm_call` route-hint context.
- Updated wrapper documentation so operators can see how Hermes should answer before using generic image, file, search, or coding tools.

### Why This Exists

- Hermes can have generic image/file/search/coding tools available, but OMH should still be considered first when the request is workflow-shaped.
- The previous route hint named the candidate workflow and next action, but it did not explicitly tell Hermes how the first chat response should be shaped.
- That left room for responses like "OMH was not needed because a generic image tool could do this," which weakens OMH's chat-first product value.

### User / Operator Impact

- A user asking for an image card, recurring digest, research brief, feedback triage, or coding delivery is more likely to see a clear OMH-shaped first response.
- The response guidance now says what Hermes should do next and what fallback to offer when an image generator, connector, coding agent, or runtime capability is missing.
- Evidence boundaries remain visible: route hints are not execution, image generation, connector I/O, review, CI, merge, or delivery evidence.

### How It Works

- `src/plugin_bundle/omh/awareness.py` reuses the existing workflow context cards instead of adding a separate routing model.
- `awareness_route_hint()` now includes a deterministic `fallback_action` per route-hint rule.
- `awareness_route_hint_context()` prints `first_response_shape` from the workflow context card plus the new fallback action in the bounded hook text.
- The hook still redacts raw user prompts and stores only metadata such as hashes, cue labels, and workflow ids.

### Files And Contracts Touched

- `src/plugin_bundle/omh/awareness.py`: route hint payload/context guidance.
- `tests/test_hook_manifest.py`: locks first-response shape, fallback action, and no-secret behavior for pre-LLM hints.
- `docs/CHAT_WRAPPER_EXAMPLES.md`: documents the richer plugin route-hint effect.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests.test_hook_manifest.HookManifestTests.test_awareness_route_hint_is_metadata_only_and_message_specific tests.test_hook_manifest.HookManifestTests.test_pre_llm_call_includes_bounded_route_hint_without_raw_message -v`
- [x] `PYTHONPATH=tests uv run python -m unittest tests.test_wrapper_contract tests.test_plugin_capabilities -v`
- [x] `PYTHONPATH=tests uv run python -m unittest tests.test_efficiency tests.test_router_content -v`
- [x] `uv run python -m src.cli docs workflows --check`
- [x] `uv run python -m compileall -q src tests`
- [x] `git diff --check`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m src.cli release product-readiness --json`
- [x] `uv build`
- [ ] Manual Hermes/TUI check: not run in this PR; live host rendering remains wrapper-owned and not observed.

## Risk

- Low. The change is additive route-hint metadata and bounded prompt context text.
- Prompt context grows by a few short lines only when route hints match, and existing efficiency tests still pass.

## Compatibility / Rollout

- Existing `omh_route_hint/v1` consumers can ignore `fallback_action`.
- Plugin hosts that only consume text context now get stronger response guidance without needing a new tool call.
- No installer, setup, runtime ledger, or release-channel behavior changes.

## Release / Claims

- [x] Release-channel impact considered (`preview`/local package behavior only; no version bump).
- [x] Runtime/native capability claims are backed by deterministic tests or marked as not observed.
- [x] Known manual Hermes checks are listed; live wrapper rendering is not claimed.

## Follow-Up

- Live Hermes wrappers can render these hint fields into compact cards and record host observations separately when available.
