### PR TITLE
Improve OMH workflow picker readability

### DIFF
--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -2227,11 +2227,7 @@ def _skill_picker_response(decision: dict[str, object], *, thread_key: str = "",
     return _chat_response(
         kind="skill_picker",
         headline="Here are the OMH workflows." if catalog_question else "Choose an OMH workflow.",
-        body=(
-            "You do not need to run a shell command for this. OMH covers planning, ops, deliverables, coding handoffs, loops, and status. Pick a workflow here, or choose Route for me and Hermes will select the safest next step."
-            if catalog_question
-            else "Pick a workflow, or choose Route for me and Hermes will select the safest next step from the request."
-        ),
+        body=_skill_picker_body(catalog_question=catalog_question),
         phase="skill_selection",
         next_action="choose_skill",
         thread_key=thread_key,
@@ -2253,6 +2249,40 @@ def _skill_picker_response(decision: dict[str, object], *, thread_key: str = "",
         ],
         claim_boundary="Choosing a skill is routing intent only; it is not plan acceptance, dispatch, execution, review, CI, or verification evidence.",
         extra_state=extra_state,
+    )
+
+
+def _skill_picker_body(*, catalog_question: bool) -> str:
+    if catalog_question:
+        return "\n".join(
+            [
+                "You do not need to run a shell command for this. OMH covers planning, ops, deliverables, coding handoffs, loops, and status.",
+                "",
+                "Start here:",
+                "- Route for me: let Hermes choose the safest workflow from your message.",
+                "- Choose workflow: pick from the grouped OMH workflow lanes.",
+                "- Search workflows: find the exact skill when you already know the job.",
+                "",
+                "Common lanes:",
+                "- Intent to plan: deep-interview, ralplan, ultragoal, loop, ultraprocess.",
+                "- Company/product ops: feedback-triage, research-brief, strategy-brief, research-department.",
+                "- Deliverables/visuals: materials-package, report-package, img-summary.",
+                "- Coding/runtime: request-to-handoff, idea-to-deploy, code-review, executor selection.",
+            ]
+        )
+    return "\n".join(
+        [
+            "Pick how to start, or choose Route for me and Hermes will select the safest next step from the request.",
+            "",
+            "Best default:",
+            "- Route for me: paste the request and let Hermes choose the workflow.",
+            "",
+            "Manual lanes:",
+            "- Plan or loop: deep-interview, ralplan, ultragoal, loop, ultraprocess.",
+            "- Ops or research: feedback-triage, research-brief, strategy-brief.",
+            "- Deliverables or visuals: materials-package, report-package, img-summary.",
+            "- Coding: request-to-handoff, idea-to-deploy, code-review, executor selection.",
+        ]
     )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3914,6 +3914,14 @@ class CliTests(unittest.TestCase):
                 self.assertEqual(payload["chat_response"]["kind"], "skill_picker")
                 picker = payload["chat_response"]["state"]["skill_picker"]
                 self.assertEqual(picker["schema_version"], "omh_skill_picker/v1")
+                self.assertIn("Best default:", payload["chat_response"]["body"])
+                self.assertIn("Manual lanes:", payload["chat_response"]["body"])
+                self.assertIn("Route for me:", payload["chat_response"]["body"])
+                rendering_blocks = payload["chat_response"]["messenger_rendering"]["body_blocks"]
+                self.assertGreaterEqual(
+                    sum(1 for block in rendering_blocks if block["type"] == "bullet"),
+                    5,
+                )
                 option_ids = {option["id"] for option in picker["options"]}
                 self.assertTrue({"oh-my-hermes", "deep-interview", "ralplan", "loop", "ultraprocess"} <= option_ids)
                 self.assertEqual(picker["featured_options"][0]["id"], "oh-my-hermes")
@@ -3964,6 +3972,14 @@ class CliTests(unittest.TestCase):
                 self.assertEqual(payload["chat_response"]["kind"], "skill_picker")
                 self.assertTrue(payload["chat_response"]["state"]["catalog_question"])
                 self.assertIn("shell command", payload["chat_response"]["body"])
+                self.assertIn("Start here:", payload["chat_response"]["body"])
+                self.assertIn("Common lanes:", payload["chat_response"]["body"])
+                self.assertIn("Route for me:", payload["chat_response"]["body"])
+                rendering_blocks = payload["chat_response"]["messenger_rendering"]["body_blocks"]
+                self.assertGreaterEqual(
+                    sum(1 for block in rendering_blocks if block["type"] == "bullet"),
+                    7,
+                )
                 picker = payload["chat_response"]["state"]["skill_picker"]
                 self.assertEqual(picker["featured_options"][0]["id"], "oh-my-hermes")
                 picker_groups = {group["id"]: group for group in picker["groups"]}

--- a/tests/test_wrapper_contract.py
+++ b/tests/test_wrapper_contract.py
@@ -741,6 +741,14 @@ class WrapperContractTests(unittest.TestCase):
         self.assertEqual(payload["next_action"], "choose_skill")
         self.assertEqual(payload["route"]["selected_skill"], "oh-my-hermes")
         self.assertEqual(payload["chat_response"]["kind"], "skill_picker")
+        self.assertIn("Best default:", payload["chat_response"]["body"])
+        self.assertIn("Manual lanes:", payload["chat_response"]["body"])
+        self.assertIn("Route for me:", payload["chat_response"]["body"])
+        rendering_blocks = payload["chat_response"]["messenger_rendering"]["body_blocks"]
+        self.assertGreaterEqual(
+            sum(1 for block in rendering_blocks if block["type"] == "bullet"),
+            5,
+        )
         picker = payload["chat_response"]["state"]["skill_picker"]
         self.assertEqual(picker["schema_version"], "omh_skill_picker/v1")
         self.assertEqual(picker["selection_mode"], "single_select")
@@ -797,6 +805,14 @@ class WrapperContractTests(unittest.TestCase):
                 self.assertTrue(payload["chat_response"]["state"]["catalog_question"])
                 self.assertIn("shell command", payload["chat_response"]["body"])
                 self.assertIn("planning, ops, deliverables, coding handoffs, loops, and status", payload["chat_response"]["body"])
+                self.assertIn("Start here:", payload["chat_response"]["body"])
+                self.assertIn("Common lanes:", payload["chat_response"]["body"])
+                self.assertIn("Route for me:", payload["chat_response"]["body"])
+                rendering_blocks = payload["chat_response"]["messenger_rendering"]["body_blocks"]
+                self.assertGreaterEqual(
+                    sum(1 for block in rendering_blocks if block["type"] == "bullet"),
+                    7,
+                )
                 picker = payload["chat_response"]["state"]["skill_picker"]
                 option_ids = {option["id"] for option in picker["options"]}
                 self.assertTrue({"oh-my-hermes", "loop", "ultraprocess"} <= option_ids)


### PR DESCRIPTION
## Summary
- Turn the OMH workflow picker body into a sectioned chat card instead of a single paragraph.
- Show the safest default (`Route for me`) separately from manual workflow lanes.
- Keep the existing `omh_skill_picker/v1` state, grouped options, and action payloads unchanged.

## Why
When a user asks Hermes what OMH can do, the response should be useful without shell approval or a long diagnostic blob. The picker already had the right data, but the body text did not help Discord/Slack-style surfaces render a scannable choice card.

## What users can do now
Users can ask `what OMH workflows are available?` or type `./omh` and see a readable card:
- Start with `Route for me` when they do not know the right workflow.
- Browse common lanes such as planning, product ops, deliverables/visuals, and coding/runtime.
- Search workflows only when they already know the job.

## Implementation
- Added a small `_skill_picker_body` helper in `src/wrapper/contract.py`.
- Catalog questions now render `Start here` and `Common lanes` sections.
- Direct `./omh` picker calls now render `Best default` and `Manual lanes` sections.
- Added wrapper contract and CLI assertions for section headers and bullet block rendering.

## Verification
- `PYTHONPATH=tests uv run python -m unittest tests.test_wrapper_contract.WrapperContractTests.test_direct_omh_invocation_exposes_skill_picker tests.test_wrapper_contract.WrapperContractTests.test_natural_catalog_questions_open_picker_without_shell tests.test_cli.CliTests.test_chat_interact_catalog_questions_open_picker_without_shell -v`
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- `uv run python -m compileall -q src tests`
- `uv run python -m src.cli docs workflows --check`
- `uv run python -m src.cli release product-readiness --json`
- `git diff --check`
- Manual smoke: `uv run python -m src.cli chat interact --source discord "what OMH workflows are available?"`
- Manual smoke: `uv run python -m src.cli chat interact --source discord "./omh"`

## Boundaries / Risks
- This remains routing intent only. It is not plan acceptance, dispatch, execution, review, CI, or verification evidence.
- Live Hermes rendering and platform-native picker widgets still require host or wrapper integration evidence.
