### PR TITLE
Add Hermes Agent architecture guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ repo-local contract for Codex agents working here.
 | --- | --- |
 | Understand what OMH is and is not | [Direction](DIRECTION.md) |
 | Understand module boundaries and local artifacts | [Architecture](ARCHITECTURE.md) |
+| Understand Hermes Agent memory, skills, gateway, cron, plugins, and OMH's role | [Hermes Agent Architecture Guide](../site/docs/hermes-agent-architecture/index.html) |
 | Compare common oh-my runtime axes and OMH gaps | [Parity Matrix](PARITY.md) |
 | Inspect runtime-readable OMH capability manifests | [Capabilities](CAPABILITIES.md) |
 | Understand safe orchestration pattern contracts | [Orchestration Patterns](ORCHESTRATION_PATTERNS.md) |
@@ -168,7 +169,10 @@ separate profile pack is explicitly selected.
 - Memory/context docs should state that OMH reviews local or wrapper-supplied
   context only; it does not read or mutate opaque Hermes internal memory.
 - The GitHub Pages site should stay a short public entry point that links back
-  to this docs set instead of becoming a second source of truth.
+  to this docs set instead of becoming a second source of truth. The
+  Hermes Agent architecture guide may use visual education copy, but claims
+  should stay grounded in inspected Hermes Agent files and OMH evidence
+  boundaries.
 
 ## Update Checklist
 

--- a/site/docs/hermes-agent-architecture/index.html
+++ b/site/docs/hermes-agent-architecture/index.html
@@ -1,0 +1,437 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Hermes Agent Architecture - OMH</title>
+    <meta
+      name="description"
+      content="A bilingual visual guide to how Hermes Agent is structured, why it feels workflow-native, and where OMH fits without overclaiming execution."
+    >
+    <link rel="stylesheet" href="../../styles.css">
+  </head>
+  <body class="docs-page architecture-post-page">
+    <header class="topbar topbar--solid" aria-label="Primary">
+      <a class="brand brand--link" href="../../">OMH</a>
+      <nav class="nav" aria-label="Primary navigation">
+        <a href="../">Docs</a>
+        <a
+          class="nav__icon"
+          href="https://github.com/rlaope/oh-my-hermes"
+          aria-label="Open OMH repository on GitHub"
+          title="GitHub repository"
+        >
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M12 2C6.48 2 2 6.58 2 12.22c0 4.52 2.87 8.35 6.85 9.7.5.09.68-.22.68-.49v-1.73c-2.78.62-3.37-1.37-3.37-1.37-.45-1.18-1.11-1.5-1.11-1.5-.91-.64.07-.63.07-.63 1 .07 1.53 1.06 1.53 1.06.9 1.56 2.35 1.11 2.92.85.09-.66.35-1.11.63-1.37-2.22-.26-4.55-1.14-4.55-5.06 0-1.12.39-2.03 1.03-2.75-.1-.26-.45-1.31.1-2.71 0 0 .84-.28 2.75 1.05A9.37 9.37 0 0 1 12 6.92c.85 0 1.7.12 2.5.35 1.9-1.33 2.74-1.05 2.74-1.05.55 1.4.2 2.45.1 2.71.64.72 1.03 1.63 1.03 2.75 0 3.93-2.34 4.79-4.57 5.05.36.32.68.94.68 1.9v2.8c0 .27.18.58.69.48A10.06 10.06 0 0 0 22 12.22C22 6.58 17.52 2 12 2Z"></path>
+          </svg>
+        </a>
+      </nav>
+    </header>
+
+    <main class="architecture-post">
+      <input class="language-radio" type="radio" name="architecture-language" id="arch-lang-en" checked>
+      <input class="language-radio" type="radio" name="architecture-language" id="arch-lang-ko">
+
+      <div class="architecture-post-shell">
+        <div class="language-switch" aria-label="Language switch">
+          <label for="arch-lang-en">English</label>
+          <label for="arch-lang-ko">한국어</label>
+        </div>
+
+        <article class="lang-panel lang-panel--en">
+          <header class="architecture-article-hero">
+            <p class="eyebrow">Architecture guide</p>
+            <h1>Hermes Agent is not just a chat box. It is a work operating layer.</h1>
+            <p>
+              Hermes Agent combines a terminal UI, messenger gateway, memory,
+              skills, cron jobs, tools, plugins, platform adapters, and agent
+              loops. OMH should sit on top as a workflow pack and evidence
+              layer, not as a hidden runtime replacement.
+            </p>
+          </header>
+
+          <section class="architecture-article-section architecture-article-section--visual">
+            <div class="architecture-system-map" aria-label="Hermes Agent architecture map">
+              <div class="system-ring system-ring--surface">
+                <span>Surfaces</span>
+                <strong>Terminal, CLI, gateway, Telegram, Discord, Slack, WhatsApp, Signal</strong>
+              </div>
+              <div class="system-ring system-ring--agent">
+                <span>Core loop</span>
+                <strong>AIAgent, prompt builder, model transport, tool loop, session persistence</strong>
+              </div>
+              <div class="system-ring system-ring--context">
+                <span>Context brain</span>
+                <strong>Memory manager, session search, context files, compression, user model</strong>
+              </div>
+              <div class="system-ring system-ring--workflow">
+                <span>Workflow body</span>
+                <strong>Skills, skill creation, curator, cron, kanban, profiles, subagents</strong>
+              </div>
+              <div class="system-ring system-ring--extension">
+                <span>Extension ports</span>
+                <strong>Tools, toolsets, MCP, plugins, platform registry, terminal backends</strong>
+              </div>
+              <div class="system-ring system-ring--omh">
+                <span>OMH layer</span>
+                <strong>Installable workflows, routing, handoffs, status cards, evidence contracts</strong>
+              </div>
+            </div>
+          </section>
+
+          <section class="architecture-article-section">
+            <h2>The simple mental model</h2>
+            <p>
+              A normal chatbot answers one conversation. Hermes Agent is built
+              closer to an operating surface for work. It can be entered from
+              the terminal or a messaging gateway. It builds a prompt from
+              identity, context, skills, memory, and platform hints. It can call
+              tools, run scheduled jobs, spawn delegated work, persist session
+              history, and use skills as procedural memory.
+            </p>
+            <p>
+              That is why OMH should not sell itself as "more commands." The
+              product value is making those Hermes capabilities easier to start,
+              safer to inspect, and clearer to explain in chat.
+            </p>
+          </section>
+
+          <section class="architecture-article-section architecture-stack-grid" aria-label="Hermes Agent subsystems">
+            <article>
+              <span>01</span>
+              <h3>Conversation surface</h3>
+              <p>
+                Hermes exposes both terminal UX and gateway UX. The gateway
+                registry lets built-in or plugin platform adapters register
+                auth, setup, delivery, privacy, and cron delivery behavior.
+              </p>
+            </article>
+            <article>
+              <span>02</span>
+              <h3>Agent loop</h3>
+              <p>
+                <code>run_agent.py</code> hosts <code>AIAgent</code>, session
+                transitions, context engine lifecycle, tool calls, response
+                handling, persistence, and background review hooks.
+              </p>
+            </article>
+            <article>
+              <span>03</span>
+              <h3>Memory and context</h3>
+              <p>
+                <code>agent/memory_manager.py</code> coordinates built-in memory
+                plus at most one external provider, prefetch, sync, and streaming
+                scrubbing so recalled context does not leak into final output.
+              </p>
+            </article>
+            <article>
+              <span>04</span>
+              <h3>Skills and learning</h3>
+              <p>
+                The prompt builder tells Hermes when to save or patch skills.
+                The curator keeps agent-created skills maintainable. This gives
+                Hermes a learning-friendly loop without requiring OMH to train a
+                model.
+              </p>
+            </article>
+            <article>
+              <span>05</span>
+              <h3>Cron and work orchestration</h3>
+              <p>
+                <code>cron/scheduler.py</code> uses locks, protected toolset
+                policy, delivery targets, parallel pools, and prompt-injection
+                scanning to run scheduled work with guardrails.
+              </p>
+            </article>
+            <article>
+              <span>06</span>
+              <h3>OMH contract layer</h3>
+              <p>
+                OMH gives Hermes workflow recipes, deterministic routing, status
+                cards, coding handoff contracts, and prepared-vs-observed
+                boundaries so wrappers can show what happened without guessing.
+              </p>
+            </article>
+          </section>
+
+          <section class="architecture-article-section">
+            <h2>Where OMH fits</h2>
+            <div class="omh-fit-flow" aria-label="Where OMH fits in Hermes work">
+              <div>
+                <span>User asks Hermes</span>
+                <strong>"Can you make this safer, clearer, or ready to ship?"</strong>
+              </div>
+              <i aria-hidden="true"></i>
+              <div>
+                <span>Hermes thinks and talks</span>
+                <strong>Clarify, research, summarize, plan, and narrate status.</strong>
+              </div>
+              <i aria-hidden="true"></i>
+              <div>
+                <span>OMH shapes the workflow</span>
+                <strong>Pick a workflow, prepare a handoff, record local evidence state.</strong>
+              </div>
+              <i aria-hidden="true"></i>
+              <div>
+                <span>Executor or wrapper observes</span>
+                <strong>Dispatch, result, review, CI, delivery, or merge evidence.</strong>
+              </div>
+            </div>
+            <p>
+              The key rule is still conservative: prepared is not observed. A
+              plan, route, prompt, button, or handoff is useful, but it is not
+              proof that code ran, an image was generated, a cron job delivered,
+              a PR passed review, or CI went green.
+            </p>
+          </section>
+
+          <section class="architecture-article-section architecture-learning-loop">
+            <div>
+              <h2>Why GEPA-style thinking matters here</h2>
+              <p>
+                Hermes can improve from execution traces, memories, and skills.
+                OMH's job is not to replace that intelligence. OMH should make
+                the traces cleaner: original request, chosen workflow, prepared
+                handoff, observed evidence, user satisfaction, failed claims,
+                and patch candidates.
+              </p>
+              <p>
+                In other words, Hermes is the capable worker. OMH is the operating layer that makes the work inspectable, routable, reviewable, and improvable over time.
+              </p>
+            </div>
+            <ol>
+              <li><strong>Trace</strong><span>request, route, tool, handoff, evidence</span></li>
+              <li><strong>Evaluate</strong><span>schema, install, status, workflow criteria</span></li>
+              <li><strong>Review</strong><span>human approval before skill or workflow mutation</span></li>
+              <li><strong>Regress</strong><span>replay the examples that used to fail</span></li>
+            </ol>
+          </section>
+
+          <section class="architecture-article-section source-ledger">
+            <h2>Local sources inspected</h2>
+            <p>
+              This page is based on local repository inspection rather than
+              marketing copy alone. The important surfaces are:
+            </p>
+            <div class="source-chip-grid">
+              <span>README.md</span>
+              <span>run_agent.py</span>
+              <span>agent/prompt_builder.py</span>
+              <span>agent/memory_manager.py</span>
+              <span>agent/skill_utils.py</span>
+              <span>agent/curator.py</span>
+              <span>gateway/run.py</span>
+              <span>gateway/platform_registry.py</span>
+              <span>cron/scheduler.py</span>
+              <span>docs/kanban/multi-gateway.md</span>
+              <span>skills/autonomous-ai-agents/hermes-agent/SKILL.md</span>
+            </div>
+          </section>
+        </article>
+
+        <article class="lang-panel lang-panel--ko" lang="ko">
+          <header class="architecture-article-hero">
+            <p class="eyebrow">아키텍처 가이드</p>
+            <h1>Hermes Agent는 단순 채팅창이 아니라, 일하는 방식을 담는 운영층입니다.</h1>
+            <p>
+              Hermes Agent는 터미널 UI, 메신저 게이트웨이, 메모리, 스킬,
+              크론 작업, 도구, 플러그인, 플랫폼 어댑터, 에이전트 루프를
+              함께 묶습니다. OMH는 그 위에서 숨은 실행기가 아니라,
+              workflow pack과 evidence layer로 붙어야 합니다.
+            </p>
+          </header>
+
+          <section class="architecture-article-section architecture-article-section--visual">
+            <div class="architecture-system-map" aria-label="Hermes Agent architecture map">
+              <div class="system-ring system-ring--surface">
+                <span>접점</span>
+                <strong>Terminal, CLI, gateway, Telegram, Discord, Slack, WhatsApp, Signal</strong>
+              </div>
+              <div class="system-ring system-ring--agent">
+                <span>핵심 루프</span>
+                <strong>AIAgent, prompt builder, model transport, tool loop, session persistence</strong>
+              </div>
+              <div class="system-ring system-ring--context">
+                <span>맥락 두뇌</span>
+                <strong>Memory manager, session search, context files, compression, user model</strong>
+              </div>
+              <div class="system-ring system-ring--workflow">
+                <span>작업 몸체</span>
+                <strong>Skills, skill creation, curator, cron, kanban, profiles, subagents</strong>
+              </div>
+              <div class="system-ring system-ring--extension">
+                <span>확장 포트</span>
+                <strong>Tools, toolsets, MCP, plugins, platform registry, terminal backends</strong>
+              </div>
+              <div class="system-ring system-ring--omh">
+                <span>OMH 층</span>
+                <strong>Installable workflows, routing, handoffs, status cards, evidence contracts</strong>
+              </div>
+            </div>
+          </section>
+
+          <section class="architecture-article-section">
+            <h2>가장 쉬운 이해 방식</h2>
+            <p>
+              보통 챗봇은 한 대화에 답합니다. Hermes Agent는 그보다
+              작업 운영면에 가깝습니다. 터미널이나 메신저 게이트웨이에서
+              들어올 수 있고, identity, context, skills, memory, platform
+              hints를 묶어 프롬프트를 만듭니다. 도구를 부르고, 예약 작업을
+              돌리고, 위임 작업을 만들고, 세션 기록을 남기고, 스킬을
+              절차적 기억처럼 사용합니다.
+            </p>
+            <p>
+              그래서 OMH는 "명령어가 더 많은 제품"으로 보이면 약합니다.
+              진짜 가치는 Hermes의 능력을 더 쉽게 시작하게 하고, 더 안전하게
+              점검하게 하고, 채팅 안에서 더 명확하게 설명하게 하는 데 있습니다.
+            </p>
+          </section>
+
+          <section class="architecture-article-section architecture-stack-grid" aria-label="Hermes Agent subsystems">
+            <article>
+              <span>01</span>
+              <h3>대화 접점</h3>
+              <p>
+                Hermes는 터미널 UX와 gateway UX를 모두 제공합니다. gateway
+                registry는 built-in 또는 plugin platform adapter가 auth,
+                setup, delivery, privacy, cron delivery behavior를 등록하게 합니다.
+              </p>
+            </article>
+            <article>
+              <span>02</span>
+              <h3>에이전트 루프</h3>
+              <p>
+                <code>run_agent.py</code>의 <code>AIAgent</code>가 session
+                transition, context engine lifecycle, tool call, response
+                handling, persistence, background review hook을 담당합니다.
+              </p>
+            </article>
+            <article>
+              <span>03</span>
+              <h3>메모리와 맥락</h3>
+              <p>
+                <code>agent/memory_manager.py</code>는 built-in memory와 최대
+                하나의 external provider를 함께 조율하고, prefetch, sync,
+                streaming scrub을 통해 recall된 맥락이 최종 응답에 새지 않도록
+                다룹니다.
+              </p>
+            </article>
+            <article>
+              <span>04</span>
+              <h3>스킬과 개선 루프</h3>
+              <p>
+                prompt builder는 언제 skill을 저장하거나 고쳐야 하는지 Hermes에
+                알려줍니다. curator는 agent-created skills를 관리합니다. 즉
+                OMH가 모델을 학습시키지 않아도, Hermes가 개선 가능한 작업장을
+                갖게 됩니다.
+              </p>
+            </article>
+            <article>
+              <span>05</span>
+              <h3>크론과 작업 오케스트레이션</h3>
+              <p>
+                <code>cron/scheduler.py</code>는 lock, protected toolset policy,
+                delivery target, parallel pool, prompt-injection scanning으로
+                예약 작업을 가드레일 안에서 실행합니다.
+              </p>
+            </article>
+            <article>
+              <span>06</span>
+              <h3>OMH 계약층</h3>
+              <p>
+                OMH는 Hermes에게 workflow recipe, deterministic routing,
+                status card, coding handoff contract, prepared-vs-observed
+                boundary를 제공해서 wrapper가 추측 없이 상태를 보여주게 합니다.
+              </p>
+            </article>
+          </section>
+
+          <section class="architecture-article-section">
+            <h2>OMH는 어디에 붙는가</h2>
+            <div class="omh-fit-flow" aria-label="Where OMH fits in Hermes work">
+              <div>
+                <span>사용자가 Hermes에게 말함</span>
+                <strong>"이걸 더 안전하게, 명확하게, 출시 가능하게 만들어줘."</strong>
+              </div>
+              <i aria-hidden="true"></i>
+              <div>
+                <span>Hermes가 생각하고 말함</span>
+                <strong>질문, 리서치, 요약, 계획, 상태 설명.</strong>
+              </div>
+              <i aria-hidden="true"></i>
+              <div>
+                <span>OMH가 workflow를 형성함</span>
+                <strong>workflow 선택, handoff 준비, local evidence state 기록.</strong>
+              </div>
+              <i aria-hidden="true"></i>
+              <div>
+                <span>executor 또는 wrapper가 관측함</span>
+                <strong>dispatch, result, review, CI, delivery, merge evidence.</strong>
+              </div>
+            </div>
+            <p>
+              핵심 규칙은 계속 보수적입니다. 준비된 것은 관측된 것이 아닙니다.
+              plan, route, prompt, button, handoff는 유용하지만, 코드가 실행됐거나
+              이미지가 생성됐거나, 크론이 전달됐거나, PR 리뷰가 통과됐거나,
+              CI가 초록불이라는 증거는 아닙니다.
+            </p>
+          </section>
+
+          <section class="architecture-article-section architecture-learning-loop">
+            <div>
+              <h2>GEPA식 사고가 여기서 중요한 이유</h2>
+              <p>
+                Hermes는 실행 기록, 메모리, 스킬을 바탕으로 더 나아질 수
+                있습니다. OMH의 역할은 그 지능을 대체하는 게 아닙니다. OMH는
+                original request, chosen workflow, prepared handoff, observed
+                evidence, user satisfaction, failed claim, patch candidate 같은
+                학습 가능한 과정을 더 깨끗하게 남겨야 합니다.
+              </p>
+              <p>
+                다시 말해 Hermes가 능력 있는 worker라면, OMH는 그 일이
+                inspectable, routable, reviewable, improvable해지도록 만드는
+                operating layer입니다.
+              </p>
+            </div>
+            <ol>
+              <li><strong>Trace</strong><span>request, route, tool, handoff, evidence</span></li>
+              <li><strong>Evaluate</strong><span>schema, install, status, workflow criteria</span></li>
+              <li><strong>Review</strong><span>skill 또는 workflow 변경 전 사람 승인</span></li>
+              <li><strong>Regress</strong><span>전에 실패했던 예제를 다시 돌려보기</span></li>
+            </ol>
+          </section>
+
+          <section class="architecture-article-section source-ledger">
+            <h2>확인한 로컬 근거</h2>
+            <p>
+              이 페이지는 홍보 문구만이 아니라 로컬 repository inspection에
+              기반합니다. 주요 근거 표면은 다음과 같습니다.
+            </p>
+            <div class="source-chip-grid">
+              <span>README.md</span>
+              <span>run_agent.py</span>
+              <span>agent/prompt_builder.py</span>
+              <span>agent/memory_manager.py</span>
+              <span>agent/skill_utils.py</span>
+              <span>agent/curator.py</span>
+              <span>gateway/run.py</span>
+              <span>gateway/platform_registry.py</span>
+              <span>cron/scheduler.py</span>
+              <span>docs/kanban/multi-gateway.md</span>
+              <span>skills/autonomous-ai-agents/hermes-agent/SKILL.md</span>
+            </div>
+          </section>
+        </article>
+      </div>
+    </main>
+
+    <footer class="footer">
+      <span>
+        OMH explains Hermes-native work without claiming hidden execution.
+      </span>
+      <span>
+        Developed by <a href="https://github.com/rlaope">rlaope</a>.
+      </span>
+    </footer>
+  </body>
+</html>

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -42,6 +42,7 @@
         <a href="#runbook">Runbook</a>
         <a href="#demo">Demo</a>
         <a href="#architecture">Architecture</a>
+        <a href="hermes-agent-architecture/">Hermes Agent guide</a>
         <a href="#playbooks">Playbooks</a>
         <a href="#roles">Roles</a>
         <a href="#discord-example">Chat example</a>
@@ -106,6 +107,17 @@
               <span class="mini-node mini-node--wide"></span>
               <span class="mini-node"></span>
               <span class="mini-link"></span>
+            </span>
+          </a>
+          <a class="doc-tile doc-tile--architecture" href="hermes-agent-architecture/">
+            <span class="doc-tile__label">Guide</span>
+            <strong>Hermes Agent explained</strong>
+            <span>Read the bilingual visual guide to memory, skills, gateway, cron, plugins, and OMH's role.</span>
+            <span class="doc-tile__visual" aria-hidden="true">
+              <span class="mini-node mini-node--wide"></span>
+              <span class="mini-link"></span>
+              <span class="mini-node"></span>
+              <span class="mini-node"></span>
             </span>
           </a>
           <a class="doc-tile doc-tile--quality" href="#quality">
@@ -393,6 +405,15 @@ uv run python examples/slack-adapter-shim.py</code>
             deterministic local contracts while Hermes stays responsible for
             conversation, planning, and status narration.
           </p>
+          <div class="architecture-article-link">
+            <strong>Hermes Agent architecture, explained.</strong>
+            <p>
+              For a broader product-facing explanation of Hermes Agent memory,
+              skills, messenger gateway, cron, plugin surfaces, learning loops,
+              and OMH's evidence boundary, read the bilingual visual guide.
+            </p>
+            <a class="text-link" href="hermes-agent-architecture/">Open architecture guide</a>
+          </div>
           <div class="architecture-map" aria-label="OMH architecture diagram">
             <div class="arch-node arch-node--source">
               <span>User message</span>

--- a/site/index.html
+++ b/site/index.html
@@ -330,6 +330,15 @@ omh setup</code>
             OMH makes the workflow contract visible, and executors or runtime
             artifacts own proof after something actually runs.
           </p>
+          <div class="architecture-article-link">
+            <strong>New: Hermes Agent architecture, explained.</strong>
+            <p>
+              Read the visual English/Korean guide to Hermes Agent memory,
+              skills, messenger gateway, cron, plugins, self-improvement loops,
+              and where OMH fits without claiming hidden execution.
+            </p>
+            <a class="text-link" href="docs/hermes-agent-architecture/">Open architecture guide</a>
+          </div>
         </div>
         <div class="architecture-layout">
           <div class="architecture-map architecture-map--story" aria-label="OMH architecture diagram">

--- a/site/styles.css
+++ b/site/styles.css
@@ -2829,6 +2829,402 @@ h1 {
   }
 }
 
+.architecture-post-page {
+  background:
+    radial-gradient(circle at 12% 4%, rgba(25, 116, 102, 0.2), transparent 28%),
+    radial-gradient(circle at 88% 12%, rgba(49, 93, 140, 0.22), transparent 32%),
+    linear-gradient(180deg, #0f1822 0, #14202b 420px, var(--paper) 421px);
+}
+
+.architecture-post {
+  min-height: 100vh;
+  padding: 118px clamp(18px, 5vw, 72px) 64px;
+}
+
+.architecture-post-shell {
+  width: min(1180px, 100%);
+  margin: 0 auto;
+}
+
+.language-radio {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.language-switch {
+  position: sticky;
+  top: 84px;
+  z-index: 5;
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-bottom: 18px;
+}
+
+.language-switch label {
+  cursor: pointer;
+  min-height: 38px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px 15px;
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  border-radius: 999px;
+  color: rgba(255, 255, 255, 0.88);
+  background: rgba(255, 255, 255, 0.12);
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.14);
+  backdrop-filter: blur(14px);
+  font-size: 14px;
+  font-weight: 800;
+}
+
+#arch-lang-en:checked ~ .architecture-post-shell label[for="arch-lang-en"],
+#arch-lang-ko:checked ~ .architecture-post-shell label[for="arch-lang-ko"] {
+  color: #09241f;
+  background: #7ed7c2;
+  border-color: rgba(126, 215, 194, 0.95);
+}
+
+.lang-panel {
+  display: none;
+}
+
+#arch-lang-en:checked ~ .architecture-post-shell .lang-panel--en,
+#arch-lang-ko:checked ~ .architecture-post-shell .lang-panel--ko {
+  display: block;
+}
+
+.architecture-article-hero {
+  overflow: hidden;
+  position: relative;
+  padding: clamp(34px, 7vw, 78px);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 28px;
+  color: #ffffff;
+  background:
+    linear-gradient(135deg, rgba(14, 24, 34, 0.84), rgba(14, 24, 34, 0.36)),
+    url("assets/hermes-agent-hero.png") center / cover no-repeat;
+  box-shadow: var(--shadow-strong);
+}
+
+.architecture-article-hero::after {
+  content: "";
+  position: absolute;
+  inset: auto 32px 28px auto;
+  width: min(320px, 38vw);
+  height: min(320px, 38vw);
+  border: 1px solid rgba(126, 215, 194, 0.26);
+  border-radius: 36px;
+  background:
+    linear-gradient(135deg, rgba(126, 215, 194, 0.24), transparent),
+    repeating-linear-gradient(90deg, rgba(255, 255, 255, 0.16) 0 1px, transparent 1px 18px);
+  transform: rotate(10deg);
+  opacity: 0.55;
+}
+
+.architecture-article-hero > * {
+  position: relative;
+  z-index: 1;
+  max-width: 760px;
+}
+
+.architecture-article-hero h1 {
+  margin: 0;
+  font-size: clamp(42px, 7vw, 84px);
+  line-height: 0.94;
+  letter-spacing: 0;
+}
+
+.architecture-article-hero p:not(.eyebrow) {
+  margin: 24px 0 0;
+  color: rgba(255, 255, 255, 0.84);
+  font-size: clamp(18px, 2.1vw, 23px);
+}
+
+.architecture-article-section {
+  margin-top: 28px;
+  padding: clamp(26px, 4vw, 42px);
+  border: 1px solid rgba(15, 24, 34, 0.08);
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.82);
+  box-shadow: var(--shadow);
+}
+
+.architecture-article-section h2 {
+  margin: 0 0 14px;
+  font-size: clamp(28px, 4vw, 46px);
+  line-height: 1;
+  letter-spacing: 0;
+}
+
+.architecture-article-section p {
+  max-width: 870px;
+  margin: 0 0 16px;
+  color: var(--muted);
+  font-size: 17px;
+}
+
+.architecture-article-section p:last-child {
+  margin-bottom: 0;
+}
+
+.architecture-article-section--visual {
+  background:
+    radial-gradient(circle at 20% 10%, rgba(126, 215, 194, 0.34), transparent 28%),
+    linear-gradient(135deg, #14202b, #203349);
+}
+
+.architecture-system-map {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 12px;
+  min-height: 460px;
+}
+
+.system-ring {
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  gap: 12px;
+  min-height: 210px;
+  padding: 22px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 22px;
+  color: #ffffff;
+  background: rgba(255, 255, 255, 0.08);
+  box-shadow: 0 18px 46px rgba(0, 0, 0, 0.18);
+}
+
+.system-ring::before {
+  content: "";
+  position: absolute;
+  inset: 16px 16px auto auto;
+  width: 64px;
+  height: 64px;
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  border-radius: 18px;
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.26), transparent),
+    rgba(255, 255, 255, 0.08);
+  transform: rotate(9deg);
+}
+
+.system-ring span {
+  position: relative;
+  z-index: 1;
+  color: rgba(255, 255, 255, 0.68);
+  font-size: 12px;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.system-ring strong {
+  position: relative;
+  z-index: 1;
+  font-size: clamp(17px, 2vw, 22px);
+  line-height: 1.12;
+}
+
+.system-ring--surface,
+.system-ring--agent,
+.system-ring--context,
+.system-ring--workflow,
+.system-ring--extension,
+.system-ring--omh {
+  grid-column: span 2;
+}
+
+.system-ring--surface {
+  background: linear-gradient(160deg, rgba(49, 93, 140, 0.74), rgba(16, 28, 40, 0.78));
+}
+
+.system-ring--agent {
+  background: linear-gradient(160deg, rgba(25, 116, 102, 0.78), rgba(16, 28, 40, 0.8));
+}
+
+.system-ring--context {
+  background: linear-gradient(160deg, rgba(179, 107, 22, 0.7), rgba(16, 28, 40, 0.76));
+}
+
+.system-ring--workflow {
+  background: linear-gradient(160deg, rgba(44, 62, 82, 0.86), rgba(16, 28, 40, 0.82));
+}
+
+.system-ring--extension {
+  background: linear-gradient(160deg, rgba(84, 84, 126, 0.76), rgba(16, 28, 40, 0.8));
+}
+
+.system-ring--omh {
+  background: linear-gradient(160deg, rgba(126, 215, 194, 0.78), rgba(25, 116, 102, 0.8));
+}
+
+.architecture-stack-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.9), rgba(241, 249, 247, 0.92));
+}
+
+.architecture-stack-grid h2 {
+  grid-column: 1 / -1;
+}
+
+.architecture-stack-grid > article {
+  min-height: 250px;
+  padding: 22px;
+  border: 1px solid rgba(15, 24, 34, 0.1);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.78);
+}
+
+.architecture-stack-grid > article > span {
+  display: inline-flex;
+  width: 42px;
+  height: 42px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 14px;
+  color: #ffffff;
+  background: var(--night);
+  font-weight: 900;
+}
+
+.architecture-stack-grid h3 {
+  margin: 18px 0 9px;
+  font-size: 20px;
+  letter-spacing: 0;
+}
+
+.architecture-stack-grid p {
+  font-size: 15px;
+}
+
+.omh-fit-flow {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 28px minmax(0, 1fr) 28px minmax(0, 1fr) 28px minmax(0, 1fr);
+  gap: 10px;
+  align-items: stretch;
+  margin: 20px 0 24px;
+}
+
+.omh-fit-flow div {
+  min-height: 170px;
+  padding: 20px;
+  border: 1px solid rgba(15, 24, 34, 0.1);
+  border-radius: 20px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.86), rgba(238, 250, 245, 0.78));
+}
+
+.omh-fit-flow span {
+  display: block;
+  margin-bottom: 12px;
+  color: var(--accent-strong);
+  font-size: 12px;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+.omh-fit-flow strong {
+  display: block;
+  font-size: 18px;
+  line-height: 1.22;
+}
+
+.omh-fit-flow i {
+  align-self: center;
+  height: 2px;
+  background: linear-gradient(90deg, var(--accent), var(--blue));
+}
+
+.architecture-learning-loop {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(280px, 0.9fr);
+  gap: 24px;
+  background:
+    linear-gradient(135deg, rgba(15, 24, 34, 0.96), rgba(25, 116, 102, 0.84));
+  color: #ffffff;
+}
+
+.architecture-learning-loop p {
+  color: rgba(255, 255, 255, 0.78);
+}
+
+.architecture-learning-loop ol {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.architecture-learning-loop li {
+  padding: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.architecture-learning-loop li strong {
+  display: block;
+  margin-bottom: 4px;
+  font-size: 18px;
+}
+
+.architecture-learning-loop li span {
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.source-ledger {
+  background: #ffffff;
+}
+
+.source-chip-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 22px;
+}
+
+.source-chip-grid span {
+  display: inline-flex;
+  align-items: center;
+  min-height: 34px;
+  padding: 7px 12px;
+  border: 1px solid rgba(25, 116, 102, 0.18);
+  border-radius: 999px;
+  color: var(--accent-strong);
+  background: rgba(238, 250, 245, 0.9);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.architecture-article-link {
+  margin-top: 22px;
+  padding: 20px;
+  border: 1px solid rgba(25, 116, 102, 0.18);
+  border-radius: 18px;
+  background:
+    linear-gradient(135deg, rgba(238, 250, 245, 0.9), rgba(255, 255, 255, 0.92));
+}
+
+.architecture-article-link strong {
+  display: block;
+  margin-bottom: 6px;
+  font-size: 19px;
+}
+
+.architecture-article-link p {
+  margin: 0 0 12px;
+  color: var(--muted);
+}
+
 @media (max-width: 840px) {
   .topbar {
     position: absolute;
@@ -2894,7 +3290,10 @@ h1 {
   .site-example,
   .docs-shell,
   .docs-grid,
-  .docs-feature-grid {
+  .docs-feature-grid,
+  .architecture-system-map,
+  .architecture-stack-grid,
+  .architecture-learning-loop {
     grid-template-columns: 1fr;
   }
 
@@ -2978,6 +3377,39 @@ h1 {
 
   .architecture-map {
     grid-template-columns: 1fr;
+  }
+
+  .architecture-post {
+    padding-top: 104px;
+  }
+
+  .language-switch {
+    position: static;
+    justify-content: flex-start;
+  }
+
+  .architecture-system-map {
+    min-height: 0;
+  }
+
+  .system-ring,
+  .system-ring--surface,
+  .system-ring--agent,
+  .system-ring--context,
+  .system-ring--workflow,
+  .system-ring--extension,
+  .system-ring--omh {
+    grid-column: auto;
+  }
+
+  .omh-fit-flow {
+    grid-template-columns: 1fr;
+  }
+
+  .omh-fit-flow i {
+    width: 2px;
+    height: 18px;
+    justify-self: center;
   }
 
   .arch-arrow {

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -912,6 +912,7 @@ class RouterContentTests(unittest.TestCase):
             Path("site/docs/index.html"),
             Path("site/docs/loop/index.html"),
             Path("site/docs/image-gen/index.html"),
+            Path("site/docs/hermes-agent-architecture/index.html"),
             Path("site/docs/intent-to-plan/index.html"),
             Path("site/docs/product-ops/index.html"),
             Path("site/docs/executor-handoff/index.html"),
@@ -939,6 +940,7 @@ class RouterContentTests(unittest.TestCase):
         site_docs = Path("site/docs/index.html").read_text(encoding="utf-8")
         site_loop = Path("site/docs/loop/index.html").read_text(encoding="utf-8")
         site_image_gen = Path("site/docs/image-gen/index.html").read_text(encoding="utf-8")
+        site_architecture_post = Path("site/docs/hermes-agent-architecture/index.html").read_text(encoding="utf-8")
         site_intent = Path("site/docs/intent-to-plan/index.html").read_text(encoding="utf-8")
         site_product_ops = Path("site/docs/product-ops/index.html").read_text(encoding="utf-8")
         site_handoff = Path("site/docs/executor-handoff/index.html").read_text(encoding="utf-8")
@@ -1089,6 +1091,7 @@ class RouterContentTests(unittest.TestCase):
         self.assertIn("Prepared handoff is not execution evidence", runbook)
         self.assertIn("examples/wrapper-golden/hermes-agent-integration.json", runbook)
         self.assertIn("Hermes Agent Integration Runbook", docs_readme)
+        self.assertIn("Hermes Agent Architecture Guide", docs_readme)
         self.assertIn("Role Surface", docs_readme)
         self.assertIn("Agent Install Protocol", docs_readme)
         self.assertIn("`deep-interview` / `ralplan` / `ultragoal` / `loop` / `ultraprocess`", docs_readme)
@@ -1160,6 +1163,8 @@ class RouterContentTests(unittest.TestCase):
         self.assertIn("Image gen prompt cards", site)
         self.assertIn("Visual summaries that match the source.", site)
         self.assertIn('href="docs/image-gen/"', site)
+        self.assertIn('href="docs/hermes-agent-architecture/"', site)
+        self.assertIn("Hermes Agent architecture, explained.", site)
         self.assertIn("assets/omh-img-summary-card.png", site)
         self.assertIn("source-specific cards for meetings, reports", site)
         self.assertIn("If no image tool is connected", site)
@@ -1187,6 +1192,8 @@ class RouterContentTests(unittest.TestCase):
         self.assertIn("visual_prompt_card/v1", site_docs)
         self.assertIn("visual_observation/v1", site_docs)
         self.assertIn("image_generation_setup/v1", site_docs)
+        self.assertIn('href="hermes-agent-architecture/"', site_docs)
+        self.assertIn("Hermes Agent explained", site_docs)
         self.assertIn('href="image-gen/"', site_docs)
         self.assertIn('href="intent-to-plan/"', site_docs)
         self.assertIn('href="product-ops/"', site_docs)
@@ -1230,6 +1237,21 @@ class RouterContentTests(unittest.TestCase):
         self.assertIn('href="../image-gen/"', site_product_ops)
         self.assertIn("Executor-ready handoff", site_handoff)
         self.assertIn("Codex, Claude Code", site_handoff)
+        self.assertIn("Hermes Agent Architecture - OMH", site_architecture_post)
+        self.assertIn("English", site_architecture_post)
+        self.assertIn("한국어", site_architecture_post)
+        self.assertIn("Hermes Agent is not just a chat box", site_architecture_post)
+        self.assertIn("Hermes Agent는 단순 채팅창", site_architecture_post)
+        self.assertIn("run_agent.py", site_architecture_post)
+        self.assertIn("agent/prompt_builder.py", site_architecture_post)
+        self.assertIn("agent/memory_manager.py", site_architecture_post)
+        self.assertIn("agent/curator.py", site_architecture_post)
+        self.assertIn("gateway/platform_registry.py", site_architecture_post)
+        self.assertIn("cron/scheduler.py", site_architecture_post)
+        self.assertIn("skills/autonomous-ai-agents/hermes-agent/SKILL.md", site_architecture_post)
+        self.assertIn("prepared-vs-observed", site_architecture_post)
+        self.assertIn("GEPA-style", site_architecture_post)
+        self.assertIn("OMH is the operating layer", site_architecture_post)
         topbar = site.split('<header class="topbar"', 1)[1].split("</header>", 1)[0]
         self.assertIn('href="docs/"', topbar)
         self.assertNotIn('href="#architecture"', topbar)


### PR DESCRIPTION
## Feature Report

### What Changed
- Added a new bilingual visual site page at `site/docs/hermes-agent-architecture/` explaining Hermes Agent architecture and where OMH fits.
- Linked the guide from the home architecture section, docs quick tiles, docs architecture section, and `docs/README.md` reading paths.
- Added site CSS for the language toggle, architecture system map, subsystem cards, OMH fit flow, learning loop panel, and source ledger.
- Extended router/content tests so the page, links, language toggle, inspected-source references, and prepared-vs-observed boundary remain locked.

### Why This Exists
Users asked for viral, educational content that helps Hermes Agent users understand what is actually inside Hermes: memory, skills, messenger gateway, cron, plugins, self-improvement loops, CLI/TUI surfaces, and how OMH fits. The goal is to make OMH feel like the practical workflow/evidence layer on top of Hermes rather than another command catalog.

### User / Operator Impact
- Visitors can now read an English/Korean guide that explains Hermes Agent as a work operating layer, not just a chat box.
- Users get a clearer mental model for why OMH exists: Hermes owns conversation and cognition, while OMH provides workflow recipes, status cards, handoffs, and evidence boundaries.
- Operators can point users to a visual source-grounded page instead of explaining memory, gateway, cron, skills, plugins, and OMH boundaries ad hoc.

### How It Works
- The page uses a CSS-only language toggle, so the site stays static and GitHub Pages-friendly.
- The visual system map groups Hermes into surfaces, core loop, context brain, workflow body, extension ports, and OMH layer.
- The learning-loop section phrases GEPA-style improvement conservatively: OMH makes traces cleaner and reviewable, but does not claim model training or hidden skill mutation.
- The source ledger names local Hermes Agent files inspected during the write-up, including `run_agent.py`, `agent/prompt_builder.py`, `agent/memory_manager.py`, `agent/curator.py`, `gateway/platform_registry.py`, `cron/scheduler.py`, and the Hermes Agent skill doc.

### Files And Contracts Touched
- `site/docs/hermes-agent-architecture/index.html`
- `site/index.html`
- `site/docs/index.html`
- `site/styles.css`
- `docs/README.md`
- `tests/test_router_content.py`

### Verification
- `UV_CACHE_DIR=/Users/rlaope/Desktop/khope/omhm/.uv-cache PYTHONPATH=tests uv run python -m unittest tests/test_router_content.py -v`
- `UV_CACHE_DIR=/Users/rlaope/Desktop/khope/omhm/.uv-cache PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- `UV_CACHE_DIR=/Users/rlaope/Desktop/khope/omhm/.uv-cache uv run python -m compileall -q src tests`
- `UV_CACHE_DIR=/Users/rlaope/Desktop/khope/omhm/.uv-cache uv run python -m src.cli docs workflows --check`
- `git diff --check`

### Compatibility / Rollout
- Static site only; no runtime command/schema change.
- The page intentionally keeps claims educational and source-grounded. It does not claim OMH patches Hermes core, runs hidden transports, or observes execution without records.

### Follow-Up
- After this first publishable draft lands, continue improving the guide with more examples, stronger diagrams, and optional social/poster assets if needed.
