### PR TITLE
Improve OMH quickstart card readability

### DIFF
--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -1380,19 +1380,24 @@ def build_chat_response_from_omh_quickstart(
             f"OMH quickstart is {card.get('status', 'unknown')}: "
             f"{doctor.get('passing', 0)}/{doctor.get('total', 0)} local checks pass."
         ),
-        (
-            f"Plugin bridge: {str(plugin_bridge.get('status', 'unknown')).replace('_', ' ')}; "
-            f"Hermes plugin use: {'observed' if bool(local_status.get('plugin_runtime_active')) else 'not observed yet'}; "
-            f"wrapper usage: {str(wrapper_usage.get('status', 'missing')).replace('_', ' ')}."
-        ),
-        f"Next in Hermes: {first_prompt}" if first_prompt else "",
+        "",
+        "Local status:",
+        f"- Plugin bridge: {str(plugin_bridge.get('status', 'unknown')).replace('_', ' ')}.",
+        f"- Hermes plugin use: {'observed' if bool(local_status.get('plugin_runtime_active')) else 'not observed yet'}.",
+        f"- Wrapper usage: {str(wrapper_usage.get('status', 'missing')).replace('_', ' ')}.",
+        "",
+        "Next in Hermes:",
+        f"- {first_prompt}" if first_prompt else "- Ask Hermes what you want to do with OMH.",
+        "- Open the workflow picker with ./omh when you want to choose manually.",
+        "- Use Show detailed status only when setup or registration looks wrong.",
+        "",
         f"Boundary: {evidence_gap}",
     ]
     observed_gaps = [str(item) for item in evidence_gaps if str(item)] if isinstance(evidence_gaps, list) else []
     return _chat_response(
         kind="quickstart",
         headline="Here is the OMH first-use path.",
-        body=" ".join(line for line in body_lines if line),
+        body="\n".join(body_lines),
         phase="status",
         next_action="show_quickstart",
         thread_key=thread_key,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -214,7 +214,11 @@ class CliTests(unittest.TestCase):
             state = payload["chat_response"]["state"]
             self.assertEqual(state["status_source"], "omh_quickstart")
             self.assertEqual(state["quickstart_card"]["schema_version"], "omh_quickstart_card/v1")
+            self.assertIn("Local status:", payload["chat_response"]["body"])
+            self.assertIn("Next in Hermes:", payload["chat_response"]["body"])
             self.assertIn("Use OMH request-to-handoff", payload["chat_response"]["body"])
+            rendering_blocks = payload["chat_response"]["messenger_rendering"]["body_blocks"]
+            self.assertGreaterEqual(sum(1 for block in rendering_blocks if block["type"] == "bullet"), 5)
             self.assertEqual(state["capability_gap_roadmap"]["schema_version"], "omh_capability_gap_roadmap/v1")
             self.assertEqual(state["roadmap_next_actions"][0]["id"], "run_setup")
             self.assertEqual(state["roadmap_next_actions"][0]["id"], "run_setup")

--- a/tests/test_wrapper_contract.py
+++ b/tests/test_wrapper_contract.py
@@ -686,8 +686,15 @@ class WrapperContractTests(unittest.TestCase):
                     self.assertEqual(payload["chat_response"]["kind"], "quickstart")
                     self.assertTrue(payload["chat_response"]["headline"].startswith("[omh] quickstart - "))
                     self.assertIn("OMH quickstart is", payload["chat_response"]["body"])
+                    self.assertIn("Local status:", payload["chat_response"]["body"])
+                    self.assertIn("Next in Hermes:", payload["chat_response"]["body"])
                     self.assertIn("Use OMH request-to-handoff", payload["chat_response"]["body"])
                     self.assertIn("Boundary:", payload["chat_response"]["body"])
+                    rendering_blocks = payload["chat_response"]["messenger_rendering"]["body_blocks"]
+                    self.assertGreaterEqual(
+                        sum(1 for block in rendering_blocks if block["type"] == "bullet"),
+                        5,
+                    )
                     state = payload["chat_response"]["state"]
                     self.assertEqual(state["status_source"], "omh_quickstart")
                     self.assertEqual(state["quickstart_card"]["schema_version"], "omh_quickstart_card/v1")


### PR DESCRIPTION
## Feature Report

### What Changed

- Reformatted the first-use OMH quickstart chat response from one dense paragraph into a sectioned card.
- The response now shows:
  - quick local readiness summary,
  - `Local status` bullets,
  - `Next in Hermes` bullets,
  - evidence boundary.
- Added wrapper and CLI tests that assert the quickstart response produces messenger-renderable bullet blocks.

### Why This Exists

- `quickstart` is one of the first surfaces a new Hermes user sees after setup.
- The previous response was correct but hard to scan in Discord, Slack, and narrow Hermes-style chat surfaces because it rendered as one paragraph.
- This keeps OMH's chat-first value clearer without adding commands or changing setup semantics.

### User / Operator Impact

- Users asking what to do after OMH setup now get a cleaner card with local state and next actions separated.
- Wrappers can render `messenger_rendering.body_blocks` as paragraph/bullet blocks instead of parsing prose.
- The card still keeps local setup readiness separate from live Hermes/plugin/runtime observation.

### How It Works

- `build_chat_response_from_omh_quickstart` now joins body lines with newlines and bullet prefixes.
- The existing `messenger_rendering_contract` turns those lines into structured paragraph and bullet blocks.
- Tests cover the chat wrapper path and the CLI `chat interact` path.

### Files And Contracts Touched

- `src/wrapper/contract.py`: quickstart body structure.
- `tests/test_wrapper_contract.py`: wrapper quickstart rendering regression coverage.
- `tests/test_cli.py`: CLI quickstart rendering regression coverage.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` (`Ran 661 tests`, `OK`)
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m src.cli docs workflows --check` (`ok: true`, tap skills 41/41)
- [x] `uv run python -m src.cli release product-readiness --json` (`status: ready`, `score: 100`, `blocking_failures: 0`)
- [x] `git diff --check`
- [x] Relevant dry-run or smoke command: `uv run python -m src.cli chat interact --source discord "what should I do next with OMH setup?"` shows sectioned quickstart body and bullet `body_blocks`
- [ ] `python3 -m omh.cli harness validate` (not run; no harness schema changes)
- [ ] `python3 -m omh.cli release checklist --json` (covered through product-readiness gate shape)
- [ ] `python3 -m omh.cli release hermes-smoke` (not run; live Hermes profile rendering requires host runtime observation)
- [ ] `omh --help` (not run; no help parser changes)
- [ ] Manual Hermes/TUI check: not run; host rendering and messenger adapter button display require live host observation.

## Risk

- Narrow risk: user-facing quickstart copy changed, but `chat_response.kind`, action ids, state fields, and evidence boundary remain stable.
- Tests lock the sectioned/bullet rendering so it does not regress to a single unbroken paragraph.

## Compatibility / Rollout

- Backward compatible for wrappers reading `body` as plain text.
- Better for wrappers reading `messenger_rendering.body_blocks`.
- No release-channel behavior change beyond preview/main workflow refresh.

## Release / Claims

- [x] Release-channel impact considered (`preview`/main workflow refresh; no package version bump)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Known manual Hermes checks are listed, including live host rendering gap

## Follow-Up

- Keep watching first-use cards in live Hermes/Discord to tune copy length and section labels.
