### PR TITLE
Add coding progress reporting policy

### DIFF
--- a/src/context_safety.py
+++ b/src/context_safety.py
@@ -7,6 +7,7 @@ from typing import Any
 
 CONTEXT_ARTIFACT_REF_SCHEMA_VERSION = "omh_context_artifact_ref/v1"
 PROGRESS_EVENT_SCHEMA_VERSION = "omh_progress_event/v1"
+CODING_PROGRESS_REPORTING_POLICY_SCHEMA_VERSION = "coding_progress_reporting_policy/v1"
 MAX_VISIBLE_MESSAGE_CHARS = 180
 MAX_SUMMARY_CHARS = 240
 MAX_PROGRESS_EVENT_SUMMARY_CHARS = 220
@@ -15,6 +16,21 @@ MAX_SOURCE_REF_CHARS = 240
 MAX_EVIDENCE_REFS = 8
 MAX_EVIDENCE_REF_CHARS = 160
 MAX_ARTIFACT_REFS = 4
+
+CODING_PROGRESS_REPORTABLE_EVENTS = (
+    "workflow_started",
+    "dispatch_to_executor",
+    "blocker_encountered",
+    "targeted_tests_failed",
+    "root_cause_identified",
+    "fix_strategy_selected",
+    "targeted_tests_passed",
+    "full_tests_started",
+    "full_tests_passed",
+    "commit_created",
+    "pr_updated",
+    "workflow_completed",
+)
 
 _PROGRESS_EVENT_TYPES = {
     "status_update",
@@ -32,6 +48,7 @@ _PROGRESS_EVENT_TYPES = {
     "commit_created",
     "pr_created",
     "pr_updated",
+    "dispatch_to_executor",
     "blocker_encountered",
     "workflow_started",
     "workflow_completed",
@@ -111,6 +128,97 @@ def build_progress_event(
             "merge-readiness, merge, or raw-log evidence unless separate observed evidence records say so."
         ),
     }
+
+
+def build_coding_progress_reporting_policy(
+    *,
+    next_action: str = "",
+    lifecycle_status: str = "",
+) -> dict[str, object]:
+    return {
+        "schema_version": CODING_PROGRESS_REPORTING_POLICY_SCHEMA_VERSION,
+        "mode": "event_triggered",
+        "metadata_only": True,
+        "raw_content_included": False,
+        "timed_polling_rejected": True,
+        "final_only_silence_rejected": True,
+        "raw_log_dumping_rejected": True,
+        "reportable_events": list(CODING_PROGRESS_REPORTABLE_EVENTS),
+        "state_guidance": {
+            "next_action": _normalize_token(next_action),
+            "lifecycle_status": _normalize_token(lifecycle_status),
+            "reportable_events": _coding_state_reportable_events(next_action),
+        },
+        "language_policy": {
+            "style": "concise",
+            "mirror_chat_language": True,
+            "korean_friendly": True,
+        },
+        "evidence_boundary": (
+            "Progress reports are concise lifecycle/status updates only. They are not execution, review, CI, "
+            "merge-readiness, or merge proof unless matching observed records exist."
+        ),
+        "forbidden_patterns": [
+            "final_only_silence_for_long_running_executor_work",
+            "raw_log_dumping",
+            "claiming_execution_review_ci_or_merge_without_observed_records",
+        ],
+    }
+
+
+def _coding_state_reportable_events(next_action: str) -> list[str]:
+    normalized = _normalize_token(next_action)
+    events_by_next_action = {
+        "dispatch_to_executor": [
+            "workflow_started",
+            "dispatch_to_executor",
+        ],
+        "wait_for_executor_evidence": [
+            "blocker_encountered",
+            "targeted_tests_failed",
+            "root_cause_identified",
+            "fix_strategy_selected",
+            "targeted_tests_passed",
+        ],
+        "surface_executor_blocker": [
+            "blocker_encountered",
+            "targeted_tests_failed",
+        ],
+        "record_verification_evidence": [
+            "targeted_tests_passed",
+            "full_tests_started",
+        ],
+        "record_review_evidence": [
+            "full_tests_passed",
+            "commit_created",
+            "pr_updated",
+        ],
+        "record_ci_evidence": [
+            "full_tests_passed",
+            "pr_updated",
+        ],
+        "record_merge_readiness": [
+            "full_tests_passed",
+            "commit_created",
+            "pr_updated",
+        ],
+        "report_completion_with_evidence": [
+            "full_tests_passed",
+            "commit_created",
+            "pr_updated",
+            "workflow_completed",
+        ],
+        "report_merge_ready": [
+            "full_tests_passed",
+            "commit_created",
+            "pr_updated",
+            "workflow_completed",
+        ],
+        "report_merged": [
+            "workflow_completed",
+        ],
+    }
+    return list(events_by_next_action.get(normalized, ["workflow_started"]))
 
 
 def compact_progress_events(

--- a/src/runtime/artifacts.py
+++ b/src/runtime/artifacts.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from ..context_safety import build_coding_progress_reporting_policy
 from ..harness_quality import build_harness_progress
 from ..local_store import (
     atomic_write_json,
@@ -516,6 +517,7 @@ def summarize_delegated_coding_status(paths: OmhPaths, run_id: str) -> dict[str,
         "merge": merge_status,
         "runtime_observation": summarize_runtime_observation_status(runtime_observations),
         "next_action": next_action,
+        "progress_reporting_policy": build_coding_progress_reporting_policy(next_action=next_action),
         "safe_summary": _delegated_status_summary(
             prepared=prepared,
             action=action,

--- a/src/wrapper/lifecycle.py
+++ b/src/wrapper/lifecycle.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+from ..context_safety import build_coding_progress_reporting_policy
 from ..coding_delegation import build_coding_delegation_payload, coding_delegation_record_payload
 from ..paths import OmhPaths
 from ..runtime.artifacts import (
@@ -165,18 +166,23 @@ def record_codex_verification(
 def report_codex_delegation_lifecycle(paths: OmhPaths, run_id: str) -> dict[str, object]:
     status = summarize_delegated_coding_status(paths, run_id)
     next_action = str(status.get("next_action", "unknown"))
+    lifecycle_status = _lifecycle_status(next_action)
     completion_report_actions = {"report_completion_with_evidence"}
     terminal_report_actions = {"report_completion_with_evidence", "report_merge_ready", "report_merged"}
     report = dict(status)
     report.update(
         {
             "lifecycle_schema_version": LIFECYCLE_SCHEMA_VERSION,
-            "lifecycle_status": _lifecycle_status(next_action),
+            "lifecycle_status": lifecycle_status,
             "can_report_completion": next_action in completion_report_actions,
             "can_report_terminal_status": next_action in terminal_report_actions,
             "blocking_reason": "" if next_action in terminal_report_actions else _blocking_reason(next_action),
             "artifact_paths": _artifact_paths(paths, run_id),
             "runtime_validation": validate_runtime(paths, run_id),
+            "progress_reporting_policy": build_coding_progress_reporting_policy(
+                next_action=next_action,
+                lifecycle_status=lifecycle_status,
+            ),
         }
     )
     return report

--- a/tests/test_coding_lifecycle.py
+++ b/tests/test_coding_lifecycle.py
@@ -20,6 +20,49 @@ from omh.paths import resolve_paths
 
 
 class CodingLifecycleTests(unittest.TestCase):
+    def test_started_codex_lifecycle_exposes_progress_reporting_policy(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+
+            payload = start_codex_delegation_lifecycle(paths, "diagnose installation health")
+
+            policy = payload["status"]["progress_reporting_policy"]
+            self.assertEqual(policy["schema_version"], "coding_progress_reporting_policy/v1")
+            self.assertEqual(policy["mode"], "event_triggered")
+            self.assertIn("workflow_started", policy["reportable_events"])
+            self.assertIn("dispatch_to_executor", policy["reportable_events"])
+
+    def test_progress_policy_guides_lifecycle_transitions_without_final_only_silence(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            started = start_codex_delegation_lifecycle(paths, "diagnose installation health")
+            run_id = started["run"]["run_id"]
+
+            prepared_policy = started["status"]["progress_reporting_policy"]
+            self.assertTrue(prepared_policy["final_only_silence_rejected"])
+            self.assertTrue(prepared_policy["raw_log_dumping_rejected"])
+            self.assertEqual(prepared_policy["state_guidance"]["next_action"], "dispatch_to_executor")
+            self.assertIn("workflow_started", prepared_policy["state_guidance"]["reportable_events"])
+            self.assertIn("dispatch_to_executor", prepared_policy["state_guidance"]["reportable_events"])
+
+            dispatched = record_codex_dispatch(paths, run_id)
+            dispatched_policy = dispatched["status"]["progress_reporting_policy"]
+            self.assertEqual(dispatched_policy["state_guidance"]["next_action"], "wait_for_executor_evidence")
+            self.assertIn("blocker_encountered", dispatched_policy["state_guidance"]["reportable_events"])
+            self.assertIn("targeted_tests_failed", dispatched_policy["state_guidance"]["reportable_events"])
+            self.assertIn("targeted_tests_passed", dispatched_policy["state_guidance"]["reportable_events"])
+
+            result = record_codex_result(paths, run_id, result="completed", evidence_refs=["codex-log"])
+            result_policy = result["status"]["progress_reporting_policy"]
+            self.assertEqual(result_policy["state_guidance"]["next_action"], "record_verification_evidence")
+            self.assertIn("full_tests_started", result_policy["state_guidance"]["reportable_events"])
+
+            verified = record_codex_verification(paths, run_id)
+            verified_policy = verified["status"]["progress_reporting_policy"]
+            self.assertEqual(verified_policy["state_guidance"]["next_action"], "report_completion_with_evidence")
+            self.assertIn("full_tests_passed", verified_policy["state_guidance"]["reportable_events"])
+            self.assertIn("workflow_completed", verified_policy["state_guidance"]["reportable_events"])
+
     def test_start_codex_lifecycle_creates_prepared_handoff_without_raw_message(self) -> None:
         with TemporaryDirectory() as tmp:
             paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")

--- a/tests/test_context_safety.py
+++ b/tests/test_context_safety.py
@@ -6,10 +6,50 @@ import unittest
 from _local_package import load_local_package
 
 load_local_package()
-from omh.context_safety import build_progress_event, raw_output_artifact_ref
+from omh.context_safety import build_coding_progress_reporting_policy, build_progress_event, raw_output_artifact_ref
 
 
 class ContextSafetyTests(unittest.TestCase):
+    def test_coding_progress_reporting_policy_is_event_triggered_and_metadata_only(self) -> None:
+        policy = build_coding_progress_reporting_policy(
+            next_action="record_verification_evidence",
+            lifecycle_status="awaiting_verification",
+        )
+
+        rendered = json.dumps(policy)
+        self.assertEqual(policy["schema_version"], "coding_progress_reporting_policy/v1")
+        self.assertEqual(policy["mode"], "event_triggered")
+        self.assertTrue(policy["timed_polling_rejected"])
+        self.assertTrue(policy["metadata_only"])
+        self.assertFalse(policy["raw_content_included"])
+        self.assertTrue(policy["language_policy"]["korean_friendly"])
+        self.assertTrue(policy["language_policy"]["mirror_chat_language"])
+        for event in (
+            "workflow_started",
+            "dispatch_to_executor",
+            "blocker_encountered",
+            "targeted_tests_failed",
+            "root_cause_identified",
+            "fix_strategy_selected",
+            "targeted_tests_passed",
+            "full_tests_started",
+            "full_tests_passed",
+            "commit_created",
+            "pr_updated",
+            "workflow_completed",
+        ):
+            self.assertIn(event, policy["reportable_events"])
+        self.assertIn("full_tests_started", policy["state_guidance"]["reportable_events"])
+        self.assertIn("not execution, review, CI", policy["evidence_boundary"])
+        self.assertNotIn("private-token-123", rendered)
+
+    def test_policy_reportable_events_are_progress_event_types(self) -> None:
+        policy = build_coding_progress_reporting_policy(next_action="dispatch_to_executor")
+
+        for event_type in policy["reportable_events"]:
+            event = build_progress_event(event_type, f"{event_type} update")
+            self.assertEqual(event["event_type"], event_type)
+
     def test_progress_event_compacts_raw_payloads_for_chat_context(self) -> None:
         raw_log = "traceback " + ("Z" * 5000)
         artifact = raw_output_artifact_ref(raw_log, source="codex-long-run.jsonl")

--- a/tests/test_runtime_lifecycle_invariants.py
+++ b/tests/test_runtime_lifecycle_invariants.py
@@ -39,8 +39,14 @@ class RuntimeLifecycleInvariantTests(unittest.TestCase):
             self.assertFalse(status["execution"]["observed"])
             self.assertFalse(status["verification"]["observed"])
             self.assertEqual(status["next_action"], "dispatch_to_executor")
+            policy = status["progress_reporting_policy"]
+            self.assertTrue(policy["metadata_only"])
+            self.assertFalse(policy["raw_content_included"])
+            self.assertTrue(policy["final_only_silence_rejected"])
+            self.assertIn("raw_log_dumping", policy["forbidden_patterns"])
             self.assertTrue(validate_runtime(paths, run_id)["ok"])
             self.assertNotIn(message, json.dumps(prepared))
+            self.assertNotIn(message, json.dumps(policy))
 
             run_path = paths.runtime_runs_dir / run_id / "run.json"
             run = json.loads(run_path.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Feature Report

### What Changed

- Added `coding_progress_reporting_policy/v1`, a deterministic metadata-only progress reporting policy for long-running Codex coding lifecycle work.
- Exposed the policy from both `report_codex_delegation_lifecycle` and lower-level delegated coding status summaries.
- Extended `omh_progress_event/v1` compatibility so every policy reportable event can also be represented as a compact progress event.

### Why This Exists

- Hermes can delegate long-running coding work to Codex, but wrappers previously had no explicit contract for when progress should be surfaced.
- That made final-only silence look acceptable even when Codex moved through meaningful stages such as dispatch, failures, fixes, targeted tests, full tests, commits, and PR updates.
- The new contract makes final-only silence, timed polling, and raw-log dumping explicit rejected patterns.

### User / Operator Impact

- Wrappers and Hermes status surfaces can now emit concise event-triggered progress updates during long-running executor work.
- Korean chats can be mirrored with Korean-friendly concise updates because the policy exposes language guidance instead of embedding prose.
- Progress updates remain boundary-safe: they are status updates only, not execution, review, CI, merge-readiness, or merge proof unless separate observed records exist.

### How It Works

- `build_coding_progress_reporting_policy()` returns a compact deterministic policy with reportable lifecycle events, state-specific guidance, language guidance, and evidence-boundary guardrails.
- `summarize_delegated_coding_status()` attaches the policy for wrappers consuming delegated coding status directly.
- `report_codex_delegation_lifecycle()` rebuilds the policy with lifecycle status context so lifecycle reports expose the current reporting guidance.
- Tests cover lifecycle start, dispatch, executor result, verification, direct delegated status, metadata-only redaction, rejected reporting patterns, and `omh_progress_event/v1` event compatibility.

### Files And Contracts Touched

- `src/context_safety.py`: new public progress reporting policy helper and event allowlist compatibility.
- `src/runtime/artifacts.py`: delegated coding status now exposes the progress policy.
- `src/wrapper/lifecycle.py`: lifecycle reports now expose state-aware progress policy guidance.
- `tests/test_context_safety.py`: direct helper and event compatibility coverage.
- `tests/test_coding_lifecycle.py`: lifecycle progress policy coverage from start through verification.
- `tests/test_runtime_lifecycle_invariants.py`: delegated status metadata-only policy coverage.

## Validation

- [ ] `python3 -m unittest discover -s tests`
- [ ] `python3 -m compileall src`
- [ ] `python3 -m omh.cli docs workflows --check`
- [ ] `python3 -m omh.cli harness validate`
- [ ] `python3 -m omh.cli release checklist --json`
- [ ] `python3 -m omh.cli release hermes-smoke`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable; workflow-learning contracts were not changed.
- [x] Relevant dry-run or smoke command:
  - `UV_CACHE_DIR=/tmp/omhm-progress-reporting-uv-cache PYTHONPATH=tests uv run python -m unittest tests.test_coding_lifecycle -v`
  - `UV_CACHE_DIR=/tmp/omhm-progress-reporting-uv-cache PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
  - `UV_CACHE_DIR=/tmp/omhm-progress-reporting-uv-cache uv run python -m compileall -q src tests`
  - `git diff --check`
- [x] Manual Hermes/TUI check, or explicit reason it was not run: not run; this PR adds deterministic local metadata contracts and does not change live Hermes/TUI rendering.

## Risk

- Narrow contract-surface risk: wrappers may start showing the new policy if they render delegated coding status generically.
- The policy is metadata-only and avoids raw message/log content, network calls, LLM calls, platform calls, and Hermes core changes.

## Compatibility / Rollout

- Backward compatible additive fields on existing status payloads.
- Existing lifecycle state names and completion gates are unchanged.
- The policy rejects final-only silence but does not force any transport-specific delivery mechanism.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- Consider adding wrapper-rendered examples if a future UI change consumes the policy directly.
