### PR TITLE
Improve OMH context card readability

### DIFF
--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -1430,17 +1430,23 @@ def build_chat_response_from_omh_context_brief(
             use_for = str(lane.get("use_for", "")).strip()
             if label and use_for:
                 lane_summaries.append(f"{label}: {use_for}")
-    first_lane_sentence = " ".join(lane_summaries[:3])
     body_lines = [
         "OMH is the Hermes workflow layer: install once, then ask Hermes in chat instead of memorizing backend commands.",
-        first_lane_sentence,
-        "Start with: ask what you want in normal language, use ./omh to open the workflow picker when you want to choose manually, or ask what to do next after setup.",
+        "",
+        "Use it for:",
+        *[f"- {summary}" for summary in lane_summaries[:3]],
+        "",
+        "How to start:",
+        "- Ask what you want in normal language.",
+        "- Open the workflow picker with ./omh when you want to choose manually.",
+        "- Ask what to do next after setup when you want the first-use path.",
+        "",
         "Boundary: this context explains routing and workflow choices; it is not execution, delivery, verification, review, CI, or merge evidence.",
     ]
     return _chat_response(
         kind="context_brief",
         headline="Here is how OMH fits into Hermes.",
-        body=" ".join(line for line in body_lines if line),
+        body="\n".join(body_lines),
         phase="route",
         next_action="show_context_brief",
         thread_key=thread_key,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3964,6 +3964,10 @@ class CliTests(unittest.TestCase):
                 self.assertEqual(payload["chat_response"]["kind"], "context_brief")
                 self.assertTrue(payload["chat_response"]["headline"].startswith("[omh] context - "))
                 self.assertIn("Hermes workflow layer", payload["chat_response"]["body"])
+                self.assertIn("Use it for:", payload["chat_response"]["body"])
+                self.assertIn("How to start:", payload["chat_response"]["body"])
+                rendering_blocks = payload["chat_response"]["messenger_rendering"]["body_blocks"]
+                self.assertGreaterEqual(sum(1 for block in rendering_blocks if block["type"] == "bullet"), 3)
                 state = payload["chat_response"]["state"]
                 self.assertEqual(state["context_brief"]["schema_version"], "omh_context_brief/v1")
                 self.assertEqual(state["context_brief"]["source"], "discord")

--- a/tests/test_wrapper_contract.py
+++ b/tests/test_wrapper_contract.py
@@ -837,7 +837,15 @@ class WrapperContractTests(unittest.TestCase):
                 self.assertTrue(response["headline"].startswith("[omh] context - "))
                 self.assertIn("Hermes workflow layer", response["body"])
                 self.assertIn("install once", response["body"])
+                self.assertIn("Use it for:", response["body"])
+                self.assertIn("How to start:", response["body"])
                 self.assertIn("workflow picker", response["body"])
+                rendering_blocks = response["messenger_rendering"]["body_blocks"]
+                self.assertGreaterEqual(len(rendering_blocks), 5)
+                self.assertGreaterEqual(
+                    sum(1 for block in rendering_blocks if block["type"] == "bullet"),
+                    3,
+                )
                 state = response["state"]
                 self.assertEqual(state["status_source"], "omh_context_brief")
                 self.assertEqual(state["context_brief"]["schema_version"], "omh_context_brief/v1")


### PR DESCRIPTION
## Feature Report

### What Changed

- Reformatted the OMH first-use `context_brief` chat response from one dense paragraph into a short card structure.
- The response now has a brief intro, `Use it for` bullets, `How to start` bullets, and the same evidence boundary.
- Added tests that assert messenger rendering produces real bullet blocks, so the card stays readable in Discord/Slack/Hermes-style surfaces.

### Why This Exists

- The previous `context_brief` worked, but its body rendered as a large unbroken paragraph in JSON and narrow chat surfaces.
- First-use OMH explanation is a product entry point; it should be scannable before the user opens the full workflow picker.

### User / Operator Impact

- A user asking "what is OMH and how do I use it?" now receives a card that is easier to read:
  - what OMH is,
  - what it is useful for,
  - how to start,
  - what is not evidence yet.
- Wrappers can render `messenger_rendering.body_blocks` directly as paragraphs and bullets.
- No behavior changes to routing, picker, quickstart, executor handoff, or runtime evidence claims.

### How It Works

- `build_chat_response_from_omh_context_brief` now joins body lines with newlines and bullet prefixes instead of collapsing everything into one sentence.
- Existing `messenger_rendering_contract` converts that body into `body_blocks` with paragraph and bullet entries.
- Tests lock both the chat response text and the structured rendering shape.

### Files And Contracts Touched

- `src/wrapper/contract.py`: `context_brief` body formatting.
- `tests/test_wrapper_contract.py`: wrapper-level bullet block regression coverage.
- `tests/test_cli.py`: CLI `chat interact` regression coverage for bullet rendering.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` (`Ran 661 tests`, `OK`)
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m src.cli docs workflows --check` (`ok: true`, tap skills 41/41)
- [x] `uv run python -m src.cli release product-readiness --json` (`status: ready`, `score: 100`, `blocking_failures: 0`)
- [x] `git diff --check`
- [x] Relevant dry-run or smoke command: `uv run python -m src.cli chat interact --source discord "what is OMH and how do I use it?"` shows sectioned body and bullet `body_blocks`
- [ ] `python3 -m omh.cli harness validate` (not run; no harness schema changes)
- [ ] `python3 -m omh.cli release checklist --json` (covered through product-readiness gate shape)
- [ ] `python3 -m omh.cli release hermes-smoke` (not run; live Hermes profile rendering requires host runtime observation)
- [ ] `omh --help` (not run; no help parser changes)
- [ ] Manual Hermes/TUI check: not run; host rendering and messenger adapter button display require live host observation.

## Risk

- Narrow risk: the text shape changes for `context_brief`, but the JSON contract, action ids, and evidence boundary remain stable.
- The new tests should prevent regressions back into large unbroken blocks.

## Compatibility / Rollout

- Backward compatible for wrappers reading `body` as plain text.
- Better for wrappers reading `messenger_rendering.body_blocks`.
- No release-channel behavior change beyond the preview/main workflow refresh.

## Release / Claims

- [x] Release-channel impact considered (`preview`/main workflow refresh; no package version bump)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Known manual Hermes checks are listed, including live host rendering gap

## Follow-Up

- Watch real chat rendering to decide whether `quickstart` should receive the same sectioned-card treatment next.
