### PR TITLE
Add task abstraction cards above chat routing

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -324,7 +324,7 @@ stay thin and point at the deeper source-owner modules.
 
 ## Routing
 
-Routing, planning, and delegation have eight local surfaces:
+Routing, planning, and delegation have these local surfaces:
 
 1. Hermes-native installed skills. The tap-compatible `skills/` directory and
    the managed `~/.omh/skills` bootstrap directory expose the same generated
@@ -335,29 +335,35 @@ Routing, planning, and delegation have eight local surfaces:
 3. Situation playbooks. `omh playbook recommend` lets wrappers map a natural
    request to a higher-level pipeline before they choose a lower-level skill,
    plan, research lane, or handoff.
-4. Wrapper-native chat orchestration. Plugin `omh_interact` and
+4. Task abstraction cards. `omh_task_card/v1` lets wrappers classify work such
+   as runtime portability, environment reproduction, or router-design feedback
+   before selecting a workflow. The card names operation primitives, workflow
+   rails, risk domains, and prepared/observed boundaries, so a request like
+   "reproduce this Hermes setup on another MacBook" is not collapsed into a
+   narrow migration workflow.
+5. Wrapper-native chat orchestration. Plugin `omh_interact` and
    `omh chat interact` let Discord, Slack, or hosted Hermes wrappers receive
    one platform-neutral `chat_interaction/v1` envelope with renderable chat
    copy, state, action buttons, and a thread key.
-5. Wrapper session persistence. `omh chat session` lets wrappers persist
+6. Wrapper session persistence. `omh chat session` lets wrappers persist
    metadata-only plan decisions, recover status by `session_id`, and link an
    accepted plan to a prepared coding run without owning execution evidence.
-6. Wrapper-native executor session actions. After a handoff is prepared, the
+7. Wrapper-native executor session actions. After a handoff is prepared, the
    wrapper can render action buttons and record observed open/attach/result or
    verification-request events as `executor_session/v1` metadata. This is the
    layer that lets a Discord or Hermes chat user ask "what is happening with
    Codex or Claude Code?" without typing backend commands.
-7. Wrapper-assisted chat routing. `omh chat route` lets Discord, Slack, or
+8. Wrapper-assisted chat routing. `omh chat route` lets Discord, Slack, or
    hosted Hermes wrappers run a deterministic pre-dispatch decision before they
    forward a plain user message to Hermes.
-8. Wrapper-assisted coding delegation. `omh coding delegate` lets wrappers turn
+9. Wrapper-assisted coding delegation. `omh coding delegate` lets wrappers turn
    implementation-shaped messages into a deterministic `coding_delegation/v1`
    handoff payload for an executor lane.
-9. Runtime observation recording. `omh runtime observe` lets wrappers or
+10. Runtime observation recording. `omh runtime observe` lets wrappers or
    operators append `runtime_observation/v1` evidence for selected runtime
    handoffs without implying unrecorded worktree, worker, verification, review,
    CI, or merge steps.
-10. Hermes-facing planning artifacts. `omh hermes plan` lets wrappers or
+11. Hermes-facing planning artifacts. `omh hermes plan` lets wrappers or
    operators create deterministic `hermes_plan/v1` planning scaffolds under
    `.hermes/plans/` without claiming that execution or review already happened.
 

--- a/docs/CHAT_WRAPPER_EXAMPLES.md
+++ b/docs/CHAT_WRAPPER_EXAMPLES.md
@@ -148,6 +148,36 @@ the local install, `omh list --json` also includes
 hints, and evidence boundaries, so a catalog answer does not degrade into a flat
 name list.
 
+## Task Abstraction Before Workflow Routing
+
+Some requests are bigger than one workflow name. If a user says "reproduce this
+Hermes and Friren setup on another MacBook, back it up to private GitHub, and
+make sure only one Discord bot answers", OMH should not invent a narrow
+`migration` workflow. The wrapper can render the `omh_task_card/v1` that sits
+above the workflow rails:
+
+```text
+Hermes Agent  BOT
+[omh] task-card - I will frame this as a high-level task first.
+
+This is a runtime portability task, not a migration workflow. First safe
+action: inventory configs, local state, plugin paths, managed skills, gateways,
+and secret locations before packaging. Use workflow rails:
+agent-ops-review, toolbelt-readiness, gateway-intent-card, doctor. Secret
+policy: encrypt before private GitHub upload. Gateway invariant: exactly one
+active responder. Not observed yet: encrypted backup archive, private GitHub
+upload, runtime restore on the second machine, gateway responder cutover.
+
+[ Open ops review ] [ Show status ] [ Record learning trace ]
+```
+
+The task card is still prepared guidance only. Backup creation, private repo
+upload, restore, gateway transfer, liveness, and verification remain
+observed-only claims until a wrapper or operator records matching evidence.
+If the user says the routing model itself was wrong, including Korean feedback
+such as "피드백인데 OMH 라우팅 설계가 잘못됐어", the same abstraction layer routes
+to `workflow-learning` instead of customer `feedback-triage`.
+
 ## Plugin-Native Chat Interaction
 
 When the managed OMH plugin is loaded, a Hermes wrapper can call the plugin

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,7 +24,7 @@ repo-local contract for Codex agents working here.
 | See the first-use Hermes prompt and evidence boundary | [Installation](INSTALLATION.md#quick-start) |
 | Understand responsibility roles and operating models | [Role Surface](ROLES.md) |
 | Choose a situation-level pipeline | [Playbooks](PLAYBOOKS.md) |
-| See Discord-style wrapper responses | [Chat Wrapper Examples](CHAT_WRAPPER_EXAMPLES.md) |
+| See task cards and Discord-style wrapper responses | [Chat Wrapper Examples](CHAT_WRAPPER_EXAMPLES.md) |
 | Render workflow quality gates in wrappers | [Harness Quality Contract](HARNESS_QUALITY.md) |
 | Install Hermes-native skills or bootstrap managed skills | [Installation](INSTALLATION.md) |
 | Run deterministic backend demos | [Chat Wrapper Examples](CHAT_WRAPPER_EXAMPLES.md#commands-used) and [fixture shims](../examples) |

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -219,6 +219,15 @@
             >
           </figure>
           <div class="docs-feature-grid" aria-label="Flagship OMH workflow families">
+            <a class="flagship-item flagship-item--docs" href="#routing">
+              <span>Task abstraction</span>
+              <h3><code>omh_task_card/v1</code> / workflow rails</h3>
+              <p>
+                Classify work such as runtime portability, environment
+                reproduction, or router-design feedback before selecting the
+                workflow rail that should carry the next safe action.
+              </p>
+            </a>
             <a class="flagship-item flagship-item--docs" href="intent-to-plan/">
               <span>Intent to plan</span>
               <h3><code>deep-interview</code> / <code>ralplan</code> / <code>ultragoal</code> / <code>loop</code> / <code>ultraprocess</code></h3>
@@ -399,6 +408,7 @@ uv run python examples/slack-adapter-shim.py</code>
           </p>
         </section>
 
+        <span id="routing" aria-hidden="true"></span>
         <section class="docs-section" id="architecture">
           <h2>Architecture at a glance</h2>
           <p>

--- a/site/index.html
+++ b/site/index.html
@@ -241,6 +241,16 @@ omh setup</code>
           </figure>
           <div class="flagship-list" aria-label="Representative OMH workflow lanes">
             <article class="flagship-item">
+              <span>Task abstraction</span>
+              <h3><code>omh_task_card/v1</code> / workflow rails</h3>
+              <p>
+                Hermes frames runtime portability, environment reproduction, or
+                router-design feedback before choosing the workflow rail that
+                should carry the next safe action.
+              </p>
+              <a class="text-link" href="docs/#routing">Open docs</a>
+            </article>
+            <article class="flagship-item">
               <span>Intent to plan</span>
               <h3><code>deep-interview</code> / <code>ralplan</code> / <code>ultragoal</code> / <code>loop</code> / <code>ultraprocess</code></h3>
               <p>

--- a/src/routing/chat.py
+++ b/src/routing/chat.py
@@ -14,6 +14,7 @@ from .policy import (
     meets_confidence_threshold,
 )
 from .recommend import recommend_skills
+from .task_cards import classify_task, task_card_recommendation
 from ..skills.catalog import SkillDefinition, primary_harness_for_skill, routable_definitions
 
 
@@ -94,6 +95,7 @@ class ChatRouteDecision:
     reason: str
     clarification: str
     routing_prompt: str
+    task_card: dict[str, object] | None
     recommendations: tuple[dict[str, object], ...]
 
     def to_dict(self) -> dict[str, object]:
@@ -121,6 +123,10 @@ def route_chat_message(
 
     definitions = routable_definitions()
     full_recommendations = recommend_skills(message, limit=len(definitions))
+    explicit_skill = explicit_skill_invocation(message, definitions)
+    task_card = classify_task(message)
+    if task_card and not explicit_skill:
+        full_recommendations = _prioritize_recommendation(full_recommendations, task_card_recommendation(task_card))
     catalog_question = is_skill_catalog_question(message)
     specific_catalog_match = (
         _specific_capability_catalog_match(full_recommendations)
@@ -131,7 +137,6 @@ def route_chat_message(
         full_recommendations = _prioritize_recommendation(full_recommendations, specific_catalog_match)
     recommendations = tuple(full_recommendations[:limit])
     top = full_recommendations[0]
-    explicit_skill = explicit_skill_invocation(message, definitions)
     candidate_skill = str(top["skill"])
     candidate_harness = primary_harness_for_skill(candidate_skill)
     candidate_score = _int_value(top["score"])
@@ -143,6 +148,16 @@ def route_chat_message(
         selected_skill = explicit_skill
         action = "dispatch"
         reason = "Explicit workflow invocation wins over heuristic routing."
+        ambiguous = False
+        task_card = None
+    elif task_card:
+        selected_skill = str(task_card.get("selected_workflow_rail", candidate_skill))
+        candidate_skill = selected_skill
+        candidate_harness = primary_harness_for_skill(candidate_skill)
+        candidate_score = max(candidate_score, _int_value(task_card.get("score", 0)))
+        candidate_confidence = str(task_card.get("confidence", "high"))
+        action = "dispatch"
+        reason = str(task_card.get("routing_reason", "Matched high-level task abstraction before workflow routing."))
         ambiguous = False
     elif catalog_question and specific_catalog_match is not None:
         selected_skill = candidate_skill
@@ -207,6 +222,7 @@ def route_chat_message(
         reason=reason,
         clarification=clarification,
         routing_prompt=_routing_prompt(action, selected_skill, candidate_skill, reason, message),
+        task_card=task_card,
         recommendations=recommendations,
     )
     return decision.to_dict()
@@ -239,6 +255,8 @@ def public_route_payload(decision: dict[str, object], *, include_message: bool =
     )
     if not include_message:
         route.pop("routing_prompt", None)
+    if not route.get("task_card"):
+        route.pop("task_card", None)
     return route
 
 
@@ -255,7 +273,7 @@ def routing_record_payload(
     channel_ref: str = "",
     user_ref: str = "",
 ) -> dict[str, object]:
-    return {
+    payload = {
         "source": decision["source"],
         "action": decision["action"],
         "selected_skill": decision["selected_skill"],
@@ -275,6 +293,10 @@ def routing_record_payload(
         "user_ref": user_ref,
         "recommendations": _compact_recommendations(decision.get("recommendations", [])),
     }
+    task_card = decision.get("task_card")
+    if isinstance(task_card, dict) and task_card:
+        payload["task_card"] = task_card
+    return payload
 
 
 def _is_ambiguous(recommendations: list[dict[str, object]]) -> bool:

--- a/src/routing/task_cards.py
+++ b/src/routing/task_cards.py
@@ -1,0 +1,313 @@
+from __future__ import annotations
+
+from .localization import normalized_phrase, routing_tokens
+
+
+TASK_CARD_SCHEMA_VERSION = "omh_task_card/v1"
+TASK_CARD_ROUTE_LEVEL = "task_abstraction"
+
+_RUNTIME_PORTABILITY_PHRASES = (
+    "another macbook",
+    "another mac",
+    "new macbook",
+    "new machine",
+    "other machine",
+    "same setup",
+    "reproduce this setup",
+    "reproduce the setup",
+    "restore this setup",
+    "environment reproduction",
+    "runtime portability",
+    "move the gateway",
+    "transfer the gateway",
+    "private github",
+    "backup the state",
+    "backup to github",
+    "migrate this setup",
+    "다른 맥북",
+    "새 맥북",
+    "다른 컴퓨터",
+    "같은 세팅",
+    "세팅 재현",
+    "환경 재현",
+    "런타임 재현",
+    "백업",
+    "복원",
+    "옮기",
+    "마이그레이션",
+    "게이트웨이 이전",
+    "프라이빗 깃허브",
+    "개인 깃허브",
+)
+_RUNTIME_CONTEXT_TOKENS = frozenset(
+    {
+        "hermes",
+        "friren",
+        "omh",
+        "agent",
+        "gateway",
+        "discord",
+        "slack",
+        "telegram",
+        "bot",
+        "responder",
+        "runtime",
+        "plugin",
+        "헤르메스",
+        "프리렌",
+        "에이전트",
+        "게이트웨이",
+        "디스코드",
+        "슬랙",
+        "텔레그램",
+        "봇",
+        "런타임",
+        "플러그인",
+    }
+)
+_RUNTIME_CONTEXT_NORMALIZED_TOKENS = frozenset(normalized_phrase(term) for term in _RUNTIME_CONTEXT_TOKENS)
+_ROUTER_DESIGN_CONTEXT_PHRASES = (
+    "higher-level task abstraction",
+    "higher level task abstraction",
+    "task abstraction",
+    "not a migration workflow",
+    "not migration workflow",
+    "router design",
+    "routing design",
+    "route this wrong",
+    "wrong route",
+    "wrong workflow",
+    "learn from this run",
+    "상위레벨",
+    "상위 레벨",
+    "작업 추상화",
+    "태스크 추상화",
+    "마이그레이션이라는 개념",
+    "마이그레이션 워크플로",
+    "라우팅 설계",
+    "잘못 라우팅",
+    "워크플로 학습",
+    "워크플로우 학습",
+    "라우팅 피드백",
+    "omh 관여",
+    "얼마나 관여",
+)
+
+def classify_task(message: str) -> dict[str, object] | None:
+    """Classify high-level user tasks before choosing lower-level workflow rails."""
+    normalized = normalized_phrase(message)
+    compact = normalized.replace(" ", "")
+    tokens = set(routing_tokens(message, stopwords=set()))
+    tokens.update(normalized.split())
+
+    if _is_router_design_feedback(normalized, compact, tokens):
+        return _router_design_feedback_card()
+    if _is_runtime_portability(normalized, compact, tokens):
+        return _runtime_portability_card()
+    return None
+
+
+def task_card_recommendation(card: dict[str, object]) -> dict[str, object]:
+    task_type = str(card.get("task_type", "unknown_task"))
+    selected = str(card.get("selected_workflow_rail", "oh-my-hermes"))
+    return {
+        "skill": selected,
+        "score": int(card.get("score", 12)),
+        "confidence": str(card.get("confidence", "high")),
+        "matched": [f"task_card:{task_type}", "task_abstraction"],
+        "next_action": str(card.get("recommended_next_action", "show_workflow_guidance")),
+        "evidence_boundary": str(card.get("claim_boundary", "")),
+        "wrapper_guidance": str(card.get("wrapper_guidance", "")),
+        "why": str(card.get("routing_reason", "Matched high-level task abstraction before workflow routing.")),
+    }
+
+
+def _is_runtime_portability(normalized: str, compact: str, tokens: set[str]) -> bool:
+    phrase_hit = _phrase_hit(_RUNTIME_PORTABILITY_PHRASES, normalized, compact)
+    if not phrase_hit:
+        return False
+    context_hits = len(tokens & _RUNTIME_CONTEXT_NORMALIZED_TOKENS)
+    if context_hits:
+        return True
+    return _phrase_hit(("gateway", "bot", "responder", "게이트웨이", "봇", "응답자"), normalized, compact)
+
+
+def _is_router_design_feedback(normalized: str, compact: str, tokens: set[str]) -> bool:
+    phrase_hit = _phrase_hit(_ROUTER_DESIGN_CONTEXT_PHRASES, normalized, compact)
+    if phrase_hit:
+        return True
+    if (
+        _phrase_hit(("피드백",), normalized, compact)
+        and "omh" in normalized
+        and _phrase_hit(("라우팅", "라우터", "워크플로", "워크플로우", "설계", "추상화"), normalized, compact)
+    ):
+        return True
+    return False
+
+
+def _phrase_hit(phrases: tuple[str, ...], normalized: str, compact: str) -> bool:
+    for phrase in phrases:
+        normalized_phrase_value = normalized_phrase(phrase)
+        if normalized_phrase_value and (
+            normalized_phrase_value in normalized or normalized_phrase_value.replace(" ", "") in compact
+        ):
+            return True
+    return False
+
+
+def _runtime_portability_card() -> dict[str, object]:
+    return {
+        "schema_version": TASK_CARD_SCHEMA_VERSION,
+        "task_type": "runtime_portability",
+        "route_level": TASK_CARD_ROUTE_LEVEL,
+        "confidence": "high",
+        "score": 60,
+        "selected_workflow_rail": "agent-ops-review",
+        "recommended_next_action": "prepare_agent_ops_review",
+        "user_facing_summary": (
+            "This is a runtime portability task with one responder invariant, not a migration workflow."
+        ),
+        "not_a_workflow": ["migration", "backup", "private_repo_upload", "gateway_transfer"],
+        "operation_primitives": [
+            "inventory",
+            "package",
+            "credential_policy",
+            "distribution",
+            "restore",
+            "verify",
+            "gateway_ownership_transfer",
+            "liveness_monitoring",
+        ],
+        "workflow_rails": [
+            {
+                "skill": "agent-ops-review",
+                "purpose": "Own the top-level operating card, blockers, risks, and next safe action.",
+            },
+            {
+                "skill": "toolbelt-readiness",
+                "purpose": "Check local CLIs, Hermes paths, plugin state, credentials, and missing tools.",
+            },
+            {
+                "skill": "gateway-intent-card",
+                "purpose": "Model origin, thread, delivery, responder ownership, and gateway handoff policy.",
+            },
+            {
+                "skill": "doctor",
+                "purpose": "Verify the restored OMH/Hermes install after files and config are present.",
+            },
+            {
+                "skill": "workflow-learning",
+                "purpose": "Record missed routing or task-abstraction feedback without silently patching skills.",
+            },
+        ],
+        "risk_domains": [
+            "secrets",
+            "duplicate_gateway_responders",
+            "private_repo_exposure",
+            "liveness_gap",
+            "config_drift",
+            "missing_runtime_observation",
+        ],
+        "evidence_boundary": {
+            "prepared": "task card, inventory plan, package plan, restore checklist",
+            "observed": [],
+            "not_observed": [
+                "encrypted backup archive",
+                "private GitHub upload",
+                "runtime restore on the second machine",
+                "Hermes restart or plugin load",
+                "gateway responder cutover",
+                "liveness check after cutover",
+            ],
+            "degraded": [
+                "missing credential inventory",
+                "unverified target machine",
+                "gateway ownership unknown",
+            ],
+        },
+        "secret_policy": {
+            "recommended_action": "encrypt before private GitHub upload",
+            "never_package_by_default": [".env", "tokens", "API keys", "OAuth refresh tokens", "session cookies"],
+            "if_user_proceeds": "record residual risk, rotate exposed credentials, and keep credential restore as observed-only evidence",
+        },
+        "gateway_transfer": {
+            "invariant": "exactly_one_active_responder",
+            "before_cutover": "disable or pause the old responder, then observe the new responder before claiming transfer complete",
+            "duplicate_responder_risk": "two active gateways can answer the same user thread and corrupt state",
+        },
+        "liveness": {
+            "prepared_checks": ["process or service presence", "Hermes response smoke", "gateway response smoke"],
+            "degraded_until": "target machine and gateway response are observed after restore",
+        },
+        "first_safe_action": (
+            "Inventory configs, local state, plugin paths, managed skills, gateways, and secret locations before packaging."
+        ),
+        "routing_reason": (
+            "Matched runtime portability/environment reproduction signals; choose a task card first and use workflows as rails."
+        ),
+        "wrapper_guidance": (
+            "Render this as a runtime portability task card. Show inventory, credential policy, restore, verify, "
+            "gateway ownership transfer, and liveness risks before any workflow-specific action."
+        ),
+        "claim_boundary": (
+            "This task card is prepared guidance only. It is not backup creation, private repo upload, restore, "
+            "gateway cutover, liveness, verification, or completion evidence."
+        ),
+    }
+
+
+def _router_design_feedback_card() -> dict[str, object]:
+    return {
+        "schema_version": TASK_CARD_SCHEMA_VERSION,
+        "task_type": "router_design_feedback",
+        "route_level": TASK_CARD_ROUTE_LEVEL,
+        "confidence": "high",
+        "score": 55,
+        "selected_workflow_rail": "workflow-learning",
+        "recommended_next_action": "audit_learning_readiness",
+        "user_facing_summary": (
+            "This is workflow/router design feedback, not customer feedback triage."
+        ),
+        "not_a_workflow": ["customer_feedback_triage", "migration"],
+        "operation_primitives": [
+            "capture_trace",
+            "classify_missed_route",
+            "add_regression_case",
+            "propose_router_patch",
+            "human_review",
+            "replay_regression",
+        ],
+        "workflow_rails": [
+            {
+                "skill": "workflow-learning",
+                "purpose": "Record route feedback, evaluate the mistake, and prepare a reviewable improvement.",
+            },
+            {
+                "skill": "oh-my-hermes",
+                "purpose": "Keep the router mental model visible without forcing a shell command on chat users.",
+            },
+        ],
+        "risk_domains": ["router_regression", "skill_drift", "unreviewed_self_patch", "customer_feedback_misroute"],
+        "evidence_boundary": {
+            "prepared": "task card, workflow-learning route, regression intent",
+            "observed": [],
+            "not_observed": [
+                "raw prompt storage",
+                "regression fixture added",
+                "skill patch approved",
+                "future behavior fixed",
+            ],
+            "degraded": ["missing minimized replay fixture"],
+        },
+        "first_safe_action": "Record a metadata-only workflow-learning trace and create a minimized regression case.",
+        "routing_reason": (
+            "Matched OMH routing/design feedback signals; route to workflow-learning before any domain-specific workflow."
+        ),
+        "wrapper_guidance": (
+            "Treat this as router-design learning material. Do not route Korean or English OMH feedback to customer feedback triage."
+        ),
+        "claim_boundary": (
+            "A workflow-learning task card is process-review evidence only. It is not a skill patch, model update, "
+            "rerun, verification, CI, or proof that future routing is fixed."
+        ),
+    }

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -481,6 +481,8 @@ def build_chat_interaction_payload(
     if _is_generic_skill_catalog_route(message, route_payload):
         route_payload = _catalog_question_route_payload(route_payload)
     base["route"] = route_payload
+    if isinstance(route_payload.get("task_card"), dict):
+        base["task_card"] = route_payload["task_card"]
 
     if _is_omh_intro_question(message) and resolved_mode in {"route", "plan", "clarify"}:
         base["mode"] = "route"
@@ -658,6 +660,14 @@ def build_chat_response_from_route(
         policy = _selected_recommendation_policy(decision, selected)
         policy_next_action = str(policy.get("next_action", ""))
         workflow_explanation_reason = _workflow_explanation_reason_for_route(decision, policy, selected)
+        task_card = _route_task_card(decision)
+        if task_card and str(task_card.get("task_type", "")) != "router_design_feedback":
+            return _chat_response_from_task_card(
+                task_card,
+                decision=decision,
+                thread_key=thread_key,
+                workflow_explanation_reason=workflow_explanation_reason,
+            )
         if selected == "loop" or policy_next_action == "start_goal_loop":
             evidence_boundary = str(policy.get("evidence_boundary", "")) or "A goal loop is orchestration state only."
             body = str(policy.get("wrapper_guidance", "")) or (
@@ -971,6 +981,7 @@ def build_chat_response_from_route(
                         "export_redacted_bundle",
                         "human_review_improvement_candidate",
                     ],
+                    **_task_card_state(decision),
                 },
             )
         next_action = policy_next_action if policy_next_action and policy_next_action != "show_workflow_guidance" else "dispatch_to_workflow"
@@ -1052,6 +1063,106 @@ def _is_file_lookup_fallback(decision: dict[str, object]) -> bool:
         for key in ("reason", "clarification", "routing_instruction")
     ).lower()
     return "file or text lookup" in text or "file/text lookup" in text
+
+
+def _route_task_card(decision: dict[str, object]) -> dict[str, object]:
+    task_card = decision.get("task_card")
+    return dict(task_card) if isinstance(task_card, dict) else {}
+
+
+def _task_card_state(decision: dict[str, object]) -> dict[str, object]:
+    task_card = _route_task_card(decision)
+    return {"task_card": task_card} if task_card else {}
+
+
+def _chat_response_from_task_card(
+    task_card: dict[str, object],
+    *,
+    decision: dict[str, object],
+    thread_key: str,
+    workflow_explanation_reason: str,
+) -> dict[str, object]:
+    task_type = str(task_card.get("task_type", "task")).replace("_", " ")
+    next_action = str(task_card.get("recommended_next_action", "prepare_agent_ops_review"))
+    rails = _task_card_rails(task_card)
+    risk_domains = _string_items(task_card.get("risk_domains", []))
+    primitives = _string_items(task_card.get("operation_primitives", []))
+    evidence_boundary = _nested(task_card, "evidence_boundary")
+    not_observed = _string_items(evidence_boundary.get("not_observed", []))
+    secret_policy = _nested(task_card, "secret_policy")
+    gateway_transfer = _nested(task_card, "gateway_transfer")
+    first_safe_action = str(task_card.get("first_safe_action", "")).strip()
+    secret_action = str(secret_policy.get("recommended_action", "")).strip()
+    invariant = str(gateway_transfer.get("invariant", "")).strip().replace("_", " ")
+
+    body_lines = [
+        f"This is a {task_type} task, not a migration workflow.",
+        f"First safe action: {first_safe_action}" if first_safe_action else "",
+        f"Use workflow rails: {', '.join(rails[:4])}." if rails else "",
+        f"Track primitives: {', '.join(_display_items(primitives[:7]))}." if primitives else "",
+        f"Risks to surface: {', '.join(_display_items(risk_domains[:5]))}." if risk_domains else "",
+        f"Secret policy: {secret_action}." if secret_action else "",
+        f"Gateway invariant: {invariant}." if invariant else "",
+        f"Not observed yet: {', '.join(_display_items(not_observed[:4]))}." if not_observed else "",
+    ]
+    body = " ".join(line for line in body_lines if line)
+    return _chat_response(
+        kind="task_card",
+        headline="I will frame this as a high-level task first.",
+        body=body,
+        phase="task_card_prepared",
+        next_action=next_action,
+        thread_key=thread_key,
+        actions=[
+            _action(next_action, _label_for_action(next_action), "primary"),
+            _action("show_status", "Show status", "secondary"),
+            _action("record_workflow_learning_trace", "Record learning trace", "secondary"),
+        ],
+        claim_boundary=str(task_card.get("claim_boundary", "A prepared task card is not observed execution evidence.")),
+        extra_state={
+            "route_action": decision.get("action", "dispatch"),
+            "confidence": decision.get("confidence", "low"),
+            "selected_workflow": decision.get("selected_skill", ""),
+            "workflow_explanation_reason": workflow_explanation_reason,
+            "task_card": task_card,
+            "task_type": task_card.get("task_type", ""),
+            "route_level": task_card.get("route_level", ""),
+            "workflow_rails": task_card.get("workflow_rails", []),
+            "operation_primitives": primitives,
+            "risk_domains": risk_domains,
+            "evidence_not_observed": not_observed,
+        },
+    )
+
+
+def _task_card_rails(task_card: dict[str, object]) -> list[str]:
+    rails: list[str] = []
+    raw_rails = task_card.get("workflow_rails", [])
+    if not isinstance(raw_rails, list):
+        return rails
+    for rail in raw_rails:
+        if isinstance(rail, dict):
+            skill = str(rail.get("skill", "")).strip()
+            if skill:
+                rails.append(skill)
+    return rails
+
+
+def _string_items(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value if str(item)]
+
+
+def _display_items(items: list[str]) -> list[str]:
+    return [item.replace("_", " ") for item in items]
+
+
+def _label_for_action(action_id: str) -> str:
+    for known_action, label in _ACK_PRIMARY_ACTIONS_BY_NEXT_ACTION.values():
+        if known_action == action_id:
+            return label
+    return action_id.replace("_", " ").title()
 
 
 def build_chat_response_from_plan(plan_payload: dict[str, object], *, thread_key: str = "") -> dict[str, object]:

--- a/tests/test_chat_router.py
+++ b/tests/test_chat_router.py
@@ -144,6 +144,107 @@ class ChatRouterTests(unittest.TestCase):
                 self.assertEqual(decision["confidence"], "high")
                 self.assertIn("guard:workflow_learning", decision["recommendations"][0]["matched"])
 
+    def test_runtime_portability_task_card_sits_above_workflow_route(self) -> None:
+        message = (
+            "I want to reproduce this Hermes and Friren setup on another MacBook, "
+            "back it up to a private GitHub repo, move the Discord gateway, and make sure only one bot answers."
+        )
+
+        decision = route_chat_message(message, source="discord")
+        task_card = decision["task_card"]
+
+        self.assertEqual(decision["action"], "dispatch")
+        self.assertEqual(decision["selected_skill"], "agent-ops-review")
+        self.assertEqual(decision["recommendations"][0]["skill"], "agent-ops-review")
+        self.assertIn("task_card:runtime_portability", decision["recommendations"][0]["matched"])
+        self.assertEqual(task_card["schema_version"], "omh_task_card/v1")
+        self.assertEqual(task_card["task_type"], "runtime_portability")
+        self.assertEqual(task_card["route_level"], "task_abstraction")
+        self.assertEqual(task_card["selected_workflow_rail"], "agent-ops-review")
+        self.assertIn("migration", task_card["not_a_workflow"])
+        self.assertTrue(
+            {
+                "inventory",
+                "package",
+                "credential_policy",
+                "distribution",
+                "restore",
+                "verify",
+                "gateway_ownership_transfer",
+            }
+            <= set(task_card["operation_primitives"])
+        )
+        self.assertTrue({"secrets", "duplicate_gateway_responders"} <= set(task_card["risk_domains"]))
+        workflow_rails = {rail["skill"] for rail in task_card["workflow_rails"]}
+        self.assertTrue(
+            {
+                "agent-ops-review",
+                "toolbelt-readiness",
+                "gateway-intent-card",
+                "workflow-learning",
+                "doctor",
+            }
+            <= workflow_rails
+        )
+        self.assertEqual(task_card["evidence_boundary"]["prepared"], "task card, inventory plan, package plan, restore checklist")
+        self.assertIn("runtime restore on the second machine", task_card["evidence_boundary"]["not_observed"])
+        self.assertIn("encrypt before private GitHub upload", task_card["secret_policy"]["recommended_action"])
+        self.assertIn("residual risk", task_card["secret_policy"]["if_user_proceeds"])
+        self.assertEqual(task_card["gateway_transfer"]["invariant"], "exactly_one_active_responder")
+        self.assertIn("one responder", task_card["user_facing_summary"])
+
+    def test_korean_runtime_portability_task_card(self) -> None:
+        decision = route_chat_message(
+            "다른 맥북에 헤르메스 프리렌 세팅 재현하고 개인 깃허브에 백업하고 "
+            "디스코드 게이트웨이 응답자가 하나만 되게 해줘",
+            source="discord",
+        )
+
+        self.assertEqual(decision["action"], "dispatch")
+        self.assertEqual(decision["selected_skill"], "agent-ops-review")
+        self.assertEqual(decision["task_card"]["task_type"], "runtime_portability")
+        self.assertGreaterEqual(decision["recommendations"][0]["score"], 60)
+        self.assertIn("task_card:runtime_portability", decision["recommendations"][0]["matched"])
+
+    def test_plain_backup_or_migration_without_runtime_context_does_not_task_cardify(self) -> None:
+        for message in (
+            "backup my photos to private GitHub",
+            "migrate this setup to another laptop",
+        ):
+            with self.subTest(message=message):
+                decision = route_chat_message(message, source="discord")
+
+                self.assertIsNone(decision["task_card"])
+                self.assertNotIn("task_card:runtime_portability", decision["recommendations"][0]["matched"])
+
+    def test_router_design_feedback_prefers_workflow_learning_over_feedback_triage(self) -> None:
+        cases = (
+            "This should be a higher-level task abstraction, not a migration workflow.",
+            "Why did OMH route this wrong? Fix the router design.",
+            "피드백인데 OMH 라우팅 설계가 잘못됐어.",
+            "더 상위레벨에서 마이그레이션이라는 개념을 한 task로 인식해야지.",
+            "이번 작업 회고하면서 OMH가 얼마나 관여했는지 봐줘.",
+        )
+
+        for message in cases:
+            with self.subTest(message=message):
+                decision = route_chat_message(message, source="discord")
+                task_card = decision["task_card"]
+
+                self.assertEqual(decision["action"], "dispatch")
+                self.assertEqual(decision["selected_skill"], "workflow-learning")
+                self.assertEqual(decision["selected_harness"], "workflow-learning")
+                self.assertEqual(task_card["task_type"], "router_design_feedback")
+                self.assertEqual(task_card["selected_workflow_rail"], "workflow-learning")
+                self.assertNotEqual(decision["selected_skill"], "feedback-triage")
+                self.assertIn("task_card:router_design_feedback", decision["recommendations"][0]["matched"])
+
+    def test_generic_korean_omh_feedback_does_not_become_router_design_card(self) -> None:
+        decision = route_chat_message("피드백인데 OMH 문서가 좋아요.", source="discord")
+
+        self.assertIsNone(decision["task_card"])
+        self.assertNotIn("task_card:router_design_feedback", decision["recommendations"][0]["matched"])
+
     def test_catalog_question_dispatches_to_router_without_shell_approval(self) -> None:
         for message in (
             "OMH로 할 수 있는 workflow가 뭐야?",

--- a/tests/test_wrapper_contract.py
+++ b/tests/test_wrapper_contract.py
@@ -130,6 +130,28 @@ class WrapperContractTests(unittest.TestCase):
         self.assertIn("clarify", actions)
         self.assertNotIn("zzzzzz", json.dumps(payload))
 
+    def test_chat_interaction_renders_task_abstraction_card_without_cli_copy(self) -> None:
+        message = (
+            "Reproduce this Hermes and Friren setup on another MacBook, backup the state to private GitHub, "
+            "and transfer the Discord gateway without duplicate responders."
+        )
+
+        payload = build_chat_interaction_payload(message, source="discord")
+
+        self.assertEqual(payload["schema_version"], "chat_interaction/v1")
+        self.assertEqual(payload["mode"], "route")
+        self.assertEqual(payload["route"]["selected_skill"], "agent-ops-review")
+        self.assertEqual(payload["route"]["task_card"]["schema_version"], "omh_task_card/v1")
+        self.assertEqual(payload["route"]["task_card"]["task_type"], "runtime_portability")
+        self.assertEqual(payload["chat_response"]["kind"], "task_card")
+        self.assertEqual(payload["chat_response"]["state"]["task_card"]["route_level"], "task_abstraction")
+        self.assertEqual(payload["next_action"], "prepare_agent_ops_review")
+        self.assertIn("runtime portability", payload["chat_response"]["body"])
+        self.assertIn("not a migration workflow", payload["chat_response"]["body"])
+        self.assertIn("encrypt before private GitHub upload", payload["chat_response"]["body"])
+        self.assertNotIn("omh migration", json.dumps(payload).lower())
+        self.assertNotIn(message, json.dumps(payload))
+
     def test_chat_interaction_surfaces_target_change_notice_without_overclaiming(self) -> None:
         notice = {
             "schema_version": "omh_target_change_notice/v1",


### PR DESCRIPTION
## Summary
- Adds `omh_task_card/v1`, a deterministic task-abstraction layer that sits above normal workflow routing.
- Routes runtime portability / environment reproduction / gateway transfer requests to a high-level task card before using workflow rails such as `agent-ops-review`, `toolbelt-readiness`, `gateway-intent-card`, `doctor`, and `workflow-learning`.
- Routes OMH router-design feedback, including Korean routing feedback, to `workflow-learning` instead of customer `feedback-triage`.

## Why
A real Hermes session showed that “reproduce this Hermes/Friren setup on another MacBook, back it up to private GitHub, and make sure only one gateway answers” is not a narrow migration workflow. It is a higher-level operational task with inventory, packaging, credential policy, restore, verification, and gateway ownership transfer rails.

## What changed
- Added `src/routing/task_cards.py` with runtime portability and router-design task cards.
- Updated chat routing so explicit workflow invocation still wins, while task cards can sit above heuristic workflow recommendations.
- Updated wrapper chat responses so runtime portability renders as a user-facing task card with safe next actions, risk domains, secret policy, and observed-only boundaries.
- Added docs and site entry points for task abstraction cards.
- Added regression coverage for English and Korean task-card routing, explicit workflow override, generic Korean OMH feedback, and plain backup/migration overmatch cases.

## User/operator behavior
A chat wrapper can now answer a request like “reproduce this Hermes setup on another MacBook” with a high-level task card instead of pretending there is a single migration command. The card explains the first safe action, names workflow rails, calls out secrets and duplicate gateway responders, and says what is not observed yet.

## Implementation notes
- `omh_task_card/v1` is local deterministic metadata only.
- Task cards do not create backups, upload to GitHub, restore machines, cut over gateways, or verify liveness.
- Router-design task cards are process-review evidence only; they do not silently patch routing or skills.
- Runtime-portability matching now requires runtime/gateway/Hermes context so plain backup or migration requests do not overmatch.

## Verification
- `PYTHONPATH=tests uv run python -m unittest tests/test_chat_router.py tests/test_wrapper_contract.py -v` PASS, 76 tests.
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` PASS, 668 tests.
- `uv run python -m compileall -q src tests` PASS.
- `uv run python -m src.cli docs workflows --check` PASS, 41/41 tap skills.
- `git diff --check` PASS.
- Manual smoke: runtime portability chat interact returns `chat_response.kind=task_card` and `task_card.schema_version=omh_task_card/v1`.
- Manual smoke: Korean OMH routing-design feedback selects `workflow-learning`, not `feedback-triage`.
- Manual smoke: explicit `feedback-triage` invocation still wins.
- Independent review: `code-reviewer` APPROVE, `architect` CLEAR after fixes.

## Risks and follow-up
- Live Hermes/Discord wrapper rendering and real MacBook restore/gateway cutover were not tested here.
- Future task-card families should avoid duplicating routing vocabulary; keep new abstractions regression-tested against overmatch examples.