### PR TITLE
Bound OMH context payloads for handoff status

### DIFF
--- a/docs/HERMES_AGENT_INTEGRATION_RUNBOOK.md
+++ b/docs/HERMES_AGENT_INTEGRATION_RUNBOOK.md
@@ -192,6 +192,14 @@ reasoning, raw JSON events, or unobserved review/CI/merge claims. If an
 explicit JSONL path cannot be read, the adapter must surface that as missing
 evidence instead of treating it as an empty observed log.
 
+Large output belongs in the wrapper or operator artifact store, not in Hermes
+chat context. `codex_progress_summary/v1` includes
+`raw_output_artifact` (`omh_context_artifact_ref/v1`), `context_budget`, capped
+evidence refs, and a bounded human-readable summary so wrappers can reference
+the raw log without copying it into the prompt. The artifact reference is
+prepared context only; it is not execution, review, CI, merge-readiness, or
+merge evidence.
+
 When Codex performs a review, wrappers can expose a human-readable review
 context summary without raw logs:
 

--- a/docs/HERMES_AGENT_INTEGRATION_RUNBOOK.md
+++ b/docs/HERMES_AGENT_INTEGRATION_RUNBOOK.md
@@ -200,6 +200,17 @@ the raw log without copying it into the prompt. The artifact reference is
 prepared context only; it is not execution, review, CI, merge-readiness, or
 merge evidence.
 
+Long executor, goal, research, and workflow runs should report meaningful
+events instead of relying on 3-5 minute polling. Use `omh_progress_event/v1` for
+state changes such as failure discovered, root cause identified, fix strategy
+selected, files or area chosen, targeted tests pass/fail, full tests
+start/pass/fail, commit created, PR created/updated, or blocker encountered.
+Each event should be one or two human-readable sentences with optional file
+refs, compact artifact refs, severity/status, and the standard claim boundary.
+Raw logs, JSONL, command output, and transcripts stay in artifacts referenced by
+the event; the event itself is progress context, not execution/review/CI/merge
+evidence.
+
 When Codex performs a review, wrappers can expose a human-readable review
 context summary without raw logs:
 

--- a/skills/oh-my-hermes/references/wrapper-routing.md
+++ b/skills/oh-my-hermes/references/wrapper-routing.md
@@ -30,6 +30,16 @@ Check `executor_readiness/v1` for Codex, Claude Code, Hermes, or oh-my runtime p
 
 With `--record`, Codex-selected real executor handoffs create `.omh/runtime/runs/<run-id>/` prepared runtime runs with `observation_status: prepared_not_observed`. Executor-choice, prompt-only, runtime-handoff, clarify, and fallback responses remain wrapper/session state.
 
+## Large Output And Context Safety
+
+Wrappers must keep raw Codex JSONL, tool output, process logs, and oversized
+executor notes out of Hermes chat context. Use `omh chat codex-progress` or the
+Codex progress fields on executor-session actions to pass only
+`codex_progress_summary/v1`, `omh_context_artifact_ref/v1`, compact evidence
+refs, and bounded human-readable summaries. Raw output belongs in a wrapper or
+operator artifact store referenced by `raw_output_artifact`; a prepared artifact
+reference is not execution, review, CI, merge-readiness, or merge evidence.
+
 ## Memory And Planning
 
 Wrappers can run `omh memory inspect`, `omh memory pack`, and `omh memory apply` to review OMH-local or wrapper-supplied context before preparing a handoff. This emits `memory_review_card/v1` and `handoff_context_pack/v1` artifacts only; it does not read or mutate opaque Hermes internal memory.

--- a/skills/oh-my-hermes/references/wrapper-routing.md
+++ b/skills/oh-my-hermes/references/wrapper-routing.md
@@ -40,6 +40,15 @@ refs, and bounded human-readable summaries. Raw output belongs in a wrapper or
 operator artifact store referenced by `raw_output_artifact`; a prepared artifact
 reference is not execution, review, CI, merge-readiness, or merge evidence.
 
+Prefer event-triggered progress over timed polling for long executor, goal,
+research, or workflow runs. Emit `omh_progress_event/v1` when a meaningful state
+changes: failure discovered, root cause identified, fix strategy selected, files
+or area chosen, targeted tests pass/fail, full tests start/pass/fail, commit
+created, PR created/updated, or blocker encountered. Keep each update to one or
+two human-readable sentences with optional compact file refs, artifact refs,
+severity, and status. Store raw logs, JSONL, command output, and transcripts as
+artifacts; pass only event summaries and refs into Hermes chat context.
+
 ## Memory And Planning
 
 Wrappers can run `omh memory inspect`, `omh memory pack`, and `omh memory apply` to review OMH-local or wrapper-supplied context before preparing a handoff. This emits `memory_review_card/v1` and `handoff_context_pack/v1` artifacts only; it does not read or mutate opaque Hermes internal memory.

--- a/src/codex_progress.py
+++ b/src/codex_progress.py
@@ -9,7 +9,9 @@ from typing import Any
 from .context_safety import (
     MAX_EVIDENCE_REFS,
     MAX_EVIDENCE_REF_CHARS,
+    MAX_PROGRESS_EVENTS,
     MAX_VISIBLE_MESSAGE_CHARS,
+    build_progress_event,
     compact_context_refs,
     compact_visible_text,
     context_budget_payload,
@@ -108,6 +110,13 @@ def summarize_codex_jsonl_text(
     activities = _observable_activity(activity_counts)
     status = terminal_status or ("activity_observed" if activities or visible_decisions else "no_observable_events")
     compact_refs, omitted_refs = compact_context_refs(evidence_refs or [])
+    raw_artifact = raw_output_artifact_ref(
+        text,
+        source=source,
+        evidence_refs=compact_refs,
+        omitted_evidence_ref_count=omitted_refs,
+    )
+    progress_events, omitted_progress_events = _progress_events(parsed_events, raw_artifact)
     return {
         "schema_version": CODEX_PROGRESS_SCHEMA_VERSION,
         "source": source,
@@ -119,18 +128,18 @@ def summarize_codex_jsonl_text(
         "assistant_visible_messages": visible_decisions[:3],
         "latest_assistant_visible_message": visible_decisions[-1] if visible_decisions else "",
         "chat_summary": _chat_summary(status, activities, visible_decisions),
+        "progress_reporting": _progress_reporting_contract(),
+        "progress_events": progress_events,
+        "latest_progress_event": progress_events[-1] if progress_events else {},
         "evidence_refs": compact_refs,
-        "raw_output_artifact": raw_output_artifact_ref(
-            text,
-            source=source,
-            evidence_refs=compact_refs,
-            omitted_evidence_ref_count=omitted_refs,
-        ),
+        "raw_output_artifact": raw_artifact,
         "context_budget": context_budget_payload(),
         "omitted": {
             "assistant_visible_message_count": max(0, len(visible_decisions) - 3),
             "evidence_ref_count": omitted_refs,
+            "progress_event_count": omitted_progress_events,
             "max_visible_message_chars": MAX_VISIBLE_MESSAGE_CHARS,
+            "max_progress_events": MAX_PROGRESS_EVENTS,
             "max_evidence_refs": MAX_EVIDENCE_REFS,
             "max_evidence_ref_chars": MAX_EVIDENCE_REF_CHARS,
         },
@@ -168,6 +177,7 @@ def build_codex_session_observation(
         "event_count": int(progress.get("event_count", 0) or 0),
         "observable_activity": list(progress.get("observable_activity", [])) if isinstance(progress.get("observable_activity"), list) else [],
         "latest_assistant_visible_message": str(progress.get("latest_assistant_visible_message", "")),
+        "latest_progress_event": progress.get("latest_progress_event", {}) if isinstance(progress.get("latest_progress_event"), dict) else {},
         "evidence_refs": _compact_list([*(evidence_refs or []), *progress.get("evidence_refs", [])])
         if isinstance(progress.get("evidence_refs", []), list)
         else _compact_list(evidence_refs or []),
@@ -470,6 +480,7 @@ def _progress_context(progress: dict[str, object]) -> dict[str, object]:
         "event_count": int(progress.get("event_count", 0) or 0),
         "observable_activity": list(progress.get("observable_activity", [])) if isinstance(progress.get("observable_activity"), list) else [],
         "chat_summary": str(progress.get("chat_summary", "")),
+        "latest_progress_event": progress.get("latest_progress_event", {}) if isinstance(progress.get("latest_progress_event"), dict) else {},
         "evidence_refs": _compact_list(progress.get("evidence_refs", [])),
         "claim_boundary": str(progress.get("claim_boundary", "")),
     }
@@ -486,6 +497,134 @@ def _terminal_success_observed(text: str) -> bool:
 
 def _compact_visible_message(value: str) -> str:
     return compact_visible_text(value, max_chars=MAX_VISIBLE_MESSAGE_CHARS)
+
+
+def _progress_events(parsed_events: list[dict[str, Any]], raw_artifact: dict[str, object]) -> tuple[list[dict[str, object]], int]:
+    events: list[dict[str, object]] = []
+    for event in parsed_events:
+        searchable = _safe_search_text(event)
+        visible = _assistant_visible_message(event)
+        summary = visible or _tool_progress_summary(searchable)
+        if not summary:
+            continue
+        event_type = _progress_event_type(searchable)
+        if not event_type:
+            continue
+        status, severity = _progress_status_and_severity(event_type)
+        events.append(
+            build_progress_event(
+                event_type,
+                summary,
+                status=status,
+                severity=severity,
+                file_refs=_file_refs(searchable),
+                artifact_refs=[raw_artifact],
+            )
+        )
+    if len(events) <= MAX_PROGRESS_EVENTS:
+        return events, 0
+    return events[-MAX_PROGRESS_EVENTS:], len(events) - MAX_PROGRESS_EVENTS
+
+
+def _progress_reporting_contract() -> dict[str, object]:
+    return {
+        "schema_version": "omh_progress_reporting/v1",
+        "mode": "event_triggered",
+        "timed_polling_required": False,
+        "preferred_triggers": [
+            "bug_or_failure_discovered",
+            "root_cause_identified",
+            "fix_strategy_selected",
+            "files_or_area_chosen",
+            "targeted_tests_pass_or_fail",
+            "full_tests_start_pass_or_fail",
+            "commit_or_pr_created_or_updated",
+            "blocker_encountered",
+        ],
+        "human_update_policy": "one_or_two_sentence_summary_only",
+        "raw_output_policy": "store_raw_output_as_artifact_and_emit_refs_only",
+    }
+
+
+def _progress_event_type(text: str) -> str:
+    lowered = text.casefold()
+    if "root cause" in lowered:
+        return "root_cause_identified"
+    if "fix strategy" in lowered or "strategy selected" in lowered or "selected strategy" in lowered:
+        return "fix_strategy_selected"
+    if "bug discovered" in lowered:
+        return "bug_discovered"
+    if "blocker" in lowered or "blocked" in lowered:
+        return "blocker_encountered"
+    if "full tests" in lowered and "start" in lowered:
+        return "full_tests_started"
+    if "full tests" in lowered and _terminal_success_observed(lowered):
+        return "full_tests_passed"
+    if "full tests" in lowered and _TERMINAL_FAILURE_RE.search(lowered):
+        return "full_tests_failed"
+    if "targeted tests" in lowered and _terminal_success_observed(lowered):
+        return "targeted_tests_passed"
+    if "targeted tests" in lowered and _TERMINAL_FAILURE_RE.search(lowered):
+        return "targeted_tests_failed"
+    if "test" in lowered and _terminal_success_observed(lowered):
+        return "targeted_tests_passed"
+    if "test" in lowered and _TERMINAL_FAILURE_RE.search(lowered):
+        return "targeted_tests_failed"
+    if "commit" in lowered and any(token in lowered for token in ("created", "committed")):
+        return "commit_created"
+    if ("pull request" in lowered or " pr " in lowered) and "created" in lowered:
+        return "pr_created"
+    if ("pull request" in lowered or " pr " in lowered) and "updated" in lowered:
+        return "pr_updated"
+    if _file_refs(text) and any(token in lowered for token in ("file", "files", "area", "chosen", "selected", "editing", "touching")):
+        return "files_area_chosen"
+    if "failure" in lowered or "failed" in lowered or "error" in lowered:
+        return "failure_discovered"
+    return ""
+
+
+def _progress_status_and_severity(event_type: str) -> tuple[str, str]:
+    if event_type.endswith("_passed") or event_type in {"commit_created", "pr_created", "pr_updated", "workflow_completed"}:
+        return "passed", "success"
+    if event_type.endswith("_failed") or event_type in {"failure_discovered", "bug_discovered"}:
+        return "failed", "error"
+    if event_type == "blocker_encountered":
+        return "blocked", "blocked"
+    if event_type.endswith("_started"):
+        return "running", "info"
+    if event_type in {"root_cause_identified", "fix_strategy_selected", "files_area_chosen"}:
+        return "observed", "warning" if event_type == "root_cause_identified" else "info"
+    return "observed", "info"
+
+
+def _tool_progress_summary(text: str) -> str:
+    if not text:
+        return ""
+    event_type = _progress_event_type(text)
+    if event_type.endswith("_passed"):
+        return "Tests passed."
+    if event_type.endswith("_failed"):
+        return "Tests failed."
+    if event_type.endswith("_started"):
+        return "Tests started."
+    if event_type == "commit_created":
+        return "Commit created."
+    if event_type == "pr_created":
+        return "Pull request created."
+    if event_type == "pr_updated":
+        return "Pull request updated."
+    if event_type == "blocker_encountered":
+        return "Blocker encountered."
+    if event_type == "files_area_chosen":
+        refs = _file_refs(text)
+        return f"Work area chosen: {', '.join(refs[:3])}."
+    return ""
+
+
+def _file_refs(text: str) -> list[str]:
+    matches = re.findall(r"\b[\w./-]+\.(?:py|md|json|jsonl|toml|yaml|yml|ts|tsx|js|jsx|sh)\b", text)
+    compact, _omitted = compact_context_refs(matches)
+    return compact
 
 
 def _is_inspection_event(text: str) -> bool:

--- a/src/codex_progress.py
+++ b/src/codex_progress.py
@@ -6,6 +6,16 @@ import re
 from pathlib import Path
 from typing import Any
 
+from .context_safety import (
+    MAX_EVIDENCE_REFS,
+    MAX_EVIDENCE_REF_CHARS,
+    MAX_VISIBLE_MESSAGE_CHARS,
+    compact_context_refs,
+    compact_visible_text,
+    context_budget_payload,
+    raw_output_artifact_ref,
+)
+
 
 CODEX_PROGRESS_SCHEMA_VERSION = "codex_progress_summary/v1"
 CODEX_SESSION_OBSERVATION_SCHEMA_VERSION = "codex_session_observation/v1"
@@ -33,7 +43,6 @@ _VISIBLE_MESSAGE_TYPES = {
 }
 _TERMINAL_FAILURE_RE = re.compile(r"\b(error|failed|failure|traceback)\b")
 _TERMINAL_SUCCESS_RE = re.compile(r"\b(completed|complete|success|succeeded|passed)\b")
-_MAX_VISIBLE_MESSAGE = 180
 _CODEX_REVIEW_STATUSES = ("not_observed", "pending", "passed", "failed", "blocked", "changes_requested", "commented")
 
 
@@ -98,6 +107,7 @@ def summarize_codex_jsonl_text(
             activity_counts["assistant_visible_decisions"] += 1
     activities = _observable_activity(activity_counts)
     status = terminal_status or ("activity_observed" if activities or visible_decisions else "no_observable_events")
+    compact_refs, omitted_refs = compact_context_refs(evidence_refs or [])
     return {
         "schema_version": CODEX_PROGRESS_SCHEMA_VERSION,
         "source": source,
@@ -109,11 +119,25 @@ def summarize_codex_jsonl_text(
         "assistant_visible_messages": visible_decisions[:3],
         "latest_assistant_visible_message": visible_decisions[-1] if visible_decisions else "",
         "chat_summary": _chat_summary(status, activities, visible_decisions),
-        "evidence_refs": _compact_list(evidence_refs or []),
+        "evidence_refs": compact_refs,
+        "raw_output_artifact": raw_output_artifact_ref(
+            text,
+            source=source,
+            evidence_refs=compact_refs,
+            omitted_evidence_ref_count=omitted_refs,
+        ),
+        "context_budget": context_budget_payload(),
+        "omitted": {
+            "assistant_visible_message_count": max(0, len(visible_decisions) - 3),
+            "evidence_ref_count": omitted_refs,
+            "max_visible_message_chars": MAX_VISIBLE_MESSAGE_CHARS,
+            "max_evidence_refs": MAX_EVIDENCE_REFS,
+            "max_evidence_ref_chars": MAX_EVIDENCE_REF_CHARS,
+        },
         "privacy": "summary_only",
         "claim_boundary": (
             "This is an observable Codex event summary. It is not raw JSONL, hidden reasoning, "
-            "review evidence, CI evidence, merge-readiness evidence, or merge evidence."
+            "review evidence, CI evidence, merge-readiness evidence, or merge evidence; raw output should stay in artifacts."
         ),
     }
 
@@ -461,12 +485,7 @@ def _terminal_success_observed(text: str) -> bool:
 
 
 def _compact_visible_message(value: str) -> str:
-    cleaned = re.sub(r"\s+", " ", value).strip()
-    if not cleaned:
-        return ""
-    if len(cleaned) <= _MAX_VISIBLE_MESSAGE:
-        return cleaned
-    return f"{cleaned[: _MAX_VISIBLE_MESSAGE - 1]}..."
+    return compact_visible_text(value, max_chars=MAX_VISIBLE_MESSAGE_CHARS)
 
 
 def _is_inspection_event(text: str) -> bool:
@@ -510,14 +529,7 @@ def _chat_summary(status: str, activities: list[str], visible_decisions: list[st
 
 
 def _compact_list(values: Any) -> list[str]:
-    if not isinstance(values, (list, tuple)):
-        return []
-    seen: list[str] = []
-    for value in values:
-        text = str(value).strip()
-        if text and text not in seen:
-            seen.append(text)
-    return seen
+    return compact_context_refs(values)[0]
 
 
 def _shell_quote(value: str) -> str:

--- a/src/context_safety.py
+++ b/src/context_safety.py
@@ -6,11 +6,38 @@ from typing import Any
 
 
 CONTEXT_ARTIFACT_REF_SCHEMA_VERSION = "omh_context_artifact_ref/v1"
+PROGRESS_EVENT_SCHEMA_VERSION = "omh_progress_event/v1"
 MAX_VISIBLE_MESSAGE_CHARS = 180
 MAX_SUMMARY_CHARS = 240
+MAX_PROGRESS_EVENT_SUMMARY_CHARS = 220
+MAX_PROGRESS_EVENTS = 6
 MAX_SOURCE_REF_CHARS = 240
 MAX_EVIDENCE_REFS = 8
 MAX_EVIDENCE_REF_CHARS = 160
+MAX_ARTIFACT_REFS = 4
+
+_PROGRESS_EVENT_TYPES = {
+    "status_update",
+    "bug_discovered",
+    "failure_discovered",
+    "root_cause_identified",
+    "fix_strategy_selected",
+    "files_area_chosen",
+    "targeted_tests_started",
+    "targeted_tests_passed",
+    "targeted_tests_failed",
+    "full_tests_started",
+    "full_tests_passed",
+    "full_tests_failed",
+    "commit_created",
+    "pr_created",
+    "pr_updated",
+    "blocker_encountered",
+    "workflow_started",
+    "workflow_completed",
+}
+_PROGRESS_EVENT_STATUSES = {"prepared", "observed", "running", "passed", "failed", "blocked"}
+_PROGRESS_EVENT_SEVERITIES = {"info", "success", "warning", "error", "blocked"}
 
 
 def compact_visible_text(value: Any, *, max_chars: int) -> str:
@@ -47,11 +74,81 @@ def compact_context_refs(
     return seen, omitted
 
 
+def build_progress_event(
+    event_type: str,
+    summary: Any,
+    *,
+    status: str = "observed",
+    severity: str = "info",
+    file_refs: list[str] | tuple[str, ...] | None = None,
+    artifact_refs: list[object] | tuple[object, ...] | None = None,
+    evidence_refs: list[str] | tuple[str, ...] | None = None,
+) -> dict[str, object]:
+    compact_files, omitted_files = compact_context_refs(file_refs or [])
+    compact_evidence, omitted_evidence = compact_context_refs(evidence_refs or [])
+    compact_artifacts, omitted_artifacts = _compact_artifact_refs(artifact_refs or [])
+    return {
+        "schema_version": PROGRESS_EVENT_SCHEMA_VERSION,
+        "event_type": _normalize_progress_event_type(event_type),
+        "status": _normalize_choice(status, _PROGRESS_EVENT_STATUSES, "observed"),
+        "severity": _normalize_choice(severity, _PROGRESS_EVENT_SEVERITIES, "info"),
+        "summary": compact_visible_text(_strip_code_fences(summary), max_chars=MAX_PROGRESS_EVENT_SUMMARY_CHARS),
+        "file_refs": compact_files,
+        "artifact_refs": compact_artifacts,
+        "evidence_refs": compact_evidence,
+        "omitted": {
+            "file_ref_count": omitted_files,
+            "artifact_ref_count": omitted_artifacts,
+            "evidence_ref_count": omitted_evidence,
+            "max_summary_chars": MAX_PROGRESS_EVENT_SUMMARY_CHARS,
+            "max_artifact_refs": MAX_ARTIFACT_REFS,
+            "max_evidence_refs": MAX_EVIDENCE_REFS,
+        },
+        "context_policy": "event_triggered_summary_only",
+        "raw_content_included": False,
+        "claim_boundary": (
+            "This progress event is a compact wrapper/status update. It is not execution, review, CI, "
+            "merge-readiness, merge, or raw-log evidence unless separate observed evidence records say so."
+        ),
+    }
+
+
+def compact_progress_events(
+    events: Any,
+    *,
+    max_items: int = MAX_PROGRESS_EVENTS,
+) -> tuple[list[dict[str, object]], int]:
+    if not isinstance(events, (list, tuple)):
+        return [], 0
+    compacted: list[dict[str, object]] = []
+    omitted = 0
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        if len(compacted) >= max_items:
+            omitted += 1
+            continue
+        compacted.append(
+            build_progress_event(
+                str(event.get("event_type", "status_update")),
+                event.get("summary", ""),
+                status=str(event.get("status", "observed")),
+                severity=str(event.get("severity", "info")),
+                file_refs=event.get("file_refs", []) if isinstance(event.get("file_refs", []), list) else [],
+                artifact_refs=event.get("artifact_refs", []) if isinstance(event.get("artifact_refs", []), list) else [],
+                evidence_refs=event.get("evidence_refs", []) if isinstance(event.get("evidence_refs", []), list) else [],
+            )
+        )
+    return compacted, omitted
+
+
 def context_budget_payload() -> dict[str, object]:
     return {
         "schema_version": "omh_context_budget/v1",
         "max_visible_message_chars": MAX_VISIBLE_MESSAGE_CHARS,
         "max_summary_chars": MAX_SUMMARY_CHARS,
+        "max_progress_event_summary_chars": MAX_PROGRESS_EVENT_SUMMARY_CHARS,
+        "max_progress_events": MAX_PROGRESS_EVENTS,
         "max_evidence_refs": MAX_EVIDENCE_REFS,
         "max_evidence_ref_chars": MAX_EVIDENCE_REF_CHARS,
         "raw_output_policy": "store_raw_output_as_artifact_and_inject_refs_and_summary_only",
@@ -80,3 +177,63 @@ def raw_output_artifact_ref(
         "raw_content_included": False,
         "claim_boundary": "Raw output should stay in artifacts; Hermes context receives only this reference and bounded summaries.",
     }
+
+
+def _normalize_progress_event_type(value: str) -> str:
+    normalized = _normalize_token(value)
+    return normalized if normalized in _PROGRESS_EVENT_TYPES else "status_update"
+
+
+def _normalize_choice(value: str, allowed: set[str], fallback: str) -> str:
+    normalized = _normalize_token(value)
+    return normalized if normalized in allowed else fallback
+
+
+def _normalize_token(value: str) -> str:
+    return str(value).strip().casefold().replace("-", "_").replace(" ", "_")
+
+
+def _strip_code_fences(value: Any) -> str:
+    return str(value).replace("```", " ")
+
+
+def _compact_artifact_refs(values: list[object] | tuple[object, ...]) -> tuple[list[dict[str, object]], int]:
+    compacted: list[dict[str, object]] = []
+    omitted = 0
+    for value in values:
+        if len(compacted) >= MAX_ARTIFACT_REFS:
+            omitted += 1
+            continue
+        artifact = _compact_artifact_ref(value)
+        if artifact:
+            compacted.append(artifact)
+    return compacted, omitted
+
+
+def _compact_artifact_ref(value: object) -> dict[str, object]:
+    if isinstance(value, dict):
+        artifact = {
+            "schema_version": compact_visible_text(value.get("schema_version", CONTEXT_ARTIFACT_REF_SCHEMA_VERSION), max_chars=80),
+            "source": compact_visible_text(value.get("source", ""), max_chars=MAX_SOURCE_REF_CHARS),
+            "sha256": compact_visible_text(value.get("sha256", ""), max_chars=80),
+            "byte_count": max(0, int(value.get("byte_count", 0) or 0)),
+            "line_count": max(0, int(value.get("line_count", 0) or 0)),
+            "storage_policy": compact_visible_text(value.get("storage_policy", "store_raw_output_as_artifact"), max_chars=80),
+            "in_context_policy": compact_visible_text(value.get("in_context_policy", "refs_and_summary_only"), max_chars=80),
+            "raw_content_included": False,
+        }
+        return {key: item for key, item in artifact.items() if not _empty_artifact_field(item)}
+    source = compact_visible_text(value, max_chars=MAX_SOURCE_REF_CHARS)
+    if not source:
+        return {}
+    return {
+        "schema_version": CONTEXT_ARTIFACT_REF_SCHEMA_VERSION,
+        "source": source,
+        "storage_policy": "store_raw_output_as_artifact",
+        "in_context_policy": "refs_and_summary_only",
+        "raw_content_included": False,
+    }
+
+
+def _empty_artifact_field(value: object) -> bool:
+    return not isinstance(value, bool) and value in ("", 0)

--- a/src/context_safety.py
+++ b/src/context_safety.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import hashlib
+import re
+from typing import Any
+
+
+CONTEXT_ARTIFACT_REF_SCHEMA_VERSION = "omh_context_artifact_ref/v1"
+MAX_VISIBLE_MESSAGE_CHARS = 180
+MAX_SUMMARY_CHARS = 240
+MAX_SOURCE_REF_CHARS = 240
+MAX_EVIDENCE_REFS = 8
+MAX_EVIDENCE_REF_CHARS = 160
+
+
+def compact_visible_text(value: Any, *, max_chars: int) -> str:
+    text = re.sub(r"\s+", " ", str(value)).strip()
+    if not text:
+        return ""
+    if len(text) <= max_chars:
+        return text
+    if max_chars <= 3:
+        return text[:max_chars]
+    return f"{text[: max_chars - 3]}..."
+
+
+def compact_context_refs(
+    values: Any,
+    *,
+    max_items: int = MAX_EVIDENCE_REFS,
+    max_chars: int = MAX_EVIDENCE_REF_CHARS,
+) -> tuple[list[str], int]:
+    if not isinstance(values, (list, tuple)):
+        return [], 0
+    seen: list[str] = []
+    omitted = 0
+    for value in values:
+        text = compact_visible_text(value, max_chars=max_chars)
+        if not text:
+            continue
+        if text in seen:
+            continue
+        if len(seen) >= max_items:
+            omitted += 1
+            continue
+        seen.append(text)
+    return seen, omitted
+
+
+def context_budget_payload() -> dict[str, object]:
+    return {
+        "schema_version": "omh_context_budget/v1",
+        "max_visible_message_chars": MAX_VISIBLE_MESSAGE_CHARS,
+        "max_summary_chars": MAX_SUMMARY_CHARS,
+        "max_evidence_refs": MAX_EVIDENCE_REFS,
+        "max_evidence_ref_chars": MAX_EVIDENCE_REF_CHARS,
+        "raw_output_policy": "store_raw_output_as_artifact_and_inject_refs_and_summary_only",
+    }
+
+
+def raw_output_artifact_ref(
+    text: str,
+    *,
+    source: str,
+    evidence_refs: list[str] | tuple[str, ...] | None = None,
+    omitted_evidence_ref_count: int = 0,
+) -> dict[str, object]:
+    compact_refs, extra_omitted = compact_context_refs(evidence_refs or [])
+    encoded = text.encode("utf-8")
+    return {
+        "schema_version": CONTEXT_ARTIFACT_REF_SCHEMA_VERSION,
+        "source": compact_visible_text(source or "stdin", max_chars=MAX_SOURCE_REF_CHARS),
+        "sha256": hashlib.sha256(encoded).hexdigest(),
+        "byte_count": len(encoded),
+        "line_count": len(text.splitlines()),
+        "evidence_refs": compact_refs,
+        "omitted_evidence_ref_count": omitted_evidence_ref_count + extra_omitted,
+        "storage_policy": "store_raw_output_as_artifact",
+        "in_context_policy": "refs_and_summary_only",
+        "raw_content_included": False,
+        "claim_boundary": "Raw output should stay in artifacts; Hermes context receives only this reference and bounded summaries.",
+    }

--- a/src/skills/render.py
+++ b/src/skills/render.py
@@ -385,6 +385,15 @@ refs, and bounded human-readable summaries. Raw output belongs in a wrapper or
 operator artifact store referenced by `raw_output_artifact`; a prepared artifact
 reference is not execution, review, CI, merge-readiness, or merge evidence.
 
+Prefer event-triggered progress over timed polling for long executor, goal,
+research, or workflow runs. Emit `omh_progress_event/v1` when a meaningful state
+changes: failure discovered, root cause identified, fix strategy selected, files
+or area chosen, targeted tests pass/fail, full tests start/pass/fail, commit
+created, PR created/updated, or blocker encountered. Keep each update to one or
+two human-readable sentences with optional compact file refs, artifact refs,
+severity, and status. Store raw logs, JSONL, command output, and transcripts as
+artifacts; pass only event summaries and refs into Hermes chat context.
+
 ## Memory And Planning
 
 Wrappers can run `omh memory inspect`, `omh memory pack`, and `omh memory apply` to review OMH-local or wrapper-supplied context before preparing a handoff. This emits `{MEMORY_REVIEW_SCHEMA}` and `{HANDOFF_CONTEXT_PACK_SCHEMA}` artifacts only; it does not read or mutate opaque Hermes internal memory.

--- a/src/skills/render.py
+++ b/src/skills/render.py
@@ -375,6 +375,16 @@ Check `executor_readiness/v1` for Codex, Claude Code, Hermes, or oh-my runtime p
 
 With `--record`, Codex-selected real executor handoffs create `.omh/runtime/runs/<run-id>/` prepared runtime runs with `observation_status: prepared_not_observed`. Executor-choice, prompt-only, runtime-handoff, clarify, and fallback responses remain wrapper/session state.
 
+## Large Output And Context Safety
+
+Wrappers must keep raw Codex JSONL, tool output, process logs, and oversized
+executor notes out of Hermes chat context. Use `omh chat codex-progress` or the
+Codex progress fields on executor-session actions to pass only
+`codex_progress_summary/v1`, `omh_context_artifact_ref/v1`, compact evidence
+refs, and bounded human-readable summaries. Raw output belongs in a wrapper or
+operator artifact store referenced by `raw_output_artifact`; a prepared artifact
+reference is not execution, review, CI, merge-readiness, or merge evidence.
+
 ## Memory And Planning
 
 Wrappers can run `omh memory inspect`, `omh memory pack`, and `omh memory apply` to review OMH-local or wrapper-supplied context before preparing a handoff. This emits `{MEMORY_REVIEW_SCHEMA}` and `{HANDOFF_CONTEXT_PACK_SCHEMA}` artifacts only; it does not read or mutate opaque Hermes internal memory.

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 from typing import Any
 
+from ..context_safety import compact_progress_events
 from ..ingress import CHAT_SOURCES, compact_source_metadata, extract_message_text, extract_source_metadata
 from ..routing.catalog_questions import is_skill_catalog_question as _is_skill_catalog_question
 from ..routing.chat import public_route_payload, route_chat_message
@@ -1702,7 +1703,28 @@ def build_status_card_from_status(status_payload: dict[str, Any]) -> dict[str, o
     harness_progress = status_payload.get("harness_progress")
     if isinstance(harness_progress, dict) and harness_progress:
         card["harness_progress"] = harness_progress
+    progress_events, omitted_progress_events = _status_progress_events(status_payload)
+    if progress_events:
+        card["progress_reporting"] = {
+            "schema_version": "omh_progress_reporting/v1",
+            "mode": "event_triggered",
+            "timed_polling_required": False,
+            "human_update_policy": "one_or_two_sentence_summary_only",
+        }
+        card["progress_events"] = progress_events
+        card["latest_progress_event"] = progress_events[-1]
+        card["omitted_progress_event_count"] = omitted_progress_events
     return card
+
+
+def _status_progress_events(status_payload: dict[str, Any]) -> tuple[list[dict[str, object]], int]:
+    events = status_payload.get("progress_events")
+    if isinstance(events, list):
+        return compact_progress_events(events)
+    latest = status_payload.get("latest_progress_event")
+    if isinstance(latest, dict) and latest:
+        return compact_progress_events([latest])
+    return [], 0
 
 
 def _status_copy(status_payload: dict[str, Any], next_action: str) -> tuple[str, str, str, str]:

--- a/src/wrapper/executor_sessions.py
+++ b/src/wrapper/executor_sessions.py
@@ -5,6 +5,7 @@ from json import JSONDecodeError
 from pathlib import Path
 from typing import Any
 
+from ..context_safety import MAX_SUMMARY_CHARS, compact_context_refs, compact_visible_text
 from ..codex_progress import build_codex_session_observation
 from ..executors import CODING_EXECUTOR_TARGETS, executor_label
 from ..local_store import atomic_write_json, ensure_dir, ensure_file, read_json_object, utc_now
@@ -637,6 +638,7 @@ def _build_executor_session_record(paths: OmhPaths, session: dict[str, Any], pat
         "claim_boundary": _claim_boundary(),
     }
     merged["evidence_refs"] = _compact_list(merged.get("evidence_refs", []))
+    merged["summary"] = compact_visible_text(merged.get("summary", ""), max_chars=MAX_SUMMARY_CHARS)
     errors = validate_executor_session_record(merged)
     if errors:
         raise ExecutorSessionError(errors[0])
@@ -1322,9 +1324,7 @@ def _claim_boundary() -> str:
 
 
 def _compact_list(values: Any) -> list[str]:
-    if not isinstance(values, (list, tuple)):
-        return []
-    return [str(value) for value in values if str(value)]
+    return compact_context_refs(values)[0]
 
 
 def _action(action_id: str, label: str, style: str, *, enabled: bool = True, payload: dict[str, object] | None = None) -> dict[str, object]:

--- a/src/wrapper/executor_sessions.py
+++ b/src/wrapper/executor_sessions.py
@@ -5,7 +5,7 @@ from json import JSONDecodeError
 from pathlib import Path
 from typing import Any
 
-from ..context_safety import MAX_SUMMARY_CHARS, compact_context_refs, compact_visible_text
+from ..context_safety import MAX_SUMMARY_CHARS, compact_context_refs, compact_progress_events, compact_visible_text
 from ..codex_progress import build_codex_session_observation
 from ..executors import CODING_EXECUTOR_TARGETS, executor_label
 from ..local_store import atomic_write_json, ensure_dir, ensure_file, read_json_object, utc_now
@@ -129,6 +129,12 @@ def build_executor_session_status(
         status["codex_session"] = codex_session
     if codex_progress:
         status["codex_progress"] = codex_progress
+        progress_events, omitted_progress_events = _progress_events_from_codex_summary(codex_progress)
+        if progress_events:
+            status["progress_reporting"] = _progress_reporting_from_codex_summary(codex_progress)
+            status["progress_events"] = progress_events
+            status["latest_progress_event"] = progress_events[-1]
+            status["omitted_progress_event_count"] = omitted_progress_events
     if record_found and record.get("schema_version") == EXECUTOR_SESSION_SCHEMA_VERSION:
         status["record"] = record
     if record_error:
@@ -490,6 +496,10 @@ def enhance_chat_response_with_executor_session(
     codex_progress = executor_status.get("codex_progress")
     if isinstance(codex_progress, dict) and codex_progress:
         session_status["codex_progress"] = codex_progress
+    for key in ("progress_reporting", "progress_events", "latest_progress_event", "omitted_progress_event_count"):
+        value = executor_status.get(key)
+        if value:
+            session_status[key] = value
     state["executor_session_status"] = session_status
     updated["state"] = state
     actions = [action for action in updated.get("actions", []) if isinstance(action, dict)]
@@ -517,9 +527,11 @@ def enhance_status_card_with_executor_session(
     updated = dict(status_card)
     updated["executor_session_status"] = _executor_status_summary(executor_status)
     updated["workspace_isolation"] = executor_status.get("workspace_isolation", {})
-    for key in ("codex_session", "codex_progress"):
+    for key in ("codex_session", "codex_progress", "progress_reporting", "progress_events", "latest_progress_event", "omitted_progress_event_count"):
         value = executor_status.get(key)
-        if isinstance(value, dict) and value:
+        if isinstance(value, (dict, list)) and value:
+            updated[key] = value
+        elif isinstance(value, int) and value:
             updated[key] = value
         else:
             updated.pop(key, None)
@@ -1350,7 +1362,33 @@ def _executor_status_summary(executor_status: dict[str, object]) -> dict[str, ob
     codex_progress = executor_status.get("codex_progress")
     if isinstance(codex_progress, dict) and codex_progress:
         summary["codex_progress"] = codex_progress
+    for key in ("progress_reporting", "progress_events", "latest_progress_event", "omitted_progress_event_count"):
+        value = executor_status.get(key)
+        if value:
+            summary[key] = value
     return summary
+
+
+def _progress_events_from_codex_summary(codex_progress: dict[str, object]) -> tuple[list[dict[str, object]], int]:
+    events = codex_progress.get("progress_events")
+    if isinstance(events, list):
+        return compact_progress_events(events)
+    latest = codex_progress.get("latest_progress_event")
+    if isinstance(latest, dict) and latest:
+        return compact_progress_events([latest])
+    return [], 0
+
+
+def _progress_reporting_from_codex_summary(codex_progress: dict[str, object]) -> dict[str, object]:
+    progress_reporting = codex_progress.get("progress_reporting")
+    if isinstance(progress_reporting, dict) and progress_reporting:
+        return progress_reporting
+    return {
+        "schema_version": "omh_progress_reporting/v1",
+        "mode": "event_triggered",
+        "timed_polling_required": False,
+        "human_update_policy": "one_or_two_sentence_summary_only",
+    }
 
 
 def _next_executor_action(executor_status: dict[str, object]) -> str:

--- a/tests/test_codex_progress.py
+++ b/tests/test_codex_progress.py
@@ -78,6 +78,46 @@ class CodexProgressTests(unittest.TestCase):
         self.assertNotIn("B" * 1000, rendered)
         self.assertIn("raw output should stay in artifacts", summary["claim_boundary"])
 
+    def test_codex_progress_emits_event_triggered_updates_without_raw_logs(self) -> None:
+        raw_noise = "full tool log " + ("N" * 5000)
+        raw = "\n".join(
+            [
+                json.dumps({"role": "assistant", "content": f"Bug discovered: delegate mode ignored the setup default. {raw_noise}"}),
+                json.dumps(
+                    {
+                        "role": "assistant",
+                        "content": "Root cause identified in src/wrapper/contract.py: default executor was not propagated.",
+                    }
+                ),
+                json.dumps(
+                    {
+                        "role": "assistant",
+                        "content": "Fix strategy selected: carry setup_profile.default_executor into the delegate handoff.",
+                    }
+                ),
+                json.dumps({"role": "assistant", "content": "Targeted tests passed: tests/test_wrapper_contract.py."}),
+            ]
+        )
+
+        summary = summarize_codex_jsonl_text(raw, evidence_refs=["codex-jsonl"], source="codex-events.jsonl")
+
+        rendered = json.dumps(summary)
+        event_types = [event["event_type"] for event in summary["progress_events"]]
+        self.assertEqual(summary["progress_reporting"]["mode"], "event_triggered")
+        self.assertFalse(summary["progress_reporting"]["timed_polling_required"])
+        self.assertIn("bug_discovered", event_types)
+        self.assertIn("root_cause_identified", event_types)
+        self.assertIn("fix_strategy_selected", event_types)
+        self.assertIn("targeted_tests_passed", event_types)
+        self.assertLessEqual(len(summary["progress_events"]), summary["context_budget"]["max_progress_events"])
+        self.assertEqual(summary["latest_progress_event"]["event_type"], "targeted_tests_passed")
+        self.assertEqual(summary["latest_progress_event"]["severity"], "success")
+        self.assertIn("tests/test_wrapper_contract.py", summary["latest_progress_event"]["file_refs"])
+        self.assertEqual(summary["latest_progress_event"]["artifact_refs"][0]["schema_version"], "omh_context_artifact_ref/v1")
+        self.assertNotIn("N" * 1000, rendered)
+        self.assertNotIn("```", rendered)
+        self.assertIn("not execution", summary["latest_progress_event"]["claim_boundary"])
+
     def test_nested_reasoning_does_not_influence_observable_summary(self) -> None:
         raw = json.dumps(
             {

--- a/tests/test_codex_progress.py
+++ b/tests/test_codex_progress.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import unittest
 
@@ -42,6 +43,40 @@ class CodexProgressTests(unittest.TestCase):
         self.assertNotIn("hidden private content", rendered)
         self.assertIn("not raw JSONL", summary["claim_boundary"])
         self.assertEqual(summary["privacy"], "summary_only")
+
+    def test_oversized_codex_progress_returns_artifact_ref_and_bounded_context(self) -> None:
+        huge_visible = "Codex tool output: " + ("A" * 5000) + " final decision"
+        huge_ref = "codex-jsonl:" + ("B" * 5000)
+        raw = "\n".join(
+            [
+                json.dumps({"role": "assistant", "content": huge_visible}),
+                json.dumps({"type": "tool_call", "tool": "rg", "args": "rg bounded context"}),
+            ]
+        )
+
+        summary = summarize_codex_jsonl_text(
+            raw,
+            evidence_refs=[huge_ref, *[f"ref-{index}" for index in range(20)]],
+            source="codex-session.jsonl",
+        )
+
+        rendered = json.dumps(summary)
+        self.assertEqual(summary["raw_output_artifact"]["schema_version"], "omh_context_artifact_ref/v1")
+        self.assertEqual(summary["raw_output_artifact"]["source"], "codex-session.jsonl")
+        self.assertEqual(summary["raw_output_artifact"]["sha256"], hashlib.sha256(raw.encode("utf-8")).hexdigest())
+        self.assertEqual(summary["raw_output_artifact"]["byte_count"], len(raw.encode("utf-8")))
+        self.assertFalse(summary["raw_output_artifact"]["raw_content_included"])
+        self.assertEqual(summary["raw_output_artifact"]["storage_policy"], "store_raw_output_as_artifact")
+        self.assertEqual(summary["raw_output_artifact"]["in_context_policy"], "refs_and_summary_only")
+        self.assertEqual(summary["context_budget"]["max_visible_message_chars"], 180)
+        self.assertEqual(summary["context_budget"]["max_evidence_refs"], 8)
+        self.assertLessEqual(len(summary["latest_assistant_visible_message"]), 180)
+        self.assertLessEqual(len(summary["evidence_refs"]), 8)
+        self.assertLessEqual(max(len(ref) for ref in summary["evidence_refs"]), 160)
+        self.assertGreater(summary["omitted"]["evidence_ref_count"], 0)
+        self.assertNotIn("A" * 1000, rendered)
+        self.assertNotIn("B" * 1000, rendered)
+        self.assertIn("raw output should stay in artifacts", summary["claim_boundary"])
 
     def test_nested_reasoning_does_not_influence_observable_summary(self) -> None:
         raw = json.dumps(

--- a/tests/test_context_safety.py
+++ b/tests/test_context_safety.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import json
+import unittest
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.context_safety import build_progress_event, raw_output_artifact_ref
+
+
+class ContextSafetyTests(unittest.TestCase):
+    def test_progress_event_compacts_raw_payloads_for_chat_context(self) -> None:
+        raw_log = "traceback " + ("Z" * 5000)
+        artifact = raw_output_artifact_ref(raw_log, source="codex-long-run.jsonl")
+
+        event = build_progress_event(
+            "root_cause_identified",
+            "Root cause identified: setup default executor propagation was missing.\n```json\n" + raw_log + "\n```",
+            status="observed",
+            severity="warning",
+            file_refs=["src/wrapper/contract.py", "src/coding_delegation.py", "x" * 1000],
+            artifact_refs=[artifact],
+            evidence_refs=[f"ref-{index}" for index in range(20)],
+        )
+
+        rendered = json.dumps(event)
+        self.assertEqual(event["schema_version"], "omh_progress_event/v1")
+        self.assertEqual(event["event_type"], "root_cause_identified")
+        self.assertEqual(event["status"], "observed")
+        self.assertEqual(event["severity"], "warning")
+        self.assertLessEqual(len(event["summary"]), 220)
+        self.assertLessEqual(len(event["file_refs"]), 8)
+        self.assertLessEqual(max(len(ref) for ref in event["file_refs"]), 160)
+        self.assertLessEqual(len(event["evidence_refs"]), 8)
+        self.assertEqual(event["artifact_refs"][0]["schema_version"], "omh_context_artifact_ref/v1")
+        self.assertFalse(event["artifact_refs"][0]["raw_content_included"])
+        self.assertNotIn("```", rendered)
+        self.assertNotIn("Z" * 1000, rendered)
+        self.assertIn("not execution", event["claim_boundary"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wrapper_contract.py
+++ b/tests/test_wrapper_contract.py
@@ -8,6 +8,7 @@ import unittest
 from _local_package import load_local_package
 
 load_local_package()
+from omh.context_safety import CONTEXT_ARTIFACT_REF_SCHEMA_VERSION
 from omh.paths import OmhPaths, resolve_paths
 from omh.profiles.setup import write_setup_profile
 from omh.wrapper_contract import (
@@ -1572,6 +1573,48 @@ class WrapperContractTests(unittest.TestCase):
         self.assertEqual(steps["review"], "complete")
         self.assertEqual(steps["ci"], "pending")
         self.assertEqual(steps["merge_ready"], "pending")
+
+    def test_status_card_preserves_generic_event_progress_without_raw_payloads(self) -> None:
+        raw_log = "workflow transcript " + ("W" * 5000)
+        card = build_status_card_from_status(
+            {
+                "run_id": "research-goal-1",
+                "next_action": "show_status",
+                "safe_summary": "Research workflow is waiting on source evidence.",
+                "progress_events": [
+                    {
+                        "event_type": "blocker_encountered",
+                        "summary": "Blocker encountered: source evidence is missing.\n```log\n" + raw_log + "\n```",
+                        "status": "blocked",
+                        "severity": "blocked",
+                        "file_refs": ["docs/DIRECTION.md", "x" * 1000],
+                        "artifact_refs": [
+                            {
+                                "schema_version": CONTEXT_ARTIFACT_REF_SCHEMA_VERSION,
+                                "source": "workflow-transcript.log",
+                                "raw_content": raw_log,
+                                "raw_content_included": True,
+                                "byte_count": len(raw_log.encode("utf-8")),
+                            }
+                        ],
+                    }
+                ],
+            }
+        )
+
+        rendered = json.dumps(card)
+        event = card["latest_progress_event"]
+        self.assertEqual(event["schema_version"], "omh_progress_event/v1")
+        self.assertEqual(event["event_type"], "blocker_encountered")
+        self.assertEqual(event["status"], "blocked")
+        self.assertEqual(event["severity"], "blocked")
+        self.assertLessEqual(len(event["summary"]), 220)
+        self.assertLessEqual(max(len(ref) for ref in event["file_refs"]), 160)
+        self.assertEqual(event["artifact_refs"][0]["schema_version"], CONTEXT_ARTIFACT_REF_SCHEMA_VERSION)
+        self.assertFalse(event["artifact_refs"][0]["raw_content_included"])
+        self.assertNotIn("W" * 1000, rendered)
+        self.assertNotIn("```", rendered)
+        self.assertIn("not execution", event["claim_boundary"])
 
     def test_status_card_preserves_harness_ladder_progress(self) -> None:
         card = build_status_card_from_status(

--- a/tests/test_wrapper_sessions.py
+++ b/tests/test_wrapper_sessions.py
@@ -805,6 +805,8 @@ class WrapperSessionTests(unittest.TestCase):
             self.assertEqual(completed["status"]["result"], "completed")
             self.assertEqual(completed["status"]["codex_progress"]["event_count"], 2)
             self.assertIn("Codex is running tests.", completed["status"]["codex_progress"]["observable_activity"])
+            self.assertEqual(completed["status"]["latest_progress_event"]["event_type"], "targeted_tests_passed")
+            self.assertEqual(completed["status"]["latest_progress_event"]["severity"], "success")
             self.assertIn("summary_only", completed["executor_session"]["codex_progress"]["privacy"])
             self.assertEqual(completed["status"]["linked_lifecycle_status"]["next_action"], "record_verification_evidence")
             with self.assertRaisesRegex(ExecutorSessionError, "after executor result is recorded"):
@@ -815,6 +817,7 @@ class WrapperSessionTests(unittest.TestCase):
             self.assertEqual(verify_request["status"]["verification"], "requested")
             status_after_verify_request = build_wrapper_session_status(paths, session_id)
             briefing = status_after_verify_request["coding_briefing"]
+            self.assertEqual(status_after_verify_request["status_card"]["latest_progress_event"]["event_type"], "targeted_tests_passed")
             states = {step["id"]: step["state"] for step in briefing["progress"]}
             self.assertEqual(states["executor_result"], "complete")
             self.assertEqual(states["verification"], "in_progress")

--- a/tests/test_wrapper_sessions.py
+++ b/tests/test_wrapper_sessions.py
@@ -822,6 +822,50 @@ class WrapperSessionTests(unittest.TestCase):
             self.assertIn("verification evidence is still needed", briefing["headline"])
             self.assertEqual(validate_runtime(paths)["ok"], True)
 
+    def test_executor_session_status_bounds_oversized_wrapper_summaries(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            message = "risky refactor"
+            raw_tool_output = "raw codex output " + ("X" * 5000)
+            huge_ref = "codex-jsonl:" + ("Y" * 5000)
+            started = create_or_resume_wrapper_session(paths, message, source="discord")
+            session_id = str(started["session"]["session_id"])
+            record_plan_decision(paths, session_id, "accept")
+            select_wrapper_session_executor(paths, session_id, "codex")
+            prepare_wrapper_session_handoff(paths, session_id, message)
+
+            opened = open_executor_session(
+                paths,
+                session_id,
+                observed=True,
+                external_session_ref="codex-thread-oversized",
+                evidence_refs=[huge_ref, *[f"ref-{index}" for index in range(20)]],
+                summary=raw_tool_output,
+                codex_session_ref="codex-session-oversized",
+                codex_progress_summary=summarize_codex_jsonl_text(
+                    json.dumps({"role": "assistant", "content": raw_tool_output}),
+                    evidence_refs=[huge_ref],
+                    source="codex-oversized.jsonl",
+                ),
+            )
+
+            status = build_wrapper_session_status(paths, session_id)
+            rendered = json.dumps(status)
+            session_record = opened["executor_session"]
+            status_record = status["executor_session_status"]["record"]
+
+            self.assertLessEqual(len(session_record["summary"]), 240)
+            self.assertLessEqual(len(status_record["summary"]), 240)
+            self.assertLessEqual(len(session_record["evidence_refs"]), 8)
+            self.assertLessEqual(max(len(ref) for ref in session_record["evidence_refs"]), 160)
+            self.assertEqual(
+                status["executor_session_status"]["codex_progress"]["raw_output_artifact"]["storage_policy"],
+                "store_raw_output_as_artifact",
+            )
+            self.assertNotIn("X" * 1000, rendered)
+            self.assertNotIn("Y" * 1000, rendered)
+            self.assertIn("raw output should stay in artifacts", status["executor_session_status"]["codex_progress"]["claim_boundary"])
+
     def test_required_worktree_isolation_disables_open_button_until_observed(self) -> None:
         with TemporaryDirectory() as tmp:
             paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")


### PR DESCRIPTION
## Summary

This PR adds a first context-safety vertical slice for OMH handoff/status surfaces after we observed large Codex/tool outputs pushing Hermes into heavy compression, session splits, and delayed chat behavior.

What changes:
- Adds `src/context_safety.py`, a deterministic helper for compact text, capped lists, and `omh_context_artifact_ref/v1` metadata.
- Updates Codex progress summaries so raw JSONL/log output is represented as bounded summaries plus artifact refs instead of being carried into chat context.
- Caps executor-session summaries and evidence refs at the persistence/status boundary, so copied tool output cannot smuggle a giant payload into wrapper status.
- Documents the wrapper/operator rule: keep large executor outputs as artifacts; pass only refs, byte counts, short summaries, and claim boundaries into Hermes.

## Why

The user-facing issue was not only coding handoff reliability. Under context pressure, OMH can degrade non-coding routing/status/workflow behavior too if wrapper surfaces inject full logs, full contracts, or copied tool output into Hermes context. This PR prevents the clearest bloat path while preserving enough state for routing and recovery.

## Boundary behavior

Artifact refs and compact summaries are routing/status metadata only. They are not dispatch, execution, verification, review, CI, merge-readiness, or merge evidence.

## Verification

Observed by Codex, then committed/pushed from Hermes after Codex hit a worktree metadata sandbox boundary:

- `UV_CACHE_DIR=/private/tmp/uv-cache PYTHONPATH=tests uv run python -m unittest tests/test_codex_progress.py tests/test_wrapper_sessions.py -v` — passed, 48 tests
- CLI codex-progress targeted test — passed
- `UV_CACHE_DIR=/private/tmp/uv-cache PYTHONPATH=tests uv run python -m compileall -q src tests` — passed
- `UV_CACHE_DIR=/private/tmp/uv-cache PYTHONPATH=tests uv run python -m src.cli docs workflows --check` — passed
- `UV_CACHE_DIR=/private/tmp/uv-cache PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — passed, 706 tests
- `git diff --check` — passed

## Remaining risk / follow-up

This is the strongest first vertical slice: Codex progress and executor-session context bloat are bounded. A broader follow-up should audit route/status/chat/awareness rails for additional budget caps and event-triggered progress reporting semantics across all OMH workflow surfaces.
