### PR TITLE
Improve OMH status card readability

### DIFF
--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -1313,18 +1313,22 @@ def build_chat_response_from_omh_status_roadmap(paths: OmhPaths, *, thread_key: 
     setup_gaps = _intish(summary.get("baseline_product_gaps", 0))
     evidence_gaps = _intish(summary.get("evidence_gaps", 0))
     optional_unknowns = _intish(summary.get("optional_or_host_unknowns", 0))
+    next_action_sentence = _section_item_without_next_prefix(_roadmap_next_action_sentence(next_actions))
     body_lines = [
-        (
-            f"OMH setup gaps: {setup_gaps}; evidence gaps: {evidence_gaps}; "
-            f"optional/host unknowns: {optional_unknowns}."
-        ),
-        _roadmap_next_action_sentence(next_actions),
+        "Current status:",
+        f"- OMH setup gaps: {setup_gaps}.",
+        f"- Evidence gaps: {evidence_gaps}.",
+        f"- Optional/host unknowns: {optional_unknowns}.",
+        "",
+        "Next action:",
+        f"- {next_action_sentence}" if next_action_sentence else "- No immediate local action is required.",
+        "",
         "Boundary: local setup, plugin install, or smoke checks are not proof that Hermes loaded the plugin, ran an executor, reviewed code, passed CI, or merged anything.",
     ]
     return _chat_response(
         kind="status",
         headline="Here is the current OMH status and next action.",
-        body=" ".join(line for line in body_lines if line),
+        body="\n".join(body_lines),
         phase="status",
         next_action="show_status",
         thread_key=thread_key,
@@ -2073,6 +2077,13 @@ def _roadmap_next_action_sentence(actions: list[dict[str, object]]) -> str:
     if why:
         return f"Next: {label}. {why}"
     return f"Next: {label}."
+
+
+def _section_item_without_next_prefix(value: str) -> str:
+    text = value.strip()
+    if text.lower().startswith("next:"):
+        return text.split(":", 1)[1].strip()
+    return text
 
 
 def _intish(value: object, default: int = 0) -> int:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -224,6 +224,31 @@ class CliTests(unittest.TestCase):
             self.assertEqual(state["roadmap_next_actions"][0]["id"], "run_setup")
             self.assertIn("omh setup", state["roadmap_next_actions"][0]["command"])
 
+    def test_chat_interact_omh_status_question_uses_sectioned_status_card(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+            status, stdout, stderr = run_cli(
+                base + ["chat", "interact", "--source", "discord", "show OMH status"],
+                output_json=False,
+            )
+
+            self.assertEqual(status, 0, stderr)
+            self.assertEqual(stderr, "")
+            payload = json.loads(stdout)
+            self.assertEqual(payload["mode"], "status")
+            self.assertEqual(payload["next_action"], "show_status")
+            self.assertEqual(payload["chat_response"]["kind"], "status")
+            self.assertIn("Current status:", payload["chat_response"]["body"])
+            self.assertIn("Next action:", payload["chat_response"]["body"])
+            self.assertNotIn("- Next:", payload["chat_response"]["body"])
+            self.assertIn("Boundary:", payload["chat_response"]["body"])
+            rendering_blocks = payload["chat_response"]["messenger_rendering"]["body_blocks"]
+            self.assertGreaterEqual(sum(1 for block in rendering_blocks if block["type"] == "bullet"), 4)
+            state = payload["chat_response"]["state"]
+            self.assertEqual(state["status_source"], "omh_probe")
+            self.assertEqual(state["capability_gap_roadmap"]["schema_version"], "omh_capability_gap_roadmap/v1")
+
     def test_learning_record_eval_and_regression_replay(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/test_wrapper_contract.py
+++ b/tests/test_wrapper_contract.py
@@ -716,8 +716,16 @@ class WrapperContractTests(unittest.TestCase):
             self.assertEqual(payload["route"]["selected_skill"], "oh-my-hermes")
             self.assertEqual(payload["chat_response"]["kind"], "status")
             self.assertTrue(payload["chat_response"]["headline"].startswith("[omh] status - "))
+            self.assertIn("Current status:", payload["chat_response"]["body"])
             self.assertIn("OMH setup gaps:", payload["chat_response"]["body"])
+            self.assertIn("Next action:", payload["chat_response"]["body"])
+            self.assertNotIn("- Next:", payload["chat_response"]["body"])
             self.assertIn("Boundary:", payload["chat_response"]["body"])
+            rendering_blocks = payload["chat_response"]["messenger_rendering"]["body_blocks"]
+            self.assertGreaterEqual(
+                sum(1 for block in rendering_blocks if block["type"] == "bullet"),
+                4,
+            )
             state = payload["chat_response"]["state"]
             self.assertEqual(state["status_source"], "omh_probe")
             roadmap = state["capability_gap_roadmap"]


### PR DESCRIPTION
## Summary
- Reformat the OMH status roadmap chat response into a scannable card with `Current status`, `Next action`, and `Boundary` sections.
- Preserve the existing `capability_gap_roadmap` JSON contract while improving messenger-facing `body_blocks` for Discord/Slack-style renderers.
- Remove the duplicated `Next:` prefix from status bullet copy so Hermes responses read naturally.

## Why
Status questions previously returned dense one-paragraph diagnostics. In chat surfaces, users need to quickly see what is currently known, what to do next, and what is still not observed evidence.

## What users can do now
When a user asks Hermes something like `show OMH status`, wrappers can render the response as a readable status card rather than a compact prose blob. The card separates setup gaps, evidence gaps, optional host unknowns, the next recommended action, and the evidence boundary.

## Implementation
- Updated `build_chat_response_from_omh_status_roadmap` in `src/wrapper/contract.py` to produce sectioned body text.
- Added a small helper to normalize roadmap next-action copy before placing it in bullet form.
- Added wrapper-contract and CLI tests that lock the sectioned status shape and messenger rendering blocks.

## Verification
- `PYTHONPATH=tests uv run python -m unittest tests.test_wrapper_contract.WrapperContractTests.test_explicit_omh_status_questions_can_still_render_probe_roadmap tests.test_cli.CliTests.test_chat_interact_omh_status_question_uses_sectioned_status_card -v`
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- `uv run python -m compileall -q src tests`
- `uv run python -m src.cli docs workflows --check`
- `uv run python -m src.cli release product-readiness --json`
- `git diff --check`

## Boundaries / Risks
- This is local wrapper rendering and roadmap guidance only. It does not prove live Hermes plugin load, executor dispatch, review, CI, merge, or messenger button rendering.
- Live Hermes host rendering still requires host-supplied runtime observation.
