### PR TITLE
Guard OMH meta routing and coding delegate records

### DIFF
--- a/docs/CHAT_WRAPPER_EXAMPLES.md
+++ b/docs/CHAT_WRAPPER_EXAMPLES.md
@@ -247,10 +247,11 @@ make an image explaining the cron feature
 
 Hermes Agent
 [OMH Route Hint]
-- workflow=img-summary; lane=materials_and_visuals; next_action=prepare_visual_prompt_card
+intent=unknown; selected=img-summary; confidence=medium
+- selected=img-summary; lane=materials_and_visuals; next_action=prepare_visual_prompt_card
   first_response_shape=Separate copy/layout/package prep from generated file or image evidence, then offer revise/copy/generate/record actions.
   fallback_action=choose_image_generator_or_prompt_only_when_missing.
-- workflow=automation-blueprint; lane=automation_and_status; next_action=prepare_scheduled_ops_blueprint
+- selected=automation-blueprint; lane=automation_and_status; next_action=prepare_scheduled_ops_blueprint
   first_response_shape=Show the prepared status, schedule, or learning shape, name the missing evidence, and expose refresh, repair, or review actions.
   fallback_action=confirm_schedule_delivery_and_tools.
 ```

--- a/docs/HERMES_AGENT_INTEGRATION_RUNBOOK.md
+++ b/docs/HERMES_AGENT_INTEGRATION_RUNBOOK.md
@@ -188,7 +188,32 @@ omh chat session status "$SESSION_ID"
 wrappers can pipe Codex JSONL or process output into it and render the compact
 `chat_summary` instead of dumping event streams into chat. The output is an
 observable event summary, not think-log access; it must not expose hidden
-reasoning, raw JSON events, or unobserved review/CI/merge claims.
+reasoning, raw JSON events, or unobserved review/CI/merge claims. If an
+explicit JSONL path cannot be read, the adapter must surface that as missing
+evidence instead of treating it as an empty observed log.
+
+When Codex performs a review, wrappers can expose a human-readable review
+context summary without raw logs:
+
+```sh
+omh chat codex-review \
+  --codex-session-ref "$CODEX_SESSION" \
+  --codex-thread-ref "$CODEX_THREAD" \
+  --codex-log-jsonl "$CODEX_JSONL" \
+  --codex-log-ref codex-jsonl \
+  --evidence-ref codex-review-summary \
+  --codex-review-status changes_requested \
+  --codex-review-summary "$HUMAN_READABLE_CODEX_REVIEW_SUMMARY" \
+  --codex-review-finding-count 2
+```
+
+`codex_review_summary/v1` is review-context metadata for Hermes narration. It
+separates the observed Codex-reviewed result from Hermes' own summary text,
+does not expose raw JSONL or hidden reasoning, and does not claim CI,
+merge-readiness, merge, or review-fix evidence. If the review requests fixes
+and an explicit `codex_session_ref` was observed, the handback contract includes
+a copyable `codex exec resume <session_id>` template for the wrapper/operator.
+OMH core still does not launch Codex or claim that fixes were applied.
 
 When a follow-up prompt arrives while Codex is still active, wrappers can combine
 the latest observed progress with a safe handling recommendation:
@@ -197,17 +222,24 @@ the latest observed progress with a safe handling recommendation:
 omh chat codex-followup "$FOLLOW_UP" \
   --session-id "$SESSION_ID" \
   --codex-log-jsonl "$CODEX_JSONL" \
-  --codex-log-ref codex-jsonl
+  --codex-log-ref codex-jsonl \
+  --codex-review-status changes_requested \
+  --codex-review-summary "$HUMAN_READABLE_CODEX_REVIEW_SUMMARY"
 ```
 
 The follow-up contract returns a prompt hash/length, the latest observable Codex
 activity summary, and a recommendation to append to the observed Codex session
 only when a same-goal wrapper session or explicit same-goal assertion is present.
 Otherwise it recommends clarifying or routing a new task. It does not append the
-prompt, launch Codex, expose raw logs, or claim review/CI/merge evidence.
+prompt, launch Codex, expose raw logs, or claim review/CI/merge evidence. When a
+review summary is provided, it is carried as compact review context for the
+resumed Codex session; it is not a hidden think log and not proof that review
+fixes have already happened.
 
 When `codex_session_ref` is observed, status includes a resume-capable launch
-contract such as `codex exec resume <session_id>`. That is still a wrapper or
+contract such as `codex exec resume <session_id>`. A generic
+`external_session_ref` or thread reference is shown as observed context only; it
+does not produce a resume command by itself. Resume remains a wrapper or
 operator action. OMH records the reference and summary metadata only; it does
 not launch Codex, and it does not claim resumed work until the wrapper records
 observed session/result evidence.

--- a/docs/HERMES_AGENT_INTEGRATION_RUNBOOK.md
+++ b/docs/HERMES_AGENT_INTEGRATION_RUNBOOK.md
@@ -169,11 +169,32 @@ the wrapper starts or attaches the terminal/app session, then calls
 For a Codex handoff, the wrapper can record an observed open and later result:
 
 ```sh
-omh chat session open-executor "$SESSION_ID" --observed --external-session-ref "$CODEX_THREAD"
-omh chat session record-executor "$SESSION_ID" --result completed --evidence-ref codex-summary
+omh chat codex-progress --jsonl "$CODEX_JSONL" --evidence-ref codex-jsonl
+omh chat session open-executor "$SESSION_ID" --observed \
+  --external-session-ref "$CODEX_THREAD" \
+  --codex-session-ref "$CODEX_SESSION" \
+  --codex-thread-ref "$CODEX_THREAD" \
+  --codex-log-jsonl "$CODEX_JSONL" \
+  --codex-log-ref codex-jsonl
+omh chat session record-executor "$SESSION_ID" --result completed \
+  --evidence-ref codex-summary \
+  --codex-log-jsonl "$CODEX_JSONL" \
+  --codex-log-ref codex-final-jsonl
 omh chat session request-verification "$SESSION_ID"
 omh chat session status "$SESSION_ID"
 ```
+
+`omh chat codex-progress` is an adapter helper for the raw-output gap: hosted
+wrappers can pipe Codex JSONL or process output into it and render the compact
+`chat_summary` instead of dumping event streams into chat. The output is an
+observable event summary, not think-log access; it must not expose hidden
+reasoning, raw JSON events, or unobserved review/CI/merge claims.
+
+When `codex_session_ref` is observed, status includes a resume-capable launch
+contract such as `codex exec resume <session_id>`. That is still a wrapper or
+operator action. OMH records the reference and summary metadata only; it does
+not launch Codex, and it does not claim resumed work until the wrapper records
+observed session/result evidence.
 
 The resulting display status lines are intended for normal chat surfaces:
 
@@ -184,6 +205,8 @@ Handoff is ready.
 Dispatch/open has been observed.
 Executor result has not been observed yet.
 Hermes verification has not been requested yet.
+Observed Codex metadata: session codex-session-1, thread codex-thread-1; event summaries=4.
+Codex observable activity summary: Codex is inspecting files/tests. Codex changed files. Status: activity_observed.
 ```
 
 When the user asks “what is happening with that coding task?”, prefer the

--- a/docs/HERMES_AGENT_INTEGRATION_RUNBOOK.md
+++ b/docs/HERMES_AGENT_INTEGRATION_RUNBOOK.md
@@ -190,6 +190,22 @@ wrappers can pipe Codex JSONL or process output into it and render the compact
 observable event summary, not think-log access; it must not expose hidden
 reasoning, raw JSON events, or unobserved review/CI/merge claims.
 
+When a follow-up prompt arrives while Codex is still active, wrappers can combine
+the latest observed progress with a safe handling recommendation:
+
+```sh
+omh chat codex-followup "$FOLLOW_UP" \
+  --session-id "$SESSION_ID" \
+  --codex-log-jsonl "$CODEX_JSONL" \
+  --codex-log-ref codex-jsonl
+```
+
+The follow-up contract returns a prompt hash/length, the latest observable Codex
+activity summary, and a recommendation to append to the observed Codex session
+only when a same-goal wrapper session or explicit same-goal assertion is present.
+Otherwise it recommends clarifying or routing a new task. It does not append the
+prompt, launch Codex, expose raw logs, or claim review/CI/merge evidence.
+
 When `codex_session_ref` is observed, status includes a resume-capable launch
 contract such as `codex exec resume <session_id>`. That is still a wrapper or
 operator action. OMH records the reference and summary metadata only; it does

--- a/src/codex_progress.py
+++ b/src/codex_progress.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import re
 from pathlib import Path
@@ -9,6 +10,7 @@ from typing import Any
 CODEX_PROGRESS_SCHEMA_VERSION = "codex_progress_summary/v1"
 CODEX_SESSION_OBSERVATION_SCHEMA_VERSION = "codex_session_observation/v1"
 CODEX_RESUME_CONTRACT_SCHEMA_VERSION = "codex_resume_contract/v1"
+CODEX_PROMPT_HANDLING_SCHEMA_VERSION = "codex_prompt_handling_contract/v1"
 
 _HIDDEN_KEYS = {
     "analysis",
@@ -169,6 +171,95 @@ def build_codex_resume_contract(session_ref: str) -> dict[str, object]:
             "The resume command is a wrapper/operator launch contract only. The wrapper backend does not launch Codex or "
             "claim resumed work until it records observed session or result evidence."
         ),
+    }
+
+
+def build_codex_prompt_handling_contract(
+    *,
+    new_prompt: str,
+    progress_summary: dict[str, object] | None = None,
+    codex_session_ref: str = "",
+    codex_thread_ref: str = "",
+    external_session_ref: str = "",
+    wrapper_session_id: str = "",
+    same_goal: bool = False,
+    evidence_refs: list[str] | tuple[str, ...] | None = None,
+) -> dict[str, object]:
+    progress = progress_summary if isinstance(progress_summary, dict) else {}
+    observation = build_codex_session_observation(
+        selected_executor_profile="codex",
+        external_session_ref=external_session_ref,
+        codex_session_ref=codex_session_ref,
+        codex_thread_ref=codex_thread_ref,
+        evidence_refs=evidence_refs or [],
+        progress_summary=progress,
+    )
+    session_ref = str(observation.get("session_ref", "")).strip()
+    same_session_scope = bool(session_ref and (same_goal or wrapper_session_id))
+    recommendation = _prompt_recommendation(session_ref=session_ref, same_session_scope=same_session_scope)
+    payload = {
+        "schema_version": CODEX_PROMPT_HANDLING_SCHEMA_VERSION,
+        "new_prompt": {
+            "sha256": hashlib.sha256(new_prompt.encode("utf-8")).hexdigest(),
+            "length": len(new_prompt),
+            "raw_prompt_stored": False,
+            "raw_prompt_echoed": False,
+        },
+        "active_codex": {
+            "observed": bool(observation.get("observed")),
+            "session_ref": session_ref,
+            "thread_ref": str(observation.get("thread_ref", "")).strip(),
+            "event_count": int(observation.get("event_count", 0) or 0),
+            "latest_progress": progress,
+        },
+        "recommendation": recommendation,
+        "adapter_contract": {
+            "metadata_only": True,
+            "raw_logs_exposed": False,
+            "hidden_reasoning_exposed": False,
+            "core_launches_codex": False,
+            "claim_boundary": (
+                "This contract summarizes observed Codex session metadata and recommends prompt handling. It is not "
+                "execution, review, CI, merge-readiness, merge, or hidden think-log evidence."
+            ),
+        },
+        "claim_boundary": (
+            "Codex follow-up handling is wrapper/operator metadata only. The core backend does not launch Codex, append "
+            "prompts, expose raw logs, or claim review/CI/merge evidence."
+        ),
+    }
+    resume = observation.get("resume", {})
+    if isinstance(resume, dict) and resume.get("available"):
+        payload["resume"] = resume
+    return payload
+
+
+def _prompt_recommendation(*, session_ref: str, same_session_scope: bool) -> dict[str, object]:
+    if session_ref and same_session_scope:
+        return {
+            "action": "append_followup_to_observed_codex_session",
+            "can_append_to_existing_session": True,
+            "requires_clarification": False,
+            "reason": "An observed Codex session_ref exists for the same wrapper session or confirmed same goal.",
+            "next_step": "Use the wrapper/operator resume path and append the follow-up prompt to the observed Codex session.",
+            "not_evidence": ["execution_result", "review", "ci", "merge_readiness", "merge"],
+        }
+    if session_ref:
+        return {
+            "action": "clarify_before_append_or_route_new",
+            "can_append_to_existing_session": False,
+            "requires_clarification": True,
+            "reason": "A Codex session_ref exists, but the new prompt is not confirmed to belong to the same goal/session.",
+            "next_step": "Ask whether to append to the observed Codex session or start/route a separate task.",
+            "not_evidence": ["execution_result", "review", "ci", "merge_readiness", "merge"],
+        }
+    return {
+        "action": "route_new_or_clarify",
+        "can_append_to_existing_session": False,
+        "requires_clarification": True,
+        "reason": "No observed Codex session_ref is available for safe resume or append handling.",
+        "next_step": "Route the prompt as a new task or ask one clarification before dispatch.",
+        "not_evidence": ["execution_result", "review", "ci", "merge_readiness", "merge"],
     }
 
 

--- a/src/codex_progress.py
+++ b/src/codex_progress.py
@@ -11,6 +11,7 @@ CODEX_PROGRESS_SCHEMA_VERSION = "codex_progress_summary/v1"
 CODEX_SESSION_OBSERVATION_SCHEMA_VERSION = "codex_session_observation/v1"
 CODEX_RESUME_CONTRACT_SCHEMA_VERSION = "codex_resume_contract/v1"
 CODEX_PROMPT_HANDLING_SCHEMA_VERSION = "codex_prompt_handling_contract/v1"
+CODEX_REVIEW_SUMMARY_SCHEMA_VERSION = "codex_review_summary/v1"
 
 _HIDDEN_KEYS = {
     "analysis",
@@ -30,9 +31,10 @@ _VISIBLE_MESSAGE_TYPES = {
     "response",
     "response_item",
 }
-_TERMINAL_FAILURE_WORDS = ("error", "failed", "failure", "traceback")
-_TERMINAL_SUCCESS_WORDS = ("completed", "complete", "success", "succeeded", "passed")
+_TERMINAL_FAILURE_RE = re.compile(r"\b(error|failed|failure|traceback)\b")
+_TERMINAL_SUCCESS_RE = re.compile(r"\b(completed|complete|success|succeeded|passed)\b")
 _MAX_VISIBLE_MESSAGE = 180
+_CODEX_REVIEW_STATUSES = ("not_observed", "pending", "passed", "failed", "blocked", "changes_requested", "commented")
 
 
 def summarize_codex_jsonl_file(
@@ -41,10 +43,7 @@ def summarize_codex_jsonl_file(
     evidence_refs: list[str] | tuple[str, ...] | None = None,
 ) -> dict[str, object]:
     source = str(path)
-    try:
-        text = Path(path).read_text(encoding="utf-8")
-    except OSError:
-        text = ""
+    text = Path(path).read_text(encoding="utf-8")
     return summarize_codex_jsonl_text(text, evidence_refs=evidence_refs, source=source)
 
 
@@ -89,16 +88,16 @@ def summarize_codex_jsonl_text(
             activity_counts["testing"] += 1
         if _is_waiting_review_event(lowered):
             activity_counts["waiting_review"] += 1
-        if not terminal_status and any(word in lowered for word in _TERMINAL_FAILURE_WORDS):
+        if not terminal_status and _TERMINAL_FAILURE_RE.search(lowered):
             terminal_status = "failed_or_error_observed"
-        if any(word in lowered for word in _TERMINAL_SUCCESS_WORDS):
+        if _terminal_success_observed(lowered):
             terminal_status = "completed_or_passed_observed"
         visible = _assistant_visible_message(event)
         if visible:
             visible_decisions.append(visible)
             activity_counts["assistant_visible_decisions"] += 1
     activities = _observable_activity(activity_counts)
-    status = terminal_status or ("activity_observed" if parsed_events else "no_observable_events")
+    status = terminal_status or ("activity_observed" if activities or visible_decisions else "no_observable_events")
     return {
         "schema_version": CODEX_PROGRESS_SCHEMA_VERSION,
         "source": source,
@@ -131,7 +130,7 @@ def build_codex_session_observation(
     if selected_executor_profile != "codex":
         return {}
     progress = progress_summary if isinstance(progress_summary, dict) else {}
-    session_ref = (codex_session_ref or external_session_ref).strip()
+    session_ref = codex_session_ref.strip()
     thread_ref = (codex_thread_ref or external_session_ref).strip()
     observed = bool(session_ref or thread_ref or progress.get("event_count"))
     resume = build_codex_resume_contract(session_ref)
@@ -184,6 +183,7 @@ def build_codex_prompt_handling_contract(
     wrapper_session_id: str = "",
     same_goal: bool = False,
     evidence_refs: list[str] | tuple[str, ...] | None = None,
+    codex_review_summary: dict[str, object] | None = None,
 ) -> dict[str, object]:
     progress = progress_summary if isinstance(progress_summary, dict) else {}
     observation = build_codex_session_observation(
@@ -228,10 +228,80 @@ def build_codex_prompt_handling_contract(
             "prompts, expose raw logs, or claim review/CI/merge evidence."
         ),
     }
+    if isinstance(codex_review_summary, dict) and codex_review_summary:
+        payload["codex_review"] = codex_review_summary
     resume = observation.get("resume", {})
     if isinstance(resume, dict) and resume.get("available"):
         payload["resume"] = resume
     return payload
+
+
+def build_codex_review_summary(
+    *,
+    review_status: str = "not_observed",
+    reviewer: str = "codex",
+    summary: str = "",
+    finding_count: int | None = None,
+    progress_summary: dict[str, object] | None = None,
+    codex_session_ref: str = "",
+    codex_thread_ref: str = "",
+    external_session_ref: str = "",
+    evidence_refs: list[str] | tuple[str, ...] | None = None,
+) -> dict[str, object]:
+    normalized_status = _normalize_review_status(review_status, summary=summary)
+    progress = progress_summary if isinstance(progress_summary, dict) else {}
+    observation = build_codex_session_observation(
+        selected_executor_profile="codex",
+        external_session_ref=external_session_ref,
+        codex_session_ref=codex_session_ref,
+        codex_thread_ref=codex_thread_ref,
+        evidence_refs=evidence_refs or [],
+        progress_summary=progress,
+    )
+    observed = normalized_status != "not_observed" or bool(summary.strip()) or bool(evidence_refs)
+    requires_fixes = normalized_status in {"failed", "blocked", "changes_requested"}
+    resume = observation.get("resume", {}) if isinstance(observation.get("resume"), dict) else {}
+    return {
+        "schema_version": CODEX_REVIEW_SUMMARY_SCHEMA_VERSION,
+        "observed": observed,
+        "reviewer": reviewer.strip() or "codex",
+        "status": normalized_status,
+        "satisfied": normalized_status == "passed",
+        "requires_fixes": requires_fixes,
+        "finding_count": max(0, int(finding_count)) if finding_count is not None else 0,
+        "finding_count_observed": finding_count is not None,
+        "human_summary": _compact_visible_message(summary) if summary.strip() else _default_review_summary(normalized_status),
+        "codex_session": observation,
+        "progress_context": _progress_context(progress),
+        "evidence_refs": _compact_list(evidence_refs or []),
+        "handback": {
+            "can_resume_for_fixes": bool(requires_fixes and resume.get("available")),
+            "resume": resume if resume.get("available") else {},
+            "recommended_action": "resume_codex_for_review_fixes" if requires_fixes else "record_review_context_only",
+            "core_launches_codex": False,
+            "raw_finding_logs_required": False,
+            "claim_boundary": (
+                "Review findings can be handed back to a wrapper/operator-managed Codex session. OMH core does not launch "
+                "Codex or claim fixes until observed executor evidence is recorded."
+            ),
+        },
+        "adapter_contract": {
+            "metadata_only": True,
+            "human_readable_summary_only": True,
+            "raw_logs_exposed": False,
+            "raw_review_events_exposed": False,
+            "hidden_reasoning_exposed": False,
+            "core_launches_codex": False,
+            "claim_boundary": (
+                "This is an observed Codex review context summary for Hermes narration. It is not raw JSONL, hidden "
+                "reasoning, CI evidence, merge-readiness evidence, or merge evidence."
+            ),
+        },
+        "claim_boundary": (
+            "A Codex review summary is review-context metadata only. It does not prove review fixes, CI, merge readiness, "
+            "or merge unless separate observed evidence is recorded."
+        ),
+    }
 
 
 def _prompt_recommendation(*, session_ref: str, same_session_scope: bool) -> dict[str, object]:
@@ -272,15 +342,23 @@ def _safe_search_text(event: dict[str, Any]) -> str:
 
 
 def _hidden_event(event: dict[str, Any]) -> bool:
+    return _hidden_marker(event)
+
+
+def _hidden_marker(value: Any) -> bool:
+    if not isinstance(value, dict):
+        return False
     for key in ("type", "event", "role"):
-        value = str(event.get(key, "")).casefold()
-        if any(hidden in value for hidden in _HIDDEN_KEYS):
+        marker = str(value.get(key, "")).casefold()
+        if any(hidden in marker for hidden in _HIDDEN_KEYS):
             return True
     return False
 
 
 def _collect_safe_strings(value: Any, parts: list[str], *, parent_key: str = "") -> None:
     if parent_key.casefold() in _HIDDEN_KEYS:
+        return
+    if _hidden_marker(value):
         return
     if isinstance(value, str):
         parts.append(value[:500])
@@ -296,6 +374,8 @@ def _collect_safe_strings(value: Any, parts: list[str], *, parent_key: str = "")
         for key, item in value.items():
             if str(key).casefold() in _HIDDEN_KEYS:
                 continue
+            if _hidden_marker(item):
+                continue
             parts.append(str(key))
             _collect_safe_strings(item, parts, parent_key=str(key))
 
@@ -303,6 +383,10 @@ def _collect_safe_strings(value: Any, parts: list[str], *, parent_key: str = "")
 def _assistant_visible_message(event: dict[str, Any]) -> str:
     if _hidden_event(event):
         return ""
+    for key in ("data", "item", "payload"):
+        payload = event.get(key)
+        if _hidden_marker(payload):
+            return ""
     event_type = str(event.get("type") or event.get("event") or event.get("role") or "").casefold()
     if event_type not in _VISIBLE_MESSAGE_TYPES and str(event.get("role", "")).casefold() != "assistant":
         return ""
@@ -317,6 +401,63 @@ def _assistant_visible_message(event: dict[str, Any]) -> str:
             if key in payload and isinstance(payload[key], str):
                 return _compact_visible_message(payload[key])
     return ""
+
+
+def _normalize_review_status(status: str, *, summary: str = "") -> str:
+    normalized = status.strip().casefold().replace("-", "_").replace(" ", "_") or "not_observed"
+    aliases = {
+        "approved": "passed",
+        "approve": "passed",
+        "request_changes": "changes_requested",
+        "requested_changes": "changes_requested",
+        "needs_changes": "changes_requested",
+        "comment": "commented",
+    }
+    normalized = aliases.get(normalized, normalized)
+    if normalized == "not_observed" and summary.strip():
+        normalized = "commented"
+    if normalized not in _CODEX_REVIEW_STATUSES:
+        raise ValueError(f"Codex review status must be one of: {', '.join(_CODEX_REVIEW_STATUSES)}")
+    return normalized
+
+
+def _default_review_summary(status: str) -> str:
+    if status == "passed":
+        return "Codex review passed."
+    if status == "changes_requested":
+        return "Codex review requested changes."
+    if status == "failed":
+        return "Codex review failed."
+    if status == "blocked":
+        return "Codex review is blocked."
+    if status == "pending":
+        return "Codex review is pending."
+    if status == "commented":
+        return "Codex review produced human-readable context."
+    return "Codex review has not been observed."
+
+
+def _progress_context(progress: dict[str, object]) -> dict[str, object]:
+    if not progress:
+        return {}
+    return {
+        "schema_version": str(progress.get("schema_version", "")),
+        "status": str(progress.get("status", "")),
+        "event_count": int(progress.get("event_count", 0) or 0),
+        "observable_activity": list(progress.get("observable_activity", [])) if isinstance(progress.get("observable_activity"), list) else [],
+        "chat_summary": str(progress.get("chat_summary", "")),
+        "evidence_refs": _compact_list(progress.get("evidence_refs", [])),
+        "claim_boundary": str(progress.get("claim_boundary", "")),
+    }
+
+
+def _terminal_success_observed(text: str) -> bool:
+    for match in _TERMINAL_SUCCESS_RE.finditer(text):
+        prefix = text[max(0, match.start() - 24) : match.start()]
+        if re.search(r"\b(no|not|never|without|pending|awaiting)\b", prefix):
+            continue
+        return True
+    return False
 
 
 def _compact_visible_message(value: str) -> str:

--- a/src/codex_progress.py
+++ b/src/codex_progress.py
@@ -1,0 +1,296 @@
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+CODEX_PROGRESS_SCHEMA_VERSION = "codex_progress_summary/v1"
+CODEX_SESSION_OBSERVATION_SCHEMA_VERSION = "codex_session_observation/v1"
+CODEX_RESUME_CONTRACT_SCHEMA_VERSION = "codex_resume_contract/v1"
+
+_HIDDEN_KEYS = {
+    "analysis",
+    "chain_of_thought",
+    "cot",
+    "hidden",
+    "internal",
+    "reasoning",
+    "thought",
+    "thinking",
+}
+_VISIBLE_MESSAGE_TYPES = {
+    "assistant",
+    "assistant_message",
+    "final",
+    "message",
+    "response",
+    "response_item",
+}
+_TERMINAL_FAILURE_WORDS = ("error", "failed", "failure", "traceback")
+_TERMINAL_SUCCESS_WORDS = ("completed", "complete", "success", "succeeded", "passed")
+_MAX_VISIBLE_MESSAGE = 180
+
+
+def summarize_codex_jsonl_file(
+    path: str | Path,
+    *,
+    evidence_refs: list[str] | tuple[str, ...] | None = None,
+) -> dict[str, object]:
+    source = str(path)
+    try:
+        text = Path(path).read_text(encoding="utf-8")
+    except OSError:
+        text = ""
+    return summarize_codex_jsonl_text(text, evidence_refs=evidence_refs, source=source)
+
+
+def summarize_codex_jsonl_text(
+    text: str,
+    *,
+    evidence_refs: list[str] | tuple[str, ...] | None = None,
+    source: str = "stdin",
+) -> dict[str, object]:
+    parsed_events: list[dict[str, Any]] = []
+    malformed_count = 0
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            item = json.loads(line)
+        except json.JSONDecodeError:
+            malformed_count += 1
+            item = {"type": "process_output", "message": line}
+        if isinstance(item, dict):
+            parsed_events.append(item)
+        else:
+            parsed_events.append({"type": "process_output", "message": str(item)})
+    activity_counts: dict[str, int] = {
+        "inspecting": 0,
+        "editing": 0,
+        "testing": 0,
+        "waiting_review": 0,
+        "assistant_visible_decisions": 0,
+    }
+    visible_decisions: list[str] = []
+    terminal_status = ""
+    for event in parsed_events:
+        searchable = _safe_search_text(event)
+        lowered = searchable.casefold()
+        if _is_inspection_event(lowered):
+            activity_counts["inspecting"] += 1
+        if _is_edit_event(lowered):
+            activity_counts["editing"] += 1
+        if _is_test_event(lowered):
+            activity_counts["testing"] += 1
+        if _is_waiting_review_event(lowered):
+            activity_counts["waiting_review"] += 1
+        if not terminal_status and any(word in lowered for word in _TERMINAL_FAILURE_WORDS):
+            terminal_status = "failed_or_error_observed"
+        if any(word in lowered for word in _TERMINAL_SUCCESS_WORDS):
+            terminal_status = "completed_or_passed_observed"
+        visible = _assistant_visible_message(event)
+        if visible:
+            visible_decisions.append(visible)
+            activity_counts["assistant_visible_decisions"] += 1
+    activities = _observable_activity(activity_counts)
+    status = terminal_status or ("activity_observed" if parsed_events else "no_observable_events")
+    return {
+        "schema_version": CODEX_PROGRESS_SCHEMA_VERSION,
+        "source": source,
+        "status": status,
+        "event_count": len(parsed_events),
+        "malformed_event_count": malformed_count,
+        "activity_counts": activity_counts,
+        "observable_activity": activities,
+        "assistant_visible_messages": visible_decisions[:3],
+        "latest_assistant_visible_message": visible_decisions[-1] if visible_decisions else "",
+        "chat_summary": _chat_summary(status, activities, visible_decisions),
+        "evidence_refs": _compact_list(evidence_refs or []),
+        "privacy": "summary_only",
+        "claim_boundary": (
+            "This is an observable Codex event summary. It is not raw JSONL, hidden reasoning, "
+            "review evidence, CI evidence, merge-readiness evidence, or merge evidence."
+        ),
+    }
+
+
+def build_codex_session_observation(
+    *,
+    selected_executor_profile: str,
+    external_session_ref: str = "",
+    codex_session_ref: str = "",
+    codex_thread_ref: str = "",
+    evidence_refs: list[str] | tuple[str, ...] | None = None,
+    progress_summary: dict[str, object] | None = None,
+) -> dict[str, object]:
+    if selected_executor_profile != "codex":
+        return {}
+    progress = progress_summary if isinstance(progress_summary, dict) else {}
+    session_ref = (codex_session_ref or external_session_ref).strip()
+    thread_ref = (codex_thread_ref or external_session_ref).strip()
+    observed = bool(session_ref or thread_ref or progress.get("event_count"))
+    resume = build_codex_resume_contract(session_ref)
+    return {
+        "schema_version": CODEX_SESSION_OBSERVATION_SCHEMA_VERSION,
+        "observed": observed,
+        "external_session_ref": external_session_ref.strip(),
+        "session_ref": session_ref,
+        "thread_ref": thread_ref,
+        "status": str(progress.get("status") or ("attached" if observed else "not_observed")),
+        "event_count": int(progress.get("event_count", 0) or 0),
+        "observable_activity": list(progress.get("observable_activity", [])) if isinstance(progress.get("observable_activity"), list) else [],
+        "latest_assistant_visible_message": str(progress.get("latest_assistant_visible_message", "")),
+        "evidence_refs": _compact_list([*(evidence_refs or []), *progress.get("evidence_refs", [])])
+        if isinstance(progress.get("evidence_refs", []), list)
+        else _compact_list(evidence_refs or []),
+        "resume": resume,
+        "claim_boundary": (
+            "Codex session references and event counts are observed wrapper metadata. They do not prove unrecorded "
+            "execution result, verification, review, CI, merge readiness, or merge."
+        ),
+    }
+
+
+def build_codex_resume_contract(session_ref: str) -> dict[str, object]:
+    available = bool(session_ref.strip())
+    argv = ["codex", "exec", "resume", session_ref.strip()] if available else []
+    return {
+        "schema_version": CODEX_RESUME_CONTRACT_SCHEMA_VERSION,
+        "available": available,
+        "argv_template": argv,
+        "shell_command_template": f"codex exec resume {_shell_quote(session_ref.strip())}" if available else "",
+        "execution_policy": "copyable_instruction_only",
+        "backend_action_owner": "wrapper",
+        "not_omh_backend_execution": True,
+        "claim_boundary": (
+            "The resume command is a wrapper/operator launch contract only. The wrapper backend does not launch Codex or "
+            "claim resumed work until it records observed session or result evidence."
+        ),
+    }
+
+
+def _safe_search_text(event: dict[str, Any]) -> str:
+    if _hidden_event(event):
+        return ""
+    parts: list[str] = []
+    _collect_safe_strings(event, parts)
+    return " ".join(parts)
+
+
+def _hidden_event(event: dict[str, Any]) -> bool:
+    for key in ("type", "event", "role"):
+        value = str(event.get(key, "")).casefold()
+        if any(hidden in value for hidden in _HIDDEN_KEYS):
+            return True
+    return False
+
+
+def _collect_safe_strings(value: Any, parts: list[str], *, parent_key: str = "") -> None:
+    if parent_key.casefold() in _HIDDEN_KEYS:
+        return
+    if isinstance(value, str):
+        parts.append(value[:500])
+        return
+    if isinstance(value, (int, float, bool)):
+        parts.append(str(value))
+        return
+    if isinstance(value, list):
+        for item in value[:20]:
+            _collect_safe_strings(item, parts, parent_key=parent_key)
+        return
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if str(key).casefold() in _HIDDEN_KEYS:
+                continue
+            parts.append(str(key))
+            _collect_safe_strings(item, parts, parent_key=str(key))
+
+
+def _assistant_visible_message(event: dict[str, Any]) -> str:
+    if _hidden_event(event):
+        return ""
+    event_type = str(event.get("type") or event.get("event") or event.get("role") or "").casefold()
+    if event_type not in _VISIBLE_MESSAGE_TYPES and str(event.get("role", "")).casefold() != "assistant":
+        return ""
+    if any(hidden in event_type for hidden in _HIDDEN_KEYS):
+        return ""
+    for key in ("message", "content", "text", "summary"):
+        if key in event and isinstance(event[key], str):
+            return _compact_visible_message(event[key])
+    payload = event.get("data")
+    if isinstance(payload, dict):
+        for key in ("message", "content", "text", "summary"):
+            if key in payload and isinstance(payload[key], str):
+                return _compact_visible_message(payload[key])
+    return ""
+
+
+def _compact_visible_message(value: str) -> str:
+    cleaned = re.sub(r"\s+", " ", value).strip()
+    if not cleaned:
+        return ""
+    if len(cleaned) <= _MAX_VISIBLE_MESSAGE:
+        return cleaned
+    return f"{cleaned[: _MAX_VISIBLE_MESSAGE - 1]}..."
+
+
+def _is_inspection_event(text: str) -> bool:
+    return any(token in text for token in ("read", "open", "grep", "rg ", "ripgrep", "sed ", "cat ", "ls ", "glob", "find", "inspect"))
+
+
+def _is_edit_event(text: str) -> bool:
+    return any(token in text for token in ("apply_patch", "patch", "write", "edit", "modified", "changed file", "diff"))
+
+
+def _is_test_event(text: str) -> bool:
+    return any(token in text for token in ("test", "pytest", "unittest", "compileall", "npm test", "cargo test", "go test", "uv run"))
+
+
+def _is_waiting_review_event(text: str) -> bool:
+    return any(token in text for token in ("waiting on review", "needs review", "review requested", "pull request", " pr ", "ci "))
+
+
+def _observable_activity(activity_counts: dict[str, int]) -> list[str]:
+    labels = []
+    if activity_counts.get("inspecting"):
+        labels.append("Codex is inspecting files/tests.")
+    if activity_counts.get("editing"):
+        labels.append("Codex changed files.")
+    if activity_counts.get("testing"):
+        labels.append("Codex is running tests.")
+    if activity_counts.get("waiting_review"):
+        labels.append("Codex is waiting on review.")
+    if activity_counts.get("assistant_visible_decisions"):
+        labels.append("Codex produced assistant-visible decision or status text.")
+    return labels
+
+
+def _chat_summary(status: str, activities: list[str], visible_decisions: list[str]) -> str:
+    if not activities and not visible_decisions:
+        return "No observable Codex activity was summarized."
+    parts = [*activities]
+    if visible_decisions:
+        parts.append(f"Codex decided via assistant-visible message: {visible_decisions[-1]}")
+    return " ".join(parts) + f" Status: {status}."
+
+
+def _compact_list(values: Any) -> list[str]:
+    if not isinstance(values, (list, tuple)):
+        return []
+    seen: list[str] = []
+    for value in values:
+        text = str(value).strip()
+        if text and text not in seen:
+            seen.append(text)
+    return seen
+
+
+def _shell_quote(value: str) -> str:
+    if not value:
+        return "''"
+    if re.fullmatch(r"[A-Za-z0-9_./:@+-]+", value):
+        return value
+    return "'" + value.replace("'", "'\"'\"'") + "'"

--- a/src/commands/chat.py
+++ b/src/commands/chat.py
@@ -5,7 +5,12 @@ import json
 import sys
 from pathlib import Path
 
-from ..codex_progress import build_codex_prompt_handling_contract, summarize_codex_jsonl_file, summarize_codex_jsonl_text
+from ..codex_progress import (
+    build_codex_prompt_handling_contract,
+    build_codex_review_summary,
+    summarize_codex_jsonl_file,
+    summarize_codex_jsonl_text,
+)
 from ..coding_delegation import CODING_EXECUTOR_TARGETS
 from ..ingress import CHAT_SOURCES, extract_message_text
 from ..installer import OmhError
@@ -268,7 +273,7 @@ def cmd_chat_session_open_executor(args: argparse.Namespace) -> int:
         )
     except FileNotFoundError as exc:
         raise OmhError(f"wrapper session not found: {args.session_id}") from exc
-    except (ExecutorSessionError, WrapperSessionError, ValueError) as exc:
+    except (OSError, ExecutorSessionError, WrapperSessionError, ValueError) as exc:
         raise OmhError(str(exc)) from exc
     return 0
 
@@ -290,7 +295,7 @@ def cmd_chat_session_attach_executor(args: argparse.Namespace) -> int:
         )
     except FileNotFoundError as exc:
         raise OmhError(f"wrapper session not found: {args.session_id}") from exc
-    except (ExecutorSessionError, WrapperSessionError, ValueError) as exc:
+    except (OSError, ExecutorSessionError, WrapperSessionError, ValueError) as exc:
         raise OmhError(str(exc)) from exc
     return 0
 
@@ -310,7 +315,7 @@ def cmd_chat_session_record_executor(args: argparse.Namespace) -> int:
         )
     except FileNotFoundError as exc:
         raise OmhError(f"wrapper session not found: {args.session_id}") from exc
-    except (ExecutorSessionError, WrapperSessionError, ValueError) as exc:
+    except (OSError, ExecutorSessionError, WrapperSessionError, ValueError) as exc:
         raise OmhError(str(exc)) from exc
     return 0
 
@@ -378,6 +383,31 @@ def cmd_chat_codex_progress(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_chat_codex_review(args: argparse.Namespace) -> int:
+    try:
+        progress = _codex_progress_from_args(args)
+        review = _codex_review_from_args(args, progress_summary=progress)
+        if review is None:
+            review = build_codex_review_summary(
+                progress_summary=progress,
+                codex_session_ref=args.codex_session_ref or "",
+                codex_thread_ref=args.codex_thread_ref or "",
+                external_session_ref=args.external_session_ref or "",
+                evidence_refs=args.evidence_ref or [],
+            )
+    except (OSError, ValueError) as exc:
+        raise OmhError(str(exc)) from exc
+    _print_json(
+        {
+            "schema_version": "codex_review_adapter/v1",
+            "codex_review": review,
+            "chat_summary": review.get("human_summary", ""),
+            "adapter_contract": review.get("adapter_contract", {}),
+        }
+    )
+    return 0
+
+
 def cmd_chat_codex_followup(args: argparse.Namespace) -> int:
     message = _chat_message(args)
     if not message:
@@ -407,6 +437,13 @@ def cmd_chat_codex_followup(args: argparse.Namespace) -> int:
                 "verification": executor_status.get("verification", ""),
             }
         evidence_refs = list(args.evidence_ref or [])
+        review_summary = _codex_review_from_args(
+            args,
+            progress_summary=progress,
+            codex_session_ref=session_ref,
+            codex_thread_ref=thread_ref,
+            external_session_ref=external_ref,
+        )
         payload = build_codex_prompt_handling_contract(
             new_prompt=message,
             progress_summary=progress,
@@ -416,6 +453,7 @@ def cmd_chat_codex_followup(args: argparse.Namespace) -> int:
             wrapper_session_id=args.session_id or "",
             same_goal=bool(args.same_goal),
             evidence_refs=evidence_refs,
+            codex_review_summary=review_summary,
         )
         if wrapper_session:
             payload["wrapper_session"] = wrapper_session
@@ -436,6 +474,40 @@ def _codex_progress_from_args(args: argparse.Namespace) -> dict[str, object] | N
     if log_ref:
         refs.append(log_ref)
     return summarize_codex_jsonl_file(Path(path), evidence_refs=refs)
+
+
+def _codex_review_from_args(
+    args: argparse.Namespace,
+    *,
+    progress_summary: dict[str, object] | None = None,
+    codex_session_ref: str = "",
+    codex_thread_ref: str = "",
+    external_session_ref: str = "",
+) -> dict[str, object] | None:
+    status = str(getattr(args, "codex_review_status", "") or "").strip()
+    summary = str(getattr(args, "codex_review_summary", "") or "").strip()
+    finding_count = getattr(args, "codex_review_finding_count", None)
+    reviewer = str(getattr(args, "codex_reviewer", "") or "codex")
+    if not status and not summary and finding_count is None:
+        return None
+    return build_codex_review_summary(
+        review_status=status or "not_observed",
+        reviewer=reviewer,
+        summary=summary,
+        finding_count=finding_count,
+        progress_summary=progress_summary,
+        codex_session_ref=codex_session_ref or str(getattr(args, "codex_session_ref", "") or ""),
+        codex_thread_ref=codex_thread_ref or str(getattr(args, "codex_thread_ref", "") or ""),
+        external_session_ref=external_session_ref or str(getattr(args, "external_session_ref", "") or ""),
+        evidence_refs=list(getattr(args, "evidence_ref", None) or []),
+    )
+
+
+def _add_codex_review_options(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--codex-review-status", default="", help="Observed Codex review status, such as passed or changes_requested.")
+    parser.add_argument("--codex-review-summary", default="", help="Human-readable Codex review summary; raw logs are not echoed.")
+    parser.add_argument("--codex-review-finding-count", type=int, default=None, help="Optional observed count of summarized Codex review findings.")
+    parser.add_argument("--codex-reviewer", default="codex", help="Observed reviewer label for the Codex review summary.")
 
 
 def _add_chat_commands(sub) -> None:
@@ -561,6 +633,19 @@ def _add_chat_commands(sub) -> None:
     codex_progress.add_argument("--evidence-ref", action="append", help="Evidence reference for the observed log/source.")
     codex_progress.set_defaults(func=cmd_chat_codex_progress)
 
+    codex_review = chat_sub.add_parser(
+        "codex-review",
+        help="Summarize observed Codex review context without raw logs or hidden reasoning.",
+    )
+    codex_review.add_argument("--external-session-ref", default="", help="Observed Codex thread/session reference from the wrapper.")
+    codex_review.add_argument("--codex-session-ref", default="", help="Observed Codex session id suitable for resume contracts.")
+    codex_review.add_argument("--codex-thread-ref", default="", help="Observed Codex thread/conversation reference when distinct from the session id.")
+    codex_review.add_argument("--codex-log-jsonl", default=None, help="Observed Codex JSONL/process output to summarize; raw events are not echoed.")
+    codex_review.add_argument("--codex-log-ref", default="", help="Evidence reference for the observed Codex log source.")
+    codex_review.add_argument("--evidence-ref", action="append", help="Evidence reference for the observed review/session/log/source.")
+    _add_codex_review_options(codex_review)
+    codex_review.set_defaults(func=cmd_chat_codex_review)
+
     codex_followup = chat_sub.add_parser(
         "codex-followup",
         help="Summarize active Codex progress and recommend safe handling for a new prompt.",
@@ -576,6 +661,7 @@ def _add_chat_commands(sub) -> None:
     codex_followup.add_argument("--codex-log-jsonl", default=None, help="Observed Codex JSONL/process output to summarize; raw events are not echoed.")
     codex_followup.add_argument("--codex-log-ref", default="", help="Evidence reference for the observed Codex log source.")
     codex_followup.add_argument("--evidence-ref", action="append", help="Evidence reference for the observed session/log/source.")
+    _add_codex_review_options(codex_followup)
     codex_followup.set_defaults(func=cmd_chat_codex_followup)
 
     session = chat_sub.add_parser("session")

--- a/src/commands/chat.py
+++ b/src/commands/chat.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
+from pathlib import Path
 
+from ..codex_progress import summarize_codex_jsonl_file, summarize_codex_jsonl_text
 from ..coding_delegation import CODING_EXECUTOR_TARGETS
 from ..ingress import CHAT_SOURCES, extract_message_text
 from ..installer import OmhError
@@ -222,6 +225,13 @@ def _add_render_profile_option(parser: argparse.ArgumentParser) -> None:
     )
 
 
+def _add_codex_observation_options(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--codex-session-ref", default="", help="Observed Codex session id suitable for resume contracts.")
+    parser.add_argument("--codex-thread-ref", default="", help="Observed Codex thread/conversation reference when distinct from the session id.")
+    parser.add_argument("--codex-log-jsonl", default=None, help="Observed Codex JSONL/process output to summarize; raw events are not echoed.")
+    parser.add_argument("--codex-log-ref", default="", help="Evidence reference for the observed Codex log source.")
+
+
 def cmd_chat_session_select_executor(args: argparse.Namespace) -> int:
     try:
         _print_json(select_wrapper_session_executor(_paths(args), args.session_id, args.executor))
@@ -242,6 +252,7 @@ def cmd_chat_session_status(args: argparse.Namespace) -> int:
 
 def cmd_chat_session_open_executor(args: argparse.Namespace) -> int:
     try:
+        codex_progress = _codex_progress_from_args(args)
         _print_json(
             open_executor_session(
                 _paths(args),
@@ -250,6 +261,9 @@ def cmd_chat_session_open_executor(args: argparse.Namespace) -> int:
                 external_session_ref=args.external_session_ref or "",
                 evidence_refs=args.evidence_ref or [],
                 summary=args.summary or "",
+                codex_session_ref=args.codex_session_ref or "",
+                codex_thread_ref=args.codex_thread_ref or "",
+                codex_progress_summary=codex_progress,
             )
         )
     except FileNotFoundError as exc:
@@ -261,6 +275,7 @@ def cmd_chat_session_open_executor(args: argparse.Namespace) -> int:
 
 def cmd_chat_session_attach_executor(args: argparse.Namespace) -> int:
     try:
+        codex_progress = _codex_progress_from_args(args)
         _print_json(
             attach_executor_session(
                 _paths(args),
@@ -268,6 +283,9 @@ def cmd_chat_session_attach_executor(args: argparse.Namespace) -> int:
                 external_session_ref=args.external_session_ref,
                 evidence_refs=args.evidence_ref or [],
                 summary=args.summary or "",
+                codex_session_ref=args.codex_session_ref or "",
+                codex_thread_ref=args.codex_thread_ref or "",
+                codex_progress_summary=codex_progress,
             )
         )
     except FileNotFoundError as exc:
@@ -279,6 +297,7 @@ def cmd_chat_session_attach_executor(args: argparse.Namespace) -> int:
 
 def cmd_chat_session_record_executor(args: argparse.Namespace) -> int:
     try:
+        codex_progress = _codex_progress_from_args(args)
         _print_json(
             record_executor_session_result(
                 _paths(args),
@@ -286,6 +305,7 @@ def cmd_chat_session_record_executor(args: argparse.Namespace) -> int:
                 result=args.result,
                 evidence_refs=args.evidence_ref or [],
                 summary=args.summary or "",
+                codex_progress_summary=codex_progress,
             )
         )
     except FileNotFoundError as exc:
@@ -331,6 +351,42 @@ def cmd_chat_native_command(args: argparse.Namespace) -> int:
     except ValueError as exc:
         raise OmhError(str(exc)) from exc
     return 0
+
+
+def cmd_chat_codex_progress(args: argparse.Namespace) -> int:
+    try:
+        if args.jsonl:
+            progress = summarize_codex_jsonl_file(args.jsonl, evidence_refs=args.evidence_ref or [])
+        else:
+            text = sys.stdin.read() if args.stdin else ""
+            progress = summarize_codex_jsonl_text(text, evidence_refs=args.evidence_ref or [], source="stdin")
+    except OSError as exc:
+        raise OmhError(str(exc)) from exc
+    _print_json(
+        {
+            "schema_version": "codex_progress_adapter/v1",
+            "progress": progress,
+            "chat_summary": progress.get("chat_summary", ""),
+            "adapter_contract": {
+                "purpose": "Turn raw Codex JSONL or process output into compact chat-safe progress/final summaries.",
+                "raw_events_exposed": False,
+                "hidden_reasoning_exposed": False,
+                "claim_boundary": progress.get("claim_boundary", ""),
+            },
+        }
+    )
+    return 0
+
+
+def _codex_progress_from_args(args: argparse.Namespace) -> dict[str, object] | None:
+    path = getattr(args, "codex_log_jsonl", None)
+    if not path:
+        return None
+    refs = list(getattr(args, "evidence_ref", None) or [])
+    log_ref = str(getattr(args, "codex_log_ref", "") or "").strip()
+    if log_ref:
+        refs.append(log_ref)
+    return summarize_codex_jsonl_file(Path(path), evidence_refs=refs)
 
 
 def _add_chat_commands(sub) -> None:
@@ -447,6 +503,15 @@ def _add_chat_commands(sub) -> None:
     )
     native_command.set_defaults(func=cmd_chat_native_command)
 
+    codex_progress = chat_sub.add_parser(
+        "codex-progress",
+        help="Summarize raw Codex JSONL or process output into compact chat-safe progress text.",
+    )
+    codex_progress.add_argument("--jsonl", default=None, help="Path to observed Codex JSONL or process output.")
+    codex_progress.add_argument("--stdin", action="store_true", help="Read observed Codex JSONL or process output from stdin.")
+    codex_progress.add_argument("--evidence-ref", action="append", help="Evidence reference for the observed log/source.")
+    codex_progress.set_defaults(func=cmd_chat_codex_progress)
+
     session = chat_sub.add_parser("session")
     session_sub = session.add_subparsers(dest="session_command", required=True)
 
@@ -514,6 +579,7 @@ def _add_chat_commands(sub) -> None:
     session_open_executor.add_argument("--external-session-ref", default="")
     session_open_executor.add_argument("--evidence-ref", action="append")
     session_open_executor.add_argument("--summary", default="")
+    _add_codex_observation_options(session_open_executor)
     session_open_executor.set_defaults(func=cmd_chat_session_open_executor)
 
     session_attach_executor = session_sub.add_parser("attach-executor")
@@ -521,6 +587,7 @@ def _add_chat_commands(sub) -> None:
     session_attach_executor.add_argument("--external-session-ref", required=True)
     session_attach_executor.add_argument("--evidence-ref", action="append")
     session_attach_executor.add_argument("--summary", default="")
+    _add_codex_observation_options(session_attach_executor)
     session_attach_executor.set_defaults(func=cmd_chat_session_attach_executor)
 
     session_record_executor = session_sub.add_parser("record-executor")
@@ -528,6 +595,8 @@ def _add_chat_commands(sub) -> None:
     session_record_executor.add_argument("--result", choices=("completed", "blocked", "failed"), required=True)
     session_record_executor.add_argument("--evidence-ref", action="append")
     session_record_executor.add_argument("--summary", default="")
+    session_record_executor.add_argument("--codex-log-jsonl", default=None, help="Observed Codex JSONL/process output to summarize; raw events are not echoed.")
+    session_record_executor.add_argument("--codex-log-ref", default="", help="Evidence reference for the observed Codex log source.")
     session_record_executor.set_defaults(func=cmd_chat_session_record_executor)
 
     session_request_verification = session_sub.add_parser("request-verification")

--- a/src/commands/chat.py
+++ b/src/commands/chat.py
@@ -5,7 +5,7 @@ import json
 import sys
 from pathlib import Path
 
-from ..codex_progress import summarize_codex_jsonl_file, summarize_codex_jsonl_text
+from ..codex_progress import build_codex_prompt_handling_contract, summarize_codex_jsonl_file, summarize_codex_jsonl_text
 from ..coding_delegation import CODING_EXECUTOR_TARGETS
 from ..ingress import CHAT_SOURCES, extract_message_text
 from ..installer import OmhError
@@ -378,6 +378,55 @@ def cmd_chat_codex_progress(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_chat_codex_followup(args: argparse.Namespace) -> int:
+    message = _chat_message(args)
+    if not message:
+        raise OmhError("codex-followup requires a new prompt")
+    try:
+        progress = _codex_progress_from_args(args)
+        session_ref = args.codex_session_ref or ""
+        thread_ref = args.codex_thread_ref or ""
+        external_ref = args.external_session_ref or ""
+        wrapper_session: dict[str, object] = {}
+        if args.session_id:
+            status = build_wrapper_session_status(_paths(args), args.session_id)
+            executor_status = status.get("executor_session_status", {}) if isinstance(status.get("executor_session_status"), dict) else {}
+            codex_session = executor_status.get("codex_session", {}) if isinstance(executor_status.get("codex_session"), dict) else {}
+            codex_progress = executor_status.get("codex_progress", {}) if isinstance(executor_status.get("codex_progress"), dict) else {}
+            session_ref = session_ref or str(codex_session.get("session_ref", ""))
+            thread_ref = thread_ref or str(codex_session.get("thread_ref", ""))
+            external_ref = external_ref or str(codex_session.get("external_session_ref", ""))
+            if progress is None and codex_progress:
+                progress = codex_progress
+            wrapper_session = {
+                "session_id": args.session_id,
+                "session_status": status.get("session_status", ""),
+                "executor_session": executor_status.get("executor_session", ""),
+                "dispatch": executor_status.get("dispatch", ""),
+                "result": executor_status.get("result", ""),
+                "verification": executor_status.get("verification", ""),
+            }
+        evidence_refs = list(args.evidence_ref or [])
+        payload = build_codex_prompt_handling_contract(
+            new_prompt=message,
+            progress_summary=progress,
+            codex_session_ref=session_ref,
+            codex_thread_ref=thread_ref,
+            external_session_ref=external_ref,
+            wrapper_session_id=args.session_id or "",
+            same_goal=bool(args.same_goal),
+            evidence_refs=evidence_refs,
+        )
+        if wrapper_session:
+            payload["wrapper_session"] = wrapper_session
+    except FileNotFoundError as exc:
+        raise OmhError(f"wrapper session not found: {args.session_id}") from exc
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        raise OmhError(str(exc)) from exc
+    _print_json(payload)
+    return 0
+
+
 def _codex_progress_from_args(args: argparse.Namespace) -> dict[str, object] | None:
     path = getattr(args, "codex_log_jsonl", None)
     if not path:
@@ -511,6 +560,23 @@ def _add_chat_commands(sub) -> None:
     codex_progress.add_argument("--stdin", action="store_true", help="Read observed Codex JSONL or process output from stdin.")
     codex_progress.add_argument("--evidence-ref", action="append", help="Evidence reference for the observed log/source.")
     codex_progress.set_defaults(func=cmd_chat_codex_progress)
+
+    codex_followup = chat_sub.add_parser(
+        "codex-followup",
+        help="Summarize active Codex progress and recommend safe handling for a new prompt.",
+    )
+    codex_followup.add_argument("message", nargs="*", help="New user prompt to handle without echoing raw text in the result.")
+    codex_followup.add_argument("--stdin", action="store_true", help="Read the new user prompt from stdin.")
+    codex_followup.add_argument("--event-json", default=None, help="Read a Slack/Discord/Hermes-like JSON event for the new prompt.")
+    codex_followup.add_argument("--session-id", default="", help="Existing wrapper session id that may already have observed Codex metadata.")
+    codex_followup.add_argument("--same-goal", action="store_true", help="Wrapper-observed assertion that the new prompt belongs to the same goal.")
+    codex_followup.add_argument("--external-session-ref", default="", help="Observed Codex thread/session reference from the wrapper.")
+    codex_followup.add_argument("--codex-session-ref", default="", help="Observed Codex session id suitable for resume contracts.")
+    codex_followup.add_argument("--codex-thread-ref", default="", help="Observed Codex thread/conversation reference when distinct from the session id.")
+    codex_followup.add_argument("--codex-log-jsonl", default=None, help="Observed Codex JSONL/process output to summarize; raw events are not echoed.")
+    codex_followup.add_argument("--codex-log-ref", default="", help="Evidence reference for the observed Codex log source.")
+    codex_followup.add_argument("--evidence-ref", action="append", help="Evidence reference for the observed session/log/source.")
+    codex_followup.set_defaults(func=cmd_chat_codex_followup)
 
     session = chat_sub.add_parser("session")
     session_sub = session.add_subparsers(dest="session_command", required=True)

--- a/src/commands/coding.py
+++ b/src/commands/coding.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -10,6 +11,8 @@ from ..executor_readiness import EXECUTOR_READINESS_PROFILES, probe_executor_rea
 from ..ingress import CHAT_SOURCES, extract_message_text, extract_source_metadata
 from ..installer import OmhError
 from ..memory import read_handoff_context_pack_file
+from ..routing.intent import META_OR_FEEDBACK_INTENTS, classify_workflow_intent
+from ..routing.localization import normalized_phrase, routing_tokens
 from ..runtime.artifacts import create_prepared_coding_delegation_run, write_coding_delegation
 from ..wrapper.lifecycle import (
     CodingLifecycleError,
@@ -48,8 +51,24 @@ def cmd_coding_delegate(args: argparse.Namespace) -> int:
             executor_target=_resolved_executor(args, default="generic"),
             context_pack=_context_pack(args),
         )
-        runtime_skip_reason = _coding_delegate_runtime_skip_reason(payload) if args.record else ""
+        runtime_skip_reason = ""
+        if args.record:
+            runtime_skip_reason = _coding_delegate_record_readiness_skip_reason(
+                message,
+                force_record=bool(args.force_record),
+            )
+            if not runtime_skip_reason:
+                runtime_skip_reason = _coding_delegate_runtime_skip_reason(payload)
+            if not runtime_skip_reason:
+                runtime_skip_reason = _coding_delegate_record_readiness_skip_reason(
+                    message,
+                    force_record=bool(args.force_record),
+                    require_dispatchable_requirements=True,
+                )
         if runtime_skip_reason:
+            if runtime_skip_reason == "requirements_or_dispatch_intent_missing":
+                payload["status"] = "blocked_requirements_missing"
+                payload["recorded"] = False
             payload["runtime"] = {
                 "recorded": False,
                 "reason": runtime_skip_reason,
@@ -101,13 +120,92 @@ def _coding_delegate_runtime_skip_reason(payload: dict[str, object]) -> str:
     return ""
 
 
+def _coding_delegate_record_readiness_skip_reason(
+    message: str,
+    *,
+    force_record: bool = False,
+    require_dispatchable_requirements: bool = False,
+) -> str:
+    intent = classify_workflow_intent(message)
+    if intent.missing_requirements_cues:
+        return "requirements_or_dispatch_intent_missing"
+    if intent.intent_class in META_OR_FEEDBACK_INTENTS and not intent.explicit_execution:
+        return "requirements_or_dispatch_intent_missing"
+    if require_dispatchable_requirements and (
+        not _coding_delegate_dispatch_intent_present(intent, force_record=force_record)
+        or not _coding_delegate_requirements_present(message)
+    ):
+        return "requirements_or_dispatch_intent_missing"
+    return ""
+
+
+def _coding_delegate_dispatch_intent_present(intent: object, *, force_record: bool = False) -> bool:
+    return bool(force_record or getattr(intent, "explicit_execution", False))
+
+
+_VAGUE_RECORD_TOKENS = frozenset(
+    {
+        "agent",
+        "code",
+        "codex",
+        "coding",
+        "cleanup",
+        "delegate",
+        "fix",
+        "handoff",
+        "implement",
+        "implementation",
+        "improve",
+        "maybe",
+        "pr",
+        "ready",
+        "refactor",
+        "request",
+        "review",
+        "risky",
+        "task",
+        "update",
+    }
+)
+
+
+def _coding_delegate_requirements_present(message: str) -> bool:
+    normalized = normalized_phrase(message)
+    tokens = set(routing_tokens(message, stopwords=set()))
+    concrete_tokens = {token for token in tokens if len(token) > 1 and token not in _VAGUE_RECORD_TOKENS}
+    if len(concrete_tokens) >= 2:
+        return True
+    if re.search(r"(?:src|tests|docs|\.github)/|[A-Za-z_][A-Za-z0-9_./-]*\.[A-Za-z0-9]+", message):
+        return True
+    concrete_phrases = (
+        "api",
+        "module",
+        "repo",
+        "auth",
+        "router",
+        "runtime",
+        "workflow",
+        "기능",
+        "이슈",
+        "변경",
+        "버그",
+        "라우팅",
+        "워크플로",
+    )
+    return any(phrase in normalized for phrase in concrete_phrases) and len(tokens) >= 3
+
+
 def _coding_delegate_record_status(reason: str) -> str:
+    if reason == "requirements_or_dispatch_intent_missing":
+        return "blocked_requirements_missing"
     if reason == "executor_choice_required":
         return "record_skipped_until_executor_selected"
     return "record_skipped"
 
 
 def _coding_delegate_record_notice(reason: str) -> str:
+    if reason == "requirements_or_dispatch_intent_missing":
+        return "Coding delegate record blocked until concrete requirements and explicit dispatch intent are present; no run was created."
     if reason == "executor_choice_required":
         return "Runtime record skipped until executor selected; no run was created."
     if reason == "prompt_only_handoff_is_wrapper_session_only":
@@ -120,6 +218,8 @@ def _coding_delegate_record_notice(reason: str) -> str:
 
 
 def _coding_delegate_record_next_action(reason: str) -> str:
+    if reason == "requirements_or_dispatch_intent_missing":
+        return "ask_requirements_or_prepare_plan"
     if reason == "executor_choice_required":
         return "select_executor_then_record"
     if reason == "prompt_only_handoff_is_wrapper_session_only":
@@ -261,6 +361,11 @@ def _add_coding_commands(sub) -> None:
         help="Include raw message and expanded delegation prompt in stdout for non-logging wrappers.",
     )
     delegate.add_argument("--record", action="store_true", help="Record a metadata-only coding delegation artifact under .omh/runtime.")
+    delegate.add_argument(
+        "--force-record",
+        action="store_true",
+        help="Override the meta/test readiness guard when an operator intentionally records a prepared Codex handoff.",
+    )
     delegate.add_argument(
         "--context-pack",
         default=None,

--- a/src/plugin_bundle/omh/awareness.py
+++ b/src/plugin_bundle/omh/awareness.py
@@ -4,6 +4,98 @@ import hashlib
 import re
 import unicodedata
 
+try:  # Keep installed plugin bundles usable even when the full package is absent.
+    from ...routing.intent import META_OR_FEEDBACK_INTENTS, classify_workflow_intent
+except ImportError:  # pragma: no cover - exercised by standalone plugin hosts.
+    from dataclasses import dataclass
+
+    META_OR_FEEDBACK_INTENTS = frozenset({"meta_discussion", "feedback_signal"})
+
+    @dataclass(frozen=True)
+    class _FallbackWorkflowIntent:
+        intent_class: str
+        explicit_execution: bool
+        mentioned_workflows: tuple[str, ...]
+        mentioned_runtime_terms: tuple[str, ...]
+        meta_cues: tuple[str, ...]
+        feedback_cues: tuple[str, ...]
+        missing_requirements_cues: tuple[str, ...]
+        routing_context: bool
+
+        @property
+        def not_executed(self) -> tuple[str, ...]:
+            if self.intent_class == "delivery_intent":
+                return ()
+            return (*self.mentioned_workflows, *self.mentioned_runtime_terms)
+
+    def classify_workflow_intent(message: str) -> _FallbackWorkflowIntent:
+        text = unicodedata.normalize("NFKC", message).casefold()
+        delivery_workflows = {
+            "ultraprocess",
+            "ralplan",
+            "ultragoal",
+            "loop",
+            "workflow-learning",
+            "code-review",
+            "team",
+            "ultrawork",
+            "ultraqa",
+        }
+        mentioned_workflows = tuple(
+            workflow for workflow in ROUTER_KEYWORD_SKILLS if workflow in text and workflow in delivery_workflows
+        )
+        runtime_terms = []
+        for term, label in (
+            ("codex", "Codex"),
+            ("coding handoff", "coding handoff"),
+            ("coding delegate", "coding delegate"),
+            ("one-cycle delivery", "one-cycle delivery"),
+            ("one cycle delivery", "one-cycle delivery"),
+        ):
+            if term in text and label not in runtime_terms:
+                runtime_terms.append(label)
+        meta_cues = tuple(
+            cue
+            for cue in ("test", "developer", "operator", "vocabulary", "route hint", "hud", "log", "trigger", "테스트", "개발자", "용어", "로그", "트리거", "오해")
+            if cue in text
+        )
+        feedback_cues = tuple(cue for cue in ("why", "wrong route", "missed route", "왜", "잘못", "오해", "누락") if cue in text)
+        missing = tuple(cue for cue in ("no requirements", "missing requirements", "요구사항은 없어", "요구사항 없음") if cue in text)
+        negated_execution = tuple(
+            cue
+            for cue in ("not asking to implement", "not asking for implementation", "not implement", "do not implement", "don't implement", "without implementation", "no implementation")
+            if cue in text
+        )
+        execution = tuple(
+            cue
+            for cue in ("implement", "make a pr", "open a pr", "dispatch", "delegate", "send to codex", "run ultraprocess", "구현", "pr 만들어", "codex로", "맡겨", "실행")
+            if cue in text and not (negated_execution and cue in {"implement", "구현"})
+        )
+        routing_context = any(
+            cue in text.split() or cue in text
+            for cue in ("routing", "route", "workflow", "handoff", "coding", "route hint", "coding handoff", "coding delegate", "라우팅", "워크플로", "코딩")
+        ) or " omh " in f" {text} "
+        specific_runtime_reference = any(term != "Codex" for term in runtime_terms)
+        workflow_or_specific_runtime = bool(mentioned_workflows or specific_runtime_reference)
+        if execution:
+            intent_class = "delivery_intent"
+        elif missing or (feedback_cues and (routing_context or workflow_or_specific_runtime)):
+            intent_class = "feedback_signal"
+        elif meta_cues and (routing_context or workflow_or_specific_runtime):
+            intent_class = "meta_discussion"
+        else:
+            intent_class = "unknown"
+        return _FallbackWorkflowIntent(
+            intent_class=intent_class,
+            explicit_execution=bool(execution),
+            mentioned_workflows=mentioned_workflows,
+            mentioned_runtime_terms=tuple(runtime_terms),
+            meta_cues=meta_cues,
+            feedback_cues=feedback_cues,
+            missing_requirements_cues=missing,
+            routing_context=routing_context,
+        )
+
 OMH_AWARENESS_SCHEMA_VERSION = "omh_awareness/v1"
 OMH_ROUTE_HINT_SCHEMA_VERSION = "omh_route_hint/v1"
 OMH_GENERIC_TOOL_CHECKPOINT_SCHEMA_VERSION = "omh_generic_tool_checkpoint/v1"
@@ -513,14 +605,21 @@ def awareness_route_hint(message: str, *, max_hints: int = 2) -> dict[str, objec
     normalized = unicodedata.normalize("NFKC", message).casefold()
     tokens = set(re.findall(r"[a-z0-9][a-z0-9_-]*", normalized))
     hint_limit = max(max_hints, 0)
+    intent = classify_workflow_intent(message)
     hints: list[dict[str, object]] = []
     if normalized.strip() and hint_limit:
+        if _prefers_workflow_learning_hint(intent):
+            hints.append(_workflow_vocabulary_reference_hint(intent))
         for rule in _ROUTE_HINT_RULES:
+            if _rule_suppressed_by_reference_intent(rule, intent):
+                continue
             phrase_matches = [phrase for phrase in rule["phrases"] if phrase in normalized]
             token_matches = [token for token in rule["tokens"] if token in tokens]
             if not phrase_matches and not token_matches:
                 continue
             workflow = str(rule["workflow"])
+            if workflow == "workflow-learning" and any(hint.get("workflow") == workflow for hint in hints):
+                continue
             context_card = workflow_context_card_for_workflow(workflow)
             hints.append(
                 {
@@ -540,12 +639,25 @@ def awareness_route_hint(message: str, *, max_hints: int = 2) -> dict[str, objec
             )
             if len(hints) >= hint_limit:
                 break
+    primary_workflow = str(hints[0]["workflow"]) if hints else ""
+    adjacent_workflows = _unique_strings(
+        str(item)
+        for hint in hints
+        if isinstance(hint, dict)
+        for item in hint.get("adjacent_workflows", [])
+    )
     return {
         "schema_version": OMH_ROUTE_HINT_SCHEMA_VERSION,
         "status": "hinted" if hints else "no_hint",
         "message_sha256": hashlib.sha256(message.encode("utf-8")).hexdigest() if message else "",
         "message_length": len(message),
-        "primary_workflow": str(hints[0]["workflow"]) if hints else "",
+        "intent_class": intent.intent_class,
+        "selected_workflow": primary_workflow,
+        "mentioned_workflows": list(intent.mentioned_workflows),
+        "mentioned_runtime_terms": list(intent.mentioned_runtime_terms),
+        "adjacent_workflows": adjacent_workflows,
+        "not_executed": list(intent.not_executed),
+        "primary_workflow": primary_workflow,
         "primary_next_action": str(hints[0]["next_action"]) if hints else "",
         "hints": hints,
         "privacy": {
@@ -565,16 +677,29 @@ def awareness_route_hint_context(message: str, *, max_hints: int = 2) -> str:
     payload = awareness_route_hint(message, max_hints=max_hints)
     if payload.get("status") != "hinted":
         return ""
+    adjacent_summary = ", ".join(str(item) for item in payload.get("adjacent_workflows", []))
+    mentioned_summary = ", ".join(str(item) for item in payload.get("mentioned_workflows", []))
+    not_executed_summary = ", ".join(str(item) for item in payload.get("not_executed", []))
     lines = [
         "[OMH Route Hint]",
         "Use this message-specific OMH hint before generic chat/tools when it fits the user intent.",
+        (
+            f"intent={payload.get('intent_class')}; selected={payload.get('selected_workflow')}; "
+            f"confidence=medium"
+        ),
     ]
+    if mentioned_summary:
+        lines.append(f"mentioned_workflows={mentioned_summary}.")
+    if adjacent_summary:
+        lines.append(f"adjacent_workflows={adjacent_summary}.")
+    if not_executed_summary:
+        lines.append(f"not_executed={not_executed_summary}.")
     for hint in payload["hints"]:
         if not isinstance(hint, dict):
             continue
         adjacent = ", ".join(str(item) for item in hint.get("adjacent_workflows", []))
         lines.append(
-            f"- workflow={hint.get('workflow')}; lane={hint.get('lane')}; "
+            f"- selected={hint.get('workflow')}; lane={hint.get('lane')}; "
             f"next_action={hint.get('next_action')}; reason={hint.get('reason')}"
         )
         context_card = hint.get("workflow_context_card")
@@ -939,6 +1064,59 @@ def _bounded_matches(matches: list[str]) -> list[str]:
             seen.append(value)
         if len(seen) >= 4:
             break
+    return seen
+
+
+def _prefers_workflow_learning_hint(intent: object) -> bool:
+    return (
+        getattr(intent, "intent_class", "") in META_OR_FEEDBACK_INTENTS
+        and not bool(getattr(intent, "explicit_execution", False))
+        and (
+            bool(getattr(intent, "mentioned_workflows", ()))
+            or bool(getattr(intent, "mentioned_runtime_terms", ()))
+            or bool(getattr(intent, "routing_context", False))
+        )
+    )
+
+
+def _workflow_vocabulary_reference_hint(intent: object) -> dict[str, object]:
+    workflow = "workflow-learning"
+    context_card = workflow_context_card_for_workflow(workflow)
+    next_action = "record_missed_route" if getattr(intent, "intent_class", "") == "feedback_signal" else "audit_learning_readiness"
+    matched_cues = list(getattr(intent, "feedback_cues", ())) + list(getattr(intent, "meta_cues", ()))
+    matched_cues.extend(getattr(intent, "mentioned_workflows", ()))
+    matched_cues.extend(getattr(intent, "mentioned_runtime_terms", ()))
+    return {
+        "id": "workflow_vocabulary_reference",
+        "workflow": workflow,
+        "lane": "automation_and_status",
+        "next_action": next_action,
+        "reason": "The message discusses OMH workflow or coding-handoff vocabulary rather than asking to execute it.",
+        "fallback_action": "record_learning_trace_or_prepare_route_review",
+        "matched_cues": _bounded_matches([str(item) for item in matched_cues]),
+        "adjacent_workflows": ["doctor", "agent-ops-review"],
+        "mentioned_workflows": list(getattr(intent, "mentioned_workflows", ())),
+        "mentioned_runtime_terms": list(getattr(intent, "mentioned_runtime_terms", ())),
+        "not_executed": list(getattr(intent, "not_executed", ())),
+        "workflow_context_card": context_card,
+        "not_evidence_yet": list(context_card.get("not_evidence_until_observed", []))
+        if isinstance(context_card, dict)
+        else [],
+    }
+
+
+def _rule_suppressed_by_reference_intent(rule: dict[str, object], intent: object) -> bool:
+    if not _prefers_workflow_learning_hint(intent):
+        return False
+    return str(rule.get("id", "")) == "coding_delivery"
+
+
+def _unique_strings(values: object) -> list[str]:
+    seen: list[str] = []
+    for item in values:
+        value = str(item).strip()
+        if value and value not in seen:
+            seen.append(value)
     return seen
 
 

--- a/src/routing/chat.py
+++ b/src/routing/chat.py
@@ -127,7 +127,8 @@ def route_chat_message(
     full_recommendations = recommend_skills(message, limit=len(definitions))
     explicit_skill = explicit_skill_invocation(message, definitions)
     task_card = classify_task(message)
-    if task_card and not explicit_skill:
+    task_card_overrides_explicit = _task_card_overrides_explicit_invocation(task_card)
+    if task_card and (not explicit_skill or task_card_overrides_explicit):
         full_recommendations = _prioritize_recommendation(full_recommendations, task_card_recommendation(task_card))
     catalog_question = is_skill_catalog_question(message)
     specific_catalog_match = (
@@ -146,7 +147,7 @@ def route_chat_message(
     ambiguous = _is_ambiguous(full_recommendations)
     file_or_text_lookup = is_file_or_text_lookup_question(message)
 
-    if explicit_skill:
+    if explicit_skill and not task_card_overrides_explicit:
         selected_skill = explicit_skill
         action = "dispatch"
         reason = "Explicit workflow invocation wins over heuristic routing."
@@ -216,10 +217,10 @@ def route_chat_message(
         selected_harness=selected_harness,
         candidate_skill=candidate_skill,
         candidate_harness=candidate_harness,
-        confidence="high" if explicit_skill else candidate_confidence,
-        score=max(candidate_score, 1) if explicit_skill else candidate_score,
+        confidence="high" if explicit_skill and not task_card_overrides_explicit else candidate_confidence,
+        score=max(candidate_score, 1) if explicit_skill and not task_card_overrides_explicit else candidate_score,
         threshold=min_confidence,
-        explicit=bool(explicit_skill),
+        explicit=bool(explicit_skill and not task_card_overrides_explicit),
         ambiguous=ambiguous,
         reason=reason,
         clarification=clarification,
@@ -228,6 +229,12 @@ def route_chat_message(
         recommendations=recommendations,
     )
     return decision.to_dict()
+
+
+def _task_card_overrides_explicit_invocation(task_card: dict[str, object] | None) -> bool:
+    if not isinstance(task_card, dict):
+        return False
+    return task_card.get("task_type") == "router_design_feedback"
 
 
 def route_chat_event(

--- a/src/routing/intent.py
+++ b/src/routing/intent.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass
+import re
 
 from .localization import normalized_phrase, routing_tokens
 
@@ -27,6 +28,10 @@ RUNTIME_VOCABULARY = {
 }
 META_OR_FEEDBACK_INTENTS = frozenset({"meta_discussion", "feedback_signal"})
 
+# These aliases preserve known English/Korean wrapper behavior. They are not a
+# multilingual understanding strategy, and new languages should not be added here
+# as an ever-growing keyword table. Prefer the structural cues below; broader
+# multilingual interpretation belongs in Hermes/LLM clarification or wrapper UX.
 _META_CUES = (
     "test",
     "testing",
@@ -134,6 +139,24 @@ _MISSING_REQUIREMENTS_CUES = (
     "요구사항 없음",
     "아직 요구사항",
 )
+_REFERENCE_CONTEXT_TOKENS = frozenset(
+    {
+        "context",
+        "hint",
+        "literal",
+        "log",
+        "ref",
+        "reference",
+        "route",
+        "routing",
+        "status",
+        "term",
+        "terminology",
+        "token",
+        "vocabulary",
+    }
+)
+_NEGATABLE_EXECUTION_CUES = frozenset(_EXECUTION_CUES)
 
 
 @dataclass(frozen=True)
@@ -142,6 +165,7 @@ class WorkflowIntent:
     explicit_execution: bool
     mentioned_workflows: tuple[str, ...]
     mentioned_runtime_terms: tuple[str, ...]
+    structural_cues: tuple[str, ...]
     meta_cues: tuple[str, ...]
     feedback_cues: tuple[str, ...]
     planning_cues: tuple[str, ...]
@@ -173,26 +197,42 @@ def classify_workflow_intent(message: str) -> WorkflowIntent:
 
     mentioned_workflows = _mentioned_workflows(normalized, tokens)
     mentioned_runtime_terms = _mentioned_runtime_terms(normalized)
+    structural_cues = _structural_cues(message, normalized, tokens)
     meta_cues = _matched_cues(_META_CUES, normalized, compact)
     feedback_cues = _matched_cues(_FEEDBACK_CUES, normalized, compact)
     planning_cues = _matched_cues(_PLANNING_CUES, normalized, compact)
-    negated_execution_cues = _matched_cues(_NEGATED_EXECUTION_CUES, normalized, compact)
+    negated_execution_cues = _compact_tuple(
+        (*_matched_cues(_NEGATED_EXECUTION_CUES, normalized, compact), *_structural_negated_execution_cues(normalized))
+    )
     execution_cues = _suppress_negated_execution_cues(
         _matched_cues(_EXECUTION_CUES, normalized, compact),
         negated_execution_cues,
     )
     missing_requirements_cues = _matched_cues(_MISSING_REQUIREMENTS_CUES, normalized, compact)
-    explicit_execution = bool(execution_cues or (_explicit_workflow_invocation(normalized, tokens) and not negated_execution_cues))
     routing_context = _routing_context(normalized, tokens)
 
     specific_runtime_reference = any(term != "Codex" for term in mentioned_runtime_terms)
     workflow_or_specific_runtime = bool(mentioned_workflows or specific_runtime_reference)
+    structural_reference = _structural_reference_context(
+        structural_cues,
+        workflow_or_specific_runtime=workflow_or_specific_runtime,
+        routing_context=routing_context,
+    )
+    explicit_workflow_marker = _explicit_workflow_invocation(normalized, tokens)
+    explicit_execution = bool(
+        execution_cues
+        or (
+            explicit_workflow_marker
+            and not negated_execution_cues
+            and not structural_reference
+        )
+    )
 
     if explicit_execution:
         intent_class = "delivery_intent"
     elif missing_requirements_cues or (feedback_cues and (routing_context or workflow_or_specific_runtime)):
         intent_class = "feedback_signal"
-    elif meta_cues and (routing_context or workflow_or_specific_runtime):
+    elif (meta_cues or structural_reference) and (routing_context or workflow_or_specific_runtime):
         intent_class = "meta_discussion"
     elif planning_cues:
         intent_class = "planning_request"
@@ -203,6 +243,7 @@ def classify_workflow_intent(message: str) -> WorkflowIntent:
         explicit_execution=explicit_execution,
         mentioned_workflows=mentioned_workflows,
         mentioned_runtime_terms=mentioned_runtime_terms,
+        structural_cues=structural_cues,
         meta_cues=meta_cues,
         feedback_cues=feedback_cues,
         planning_cues=planning_cues,
@@ -239,6 +280,56 @@ def _mentioned_runtime_terms(normalized: str) -> tuple[str, ...]:
     return tuple(mentioned)
 
 
+def _structural_cues(message: str, normalized: str, tokens: set[str]) -> tuple[str, ...]:
+    cues: list[str] = []
+    if _explicit_workflow_invocation(normalized, tokens):
+        cues.append("workflow_marker")
+    if _quoted_known_term_reference(message):
+        cues.append("quoted_known_term")
+    if tokens & _REFERENCE_CONTEXT_TOKENS:
+        cues.append("reference_context_token")
+    if _symbolic_negated_execution(normalized):
+        cues.append("symbolic_negated_execution")
+    if _routing_context(normalized, tokens):
+        cues.append("routing_context")
+    return tuple(cues)
+
+
+def _quoted_known_term_reference(message: str) -> bool:
+    normalized = normalized_phrase(message)
+    quoted_chunks = re.findall(r"[`\"']([^`\"']+)[`\"']", normalized)
+    if not quoted_chunks:
+        return False
+    known_terms = tuple(normalized_phrase(term) for term in (*WORKFLOW_VOCABULARY, *RUNTIME_VOCABULARY))
+    return any(any(term and term in chunk for term in known_terms) for chunk in quoted_chunks)
+
+
+def _structural_reference_context(
+    structural_cues: tuple[str, ...],
+    *,
+    workflow_or_specific_runtime: bool,
+    routing_context: bool,
+) -> bool:
+    cues = set(structural_cues)
+    if {"quoted_known_term", "symbolic_negated_execution"} & cues:
+        return True
+    return bool(
+        "reference_context_token" in cues
+        and workflow_or_specific_runtime
+        and (routing_context or "workflow_marker" in cues)
+    )
+
+
+def _structural_negated_execution_cues(normalized: str) -> tuple[str, ...]:
+    return ("symbolic_negated_execution",) if _symbolic_negated_execution(normalized) else ()
+
+
+def _symbolic_negated_execution(normalized: str) -> bool:
+    if "!=" not in normalized and "≠" not in normalized:
+        return False
+    return any(normalized_phrase(cue) in normalized for cue in _EXECUTION_CUES)
+
+
 def _matched_cues(cues: tuple[str, ...], normalized: str, compact: str) -> tuple[str, ...]:
     matches: list[str] = []
     for cue in cues:
@@ -250,13 +341,21 @@ def _matched_cues(cues: tuple[str, ...], normalized: str, compact: str) -> tuple
     return tuple(matches)
 
 
+def _compact_tuple(values: tuple[str, ...]) -> tuple[str, ...]:
+    seen: list[str] = []
+    for value in values:
+        if value and value not in seen:
+            seen.append(value)
+    return tuple(seen)
+
+
 def _suppress_negated_execution_cues(
     execution_cues: tuple[str, ...],
     negated_execution_cues: tuple[str, ...],
 ) -> tuple[str, ...]:
     if not negated_execution_cues:
         return execution_cues
-    return tuple(cue for cue in execution_cues if cue not in {"implement", "implementation", "구현", "구현해", "구현해줘"})
+    return tuple(cue for cue in execution_cues if cue not in _NEGATABLE_EXECUTION_CUES)
 
 
 def _explicit_workflow_invocation(normalized: str, tokens: set[str]) -> bool:

--- a/src/routing/intent.py
+++ b/src/routing/intent.py
@@ -1,0 +1,300 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+
+from .localization import normalized_phrase, routing_tokens
+
+
+WORKFLOW_VOCABULARY = (
+    "deep-interview",
+    "ralplan",
+    "ultragoal",
+    "loop",
+    "ultraprocess",
+    "workflow-learning",
+    "code-review",
+    "team",
+    "ultrawork",
+    "ultraqa",
+)
+RUNTIME_VOCABULARY = {
+    "codex": "Codex",
+    "coding handoff": "coding handoff",
+    "coding delegate": "coding delegate",
+    "one-cycle delivery": "one-cycle delivery",
+    "one cycle delivery": "one-cycle delivery",
+    "coding-agent": "coding-agent",
+}
+META_OR_FEEDBACK_INTENTS = frozenset({"meta_discussion", "feedback_signal"})
+
+_META_CUES = (
+    "test",
+    "testing",
+    "fixture",
+    "smoke test",
+    "developer",
+    "operator",
+    "meta",
+    "vocabulary",
+    "terminology",
+    "term",
+    "route hint",
+    "hud",
+    "log",
+    "trigger",
+    "not asking to implement",
+    "not asking for implementation",
+    "테스트",
+    "픽스처",
+    "개발자",
+    "운영자",
+    "용어",
+    "라우팅",
+    "라우터",
+    "로그",
+    "트리거",
+    "오해",
+    "설명",
+)
+_FEEDBACK_CUES = (
+    "why did",
+    "why is",
+    "why does",
+    "confusing",
+    "confused",
+    "wrong route",
+    "wrong workflow",
+    "misroute",
+    "misrouted",
+    "missed route",
+    "skipped omh",
+    "route this wrong",
+    "routing is wrong",
+    "왜",
+    "왜 뜨",
+    "잘못",
+    "오해",
+    "안 썼",
+    "누락",
+)
+_PLANNING_CUES = (
+    "plan",
+    "proposal",
+    "improvement",
+    "prepare a plan",
+    "planning",
+    "계획",
+    "개선안",
+    "제안",
+)
+_EXECUTION_CUES = (
+    "implement",
+    "implementation",
+    "make a pr",
+    "open a pr",
+    "prepare a pr",
+    "pr-ready",
+    "dispatch",
+    "delegate",
+    "send to codex",
+    "run ultraprocess",
+    "run $ultraprocess",
+    "execute",
+    "merge",
+    "구현",
+    "구현해",
+    "구현해줘",
+    "pr 만들어",
+    "pr까지",
+    "codex로",
+    "맡겨",
+    "보내",
+    "실행",
+)
+_NEGATED_EXECUTION_CUES = (
+    "not asking to implement",
+    "not asking for implementation",
+    "not implement",
+    "do not implement",
+    "don't implement",
+    "without implementation",
+    "no implementation",
+    "구현 요청 아님",
+    "구현하라는 뜻 아님",
+    "구현하지 말고",
+)
+_MISSING_REQUIREMENTS_CUES = (
+    "no requirements",
+    "without requirements",
+    "requirements are missing",
+    "missing requirements",
+    "no real requirements",
+    "요구사항은 없어",
+    "요구사항 없어",
+    "요구사항 없음",
+    "아직 요구사항",
+)
+
+
+@dataclass(frozen=True)
+class WorkflowIntent:
+    intent_class: str
+    explicit_execution: bool
+    mentioned_workflows: tuple[str, ...]
+    mentioned_runtime_terms: tuple[str, ...]
+    meta_cues: tuple[str, ...]
+    feedback_cues: tuple[str, ...]
+    planning_cues: tuple[str, ...]
+    execution_cues: tuple[str, ...]
+    missing_requirements_cues: tuple[str, ...]
+    routing_context: bool
+
+    def to_dict(self) -> dict[str, object]:
+        data = asdict(self)
+        for key, value in list(data.items()):
+            if isinstance(value, tuple):
+                data[key] = list(value)
+        data["not_executed"] = list(self.not_executed)
+        return data
+
+    @property
+    def not_executed(self) -> tuple[str, ...]:
+        if self.intent_class == "delivery_intent":
+            return ()
+        return (*self.mentioned_workflows, *self.mentioned_runtime_terms)
+
+
+def classify_workflow_intent(message: str) -> WorkflowIntent:
+    """Classify whether workflow vocabulary is a reference or execution intent."""
+    normalized = normalized_phrase(message)
+    tokens = set(routing_tokens(message, stopwords=set()))
+    tokens.update(normalized.split())
+    compact = normalized.replace(" ", "")
+
+    mentioned_workflows = _mentioned_workflows(normalized, tokens)
+    mentioned_runtime_terms = _mentioned_runtime_terms(normalized)
+    meta_cues = _matched_cues(_META_CUES, normalized, compact)
+    feedback_cues = _matched_cues(_FEEDBACK_CUES, normalized, compact)
+    planning_cues = _matched_cues(_PLANNING_CUES, normalized, compact)
+    negated_execution_cues = _matched_cues(_NEGATED_EXECUTION_CUES, normalized, compact)
+    execution_cues = _suppress_negated_execution_cues(
+        _matched_cues(_EXECUTION_CUES, normalized, compact),
+        negated_execution_cues,
+    )
+    missing_requirements_cues = _matched_cues(_MISSING_REQUIREMENTS_CUES, normalized, compact)
+    explicit_execution = bool(execution_cues or (_explicit_workflow_invocation(normalized, tokens) and not negated_execution_cues))
+    routing_context = _routing_context(normalized, tokens)
+
+    specific_runtime_reference = any(term != "Codex" for term in mentioned_runtime_terms)
+    workflow_or_specific_runtime = bool(mentioned_workflows or specific_runtime_reference)
+
+    if explicit_execution:
+        intent_class = "delivery_intent"
+    elif missing_requirements_cues or (feedback_cues and (routing_context or workflow_or_specific_runtime)):
+        intent_class = "feedback_signal"
+    elif meta_cues and (routing_context or workflow_or_specific_runtime):
+        intent_class = "meta_discussion"
+    elif planning_cues:
+        intent_class = "planning_request"
+    else:
+        intent_class = "unknown"
+    return WorkflowIntent(
+        intent_class=intent_class,
+        explicit_execution=explicit_execution,
+        mentioned_workflows=mentioned_workflows,
+        mentioned_runtime_terms=mentioned_runtime_terms,
+        meta_cues=meta_cues,
+        feedback_cues=feedback_cues,
+        planning_cues=planning_cues,
+        execution_cues=execution_cues,
+        missing_requirements_cues=missing_requirements_cues,
+        routing_context=routing_context,
+    )
+
+
+def is_workflow_meta_or_feedback(message: str) -> bool:
+    intent = classify_workflow_intent(message)
+    return intent.intent_class in META_OR_FEEDBACK_INTENTS and not intent.explicit_execution
+
+
+def has_missing_requirements_signal(message: str) -> bool:
+    return bool(classify_workflow_intent(message).missing_requirements_cues)
+
+
+def _mentioned_workflows(normalized: str, tokens: set[str]) -> tuple[str, ...]:
+    mentioned: list[str] = []
+    for workflow in WORKFLOW_VOCABULARY:
+        normalized_workflow = normalized_phrase(workflow)
+        if normalized_workflow in tokens or normalized_workflow in normalized:
+            mentioned.append(workflow)
+    return tuple(mentioned)
+
+
+def _mentioned_runtime_terms(normalized: str) -> tuple[str, ...]:
+    mentioned: list[str] = []
+    for term, label in RUNTIME_VOCABULARY.items():
+        normalized_term = normalized_phrase(term)
+        if normalized_term and normalized_term in normalized and label not in mentioned:
+            mentioned.append(label)
+    return tuple(mentioned)
+
+
+def _matched_cues(cues: tuple[str, ...], normalized: str, compact: str) -> tuple[str, ...]:
+    matches: list[str] = []
+    for cue in cues:
+        normalized_cue = normalized_phrase(cue)
+        if not normalized_cue:
+            continue
+        if normalized_cue in normalized or normalized_cue.replace(" ", "") in compact:
+            matches.append(cue)
+    return tuple(matches)
+
+
+def _suppress_negated_execution_cues(
+    execution_cues: tuple[str, ...],
+    negated_execution_cues: tuple[str, ...],
+) -> tuple[str, ...]:
+    if not negated_execution_cues:
+        return execution_cues
+    return tuple(cue for cue in execution_cues if cue not in {"implement", "implementation", "구현", "구현해", "구현해줘"})
+
+
+def _explicit_workflow_invocation(normalized: str, tokens: set[str]) -> bool:
+    for workflow in WORKFLOW_VOCABULARY:
+        if f"${workflow}" in normalized or f"/{workflow}" in normalized or f"./{workflow}" in normalized:
+            return True
+    return "dispatch" in tokens or "execute" in tokens
+
+
+def _routing_context(normalized: str, tokens: set[str]) -> bool:
+    context_tokens = {
+        "omh",
+        "oh-my-hermes",
+        "route",
+        "routing",
+        "router",
+        "workflow",
+        "workflows",
+        "handoff",
+        "coding",
+        "라우팅",
+        "라우터",
+        "워크플로",
+        "워크플로우",
+        "코딩",
+    }
+    context_phrases = {
+        "oh-my-hermes",
+        "route hint",
+        "handoff",
+        "coding handoff",
+        "coding delegate",
+        "one-cycle delivery",
+        "one cycle delivery",
+        "라우팅",
+        "라우터",
+        "워크플로",
+        "워크플로우",
+        "코딩",
+    }
+    return bool(tokens & context_tokens) or any(term in normalized for term in context_phrases)

--- a/src/routing/task_cards.py
+++ b/src/routing/task_cards.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from .localization import normalized_phrase, routing_tokens
+from .intent import META_OR_FEEDBACK_INTENTS, classify_workflow_intent
 
 
 TASK_CARD_SCHEMA_VERSION = "omh_task_card/v1"
@@ -99,8 +100,9 @@ def classify_task(message: str) -> dict[str, object] | None:
     compact = normalized.replace(" ", "")
     tokens = set(routing_tokens(message, stopwords=set()))
     tokens.update(normalized.split())
+    intent = classify_workflow_intent(message)
 
-    if _is_router_design_feedback(normalized, compact, tokens):
+    if _is_router_design_feedback(normalized, compact, tokens, intent):
         return _router_design_feedback_card()
     if _is_runtime_portability(normalized, compact, tokens):
         return _runtime_portability_card()
@@ -132,9 +134,40 @@ def _is_runtime_portability(normalized: str, compact: str, tokens: set[str]) -> 
     return _phrase_hit(("gateway", "bot", "responder", "게이트웨이", "봇", "응답자"), normalized, compact)
 
 
-def _is_router_design_feedback(normalized: str, compact: str, tokens: set[str]) -> bool:
+def _is_router_design_feedback(normalized: str, compact: str, tokens: set[str], intent: object) -> bool:
     phrase_hit = _phrase_hit(_ROUTER_DESIGN_CONTEXT_PHRASES, normalized, compact)
     if phrase_hit:
+        return True
+    if "missed route" in normalized or "workflow-learning" in normalized:
+        return False
+    if (
+        getattr(intent, "intent_class", "") in META_OR_FEEDBACK_INTENTS
+        and not bool(getattr(intent, "explicit_execution", False))
+        and (
+            bool(getattr(intent, "mentioned_workflows", ()))
+            or bool(getattr(intent, "mentioned_runtime_terms", ()))
+            or bool(getattr(intent, "missing_requirements_cues", ()))
+            or _phrase_hit(
+                (
+                    "route",
+                    "routing",
+                    "router",
+                    "workflow",
+                    "workflow route",
+                    "coding handoff",
+                    "coding delegate",
+                    "codex",
+                    "라우팅",
+                    "라우터",
+                    "워크플로",
+                    "워크플로우",
+                    "코딩 핸드오프",
+                ),
+                normalized,
+                compact,
+            )
+        )
+    ):
         return True
     if (
         _phrase_hit(("피드백",), normalized, compact)

--- a/src/wrapper/executor_sessions.py
+++ b/src/wrapper/executor_sessions.py
@@ -5,6 +5,7 @@ from json import JSONDecodeError
 from pathlib import Path
 from typing import Any
 
+from ..codex_progress import build_codex_session_observation
 from ..executors import CODING_EXECUTOR_TARGETS, executor_label
 from ..local_store import atomic_write_json, ensure_dir, ensure_file, read_json_object, utc_now
 from ..paths import OmhPaths
@@ -71,6 +72,8 @@ def build_executor_session_status(
     attached = bool(record.get("attached", False))
     status_blocker = record_error or linked_status_error or ""
     isolation_status = _isolation_status(paths, session, linked_status, runtime_status)
+    codex_session = record.get("codex_session", {}) if isinstance(record.get("codex_session"), dict) else {}
+    codex_progress = record.get("codex_progress", {}) if isinstance(record.get("codex_progress"), dict) else {}
     status = {
         "schema_version": EXECUTOR_SESSION_STATUS_SCHEMA_VERSION,
         "session_id": session_id,
@@ -101,6 +104,7 @@ def build_executor_session_status(
             f"dispatch: {'observed' if dispatch_observed else 'not_observed'}",
             f"result: {result_status}",
             f"verification: {verification_status}",
+            *_codex_status_lines(codex_session, codex_progress),
         ],
         "display_status_lines": _display_status_lines(
             executor=executor,
@@ -112,12 +116,18 @@ def build_executor_session_status(
             verification_status=verification_status,
             status_blocker=status_blocker,
             isolation_status=isolation_status,
+            codex_session=codex_session,
+            codex_progress=codex_progress,
         ),
         "claim_boundary": (
             "Executor session status is wrapper/operator metadata. It does not prove execution, "
             "result, verification, review, CI, or merge unless the matching observed evidence is recorded."
         ),
     }
+    if codex_session:
+        status["codex_session"] = codex_session
+    if codex_progress:
+        status["codex_progress"] = codex_progress
     if record_found and record.get("schema_version") == EXECUTOR_SESSION_SCHEMA_VERSION:
         status["record"] = record
     if record_error:
@@ -295,6 +305,9 @@ def open_executor_session(
     external_session_ref: str = "",
     evidence_refs: list[str] | tuple[str, ...] | None = None,
     summary: str = "",
+    codex_session_ref: str = "",
+    codex_thread_ref: str = "",
+    codex_progress_summary: dict[str, object] | None = None,
 ) -> dict[str, object]:
     if external_session_ref.strip() and not observed:
         raise ExecutorSessionError("open-executor --external-session-ref requires --observed")
@@ -310,6 +323,16 @@ def open_executor_session(
         "evidence_refs": list(evidence_refs or []),
         "summary": summary or _open_summary(session, observed=observed),
     }
+    patch.update(
+        _codex_observation_patch(
+            session,
+            external_session_ref=external_session_ref,
+            codex_session_ref=codex_session_ref,
+            codex_thread_ref=codex_thread_ref,
+            evidence_refs=evidence_refs or [],
+            progress_summary=codex_progress_summary,
+        )
+    )
     record = _build_executor_session_record(paths, session, patch)
     if observed:
         _observe_dispatch(paths, session, record, summary=summary, evidence_refs=list(evidence_refs or []))
@@ -325,24 +348,38 @@ def attach_executor_session(
     external_session_ref: str,
     evidence_refs: list[str] | tuple[str, ...] | None = None,
     summary: str = "",
+    codex_session_ref: str = "",
+    codex_thread_ref: str = "",
+    codex_progress_summary: dict[str, object] | None = None,
 ) -> dict[str, object]:
     if not external_session_ref.strip():
         raise ExecutorSessionError("attach-executor requires --external-session-ref")
     session = _existing_session(paths, session_id)
     _require_prepared_handoff(session)
     _require_no_observed_result(paths, session)
+    patch = {
+        "status": "running",
+        "open_action": "observed",
+        "attached": True,
+        "external_session_ref": external_session_ref,
+        "dispatch_observed": True,
+        "evidence_refs": list(evidence_refs or []),
+        "summary": summary or "Wrapper attached an observed executor session reference.",
+    }
+    patch.update(
+        _codex_observation_patch(
+            session,
+            external_session_ref=external_session_ref,
+            codex_session_ref=codex_session_ref,
+            codex_thread_ref=codex_thread_ref,
+            evidence_refs=evidence_refs or [],
+            progress_summary=codex_progress_summary,
+        )
+    )
     record = _build_executor_session_record(
         paths,
         session,
-        {
-            "status": "running",
-            "open_action": "observed",
-            "attached": True,
-            "external_session_ref": external_session_ref,
-            "dispatch_observed": True,
-            "evidence_refs": list(evidence_refs or []),
-            "summary": summary or "Wrapper attached an observed executor session reference.",
-        },
+        patch,
     )
     _observe_dispatch(paths, session, record, summary=summary, evidence_refs=list(evidence_refs or []))
     record = _write_executor_session(paths, record)
@@ -357,6 +394,7 @@ def record_executor_session_result(
     result: str,
     evidence_refs: list[str] | tuple[str, ...] | None = None,
     summary: str = "",
+    codex_progress_summary: dict[str, object] | None = None,
 ) -> dict[str, object]:
     if result not in {"completed", "blocked", "failed"}:
         raise ExecutorSessionError("executor result must be completed, blocked, or failed")
@@ -371,16 +409,31 @@ def record_executor_session_result(
     refs = list(evidence_refs or [])
     if str(session.get("current_run_id", "")):
         _record_codex_result_if_needed(paths, session, result=result, evidence_refs=refs)
+    patch = {
+        "status": result,
+        "result": result,
+        "result_observed": True,
+        "evidence_refs": refs,
+        "summary": summary or f"Wrapper recorded executor result: {result}.",
+    }
+    if isinstance(codex_progress_summary, dict):
+        patch["codex_progress"] = codex_progress_summary
+        patch["codex_session"] = build_codex_session_observation(
+            selected_executor_profile=_selected_executor(session, current),
+            external_session_ref=str(current.get("external_session_ref", "")),
+            codex_session_ref=str(current.get("codex_session", {}).get("session_ref", ""))
+            if isinstance(current.get("codex_session"), dict)
+            else "",
+            codex_thread_ref=str(current.get("codex_session", {}).get("thread_ref", ""))
+            if isinstance(current.get("codex_session"), dict)
+            else "",
+            evidence_refs=refs,
+            progress_summary=codex_progress_summary,
+        )
     record = _merge_executor_session(
         paths,
         session,
-        {
-            "status": result,
-            "result": result,
-            "result_observed": True,
-            "evidence_refs": refs,
-            "summary": summary or f"Wrapper recorded executor result: {result}.",
-        },
+        patch,
     )
     _append_executor_event(paths, session_id, f"executor_session_{result}", record)
     return {"schema_version": "executor_session_result/v1", "executor_session": record, "status": build_executor_session_status(paths, session)}
@@ -421,7 +474,7 @@ def enhance_chat_response_with_executor_session(
 ) -> dict[str, object]:
     updated = dict(response)
     state = dict(updated.get("state", {})) if isinstance(updated.get("state"), dict) else {}
-    state["executor_session_status"] = {
+    session_status = {
         "schema_version": executor_status.get("schema_version", EXECUTOR_SESSION_STATUS_SCHEMA_VERSION),
         "coding_agent": executor_status.get("coding_agent", ""),
         "executor_session": executor_status.get("executor_session", ""),
@@ -430,6 +483,13 @@ def enhance_chat_response_with_executor_session(
         "result": executor_status.get("result", ""),
         "verification": executor_status.get("verification", ""),
     }
+    codex_session = executor_status.get("codex_session")
+    if isinstance(codex_session, dict) and codex_session:
+        session_status["codex_session"] = codex_session
+    codex_progress = executor_status.get("codex_progress")
+    if isinstance(codex_progress, dict) and codex_progress:
+        session_status["codex_progress"] = codex_progress
+    state["executor_session_status"] = session_status
     updated["state"] = state
     actions = [action for action in updated.get("actions", []) if isinstance(action, dict)]
     action_ids = {str(action.get("id", "")) for action in actions}
@@ -456,6 +516,12 @@ def enhance_status_card_with_executor_session(
     updated = dict(status_card)
     updated["executor_session_status"] = _executor_status_summary(executor_status)
     updated["workspace_isolation"] = executor_status.get("workspace_isolation", {})
+    for key in ("codex_session", "codex_progress"):
+        value = executor_status.get(key)
+        if isinstance(value, dict) and value:
+            updated[key] = value
+        else:
+            updated.pop(key, None)
     updated["executor_status_lines"] = list(executor_status.get("status_lines", [])) if isinstance(executor_status.get("status_lines"), list) else []
     updated["executor_display_status_lines"] = (
         list(executor_status.get("display_status_lines", [])) if isinstance(executor_status.get("display_status_lines"), list) else []
@@ -577,6 +643,33 @@ def _build_executor_session_record(paths: OmhPaths, session: dict[str, Any], pat
     return merged
 
 
+def _codex_observation_patch(
+    session: dict[str, Any],
+    *,
+    external_session_ref: str,
+    codex_session_ref: str,
+    codex_thread_ref: str,
+    evidence_refs: list[str] | tuple[str, ...],
+    progress_summary: dict[str, object] | None,
+) -> dict[str, object]:
+    executor = str(session.get("selected_executor_profile") or "choose")
+    progress = progress_summary if isinstance(progress_summary, dict) else {}
+    observation = build_codex_session_observation(
+        selected_executor_profile=executor,
+        external_session_ref=external_session_ref,
+        codex_session_ref=codex_session_ref,
+        codex_thread_ref=codex_thread_ref,
+        evidence_refs=evidence_refs,
+        progress_summary=progress,
+    )
+    if not observation:
+        return {}
+    patch: dict[str, object] = {"codex_session": observation}
+    if progress:
+        patch["codex_progress"] = progress
+    return patch
+
+
 def _write_executor_session(paths: OmhPaths, record: dict[str, Any]) -> dict[str, Any]:
     atomic_write_json(_executor_session_path(paths, str(record["session_id"])), record, private=True)
     return record
@@ -602,6 +695,8 @@ def validate_executor_session_record(record: dict[str, Any]) -> list[str]:
         "verification_requested",
         "evidence_refs",
         "summary",
+        "codex_session",
+        "codex_progress",
         "claim_boundary",
     }
     extra = sorted(set(record) - allowed)
@@ -645,6 +740,9 @@ def validate_executor_session_record(record: dict[str, Any]) -> list[str]:
         for index, value in enumerate(record["evidence_refs"]):
             if not isinstance(value, str):
                 errors.append(f"executor_session evidence_refs[{index}] must be a string")
+    for key in ("codex_session", "codex_progress"):
+        if key in record and not isinstance(record.get(key), dict):
+            errors.append(f"executor_session {key} must be an object")
     if record.get("result") != "not_observed" and record.get("result_observed") is not True:
         errors.append("executor_session observed result requires result_observed=true")
     if record.get("verification") == "requested" and record.get("verification_requested") is not True:
@@ -945,6 +1043,7 @@ def _executor_launch_contract(
         "workspace_hint": _workspace_hint(isolation_status),
         "command_templates": templates,
         "copy_blocks": _launch_copy_blocks(label, prompt_placeholder, templates),
+        "resume_capability": _resume_capability_template(executor),
         "after_launch_backend_action": "open-executor",
         "observed_transition": "dispatch/open observed",
         "claim_boundary": (
@@ -976,6 +1075,13 @@ def _launch_command_templates(
                 "argv_template": ["codex", "--cd", workspace_placeholder, prompt_placeholder],
                 "shell_command_template": f"codex --cd {workspace_shell_placeholder} {shell_placeholder}",
                 "when_to_use": "Use when the wrapper knows the repository path and wants Codex rooted there.",
+            },
+            {
+                "id": "codex_resume_session",
+                "label": "Resume an observed Codex session",
+                "argv_template": ["codex", "exec", "resume", "{codex_session_ref}"],
+                "shell_command_template": "codex exec resume {codex_session_ref_shell_quoted}",
+                "when_to_use": "Use only after recorded status shows an observed Codex session_ref for this handoff or follow-up.",
             },
         ]
     if executor == "claude-code":
@@ -1028,6 +1134,28 @@ def _launch_copy_blocks(
             }
         )
     return blocks
+
+
+def _resume_capability_template(executor: str) -> dict[str, object]:
+    if executor != "codex":
+        return {
+            "available": False,
+            "reason": "Resume command template is only defined for Codex executor sessions.",
+        }
+    return {
+        "schema_version": "codex_resume_contract/v1",
+        "available": True,
+        "requires_observed_session_ref": True,
+        "argv_template": ["codex", "exec", "resume", "{codex_session_ref}"],
+        "shell_command_template": "codex exec resume {codex_session_ref_shell_quoted}",
+        "execution_policy": "copyable_instruction_only",
+        "backend_action_owner": "wrapper",
+        "not_omh_backend_execution": True,
+        "claim_boundary": (
+            "This is a resume-capable launch contract for wrappers. The wrapper backend does not run Codex or claim "
+            "resumed work until observed session or result evidence is recorded."
+        ),
+    }
 
 
 def _isolation_action(
@@ -1094,6 +1222,8 @@ def _display_status_lines(
     verification_status: str,
     status_blocker: str,
     isolation_status: dict[str, object],
+    codex_session: dict[str, object],
+    codex_progress: dict[str, object],
 ) -> list[str]:
     coding_agent_line = (
         "Coding agent is not selected yet."
@@ -1109,6 +1239,12 @@ def _display_status_lines(
         _result_display_line(result_status),
         _verification_display_line(verification_status),
     ]
+    if codex_session:
+        lines.append(_codex_session_display_line(codex_session))
+    if codex_progress:
+        summary = str(codex_progress.get("chat_summary", "")).strip()
+        if summary:
+            lines.append(f"Codex observable activity summary: {summary}")
     if status_blocker:
         lines.append(f"Action is blocked until OMH can read valid evidence: {status_blocker}")
     return lines
@@ -1152,6 +1288,32 @@ def _verification_display_line(verification_status: str) -> str:
     return "Hermes verification has not been requested yet."
 
 
+def _codex_session_display_line(codex_session: dict[str, object]) -> str:
+    session_ref = str(codex_session.get("session_ref", "")).strip()
+    thread_ref = str(codex_session.get("thread_ref", "")).strip()
+    event_count = int(codex_session.get("event_count", 0) or 0)
+    refs = []
+    if session_ref:
+        refs.append(f"session {session_ref}")
+    if thread_ref and thread_ref != session_ref:
+        refs.append(f"thread {thread_ref}")
+    ref_text = ", ".join(refs) if refs else "reference not recorded"
+    return f"Observed Codex metadata: {ref_text}; event summaries={event_count}."
+
+
+def _codex_status_lines(codex_session: dict[str, object], codex_progress: dict[str, object]) -> list[str]:
+    if not codex_session and not codex_progress:
+        return []
+    lines = []
+    if codex_session:
+        session_ref = str(codex_session.get("session_ref", "")).strip()
+        thread_ref = str(codex_session.get("thread_ref", "")).strip()
+        lines.append(f"codex-session: {'observed' if codex_session.get('observed') else 'not_observed'}({session_ref or thread_ref})")
+    if codex_progress:
+        lines.append(f"codex-progress: {codex_progress.get('status', 'unknown')}; events={codex_progress.get('event_count', 0)}")
+    return lines
+
+
 def _claim_boundary() -> str:
     return (
         "Executor session records are metadata-only wrapper/operator observations. "
@@ -1172,7 +1334,7 @@ def _action(action_id: str, label: str, style: str, *, enabled: bool = True, pay
 
 
 def _executor_status_summary(executor_status: dict[str, object]) -> dict[str, object]:
-    return {
+    summary = {
         "schema_version": executor_status.get("schema_version", EXECUTOR_SESSION_STATUS_SCHEMA_VERSION),
         "coding_agent": executor_status.get("coding_agent", ""),
         "executor_session": executor_status.get("executor_session", ""),
@@ -1182,6 +1344,13 @@ def _executor_status_summary(executor_status: dict[str, object]) -> dict[str, ob
         "result": executor_status.get("result", ""),
         "verification": executor_status.get("verification", ""),
     }
+    codex_session = executor_status.get("codex_session")
+    if isinstance(codex_session, dict) and codex_session:
+        summary["codex_session"] = codex_session
+    codex_progress = executor_status.get("codex_progress")
+    if isinstance(codex_progress, dict) and codex_progress:
+        summary["codex_progress"] = codex_progress
+    return summary
 
 
 def _next_executor_action(executor_status: dict[str, object]) -> str:

--- a/src/wrapper/route_hints.py
+++ b/src/wrapper/route_hints.py
@@ -23,7 +23,13 @@ def build_chat_route_hint_payload(
     generic_tool_checkpoint = _generic_tool_checkpoint()
     hints = [hint for hint in route_hint.get("hints", []) if isinstance(hint, dict)]
     primary_hint = hints[0] if hints else {}
-    response = _response_for_hint(primary_hint, hints, source=source, generic_tool_checkpoint=generic_tool_checkpoint)
+    response = _response_for_hint(
+        primary_hint,
+        hints,
+        route_hint=route_hint,
+        source=source,
+        generic_tool_checkpoint=generic_tool_checkpoint,
+    )
     payload: dict[str, object] = {
         "schema_version": CHAT_ROUTE_HINT_SCHEMA_VERSION,
         "source": source,
@@ -73,6 +79,7 @@ def _response_for_hint(
     primary_hint: dict[str, object],
     hints: list[dict[str, object]],
     *,
+    route_hint: dict[str, object],
     source: str,
     generic_tool_checkpoint: dict[str, object],
 ) -> dict[str, object]:
@@ -162,6 +169,12 @@ def _response_for_hint(
                 "schema_version": "omh_route_hint/v1",
                 "primary_workflow": workflow,
                 "primary_next_action": next_action,
+                "intent_class": str(route_hint.get("intent_class") or ""),
+                "selected_workflow": str(route_hint.get("selected_workflow") or workflow),
+                "mentioned_workflows": list(route_hint.get("mentioned_workflows", [])),
+                "mentioned_runtime_terms": list(route_hint.get("mentioned_runtime_terms", [])),
+                "adjacent_workflows": list(route_hint.get("adjacent_workflows", [])),
+                "not_executed": list(route_hint.get("not_executed", [])),
                 "hints": hints,
             },
         },

--- a/tests/test_chat_router.py
+++ b/tests/test_chat_router.py
@@ -13,6 +13,7 @@ from omh.chat_router import (
     route_chat_message,
     routing_record_payload,
 )
+from omh.routing.intent import classify_workflow_intent
 from omh.skills.catalog import primary_harness_for_skill
 
 
@@ -332,6 +333,7 @@ class ChatRouterTests(unittest.TestCase):
             "가상 프로젝트로 OMH 라우팅을 테스트해보자. 아직 요구사항은 없어.",
             "OMH developer note: one-cycle delivery is only vocabulary in this setup test.",
             "OMH developer test: Codex handoff vocabulary, not asking to implement.",
+            "OMH route: `$ultraprocess` ≠ ejecutar; Codex handoff token only.",
         )
 
         for message in cases:
@@ -345,6 +347,20 @@ class ChatRouterTests(unittest.TestCase):
                 self.assertEqual(task_card["task_type"], "router_design_feedback")
                 self.assertFalse(decision["explicit"])
                 self.assertNotEqual(decision["selected_skill"], "ultraprocess")
+
+    def test_workflow_intent_prefers_structural_cues_over_language_tables(self) -> None:
+        intent = classify_workflow_intent("OMH route: `$ultraprocess` ≠ ejecutar; Codex handoff token only.")
+
+        self.assertEqual(intent.intent_class, "meta_discussion")
+        self.assertFalse(intent.explicit_execution)
+        self.assertIn("quoted_known_term", intent.structural_cues)
+        self.assertIn("reference_context_token", intent.structural_cues)
+        self.assertIn("ultraprocess", intent.not_executed)
+        self.assertIn("Codex", intent.not_executed)
+
+        delivery = classify_workflow_intent("$ultraprocess implement this change")
+        self.assertEqual(delivery.intent_class, "delivery_intent")
+        self.assertTrue(delivery.explicit_execution)
 
     def test_generic_korean_omh_feedback_does_not_become_router_design_card(self) -> None:
         decision = route_chat_message("피드백인데 OMH 문서가 좋아요.", source="discord")

--- a/tests/test_chat_router.py
+++ b/tests/test_chat_router.py
@@ -324,6 +324,28 @@ class ChatRouterTests(unittest.TestCase):
                 self.assertNotEqual(decision["selected_skill"], "feedback-triage")
                 self.assertIn("task_card:router_design_feedback", decision["recommendations"][0]["matched"])
 
+    def test_workflow_vocabulary_meta_discussion_does_not_select_delivery(self) -> None:
+        cases = (
+            "왜 ultraprocess 로그가 떠?",
+            "ultraprocess 용어를 테스트해보자",
+            "Codex handoff라는 용어를 쓰면 라우팅이 오해되는 것 같아.",
+            "가상 프로젝트로 OMH 라우팅을 테스트해보자. 아직 요구사항은 없어.",
+            "OMH developer note: one-cycle delivery is only vocabulary in this setup test.",
+            "OMH developer test: Codex handoff vocabulary, not asking to implement.",
+        )
+
+        for message in cases:
+            with self.subTest(message=message):
+                decision = route_chat_message(message, source="discord")
+                task_card = decision["task_card"]
+
+                self.assertEqual(decision["action"], "dispatch")
+                self.assertEqual(decision["selected_skill"], "workflow-learning")
+                self.assertEqual(decision["selected_harness"], "workflow-learning")
+                self.assertEqual(task_card["task_type"], "router_design_feedback")
+                self.assertFalse(decision["explicit"])
+                self.assertNotEqual(decision["selected_skill"], "ultraprocess")
+
     def test_generic_korean_omh_feedback_does_not_become_router_design_card(self) -> None:
         decision = route_chat_message("피드백인데 OMH 문서가 좋아요.", source="discord")
 
@@ -398,6 +420,7 @@ class ChatRouterTests(unittest.TestCase):
             "웹서치해서 최신 자료와 출처 정리해줘",
             "search the web for current sources and citations",
             "查一下最新资料和来源",
+            "web-research로 Hermes Agent와 Oh My Codex/OpenCode 계열을 비교해서 OMHM 포지셔닝 근거를 찾아줘.",
         )
 
         for message in cases:
@@ -418,6 +441,7 @@ class ChatRouterTests(unittest.TestCase):
             "every morning competitor research then prepare a PR",
             "codex로 이 기능 구현 맡겨줘",
             "이 이슈를 Codex로 구현하게 맡기고 진행상태 추적해줘",
+            "$ultraprocess로 이 repo 변경을 PR-ready까지 준비해줘",
         )
 
         for message in cases:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -98,7 +98,7 @@ class CliTests(unittest.TestCase):
         self.assertEqual(payload["source"], "discord")
         self.assertEqual(payload["route_hint"]["primary_workflow"], "img-summary")
         self.assertEqual(payload["route_hint"]["primary_next_action"], "prepare_visual_prompt_card")
-        self.assertIn("workflow=img-summary", payload["prompt_context"])
+        self.assertIn("selected=img-summary", payload["prompt_context"])
         self.assertIn("generic tool can render", payload["normal_response_contract"]["when_generic_tool_is_available"])
         self.assertFalse(payload["message"]["raw_prompt_echoed"])
         self.assertFalse(payload["message"]["raw_prompt_stored"])
@@ -3788,7 +3788,7 @@ class CliTests(unittest.TestCase):
         payload = json.loads(stdout)
         self.assertEqual(payload["route_hint"]["primary_workflow"], "workflow-learning")
         self.assertIn("[OMH Route Hint]", payload["prompt_context"])
-        self.assertIn("workflow=workflow-learning", payload["prompt_context"])
+        self.assertIn("selected=workflow-learning", payload["prompt_context"])
         self.assertIn("Prompt context is for Hermes routing guidance only", payload["prompt_context_boundary"])
 
     def test_chat_route_file_lookup_does_not_emit_workflow_clarification(self) -> None:
@@ -5363,7 +5363,7 @@ class CliTests(unittest.TestCase):
             root = Path(tmp)
             omh_home = root / ".omh"
             hermes_home = root / ".hermes"
-            hostile = "refactor api; rm -rf / # nope"
+            hostile = "implement cleanup of duplicated routing code in src/routing/policy.py with secret-token-123"
 
             status, stdout, stderr = run_cli(
                 [
@@ -5405,6 +5405,133 @@ class CliTests(unittest.TestCase):
             self.assertEqual(shown["coding_delegation"]["executor_handoff"]["executor_target"], "codex")
             self.assertNotIn(hostile, json.dumps(shown["coding_delegation"]))
 
+    def test_coding_delegate_record_blocks_meta_vocabulary_without_runtime_mutation(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / ".omh"
+            hermes_home = root / ".hermes"
+            message = (
+                "OMH developer test: Codex coding handoff and ultraprocess one-cycle delivery "
+                "are vocabulary only; no requirements yet."
+            )
+
+            status, stdout, stderr = run_cli(
+                [
+                    "--omh-home",
+                    str(omh_home),
+                    "--hermes-home",
+                    str(hermes_home),
+                    "coding",
+                    "delegate",
+                    "--record",
+                    "--executor",
+                    "codex",
+                    "--source",
+                    "discord",
+                    message,
+                ]
+            )
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            payload = json.loads(stdout)
+            self.assertEqual(payload["schema_version"], "coding_delegation/v1")
+            self.assertEqual(payload["status"], "blocked_requirements_missing")
+            self.assertFalse(payload["recorded"])
+            self.assertEqual(payload["runtime"]["recorded"], False)
+            self.assertEqual(payload["runtime"]["reason"], "requirements_or_dispatch_intent_missing")
+            self.assertEqual(payload["runtime"]["run_created"], False)
+            self.assertEqual(payload["runtime"]["record_status"], "blocked_requirements_missing")
+            self.assertEqual(payload["runtime"]["next_action"], "ask_requirements_or_prepare_plan")
+            self.assertFalse((omh_home / "runtime" / "runs").exists())
+
+            status, stdout, stderr = run_cli(
+                ["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "hud", "--json"]
+            )
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            hud = json.loads(stdout)
+            self.assertNotIn("coding-agent:prepared(codex)", hud["display"]["line"])
+            self.assertEqual(hud["runtime"]["evidence_state"], "idle")
+
+            forced_home = root / ".omh-forced"
+            status, stdout, stderr = run_cli(
+                [
+                    "--omh-home",
+                    str(forced_home),
+                    "--hermes-home",
+                    str(hermes_home),
+                    "coding",
+                    "delegate",
+                    "--record",
+                    "--force-record",
+                    "--executor",
+                    "codex",
+                    "--source",
+                    "discord",
+                    message,
+                ]
+            )
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            forced = json.loads(stdout)
+            self.assertEqual(forced["status"], "blocked_requirements_missing")
+            self.assertEqual(forced["runtime"]["reason"], "requirements_or_dispatch_intent_missing")
+            self.assertFalse((forced_home / "runtime" / "runs").exists())
+
+            vague_home = root / ".omh-vague"
+            status, stdout, stderr = run_cli(
+                [
+                    "--omh-home",
+                    str(vague_home),
+                    "--hermes-home",
+                    str(hermes_home),
+                    "coding",
+                    "delegate",
+                    "--record",
+                    "--executor",
+                    "codex",
+                    "--source",
+                    "discord",
+                    "risky refactor",
+                ]
+            )
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            vague = json.loads(stdout)
+            self.assertEqual(vague["status"], "blocked_requirements_missing")
+            self.assertEqual(vague["runtime"]["reason"], "requirements_or_dispatch_intent_missing")
+            self.assertFalse((vague_home / "runtime" / "runs").exists())
+
+            forced_vague_home = root / ".omh-vague-forced"
+            status, stdout, stderr = run_cli(
+                [
+                    "--omh-home",
+                    str(forced_vague_home),
+                    "--hermes-home",
+                    str(hermes_home),
+                    "coding",
+                    "delegate",
+                    "--record",
+                    "--force-record",
+                    "--executor",
+                    "codex",
+                    "--source",
+                    "discord",
+                    "risky refactor",
+                ]
+            )
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            vague = json.loads(stdout)
+            self.assertEqual(vague["status"], "blocked_requirements_missing")
+            self.assertEqual(vague["runtime"]["reason"], "requirements_or_dispatch_intent_missing")
+            self.assertFalse((forced_vague_home / "runtime" / "runs").exists())
+
     def test_runtime_delegation_status_summarizes_prepared_codex_handoff(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -5422,8 +5549,7 @@ class CliTests(unittest.TestCase):
                     "--record",
                     "--executor",
                     "codex",
-                    "risky",
-                    "refactor",
+                    "implement risky status migration in src/runtime/status.py",
                 ]
             )
 
@@ -5492,8 +5618,7 @@ class CliTests(unittest.TestCase):
                     "--record",
                     "--executor",
                     "codex",
-                    "risky",
-                    "refactor",
+                    "implement risky status migration in src/runtime/status.py",
                 ]
             )
             self.assertEqual(status, 0)
@@ -5758,8 +5883,7 @@ class CliTests(unittest.TestCase):
                     "--record",
                     "--executor",
                     "codex",
-                    "risky",
-                    "refactor",
+                    "implement status badge in src/runtime/status.py",
                 ]
             )
             self.assertEqual(stderr, "")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5235,6 +5235,86 @@ class CliTests(unittest.TestCase):
             self.assertEqual(status, 0)
             self.assertEqual(json.loads(stdout)["status"]["verification"], "requested")
 
+    def test_chat_codex_progress_sanitizes_logs_and_session_status_exposes_resume(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            home_args = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+            raw_log = "\n".join(
+                [
+                    json.dumps({"type": "tool_call", "tool": "rg", "args": "rg codex tests"}),
+                    json.dumps({"type": "tool_call", "tool": "apply_patch", "message": "modified src/codex_progress.py"}),
+                    json.dumps({"type": "reasoning", "analysis": "do not expose hidden reasoning"}),
+                    json.dumps({"role": "assistant", "content": "I changed files and will run tests."}),
+                ]
+            )
+            log_path = root / "codex.jsonl"
+            log_path.write_text(raw_log, encoding="utf-8")
+
+            status, stdout, stderr = run_cli(home_args + ["chat", "codex-progress", "--stdin", "--evidence-ref", "codex-raw"], stdin_text=raw_log)
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            progress = json.loads(stdout)
+            self.assertEqual(progress["schema_version"], "codex_progress_adapter/v1")
+            self.assertFalse(progress["adapter_contract"]["raw_events_exposed"])
+            self.assertFalse(progress["adapter_contract"]["hidden_reasoning_exposed"])
+            self.assertIn("Codex changed files.", progress["chat_summary"])
+            self.assertNotIn("do not expose hidden reasoning", json.dumps(progress))
+
+            message = "risky refactor"
+            status, stdout, stderr = run_cli(
+                home_args
+                + [
+                    "chat",
+                    "session",
+                    "start",
+                    "--source",
+                    "discord",
+                    "--source-event-id",
+                    "m1",
+                    "--channel-ref",
+                    "c1",
+                    message,
+                ]
+            )
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            session_id = json.loads(stdout)["session"]["session_id"]
+            self.assertEqual(run_cli(home_args + ["chat", "session", "accept-plan", session_id])[0], 0)
+            self.assertEqual(run_cli(home_args + ["chat", "session", "select-executor", session_id, "codex"])[0], 0)
+            self.assertEqual(run_cli(home_args + ["chat", "session", "prepare-handoff", session_id, message])[0], 0)
+
+            status, stdout, stderr = run_cli(
+                home_args
+                + [
+                    "chat",
+                    "session",
+                    "open-executor",
+                    session_id,
+                    "--observed",
+                    "--external-session-ref",
+                    "codex-thread-1",
+                    "--codex-session-ref",
+                    "codex-session-1",
+                    "--codex-thread-ref",
+                    "codex-thread-1",
+                    "--codex-log-jsonl",
+                    str(log_path),
+                    "--codex-log-ref",
+                    "codex-jsonl",
+                ]
+            )
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            opened = json.loads(stdout)
+            codex_session = opened["status"]["codex_session"]
+            self.assertEqual(codex_session["session_ref"], "codex-session-1")
+            self.assertEqual(codex_session["thread_ref"], "codex-thread-1")
+            self.assertEqual(codex_session["resume"]["argv_template"], ["codex", "exec", "resume", "codex-session-1"])
+            self.assertEqual(opened["status"]["codex_progress"]["event_count"], 4)
+            self.assertIn("Codex changed files.", opened["status"]["codex_progress"]["observable_activity"])
+            self.assertEqual(opened["status"]["result"], "not_observed")
+            self.assertEqual(opened["status"]["verification"], "not_requested")
+
     def test_runtime_observe_rejects_plain_workflow_run_without_runtime_handoff(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5315,6 +5315,37 @@ class CliTests(unittest.TestCase):
             self.assertEqual(opened["status"]["result"], "not_observed")
             self.assertEqual(opened["status"]["verification"], "not_requested")
 
+            follow_up_prompt = "continue the same PR with a small follow-up"
+            status, stdout, stderr = run_cli(
+                home_args
+                + [
+                    "chat",
+                    "codex-followup",
+                    "--session-id",
+                    session_id,
+                    "--codex-log-jsonl",
+                    str(log_path),
+                    "--codex-log-ref",
+                    "codex-jsonl",
+                    follow_up_prompt,
+                ]
+            )
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            followup = json.loads(stdout)
+            self.assertEqual(followup["schema_version"], "codex_prompt_handling_contract/v1")
+            self.assertEqual(followup["recommendation"]["action"], "append_followup_to_observed_codex_session")
+            self.assertEqual(followup["resume"]["argv_template"], ["codex", "exec", "resume", "codex-session-1"])
+            self.assertEqual(followup["active_codex"]["latest_progress"]["event_count"], 4)
+            self.assertFalse(followup["adapter_contract"]["raw_logs_exposed"])
+            self.assertFalse(followup["adapter_contract"]["hidden_reasoning_exposed"])
+            self.assertNotIn(follow_up_prompt, json.dumps(followup))
+
+            status, stdout, stderr = run_cli(home_args + ["chat", "codex-followup", "separate task"])
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            self.assertEqual(json.loads(stdout)["recommendation"]["action"], "route_new_or_clarify")
+
     def test_runtime_observe_rejects_plain_workflow_run_without_runtime_handoff(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5260,6 +5260,11 @@ class CliTests(unittest.TestCase):
             self.assertIn("Codex changed files.", progress["chat_summary"])
             self.assertNotIn("do not expose hidden reasoning", json.dumps(progress))
 
+            status, stdout, stderr = run_cli(home_args + ["chat", "codex-progress", "--jsonl", str(root / "missing.jsonl")])
+            self.assertNotEqual(status, 0)
+            self.assertEqual(stdout, "")
+            self.assertIn("missing.jsonl", stderr)
+
             message = "risky refactor"
             status, stdout, stderr = run_cli(
                 home_args
@@ -5315,6 +5320,42 @@ class CliTests(unittest.TestCase):
             self.assertEqual(opened["status"]["result"], "not_observed")
             self.assertEqual(opened["status"]["verification"], "not_requested")
 
+            status, stdout, stderr = run_cli(
+                home_args
+                + [
+                    "chat",
+                    "codex-review",
+                    "--codex-session-ref",
+                    "codex-session-1",
+                    "--codex-thread-ref",
+                    "codex-thread-1",
+                    "--codex-log-jsonl",
+                    str(log_path),
+                    "--codex-log-ref",
+                    "codex-jsonl",
+                    "--evidence-ref",
+                    "codex-review-summary",
+                    "--codex-review-status",
+                    "changes_requested",
+                    "--codex-review-summary",
+                    "Codex review found one bounded issue for the executor to fix.",
+                    "--codex-review-finding-count",
+                    "1",
+                ]
+            )
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            review = json.loads(stdout)
+            self.assertEqual(review["schema_version"], "codex_review_adapter/v1")
+            self.assertEqual(review["codex_review"]["schema_version"], "codex_review_summary/v1")
+            self.assertEqual(review["codex_review"]["status"], "changes_requested")
+            self.assertEqual(review["codex_review"]["finding_count"], 1)
+            self.assertEqual(review["codex_review"]["handback"]["resume"]["argv_template"], ["codex", "exec", "resume", "codex-session-1"])
+            self.assertFalse(review["adapter_contract"]["raw_logs_exposed"])
+            self.assertFalse(review["adapter_contract"]["hidden_reasoning_exposed"])
+            self.assertIn("Codex review found one bounded issue", review["chat_summary"])
+            self.assertNotIn("do not expose hidden reasoning", json.dumps(review))
+
             follow_up_prompt = "continue the same PR with a small follow-up"
             status, stdout, stderr = run_cli(
                 home_args
@@ -5327,6 +5368,14 @@ class CliTests(unittest.TestCase):
                     str(log_path),
                     "--codex-log-ref",
                     "codex-jsonl",
+                    "--evidence-ref",
+                    "codex-review-summary",
+                    "--codex-review-status",
+                    "changes_requested",
+                    "--codex-review-summary",
+                    "Codex review found one bounded issue for the executor to fix.",
+                    "--codex-review-finding-count",
+                    "1",
                     follow_up_prompt,
                 ]
             )
@@ -5339,6 +5388,9 @@ class CliTests(unittest.TestCase):
             self.assertEqual(followup["active_codex"]["latest_progress"]["event_count"], 4)
             self.assertFalse(followup["adapter_contract"]["raw_logs_exposed"])
             self.assertFalse(followup["adapter_contract"]["hidden_reasoning_exposed"])
+            self.assertEqual(followup["codex_review"]["status"], "changes_requested")
+            self.assertEqual(followup["codex_review"]["handback"]["recommended_action"], "resume_codex_for_review_fixes")
+            self.assertEqual(followup["codex_review"]["handback"]["resume"]["argv_template"], ["codex", "exec", "resume", "codex-session-1"])
             self.assertNotIn(follow_up_prompt, json.dumps(followup))
 
             status, stdout, stderr = run_cli(home_args + ["chat", "codex-followup", "separate task"])

--- a/tests/test_codex_progress.py
+++ b/tests/test_codex_progress.py
@@ -6,7 +6,12 @@ import unittest
 from _local_package import load_local_package
 
 load_local_package()
-from omh.codex_progress import build_codex_prompt_handling_contract, build_codex_session_observation, summarize_codex_jsonl_text
+from omh.codex_progress import (
+    build_codex_prompt_handling_contract,
+    build_codex_review_summary,
+    build_codex_session_observation,
+    summarize_codex_jsonl_text,
+)
 
 
 class CodexProgressTests(unittest.TestCase):
@@ -38,6 +43,36 @@ class CodexProgressTests(unittest.TestCase):
         self.assertIn("not raw JSONL", summary["claim_boundary"])
         self.assertEqual(summary["privacy"], "summary_only")
 
+    def test_nested_reasoning_does_not_influence_observable_summary(self) -> None:
+        raw = json.dumps(
+            {
+                "type": "response_item",
+                "item": {
+                    "type": "reasoning",
+                    "summary": [{"text": "hidden tests passed and apply_patch changed files"}],
+                },
+            }
+        )
+
+        summary = summarize_codex_jsonl_text(raw, source="codex-run.jsonl")
+
+        self.assertEqual(summary["event_count"], 1)
+        self.assertEqual(summary["status"], "no_observable_events")
+        self.assertEqual(summary["activity_counts"]["testing"], 0)
+        self.assertEqual(summary["activity_counts"]["editing"], 0)
+        rendered = json.dumps(summary)
+        self.assertNotIn("hidden tests passed", rendered)
+        self.assertNotIn("completed_or_passed_observed", rendered)
+
+    def test_terminal_status_avoids_negated_or_partial_success_words(self) -> None:
+        negated = summarize_codex_jsonl_text(
+            json.dumps({"role": "assistant", "content": "Tests are not completed; this is an incomplete run."})
+        )
+        passed = summarize_codex_jsonl_text(json.dumps({"role": "assistant", "content": "Tests passed."}))
+
+        self.assertNotEqual(negated["status"], "completed_or_passed_observed")
+        self.assertEqual(passed["status"], "completed_or_passed_observed")
+
     def test_codex_session_observation_exposes_resume_contract_without_execution_claim(self) -> None:
         progress = summarize_codex_jsonl_text(
             json.dumps({"role": "assistant", "content": "Done with the patch."}),
@@ -60,6 +95,18 @@ class CodexProgressTests(unittest.TestCase):
         self.assertEqual(observation["resume"]["argv_template"], ["codex", "exec", "resume", "session-1"])
         self.assertTrue(observation["resume"]["not_omh_backend_execution"])
         self.assertIn("do not prove", observation["claim_boundary"])
+
+    def test_codex_session_resume_requires_explicit_codex_session_ref(self) -> None:
+        observation = build_codex_session_observation(
+            selected_executor_profile="codex",
+            external_session_ref="codex-thread-only",
+        )
+
+        self.assertTrue(observation["observed"])
+        self.assertEqual(observation["session_ref"], "")
+        self.assertEqual(observation["thread_ref"], "codex-thread-only")
+        self.assertFalse(observation["resume"]["available"])
+        self.assertEqual(observation["resume"]["argv_template"], [])
 
     def test_followup_contract_recommends_append_only_for_same_observed_session(self) -> None:
         progress = summarize_codex_jsonl_text(
@@ -94,6 +141,48 @@ class CodexProgressTests(unittest.TestCase):
         new_route = build_codex_prompt_handling_contract(new_prompt="new task", progress_summary=progress)
         self.assertEqual(new_route["recommendation"]["action"], "route_new_or_clarify")
         self.assertNotIn("resume", new_route)
+
+    def test_review_summary_is_human_readable_and_resume_bound_to_session_ref(self) -> None:
+        progress = summarize_codex_jsonl_text(
+            "\n".join(
+                [
+                    json.dumps({"type": "tool_call", "tool": "rg", "args": "rg review"}),
+                    json.dumps({"type": "response_item", "item": {"type": "reasoning", "summary": "hidden review thought"}}),
+                ]
+            ),
+            evidence_refs=["codex-jsonl"],
+        )
+
+        review = build_codex_review_summary(
+            review_status="changes_requested",
+            summary="Codex review found two bounded issues to fix.",
+            finding_count=2,
+            progress_summary=progress,
+            codex_session_ref="codex-session-1",
+            codex_thread_ref="codex-thread-1",
+            evidence_refs=["codex-review-summary"],
+        )
+
+        self.assertEqual(review["schema_version"], "codex_review_summary/v1")
+        self.assertTrue(review["observed"])
+        self.assertEqual(review["status"], "changes_requested")
+        self.assertTrue(review["requires_fixes"])
+        self.assertEqual(review["finding_count"], 2)
+        self.assertEqual(review["handback"]["recommended_action"], "resume_codex_for_review_fixes")
+        self.assertEqual(review["handback"]["resume"]["argv_template"], ["codex", "exec", "resume", "codex-session-1"])
+        self.assertFalse(review["adapter_contract"]["raw_logs_exposed"])
+        self.assertFalse(review["adapter_contract"]["hidden_reasoning_exposed"])
+        rendered = json.dumps(review)
+        self.assertIn("Codex review found two bounded issues", rendered)
+        self.assertNotIn("hidden review thought", rendered)
+
+        thread_only = build_codex_review_summary(
+            review_status="changes_requested",
+            summary="Review needs fixes.",
+            external_session_ref="codex-thread-only",
+        )
+        self.assertFalse(thread_only["handback"]["can_resume_for_fixes"])
+        self.assertEqual(thread_only["handback"]["resume"], {})
 
 
 if __name__ == "__main__":

--- a/tests/test_codex_progress.py
+++ b/tests/test_codex_progress.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import json
+import unittest
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.codex_progress import build_codex_session_observation, summarize_codex_jsonl_text
+
+
+class CodexProgressTests(unittest.TestCase):
+    def test_summarizes_observable_codex_jsonl_without_raw_or_hidden_text(self) -> None:
+        raw = "\n".join(
+            [
+                json.dumps({"type": "tool_call", "tool": "rg", "args": "rg risky tests"}),
+                json.dumps({"type": "tool_call", "tool": "apply_patch", "message": "modified src/wrapper/executor_sessions.py"}),
+                json.dumps({"type": "tool_call", "command": "python -m unittest tests/test_cli.py"}),
+                json.dumps({"type": "reasoning", "analysis": "hidden private reasoning should never render"}),
+                json.dumps({"type": "reasoning", "content": "hidden private content should never influence summaries"}),
+                json.dumps({"role": "assistant", "content": "I will wait on review after tests pass."}),
+            ]
+        )
+
+        summary = summarize_codex_jsonl_text(raw, evidence_refs=["codex-jsonl"], source="codex-run.jsonl")
+
+        self.assertEqual(summary["schema_version"], "codex_progress_summary/v1")
+        self.assertEqual(summary["event_count"], 6)
+        self.assertEqual(summary["malformed_event_count"], 0)
+        self.assertGreater(summary["activity_counts"]["inspecting"], 0)
+        self.assertGreater(summary["activity_counts"]["editing"], 0)
+        self.assertGreater(summary["activity_counts"]["testing"], 0)
+        self.assertIn("Codex changed files.", summary["observable_activity"])
+        self.assertIn("Codex decided via assistant-visible message", summary["chat_summary"])
+        rendered = json.dumps(summary)
+        self.assertNotIn("hidden private reasoning", rendered)
+        self.assertNotIn("hidden private content", rendered)
+        self.assertIn("not raw JSONL", summary["claim_boundary"])
+        self.assertEqual(summary["privacy"], "summary_only")
+
+    def test_codex_session_observation_exposes_resume_contract_without_execution_claim(self) -> None:
+        progress = summarize_codex_jsonl_text(
+            json.dumps({"role": "assistant", "content": "Done with the patch."}),
+            evidence_refs=["codex-summary"],
+        )
+
+        observation = build_codex_session_observation(
+            selected_executor_profile="codex",
+            external_session_ref="thread-1",
+            codex_session_ref="session-1",
+            codex_thread_ref="thread-1",
+            evidence_refs=["button-open"],
+            progress_summary=progress,
+        )
+
+        self.assertTrue(observation["observed"])
+        self.assertEqual(observation["session_ref"], "session-1")
+        self.assertEqual(observation["thread_ref"], "thread-1")
+        self.assertEqual(observation["event_count"], 1)
+        self.assertEqual(observation["resume"]["argv_template"], ["codex", "exec", "resume", "session-1"])
+        self.assertTrue(observation["resume"]["not_omh_backend_execution"])
+        self.assertIn("do not prove", observation["claim_boundary"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_codex_progress.py
+++ b/tests/test_codex_progress.py
@@ -6,7 +6,7 @@ import unittest
 from _local_package import load_local_package
 
 load_local_package()
-from omh.codex_progress import build_codex_session_observation, summarize_codex_jsonl_text
+from omh.codex_progress import build_codex_prompt_handling_contract, build_codex_session_observation, summarize_codex_jsonl_text
 
 
 class CodexProgressTests(unittest.TestCase):
@@ -60,6 +60,40 @@ class CodexProgressTests(unittest.TestCase):
         self.assertEqual(observation["resume"]["argv_template"], ["codex", "exec", "resume", "session-1"])
         self.assertTrue(observation["resume"]["not_omh_backend_execution"])
         self.assertIn("do not prove", observation["claim_boundary"])
+
+    def test_followup_contract_recommends_append_only_for_same_observed_session(self) -> None:
+        progress = summarize_codex_jsonl_text(
+            json.dumps({"type": "tool_call", "tool": "rg", "args": "rg codex"}),
+            evidence_refs=["codex-jsonl"],
+        )
+
+        append = build_codex_prompt_handling_contract(
+            new_prompt="continue the same PR",
+            progress_summary=progress,
+            codex_session_ref="session-1",
+            codex_thread_ref="thread-1",
+            wrapper_session_id="ws-1",
+        )
+
+        self.assertEqual(append["recommendation"]["action"], "append_followup_to_observed_codex_session")
+        self.assertEqual(append["resume"]["argv_template"], ["codex", "exec", "resume", "session-1"])
+        self.assertEqual(append["new_prompt"]["raw_prompt_stored"], False)
+        self.assertNotIn("continue the same PR", json.dumps(append))
+        self.assertFalse(append["adapter_contract"]["raw_logs_exposed"])
+        self.assertFalse(append["adapter_contract"]["hidden_reasoning_exposed"])
+
+        clarify = build_codex_prompt_handling_contract(
+            new_prompt="maybe a separate task",
+            progress_summary=progress,
+            codex_session_ref="session-1",
+        )
+
+        self.assertEqual(clarify["recommendation"]["action"], "clarify_before_append_or_route_new")
+        self.assertIn("resume", clarify)
+
+        new_route = build_codex_prompt_handling_contract(new_prompt="new task", progress_summary=progress)
+        self.assertEqual(new_route["recommendation"]["action"], "route_new_or_clarify")
+        self.assertNotIn("resume", new_route)
 
 
 if __name__ == "__main__":

--- a/tests/test_hook_manifest.py
+++ b/tests/test_hook_manifest.py
@@ -93,12 +93,33 @@ class HookManifestTests(unittest.TestCase):
         self.assertEqual(payload["primary_workflow"], "workflow-learning")
         self.assertEqual(payload["primary_next_action"], "record_missed_route")
         self.assertEqual(payload["hints"][0]["next_action"], "record_missed_route")
-        self.assertIn("workflow=workflow-learning", context)
+        self.assertIn("selected=workflow-learning", context)
         self.assertIn("next_action=record_missed_route", context)
         self.assertNotIn(message, serialized)
         self.assertNotIn(message, context)
         self.assertNotIn("secret-token-123", serialized)
         self.assertNotIn("secret-token-123", context)
+
+    def test_awareness_route_hint_marks_workflow_vocabulary_as_mentioned_not_selected(self) -> None:
+        message = "왜 ultraprocess 로그가 떠? Codex handoff 테스트 용어일 뿐이야."
+
+        payload = awareness_route_hint(message)
+        context_result = pre_llm_call(user_message=message, is_first_turn=False)
+        context = context_result["context"] if context_result else ""
+
+        self.assertEqual(payload["status"], "hinted")
+        self.assertEqual(payload["primary_workflow"], "workflow-learning")
+        self.assertEqual(payload["selected_workflow"], "workflow-learning")
+        self.assertIn(payload["intent_class"], {"meta_discussion", "feedback_signal"})
+        self.assertIn("ultraprocess", payload["mentioned_workflows"])
+        self.assertIn("Codex", payload["mentioned_runtime_terms"])
+        self.assertIn("ultraprocess", payload["not_executed"])
+        self.assertIn("Codex", payload["not_executed"])
+        self.assertIn("selected=workflow-learning", context)
+        self.assertIn("mentioned_workflows=ultraprocess", context)
+        self.assertIn("not_executed=ultraprocess, Codex", context)
+        self.assertNotIn("selected=ultraprocess", context)
+        self.assertNotIn(message, context)
 
     def test_pre_llm_call_includes_bounded_route_hint_without_raw_message(self) -> None:
         message = "make an image explaining the cron feature with secret-token-123"
@@ -109,8 +130,8 @@ class HookManifestTests(unittest.TestCase):
 
         self.assertIn("[OMH Awareness]", context)
         self.assertIn("[OMH Route Hint]", context)
-        self.assertIn("workflow=img-summary", context)
-        self.assertIn("workflow=automation-blueprint", context)
+        self.assertIn("selected=img-summary", context)
+        self.assertIn("selected=automation-blueprint", context)
         self.assertIn("first_response_shape=Separate copy/layout/package prep", context)
         self.assertIn("fallback_action=choose_image_generator_or_prompt_only_when_missing", context)
         self.assertIn("fallback_action=confirm_schedule_delivery_and_tools", context)
@@ -143,7 +164,7 @@ class HookManifestTests(unittest.TestCase):
 
         self.assertNotIn("[OMH Awareness]", context)
         self.assertNotIn("[OMH Route Hint]", context)
-        self.assertNotIn("workflow=img-summary", context)
+        self.assertNotIn("selected=img-summary", context)
 
     def test_pre_llm_call_includes_catalog_question_hint_without_raw_message(self) -> None:
         message = "what OMH workflows are available with secret-token-123?"

--- a/tests/test_hud.py
+++ b/tests/test_hud.py
@@ -43,7 +43,7 @@ class HudCliTests(unittest.TestCase):
                     "--record",
                     "--executor",
                     "codex",
-                    "Safely add feature without overclaiming.",
+                    "implement safe status feature in src/runtime/status.py without overclaiming",
                 ]
             )
             self.assertEqual(stderr, "")

--- a/tests/test_menubar_status.py
+++ b/tests/test_menubar_status.py
@@ -38,7 +38,7 @@ class MenubarStatusTests(unittest.TestCase):
                     "discord",
                     "--channel-ref",
                     "C123",
-                    "Safely add feature without overclaiming.",
+                    "implement safe status feature in src/runtime/status.py without overclaiming",
                 ]
             )
             self.assertEqual(stderr, "")
@@ -131,7 +131,7 @@ class MenubarStatusTests(unittest.TestCase):
                         "discord",
                         "--channel-ref",
                         "C123",
-                        "Safely add feature without overclaiming.",
+                        "implement safe status feature in src/runtime/status.py without overclaiming",
                     ]
                 )[0],
                 0,
@@ -312,7 +312,10 @@ class MenubarStatusTests(unittest.TestCase):
             omh_home = root / ".omh"
             hermes_home = root / ".hermes"
             self.assertEqual(run_cli(["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "setup"])[0], 0)
-            for message in ("First coding task.", "Second coding task."):
+            for message in (
+                "implement first coding task in src/runtime/first.py",
+                "implement second coding task in src/runtime/second.py",
+            ):
                 self.assertEqual(
                     run_cli(
                         [

--- a/tests/test_plugin_capabilities.py
+++ b/tests/test_plugin_capabilities.py
@@ -269,6 +269,14 @@ class PluginCapabilitiesTests(unittest.TestCase):
                         "limit": 2,
                     }})
                 )
+                context_meta = json.loads(
+                    context_handler({{
+                        "message": "왜 ultraprocess 로그가 떠? Codex handoff 테스트 용어일 뿐이야.",
+                        "source": "discord",
+                        "limit": 2,
+                        "include_prompt_context": True,
+                    }})
+                )
                 interaction = json.loads(
                     interact_handler({{
                         "message": "make an image summary for this PR with secret-token-123",
@@ -360,6 +368,10 @@ class PluginCapabilitiesTests(unittest.TestCase):
                     "context_catalog_next_action": context_catalog["catalog_question"]["next_action"],
                     "context_catalog_tool": context_catalog["catalog_question"]["recommended_tool"],
                     "context_catalog_serialized": json.dumps(context_catalog, sort_keys=True),
+                    "context_meta_primary_workflow": context_meta["route_hint"]["primary_workflow"],
+                    "context_meta_mentioned_workflows": context_meta["route_hint"]["mentioned_workflows"],
+                    "context_meta_runtime_terms": context_meta["route_hint"]["mentioned_runtime_terms"],
+                    "context_meta_prompt_context": context_meta["prompt_context"],
                     "interaction_schema": interaction["schema_version"],
                     "interaction_degraded": interaction["degraded"],
                     "interaction_source": interaction["source_backend"],
@@ -474,13 +486,18 @@ class PluginCapabilitiesTests(unittest.TestCase):
             self.assertEqual(payload["context_source"], "standalone_plugin_bundle_fallback")
             self.assertEqual(payload["context_plugin_tool"], "omh_context")
             self.assertEqual(payload["context_primary_workflow"], "img-summary")
-            self.assertIn("workflow=img-summary", payload["context_prompt_context"])
+            self.assertIn("selected=img-summary", payload["context_prompt_context"])
             self.assertIn("generic tool can render", payload["context_serialized"])
             self.assertNotIn("secret-token-123", payload["context_serialized"])
             self.assertEqual(payload["context_catalog_status"], "matched")
             self.assertEqual(payload["context_catalog_next_action"], "show_workflow_picker")
             self.assertEqual(payload["context_catalog_tool"], "omh_capabilities")
             self.assertNotIn("secret-token-123", payload["context_catalog_serialized"])
+            self.assertEqual(payload["context_meta_primary_workflow"], "workflow-learning")
+            self.assertIn("ultraprocess", payload["context_meta_mentioned_workflows"])
+            self.assertIn("Codex", payload["context_meta_runtime_terms"])
+            self.assertIn("selected=workflow-learning", payload["context_meta_prompt_context"])
+            self.assertNotIn("selected=ultraprocess", payload["context_meta_prompt_context"])
             self.assertEqual(payload["interaction_schema"], "chat_interaction/v1")
             self.assertTrue(payload["interaction_degraded"])
             self.assertEqual(payload["interaction_source"], "standalone_plugin_bundle_fallback")

--- a/tests/test_plugin_distribution.py
+++ b/tests/test_plugin_distribution.py
@@ -287,7 +287,7 @@ class PluginDistributionTests(unittest.TestCase):
                     "--record",
                     "--executor",
                     "codex",
-                    "Safely add feature without overclaiming.",
+                    "implement safe status feature in src/runtime/status.py without overclaiming",
                 ]
             )
             self.assertEqual(status, 0)
@@ -369,7 +369,7 @@ class PluginDistributionTests(unittest.TestCase):
             self.assertEqual(context_brief["source_backend"], "package_context")
             self.assertEqual(context_brief["route_hint"]["primary_workflow"], "img-summary")
             self.assertIn("generic tool can render", context_brief["normal_response_contract"]["when_generic_tool_is_available"])
-            self.assertIn("workflow=img-summary", context_brief["prompt_context"])
+            self.assertIn("selected=img-summary", context_brief["prompt_context"])
             self.assertFalse(context_brief["message"]["raw_prompt_echoed"])
             self.assertNotIn("secret-token-123", json.dumps(context_brief, sort_keys=True))
 

--- a/tests/test_wrapper_sessions.py
+++ b/tests/test_wrapper_sessions.py
@@ -11,6 +11,7 @@ from _local_package import load_local_package
 
 load_local_package()
 from omh.coding_lifecycle import record_codex_dispatch, record_codex_result, record_codex_verification, start_codex_delegation_lifecycle
+from omh.codex_progress import summarize_codex_jsonl_text
 from omh.paths import resolve_paths
 from omh.runtime_artifacts import (
     create_run,
@@ -709,6 +710,9 @@ class WrapperSessionTests(unittest.TestCase):
             self.assertEqual(codex_launch["command_templates"][0]["shell_command_template"], "codex {executor_prompt_shell_quoted}")
             self.assertEqual(codex_launch["command_templates"][1]["argv_template"], ["codex", "--cd", "{workspace_path}", "{executor_prompt}"])
             self.assertEqual(codex_launch["command_templates"][1]["shell_command_template"], "codex --cd {workspace_path_shell_quoted} {executor_prompt_shell_quoted}")
+            self.assertEqual(codex_launch["command_templates"][2]["argv_template"], ["codex", "exec", "resume", "{codex_session_ref}"])
+            self.assertEqual(codex_launch["resume_capability"]["argv_template"], ["codex", "exec", "resume", "{codex_session_ref}"])
+            self.assertTrue(codex_launch["resume_capability"]["not_omh_backend_execution"])
             self.assertEqual(codex_launch["after_launch_backend_action"], "open-executor")
             self.assertIn("not proof of execution", codex_launch["claim_boundary"])
             self.assertEqual(prepared_actions["attach_executor_session"]["label"], "Attach coding session")
@@ -728,13 +732,31 @@ class WrapperSessionTests(unittest.TestCase):
                 session_id,
                 observed=True,
                 external_session_ref="codex-thread-1",
+                codex_session_ref="codex-session-1",
+                codex_thread_ref="codex-thread-1",
                 evidence_refs=["discord-button"],
+                codex_progress_summary=summarize_codex_jsonl_text(
+                    "\n".join(
+                        [
+                            json.dumps({"type": "tool_call", "tool": "rg", "args": "rg executor_session tests"}),
+                            json.dumps({"role": "assistant", "content": "I am inspecting files before editing."}),
+                        ]
+                    ),
+                    evidence_refs=["codex-jsonl"],
+                ),
             )
 
             opened_status = opened["status"]
             self.assertEqual(opened_status["coding_agent"], "running(codex)")
             self.assertEqual(opened_status["executor_session"], "attached")
             self.assertEqual(opened_status["dispatch"], "observed")
+            self.assertEqual(opened_status["codex_session"]["session_ref"], "codex-session-1")
+            self.assertEqual(opened_status["codex_session"]["thread_ref"], "codex-thread-1")
+            self.assertEqual(opened_status["codex_session"]["resume"]["argv_template"], ["codex", "exec", "resume", "codex-session-1"])
+            self.assertEqual(opened_status["codex_progress"]["event_count"], 2)
+            self.assertIn("Codex is inspecting files/tests.", opened_status["codex_progress"]["observable_activity"])
+            self.assertIn("codex-session: observed(codex-session-1)", opened_status["status_lines"])
+            self.assertIn("Observed Codex metadata: session codex-session-1, thread codex-thread-1", "\n".join(opened_status["display_status_lines"]))
             self.assertEqual(opened_status["linked_lifecycle_status"]["next_action"], "wait_for_executor_evidence")
             opened_actions = {action["id"]: action for action in opened_status["actions"]}
             self.assertFalse(opened_actions["open_executor_session"]["enabled"])
@@ -748,10 +770,22 @@ class WrapperSessionTests(unittest.TestCase):
                 session_id,
                 result="completed",
                 evidence_refs=["codex-summary"],
+                codex_progress_summary=summarize_codex_jsonl_text(
+                    "\n".join(
+                        [
+                            json.dumps({"type": "tool_call", "command": "python -m unittest tests/test_wrapper_sessions.py"}),
+                            json.dumps({"role": "assistant", "content": "Tests passed; waiting on review."}),
+                        ]
+                    ),
+                    evidence_refs=["codex-final-jsonl"],
+                ),
             )
 
             self.assertEqual(completed["status"]["coding_agent"], "completed(codex)")
             self.assertEqual(completed["status"]["result"], "completed")
+            self.assertEqual(completed["status"]["codex_progress"]["event_count"], 2)
+            self.assertIn("Codex is running tests.", completed["status"]["codex_progress"]["observable_activity"])
+            self.assertIn("summary_only", completed["executor_session"]["codex_progress"]["privacy"])
             self.assertEqual(completed["status"]["linked_lifecycle_status"]["next_action"], "record_verification_evidence")
             with self.assertRaisesRegex(ExecutorSessionError, "after executor result is recorded"):
                 attach_executor_session(paths, session_id, external_session_ref="codex-thread-2")


### PR DESCRIPTION
## Summary

This PR tightens OMH routing and coding-delegation safety after a Discord smoke test exposed two misleading states:

- OMH developer/operator vocabulary such as `ultraprocess`, Codex, coding handoff, and one-cycle delivery could be interpreted as delivery intent even when the user was discussing routing behavior or test setup.
- `omh coding delegate --record` could create a prepared Codex runtime artifact before there were concrete requirements or explicit dispatch intent, making HUD/status look like a real prepared coding handoff.

## What changed

- Added deterministic workflow-intent classification for meta discussion, feedback signals, planning, and delivery intent.
- Routed workflow/coding vocabulary feedback to workflow-learning/router-design feedback instead of `ultraprocess` unless explicit execution intent is present.
- Extended route hint payloads and prompt context with `intent_class`, `selected_workflow`, `mentioned_workflows`, `mentioned_runtime_terms`, `adjacent_workflows`, and `not_executed` so logs do not imply execution.
- Added a standalone plugin fallback classifier so installed plugin bundles keep the same route-hint boundary even without the full package import path.
- Added `omh coding delegate --record` readiness gating so missing-requirements/meta/vague requests return `blocked_requirements_missing` without creating `.omh/runtime/runs` or changing HUD to `coding-agent:prepared(codex)`.
- Added `--force-record` as an explicit operator override flag, while still blocking meta/missing-requirements cases.
- Updated chat wrapper examples and regression coverage.

## User/operator impact

After this change, OMH developers can discuss or test terms like `ultraprocess`, Codex, and coding handoff without accidentally making route hints or HUD status look like a delivery workflow was selected or a Codex handoff was prepared. Real delivery prompts such as `$ultraprocess ... PR-ready` and concrete Codex implementation requests still route and record normally.

## Verification

Observed locally on `/Users/rlaope/Desktop/khope/omhm-routing-safety`:

```sh
PYTHONPATH=tests /opt/homebrew/bin/python3.12 -m unittest discover -s tests -v
# Ran 684 tests in 15.223s — OK

PYTHONPATH=tests /opt/homebrew/bin/python3.12 -m compileall -q src tests
PYTHONPATH=tests /opt/homebrew/bin/python3.12 -m src.cli docs workflows --check
# ok=true, tap_skills checked=43 expected=43

git diff --check
# exit 0
```

Additional handoff evidence:

- Codex CLI observed: `codex-cli 0.140.0`
- Codex exec handoff process: `proc_cec2fdfe81d1`
- Codex performed the implementation in isolated worktree `omhm-routing-safety`; Hermes inspected the diff, fixed one overbroad comparison cue, reran verification, committed, and opened this PR.

## Risks / follow-up

- The classifier is deterministic and intentionally conservative; future OMH vocabulary may need additional cue tests.
- Live Discord/plugin rendering should be checked after deployment because this PR verifies local package/plugin behavior, not a live gateway restart.
- This PR does not merge itself.
