### PR TITLE
feat: observe Codex loop queue progress

### DIFF
--- a/src/commands/loop.py
+++ b/src/commands/loop.py
@@ -9,13 +9,16 @@ from ..goal_loop import (
     PERMISSION_PROFILES,
     assess_loopability,
     block_loop_queue_item,
+    build_loop_cycle_narration,
     build_loop_queue_handoff,
     build_loop_start_card,
     build_loop_status_card,
     create_loop_cycle,
+    dispatch_loop_queue_item,
     inspect_loop_queue_item,
     list_loop_queue,
     list_loop_cycles,
+    observe_codex_loop_queue_item,
     observe_loop_queue_item,
     read_loop_cycle,
     record_loop_feedback,
@@ -222,6 +225,56 @@ def cmd_loop_queue_handoff(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_loop_queue_dispatch(args: argparse.Namespace) -> int:
+    try:
+        cycle = dispatch_loop_queue_item(
+            _paths(args),
+            args.loop_id,
+            args.queue_id,
+            executor=args.executor,
+            session_ref=args.codex_session_ref or args.session_ref or "",
+            thread_ref=args.codex_thread_ref or args.thread_ref or "",
+            evidence_refs=args.evidence_ref or [],
+            summary=args.summary or "",
+        )
+        _print_json({"loop": cycle, "status_card": build_loop_status_card(_paths(args), args.loop_id)})
+    except (FileNotFoundError, ValueError) as exc:
+        raise OmhError(str(exc)) from exc
+    return 0
+
+
+def cmd_loop_queue_observe_codex(args: argparse.Namespace) -> int:
+    try:
+        log_text = ""
+        if args.codex_log_text:
+            log_text = args.codex_log_text
+        elif args.codex_log_jsonl:
+            from pathlib import Path
+
+            log_text = Path(args.codex_log_jsonl).read_text(encoding="utf-8")
+        cycle = observe_codex_loop_queue_item(
+            _paths(args),
+            args.loop_id,
+            args.queue_id,
+            codex_log_text=log_text,
+            evidence_refs=args.evidence_ref or [],
+            codex_log_ref=args.codex_log_ref or "",
+            summary=args.summary or "",
+        )
+        _print_json({"loop": cycle, "narration": build_loop_cycle_narration(_paths(args), args.loop_id, args.queue_id)})
+    except (FileNotFoundError, OSError, ValueError) as exc:
+        raise OmhError(str(exc)) from exc
+    return 0
+
+
+def cmd_loop_queue_narrate(args: argparse.Namespace) -> int:
+    try:
+        _print_json({"narration": build_loop_cycle_narration(_paths(args), args.loop_id, args.queue_id)})
+    except (FileNotFoundError, ValueError) as exc:
+        raise OmhError(str(exc)) from exc
+    return 0
+
+
 def cmd_loop_queue_observe(args: argparse.Namespace) -> int:
     try:
         cycle = observe_loop_queue_item(
@@ -350,6 +403,33 @@ def _add_loop_commands(sub) -> None:
     queue_handoff.add_argument("--loop", dest="loop_id", required=True)
     queue_handoff.add_argument("--queue", dest="queue_id", required=True)
     queue_handoff.set_defaults(func=cmd_loop_queue_handoff)
+
+    queue_dispatch = queue_sub.add_parser("dispatch")
+    queue_dispatch.add_argument("--loop", dest="loop_id", required=True)
+    queue_dispatch.add_argument("--queue", dest="queue_id", required=True)
+    queue_dispatch.add_argument("--executor", choices=LOOP_EXECUTOR_OPTION_IDS, required=True)
+    queue_dispatch.add_argument("--session-ref", default="")
+    queue_dispatch.add_argument("--thread-ref", default="")
+    queue_dispatch.add_argument("--codex-session-ref", default="")
+    queue_dispatch.add_argument("--codex-thread-ref", default="")
+    queue_dispatch.add_argument("--evidence-ref", action="append")
+    queue_dispatch.add_argument("--summary", default="")
+    queue_dispatch.set_defaults(func=cmd_loop_queue_dispatch)
+
+    queue_observe_codex = queue_sub.add_parser("observe-codex")
+    queue_observe_codex.add_argument("--loop", dest="loop_id", required=True)
+    queue_observe_codex.add_argument("--queue", dest="queue_id", required=True)
+    queue_observe_codex.add_argument("--codex-log-jsonl", default="")
+    queue_observe_codex.add_argument("--codex-log-text", default="")
+    queue_observe_codex.add_argument("--codex-log-ref", default="")
+    queue_observe_codex.add_argument("--evidence-ref", action="append", required=True)
+    queue_observe_codex.add_argument("--summary", default="")
+    queue_observe_codex.set_defaults(func=cmd_loop_queue_observe_codex)
+
+    queue_narrate = queue_sub.add_parser("narrate")
+    queue_narrate.add_argument("--loop", dest="loop_id", required=True)
+    queue_narrate.add_argument("--queue", dest="queue_id", default="")
+    queue_narrate.set_defaults(func=cmd_loop_queue_narrate)
 
     queue_observe = queue_sub.add_parser("observe")
     queue_observe.add_argument("--loop", dest="loop_id", required=True)

--- a/src/goal_loop.py
+++ b/src/goal_loop.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable
 
+from .codex_progress import summarize_codex_jsonl_text
 from .goal_ledger import build_goal_completion_gate, read_goal_ledger
 from .hashutil import sha256_text
 from .local_store import atomic_write_json, ensure_dir, read_json_object, utc_now
@@ -26,6 +27,8 @@ LOOP_VERIFICATION_PLAN_SCHEMA = "loop_verification_plan/v1"
 LOOP_FAILURE_MODE_SUMMARY_SCHEMA = "loop_failure_mode_summary/v1"
 LOOP_SMALL_LOOP_GUIDANCE_SCHEMA = "loop_small_loop_guidance/v1"
 LOOP_RUN_ONCE_RESULT_SCHEMA = "loop_run_once_result/v1"
+EXECUTOR_LOOP_CAPABILITY_SCHEMA = "executor_loop_capability/v1"
+LOOP_CYCLE_NARRATION_SCHEMA = "loop_cycle_narration/v1"
 
 LOOP_PHASES = {
     "interview",
@@ -213,6 +216,52 @@ def create_loop_cycle(
     ensure_dir(_loop_dir(paths, loop_id), private=True)
     atomic_write_json(loop_cycle_path(paths, loop_id), cycle, private=True)
     return cycle
+
+
+def loop_executor_capability(executor: str) -> dict[str, Any]:
+    selected = _safe_summary(executor or "choose", limit=120) or "choose"
+    if selected == "claude-code":
+        loop_mode = "native"
+        dispatch_owner = "executor"
+        observability = ["native_loop_or_goal", "prompt_handoff", "wrapper_observation"]
+        next_action = "prepare_claude_code_native_loop_handoff"
+    elif selected == "codex":
+        loop_mode = "omh_managed"
+        dispatch_owner = "omh_wrapper"
+        observability = ["codex_session_ref", "codex_progress_summary/v1", "codex_review_summary/v1"]
+        next_action = "dispatch_or_resume_codex_session_then_observe"
+    elif selected == "hermes":
+        loop_mode = "omh_managed"
+        dispatch_owner = "omh_wrapper"
+        observability = ["loop_cycle/v1", "loop_queue_item/v1", "goal_ledger/v1"]
+        next_action = "continue_omh_managed_loop"
+    elif selected == "generic":
+        loop_mode = "prompt_handoff"
+        dispatch_owner = "human_operator"
+        observability = ["manual_evidence_ref"]
+        next_action = "prepare_prompt_handoff"
+    elif selected in {"choose", "omx-runtime"}:
+        loop_mode = "prompt_handoff"
+        dispatch_owner = "human_operator"
+        observability = ["runtime_handoff", "manual_evidence_ref"]
+        next_action = "choose_executor_or_runtime"
+    else:
+        loop_mode = "unsupported"
+        dispatch_owner = "human_operator"
+        observability = []
+        next_action = "choose_supported_executor"
+    return {
+        "schema_version": EXECUTOR_LOOP_CAPABILITY_SCHEMA,
+        "executor": selected,
+        "loop_mode": loop_mode,
+        "dispatch_owner": dispatch_owner,
+        "observability": observability,
+        "next_action": next_action,
+        "claim_boundary": (
+            "Executor loop capability is routing metadata only. It is not dispatch, implementation, "
+            "review, CI, merge, or goal completion evidence."
+        ),
+    }
 
 
 def _enforce_loopability_start(assessment: dict[str, Any], *, allow_unloopable: bool) -> None:
@@ -601,6 +650,127 @@ def build_loop_queue_handoff(paths: OmhPaths, loop_id: str, queue_id: str) -> di
         "connector_plan": item.get("connector_plan", _connector_plan("", "", str(item.get("planned_action", "")))),
         "next_action": "observe_or_block_loop_queue",
         "actions": ["observe_loop_queue", "block_loop_queue", "show_loop_status"],
+        "claim_boundary": _runtime_claim_boundary(),
+    }
+
+
+def dispatch_loop_queue_item(
+    paths: OmhPaths,
+    loop_id: str,
+    queue_id: str,
+    *,
+    executor: str,
+    session_ref: str = "",
+    thread_ref: str = "",
+    evidence_refs: Iterable[str] | None = None,
+    summary: str = "",
+) -> dict[str, Any]:
+    refs = _safe_list(evidence_refs or [], limit=320)
+    cycle = read_loop_cycle(paths, loop_id)
+    runtime, item = _queue_item_ref(cycle, queue_id)
+    if item.get("status") != "prepared_not_observed":
+        raise ValueError("only prepared_not_observed loop queue items can record executor dispatch")
+    capability = loop_executor_capability(executor)
+    item["executor_session"] = {
+        **_empty_executor_session(str(capability["executor"])),
+        "executor": capability["executor"],
+        "loop_mode": capability["loop_mode"],
+        "dispatch_owner": capability["dispatch_owner"],
+        "dispatch_status": "dispatched" if refs or session_ref.strip() or thread_ref.strip() else "prepared",
+        "session_ref": _safe_summary(session_ref, limit=220) if session_ref.strip() else "",
+        "thread_ref": _safe_summary(thread_ref, limit=220) if thread_ref.strip() else "",
+        "dispatch_evidence_refs": refs,
+        "summary": _safe_summary(summary, limit=320) if summary.strip() else "Executor dispatch metadata recorded for this loop queue item.",
+        "capability": capability,
+    }
+    runtime["last_queue_id"] = str(item["queue_id"])
+    runtime["last_queue_status"] = str(item["status"])
+    cycle["runtime"] = runtime
+    cycle["next_action"] = "observe_runtime_queue"
+    return _write_loop(paths, cycle)
+
+
+def observe_codex_loop_queue_item(
+    paths: OmhPaths,
+    loop_id: str,
+    queue_id: str,
+    *,
+    codex_log_text: str = "",
+    evidence_refs: Iterable[str] | None = None,
+    codex_log_ref: str = "",
+    summary: str = "",
+) -> dict[str, Any]:
+    refs = _safe_list(evidence_refs or [], limit=320)
+    log_ref = _safe_summary(codex_log_ref, limit=320) if codex_log_ref.strip() else ""
+    all_refs = _safe_list([*refs, *([log_ref] if log_ref else [])], limit=320)
+    if not all_refs:
+        raise ValueError("Codex loop queue observation requires at least one evidence ref")
+    cycle = read_loop_cycle(paths, loop_id)
+    runtime, item = _queue_item_ref(cycle, queue_id)
+    if item.get("status") != "prepared_not_observed":
+        raise ValueError("only prepared_not_observed loop queue items can observe Codex progress")
+    progress = summarize_codex_jsonl_text(
+        codex_log_text,
+        evidence_refs=all_refs,
+        source=log_ref or "codex-loop-observation",
+    )
+    existing = _dict_value(item, "executor_session")
+    executor_session = {
+        **_empty_executor_session("codex"),
+        **existing,
+        "executor": "codex",
+        "loop_mode": "omh_managed",
+        "dispatch_owner": "omh_wrapper",
+        "dispatch_status": "progress_observed",
+        "progress_summary": progress,
+        "summary": _safe_summary(summary, limit=320) if summary.strip() else str(progress.get("chat_summary", "")),
+        "progress_evidence_refs": all_refs,
+        "capability": loop_executor_capability("codex"),
+    }
+    item["executor_session"] = executor_session
+    item["status"] = "observed"
+    item["observed"] = True
+    item["observed_at"] = utc_now()
+    item["observed_evidence_refs"] = _safe_list([*_string_list(item.get("observed_evidence_refs", [])), *all_refs], limit=320)
+    item["observation_summary"] = executor_session["summary"] or "Codex progress observed for this loop queue item."
+    runtime["last_queue_id"] = str(item["queue_id"])
+    runtime["last_queue_status"] = "observed"
+    cycle["runtime"] = runtime
+    cycle["phase"] = "feedback"
+    cycle["wait_reason"] = "none"
+    cycle["next_action"] = "record_feedback"
+    return _write_loop(paths, cycle)
+
+
+def build_loop_cycle_narration(paths: OmhPaths, loop_id: str, queue_id: str = "") -> dict[str, Any]:
+    cycle = read_loop_cycle(paths, loop_id)
+    item: dict[str, Any] = {}
+    if queue_id:
+        item = _queue_item_ref(cycle, queue_id)[1]
+    else:
+        runtime = _runtime_state(cycle.get("runtime"))
+        queue = [entry for entry in runtime.get("queue", []) if isinstance(entry, dict)]
+        item = queue[-1] if queue else {}
+    goal = _dict_value(cycle, "goal")
+    executor_session = _dict_value(item, "executor_session")
+    executor = str(executor_session.get("executor") or _preferred_executor(_dict_value(cycle, "authority_envelope")) or "selected executor")
+    executor_label = "Codex" if executor == "codex" else ("Claude Code" if executor == "claude-code" else executor)
+    progress = _dict_value(executor_session, "progress_summary")
+    progress_text = str(progress.get("chat_summary") or executor_session.get("summary") or item.get("observation_summary") or "아직 관측된 실행 요약은 없어.")
+    status = str(item.get("status", "")) or str(cycle.get("phase", ""))
+    return {
+        "schema_version": LOOP_CYCLE_NARRATION_SCHEMA,
+        "loop_id": str(cycle.get("loop_id", loop_id)),
+        "queue_id": str(item.get("queue_id", queue_id)),
+        "headline": "이번 사이클을 시작합니다." if status == "prepared_not_observed" else "이번 사이클 진행 상황입니다.",
+        "cycle_state": status,
+        "problem_definition": str(goal.get("current_loop_goal") or goal.get("reframe") or goal.get("summary", "")),
+        "planned_approach": str(item.get("planned_action", cycle.get("next_action", "continue_loop"))),
+        "executor_status": f"{executor_label} 상태: {executor_session.get('dispatch_status', 'not_dispatched')}",
+        "progress_summary": progress_text,
+        "verification_status": str(_dict_value(item, "verification_plan").get("expected_signal", "verification not planned yet")),
+        "next_message": _narration_next_message(status, executor_session),
+        "not_evidence_yet": ["implementation", "review", "ci", "merge", "goal_completion"],
         "claim_boundary": _runtime_claim_boundary(),
     }
 
@@ -1401,6 +1571,7 @@ def _runtime_queue_item(
             if is_prepared
             else _connector_plan("", "", planned_action)
         ),
+        "executor_session": _empty_executor_session(_preferred_executor(envelope)),
         "verification_plan": _verification_plan(planned_action, pattern, is_prepared=is_prepared),
         "note": _safe_summary(note, limit=240) if note.strip() else "",
         "observed": False,
@@ -1500,6 +1671,47 @@ def _connector_plan(connector: str, connector_action: str, planned_action: str) 
         "evidence_refs": [],
         "boundary": "OMH records connector intent only; connector I/O requires a separate observed wrapper action.",
     }
+
+
+def _preferred_executor(envelope: dict[str, Any]) -> str:
+    executors = _string_list(envelope.get("allowed_executors", []))
+    if "codex" in executors:
+        return "codex"
+    if "claude-code" in executors:
+        return "claude-code"
+    return executors[0] if executors else "choose"
+
+
+def _empty_executor_session(executor: str = "choose") -> dict[str, Any]:
+    capability = loop_executor_capability(executor)
+    return {
+        "executor": capability["executor"],
+        "loop_mode": capability["loop_mode"],
+        "dispatch_owner": capability["dispatch_owner"],
+        "dispatch_status": "not_requested",
+        "session_ref": "",
+        "thread_ref": "",
+        "dispatch_evidence_refs": [],
+        "progress_evidence_refs": [],
+        "progress_summary": {},
+        "review_summary": {},
+        "summary": "",
+        "capability": capability,
+        "claim_boundary": capability["claim_boundary"],
+    }
+
+
+def _narration_next_message(status: str, executor_session: dict[str, Any]) -> str:
+    dispatch_status = str(executor_session.get("dispatch_status", ""))
+    if status == "prepared_not_observed" and dispatch_status in {"", "not_requested", "prepared"}:
+        return "아직 실행 증거는 없고, 다음 단계는 선택한 코딩 에이전트에 이 큐 항목을 넘기는 거야."
+    if dispatch_status == "dispatched":
+        return "코딩 에이전트 세션은 기록됐고, 다음 단계는 진행 로그나 결과 evidence를 관측하는 거야."
+    if dispatch_status == "progress_observed":
+        return "진행은 관측됐고, 다음 단계는 검증/리뷰 evidence를 기록한 뒤 다음 사이클을 결정하는 거야."
+    if status == "observed":
+        return "큐 항목은 관측됐고, 다음 단계는 feedback 또는 verification artifact를 기록하는 거야."
+    return "현재 루프 상태를 확인하고 다음 관측 가능한 행동을 정해야 해."
 
 
 def _verification_plan(planned_action: str, workflow_pattern: str, *, is_prepared: bool) -> dict[str, Any]:

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -6,7 +6,7 @@ from typing import Any
 from ..ingress import CHAT_SOURCES, compact_source_metadata, extract_message_text, extract_source_metadata
 from ..routing.catalog_questions import is_skill_catalog_question as _is_skill_catalog_question
 from ..routing.chat import public_route_payload, route_chat_message
-from ..coding_delegation import build_coding_delegation_payload
+from ..coding_delegation import CODING_EXECUTOR_TARGETS, build_coding_delegation_payload
 from ..context import build_context_brief
 from ..executors import executor_label
 from ..goal_loop import build_loop_start_card
@@ -17,6 +17,7 @@ from ..plugin_bundle.omh.awareness import workflow_context_card_for_workflow, wo
 from ..probe import probe_capabilities
 from ..quickstart import build_quickstart_card
 from ..skills.catalog import installable_skill_definitions, primary_harness_for_skill, retained_delegation_skill_names
+from ..setup_profiles import read_setup_profile
 from ..visual_summary import image_generation_setup_fallback
 from .hermes_runtime import (
     hermes_coding_team_body,
@@ -576,6 +577,35 @@ def build_chat_interaction_payload(
         base["next_action"] = str(_nested(base["chat_response"], "state").get("next_action", "show_command_preview"))
         return _finish_interaction(base, target_notice)
 
+    if resolved_mode == "delegate":
+        resolved_executor_target, executor_resolution = _resolve_delegate_executor_target(executor_target, paths)
+        delegation = build_coding_delegation_payload(
+            message,
+            source=source,
+            limit=limit,
+            include_message=include_message,
+            source_metadata=metadata,
+            executor_target=resolved_executor_target,
+        )
+        delegation["executor_resolution"] = executor_resolution
+        base["delegation"] = delegation
+        base["executor_resolution"] = executor_resolution
+        action = str(_nested(delegation, "delegation").get("action", "fallback"))
+        if action == "delegate" and delegation.get("executor_handoff"):
+            base["next_action"] = "send_to_executor"
+        elif action == "delegate" and delegation.get("runtime_handoff"):
+            base["next_action"] = "show_runtime_handoff"
+        elif action == "delegate" and delegation.get("prompt_handoff"):
+            base["next_action"] = "show_prompt_handoff"
+        elif action == "delegate" and _nested(delegation, "executor_selection").get("choice_required"):
+            base["next_action"] = "choose_executor"
+        elif action == "clarify":
+            base["next_action"] = "answer_clarification"
+        else:
+            base["next_action"] = "route_coding_request"
+        base["chat_response"] = build_chat_response_from_delegation(delegation, thread_key=str(base["thread_key"]))
+        return _finish_interaction(base, target_notice)
+
     if resolved_mode == "clarify" or route["action"] != "dispatch":
         base["chat_response"] = build_chat_response_from_route(
             route_payload,
@@ -599,32 +629,6 @@ def build_chat_interaction_payload(
             base["loop_start_card"] = loop_start_card
         return _finish_interaction(base, target_notice)
 
-    if resolved_mode == "delegate":
-        delegation = build_coding_delegation_payload(
-            message,
-            source=source,
-            limit=limit,
-            include_message=include_message,
-            source_metadata=metadata,
-            executor_target=executor_target,
-        )
-        base["delegation"] = delegation
-        action = str(_nested(delegation, "delegation").get("action", "fallback"))
-        if action == "delegate" and delegation.get("executor_handoff"):
-            base["next_action"] = "send_to_executor"
-        elif action == "delegate" and delegation.get("runtime_handoff"):
-            base["next_action"] = "show_runtime_handoff"
-        elif action == "delegate" and delegation.get("prompt_handoff"):
-            base["next_action"] = "show_prompt_handoff"
-        elif action == "delegate" and _nested(delegation, "executor_selection").get("choice_required"):
-            base["next_action"] = "choose_executor"
-        elif action == "clarify":
-            base["next_action"] = "answer_clarification"
-        else:
-            base["next_action"] = "route_coding_request"
-        base["chat_response"] = build_chat_response_from_delegation(delegation, thread_key=str(base["thread_key"]))
-        return _finish_interaction(base, target_notice)
-
     plan = build_hermes_plan_payload(message, source=source, limit=limit, source_metadata=metadata)
     base["plan"] = _public_plan_payload(plan, include_message=include_message)
     contract = _nested(plan, "wrapper_contract")
@@ -632,6 +636,42 @@ def build_chat_interaction_payload(
     base["next_action"] = "present_plan" if next_action == "prepare_coding_delegation_after_plan_acceptance" else next_action
     base["chat_response"] = build_chat_response_from_plan(plan, thread_key=str(base["thread_key"]))
     return _finish_interaction(base, target_notice)
+
+
+def _resolve_delegate_executor_target(executor_target: str, paths: OmhPaths | None) -> tuple[str, dict[str, object]]:
+    requested = str(executor_target or "choose").strip() or "choose"
+    setup_default = "choose"
+    setup_available = False
+    if paths is not None:
+        try:
+            profile = read_setup_profile(paths)
+        except (OSError, ValueError):
+            profile = None
+        if isinstance(profile, dict):
+            candidate = str(profile.get("default_executor", "") or "").strip()
+            if candidate in CODING_EXECUTOR_TARGETS:
+                setup_default = candidate
+                setup_available = True
+
+    if requested != "choose":
+        resolved = requested
+        source = "explicit"
+    elif setup_available:
+        resolved = setup_default
+        source = "setup_profile"
+    else:
+        resolved = "choose"
+        source = "caller_default"
+
+    return resolved, {
+        "schema_version": "executor_resolution/v1",
+        "source": source,
+        "requested_executor_target": requested,
+        "default_executor": setup_default,
+        "resolved_executor_target": resolved,
+        "explicit_override": requested != "choose",
+        "claim_boundary": "Executor default resolution is routing preference only; it is not dispatch, execution, review, CI, or merge evidence.",
+    }
 
 
 def build_chat_status_interaction(
@@ -1264,6 +1304,7 @@ def build_chat_response_from_plan(plan_payload: dict[str, object], *, thread_key
 
 def build_chat_response_from_delegation(delegation_payload: dict[str, object], *, thread_key: str = "") -> dict[str, object]:
     delegation = _nested(delegation_payload, "delegation")
+    executor_resolution = _nested(delegation_payload, "executor_resolution")
     action = str(delegation.get("action", "fallback"))
     if action == "delegate" and delegation_payload.get("executor_handoff"):
         handoff = _nested(delegation_payload, "executor_handoff")
@@ -1290,6 +1331,7 @@ def build_chat_response_from_delegation(delegation_payload: dict[str, object], *
                 "dispatch_policy": delegation_payload.get("dispatch_policy", "ask_before_dispatch"),
                 "executor_target": handoff.get("executor_target", "codex"),
                 "executor_readiness": delegation_payload.get("executor_readiness", {}),
+                "executor_resolution": executor_resolution,
             },
         )
     if action == "delegate" and delegation_payload.get("prompt_handoff"):
@@ -1317,6 +1359,7 @@ def build_chat_response_from_delegation(delegation_payload: dict[str, object], *
                 "dispatch_policy": "prepare_only",
                 "dispatchable": False,
                 "executor_readiness": delegation_payload.get("executor_readiness", {}),
+                "executor_resolution": executor_resolution,
             },
         )
     if action == "delegate" and delegation_payload.get("runtime_handoff"):
@@ -1371,6 +1414,7 @@ def build_chat_response_from_delegation(delegation_payload: dict[str, object], *
                 "dispatch_policy": "prepare_only",
                 "dispatchable": False,
                 "executor_readiness": delegation_payload.get("executor_readiness", {}),
+                "executor_resolution": executor_resolution,
             },
         )
     if action == "delegate" and _nested(delegation_payload, "executor_selection").get("choice_required"):
@@ -1391,6 +1435,7 @@ def build_chat_response_from_delegation(delegation_payload: dict[str, object], *
                 "dispatchable": False,
                 "executor_options": _nested(delegation_payload, "executor_selection").get("options", []),
                 "executor_readiness": delegation_payload.get("executor_readiness", {}),
+                "executor_resolution": executor_resolution,
             },
         )
     if action == "clarify":

--- a/src/wrapper/sessions.py
+++ b/src/wrapper/sessions.py
@@ -107,6 +107,7 @@ def create_or_resume_wrapper_session(
         source_metadata=source_metadata,
         executor_target=executor_target,
         target_notice=target_notice,
+        paths=paths,
     )
     thread_key = str(interaction["thread_key"])
     session_id = session_id_for_thread_key(thread_key)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4323,27 +4323,68 @@ class CliTests(unittest.TestCase):
                 + [
                     "loop",
                     "queue",
-                    "observe",
+                    "dispatch",
                     "--loop",
                     "loop-cli",
                     "--queue",
                     queue_id,
+                    "--executor",
+                    "codex",
+                    "--codex-session-ref",
+                    "codex-session-cli",
                     "--evidence-ref",
-                    "wrapper:queue:observed",
+                    "wrapper:codex-dispatch:cli",
                     "--summary",
-                    "Wrapper observed the queued step.",
+                    "Codex session opened for this loop tick.",
                 ]
             )
             self.assertEqual(stderr, "")
             self.assertEqual(status, 0)
-            observed = json.loads(stdout)
+            dispatched = json.loads(stdout)
+            self.assertEqual(dispatched["loop"]["runtime"]["queue"][0]["status"], "prepared_not_observed")
+            self.assertEqual(dispatched["loop"]["runtime"]["queue"][0]["executor_session"]["dispatch_status"], "dispatched")
+            self.assertEqual(dispatched["loop"]["runtime"]["queue"][0]["executor_session"]["session_ref"], "codex-session-cli")
+
+            status, stdout, stderr = run_cli(home + ["loop", "queue", "narrate", "--loop", "loop-cli", "--queue", queue_id])
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            narration = json.loads(stdout)["narration"]
+            self.assertEqual(narration["schema_version"], "loop_cycle_narration/v1")
+            self.assertIn("Codex", narration["executor_status"])
+
+            status, stdout, stderr = run_cli(
+                home
+                + [
+                    "loop",
+                    "queue",
+                    "observe-codex",
+                    "--loop",
+                    "loop-cli",
+                    "--queue",
+                    queue_id,
+                    "--codex-log-text",
+                    '{"type":"tool_call","tool":"rg","args":"rg loop"}\n{"role":"assistant","content":"I defined the issue and started implementation."}',
+                    "--codex-log-ref",
+                    "codex-log:cli",
+                    "--evidence-ref",
+                    "codex-jsonl:cli",
+                    "--summary",
+                    "Codex defined the issue and started implementation.",
+                ]
+            )
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            codex_observed = json.loads(stdout)
+            self.assertEqual(codex_observed["loop"]["runtime"]["queue"][0]["status"], "observed")
+            self.assertEqual(codex_observed["loop"]["runtime"]["queue"][0]["executor_session"]["dispatch_status"], "progress_observed")
+            self.assertEqual(codex_observed["narration"]["schema_version"], "loop_cycle_narration/v1")
+
+            observed = codex_observed
             self.assertEqual(observed["loop"]["runtime"]["queue"][0]["status"], "observed")
             self.assertTrue(observed["loop"]["runtime"]["queue"][0]["observed"])
             self.assertFalse(observed["loop"]["runtime"]["queue"][0]["worktree_plan"]["created"])
             self.assertFalse(observed["loop"]["runtime"]["queue"][0]["subagent_plan"]["dispatched"])
             self.assertFalse(observed["loop"]["runtime"]["queue"][0]["connector_plan"]["dispatched"])
-            self.assertEqual(observed["status_card"]["runtime_summary"]["observed_queue_count"], 1)
-            self.assertEqual(observed["status_card"]["failure_mode_summary"]["warnings"][0]["id"], "verification_gap")
 
             status, stdout, stderr = run_cli(home + ["loop", "permit", "--loop", "loop-cli", "--allow-action", "merge"])
             self.assertEqual(stderr, "")

--- a/tests/test_loop_cycle.py
+++ b/tests/test_loop_cycle.py
@@ -13,12 +13,16 @@ from omh.goal_loop import (
     LOOP_STATUS_CARD_SCHEMA,
     assess_loopability,
     block_loop_queue_item,
+    build_loop_cycle_narration,
     build_loop_queue_handoff,
     build_loop_start_card,
     build_loop_status_card,
     create_loop_cycle,
+    dispatch_loop_queue_item,
     inspect_loop_queue_item,
     list_loop_queue,
+    loop_executor_capability,
+    observe_codex_loop_queue_item,
     observe_loop_queue_item,
     record_loop_feedback,
     run_loop_once_result,
@@ -325,6 +329,76 @@ class GoalLoopTests(unittest.TestCase):
         self.assertEqual(len(second["runtime"]["queue"]), 1)
         self.assertEqual(card["next_action"], "observe_runtime_queue")
         self.assertEqual(card["failure_mode_summary"]["warnings"][0]["id"], "verification_gap")
+
+    def test_loop_executor_capability_selects_native_or_omh_managed_loop(self) -> None:
+        claude = loop_executor_capability("claude-code")
+        codex = loop_executor_capability("codex")
+        hermes = loop_executor_capability("hermes")
+        generic = loop_executor_capability("generic")
+
+        self.assertEqual(claude["schema_version"], "executor_loop_capability/v1")
+        self.assertEqual(claude["loop_mode"], "native")
+        self.assertEqual(claude["dispatch_owner"], "executor")
+        self.assertIn("native_loop_or_goal", claude["observability"])
+        self.assertEqual(codex["loop_mode"], "omh_managed")
+        self.assertEqual(codex["dispatch_owner"], "omh_wrapper")
+        self.assertIn("codex_progress_summary/v1", codex["observability"])
+        self.assertEqual(hermes["loop_mode"], "omh_managed")
+        self.assertEqual(generic["loop_mode"], "prompt_handoff")
+        self.assertIn("not dispatch", codex["claim_boundary"])
+
+    def test_loop_codex_dispatch_observation_and_narration_keep_boundaries(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            cycle = create_loop_cycle(
+                paths,
+                goal_summary="Run a coding-agent loop through Codex while Hermes narrates progress",
+                goal_reframe="Prepare one Codex-backed loop step, observe progress, and report a human-readable status.",
+                success_criteria=["Codex session metadata is observed", "Hermes narration does not claim CI or merge"],
+                permission_profile="execute_with_gates",
+                allowed_executors=["codex"],
+            )
+            ticked = tick_loop_runtime(paths, cycle["loop_id"], workflow_pattern="single_step")
+            queue_id = ticked["runtime"]["queue"][0]["queue_id"]
+
+            dispatched = dispatch_loop_queue_item(
+                paths,
+                cycle["loop_id"],
+                queue_id,
+                executor="codex",
+                session_ref="codex-session-1",
+                thread_ref="codex-thread-1",
+                evidence_refs=["wrapper:codex-dispatch:1"],
+                summary="Codex session opened for this loop tick.",
+            )
+            observed = observe_codex_loop_queue_item(
+                paths,
+                cycle["loop_id"],
+                queue_id,
+                codex_log_text='{"type":"tool_call","tool":"rg","args":"rg loop"}\n{"role":"assistant","content":"I defined the issue and started the implementation."}',
+                evidence_refs=["codex-jsonl:1"],
+                codex_log_ref="codex-session-log:1",
+                summary="Codex defined the issue and started implementation.",
+            )
+            narration = build_loop_cycle_narration(paths, cycle["loop_id"], queue_id)
+
+        dispatched_item = dispatched["runtime"]["queue"][0]
+        observed_item = observed["runtime"]["queue"][0]
+        self.assertEqual(dispatched_item["status"], "prepared_not_observed")
+        self.assertEqual(dispatched_item["executor_session"]["dispatch_status"], "dispatched")
+        self.assertEqual(dispatched_item["executor_session"]["session_ref"], "codex-session-1")
+        self.assertFalse(dispatched_item["observed"])
+        self.assertEqual(observed_item["status"], "observed")
+        self.assertTrue(observed_item["observed"])
+        self.assertEqual(observed_item["executor_session"]["dispatch_status"], "progress_observed")
+        self.assertEqual(observed_item["executor_session"]["progress_summary"]["schema_version"], "codex_progress_summary/v1")
+        self.assertIn("codex-jsonl:1", observed_item["observed_evidence_refs"])
+        self.assertEqual(narration["schema_version"], "loop_cycle_narration/v1")
+        self.assertIn("이번 사이클", narration["headline"])
+        self.assertIn("Codex", narration["executor_status"])
+        self.assertIn("implementation", narration["not_evidence_yet"])
+        self.assertIn("ci", narration["not_evidence_yet"])
+        self.assertEqual(validate_loop_cycle(observed), {"ok": True, "errors": []})
 
     def test_loop_queue_lifecycle_lists_handoffs_observes_and_blocks_items(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_wrapper_contract.py
+++ b/tests/test_wrapper_contract.py
@@ -8,7 +8,8 @@ import unittest
 from _local_package import load_local_package
 
 load_local_package()
-from omh.paths import OmhPaths
+from omh.paths import OmhPaths, resolve_paths
+from omh.profiles.setup import write_setup_profile
 from omh.wrapper_contract import (
     build_chat_interaction_payload,
     build_chat_response_from_status,
@@ -213,6 +214,46 @@ class WrapperContractTests(unittest.TestCase):
         rendering = payload["chat_response"]["messenger_rendering"]
         self.assertIn("multiple Hermes agent targets", rendering["body_preview"])
         self.assertIn("Target topology is setup evidence only", rendering["claim_boundary"])
+
+    def test_delegate_mode_uses_setup_default_codex_executor_when_available(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            write_setup_profile(paths, default_executor="codex")
+
+            payload = build_chat_interaction_payload(
+                "implement a focused parser fix in src/parser.py and update tests",
+                source="discord",
+                mode="delegate",
+                paths=paths,
+            )
+
+        self.assertEqual(payload["next_action"], "send_to_executor")
+        self.assertEqual(payload["executor_resolution"]["source"], "setup_profile")
+        self.assertEqual(payload["executor_resolution"]["default_executor"], "codex")
+        self.assertEqual(payload["delegation"]["selected_executor_profile"], "codex")
+        self.assertIn("executor_handoff", payload["delegation"])
+        self.assertEqual(payload["chat_response"]["state"]["executor_target"], "codex")
+
+    def test_delegate_mode_preserves_explicit_executor_override_over_setup_default(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            write_setup_profile(paths, default_executor="codex")
+
+            payload = build_chat_interaction_payload(
+                "implement a focused parser fix in src/parser.py and update tests",
+                source="discord",
+                mode="delegate",
+                executor_target="claude-code",
+                paths=paths,
+            )
+
+        self.assertEqual(payload["next_action"], "show_prompt_handoff")
+        self.assertEqual(payload["executor_resolution"]["source"], "explicit")
+        self.assertEqual(payload["executor_resolution"]["default_executor"], "codex")
+        self.assertEqual(payload["executor_resolution"]["resolved_executor_target"], "claude-code")
+        self.assertEqual(payload["delegation"]["selected_executor_profile"], "claude-code")
+        self.assertNotIn("executor_handoff", payload["delegation"])
+        self.assertIn("prompt_handoff", payload["delegation"])
 
     def test_clarify_mode_has_no_handoff_actions(self) -> None:
         payload = build_chat_interaction_payload("fix maybe", mode="delegate")

--- a/tests/test_wrapper_sessions.py
+++ b/tests/test_wrapper_sessions.py
@@ -13,6 +13,7 @@ load_local_package()
 from omh.coding_lifecycle import record_codex_dispatch, record_codex_result, record_codex_verification, start_codex_delegation_lifecycle
 from omh.codex_progress import summarize_codex_jsonl_text
 from omh.paths import resolve_paths
+from omh.profiles.setup import write_setup_profile
 from omh.runtime_artifacts import (
     create_run,
     export_runtime,
@@ -46,6 +47,25 @@ from omh.wrapper_sessions import (
 
 
 class WrapperSessionTests(unittest.TestCase):
+    def test_session_delegate_mode_uses_setup_default_codex_executor_when_available(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            write_setup_profile(paths, default_executor="codex")
+
+            started = create_or_resume_wrapper_session(
+                paths,
+                "implement a focused parser fix in src/parser.py and update tests",
+                source="hermes",
+                mode="delegate",
+                source_metadata={"source_event_id": "m1", "channel_ref": "c1"},
+            )
+
+        interaction = started["interaction"]
+        self.assertEqual(interaction["next_action"], "send_to_executor")
+        self.assertEqual(interaction["executor_resolution"]["source"], "setup_profile")
+        self.assertEqual(interaction["delegation"]["selected_executor_profile"], "codex")
+        self.assertIn("executor_handoff", interaction["delegation"])
+
     def test_session_start_is_metadata_only_and_resumable(self) -> None:
         with TemporaryDirectory() as tmp:
             paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")


### PR DESCRIPTION
## Summary
- add loop executor capability metadata for native vs OMH-managed coding loops
- add loop queue dispatch, Codex progress observation, and narration primitives
- expose queue dispatch / observe-codex / narrate CLI commands and cover them in tests

## Verification
- PYTHONPYCACHEPREFIX=/private/tmp/omh-loop-pycache PYTHONPATH=tests /opt/homebrew/bin/python3.12 -m unittest discover -s tests -v

## Notes
- No merge performed; waiting for maintainer approval.