### PR TITLE
Add OMH quickstart status card

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,9 @@ omh doctor
 That is the normal path. The installer only prepares the isolated `omh` command
 package; `omh setup` is the explicit step that installs OMH workflows and
 registers them with Hermes. On a first install, press Enter through the
-recommended setup choices, then restart or reload Hermes Agent.
+recommended setup choices, then restart or reload Hermes Agent. If you want a
+short "what now?" card after setup, run `omh quickstart`; it shows the first
+Hermes prompts plus what has and has not been observed yet.
 
 If your Hermes environment supports skill taps, this Hermes-native path also
 works:

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -27,6 +27,23 @@ First-run expectation:
 3. You restart or reload Hermes Agent.
 4. You ask Hermes: `Use OMH request-to-handoff for: I want to safely add a feature to this repo.`
 
+If the next step is still unclear, run:
+
+```sh
+omh quickstart
+```
+
+`omh quickstart` prints a compact first-use card instead of a deep diagnostic
+dump. It reads the current doctor/probe state, suggests the next Hermes chat
+prompt, and separates local readiness from evidence that still has to be
+observed by Hermes or a wrapper. The JSON form is `omh_quickstart_card/v1` and
+is intended for wrappers that want to render the same "what now?" card in a
+chat surface:
+
+```sh
+omh quickstart --json
+```
+
 ## What Setup Changes
 
 OMH's setup footprint is intentionally bounded:

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@ repo-local contract for Codex agents working here.
 | Review stale local context and executor handoff packs | [Memory Context Review](MEMORY_CONTEXT.md) |
 | Operate a Hermes-agent wrapper safely | [Hermes Agent Integration Runbook](HERMES_AGENT_INTEGRATION_RUNBOOK.md) |
 | Install from an AI-agent protocol | [Agent Install Protocol](../INSTALL_FOR_AGENTS.md) |
+| See the first-use Hermes prompt and evidence boundary | [Installation](INSTALLATION.md#quick-start) |
 | Understand responsibility roles and operating models | [Role Surface](ROLES.md) |
 | Choose a situation-level pipeline | [Playbooks](PLAYBOOKS.md) |
 | See Discord-style wrapper responses | [Chat Wrapper Examples](CHAT_WRAPPER_EXAMPLES.md) |

--- a/src/commands/main.py
+++ b/src/commands/main.py
@@ -89,6 +89,7 @@ from .mcp import (
     cmd_mcp_sessions,
 )
 from .plugin import _add_plugin_commands, cmd_plugin_observations, cmd_plugin_observe_host
+from .quickstart import _add_quickstart_commands, cmd_quickstart
 from .ops import (
     _add_ops_commands,
     cmd_ops_agent_review,
@@ -157,7 +158,8 @@ def build_parser() -> argparse.ArgumentParser:
         epilog=(
             "Quick start:\n"
             "  omh setup\n"
-            "  omh doctor\n\n"
+            "  omh doctor\n"
+            "  omh quickstart\n\n"
             "First five minutes:\n"
             "  1. Run setup, accepting the recommended choices.\n"
             "  2. Restart or reload Hermes Agent.\n"
@@ -209,6 +211,7 @@ def build_parser() -> argparse.ArgumentParser:
     sub = parser.add_subparsers(dest="command", metavar="<command>")
 
     _add_top_level_commands(sub)
+    _add_quickstart_commands(sub)
     _add_docs_commands(sub)
     _add_harness_commands(sub)
     _add_cases_commands(sub)
@@ -252,6 +255,7 @@ when it can prove the command came from the install.sh-managed OMH venv.
 Start:
   omh setup              Install skills and connect them to Hermes
   omh doctor             Check local OMH health and registration
+  omh quickstart         Show what to do next in Hermes
   omh update             Refresh managed skills and update metadata
 
 First five minutes:
@@ -260,6 +264,7 @@ First five minutes:
   3. Ask Hermes the prompt below.
 
 Useful operator commands:
+  omh quickstart         Show first-use prompts and evidence boundaries
   omh recommend "risky refactor"
   omh cases recommend "daily competitor digest"
   omh cases readiness   Check the G1-G10 readiness rollup

--- a/src/commands/quickstart.py
+++ b/src/commands/quickstart.py
@@ -1,0 +1,318 @@
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+from .. import __version__
+from ..doctor import doctor_ok, recommended_next_action, run_doctor
+from ..probe import probe_capabilities
+from .common import _paths, _print_json, _wants_json
+
+QUICKSTART_CARD_SCHEMA_VERSION = "omh_quickstart_card/v1"
+
+
+def cmd_quickstart(args: argparse.Namespace) -> int:
+    card = build_quickstart_card(args)
+    if _wants_json(args):
+        _print_json(card)
+    else:
+        _print_quickstart_card(card)
+    return 0
+
+
+def build_quickstart_card(args: argparse.Namespace) -> dict[str, object]:
+    paths = _paths(args)
+    checks = run_doctor(paths)
+    probe = probe_capabilities(paths, include_roadmap=True)
+    capabilities = _capabilities_by_name(probe.get("capabilities", []))
+    doctor_status = _doctor_status(checks)
+    plugin_bridge = _plugin_bridge_status(probe, capabilities)
+    wrapper_usage = _capability_status(capabilities, "wrapper_metadata", default_status="missing")
+    runtime_observed = bool(probe.get("plugin_runtime_observed"))
+    runtime_active = bool(probe.get("plugin_runtime_active"))
+    source = str(getattr(args, "source", "hermes") or "hermes")
+
+    card = {
+        "schema_version": QUICKSTART_CARD_SCHEMA_VERSION,
+        "status": "ready" if doctor_status["blocking"] == 0 else "needs_attention",
+        "omh_version": __version__,
+        "source": source,
+        "paths": {
+            "omh_home": str(paths.omh_home),
+            "hermes_home": str(paths.hermes_home),
+            "skills_dir": str(paths.skills_dir),
+            "hermes_config": str(paths.hermes_config_path),
+        },
+        "local_status": {
+            "doctor": doctor_status,
+            "plugin_bridge": plugin_bridge,
+            "plugin_runtime_observed": runtime_observed,
+            "plugin_runtime_active": runtime_active,
+            "wrapper_usage": wrapper_usage,
+            "target_topology": probe.get("target_topology", {}),
+            "native_integration_claim_ready": bool(probe.get("native_integration_claim_ready")),
+        },
+        "first_five_minutes": [
+            "Restart or reload Hermes Agent after setup.",
+            "Ask Hermes: Use OMH request-to-handoff for: I want to safely add a feature to this repo.",
+            "If you want to choose manually, type ./omh or ask Hermes what OMH workflows are available.",
+        ],
+        "chat_prompts": [
+            {
+                "label": "safe feature work",
+                "prompt": "Use OMH request-to-handoff for: I want to safely add a feature to this repo.",
+                "expected_workflow": "request-to-handoff",
+            },
+            {
+                "label": "image summary card",
+                "prompt": "Use OMH img-summary for: summarize this PR as a shareable image card.",
+                "expected_workflow": "img-summary",
+            },
+            {
+                "label": "ambitious loop",
+                "prompt": "Use OMH loop for: improve this repo's first-run experience until the next bottleneck is verified.",
+                "expected_workflow": "loop",
+            },
+        ],
+        "wrapper_actions": [
+            {
+                "id": "open_workflow_picker",
+                "label": "Open OMH picker",
+                "surface": source,
+                "copy": "Show ./omh or the compact OMH workflow picker.",
+                "records_evidence": False,
+            },
+            {
+                "id": "record_wrapper_usage",
+                "label": "Record wrapper usage when Hermes uses OMH",
+                "surface": source,
+                "copy": "Record route/session metadata only after the wrapper has actually used an OMH workflow.",
+                "records_evidence": True,
+            },
+            {
+                "id": "observe_plugin_runtime",
+                "label": "Observe Hermes plugin runtime",
+                "surface": "hermes-host",
+                "copy": "Record host-supplied plugin load/use evidence only after Hermes reports it.",
+                "records_evidence": True,
+            },
+        ],
+        "not_evidence_yet": [
+            "A ready local plugin bridge is not proof that Hermes loaded or used the plugin.",
+            "A prepared handoff is not code execution, review, CI, merge readiness, or merge evidence.",
+            "A wrapper card is not runtime evidence until matching observation records exist.",
+        ],
+        "operator_next_actions": _operator_next_actions(checks, probe),
+        "claim_boundary": probe.get("claim_boundary", ""),
+    }
+    return card
+
+
+def _capabilities_by_name(capabilities: object) -> dict[str, dict[str, object]]:
+    if not isinstance(capabilities, list):
+        return {}
+    by_name: dict[str, dict[str, object]] = {}
+    for capability in capabilities:
+        if not isinstance(capability, dict):
+            continue
+        name = str(capability.get("name", "")).strip()
+        if name:
+            by_name[name] = capability
+    return by_name
+
+
+def _doctor_status(checks: list[object]) -> dict[str, object]:
+    blocking = [
+        str(getattr(check, "name", "unknown"))
+        for check in checks
+        if not bool(getattr(check, "ok", False)) and str(getattr(check, "severity", "")) == "blocking"
+    ]
+    warnings = [
+        str(getattr(check, "name", "unknown"))
+        for check in checks
+        if str(getattr(check, "severity", "")) == "warning"
+    ]
+    return {
+        "status": "ok" if doctor_ok(checks) else "needs_attention",
+        "passing": sum(1 for check in checks if bool(getattr(check, "ok", False))),
+        "total": len(checks),
+        "blocking": len(blocking),
+        "warnings": len(warnings),
+        "blocking_checks": blocking,
+        "warning_checks": warnings,
+        "recommended_next_action": recommended_next_action(checks),
+    }
+
+
+def _plugin_bridge_status(probe: dict[str, object], capabilities: dict[str, dict[str, object]]) -> dict[str, object]:
+    bundle = _capability_status(capabilities, "omh_plugin_bundle")
+    import_smoke = _capability_status(capabilities, "plugin_import_smoke")
+    register_smoke = _capability_status(capabilities, "plugin_register_smoke")
+    distribution_ready = bool(probe.get("plugin_distribution_ready"))
+    if distribution_ready and import_smoke["status"] == "available" and register_smoke["status"] == "available":
+        status = "ready_locally"
+        message = "Plugin bridge is installed and passed local import/register smoke."
+    elif bundle["status"] == "missing":
+        status = "missing"
+        message = "Plugin bridge is not installed locally."
+    else:
+        status = "needs_attention"
+        message = "Plugin bridge exists but local smoke evidence is incomplete."
+    return {
+        "status": status,
+        "distribution_ready": distribution_ready,
+        "bundle": bundle,
+        "import_smoke": import_smoke,
+        "register_smoke": register_smoke,
+        "message": message,
+    }
+
+
+def _capability_status(
+    capabilities: dict[str, dict[str, object]],
+    name: str,
+    *,
+    default_status: str = "unknown",
+) -> dict[str, object]:
+    capability = capabilities.get(name, {})
+    if not capability:
+        return {"status": default_status, "message": "", "evidence": ""}
+    return {
+        "status": str(capability.get("status", default_status)),
+        "message": str(capability.get("message", "")),
+        "evidence": str(capability.get("evidence", "")),
+    }
+
+
+def _operator_next_actions(checks: list[object], probe: dict[str, object]) -> list[dict[str, str]]:
+    actions: list[dict[str, str]] = []
+    next_action = recommended_next_action(checks)
+    if next_action:
+        actions.append({"kind": "doctor", "label": "Doctor next action", "next": next_action})
+    roadmap = probe.get("capability_gap_roadmap", {})
+    if isinstance(roadmap, dict):
+        for action in roadmap.get("next_actions", [])[:3]:
+            if not isinstance(action, dict):
+                continue
+            label = str(action.get("label", "")).strip() or "Capability next action"
+            next_step = str(action.get("next_step") or action.get("command") or action.get("description") or "").strip()
+            if next_step:
+                actions.append({"kind": str(action.get("kind", "roadmap")), "label": label, "next": next_step})
+    return actions
+
+
+def _print_quickstart_card(card: dict[str, object]) -> None:
+    use_color = _use_color()
+    status = str(card.get("status", "unknown"))
+    local_status = card.get("local_status", {})
+    if not isinstance(local_status, dict):
+        local_status = {}
+    doctor = local_status.get("doctor", {})
+    plugin_bridge = local_status.get("plugin_bridge", {})
+    wrapper_usage = local_status.get("wrapper_usage", {})
+    target_topology = local_status.get("target_topology", {})
+    if not isinstance(doctor, dict):
+        doctor = {}
+    if not isinstance(plugin_bridge, dict):
+        plugin_bridge = {}
+    if not isinstance(wrapper_usage, dict):
+        wrapper_usage = {}
+    if not isinstance(target_topology, dict):
+        target_topology = {}
+
+    print(_color("OMH quickstart", "1;36", use_color))
+    print(_color("Summary", "1;32", use_color))
+    print(f"  Status: {_status_label(status, use_color)}")
+    print(f"  OMH version: {card.get('omh_version', '')}")
+    print(f"  Local install: {doctor.get('status', 'unknown')} ({doctor.get('passing', 0)}/{doctor.get('total', 0)} checks)")
+    print(f"  Plugin bridge: {_plugin_bridge_label(str(plugin_bridge.get('status', 'unknown')))}")
+    print(f"  Live Hermes plugin use: {_observed_label(bool(local_status.get('plugin_runtime_active')), positive='observed', negative='not observed yet')}")
+    print(f"  Wrapper usage: {_wrapper_usage_label(str(wrapper_usage.get('status', 'missing')))}")
+    print(
+        "  Target topology: "
+        f"{target_topology.get('mode', 'unknown')} "
+        f"({target_topology.get('known_target_count', 0)} known target(s))"
+    )
+
+    print(_color("Do this in Hermes", "1;32", use_color))
+    for line in _string_list(card.get("first_five_minutes", [])):
+        print(f"  - {line}")
+
+    print(_color("Try one prompt", "1;32", use_color))
+    for prompt in _dict_list(card.get("chat_prompts", []))[:3]:
+        print(f"  - {prompt.get('label', 'prompt')}: {prompt.get('prompt', '')}")
+
+    print(_color("Still not evidence", "1;32", use_color))
+    for line in _string_list(card.get("not_evidence_yet", [])):
+        print(f"  - {line}")
+
+    actions = _dict_list(card.get("operator_next_actions", []))
+    if actions:
+        print(_color("Operator next actions", "1;32", use_color))
+        for action in actions[:4]:
+            print(f"  - {action.get('label', 'Next')}: {action.get('next', '')}")
+    print("  For machine-readable output, rerun with `--json`.")
+
+
+def _string_list(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value if str(item)]
+
+
+def _dict_list(value: object) -> list[dict[str, object]]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, dict)]
+
+
+def _status_label(status: str, use_color: bool) -> str:
+    if status == "ready":
+        return _color("ready", "1;32", use_color)
+    if status == "needs_attention":
+        return _color("needs attention", "1;33", use_color)
+    return status
+
+
+def _plugin_bridge_label(status: str) -> str:
+    if status == "ready_locally":
+        return "ready locally"
+    return status.replace("_", " ")
+
+
+def _wrapper_usage_label(status: str) -> str:
+    if status == "available":
+        return "recorded"
+    if status == "missing":
+        return "not recorded yet"
+    return status
+
+
+def _observed_label(observed: bool, *, positive: str, negative: str) -> str:
+    return positive if observed else negative
+
+
+def _use_color() -> bool:
+    return sys.stdout.isatty() and not os.environ.get("NO_COLOR")
+
+
+def _color(text: str, code: str, enabled: bool) -> str:
+    if not enabled:
+        return text
+    return f"\033[{code}m{text}\033[0m"
+
+
+def _add_quickstart_commands(sub) -> None:
+    quickstart = sub.add_parser(
+        "quickstart",
+        help="Show the first-use OMH/Hermes path and current evidence boundaries.",
+    )
+    quickstart.add_argument("--json", action="store_true", help="Print the full machine-readable quickstart card.")
+    quickstart.add_argument(
+        "--source",
+        default="hermes",
+        choices=("hermes", "discord", "slack", "telegram", "terminal", "wrapper"),
+        help="Surface that will render the card.",
+    )
+    quickstart.set_defaults(func=cmd_quickstart)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,6 +26,7 @@ class CliTests(unittest.TestCase):
         self.assertEqual(stderr, "")
         self.assertIn("OMH - oh-my-hermes", stdout)
         self.assertIn("omh setup", stdout)
+        self.assertIn("omh quickstart", stdout)
         self.assertIn("Agent chat with installed OMH skills", stdout)
         self.assertIn("First five minutes:", stdout)
         self.assertIn("If `omh` is not found", stdout)
@@ -42,6 +43,8 @@ class CliTests(unittest.TestCase):
         self.assertIn("`omh` was not found", help_text)
         self.assertIn("setup", help_text)
         self.assertIn("Connect OMH workflows to the target Hermes profile", help_text)
+        self.assertIn("quickstart", help_text)
+        self.assertIn("Show the first-use OMH/Hermes path", help_text)
         self.assertIn("chat", help_text)
         self.assertIn("wrapper chat events", help_text)
         self.assertIn("omh cases recommend", help_text)
@@ -668,6 +671,49 @@ class CliTests(unittest.TestCase):
             command_check = {check["name"]: check for check in doctor_payload["checks"]}["command_path"]
             self.assertEqual(command_check["severity"], "ok")
             self.assertTrue(command_check["observed"])
+
+    def test_quickstart_card_shows_first_use_path_without_recording_runtime_evidence(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+
+            with patch("omh.command_path.shutil.which", return_value="/usr/local/bin/omh"):
+                status, stdout, stderr = run_cli(base + ["setup", "--no-interactive"], output_json=False)
+
+            self.assertEqual(status, 0, stderr)
+            self.assertEqual(stderr, "")
+            self.assertIn("OMH setup complete.", stdout)
+
+            with patch("omh.command_path.shutil.which", return_value="/usr/local/bin/omh"):
+                status, stdout, stderr = run_cli(base + ["quickstart"], output_json=False)
+
+            self.assertEqual(status, 0, stderr)
+            self.assertEqual(stderr, "")
+            self.assertIn("OMH quickstart", stdout)
+            self.assertIn("Status: ready", stdout)
+            self.assertIn("Plugin bridge: ready locally", stdout)
+            self.assertIn("Live Hermes plugin use: not observed yet", stdout)
+            self.assertIn("Wrapper usage: not recorded yet", stdout)
+            self.assertIn("Use OMH request-to-handoff", stdout)
+            self.assertIn("A ready local plugin bridge is not proof", stdout)
+            self.assertIn("For machine-readable output, rerun with `--json`.", stdout)
+            self.assertFalse((root / ".omh" / "runtime" / "wrapper_sessions").exists())
+
+            with patch("omh.command_path.shutil.which", return_value="/usr/local/bin/omh"):
+                status, stdout, stderr = run_cli(base + ["quickstart", "--source", "discord", "--json"], output_json=False)
+
+            self.assertEqual(status, 0, stderr)
+            self.assertEqual(stderr, "")
+            payload = json.loads(stdout)
+            self.assertEqual(payload["schema_version"], "omh_quickstart_card/v1")
+            self.assertEqual(payload["status"], "ready")
+            self.assertEqual(payload["source"], "discord")
+            self.assertEqual(payload["local_status"]["plugin_bridge"]["status"], "ready_locally")
+            self.assertFalse(payload["local_status"]["plugin_runtime_observed"])
+            self.assertFalse(payload["local_status"]["plugin_runtime_active"])
+            self.assertEqual(payload["local_status"]["wrapper_usage"]["status"], "missing")
+            self.assertIn("request-to-handoff", payload["chat_prompts"][0]["expected_workflow"])
+            self.assertTrue(any(action["id"] == "record_wrapper_usage" for action in payload["wrapper_actions"]))
 
     def test_setup_recovers_bare_null_external_dirs_shape(self) -> None:
         with TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Feature Report

### What Changed

- Added `omh quickstart`, a compact first-use status card for users and wrappers after install/setup.
- The command emits a human-readable summary by default and `omh_quickstart_card/v1` with `--json`.
- Root help and the no-arg welcome screen now surface `omh quickstart` alongside `setup` and `doctor`.
- README and installation docs now point users to the quickstart card when the post-setup next step is unclear.

### Why This Exists

- OMH already had strong `doctor` and `probe` surfaces, but those are diagnostic/operator-heavy.
- New users who skip docs still need one short answer to: "What should I do in Hermes now, and what is not evidence yet?"
- This keeps OMH chat-first: the CLI remains support infrastructure while the card gives Hermes prompts and wrapper-renderable actions.

### User / Operator Impact

- After `omh setup` and `omh doctor`, a user can run `omh quickstart` to see:
  - local setup readiness,
  - plugin bridge local readiness,
  - whether live Hermes plugin use is observed,
  - whether wrapper usage has been recorded,
  - first Hermes prompts to try.
- Wrapper operators can consume `omh quickstart --json` and render the same first-use card in Discord/Slack/Telegram/Hermes surfaces without shelling through `doctor`/`probe` manually.
- The command does not create wrapper sessions or plugin observations; it only reads current state.

### How It Works

- `src/commands/quickstart.py` builds the card from `run_doctor()` and `probe_capabilities(..., include_roadmap=True)`.
- The card separates:
  - `plugin_bridge.status=ready_locally` from live Hermes runtime evidence,
  - `plugin_runtime_observed/plugin_runtime_active`,
  - `wrapper_usage` from actual wrapper session artifacts,
  - first-use prompts from operator next actions.
- `src/commands/main.py` registers the command and adds it to help/welcome text.

### Files And Contracts Touched

- `src/commands/quickstart.py`: new `omh_quickstart_card/v1` builder and human renderer.
- `src/commands/main.py`: top-level command registration and first-use discoverability.
- `tests/test_cli.py`: quickstart human/JSON contract plus no-fake-evidence assertions.
- `README.md`, `docs/INSTALLATION.md`, `docs/README.md`: conservative docs sync.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests.test_cli.CliTests.test_quickstart_card_shows_first_use_path_without_recording_runtime_evidence -v`
- [x] `PYTHONPATH=tests uv run python -m unittest tests.test_cli.CliTests.test_no_arg_cli_shows_welcome_instead_of_error tests.test_cli.CliTests.test_root_help_explains_command_lanes -v`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` (658 tests)
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m src.cli docs workflows --check`
- [ ] `python3 -m omh.cli harness validate` (not directly run; docs/workflows generated-surface check was run instead)
- [x] `uv run python -m src.cli release product-readiness --json` (ready, score 100, 1 non-blocking warning)
- [ ] `python3 -m omh.cli release checklist --json` (not run for this narrow CLI support surface)
- [ ] `python3 -m omh.cli release hermes-smoke` (not run; no live Hermes smoke in this PR)
- [x] `uv run python -m src.cli quickstart`
- [x] `uv run python -m src.cli quickstart --json`
- [x] `git diff --check`
- [x] `uv build`
- [ ] Manual Hermes/TUI check: not run; live Hermes plugin load/use remains explicitly unobserved.

## Risk

- Low implementation risk: read-only command, no state mutation, no new dependency, no network/API call.
- UX risk: one more command could look CLI-centered if overpromoted. The copy frames it as a first-use support card and keeps normal use in Hermes chat.

## Compatibility / Rollout

- Backward compatible: no existing command, schema, or artifact behavior changes.
- Package build confirmed `omh/commands/quickstart.py` is included in wheel/sdist.
- Works for user/project/custom homes through the existing `_paths()` mechanism.

## Release / Claims

- [x] Release-channel impact considered: this is preview/stable-compatible CLI support infrastructure.
- [x] Runtime/native capability claims are backed by current doctor/probe evidence or marked as not observed.
- [x] Known manual Hermes checks are listed: live Hermes plugin load/use and wrapper rendering were not observed.

## Follow-Up

- A future wrapper PR can render `omh_quickstart_card/v1` directly as a native chat card when a user asks "what do I do after setup?".
