### PR TITLE
Fix OMH quality-loop routing intent

### DIFF
--- a/src/plugin_bundle/omh/awareness.py
+++ b/src/plugin_bundle/omh/awareness.py
@@ -50,6 +50,31 @@ except ImportError:  # pragma: no cover - exercised by standalone plugin hosts.
                 *(f"handoff:{cue}" for cue in self.handoff_cues),
             )
 
+    def _fallback_contains_non_ascii(value: str) -> bool:
+        return any(ord(char) > 127 for char in value)
+
+    def _fallback_contains_bounded_english_cue(text: str, cue: str) -> bool:
+        parts = re.findall(r"[a-z0-9]+", cue)
+        if not parts:
+            return False
+        separator = r"[\s_-]+"
+        pattern = r"(?<![a-z0-9])" + separator.join(re.escape(part) for part in parts) + r"(?![a-z0-9])"
+        return re.search(pattern, text) is not None
+
+    def _fallback_matched_omh_quality_cues(cues: tuple[str, ...], text: str, compact: str) -> tuple[str, ...]:
+        matches = []
+        for cue in cues:
+            normalized_cue = unicodedata.normalize("NFKC", cue).casefold()
+            if not normalized_cue:
+                continue
+            if _fallback_contains_non_ascii(normalized_cue):
+                if normalized_cue in text or normalized_cue.replace(" ", "") in compact:
+                    matches.append(cue)
+                continue
+            if _fallback_contains_bounded_english_cue(text, normalized_cue):
+                matches.append(cue)
+        return tuple(matches)
+
     def classify_omh_quality_intent(message: str) -> _FallbackOmhQualityIntent:
         text = unicodedata.normalize("NFKC", message).casefold()
         compact = text.replace(" ", "")
@@ -57,9 +82,8 @@ except ImportError:  # pragma: no cover - exercised by standalone plugin hosts.
         if re.search(r"(?<![a-z0-9])omh(?![a-z0-9])", text):
             system_target_cues.append("omh")
         system_target_cues.extend(cue for cue in ("oh-my-hermes", "oh my hermes") if cue in text and cue not in system_target_cues)
-        quality_domain_cues = tuple(
-            cue
-            for cue in (
+        quality_domain_cues = _fallback_matched_omh_quality_cues(
+            (
                 "route quality",
                 "router",
                 "routing",
@@ -79,22 +103,58 @@ except ImportError:  # pragma: no cover - exercised by standalone plugin hosts.
                 "진행상태",
                 "진행 상태",
                 "코딩 handoff",
-            )
-            if cue in text or cue.replace(" ", "") in compact
+            ),
+            text,
+            compact,
         )
-        improvement_cues = tuple(
-            cue
-            for cue in ("improve", "improvement", "fix", "harden", "audit", "find and fix", "개선", "고쳐", "찾아", "점검")
-            if cue in text or cue.replace(" ", "") in compact
+        improvement_cues = _fallback_matched_omh_quality_cues(
+            (
+                "improve",
+                "improvement",
+                "fix",
+                "fixed",
+                "fixes",
+                "fixing",
+                "harden",
+                "audit",
+                "find and fix",
+                "개선",
+                "고쳐",
+                "찾아",
+                "점검",
+            ),
+            text,
+            compact,
         )
-        quality_cues = tuple(
-            cue
-            for cue in ("bug", "bugs", "failure", "loss", "regression", "reliability", "quality", "버그", "유사버그", "손실", "신뢰성", "품질")
-            if cue in text or cue.replace(" ", "") in compact
+        quality_cues = _fallback_matched_omh_quality_cues(
+            (
+                "bug",
+                "bugs",
+                "failure",
+                "loss",
+                "regression",
+                "reliability",
+                "quality",
+                "버그",
+                "유사버그",
+                "손실",
+                "신뢰성",
+                "품질",
+            ),
+            text,
+            compact,
         )
-        loop_cues = tuple(cue for cue in ("loop", "continuous", "keep", "루프", "계속") if cue in text)
-        handoff_cues = tuple(cue for cue in ("coding handoff", "handoff", "코딩") if cue in text)
-        customer_feedback_cues = tuple(cue for cue in ("customer", "payment", "고객", "결제", "피드백", "제보") if cue in text)
+        loop_cues = _fallback_matched_omh_quality_cues(
+            ("loop", "continuous", "keep", "keeps", "keeping", "루프", "계속"),
+            text,
+            compact,
+        )
+        handoff_cues = _fallback_matched_omh_quality_cues(("coding handoff", "handoff", "코딩"), text, compact)
+        customer_feedback_cues = _fallback_matched_omh_quality_cues(
+            ("customer", "payment", "고객", "결제", "피드백", "제보"),
+            text,
+            compact,
+        )
         applies = bool(system_target_cues and (quality_domain_cues or handoff_cues) and (improvement_cues or loop_cues or quality_cues))
         if customer_feedback_cues and not system_target_cues:
             applies = False

--- a/src/plugin_bundle/omh/awareness.py
+++ b/src/plugin_bundle/omh/awareness.py
@@ -5,7 +5,7 @@ import re
 import unicodedata
 
 try:  # Keep installed plugin bundles usable even when the full package is absent.
-    from ...routing.intent import META_OR_FEEDBACK_INTENTS, classify_workflow_intent
+    from ...routing.intent import META_OR_FEEDBACK_INTENTS, classify_omh_quality_intent, classify_workflow_intent
 except ImportError:  # pragma: no cover - exercised by standalone plugin hosts.
     from dataclasses import dataclass
 
@@ -27,6 +27,86 @@ except ImportError:  # pragma: no cover - exercised by standalone plugin hosts.
             if self.intent_class == "delivery_intent":
                 return ()
             return (*self.mentioned_workflows, *self.mentioned_runtime_terms)
+
+    @dataclass(frozen=True)
+    class _FallbackOmhQualityIntent:
+        applies: bool
+        target_cues: tuple[str, ...]
+        improvement_cues: tuple[str, ...]
+        quality_cues: tuple[str, ...]
+        loop_cues: tuple[str, ...]
+        handoff_cues: tuple[str, ...]
+        customer_feedback_cues: tuple[str, ...]
+        matched_label: str = "semantic:omh_quality_improvement_loop"
+        primary_workflow: str = "ultraprocess"
+
+        @property
+        def matched_cues(self) -> tuple[str, ...]:
+            return (
+                *(f"target:{cue}" for cue in self.target_cues),
+                *(f"improve:{cue}" for cue in self.improvement_cues),
+                *(f"quality:{cue}" for cue in self.quality_cues),
+                *(f"loop:{cue}" for cue in self.loop_cues),
+                *(f"handoff:{cue}" for cue in self.handoff_cues),
+            )
+
+    def classify_omh_quality_intent(message: str) -> _FallbackOmhQualityIntent:
+        text = unicodedata.normalize("NFKC", message).casefold()
+        compact = text.replace(" ", "")
+        system_target_cues = []
+        if re.search(r"(?<![a-z0-9])omh(?![a-z0-9])", text):
+            system_target_cues.append("omh")
+        system_target_cues.extend(cue for cue in ("oh-my-hermes", "oh my hermes") if cue in text and cue not in system_target_cues)
+        quality_domain_cues = tuple(
+            cue
+            for cue in (
+                "route quality",
+                "router",
+                "routing",
+                "route hint",
+                "context loss",
+                "context-loss",
+                "context safety",
+                "progress reporting",
+                "progress evidence",
+                "coding handoff",
+                "handoff reliability",
+                "라우터",
+                "라우팅",
+                "맥락",
+                "컨텍스트",
+                "컨텍스트 손실",
+                "진행상태",
+                "진행 상태",
+                "코딩 handoff",
+            )
+            if cue in text or cue.replace(" ", "") in compact
+        )
+        improvement_cues = tuple(
+            cue
+            for cue in ("improve", "improvement", "fix", "harden", "audit", "find and fix", "개선", "고쳐", "찾아", "점검")
+            if cue in text or cue.replace(" ", "") in compact
+        )
+        quality_cues = tuple(
+            cue
+            for cue in ("bug", "bugs", "failure", "loss", "regression", "reliability", "quality", "버그", "유사버그", "손실", "신뢰성", "품질")
+            if cue in text or cue.replace(" ", "") in compact
+        )
+        loop_cues = tuple(cue for cue in ("loop", "continuous", "keep", "루프", "계속") if cue in text)
+        handoff_cues = tuple(cue for cue in ("coding handoff", "handoff", "코딩") if cue in text)
+        customer_feedback_cues = tuple(cue for cue in ("customer", "payment", "고객", "결제", "피드백", "제보") if cue in text)
+        applies = bool(system_target_cues and (quality_domain_cues or handoff_cues) and (improvement_cues or loop_cues or quality_cues))
+        if customer_feedback_cues and not system_target_cues:
+            applies = False
+        return _FallbackOmhQualityIntent(
+            applies=applies,
+            target_cues=(*tuple(system_target_cues), *quality_domain_cues),
+            improvement_cues=improvement_cues,
+            quality_cues=quality_cues,
+            loop_cues=loop_cues,
+            handoff_cues=handoff_cues,
+            customer_feedback_cues=customer_feedback_cues,
+        )
 
     def classify_workflow_intent(message: str) -> _FallbackWorkflowIntent:
         text = unicodedata.normalize("NFKC", message).casefold()
@@ -606,11 +686,18 @@ def awareness_route_hint(message: str, *, max_hints: int = 2) -> dict[str, objec
     tokens = set(re.findall(r"[a-z0-9][a-z0-9_-]*", normalized))
     hint_limit = max(max_hints, 0)
     intent = classify_workflow_intent(message)
+    omh_quality_intent = classify_omh_quality_intent(message)
     hints: list[dict[str, object]] = []
     if normalized.strip() and hint_limit:
-        if _prefers_workflow_learning_hint(intent):
+        if omh_quality_intent.applies:
+            hints.append(_omh_quality_improvement_hint(omh_quality_intent))
+        if len(hints) < hint_limit and _prefers_workflow_learning_hint(intent) and not omh_quality_intent.applies:
             hints.append(_workflow_vocabulary_reference_hint(intent))
         for rule in _ROUTE_HINT_RULES:
+            if len(hints) >= hint_limit:
+                break
+            if _rule_suppressed_by_omh_quality_intent(rule, omh_quality_intent):
+                continue
             if _rule_suppressed_by_reference_intent(rule, intent):
                 continue
             phrase_matches = [phrase for phrase in rule["phrases"] if phrase in normalized]
@@ -618,6 +705,8 @@ def awareness_route_hint(message: str, *, max_hints: int = 2) -> dict[str, objec
             if not phrase_matches and not token_matches:
                 continue
             workflow = str(rule["workflow"])
+            if any(isinstance(hint, dict) and hint.get("workflow") == workflow for hint in hints):
+                continue
             if workflow == "workflow-learning" and any(hint.get("workflow") == workflow for hint in hints):
                 continue
             context_card = workflow_context_card_for_workflow(workflow)
@@ -1079,6 +1168,28 @@ def _prefers_workflow_learning_hint(intent: object) -> bool:
     )
 
 
+def _omh_quality_improvement_hint(intent: object) -> dict[str, object]:
+    workflow = "ultraprocess"
+    context_card = workflow_context_card_for_workflow(workflow)
+    return {
+        "id": "omh_quality_improvement_loop",
+        "workflow": workflow,
+        "lane": "coding_handoff",
+        "next_action": "prepare_one_cycle_delivery",
+        "reason": (
+            "The whole request is about improving OMH routing, context, progress, or coding-handoff quality; "
+            "bug or failure words are evidence for a coding/process lane, not customer feedback triage."
+        ),
+        "fallback_action": "prepare_loop_or_coding_handoff_quality_regression",
+        "matched_cues": _bounded_matches([str(item) for item in getattr(intent, "matched_cues", ())]),
+        "adjacent_workflows": ["loop", "workflow-learning", "code-review", "agent-ops-review"],
+        "workflow_context_card": context_card,
+        "not_evidence_yet": list(context_card.get("not_evidence_until_observed", []))
+        if isinstance(context_card, dict)
+        else [],
+    }
+
+
 def _workflow_vocabulary_reference_hint(intent: object) -> dict[str, object]:
     workflow = "workflow-learning"
     context_card = workflow_context_card_for_workflow(workflow)
@@ -1109,6 +1220,10 @@ def _rule_suppressed_by_reference_intent(rule: dict[str, object], intent: object
     if not _prefers_workflow_learning_hint(intent):
         return False
     return str(rule.get("id", "")) == "coding_delivery"
+
+
+def _rule_suppressed_by_omh_quality_intent(rule: dict[str, object], intent: object) -> bool:
+    return bool(getattr(intent, "applies", False)) and str(rule.get("id", "")) == "customer_signal"
 
 
 def _unique_strings(values: object) -> list[str]:

--- a/src/routing/intent.py
+++ b/src/routing/intent.py
@@ -311,6 +311,9 @@ _OMH_IMPROVEMENT_CUES = (
     "improve",
     "improvement",
     "fix",
+    "fixed",
+    "fixes",
+    "fixing",
     "harden",
     "strengthen",
     "audit",
@@ -349,6 +352,8 @@ _OMH_LOOP_CUES = (
     "continuous",
     "continue",
     "keep",
+    "keeps",
+    "keeping",
     "recurring",
     "루프",
     "계속",
@@ -391,12 +396,12 @@ def classify_omh_quality_intent(message: str) -> OmhQualityIntent:
     compact = normalized.replace(" ", "")
 
     system_target_cues = _matched_omh_system_target_cues(normalized)
-    quality_domain_cues = _matched_cues(_OMH_QUALITY_DOMAIN_CUES, normalized, compact)
-    improvement_cues = _matched_cues(_OMH_IMPROVEMENT_CUES, normalized, compact)
-    quality_cues = _matched_cues(_OMH_QUALITY_PROBLEM_CUES, normalized, compact)
-    loop_cues = _matched_cues(_OMH_LOOP_CUES, normalized, compact)
-    handoff_cues = _matched_cues(_OMH_HANDOFF_CUES, normalized, compact)
-    customer_feedback_cues = _matched_cues(_CUSTOMER_FEEDBACK_CUES, normalized, compact)
+    quality_domain_cues = _matched_omh_quality_cues(_OMH_QUALITY_DOMAIN_CUES, normalized, compact)
+    improvement_cues = _matched_omh_quality_cues(_OMH_IMPROVEMENT_CUES, normalized, compact)
+    quality_cues = _matched_omh_quality_cues(_OMH_QUALITY_PROBLEM_CUES, normalized, compact)
+    loop_cues = _matched_omh_quality_cues(_OMH_LOOP_CUES, normalized, compact)
+    handoff_cues = _matched_omh_quality_cues(_OMH_HANDOFF_CUES, normalized, compact)
+    customer_feedback_cues = _matched_omh_quality_cues(_CUSTOMER_FEEDBACK_CUES, normalized, compact)
 
     target_cues = _compact_tuple((*system_target_cues, *quality_domain_cues))
     has_omh_subject = bool(system_target_cues)
@@ -430,6 +435,34 @@ def _matched_omh_system_target_cues(normalized: str) -> tuple[str, ...]:
         if cue in normalized and cue not in cues:
             cues.append(cue)
     return tuple(cues)
+
+
+def _matched_omh_quality_cues(cues: tuple[str, ...], normalized: str, compact: str) -> tuple[str, ...]:
+    matches: list[str] = []
+    for cue in cues:
+        normalized_cue = normalized_phrase(cue)
+        if not normalized_cue:
+            continue
+        if _contains_non_ascii(normalized_cue):
+            if normalized_cue in normalized or normalized_cue.replace(" ", "") in compact:
+                matches.append(cue)
+            continue
+        if _contains_bounded_english_cue(normalized, normalized_cue):
+            matches.append(cue)
+    return tuple(matches)
+
+
+def _contains_non_ascii(value: str) -> bool:
+    return any(ord(char) > 127 for char in value)
+
+
+def _contains_bounded_english_cue(normalized: str, normalized_cue: str) -> bool:
+    parts = re.findall(r"[a-z0-9]+", normalized_cue)
+    if not parts:
+        return False
+    separator = r"[\s_-]+"
+    pattern = r"(?<![a-z0-9])" + separator.join(re.escape(part) for part in parts) + r"(?![a-z0-9])"
+    return re.search(pattern, normalized) is not None
 
 
 def is_workflow_meta_or_feedback(message: str) -> bool:

--- a/src/routing/intent.py
+++ b/src/routing/intent.py
@@ -188,6 +188,31 @@ class WorkflowIntent:
         return (*self.mentioned_workflows, *self.mentioned_runtime_terms)
 
 
+@dataclass(frozen=True)
+class OmhQualityIntent:
+    applies: bool
+    target_cues: tuple[str, ...]
+    improvement_cues: tuple[str, ...]
+    quality_cues: tuple[str, ...]
+    loop_cues: tuple[str, ...]
+    handoff_cues: tuple[str, ...]
+    customer_feedback_cues: tuple[str, ...]
+    matched_label: str = "semantic:omh_quality_improvement_loop"
+    primary_workflow: str = "ultraprocess"
+
+    @property
+    def matched_cues(self) -> tuple[str, ...]:
+        return _compact_tuple(
+            (
+                *(f"target:{cue}" for cue in self.target_cues),
+                *(f"improve:{cue}" for cue in self.improvement_cues),
+                *(f"quality:{cue}" for cue in self.quality_cues),
+                *(f"loop:{cue}" for cue in self.loop_cues),
+                *(f"handoff:{cue}" for cue in self.handoff_cues),
+            )
+        )
+
+
 def classify_workflow_intent(message: str) -> WorkflowIntent:
     """Classify whether workflow vocabulary is a reference or execution intent."""
     normalized = normalized_phrase(message)
@@ -251,6 +276,160 @@ def classify_workflow_intent(message: str) -> WorkflowIntent:
         missing_requirements_cues=missing_requirements_cues,
         routing_context=routing_context,
     )
+
+
+_OMH_SYSTEM_TARGET_CUES = (
+    "omh",
+    "oh-my-hermes",
+    "oh my hermes",
+)
+_OMH_QUALITY_DOMAIN_CUES = (
+    "route quality",
+    "router quality",
+    "router",
+    "routing",
+    "route hint",
+    "context loss",
+    "context-loss",
+    "context safety",
+    "context-safety",
+    "progress reporting",
+    "progress evidence",
+    "event progress",
+    "coding handoff",
+    "handoff reliability",
+    "라우터",
+    "라우팅",
+    "맥락",
+    "컨텍스트",
+    "컨텍스트 손실",
+    "진행상태",
+    "진행 상태",
+    "코딩 handoff",
+)
+_OMH_IMPROVEMENT_CUES = (
+    "improve",
+    "improvement",
+    "fix",
+    "harden",
+    "strengthen",
+    "audit",
+    "find and fix",
+    "keep finding",
+    "개선",
+    "개선해",
+    "고쳐",
+    "찾아",
+    "점검",
+    "강화",
+)
+_OMH_QUALITY_PROBLEM_CUES = (
+    "bug",
+    "bugs",
+    "failure",
+    "failures",
+    "loss",
+    "missing",
+    "regression",
+    "reliability",
+    "quality",
+    "performance balance",
+    "버그",
+    "유사버그",
+    "실패",
+    "손실",
+    "누락",
+    "회귀",
+    "신뢰성",
+    "품질",
+    "성능균형",
+)
+_OMH_LOOP_CUES = (
+    "loop",
+    "continuous",
+    "continue",
+    "keep",
+    "recurring",
+    "루프",
+    "계속",
+    "반복",
+)
+_OMH_HANDOFF_CUES = (
+    "coding handoff",
+    "handoff",
+    "코딩",
+    "위임",
+)
+_CUSTOMER_FEEDBACK_CUES = (
+    "customer",
+    "customers",
+    "user feedback",
+    "payment failure",
+    "payment failures",
+    "payment",
+    "billing",
+    "checkout",
+    "product feedback",
+    "feature request",
+    "고객",
+    "사용자",
+    "결제",
+    "피드백",
+    "제보",
+)
+
+
+def classify_omh_quality_intent(message: str) -> OmhQualityIntent:
+    """Classify deterministic OMH self-improvement loop intent.
+
+    This is a semantic feature layer over local cues: product/customer bug words
+    are only decisive when the request subject is customer feedback; OMH bug
+    words become evidence for improving routing, context, progress, or handoff
+    quality when the request is about OMH itself.
+    """
+    normalized = normalized_phrase(message)
+    compact = normalized.replace(" ", "")
+
+    system_target_cues = _matched_omh_system_target_cues(normalized)
+    quality_domain_cues = _matched_cues(_OMH_QUALITY_DOMAIN_CUES, normalized, compact)
+    improvement_cues = _matched_cues(_OMH_IMPROVEMENT_CUES, normalized, compact)
+    quality_cues = _matched_cues(_OMH_QUALITY_PROBLEM_CUES, normalized, compact)
+    loop_cues = _matched_cues(_OMH_LOOP_CUES, normalized, compact)
+    handoff_cues = _matched_cues(_OMH_HANDOFF_CUES, normalized, compact)
+    customer_feedback_cues = _matched_cues(_CUSTOMER_FEEDBACK_CUES, normalized, compact)
+
+    target_cues = _compact_tuple((*system_target_cues, *quality_domain_cues))
+    has_omh_subject = bool(system_target_cues)
+    has_quality_domain = bool(quality_domain_cues or handoff_cues)
+    has_improvement_motion = bool(improvement_cues or loop_cues)
+    has_quality_evidence = bool(quality_cues)
+    customer_feedback_subject = bool(customer_feedback_cues) and not has_omh_subject
+    applies = (
+        has_omh_subject
+        and has_quality_domain
+        and (has_improvement_motion or has_quality_evidence)
+        and not customer_feedback_subject
+    )
+
+    return OmhQualityIntent(
+        applies=applies,
+        target_cues=target_cues,
+        improvement_cues=improvement_cues,
+        quality_cues=quality_cues,
+        loop_cues=loop_cues,
+        handoff_cues=handoff_cues,
+        customer_feedback_cues=customer_feedback_cues,
+    )
+
+
+def _matched_omh_system_target_cues(normalized: str) -> tuple[str, ...]:
+    cues: list[str] = []
+    if re.search(r"(?<![a-z0-9])omh(?![a-z0-9])", normalized):
+        cues.append("omh")
+    for cue in ("oh-my-hermes", "oh my hermes"):
+        if cue in normalized and cue not in cues:
+            cues.append(cue)
+    return tuple(cues)
 
 
 def is_workflow_meta_or_feedback(message: str) -> bool:

--- a/src/routing/policy.py
+++ b/src/routing/policy.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from .intent import classify_omh_quality_intent
 from .localization import normalized_phrase, routing_tokens
 
 
@@ -1467,6 +1468,21 @@ WORKFLOW_LEARNING_GUARD = RoutingGuardRule(
     why="Matched guard/trigger metadata; workflow improvement requests should become a learning trace, review candidate, or regression instead of generic skill management.",
     activation_status="active",
 )
+OMH_QUALITY_IMPROVEMENT_GUARD = RoutingGuardRule(
+    id="omh_quality_improvement_loop_before_feedback_triage",
+    rule=(
+        "OMH self-improvement requests about router quality, context loss, progress reporting, or coding-handoff "
+        "reliability should route to the process/coding lane even when bug words are present."
+    ),
+    matched_label="guard:omh_quality_improvement_loop",
+    preferred_skills=("ultraprocess",),
+    score_boost=48,
+    why=(
+        "Matched semantic OMH quality-improvement intent; bug/failure terms are evidence for improving OMH "
+        "routing/context/handoff behavior, not customer feedback triage."
+    ),
+    activation_status="active",
+)
 WEB_RESEARCH_BEFORE_PROCESS_GUARD = RoutingGuardRule(
     id="web_research_before_process",
     rule="Plain web/source/current-evidence requests should route to web research before one-cycle delivery.",
@@ -1643,6 +1659,7 @@ ROUTING_GUARD_RULES = (
     FEEDBACK_BEFORE_CODING_GUARD,
     PRODUCT_SHAPING_GUARD,
     WORKFLOW_LEARNING_GUARD,
+    OMH_QUALITY_IMPROVEMENT_GUARD,
     PAPER_LEARNING_GUARD,
     RESEARCH_DEPARTMENT_GUARD,
     SCHEDULED_OPS_BLUEPRINT_GUARD,
@@ -1708,6 +1725,8 @@ def active_routing_guard_rules(
         rules.append(PRODUCT_SHAPING_GUARD)
     if _workflow_learning_guard_applies(normalized_query, query_tokens):
         rules.append(WORKFLOW_LEARNING_GUARD)
+    if _omh_quality_improvement_guard_applies(normalized_query):
+        rules.append(OMH_QUALITY_IMPROVEMENT_GUARD)
     delivery_cycle_applies = _delivery_cycle_guard_applies(normalized_query, query_tokens)
     paper_learning_applies = (
         not delivery_cycle_applies and _paper_learning_guard_applies(normalized_query, query_tokens)
@@ -1800,6 +1819,10 @@ def _workflow_learning_guard_applies(normalized_query: str, query_tokens: set[st
     if future_improvement and workflow_or_skill and bool(_WORKFLOW_LEARNING_CONTEXT_TOKENS & query_tokens):
         return True
     return False
+
+
+def _omh_quality_improvement_guard_applies(normalized_query: str) -> bool:
+    return classify_omh_quality_intent(normalized_query).applies
 
 
 def _scheduled_ops_blueprint_guard_applies(normalized_query: str, query_tokens: set[str]) -> bool:

--- a/src/routing/recommend.py
+++ b/src/routing/recommend.py
@@ -52,6 +52,7 @@ _GUARDRAIL_CANDIDATE_INJECTION_IDS = frozenset(
         "missed_workflow_operating_record_recovery",
         "product_shaping_before_ops_review",
         "workflow_learning_before_skill_management",
+        "omh_quality_improvement_loop_before_feedback_triage",
     }
 )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -147,6 +147,53 @@ class CliTests(unittest.TestCase):
         payload = json.loads(stdout)
         self.assertNotIn("catalog_question", payload)
 
+    def test_context_brief_routes_omh_quality_loops_to_process_before_feedback_triage(self) -> None:
+        cases = (
+            "updated OMH로 라우터/맥락/컨텍스트 손실/성능균형/코딩 handoff 유사버그를 계속 찾아 개선하는 루프 실행",
+            "Run a loop to find and fix OMH router context-loss and coding handoff bugs with progress evidence.",
+            "OMH 라우팅 품질과 진행상태 보고 버그를 계속 찾아서 코딩 handoff 신뢰성을 개선해줘",
+        )
+
+        for message in cases:
+            with self.subTest(message=message):
+                status, stdout, stderr = run_cli(
+                    ["context", "brief", "--source", "discord", "--prompt-context", "--json", message],
+                    output_json=False,
+                )
+
+                self.assertEqual(status, 0, stderr)
+                self.assertEqual(stderr, "")
+                payload = json.loads(stdout)
+                route_hint = payload["route_hint"]
+                self.assertEqual(route_hint["primary_workflow"], "ultraprocess")
+                self.assertEqual(route_hint["primary_next_action"], "prepare_one_cycle_delivery")
+                self.assertNotEqual(route_hint["hints"][0]["workflow"], "feedback-triage")
+                self.assertIn("selected=ultraprocess", payload["prompt_context"])
+                self.assertIn("not workflow execution", route_hint["claim_boundary"])
+                self.assertFalse(payload["message"]["raw_prompt_echoed"])
+                self.assertFalse(payload["message"]["raw_prompt_stored"])
+
+    def test_context_brief_keeps_customer_bug_reports_on_feedback_triage(self) -> None:
+        cases = (
+            "고객 버그 제보를 분류해줘",
+            "payment failures keep coming up from customer feedback",
+        )
+
+        for message in cases:
+            with self.subTest(message=message):
+                status, stdout, stderr = run_cli(
+                    ["context", "brief", "--source", "discord", "--prompt-context", "--json", message],
+                    output_json=False,
+                )
+
+                self.assertEqual(status, 0, stderr)
+                self.assertEqual(stderr, "")
+                payload = json.loads(stdout)
+                route_hint = payload["route_hint"]
+                self.assertEqual(route_hint["primary_workflow"], "feedback-triage")
+                self.assertEqual(route_hint["primary_next_action"], "classify_signal_and_prepare_investigation")
+                self.assertIn("selected=feedback-triage", payload["prompt_context"])
+
     def test_chat_interact_routes_workflow_learning_to_audit_actions(self) -> None:
         status, stdout, stderr = run_cli(
             ["chat", "interact", "--source", "discord", "learn from this workflow run"],
@@ -2845,6 +2892,43 @@ class CliTests(unittest.TestCase):
         self.assertEqual(recommendations[0]["skill"], "feedback-triage")
         self.assertEqual(recommendations[0]["next_action"], "triage_feedback")
         self.assertIn("Feedback triage", recommendations[0]["evidence_boundary"])
+
+    def test_recommend_omh_quality_loop_routes_to_process_despite_bug_terms(self) -> None:
+        cases = (
+            "updated OMH로 라우터/맥락/컨텍스트 손실/성능균형/코딩 handoff 유사버그를 계속 찾아 개선하는 루프 실행",
+            "Run a loop to find and fix OMH router context-loss and coding handoff bugs with progress evidence.",
+            "OMH 라우팅 품질과 진행상태 보고 버그를 계속 찾아서 코딩 handoff 신뢰성을 개선해줘",
+        )
+
+        for message in cases:
+            with self.subTest(message=message):
+                status, stdout, stderr = run_cli(["recommend", message, "--limit", "3"])
+
+                self.assertEqual(stderr, "")
+                self.assertEqual(status, 0)
+                recommendations = json.loads(stdout)["recommendations"]
+                self.assertEqual(recommendations[0]["skill"], "ultraprocess")
+                self.assertEqual(recommendations[0]["next_action"], "start_ultraprocess")
+                self.assertIn("guard:omh_quality_improvement_loop", recommendations[0]["matched"])
+                self.assertNotEqual(recommendations[0]["skill"], "feedback-triage")
+                self.assertIn("process orchestration", recommendations[0]["evidence_boundary"])
+
+    def test_recommend_customer_bug_feedback_stays_feedback_triage(self) -> None:
+        cases = (
+            "고객 버그 제보를 분류해줘",
+            "payment failures keep coming up from customer feedback",
+        )
+
+        for message in cases:
+            with self.subTest(message=message):
+                status, stdout, stderr = run_cli(["recommend", message, "--limit", "3"])
+
+                self.assertEqual(stderr, "")
+                self.assertEqual(status, 0)
+                recommendations = json.loads(stdout)["recommendations"]
+                self.assertEqual(recommendations[0]["skill"], "feedback-triage")
+                self.assertEqual(recommendations[0]["next_action"], "triage_feedback")
+                self.assertIn("Feedback triage", recommendations[0]["evidence_boundary"])
 
     def test_recommend_multilingual_signals_route_without_external_translation(self) -> None:
         cases = (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,6 +17,7 @@ from omh.commands import setup as setup_commands
 from omh.commands.main import build_parser
 from omh.commands.language import LANGUAGE_CODES, MESSAGES
 from omh.config_adapter import external_dirs
+from omh.routing.intent import classify_omh_quality_intent
 from omh.skill_pack import builtin_skill_reference_templates, builtin_skill_templates
 class CliTests(unittest.TestCase):
     def test_no_arg_cli_shows_welcome_instead_of_error(self) -> None:
@@ -172,6 +173,30 @@ class CliTests(unittest.TestCase):
                 self.assertIn("not workflow execution", route_hint["claim_boundary"])
                 self.assertFalse(payload["message"]["raw_prompt_echoed"])
                 self.assertFalse(payload["message"]["raw_prompt_stored"])
+
+    def test_omh_router_prefix_reference_does_not_trigger_quality_loop(self) -> None:
+        message = "What is the OMH router prefix syntax?"
+
+        intent = classify_omh_quality_intent(message)
+
+        self.assertFalse(intent.applies)
+        self.assertNotIn("improve:fix", intent.matched_cues)
+
+    def test_recommend_omh_router_prefix_reference_does_not_select_quality_loop(self) -> None:
+        message = "What is the OMH router prefix syntax?"
+        status, stdout, stderr = run_cli(["recommend", message, "--limit", "3"])
+
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        recommendations = json.loads(stdout)["recommendations"]
+        self.assertNotEqual(recommendations[0]["skill"], "ultraprocess")
+        guarded_process_routes = [
+            recommendation
+            for recommendation in recommendations
+            if recommendation["skill"] == "ultraprocess"
+            and "guard:omh_quality_improvement_loop" in recommendation["matched"]
+        ]
+        self.assertEqual(guarded_process_routes, [])
 
     def test_context_brief_keeps_customer_bug_reports_on_feedback_triage(self) -> None:
         cases = (


### PR DESCRIPTION
## Summary

This PR fixes the routing-quality regression found by the OMH self-improvement loop after PR #254 was merged and installed locally.

The live finding was that a request about improving OMH router/context/coding-handoff quality was routed primarily to `feedback-triage` because it contained the Korean word `버그`. That exposed a deeper issue: routing treated generic bug keywords as primary selectors instead of semantic evidence inside the whole request intent.

What changed:
- Adds deterministic `classify_omh_quality_intent` in `src/routing/intent.py`.
- Connects the same semantic intent layer to plugin/context route hints and package `omh recommend` guardrails.
- Routes OMH/router/context/progress/coding-handoff quality loops to the coding/process lane (`ultraprocess`) even when bug/failure words appear.
- Keeps actual customer/product bug reports routed to `feedback-triage`.
- Avoids substring false positives such as treating `OMHM` as `OMH`.
- Adds Korean/English paraphrase regressions plus customer-bug counterexamples.

## Why

The fix is intentionally not a keyword-ordering patch. Keywords like `bug` / `버그` remain useful evidence, but they should not override the semantic subject and goal of the request. OMH self-improvement loops need to be recognized as router/context/handoff quality work; customer bug reports still need feedback triage.

## Verification

Observed by Codex:

- `UV_CACHE_DIR=/tmp/omhm-routing-safety-uv-cache PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — passed, 713 tests
- `UV_CACHE_DIR=/tmp/omhm-routing-safety-uv-cache uv run python -m compileall -q src tests` — passed
- `git diff --check` — passed

## Remaining risk

Live installed Hermes/OMH plugin reload has not been tested after this commit. After merge, run `omh setup --default-executor codex --force`, `omh doctor`, and re-run the same live route/context prompt.
