### PR TITLE
Add observation-first work reporting slice

### DIFF
--- a/docs/DIRECTION.md
+++ b/docs/DIRECTION.md
@@ -68,6 +68,15 @@ language unless the user asks for JSON, schema output, debug data, or an API
 payload. JSON/code-block output is an internal or opt-in surface, not normal
 chat UX.
 
+Internal awareness rails such as `[OMH Awareness]`, native bridge status
+context, evidence-boundary reminders, process wrappers, and raw CI/watch
+transcripts are inputs to reporting, not user-facing status copy. Adapters
+should omit silent successful completions and summarize meaningful output into
+the channel's natural voice. For example, Discord/Korean progress can use a
+calm friendly voice while CI/DCO output becomes compact check status lines with
+names, pass/pending/fail state, durations, and links instead of raw watcher
+text.
+
 Markdown export is useful for a wiki, notes, release recap, or later review,
 but it is not a backend requirement for the first reporting slice. A
 deterministic markdown projection from the structured summary is enough until a

--- a/docs/DIRECTION.md
+++ b/docs/DIRECTION.md
@@ -34,12 +34,48 @@ Quality should show up as:
 
 - better request classification from local catalog metadata
 - better Hermes-side interview, research, and planning output
+- observation-first reporting that helps Hermes explain what happened after work
+  starts or completes
 - clearer wrapper response states and actions
 - stronger prepared handoff payloads for coding executors
 - stricter evidence boundaries for dispatch, execution, review, CI, and merge
 - documentation and tests that keep public claims aligned with code
 
 The goal is parity of seriousness, not parity of implementation shape.
+
+## Observation-First Reporting
+
+OMH should optimize for helping Hermes observe, summarize, and explain work,
+not for exhaustively unifying every possible handoff order. Reverts and reruns
+are often cheap. Losing the context of what Hermes invoked, what was observed,
+what remains unobserved, and how to explain that to the user is more expensive.
+
+The reporting direction is:
+
+- structured state is the internal truth
+- plain text is the default user experience
+- markdown is a secondary durable knowledge surface
+- workflow learning receives selected, sanitized summaries only
+
+Structured summaries should be metadata-only by default. They can store schema
+versions, work ids, workflow ids, message hashes and lengths, bounded evidence
+references, progress events, observation refs, and claim boundaries. They must
+not store raw prompts, raw platform events, raw logs, hidden reasoning, or
+transcripts by default.
+
+Hermes-facing progress, completion, and blocker updates should render as plain
+language unless the user asks for JSON, schema output, debug data, or an API
+payload. JSON/code-block output is an internal or opt-in surface, not normal
+chat UX.
+
+Markdown export is useful for a wiki, notes, release recap, or later review,
+but it is not a backend requirement for the first reporting slice. A
+deterministic markdown projection from the structured summary is enough until a
+real wiki store is intentionally designed.
+
+Workflow learning should consume selected report summaries and bounded evidence
+refs. It should not learn by dumping every chat message, executor log, or
+private transcript into a learning artifact.
 
 ## Project Type
 

--- a/src/runtime/artifacts.py
+++ b/src/runtime/artifacts.py
@@ -426,6 +426,11 @@ def summarize_delegated_coding_status(paths: OmhPaths, run_id: str) -> dict[str,
     response_observed = bool(wrapper.get("hermes_response_observed", False))
     verification_observed = bool(wrapper.get("verification_observed", False))
     completion_status = str(wrapper.get("completion_status") or "unknown")
+    verification_status = _verification_status_summary(
+        observed=verification_observed,
+        completion_status=completion_status,
+        unobserved_gaps=wrapper.get("unobserved_gaps", []),
+    )
     review_required = bool(review.get("required", coding.get("review_required", False)))
     review_workflow = review.get("workflow") if review else coding.get("review_workflow")
     review_status = _review_status_summary(review_required, review_workflow, review, review_record)
@@ -497,6 +502,7 @@ def summarize_delegated_coding_status(paths: OmhPaths, run_id: str) -> dict[str,
             "unobserved_gaps": wrapper.get("unobserved_gaps", []),
         },
         "verification": {
+            **verification_status,
             "observed": verification_observed,
             "expected": coding.get("verification", []),
         },
@@ -773,6 +779,19 @@ def _downstream_gate_progress_state(
     if review_status.get("satisfied") and ci_status.get("satisfied") and merge_status.get("satisfied"):
         return "complete"
     return "pending"
+
+
+def _verification_status_summary(*, observed: bool, completion_status: str, unobserved_gaps: Any) -> dict[str, Any]:
+    gaps = _string_list(unobserved_gaps)
+    if observed:
+        status = "passed"
+    elif completion_status == "failed":
+        status = "failed"
+    elif completion_status == "blocked" or gaps:
+        status = "blocked"
+    else:
+        status = "not_observed"
+    return {"status": status, "satisfied": observed}
 
 
 def _object_or_empty(value: Any) -> dict[str, Any]:

--- a/src/work_reporting.py
+++ b/src/work_reporting.py
@@ -59,6 +59,52 @@ _VERIFICATION_SUCCESS_STATUSES = {"passed", "satisfied", "completed", "verified"
 _NON_PROGRESS_STATUSES = {"", "not_observed", "not_required", "pending"}
 _OBSERVATION_EVENT_STATUSES = ("observed", "blocked", "failed", "not_observed")
 _OBSERVATION_EVENT_EVIDENCE_STATUSES = {"observed", "blocked", "failed"}
+_INTERNAL_REPORT_MARKERS = (
+    "[OMH Awareness]",
+    "OMH Awareness Primer",
+    "[OMH] Native bridge status context",
+    "Native bridge status context",
+    "Evidence boundary: prepared handoffs are not execution, review, CI, merge-readiness, or merge evidence",
+)
+_CHECK_STATUS_ALIASES = {
+    "pass": "pass",
+    "passed": "pass",
+    "passing": "pass",
+    "completed": "pass",
+    "success": "pass",
+    "successful": "pass",
+    "succeeded": "pass",
+    "ok": "pass",
+    "neutral": "pass",
+    "skip": "skipped",
+    "skipped": "skipped",
+    "pending": "pending",
+    "queued": "pending",
+    "waiting": "pending",
+    "requested": "pending",
+    "expected": "pending",
+    "in_progress": "pending",
+    "in-progress": "pending",
+    "progress": "pending",
+    "running": "pending",
+    "fail": "fail",
+    "failed": "fail",
+    "failure": "fail",
+    "error": "fail",
+    "cancelled": "fail",
+    "canceled": "fail",
+    "timed_out": "fail",
+    "timed-out": "fail",
+    "action_required": "fail",
+    "startup_failure": "fail",
+}
+_CHECK_STATUS_ORDER = ("fail", "pending", "pass", "skipped", "unknown")
+_CHECK_WATCH_NOISE = (
+    "refreshing checks status",
+    "press ctrl+c to quit",
+    "watching checks",
+    "waiting for checks",
+)
 
 
 def build_work_observation_summary(
@@ -188,6 +234,10 @@ def build_work_observation_summary(
             "default_format": "plain_text",
             "json_default": False,
             "code_block_default": False,
+            "tone_policy": "adapter_selected_channel_voice",
+            "default_voice": "conservative",
+            "supported_tone_options": ["locale", "voice"],
+            "internal_rails_policy": "summarize_or_omit_prompt_only_context",
             "plain_text_renderers": ["progress", "completion", "blocker", "status"],
             "machine_readable_payload": "internal_or_opt_in",
         },
@@ -280,12 +330,14 @@ def build_work_observation_summary_from_status(
     )
 
 
-def render_progress_report(summary: dict[str, Any]) -> str:
+def render_progress_report(summary: dict[str, Any], *, locale: str = "", voice: str = "") -> str:
     validate = validate_work_observation_summary(summary)
     if validate:
         raise ValueError("; ".join(validate))
     title = str(summary["title"])
     status = _status_phrase(str(summary.get("status", "unknown")))
+    if _friendly_ko(locale=locale, voice=voice):
+        return _render_friendly_ko_progress_report(summary)
     lines = [f"Progress: {title} is {status}."]
     latest = _object(_object(summary.get("progress")).get("latest_event"))
     safe_summary = str(_object(summary.get("progress")).get("safe_summary", ""))
@@ -297,18 +349,20 @@ def render_progress_report(summary: dict[str, Any]) -> str:
     next_action = str(summary.get("next_action", "show_status"))
     if next_action:
         lines.append(f"Next: {next_action}.")
-    lines.append(_boundary_line(summary))
-    return _plain(lines)
+    lines.append(_boundary_line(summary, locale=locale, voice=voice))
+    return _plain(lines, locale=locale, voice=voice)
 
 
-def render_status_report(summary: dict[str, Any]) -> str:
-    return render_progress_report(summary)
+def render_status_report(summary: dict[str, Any], *, locale: str = "", voice: str = "") -> str:
+    return render_progress_report(summary, locale=locale, voice=voice)
 
 
-def render_completion_report(summary: dict[str, Any]) -> str:
+def render_completion_report(summary: dict[str, Any], *, locale: str = "", voice: str = "") -> str:
     validate = validate_work_observation_summary(summary)
     if validate:
         raise ValueError("; ".join(validate))
+    if _friendly_ko(locale=locale, voice=voice):
+        return _render_friendly_ko_completion_report(summary)
     title = str(summary["title"])
     if summary.get("status") == "completed":
         lines = [f"Completed: {title}."]
@@ -318,14 +372,16 @@ def render_completion_report(summary: dict[str, Any]) -> str:
     if observed:
         lines.append(f"Observed: {', '.join(observed[:5])}.")
     lines.extend(_evidence_lines(summary))
-    lines.append(_boundary_line(summary))
-    return _plain(lines)
+    lines.append(_boundary_line(summary, locale=locale, voice=voice))
+    return _plain(lines, locale=locale, voice=voice)
 
 
-def render_blocker_report(summary: dict[str, Any]) -> str:
+def render_blocker_report(summary: dict[str, Any], *, locale: str = "", voice: str = "") -> str:
     validate = validate_work_observation_summary(summary)
     if validate:
         raise ValueError("; ".join(validate))
+    if _friendly_ko(locale=locale, voice=voice):
+        return _render_friendly_ko_blocker_report(summary)
     title = str(summary["title"])
     blockers = _string_items(summary.get("blockers"))
     lines = [f"Blocked: {title}."]
@@ -337,8 +393,75 @@ def render_blocker_report(summary: dict[str, Any]) -> str:
     if next_action:
         lines.append(f"Next: {next_action}.")
     lines.extend(_evidence_lines(summary))
-    lines.append(_boundary_line(summary))
-    return _plain(lines)
+    lines.append(_boundary_line(summary, locale=locale, voice=voice))
+    return _plain(lines, locale=locale, voice=voice)
+
+
+def build_background_completion_report(
+    *,
+    process_ref: str = "",
+    exit_code: int | str | None = None,
+    output: str = "",
+    command: str = "",
+    locale: str = "",
+    voice: str = "",
+) -> str | None:
+    """Render background completion output as a user-safe status summary."""
+
+    parsed = _parse_background_completion(output)
+    resolved_process = process_ref or parsed["process_ref"]
+    resolved_exit_code = _int_exit_code(exit_code if exit_code is not None else parsed["exit_code"])
+    visible_output = _strip_check_watch_noise(parsed["output"] if parsed["matched"] else output)
+    visible_output = sanitize_user_report_text(visible_output, locale=locale, voice=voice)
+    if resolved_exit_code == 0 and not visible_output.strip():
+        return None
+    if visible_output.strip() or "gh pr checks" in command.casefold():
+        check_rollup = format_check_rollup(visible_output, locale=locale, voice=voice)
+        if check_rollup:
+            return check_rollup
+    status_line = _background_completion_status_line(
+        process_ref=resolved_process,
+        exit_code=resolved_exit_code,
+        locale=locale,
+        voice=voice,
+    )
+    if not visible_output.strip():
+        return status_line
+    lines = [status_line, *_meaningful_output_lines(visible_output)]
+    return _plain(lines, locale=locale, voice=voice)
+
+
+def format_check_rollup(checks: Any, *, locale: str = "", voice: str = "") -> str:
+    """Format check rows or gh-pr-checks text without dumping watcher transcripts."""
+
+    rows = _dedupe_check_rows(_check_rows(checks))
+    if not rows:
+        return ""
+    counts = {status: 0 for status in _CHECK_STATUS_ORDER}
+    for row in rows:
+        counts[row["status"]] = counts.get(row["status"], 0) + 1
+    if _friendly_ko(locale=locale, voice=voice):
+        lines = [_ko_check_summary(counts)]
+        lines.extend(_ko_check_line(row) for row in rows[:12])
+        if len(rows) > 12:
+            lines.append(f"- 외 {len(rows) - 12}개 체크")
+        return _plain(lines, locale=locale, voice=voice)
+    lines = [_english_check_summary(counts)]
+    lines.extend(_english_check_line(row) for row in rows[:12])
+    if len(rows) > 12:
+        lines.append(f"- {len(rows) - 12} more checks.")
+    return _plain(lines, locale=locale, voice=voice)
+
+
+def sanitize_user_report_text(value: Any, *, locale: str = "", voice: str = "") -> str:
+    """Remove prompt-only OMH rails from user-facing report text."""
+
+    text = _strip_code_fences(value)
+    if not text.strip():
+        return ""
+    if _contains_internal_report_marker(text):
+        return _internal_context_user_summary(locale=locale, voice=voice)
+    return text
 
 
 def build_markdown_export(summary: dict[str, Any]) -> dict[str, Any]:
@@ -561,6 +684,333 @@ def _markdown_for_summary(summary: dict[str, Any]) -> str:
     return "\n".join(lines).strip() + "\n"
 
 
+def _render_friendly_ko_progress_report(summary: dict[str, Any]) -> str:
+    title = str(summary["title"])
+    status = str(summary.get("status", "unknown"))
+    latest = _object(_object(summary.get("progress")).get("latest_event"))
+    safe_summary = str(_object(summary.get("progress")).get("safe_summary", ""))
+    detail = str(latest.get("summary") or safe_summary)
+    lines = [_ko_status_sentence(title, status)]
+    if detail:
+        lines.append(detail)
+    lines.extend(_ko_evidence_lines(summary))
+    next_action = str(summary.get("next_action", "show_status"))
+    if next_action and next_action != "show_status":
+        lines.append(f"다음은 {next_action} 쪽을 볼게.")
+    lines.append(_boundary_line(summary, locale="ko", voice="friendly"))
+    return _plain(lines, locale="ko", voice="friendly")
+
+
+def _render_friendly_ko_completion_report(summary: dict[str, Any]) -> str:
+    title = str(summary["title"])
+    status = str(summary.get("status", "unknown"))
+    lines = [f"{title} 작업은 끝났어." if status == "completed" else f"{title} 작업은 아직 완료로 확인되진 않았어."]
+    observed = _string_items(_object(summary.get("observations")).get("observed_events"))
+    if observed:
+        lines.append(f"확인된 항목은 {', '.join(observed[:5])}이야.")
+    lines.extend(_ko_evidence_lines(summary))
+    lines.append(_boundary_line(summary, locale="ko", voice="friendly"))
+    return _plain(lines, locale="ko", voice="friendly")
+
+
+def _render_friendly_ko_blocker_report(summary: dict[str, Any]) -> str:
+    title = str(summary["title"])
+    blockers = _string_items(summary.get("blockers"))
+    lines = [f"{title} 작업은 지금 막혀 있어."]
+    if blockers:
+        lines.append(f"이유는 {'; '.join(blockers[:3])}야.")
+    else:
+        lines.append("아직 필요한 확인 근거가 안 잡혔어.")
+    next_action = str(summary.get("next_action", "show_status"))
+    if next_action and next_action != "show_status":
+        lines.append(f"다음은 {next_action} 쪽을 볼게.")
+    lines.extend(_ko_evidence_lines(summary))
+    lines.append(_boundary_line(summary, locale="ko", voice="friendly"))
+    return _plain(lines, locale="ko", voice="friendly")
+
+
+def _ko_status_sentence(title: str, status: str) -> str:
+    if status == "completed":
+        return f"{title} 작업은 끝났어."
+    if status == "blocked":
+        return f"{title} 작업은 지금 막혀 있어."
+    if status == "failed":
+        return f"{title} 작업에서 실패가 확인됐어."
+    if status == "prepared_not_observed":
+        return f"{title} 작업은 준비됐고, 아직 실행 확인은 기다리는 중이야."
+    if status == "unknown":
+        return f"{title} 작업 상태는 아직 확실하지 않아."
+    return f"{title} 작업은 진행 중이야."
+
+
+def _ko_evidence_lines(summary: dict[str, Any]) -> list[str]:
+    refs = _string_items(_object(summary.get("observations")).get("evidence_refs"))
+    if not refs:
+        return []
+    return [f"확인한 근거: {', '.join(refs[:4])}."]
+
+
+def _friendly_ko(*, locale: str, voice: str) -> bool:
+    return _token(locale) in {"ko", "ko_kr", "kr", "korean"} and _token(voice) in {
+        "friendly",
+        "casual",
+        "discord",
+        "calm",
+    }
+
+
+def _parse_background_completion(output: str) -> dict[str, Any]:
+    text = str(output or "")
+    match = re.match(
+        r"\s*\[Background process\s+(?P<process>[^\s\]]+)\s+finished with exit code\s+"
+        r"(?P<exit_code>-?\d+)~?\s*(?:Here(?:'|’)s the final output:\s*)?\]?\s*",
+        text,
+        flags=re.IGNORECASE,
+    )
+    if not match:
+        return {"matched": False, "process_ref": "", "exit_code": None, "output": text}
+    return {
+        "matched": True,
+        "process_ref": str(match.group("process")),
+        "exit_code": str(match.group("exit_code")),
+        "output": text[match.end() :].strip(),
+    }
+
+
+def _int_exit_code(value: int | str | None) -> int | None:
+    if value is None or value == "":
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _background_completion_status_line(
+    *,
+    process_ref: str,
+    exit_code: int | None,
+    locale: str,
+    voice: str,
+) -> str:
+    label = process_ref or "background process"
+    succeeded = exit_code == 0
+    if _friendly_ko(locale=locale, voice=voice):
+        if succeeded:
+            return "백그라운드 작업은 조용히 끝났어."
+        if exit_code is None:
+            return "백그라운드 작업이 끝났고, 출력만 요약할게."
+        return f"백그라운드 작업이 exit code {exit_code}로 끝났어."
+    if succeeded:
+        return f"Background process {label} completed successfully."
+    if exit_code is None:
+        return f"Background process {label} completed with output."
+    return f"Background process {label} finished with exit code {exit_code}."
+
+
+def _meaningful_output_lines(output: str) -> list[str]:
+    lines: list[str] = []
+    for line in output.splitlines():
+        cleaned = line.strip()
+        if not cleaned:
+            continue
+        if _is_check_watch_noise(cleaned):
+            continue
+        lines.append(cleaned)
+        if len(lines) >= 4:
+            break
+    return lines
+
+
+def _strip_check_watch_noise(output: str) -> str:
+    lines = [line for line in str(output or "").splitlines() if not _is_check_watch_noise(line)]
+    return "\n".join(lines).strip()
+
+
+def _is_check_watch_noise(line: str) -> bool:
+    lowered = _strip_ansi(line).casefold()
+    return any(noise in lowered for noise in _CHECK_WATCH_NOISE)
+
+
+def _check_rows(checks: Any) -> list[dict[str, str]]:
+    if isinstance(checks, dict):
+        if isinstance(checks.get("checks"), list):
+            return _check_rows(checks["checks"])
+        row = _check_row_from_dict(checks)
+        return [row] if row else []
+    if isinstance(checks, (list, tuple)):
+        rows: list[dict[str, str]] = []
+        for item in checks:
+            rows.extend(_check_rows(item))
+        return rows
+    if isinstance(checks, str):
+        return _check_rows_from_text(checks)
+    return []
+
+
+def _check_row_from_dict(value: dict[str, Any]) -> dict[str, str]:
+    name = str(value.get("name") or value.get("check") or value.get("workflow") or value.get("title") or "").strip()
+    raw_status = str(
+        value.get("conclusion")
+        or value.get("status")
+        or value.get("state")
+        or value.get("result")
+        or ""
+    )
+    status = _normalize_check_status(raw_status)
+    if not name or not status:
+        return {}
+    duration = str(value.get("duration") or value.get("elapsed") or value.get("time") or "").strip()
+    url = str(value.get("url") or value.get("link") or value.get("details_url") or value.get("target_url") or "").strip()
+    return {"name": name, "status": status, "duration": duration, "url": url}
+
+
+def _check_rows_from_text(output: str) -> list[dict[str, str]]:
+    rows: list[dict[str, str]] = []
+    for raw_line in output.splitlines():
+        line = _strip_ansi(raw_line).strip()
+        if not line or _is_check_watch_noise(line) or _is_check_header(line):
+            continue
+        row = _check_row_from_line(line)
+        if row:
+            rows.append(row)
+    return rows
+
+
+def _check_row_from_line(line: str) -> dict[str, str]:
+    pieces = [piece.strip() for piece in re.split(r"\t+", line) if piece.strip()]
+    if len(pieces) < 2:
+        pieces = [piece.strip() for piece in re.split(r"\s{2,}", line) if piece.strip()]
+    if len(pieces) < 2:
+        return _check_row_from_loose_line(line)
+    url = _first_url(pieces)
+    status_index = -1
+    status = ""
+    for index, piece in enumerate(pieces):
+        normalized = _normalize_check_status(piece)
+        if normalized:
+            status_index = index
+            status = normalized
+            break
+    if status_index <= 0:
+        return _check_row_from_loose_line(line)
+    name = _clean_check_name(" ".join(pieces[:status_index]))
+    duration = _first_duration([piece for index, piece in enumerate(pieces[status_index + 1 :]) if piece != url])
+    if not name:
+        return {}
+    return {"name": name, "status": status, "duration": duration, "url": url}
+
+
+def _check_row_from_loose_line(line: str) -> dict[str, str]:
+    url = _first_url([line])
+    without_url = line.replace(url, "").strip() if url else line
+    match = re.search(
+        r"(?P<status>pass(?:ed)?|fail(?:ed)?|pending|queued|in[ _-]?progress|running|success(?:ful)?|skipped|cancelled|canceled|error)",
+        without_url,
+        flags=re.IGNORECASE,
+    )
+    if not match:
+        return {}
+    status = _normalize_check_status(match.group("status"))
+    name = _clean_check_name(without_url[: match.start()].strip(" :-—–") or without_url[match.end() :].strip(" :-—–"))
+    duration = _first_duration([without_url])
+    if not name or not status:
+        return {}
+    return {"name": name, "status": status, "duration": duration, "url": url}
+
+
+def _dedupe_check_rows(rows: list[dict[str, str]]) -> list[dict[str, str]]:
+    deduped: dict[tuple[str, str], dict[str, str]] = {}
+    order: list[tuple[str, str]] = []
+    for row in rows:
+        name = row.get("name", "").strip()
+        if not name:
+            continue
+        key = (name.casefold(), row.get("url", "").strip())
+        if key not in deduped:
+            order.append(key)
+        deduped[key] = row
+    return [deduped[key] for key in order]
+
+
+def _normalize_check_status(value: str) -> str:
+    normalized = _token(value)
+    if normalized in _CHECK_STATUS_ALIASES:
+        return _CHECK_STATUS_ALIASES[normalized]
+    lowered = value.strip().casefold()
+    return _CHECK_STATUS_ALIASES.get(lowered, "")
+
+
+def _english_check_summary(counts: dict[str, int]) -> str:
+    parts = [f"{counts[status]} {status}" for status in _CHECK_STATUS_ORDER if counts.get(status)]
+    return f"Checks: {', '.join(parts)}." if parts else "Checks: no check rows found."
+
+
+def _english_check_line(row: dict[str, str]) -> str:
+    suffix = _check_suffix(row)
+    return f"- {row['name']}: {row['status']}{suffix}"
+
+
+def _ko_check_summary(counts: dict[str, int]) -> str:
+    labels = {"pass": "통과", "pending": "대기 중", "fail": "실패", "skipped": "건너뜀", "unknown": "상태 미확인"}
+    parts = [f"{counts[status]}개 {labels[status]}" for status in _CHECK_STATUS_ORDER if counts.get(status)]
+    return f"체크는 {', '.join(parts)}이야." if parts else "확인할 체크 행은 없었어."
+
+
+def _ko_check_line(row: dict[str, str]) -> str:
+    labels = {"pass": "통과", "pending": "대기", "fail": "실패", "skipped": "건너뜀", "unknown": "미확인"}
+    suffix = _check_suffix(row)
+    return f"- {row['name']}: {labels.get(row['status'], row['status'])}{suffix}"
+
+
+def _check_suffix(row: dict[str, str]) -> str:
+    parts = []
+    if row.get("duration"):
+        parts.append(f"({row['duration']})")
+    if row.get("url"):
+        parts.append(row["url"])
+    return f" {' '.join(parts)}." if parts else "."
+
+
+def _is_check_header(line: str) -> bool:
+    lowered = line.casefold()
+    return "name" in lowered and "status" in lowered and ("url" in lowered or "elapsed" in lowered)
+
+
+def _clean_check_name(value: str) -> str:
+    return re.sub(r"^[✓✔✗✘x!•*\-\s]+", "", value).strip(" :-—–")
+
+
+def _first_url(values: list[str]) -> str:
+    for value in values:
+        match = re.search(r"https?://\S+", value)
+        if match:
+            return match.group(0).rstrip(".,)")
+    return ""
+
+
+def _first_duration(values: list[str]) -> str:
+    for value in values:
+        match = re.search(r"\b(?:\d+(?:\.\d+)?(?:ms|s|m|h|d)){1,4}\b|\b\d+:\d+(?::\d+)?\b", value)
+        if match:
+            return match.group(0)
+    return ""
+
+
+def _strip_ansi(value: str) -> str:
+    return re.sub(r"\x1b\[[0-9;?]*[ -/]*[@-~]", "", value)
+
+
+def _contains_internal_report_marker(text: str) -> bool:
+    return any(marker.casefold() in text.casefold() for marker in _INTERNAL_REPORT_MARKERS)
+
+
+def _internal_context_user_summary(*, locale: str, voice: str) -> str:
+    if _friendly_ko(locale=locale, voice=voice):
+        return "내부 OMH 상태는 확인했고, 사용자에게는 필요한 진행 상황만 짧게 전할게."
+    return "Internal OMH status context was observed; user-facing output should summarize only the relevant status."
+
+
 def _evidence_lines(summary: dict[str, Any]) -> list[str]:
     refs = _string_items(_object(summary.get("observations")).get("evidence_refs"))
     if not refs:
@@ -568,9 +1018,13 @@ def _evidence_lines(summary: dict[str, Any]) -> list[str]:
     return [f"Evidence: {', '.join(refs[:4])}."]
 
 
-def _boundary_line(summary: dict[str, Any]) -> str:
+def _boundary_line(summary: dict[str, Any], *, locale: str = "", voice: str = "") -> str:
     items = _string_items(_object(summary.get("evidence_boundary")).get("not_evidence_until_observed"))
-    return f"Not evidence until observed: {', '.join(items[:5])}."
+    if not items:
+        return ""
+    if _friendly_ko(locale=locale, voice=voice):
+        return f"아직 확인 근거가 필요한 부분: {', '.join(items[:5])}."
+    return f"Still waiting on observed proof for: {', '.join(items[:5])}."
 
 
 def _default_summary(summary: dict[str, Any]) -> str:
@@ -580,8 +1034,14 @@ def _default_summary(summary: dict[str, Any]) -> str:
     return f"{summary.get('report_kind', 'status')} report for {summary.get('work_id', 'unknown-work')}."
 
 
-def _plain(lines: list[str]) -> str:
-    cleaned = [compact_visible_text(_strip_code_fences(line), max_chars=320) for line in lines if str(line).strip()]
+def _plain(lines: list[str], *, locale: str = "", voice: str = "") -> str:
+    cleaned: list[str] = []
+    for line in lines:
+        if not str(line).strip():
+            continue
+        sanitized = sanitize_user_report_text(line, locale=locale, voice=voice)
+        if sanitized.strip():
+            cleaned.append(compact_visible_text(sanitized, max_chars=320))
     return "\n".join(cleaned).strip()
 
 

--- a/src/work_reporting.py
+++ b/src/work_reporting.py
@@ -70,12 +70,10 @@ _CHECK_STATUS_ALIASES = {
     "pass": "pass",
     "passed": "pass",
     "passing": "pass",
-    "completed": "pass",
     "success": "pass",
     "successful": "pass",
     "succeeded": "pass",
     "ok": "pass",
-    "neutral": "pass",
     "skip": "skipped",
     "skipped": "skipped",
     "pending": "pending",
@@ -142,8 +140,17 @@ def build_work_observation_summary(
     compact_events, omitted_events = _compact_observation_events(observed_events or [])
     compact_progress, omitted_progress = compact_progress_events(progress_events or [])
     compact_blockers, omitted_blockers = _compact_strings(blockers or [], max_items=MAX_BLOCKERS, max_chars=180)
+    explicit_boundary_items = [item for item in (not_evidence_until_observed or []) if str(item).strip()]
     boundary_items, omitted_boundary = compact_context_refs(
-        [*_DEFAULT_NOT_EVIDENCE, *(not_evidence_until_observed or [])],
+        [*_DEFAULT_NOT_EVIDENCE, *explicit_boundary_items],
+        max_items=16,
+        max_chars=80,
+    )
+    active_boundary_items, omitted_active_boundary = compact_context_refs(
+        [
+            *explicit_boundary_items,
+            *[event["event_type"] for event in compact_events if event["status"] == "not_observed"],
+        ],
         max_items=16,
         max_chars=80,
     )
@@ -224,7 +231,9 @@ def build_work_observation_summary(
         "evidence_boundary": {
             "schema_version": "work_evidence_boundary/v1",
             "not_evidence_until_observed": boundary_items,
+            "active_not_observed_gaps": active_boundary_items,
             "omitted_not_evidence_count": omitted_boundary,
+            "omitted_active_gap_count": omitted_active_boundary,
             "claim_boundary": (
                 "This report summarizes metadata and observed references only. Prepared handoffs and summaries are not "
                 "execution, verification, review, CI, merge-readiness, or merge evidence until matching observations exist."
@@ -237,6 +246,8 @@ def build_work_observation_summary(
             "tone_policy": "adapter_selected_channel_voice",
             "default_voice": "conservative",
             "supported_tone_options": ["locale", "voice"],
+            "supported_voices": ["friendly", "polite", "formal", "conservative"],
+            "korean_default_voice": "polite",
             "internal_rails_policy": "summarize_or_omit_prompt_only_context",
             "plain_text_renderers": ["progress", "completion", "blocker", "status"],
             "machine_readable_payload": "internal_or_opt_in",
@@ -320,13 +331,7 @@ def build_work_observation_summary_from_status(
         ],
         safe_summary=str(status_payload.get("safe_summary", "")),
         next_action=str(status_payload.get("next_action") or "show_status"),
-        not_evidence_until_observed=[
-            "execution" if execution.get("observed") is not True else "",
-            "verification" if verification.get("observed") is not True else "",
-            "review" if str(review.get("status", "not_observed")) in {"not_observed", "pending"} else "",
-            "ci" if str(ci.get("status", "not_observed")) in {"not_observed", "pending"} else "",
-            "merge" if str(merge.get("status", "not_observed")) in {"not_observed", "pending", "not_ready"} else "",
-        ],
+        not_evidence_until_observed=_status_payload_active_gaps(execution, verification, review, ci, merge),
     )
 
 
@@ -338,6 +343,8 @@ def render_progress_report(summary: dict[str, Any], *, locale: str = "", voice: 
     status = _status_phrase(str(summary.get("status", "unknown")))
     if _friendly_ko(locale=locale, voice=voice):
         return _render_friendly_ko_progress_report(summary)
+    if _polite_ko(locale=locale, voice=voice):
+        return _render_polite_ko_progress_report(summary)
     lines = [f"Progress: {title} is {status}."]
     latest = _object(_object(summary.get("progress")).get("latest_event"))
     safe_summary = str(_object(summary.get("progress")).get("safe_summary", ""))
@@ -363,6 +370,8 @@ def render_completion_report(summary: dict[str, Any], *, locale: str = "", voice
         raise ValueError("; ".join(validate))
     if _friendly_ko(locale=locale, voice=voice):
         return _render_friendly_ko_completion_report(summary)
+    if _polite_ko(locale=locale, voice=voice):
+        return _render_polite_ko_completion_report(summary)
     title = str(summary["title"])
     if summary.get("status") == "completed":
         lines = [f"Completed: {title}."]
@@ -382,6 +391,8 @@ def render_blocker_report(summary: dict[str, Any], *, locale: str = "", voice: s
         raise ValueError("; ".join(validate))
     if _friendly_ko(locale=locale, voice=voice):
         return _render_friendly_ko_blocker_report(summary)
+    if _polite_ko(locale=locale, voice=voice):
+        return _render_polite_ko_blocker_report(summary)
     title = str(summary["title"])
     blockers = _string_items(summary.get("blockers"))
     lines = [f"Blocked: {title}."]
@@ -441,10 +452,16 @@ def format_check_rollup(checks: Any, *, locale: str = "", voice: str = "") -> st
     for row in rows:
         counts[row["status"]] = counts.get(row["status"], 0) + 1
     if _friendly_ko(locale=locale, voice=voice):
-        lines = [_ko_check_summary(counts)]
+        lines = [_friendly_ko_check_summary(counts)]
         lines.extend(_ko_check_line(row) for row in rows[:12])
         if len(rows) > 12:
             lines.append(f"- 외 {len(rows) - 12}개 체크")
+        return _plain(lines, locale=locale, voice=voice)
+    if _polite_ko(locale=locale, voice=voice):
+        lines = [_polite_ko_check_summary(counts)]
+        lines.extend(_ko_check_line(row) for row in rows[:12])
+        if len(rows) > 12:
+            lines.append(f"- 외 {len(rows) - 12}개 체크입니다.")
         return _plain(lines, locale=locale, voice=voice)
     lines = [_english_check_summary(counts)]
     lines.extend(_english_check_line(row) for row in rows[:12])
@@ -534,6 +551,8 @@ def validate_work_observation_summary(summary: dict[str, Any]) -> list[str]:
         _require(isinstance(observations.get(key), list), errors, f"observations.{key} must be a list")
     boundary = _object(summary.get("evidence_boundary"))
     _require(isinstance(boundary.get("not_evidence_until_observed"), list), errors, "evidence boundary must list non-evidence")
+    if "active_not_observed_gaps" in boundary:
+        _require(isinstance(boundary.get("active_not_observed_gaps"), list), errors, "active evidence gaps must be a list")
     _require("not" in str(boundary.get("claim_boundary", "")).lower(), errors, "claim boundary must preserve non-evidence language")
     user_report = _object(summary.get("user_report"))
     _require(user_report.get("default_format") == "plain_text", errors, "default user report format must be plain_text")
@@ -729,6 +748,51 @@ def _render_friendly_ko_blocker_report(summary: dict[str, Any]) -> str:
     return _plain(lines, locale="ko", voice="friendly")
 
 
+def _render_polite_ko_progress_report(summary: dict[str, Any]) -> str:
+    title = str(summary["title"])
+    status = str(summary.get("status", "unknown"))
+    latest = _object(_object(summary.get("progress")).get("latest_event"))
+    safe_summary = str(_object(summary.get("progress")).get("safe_summary", ""))
+    detail = str(latest.get("summary") or safe_summary)
+    lines = [_ko_polite_status_sentence(title, status)]
+    if detail:
+        lines.append(detail)
+    lines.extend(_ko_evidence_lines(summary))
+    next_action = str(summary.get("next_action", "show_status"))
+    if next_action and next_action != "show_status":
+        lines.append(f"다음은 {next_action} 항목을 확인하겠습니다.")
+    lines.append(_boundary_line(summary, locale="ko", voice="polite"))
+    return _plain(lines, locale="ko", voice="polite")
+
+
+def _render_polite_ko_completion_report(summary: dict[str, Any]) -> str:
+    title = str(summary["title"])
+    status = str(summary.get("status", "unknown"))
+    lines = [f"{title} 작업은 완료되었습니다." if status == "completed" else f"{title} 작업은 아직 완료로 확인되지 않았습니다."]
+    observed = _string_items(_object(summary.get("observations")).get("observed_events"))
+    if observed:
+        lines.append(f"확인된 항목은 {', '.join(observed[:5])}입니다.")
+    lines.extend(_ko_evidence_lines(summary))
+    lines.append(_boundary_line(summary, locale="ko", voice="polite"))
+    return _plain(lines, locale="ko", voice="polite")
+
+
+def _render_polite_ko_blocker_report(summary: dict[str, Any]) -> str:
+    title = str(summary["title"])
+    blockers = _string_items(summary.get("blockers"))
+    lines = [f"{title} 작업은 현재 막혀 있습니다."]
+    if blockers:
+        lines.append(f"이유: {'; '.join(blockers[:3])}입니다.")
+    else:
+        lines.append("아직 필요한 확인 근거가 관찰되지 않았습니다.")
+    next_action = str(summary.get("next_action", "show_status"))
+    if next_action and next_action != "show_status":
+        lines.append(f"다음은 {next_action} 항목을 확인하겠습니다.")
+    lines.extend(_ko_evidence_lines(summary))
+    lines.append(_boundary_line(summary, locale="ko", voice="polite"))
+    return _plain(lines, locale="ko", voice="polite")
+
+
 def _ko_status_sentence(title: str, status: str) -> str:
     if status == "completed":
         return f"{title} 작업은 끝났어."
@@ -743,6 +807,20 @@ def _ko_status_sentence(title: str, status: str) -> str:
     return f"{title} 작업은 진행 중이야."
 
 
+def _ko_polite_status_sentence(title: str, status: str) -> str:
+    if status == "completed":
+        return f"{title} 작업은 완료되었습니다."
+    if status == "blocked":
+        return f"{title} 작업은 현재 막혀 있습니다."
+    if status == "failed":
+        return f"{title} 작업에서 실패가 확인되었습니다."
+    if status == "prepared_not_observed":
+        return f"{title} 작업은 준비되었고, 아직 실행 확인을 기다리는 중입니다."
+    if status == "unknown":
+        return f"{title} 작업 상태는 아직 확실하지 않습니다."
+    return f"{title} 작업은 진행 중입니다."
+
+
 def _ko_evidence_lines(summary: dict[str, Any]) -> list[str]:
     refs = _string_items(_object(summary.get("observations")).get("evidence_refs"))
     if not refs:
@@ -750,13 +828,21 @@ def _ko_evidence_lines(summary: dict[str, Any]) -> list[str]:
     return [f"확인한 근거: {', '.join(refs[:4])}."]
 
 
+def _korean_locale(locale: str) -> bool:
+    return _token(locale) in {"ko", "ko_kr", "kr", "korean"}
+
+
 def _friendly_ko(*, locale: str, voice: str) -> bool:
-    return _token(locale) in {"ko", "ko_kr", "kr", "korean"} and _token(voice) in {
+    return _korean_locale(locale) and _token(voice) in {
         "friendly",
         "casual",
         "discord",
         "calm",
     }
+
+
+def _polite_ko(*, locale: str, voice: str) -> bool:
+    return _korean_locale(locale) and not _friendly_ko(locale=locale, voice=voice)
 
 
 def _parse_background_completion(output: str) -> dict[str, Any]:
@@ -801,6 +887,12 @@ def _background_completion_status_line(
         if exit_code is None:
             return "백그라운드 작업이 끝났고, 출력만 요약할게."
         return f"백그라운드 작업이 exit code {exit_code}로 끝났어."
+    if _polite_ko(locale=locale, voice=voice):
+        if succeeded:
+            return "백그라운드 작업은 조용히 완료되었습니다."
+        if exit_code is None:
+            return "백그라운드 작업이 완료되어 출력을 요약하겠습니다."
+        return f"백그라운드 작업이 exit code {exit_code}로 종료되었습니다."
     if succeeded:
         return f"Background process {label} completed successfully."
     if exit_code is None:
@@ -850,14 +942,7 @@ def _check_rows(checks: Any) -> list[dict[str, str]]:
 
 def _check_row_from_dict(value: dict[str, Any]) -> dict[str, str]:
     name = str(value.get("name") or value.get("check") or value.get("workflow") or value.get("title") or "").strip()
-    raw_status = str(
-        value.get("conclusion")
-        or value.get("status")
-        or value.get("state")
-        or value.get("result")
-        or ""
-    )
-    status = _normalize_check_status(raw_status)
+    status = _check_status_from_structured_row(value)
     if not name or not status:
         return {}
     duration = str(value.get("duration") or value.get("elapsed") or value.get("time") or "").strip()
@@ -941,6 +1026,41 @@ def _normalize_check_status(value: str) -> str:
     return _CHECK_STATUS_ALIASES.get(lowered, "")
 
 
+def _check_status_from_structured_row(value: dict[str, Any]) -> str:
+    explicit_result = value.get("conclusion")
+    if explicit_result in ("", None):
+        explicit_result = value.get("result")
+    if explicit_result not in ("", None):
+        return _normalize_check_conclusion(str(explicit_result))
+    state = str(value.get("status") or value.get("state") or "")
+    if _token(state) == "completed":
+        return "unknown"
+    return _normalize_check_status(state)
+
+
+def _normalize_check_conclusion(value: str) -> str:
+    normalized = _token(value)
+    if normalized in {"success", "successful", "succeeded", "pass", "passed", "passing", "ok"}:
+        return "pass"
+    if normalized in {"skip", "skipped"}:
+        return "skipped"
+    if normalized in {
+        "fail",
+        "failed",
+        "failure",
+        "error",
+        "cancelled",
+        "canceled",
+        "timed_out",
+        "action_required",
+        "startup_failure",
+    }:
+        return "fail"
+    if normalized in {"pending", "queued", "waiting", "requested", "expected", "in_progress", "progress", "running"}:
+        return "pending"
+    return "unknown"
+
+
 def _english_check_summary(counts: dict[str, int]) -> str:
     parts = [f"{counts[status]} {status}" for status in _CHECK_STATUS_ORDER if counts.get(status)]
     return f"Checks: {', '.join(parts)}." if parts else "Checks: no check rows found."
@@ -951,10 +1071,16 @@ def _english_check_line(row: dict[str, str]) -> str:
     return f"- {row['name']}: {row['status']}{suffix}"
 
 
-def _ko_check_summary(counts: dict[str, int]) -> str:
+def _friendly_ko_check_summary(counts: dict[str, int]) -> str:
     labels = {"pass": "통과", "pending": "대기 중", "fail": "실패", "skipped": "건너뜀", "unknown": "상태 미확인"}
     parts = [f"{counts[status]}개 {labels[status]}" for status in _CHECK_STATUS_ORDER if counts.get(status)]
     return f"체크는 {', '.join(parts)}이야." if parts else "확인할 체크 행은 없었어."
+
+
+def _polite_ko_check_summary(counts: dict[str, int]) -> str:
+    labels = {"pass": "통과", "pending": "대기 중", "fail": "실패", "skipped": "건너뜀", "unknown": "상태 미확인"}
+    parts = [f"{counts[status]}개 {labels[status]}" for status in _CHECK_STATUS_ORDER if counts.get(status)]
+    return f"체크는 {', '.join(parts)}입니다." if parts else "확인할 체크 행은 없습니다."
 
 
 def _ko_check_line(row: dict[str, str]) -> str:
@@ -1008,6 +1134,8 @@ def _contains_internal_report_marker(text: str) -> bool:
 def _internal_context_user_summary(*, locale: str, voice: str) -> str:
     if _friendly_ko(locale=locale, voice=voice):
         return "내부 OMH 상태는 확인했고, 사용자에게는 필요한 진행 상황만 짧게 전할게."
+    if _polite_ko(locale=locale, voice=voice):
+        return "내부 OMH 상태는 확인했으며, 사용자에게는 필요한 진행 상황만 요약하겠습니다."
     return "Internal OMH status context was observed; user-facing output should summarize only the relevant status."
 
 
@@ -1019,12 +1147,34 @@ def _evidence_lines(summary: dict[str, Any]) -> list[str]:
 
 
 def _boundary_line(summary: dict[str, Any], *, locale: str = "", voice: str = "") -> str:
-    items = _string_items(_object(summary.get("evidence_boundary")).get("not_evidence_until_observed"))
+    boundary = _object(summary.get("evidence_boundary"))
+    items = _active_boundary_items(summary)
+    claim_boundary = str(boundary.get("claim_boundary") or "")
     if not items:
+        if _friendly_ko(locale=locale, voice=voice):
+            return "준비된 핸드오프나 요약은 실제 관찰 기록이 있어야 실행, 검증, 리뷰, CI, 머지 근거로 볼 수 있어."
+        if _polite_ko(locale=locale, voice=voice):
+            return "준비된 핸드오프나 요약은 실제 관찰 기록이 있어야 실행, 검증, 리뷰, CI, 머지 근거로 볼 수 있습니다."
+        if claim_boundary:
+            return (
+                "Claim rule: prepared handoffs and summaries need matching observations before they count as "
+                "execution, verification, review, CI, merge-readiness, or merge evidence."
+            )
         return ""
     if _friendly_ko(locale=locale, voice=voice):
         return f"아직 확인 근거가 필요한 부분: {', '.join(items[:5])}."
+    if _polite_ko(locale=locale, voice=voice):
+        return f"아직 확인 근거가 필요한 부분: {', '.join(items[:5])}입니다."
     return f"Still waiting on observed proof for: {', '.join(items[:5])}."
+
+
+def _active_boundary_items(summary: dict[str, Any]) -> list[str]:
+    boundary = _object(summary.get("evidence_boundary"))
+    active = _string_items(boundary.get("active_not_observed_gaps"))
+    if active:
+        return active
+    observations = _object(summary.get("observations"))
+    return _string_items(observations.get("not_observed_events"))
 
 
 def _default_summary(summary: dict[str, Any]) -> str:
@@ -1053,6 +1203,7 @@ def _status_from_status_payload(status_payload: dict[str, Any]) -> str:
     review = _object(status_payload.get("review"))
     ci = _object(status_payload.get("ci"))
     merge = _object(status_payload.get("merge"))
+    runtime_observation = _object(status_payload.get("runtime_observation"))
     next_action = str(status_payload.get("next_action", ""))
     lifecycle = str(status_payload.get("lifecycle_status", ""))
     terminal_requested = lifecycle in {"reportable", "merge_ready", "merged"} or next_action in {
@@ -1063,6 +1214,9 @@ def _status_from_status_payload(status_payload: dict[str, Any]) -> str:
     failed_or_blocked = _failed_or_blocked_status(execution, verification, review, ci, merge)
     if failed_or_blocked:
         return failed_or_blocked
+    runtime_failed_or_blocked = _runtime_failed_or_blocked_status(runtime_observation)
+    if runtime_failed_or_blocked:
+        return runtime_failed_or_blocked
     if terminal_requested and _terminal_evidence_satisfied(execution, verification, review, ci, merge):
         return "completed"
     if next_action.startswith("surface_") or "blocker" in next_action:
@@ -1078,6 +1232,26 @@ def _status_from_status_payload(status_payload: dict[str, Any]) -> str:
     ):
         return "prepared_not_observed"
     return "in_progress"
+
+
+def _status_payload_active_gaps(
+    execution: dict[str, Any],
+    verification: dict[str, Any],
+    review: dict[str, Any],
+    ci: dict[str, Any],
+    merge: dict[str, Any],
+) -> list[str]:
+    return [
+        item
+        for item in (
+            "execution" if execution.get("observed") is not True else "",
+            "verification" if verification.get("observed") is not True else "",
+            "review" if str(review.get("status", "not_observed")) in {"not_observed", "pending"} else "",
+            "ci" if str(ci.get("status", "not_observed")) in {"not_observed", "pending"} else "",
+            "merge" if str(merge.get("status", "not_observed")) in {"not_observed", "pending", "not_ready"} else "",
+        )
+        if item
+    ]
 
 
 def _terminal_evidence_satisfied(
@@ -1161,6 +1335,22 @@ def _failed_or_blocked_status(*stages: dict[str, Any]) -> str:
     blocked = False
     for stage in stages:
         status = str(stage.get("status", ""))
+        if status == "failed":
+            return "failed"
+        if status == "blocked":
+            blocked = True
+    return "blocked" if blocked else ""
+
+
+def _runtime_failed_or_blocked_status(runtime_observation: dict[str, Any]) -> str:
+    if _string_items(runtime_observation.get("failed_events")):
+        return "failed"
+    latest = _object(runtime_observation.get("latest"))
+    blocked = bool(_string_items(runtime_observation.get("blocked_events")))
+    for record in latest.values():
+        if not isinstance(record, dict):
+            continue
+        status = _token(record.get("status") or "")
         if status == "failed":
             return "failed"
         if status == "blocked":

--- a/src/work_reporting.py
+++ b/src/work_reporting.py
@@ -331,7 +331,14 @@ def build_work_observation_summary_from_status(
         ],
         safe_summary=str(status_payload.get("safe_summary", "")),
         next_action=str(status_payload.get("next_action") or "show_status"),
-        not_evidence_until_observed=_status_payload_active_gaps(execution, verification, review, ci, merge),
+        not_evidence_until_observed=_status_payload_active_gaps(
+            execution,
+            verification,
+            review,
+            ci,
+            merge,
+            runtime_observation=runtime_observation,
+        ),
     )
 
 
@@ -1248,6 +1255,8 @@ def _status_from_status_payload(status_payload: dict[str, Any]) -> str:
     runtime_failed_or_blocked = _runtime_failed_or_blocked_status(runtime_observation)
     if runtime_failed_or_blocked:
         return runtime_failed_or_blocked
+    if terminal_requested and _runtime_completion_satisfied(runtime_observation):
+        return "completed"
     if terminal_requested and _terminal_evidence_satisfied(execution, verification, review, ci, merge):
         return "completed"
     if next_action.startswith("surface_") or "blocker" in next_action:
@@ -1271,7 +1280,11 @@ def _status_payload_active_gaps(
     review: dict[str, Any],
     ci: dict[str, Any],
     merge: dict[str, Any],
+    *,
+    runtime_observation: dict[str, Any] | None = None,
 ) -> list[str]:
+    if _runtime_completion_satisfied(_object(runtime_observation)):
+        return []
     return [
         item
         for item in (
@@ -1364,7 +1377,7 @@ def _runtime_observation_events(runtime_observation: dict[str, Any]) -> list[dic
 
 def _runtime_observation_event(latest: dict[str, Any], event_type: str, fallback_status: str) -> dict[str, Any]:
     record = _object(latest.get(event_type))
-    status = fallback_status if fallback_status == "not_observed" else str(record.get("status") or fallback_status)
+    status = fallback_status if fallback_status == "not_observed" else _runtime_observation_event_status(record, fallback_status)
     event: dict[str, Any] = {
         "event_type": str(record.get("event_type") or event_type),
         "status": status,
@@ -1373,6 +1386,15 @@ def _runtime_observation_event(latest: dict[str, Any], event_type: str, fallback
         event["summary"] = str(record.get("summary") or "")
         event["evidence_refs"] = _string_items(record.get("evidence_refs"))
     return event
+
+
+def _runtime_observation_event_status(record: dict[str, Any], fallback_status: str) -> str:
+    status = _token(record.get("status") or fallback_status)
+    if status in {"observed", "completed", "passed", "satisfied", "success", "succeeded", "verified"}:
+        return "observed"
+    if status in {"blocked", "failed"}:
+        return status
+    return "not_observed"
 
 
 def _failed_or_blocked_status(*stages: dict[str, Any]) -> str:
@@ -1400,6 +1422,26 @@ def _runtime_failed_or_blocked_status(runtime_observation: dict[str, Any]) -> st
         if status == "blocked":
             blocked = True
     return "blocked" if blocked else ""
+
+
+def _runtime_completion_satisfied(runtime_observation: dict[str, Any]) -> bool:
+    if not runtime_observation:
+        return False
+    if _string_items(runtime_observation.get("failed_events")) or _string_items(runtime_observation.get("blocked_events")):
+        return False
+    if _string_items(runtime_observation.get("not_observed_events")) or _string_items(runtime_observation.get("missing_events")):
+        return False
+    observed_events = _string_items(runtime_observation.get("observed_events"))
+    if not observed_events:
+        return False
+    latest = _object(runtime_observation.get("latest"))
+    success_statuses = {"", "observed", "completed", "passed", "satisfied", "success", "succeeded", "verified"}
+    for event_type in observed_events:
+        record = _object(latest.get(event_type))
+        status = _token(record.get("status") or "observed")
+        if status not in success_statuses:
+            return False
+    return True
 
 
 def _post_prepared_work_observed(

--- a/src/work_reporting.py
+++ b/src/work_reporting.py
@@ -1255,7 +1255,8 @@ def _status_from_status_payload(status_payload: dict[str, Any]) -> str:
     runtime_failed_or_blocked = _runtime_failed_or_blocked_status(runtime_observation)
     if runtime_failed_or_blocked:
         return runtime_failed_or_blocked
-    if terminal_requested and _runtime_completion_satisfied(runtime_observation):
+    runtime_terminal_requested = _runtime_terminal_requested(runtime_observation)
+    if (terminal_requested or runtime_terminal_requested) and _runtime_completion_satisfied(runtime_observation):
         return "completed"
     if terminal_requested and _terminal_evidence_satisfied(execution, verification, review, ci, merge):
         return "completed"
@@ -1442,6 +1443,16 @@ def _runtime_completion_satisfied(runtime_observation: dict[str, Any]) -> bool:
         if status not in success_statuses:
             return False
     return True
+
+
+def _runtime_terminal_requested(runtime_observation: dict[str, Any]) -> bool:
+    next_action = _token(runtime_observation.get("next_action") or "")
+    status = _token(runtime_observation.get("status") or runtime_observation.get("lifecycle_status") or "")
+    return next_action in {"report_runtime_observed", "report_completion_with_evidence"} or status in {
+        "completed",
+        "reportable",
+        "runtime_observed",
+    }
 
 
 def _post_prepared_work_observed(

--- a/src/work_reporting.py
+++ b/src/work_reporting.py
@@ -484,8 +484,21 @@ def sanitize_user_report_text(value: Any, *, locale: str = "", voice: str = "") 
     if not text.strip():
         return ""
     if _contains_internal_report_marker(text):
+        scrubbed = _scrub_internal_report_lines(text)
+        if scrubbed.strip():
+            return scrubbed
         return _internal_context_user_summary(locale=locale, voice=voice)
     return text
+
+
+def _scrub_internal_report_lines(text: str) -> str:
+    kept: list[str] = []
+    for line in str(text or "").splitlines():
+        if _contains_internal_report_marker(line):
+            continue
+        if line.strip():
+            kept.append(line)
+    return "\n".join(kept).strip()
 
 
 def build_markdown_export(summary: dict[str, Any]) -> dict[str, Any]:

--- a/src/work_reporting.py
+++ b/src/work_reporting.py
@@ -992,12 +992,25 @@ def _check_rows_from_text(output: str) -> list[dict[str, str]]:
     rows: list[dict[str, str]] = []
     for raw_line in output.splitlines():
         line = _strip_ansi(raw_line).strip()
-        if not line or _is_check_watch_noise(line) or _is_check_header(line):
+        if not line or _is_check_watch_noise(line) or _is_check_header(line) or _is_check_summary_prose(line):
             continue
         row = _check_row_from_line(line)
         if row:
             rows.append(row)
     return rows
+
+
+def _is_check_summary_prose(line: str) -> bool:
+    normalized = " ".join(str(line or "").casefold().split())
+    if not normalized:
+        return False
+    if normalized.startswith("some checks were") or normalized.startswith("all checks"):
+        return True
+    if re.match(r"^\d+\s+(failing|failed|successful|pending|skipped|cancelled|canceled)\b", normalized):
+        return True
+    if "checks were not successful" in normalized or "checks have failed" in normalized:
+        return True
+    return False
 
 
 def _check_row_from_line(line: str) -> dict[str, str]:

--- a/src/work_reporting.py
+++ b/src/work_reporting.py
@@ -57,6 +57,8 @@ _POST_PREPARED_NEXT_ACTIONS = {
 }
 _VERIFICATION_SUCCESS_STATUSES = {"passed", "satisfied", "completed", "verified"}
 _NON_PROGRESS_STATUSES = {"", "not_observed", "not_required", "pending"}
+_OBSERVATION_EVENT_STATUSES = ("observed", "blocked", "failed", "not_observed")
+_OBSERVATION_EVENT_EVIDENCE_STATUSES = {"observed", "blocked", "failed"}
 
 
 def build_work_observation_summary(
@@ -243,6 +245,7 @@ def build_work_observation_summary_from_status(
     status = _status_from_status_payload(status_payload)
     evidence_refs = [
         *_observed_stage_evidence_refs(execution),
+        *_observed_stage_evidence_refs(verification),
         *_observed_stage_evidence_refs(review),
         *_observed_stage_evidence_refs(ci),
         *_observed_stage_evidence_refs(merge),
@@ -504,12 +507,14 @@ def _compact_observation_events(events: list[dict[str, Any]] | tuple[dict[str, A
         if len(compacted) >= MAX_OBSERVATION_EVENTS:
             omitted += 1
             continue
-        evidence_refs, omitted_refs = compact_context_refs(event.get("evidence_refs", []))
+        status = _observation_event_status(event)
+        refs = event.get("evidence_refs", []) if status in _OBSERVATION_EVENT_EVIDENCE_STATUSES else []
+        evidence_refs, omitted_refs = compact_context_refs(refs)
         compacted.append(
             {
                 "schema_version": WORK_OBSERVATION_EVENT_REF_SCHEMA_VERSION,
                 "event_type": _token(str(event.get("event_type") or "status_update")),
-                "status": _choice(str(event.get("status") or "observed"), ("observed", "blocked", "failed", "not_observed"), "observed"),
+                "status": status,
                 "summary": compact_visible_text(_strip_code_fences(event.get("summary", "")), max_chars=180),
                 "evidence_refs": evidence_refs,
                 "raw_content_included": False,
@@ -522,9 +527,13 @@ def _compact_observation_events(events: list[dict[str, Any]] | tuple[dict[str, A
 def _event_evidence_refs(events: list[dict[str, Any]] | tuple[dict[str, Any], ...]) -> list[str]:
     refs: list[str] = []
     for event in events:
-        if isinstance(event, dict):
+        if isinstance(event, dict) and _observation_event_status(event) in _OBSERVATION_EVENT_EVIDENCE_STATUSES:
             refs.extend(_string_items(event.get("evidence_refs")))
     return refs
+
+
+def _observation_event_status(event: dict[str, Any]) -> str:
+    return _choice(str(event.get("status") or "observed"), _OBSERVATION_EVENT_STATUSES, "observed")
 
 
 def _compact_strings(values: list[str] | tuple[str, ...], *, max_items: int, max_chars: int) -> tuple[list[str], int]:

--- a/src/work_reporting.py
+++ b/src/work_reporting.py
@@ -250,24 +250,7 @@ def build_work_observation_summary_from_status(
         *_observed_stage_evidence_refs(ci),
         *_observed_stage_evidence_refs(merge),
     ]
-    observed_events = [
-        *[
-            {"event_type": event_type, "status": "observed"}
-            for event_type in _string_items(runtime_observation.get("observed_events"))
-        ],
-        *[
-            {"event_type": event_type, "status": "blocked"}
-            for event_type in _string_items(runtime_observation.get("blocked_events"))
-        ],
-        *[
-            {"event_type": event_type, "status": "failed"}
-            for event_type in _string_items(runtime_observation.get("failed_events"))
-        ],
-        *[
-            {"event_type": event_type, "status": "not_observed"}
-            for event_type in _string_items(runtime_observation.get("missing_events"))
-        ],
-    ]
+    observed_events = _runtime_observation_events(runtime_observation)
     progress_events = _string_items(status_payload.get("safe_summary"))
     return build_work_observation_summary(
         work_id=run_id,
@@ -679,6 +662,39 @@ def _observed_stage_evidence_refs(stage: dict[str, Any]) -> list[str]:
     if stage.get("observed") is True or stage.get("satisfied") is True:
         return _string_items(stage.get("evidence_refs"))
     return []
+
+
+def _runtime_observation_events(runtime_observation: dict[str, Any]) -> list[dict[str, Any]]:
+    latest = _object(runtime_observation.get("latest"))
+    events: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for field, fallback_status in (
+        ("observed_events", "observed"),
+        ("blocked_events", "blocked"),
+        ("failed_events", "failed"),
+        ("not_observed_events", "not_observed"),
+        ("missing_events", "not_observed"),
+    ):
+        for event_type in _string_items(runtime_observation.get(field)):
+            event_key = _token(event_type)
+            if event_key in seen:
+                continue
+            seen.add(event_key)
+            events.append(_runtime_observation_event(latest, event_type, fallback_status))
+    return events
+
+
+def _runtime_observation_event(latest: dict[str, Any], event_type: str, fallback_status: str) -> dict[str, Any]:
+    record = _object(latest.get(event_type))
+    status = fallback_status if fallback_status == "not_observed" else str(record.get("status") or fallback_status)
+    event: dict[str, Any] = {
+        "event_type": str(record.get("event_type") or event_type),
+        "status": status,
+    }
+    if record:
+        event["summary"] = str(record.get("summary") or "")
+        event["evidence_refs"] = _string_items(record.get("evidence_refs"))
+    return event
 
 
 def _failed_or_blocked_status(*stages: dict[str, Any]) -> str:

--- a/src/work_reporting.py
+++ b/src/work_reporting.py
@@ -48,6 +48,15 @@ _FORBIDDEN_RAW_KEYS = {
     "transcript",
     "conversation",
 }
+_POST_PREPARED_NEXT_ACTIONS = {
+    "wait_for_executor_evidence",
+    "record_verification_evidence",
+    "record_review_evidence",
+    "record_ci_evidence",
+    "record_merge_readiness",
+}
+_VERIFICATION_SUCCESS_STATUSES = {"passed", "satisfied", "completed", "verified"}
+_NON_PROGRESS_STATUSES = {"", "not_observed", "not_required", "pending"}
 
 
 def build_work_observation_summary(
@@ -586,6 +595,7 @@ def _plain(lines: list[str]) -> str:
 
 def _status_from_status_payload(status_payload: dict[str, Any]) -> str:
     prepared = _object(status_payload.get("prepared"))
+    wrapper = _object(status_payload.get("wrapper"))
     execution = _object(status_payload.get("execution"))
     verification = _object(status_payload.get("verification"))
     review = _object(status_payload.get("review"))
@@ -598,11 +608,22 @@ def _status_from_status_payload(status_payload: dict[str, Any]) -> str:
         "report_merge_ready",
         "report_merged",
     }
+    failed_or_blocked = _failed_or_blocked_status(execution, verification, review, ci, merge)
+    if failed_or_blocked:
+        return failed_or_blocked
     if terminal_requested and _terminal_evidence_satisfied(execution, verification, review, ci, merge):
         return "completed"
     if next_action.startswith("surface_") or "blocker" in next_action:
         return "blocked"
-    if str(prepared.get("status", "")) == "prepared_not_observed":
+    if str(prepared.get("status", "")) == "prepared_not_observed" and not _post_prepared_work_observed(
+        next_action=next_action,
+        wrapper=wrapper,
+        execution=execution,
+        verification=verification,
+        review=review,
+        ci=ci,
+        merge=merge,
+    ):
         return "prepared_not_observed"
     return "in_progress"
 
@@ -617,11 +638,17 @@ def _terminal_evidence_satisfied(
     return (
         execution.get("observed") is True
         and str(execution.get("status", "")) == "completed"
-        and verification.get("observed") is True
+        and _verification_satisfied(verification)
         and _gate_satisfied(review)
         and _gate_satisfied(ci)
         and _gate_satisfied(merge)
     )
+
+
+def _verification_satisfied(verification: dict[str, Any]) -> bool:
+    if verification.get("satisfied") is True:
+        return True
+    return verification.get("observed") is True and str(verification.get("status", "")) in _VERIFICATION_SUCCESS_STATUSES
 
 
 def _gate_satisfied(stage: dict[str, Any]) -> bool:
@@ -643,6 +670,43 @@ def _observed_stage_evidence_refs(stage: dict[str, Any]) -> list[str]:
     if stage.get("observed") is True or stage.get("satisfied") is True:
         return _string_items(stage.get("evidence_refs"))
     return []
+
+
+def _failed_or_blocked_status(*stages: dict[str, Any]) -> str:
+    blocked = False
+    for stage in stages:
+        status = str(stage.get("status", ""))
+        if status == "failed":
+            return "failed"
+        if status == "blocked":
+            blocked = True
+    return "blocked" if blocked else ""
+
+
+def _post_prepared_work_observed(
+    *,
+    next_action: str,
+    wrapper: dict[str, Any],
+    execution: dict[str, Any],
+    verification: dict[str, Any],
+    review: dict[str, Any],
+    ci: dict[str, Any],
+    merge: dict[str, Any],
+) -> bool:
+    if next_action in _POST_PREPARED_NEXT_ACTIONS:
+        return True
+    if wrapper.get("prompt_dispatched") is True or wrapper.get("hermes_response_observed") is True:
+        return True
+    return any(_stage_has_observed_progress(stage) for stage in (execution, verification, review, ci, merge))
+
+
+def _stage_has_observed_progress(stage: dict[str, Any]) -> bool:
+    if not stage:
+        return False
+    status = str(stage.get("status", ""))
+    if status in _NON_PROGRESS_STATUSES:
+        return False
+    return stage.get("observed") is True or stage.get("satisfied") is True or bool(_string_items(stage.get("evidence_refs")))
 
 
 def _status_phrase(status: str) -> str:

--- a/src/work_reporting.py
+++ b/src/work_reporting.py
@@ -426,7 +426,7 @@ def build_background_completion_report(
     visible_output = sanitize_user_report_text(visible_output, locale=locale, voice=voice)
     if resolved_exit_code == 0 and not visible_output.strip():
         return None
-    if visible_output.strip() or "gh pr checks" in command.casefold():
+    if _should_render_background_check_rollup(command=command, output=visible_output):
         check_rollup = format_check_rollup(visible_output, locale=locale, voice=voice)
         if check_rollup:
             return check_rollup
@@ -912,6 +912,34 @@ def _meaningful_output_lines(output: str) -> list[str]:
         if len(lines) >= 4:
             break
     return lines
+
+
+def _should_render_background_check_rollup(*, command: str, output: str) -> bool:
+    """Return true when background output is plausibly CI/check rollup text."""
+
+    if not str(output or "").strip():
+        return False
+    command_lower = str(command or "").casefold()
+    if "gh pr checks" in command_lower or "gh run watch" in command_lower:
+        return True
+    meaningful_lines = [
+        _strip_ansi(line).strip()
+        for line in str(output or "").splitlines()
+        if line.strip() and not _is_check_watch_noise(line) and not _is_check_header(line)
+    ]
+    if not meaningful_lines:
+        return False
+    for line in meaningful_lines:
+        # `gh pr checks` rows are tabular (`name<TAB>status<TAB>duration<TAB>url`) or
+        # aligned by repeated spaces. Avoid treating ordinary text like
+        # `1 passed in 0.2s` as a check row.
+        if "\t" in line:
+            pieces = [piece.strip() for piece in re.split(r"\t+", line) if piece.strip()]
+        else:
+            pieces = [piece.strip() for piece in re.split(r"\s{2,}", line) if piece.strip()]
+        if len(pieces) >= 2 and any(_normalize_check_status(piece) for piece in pieces[1:]):
+            return True
+    return False
 
 
 def _strip_check_watch_noise(output: str) -> str:

--- a/src/work_reporting.py
+++ b/src/work_reporting.py
@@ -658,7 +658,10 @@ def _event_evidence_refs(events: list[dict[str, Any]] | tuple[dict[str, Any], ..
 
 
 def _observation_event_status(event: dict[str, Any]) -> str:
-    return _choice(str(event.get("status") or "observed"), _OBSERVATION_EVENT_STATUSES, "observed")
+    raw_status = event.get("status")
+    if raw_status is None or str(raw_status).strip() == "":
+        return "observed"
+    return _choice(str(raw_status), _OBSERVATION_EVENT_STATUSES, "not_observed")
 
 
 def _compact_strings(values: list[str] | tuple[str, ...], *, max_items: int, max_chars: int) -> tuple[list[str], int]:
@@ -1272,14 +1275,27 @@ def _status_payload_active_gaps(
     return [
         item
         for item in (
-            "execution" if execution.get("observed") is not True else "",
-            "verification" if verification.get("observed") is not True else "",
-            "review" if str(review.get("status", "not_observed")) in {"not_observed", "pending"} else "",
-            "ci" if str(ci.get("status", "not_observed")) in {"not_observed", "pending"} else "",
-            "merge" if str(merge.get("status", "not_observed")) in {"not_observed", "pending", "not_ready"} else "",
+            "execution" if _stage_is_active_gap(execution, observed_field=True) else "",
+            "verification" if _stage_is_active_gap(verification, observed_field=True) else "",
+            "review" if _stage_is_active_gap(review) else "",
+            "ci" if _stage_is_active_gap(ci) else "",
+            "merge" if _stage_is_active_gap(merge) else "",
         )
         if item
     ]
+
+
+def _stage_is_active_gap(stage: dict[str, Any], *, observed_field: bool = False) -> bool:
+    if not stage:
+        return False
+    required = stage.get("required") is True
+    present_status = "status" in stage
+    if not required and not present_status:
+        return False
+    status = str(stage.get("status", ""))
+    if observed_field and stage.get("observed") is not True:
+        return True
+    return status in {"not_observed", "pending", "not_ready"}
 
 
 def _terminal_evidence_satisfied(

--- a/src/work_reporting.py
+++ b/src/work_reporting.py
@@ -1396,11 +1396,14 @@ def _runtime_observation_events(runtime_observation: dict[str, Any]) -> list[dic
 
 
 def _runtime_observation_applicable(runtime_observation: dict[str, Any]) -> bool:
+    next_action = _token(runtime_observation.get("next_action") or "")
     return bool(
         _string_items(runtime_observation.get("observed_events"))
         or _string_items(runtime_observation.get("blocked_events"))
         or _string_items(runtime_observation.get("failed_events"))
-        or _token(runtime_observation.get("next_action") or "") in {"report_runtime_observed", "record_runtime_observation"}
+        or _string_items(runtime_observation.get("not_observed_events"))
+        or next_action in {"report_runtime_observed", "record_runtime_observation"}
+        or next_action.startswith("record_runtime_observation:")
         or _token(runtime_observation.get("status") or runtime_observation.get("lifecycle_status") or "")
         in {"running", "started", "completed", "reportable", "runtime_observed"}
     )

--- a/src/work_reporting.py
+++ b/src/work_reporting.py
@@ -1041,7 +1041,7 @@ def _check_row_from_loose_line(line: str) -> dict[str, str]:
     url = _first_url([line])
     without_url = line.replace(url, "").strip() if url else line
     match = re.search(
-        r"(?P<status>pass(?:ed)?|fail(?:ed)?|pending|queued|in[ _-]?progress|running|success(?:ful)?|skipped|cancelled|canceled|error)",
+        r"(?<![A-Za-z0-9_])(?P<status>pass(?:ed)?|fail(?:ed)?|pending|queued|in[ _-]?progress|running|success(?:ful)?|skipped|cancelled|canceled|error)(?![A-Za-z0-9_])",
         without_url,
         flags=re.IGNORECASE,
     )
@@ -1155,7 +1155,9 @@ def _is_check_header(line: str) -> bool:
 
 
 def _clean_check_name(value: str) -> str:
-    return re.sub(r"^[✓✔✗✘x!•*\-\s]+", "", value).strip(" :-—–")
+    cleaned = re.sub(r"^[✓✔✗✘!•*\-\s]+", "", value).strip(" :-—–")
+    cleaned = re.sub(r"^(?i:x)\s+", "", cleaned).strip(" :-—–")
+    return cleaned
 
 
 def _first_url(values: list[str]) -> str:

--- a/src/work_reporting.py
+++ b/src/work_reporting.py
@@ -1,0 +1,703 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from typing import Any
+
+from .context_safety import (
+    MAX_EVIDENCE_REFS,
+    MAX_PROGRESS_EVENTS,
+    compact_context_refs,
+    compact_progress_events,
+    compact_visible_text,
+)
+
+
+WORK_OBSERVATION_SUMMARY_SCHEMA_VERSION = "work_observation_summary/v1"
+WORK_REPORT_MARKDOWN_EXPORT_SCHEMA_VERSION = "work_report_markdown_export/v1"
+WORK_OBSERVATION_EVENT_REF_SCHEMA_VERSION = "work_observation_event_ref/v1"
+REPORT_KINDS = ("progress", "completion", "blocker", "status")
+REPORT_STATUSES = ("prepared_not_observed", "in_progress", "completed", "blocked", "failed", "unknown")
+MAX_TITLE_CHARS = 120
+MAX_LEARNING_NOTE_CHARS = 180
+MAX_BLOCKERS = 5
+MAX_OBSERVATION_EVENTS = 12
+_DEFAULT_NOT_EVIDENCE = (
+    "prepared_not_observed",
+    "execution",
+    "verification",
+    "review",
+    "ci",
+    "merge_readiness",
+    "merge",
+    "raw logs",
+)
+_FORBIDDEN_RAW_KEYS = {
+    "message",
+    "source_message",
+    "raw_message",
+    "prompt",
+    "raw_prompt",
+    "prompt_body",
+    "body_text",
+    "raw_text",
+    "raw_logs",
+    "stdout",
+    "stderr",
+    "transcript",
+    "conversation",
+}
+
+
+def build_work_observation_summary(
+    *,
+    work_id: str,
+    title: str,
+    report_kind: str = "status",
+    status: str = "unknown",
+    workflow: str = "",
+    harness: str = "",
+    owner: str = "hermes",
+    source_kind: str = "work",
+    source_ref: str = "",
+    source_message: str = "",
+    source_metadata: dict[str, Any] | None = None,
+    evidence_refs: list[str] | tuple[str, ...] | None = None,
+    prepared_refs: list[str] | tuple[str, ...] | None = None,
+    artifact_refs: list[str] | tuple[str, ...] | None = None,
+    observed_events: list[dict[str, Any]] | tuple[dict[str, Any], ...] | None = None,
+    progress_events: list[dict[str, Any]] | tuple[dict[str, Any], ...] | None = None,
+    blockers: list[str] | tuple[str, ...] | None = None,
+    next_action: str = "",
+    safe_summary: str = "",
+    not_evidence_until_observed: list[str] | tuple[str, ...] | None = None,
+    learning_candidate: bool = False,
+    learning_notes: str = "",
+    updated_at: str = "",
+) -> dict[str, Any]:
+    """Build a metadata-only summary for Hermes-facing work reports."""
+
+    event_evidence_refs = _event_evidence_refs(observed_events or [])
+    compact_evidence, omitted_evidence = compact_context_refs([*(evidence_refs or []), *event_evidence_refs])
+    compact_prepared, omitted_prepared = compact_context_refs(prepared_refs or [])
+    compact_artifacts, omitted_artifacts = compact_context_refs(artifact_refs or [])
+    compact_events, omitted_events = _compact_observation_events(observed_events or [])
+    compact_progress, omitted_progress = compact_progress_events(progress_events or [])
+    compact_blockers, omitted_blockers = _compact_strings(blockers or [], max_items=MAX_BLOCKERS, max_chars=180)
+    boundary_items, omitted_boundary = compact_context_refs(
+        [*_DEFAULT_NOT_EVIDENCE, *(not_evidence_until_observed or [])],
+        max_items=16,
+        max_chars=80,
+    )
+    report_kind = _choice(report_kind, REPORT_KINDS, "status")
+    status = _choice(status, REPORT_STATUSES, "unknown")
+    work_id = compact_visible_text(work_id or "unknown-work", max_chars=160)
+    title = compact_visible_text(_strip_code_fences(title or "Work report"), max_chars=MAX_TITLE_CHARS)
+    summary_ref = _summary_ref(work_id, title, report_kind, status)
+    source = _source_summary(
+        source_kind=source_kind,
+        source_ref=source_ref,
+        source_message=source_message,
+        source_metadata=source_metadata or {},
+    )
+    summary = {
+        "schema_version": WORK_OBSERVATION_SUMMARY_SCHEMA_VERSION,
+        "record_type": "work_observation_summary",
+        "summary_ref": summary_ref,
+        "work_id": work_id,
+        "title": title,
+        "report_kind": report_kind,
+        "status": status,
+        "updated_at": compact_visible_text(updated_at, max_chars=80),
+        "scope": {
+            "workflow": _token(workflow or "unknown"),
+            "harness": _token(harness or "unknown"),
+            "owner": _token(owner or "hermes"),
+        },
+        "source": source,
+        "privacy": {
+            "mode": "metadata_only",
+            "metadata_only": True,
+            "raw_prompt_stored": False,
+            "raw_message_stored": False,
+            "raw_logs_stored": False,
+            "raw_output_stored_in_summary": False,
+            "stored_fields": [
+                "work id",
+                "message hash and length",
+                "workflow and harness ids",
+                "bounded evidence references",
+                "bounded observation events",
+                "bounded progress events",
+                "claim boundaries",
+            ],
+        },
+        "observations": {
+            "schema_version": "work_observation_refs/v1",
+            "observed_events": [event["event_type"] for event in compact_events if event["status"] == "observed"],
+            "blocked_events": [event["event_type"] for event in compact_events if event["status"] == "blocked"],
+            "failed_events": [event["event_type"] for event in compact_events if event["status"] == "failed"],
+            "not_observed_events": [event["event_type"] for event in compact_events if event["status"] == "not_observed"],
+            "events": compact_events,
+            "evidence_refs": compact_evidence,
+            "prepared_refs": compact_prepared,
+            "artifact_refs": compact_artifacts,
+            "raw_content_included": False,
+            "omitted": {
+                "event_count": omitted_events,
+                "evidence_ref_count": omitted_evidence,
+                "prepared_ref_count": omitted_prepared,
+                "artifact_ref_count": omitted_artifacts,
+            },
+        },
+        "progress": {
+            "schema_version": "work_progress_digest/v1",
+            "events": compact_progress,
+            "latest_event": compact_progress[-1] if compact_progress else {},
+            "safe_summary": compact_visible_text(_strip_code_fences(safe_summary), max_chars=240),
+            "omitted": {
+                "progress_event_count": omitted_progress,
+                "max_progress_events": MAX_PROGRESS_EVENTS,
+            },
+        },
+        "blockers": compact_blockers,
+        "omitted_blocker_count": omitted_blockers,
+        "next_action": _token(next_action or "show_status"),
+        "evidence_boundary": {
+            "schema_version": "work_evidence_boundary/v1",
+            "not_evidence_until_observed": boundary_items,
+            "omitted_not_evidence_count": omitted_boundary,
+            "claim_boundary": (
+                "This report summarizes metadata and observed references only. Prepared handoffs and summaries are not "
+                "execution, verification, review, CI, merge-readiness, or merge evidence until matching observations exist."
+            ),
+        },
+        "user_report": {
+            "default_format": "plain_text",
+            "json_default": False,
+            "code_block_default": False,
+            "plain_text_renderers": ["progress", "completion", "blocker", "status"],
+            "machine_readable_payload": "internal_or_opt_in",
+        },
+        "exports": {
+            "markdown": {
+                "available": True,
+                "default": False,
+                "intended_surface": "wiki_or_markdown",
+                "schema_version": WORK_REPORT_MARKDOWN_EXPORT_SCHEMA_VERSION,
+            },
+            "json": {
+                "available": True,
+                "default": False,
+                "intended_surface": "api_debug_or_internal",
+            },
+        },
+        "learning": _learning_hint(
+            summary_ref=summary_ref,
+            candidate=learning_candidate,
+            workflow=workflow,
+            harness=harness,
+            notes=learning_notes,
+            evidence_refs=compact_evidence,
+            omitted_evidence_ref_count=omitted_evidence,
+        ),
+        "overclaim_guard": [
+            "Plain text is the default user experience.",
+            "Structured JSON is internal or opt-in.",
+            "Markdown export is a durable knowledge surface, not the default chat report.",
+            "Learning receives selected metadata-only summaries, not raw prompt or log dumps.",
+        ],
+    }
+    errors = validate_work_observation_summary(summary)
+    if errors:
+        raise ValueError("; ".join(errors))
+    return summary
+
+
+def build_work_observation_summary_from_status(
+    status_payload: dict[str, Any],
+    *,
+    report_kind: str = "status",
+    title: str = "",
+) -> dict[str, Any]:
+    """Project an existing delegated/runtime status payload into the report contract."""
+
+    prepared = _object(status_payload.get("prepared"))
+    execution = _object(status_payload.get("execution"))
+    verification = _object(status_payload.get("verification"))
+    review = _object(status_payload.get("review"))
+    ci = _object(status_payload.get("ci"))
+    merge = _object(status_payload.get("merge"))
+    runtime_observation = _object(status_payload.get("runtime_observation"))
+    run_id = str(status_payload.get("run_id") or "unknown-run")
+    status = _status_from_status_payload(status_payload)
+    evidence_refs = [
+        *_observed_stage_evidence_refs(execution),
+        *_observed_stage_evidence_refs(review),
+        *_observed_stage_evidence_refs(ci),
+        *_observed_stage_evidence_refs(merge),
+    ]
+    observed_events = [
+        *[
+            {"event_type": event_type, "status": "observed"}
+            for event_type in _string_items(runtime_observation.get("observed_events"))
+        ],
+        *[
+            {"event_type": event_type, "status": "blocked"}
+            for event_type in _string_items(runtime_observation.get("blocked_events"))
+        ],
+        *[
+            {"event_type": event_type, "status": "failed"}
+            for event_type in _string_items(runtime_observation.get("failed_events"))
+        ],
+        *[
+            {"event_type": event_type, "status": "not_observed"}
+            for event_type in _string_items(runtime_observation.get("missing_events"))
+        ],
+    ]
+    progress_events = _string_items(status_payload.get("safe_summary"))
+    return build_work_observation_summary(
+        work_id=run_id,
+        title=title or f"Work status for {run_id}",
+        report_kind=report_kind,
+        status=status,
+        workflow=str(prepared.get("workflow") or status_payload.get("workflow") or "unknown"),
+        harness=str(prepared.get("harness") or status_payload.get("harness") or "unknown"),
+        source_kind="delegated_coding_status",
+        source_ref=f"runtime:{run_id}",
+        evidence_refs=evidence_refs,
+        prepared_refs=[f"delegated_coding_status/v1:{run_id}"],
+        observed_events=observed_events,
+        progress_events=[
+            {"event_type": "status_update", "status": "observed", "summary": item}
+            for item in progress_events
+        ],
+        safe_summary=str(status_payload.get("safe_summary", "")),
+        next_action=str(status_payload.get("next_action") or "show_status"),
+        not_evidence_until_observed=[
+            "execution" if execution.get("observed") is not True else "",
+            "verification" if verification.get("observed") is not True else "",
+            "review" if str(review.get("status", "not_observed")) in {"not_observed", "pending"} else "",
+            "ci" if str(ci.get("status", "not_observed")) in {"not_observed", "pending"} else "",
+            "merge" if str(merge.get("status", "not_observed")) in {"not_observed", "pending", "not_ready"} else "",
+        ],
+    )
+
+
+def render_progress_report(summary: dict[str, Any]) -> str:
+    validate = validate_work_observation_summary(summary)
+    if validate:
+        raise ValueError("; ".join(validate))
+    title = str(summary["title"])
+    status = _status_phrase(str(summary.get("status", "unknown")))
+    lines = [f"Progress: {title} is {status}."]
+    latest = _object(_object(summary.get("progress")).get("latest_event"))
+    safe_summary = str(_object(summary.get("progress")).get("safe_summary", ""))
+    if latest.get("summary"):
+        lines.append(str(latest["summary"]))
+    elif safe_summary:
+        lines.append(safe_summary)
+    lines.extend(_evidence_lines(summary))
+    next_action = str(summary.get("next_action", "show_status"))
+    if next_action:
+        lines.append(f"Next: {next_action}.")
+    lines.append(_boundary_line(summary))
+    return _plain(lines)
+
+
+def render_status_report(summary: dict[str, Any]) -> str:
+    return render_progress_report(summary)
+
+
+def render_completion_report(summary: dict[str, Any]) -> str:
+    validate = validate_work_observation_summary(summary)
+    if validate:
+        raise ValueError("; ".join(validate))
+    title = str(summary["title"])
+    if summary.get("status") == "completed":
+        lines = [f"Completed: {title}."]
+    else:
+        lines = [f"Completion is not observed yet for {title}."]
+    observed = _string_items(_object(summary.get("observations")).get("observed_events"))
+    if observed:
+        lines.append(f"Observed: {', '.join(observed[:5])}.")
+    lines.extend(_evidence_lines(summary))
+    lines.append(_boundary_line(summary))
+    return _plain(lines)
+
+
+def render_blocker_report(summary: dict[str, Any]) -> str:
+    validate = validate_work_observation_summary(summary)
+    if validate:
+        raise ValueError("; ".join(validate))
+    title = str(summary["title"])
+    blockers = _string_items(summary.get("blockers"))
+    lines = [f"Blocked: {title}."]
+    if blockers:
+        lines.append(f"Reason: {'; '.join(blockers[:3])}.")
+    else:
+        lines.append("Reason: required evidence is not observed.")
+    next_action = str(summary.get("next_action", "show_status"))
+    if next_action:
+        lines.append(f"Next: {next_action}.")
+    lines.extend(_evidence_lines(summary))
+    lines.append(_boundary_line(summary))
+    return _plain(lines)
+
+
+def build_markdown_export(summary: dict[str, Any]) -> dict[str, Any]:
+    validate = validate_work_observation_summary(summary)
+    if validate:
+        raise ValueError("; ".join(validate))
+    markdown = _markdown_for_summary(summary)
+    export = {
+        "schema_version": WORK_REPORT_MARKDOWN_EXPORT_SCHEMA_VERSION,
+        "record_type": "work_report_markdown_export",
+        "export_mode": "opt_in",
+        "source_schema_version": summary["schema_version"],
+        "source_summary_ref": summary["summary_ref"],
+        "markdown": markdown,
+        "privacy": {
+            "mode": "metadata_only",
+            "raw_prompt_stored": False,
+            "raw_logs_stored": False,
+        },
+        "claim_boundary": "Markdown export is a secondary durable knowledge surface. It is not the default chat UX.",
+    }
+    errors = validate_markdown_export(export)
+    if errors:
+        raise ValueError("; ".join(errors))
+    return export
+
+
+def validate_markdown_export(export: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if not isinstance(export, dict):
+        return ["markdown export must be an object"]
+    _require(
+        export.get("schema_version") == WORK_REPORT_MARKDOWN_EXPORT_SCHEMA_VERSION,
+        errors,
+        "schema_version must be work_report_markdown_export/v1",
+    )
+    _require(export.get("export_mode") == "opt_in", errors, "markdown export must be opt_in")
+    _require(isinstance(export.get("markdown"), str), errors, "markdown export must include markdown text")
+    _require("```" not in str(export.get("markdown", "")), errors, "markdown export must not use code fences")
+    privacy = _object(export.get("privacy"))
+    _require(privacy.get("mode") == "metadata_only", errors, "markdown export privacy mode must be metadata_only")
+    _require(privacy.get("raw_prompt_stored") is False, errors, "markdown export must not store raw prompts")
+    _require(privacy.get("raw_logs_stored") is False, errors, "markdown export must not store raw logs")
+    _require("not the default" in str(export.get("claim_boundary", "")).lower(), errors, "markdown export boundary must be explicit")
+    _reject_forbidden_raw_keys(export, errors)
+    return errors
+
+
+def validate_work_observation_summary(summary: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if not isinstance(summary, dict):
+        return ["summary must be an object"]
+    _require(summary.get("schema_version") == WORK_OBSERVATION_SUMMARY_SCHEMA_VERSION, errors, "schema_version must be work_observation_summary/v1")
+    for key in ("record_type", "summary_ref", "work_id", "title", "report_kind", "status", "scope", "source", "privacy", "observations", "progress", "evidence_boundary", "user_report", "exports", "learning"):
+        _require(key in summary, errors, f"missing {key}")
+    _require(summary.get("report_kind") in REPORT_KINDS, errors, "report_kind is unsupported")
+    _require(summary.get("status") in REPORT_STATUSES, errors, "status is unsupported")
+    privacy = _object(summary.get("privacy"))
+    _require(privacy.get("metadata_only") is True, errors, "privacy.metadata_only must be true")
+    _require(privacy.get("raw_prompt_stored") is False, errors, "raw prompts must not be stored")
+    _require(privacy.get("raw_logs_stored") is False, errors, "raw logs must not be stored")
+    source = _object(summary.get("source"))
+    sha = str(source.get("message_sha256", ""))
+    if sha:
+        _require(bool(re.fullmatch(r"[0-9a-f]{64}", sha)), errors, "source.message_sha256 must be sha256 hex")
+    _require(source.get("raw_message_stored") is False, errors, "source raw message must not be stored")
+    observations = _object(summary.get("observations"))
+    _require(observations.get("raw_content_included") is False, errors, "observations must not include raw content")
+    for key in ("evidence_refs", "prepared_refs", "artifact_refs", "events"):
+        _require(isinstance(observations.get(key), list), errors, f"observations.{key} must be a list")
+    boundary = _object(summary.get("evidence_boundary"))
+    _require(isinstance(boundary.get("not_evidence_until_observed"), list), errors, "evidence boundary must list non-evidence")
+    _require("not" in str(boundary.get("claim_boundary", "")).lower(), errors, "claim boundary must preserve non-evidence language")
+    user_report = _object(summary.get("user_report"))
+    _require(user_report.get("default_format") == "plain_text", errors, "default user report format must be plain_text")
+    _require(user_report.get("json_default") is False, errors, "JSON must not be default user UX")
+    _require(user_report.get("code_block_default") is False, errors, "code blocks must not be default user UX")
+    exports = _object(summary.get("exports"))
+    markdown = _object(exports.get("markdown"))
+    _require(markdown.get("default") is False, errors, "markdown export must be opt-in")
+    json_export = _object(exports.get("json"))
+    _require(json_export.get("default") is False, errors, "json export must be opt-in")
+    learning = _object(summary.get("learning"))
+    _require(learning.get("raw_prompt_included") is False, errors, "learning hints must not include raw prompt")
+    _require(learning.get("raw_logs_included") is False, errors, "learning hints must not include raw logs")
+    _require(len(str(learning.get("notes", ""))) <= MAX_LEARNING_NOTE_CHARS, errors, "learning notes must be bounded")
+    _require(len(_string_items(learning.get("evidence_refs"))) <= MAX_EVIDENCE_REFS, errors, "learning evidence refs must be bounded")
+    _reject_forbidden_raw_keys(summary, errors)
+    return errors
+
+
+def _source_summary(
+    *,
+    source_kind: str,
+    source_ref: str,
+    source_message: str,
+    source_metadata: dict[str, Any],
+) -> dict[str, Any]:
+    message = source_message or ""
+    encoded = message.encode("utf-8")
+    return {
+        "kind": _token(source_kind or "work"),
+        "source_ref": compact_visible_text(source_ref, max_chars=160),
+        "message_sha256": hashlib.sha256(encoded).hexdigest() if message else "",
+        "message_length": len(message),
+        "source_metadata_keys": sorted(_token(key) for key in source_metadata.keys()),
+        "raw_message_stored": False,
+    }
+
+
+def _learning_hint(
+    *,
+    summary_ref: str,
+    candidate: bool,
+    workflow: str,
+    harness: str,
+    notes: str,
+    evidence_refs: list[str],
+    omitted_evidence_ref_count: int,
+) -> dict[str, Any]:
+    compact_refs, extra_omitted = compact_context_refs(evidence_refs)
+    return {
+        "schema_version": "work_report_learning_hint/v1",
+        "candidate": bool(candidate),
+        "selection": "selected" if candidate else "not_selected",
+        "summary_ref": summary_ref,
+        "workflow": _token(workflow or "unknown"),
+        "harness": _token(harness or "unknown"),
+        "notes": compact_visible_text(_strip_code_fences(notes), max_chars=MAX_LEARNING_NOTE_CHARS),
+        "evidence_refs": compact_refs,
+        "raw_prompt_included": False,
+        "raw_logs_included": False,
+        "export_policy": "selected_sanitized_summary_only",
+        "omitted": {
+            "evidence_ref_count": omitted_evidence_ref_count + extra_omitted,
+            "max_note_chars": MAX_LEARNING_NOTE_CHARS,
+            "max_evidence_refs": MAX_EVIDENCE_REFS,
+        },
+        "claim_boundary": "Learning hints are candidates for later review; they are not skill patches or raw transcript exports.",
+    }
+
+
+def _compact_observation_events(events: list[dict[str, Any]] | tuple[dict[str, Any], ...]) -> tuple[list[dict[str, Any]], int]:
+    compacted: list[dict[str, Any]] = []
+    omitted = 0
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        if len(compacted) >= MAX_OBSERVATION_EVENTS:
+            omitted += 1
+            continue
+        evidence_refs, omitted_refs = compact_context_refs(event.get("evidence_refs", []))
+        compacted.append(
+            {
+                "schema_version": WORK_OBSERVATION_EVENT_REF_SCHEMA_VERSION,
+                "event_type": _token(str(event.get("event_type") or "status_update")),
+                "status": _choice(str(event.get("status") or "observed"), ("observed", "blocked", "failed", "not_observed"), "observed"),
+                "summary": compact_visible_text(_strip_code_fences(event.get("summary", "")), max_chars=180),
+                "evidence_refs": evidence_refs,
+                "raw_content_included": False,
+                "omitted": {"evidence_ref_count": omitted_refs},
+            }
+        )
+    return compacted, omitted
+
+
+def _event_evidence_refs(events: list[dict[str, Any]] | tuple[dict[str, Any], ...]) -> list[str]:
+    refs: list[str] = []
+    for event in events:
+        if isinstance(event, dict):
+            refs.extend(_string_items(event.get("evidence_refs")))
+    return refs
+
+
+def _compact_strings(values: list[str] | tuple[str, ...], *, max_items: int, max_chars: int) -> tuple[list[str], int]:
+    compacted: list[str] = []
+    omitted = 0
+    for value in values:
+        text = compact_visible_text(_strip_code_fences(value), max_chars=max_chars)
+        if not text:
+            continue
+        if len(compacted) >= max_items:
+            omitted += 1
+            continue
+        compacted.append(text)
+    return compacted, omitted
+
+
+def _markdown_for_summary(summary: dict[str, Any]) -> str:
+    observations = _object(summary.get("observations"))
+    evidence_refs = _string_items(observations.get("evidence_refs"))
+    prepared_refs = _string_items(observations.get("prepared_refs"))
+    boundary = _string_items(_object(summary.get("evidence_boundary")).get("not_evidence_until_observed"))
+    lines = [
+        f"# {summary['title']}",
+        "",
+        f"- Work: {summary['work_id']}",
+        f"- Status: {summary['status']}",
+        f"- Report: {summary['report_kind']}",
+        f"- Next: {summary.get('next_action', 'show_status')}",
+        "",
+        "## Summary",
+        _plain([str(_object(summary.get("progress")).get("safe_summary") or _default_summary(summary))]),
+        "",
+        "## Evidence",
+    ]
+    lines.extend([f"- {item}" for item in evidence_refs] or ["- No evidence references recorded."])
+    if prepared_refs:
+        lines.extend(["", "## Prepared References", *[f"- {item}" for item in prepared_refs]])
+    lines.extend(["", "## Evidence Boundary", *[f"- {item}" for item in boundary[:8]]])
+    learning = _object(summary.get("learning"))
+    if learning.get("candidate"):
+        lines.extend(["", "## Learning Hint", f"- {learning.get('notes') or 'Selected metadata-only summary.'}"])
+    return "\n".join(lines).strip() + "\n"
+
+
+def _evidence_lines(summary: dict[str, Any]) -> list[str]:
+    refs = _string_items(_object(summary.get("observations")).get("evidence_refs"))
+    if not refs:
+        return []
+    return [f"Evidence: {', '.join(refs[:4])}."]
+
+
+def _boundary_line(summary: dict[str, Any]) -> str:
+    items = _string_items(_object(summary.get("evidence_boundary")).get("not_evidence_until_observed"))
+    return f"Not evidence until observed: {', '.join(items[:5])}."
+
+
+def _default_summary(summary: dict[str, Any]) -> str:
+    latest = _object(_object(summary.get("progress")).get("latest_event"))
+    if latest.get("summary"):
+        return str(latest["summary"])
+    return f"{summary.get('report_kind', 'status')} report for {summary.get('work_id', 'unknown-work')}."
+
+
+def _plain(lines: list[str]) -> str:
+    cleaned = [compact_visible_text(_strip_code_fences(line), max_chars=320) for line in lines if str(line).strip()]
+    return "\n".join(cleaned).strip()
+
+
+def _status_from_status_payload(status_payload: dict[str, Any]) -> str:
+    prepared = _object(status_payload.get("prepared"))
+    execution = _object(status_payload.get("execution"))
+    verification = _object(status_payload.get("verification"))
+    review = _object(status_payload.get("review"))
+    ci = _object(status_payload.get("ci"))
+    merge = _object(status_payload.get("merge"))
+    next_action = str(status_payload.get("next_action", ""))
+    lifecycle = str(status_payload.get("lifecycle_status", ""))
+    terminal_requested = lifecycle in {"reportable", "merge_ready", "merged"} or next_action in {
+        "report_completion_with_evidence",
+        "report_merge_ready",
+        "report_merged",
+    }
+    if terminal_requested and _terminal_evidence_satisfied(execution, verification, review, ci, merge):
+        return "completed"
+    if next_action.startswith("surface_") or "blocker" in next_action:
+        return "blocked"
+    if str(prepared.get("status", "")) == "prepared_not_observed":
+        return "prepared_not_observed"
+    return "in_progress"
+
+
+def _terminal_evidence_satisfied(
+    execution: dict[str, Any],
+    verification: dict[str, Any],
+    review: dict[str, Any],
+    ci: dict[str, Any],
+    merge: dict[str, Any],
+) -> bool:
+    return (
+        execution.get("observed") is True
+        and str(execution.get("status", "")) == "completed"
+        and verification.get("observed") is True
+        and _gate_satisfied(review)
+        and _gate_satisfied(ci)
+        and _gate_satisfied(merge)
+    )
+
+
+def _gate_satisfied(stage: dict[str, Any]) -> bool:
+    if not stage:
+        return True
+    if stage.get("satisfied") is True:
+        return True
+    required = stage.get("required") is True
+    status = str(stage.get("status", ""))
+    observed = stage.get("observed") is True
+    if not required and status in {"", "not_required", "not_observed"}:
+        return True
+    return observed and status in {"passed", "ready", "merged"}
+
+
+def _observed_stage_evidence_refs(stage: dict[str, Any]) -> list[str]:
+    if not isinstance(stage, dict):
+        return []
+    if stage.get("observed") is True or stage.get("satisfied") is True:
+        return _string_items(stage.get("evidence_refs"))
+    return []
+
+
+def _status_phrase(status: str) -> str:
+    return {
+        "prepared_not_observed": "prepared but not observed",
+        "in_progress": "in progress",
+        "completed": "completed",
+        "blocked": "blocked",
+        "failed": "failed",
+        "unknown": "at an unknown status",
+    }.get(status, status.replace("_", " "))
+
+
+def _summary_ref(work_id: str, title: str, report_kind: str, status: str) -> str:
+    payload = json.dumps({"work_id": work_id, "title": title, "report_kind": report_kind, "status": status}, sort_keys=True)
+    return f"omh-work-observation:{hashlib.sha256(payload.encode('utf-8')).hexdigest()[:16]}"
+
+
+def _choice(value: str, allowed: tuple[str, ...], fallback: str) -> str:
+    normalized = _token(value)
+    return normalized if normalized in allowed else fallback
+
+
+def _token(value: Any) -> str:
+    return re.sub(r"[^a-z0-9_./:-]+", "_", str(value).strip().casefold().replace("-", "_").replace(" ", "_")).strip("_")
+
+
+def _strip_code_fences(value: Any) -> str:
+    return str(value).replace("```", " ")
+
+
+def _object(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _string_items(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [value] if value else []
+    if not isinstance(value, (list, tuple)):
+        return []
+    return [str(item) for item in value if isinstance(item, (str, int, float)) and str(item)]
+
+
+def _require(condition: bool, errors: list[str], message: str) -> None:
+    if not condition:
+        errors.append(message)
+
+
+def _reject_forbidden_raw_keys(value: Any, errors: list[str], *, path: str = "") -> None:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            normalized = _token(key)
+            if normalized in _FORBIDDEN_RAW_KEYS:
+                errors.append(f"forbidden raw field: {path}{key}")
+            _reject_forbidden_raw_keys(child, errors, path=f"{path}{key}.")
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            _reject_forbidden_raw_keys(child, errors, path=f"{path}{index}.")

--- a/src/work_reporting.py
+++ b/src/work_reporting.py
@@ -1270,6 +1270,7 @@ def _status_from_status_payload(status_payload: dict[str, Any]) -> str:
         review=review,
         ci=ci,
         merge=merge,
+        runtime_observation=runtime_observation,
     ):
         return "prepared_not_observed"
     return "in_progress"
@@ -1360,6 +1361,7 @@ def _runtime_observation_events(runtime_observation: dict[str, Any]) -> list[dic
     latest = _object(runtime_observation.get("latest"))
     events: list[dict[str, Any]] = []
     seen: set[str] = set()
+    runtime_applicable = _runtime_observation_applicable(runtime_observation)
     for field, fallback_status in (
         ("observed_events", "observed"),
         ("blocked_events", "blocked"),
@@ -1367,6 +1369,8 @@ def _runtime_observation_events(runtime_observation: dict[str, Any]) -> list[dic
         ("not_observed_events", "not_observed"),
         ("missing_events", "not_observed"),
     ):
+        if field in {"not_observed_events", "missing_events"} and not runtime_applicable:
+            continue
         for event_type in _string_items(runtime_observation.get(field)):
             event_key = _token(event_type)
             if event_key in seen:
@@ -1374,6 +1378,17 @@ def _runtime_observation_events(runtime_observation: dict[str, Any]) -> list[dic
             seen.add(event_key)
             events.append(_runtime_observation_event(latest, event_type, fallback_status))
     return events
+
+
+def _runtime_observation_applicable(runtime_observation: dict[str, Any]) -> bool:
+    return bool(
+        _string_items(runtime_observation.get("observed_events"))
+        or _string_items(runtime_observation.get("blocked_events"))
+        or _string_items(runtime_observation.get("failed_events"))
+        or _token(runtime_observation.get("next_action") or "") in {"report_runtime_observed", "record_runtime_observation"}
+        or _token(runtime_observation.get("status") or runtime_observation.get("lifecycle_status") or "")
+        in {"running", "started", "completed", "reportable", "runtime_observed"}
+    )
 
 
 def _runtime_observation_event(latest: dict[str, Any], event_type: str, fallback_status: str) -> dict[str, Any]:
@@ -1464,12 +1479,23 @@ def _post_prepared_work_observed(
     review: dict[str, Any],
     ci: dict[str, Any],
     merge: dict[str, Any],
+    runtime_observation: dict[str, Any] | None = None,
 ) -> bool:
     if next_action in _POST_PREPARED_NEXT_ACTIONS:
         return True
     if wrapper.get("prompt_dispatched") is True or wrapper.get("hermes_response_observed") is True:
         return True
+    if _runtime_observation_has_progress(_object(runtime_observation)):
+        return True
     return any(_stage_has_observed_progress(stage) for stage in (execution, verification, review, ci, merge))
+
+
+def _runtime_observation_has_progress(runtime_observation: dict[str, Any]) -> bool:
+    return bool(
+        _string_items(runtime_observation.get("observed_events"))
+        or _string_items(runtime_observation.get("blocked_events"))
+        or _string_items(runtime_observation.get("failed_events"))
+    )
 
 
 def _stage_has_observed_progress(stage: dict[str, Any]) -> bool:

--- a/tests/test_coding_lifecycle.py
+++ b/tests/test_coding_lifecycle.py
@@ -177,6 +177,8 @@ class CodingLifecycleTests(unittest.TestCase):
 
             self.assertFalse(payload["wrapper"]["verification_observed"])
             self.assertEqual(payload["wrapper"]["completion_status"], "failed")
+            self.assertEqual(payload["status"]["verification"]["status"], "failed")
+            self.assertFalse(payload["status"]["verification"]["satisfied"])
             self.assertEqual(payload["status"]["next_action"], "record_verification_evidence")
             self.assertFalse(payload["status"]["can_report_completion"])
             self.assertIn("tests failed", payload["status"]["wrapper"]["unobserved_gaps"])

--- a/tests/test_runtime_lifecycle_invariants.py
+++ b/tests/test_runtime_lifecycle_invariants.py
@@ -38,6 +38,8 @@ class RuntimeLifecycleInvariantTests(unittest.TestCase):
             self.assertFalse(status["wrapper"]["prompt_dispatched"])
             self.assertFalse(status["execution"]["observed"])
             self.assertFalse(status["verification"]["observed"])
+            self.assertEqual(status["verification"]["status"], "not_observed")
+            self.assertFalse(status["verification"]["satisfied"])
             self.assertEqual(status["next_action"], "dispatch_to_executor")
             policy = status["progress_reporting_policy"]
             self.assertTrue(policy["metadata_only"])
@@ -138,6 +140,8 @@ class RuntimeLifecycleInvariantTests(unittest.TestCase):
             self.assertEqual(status["next_action"], "report_completion_with_evidence")
             self.assertTrue(status["execution"]["observed"])
             self.assertTrue(status["verification"]["observed"])
+            self.assertEqual(status["verification"]["status"], "passed")
+            self.assertTrue(status["verification"]["satisfied"])
             self.assertTrue(validate_runtime(paths, run_id)["ok"])
 
 

--- a/tests/test_work_reporting.py
+++ b/tests/test_work_reporting.py
@@ -303,6 +303,50 @@ class WorkReportingTests(unittest.TestCase):
         self.assertIn("Completed: Work status for run-complete.", rendered)
         self.assertIn("executor-result.json", rendered)
 
+    def test_completion_report_does_not_render_default_boundaries_as_active_gaps(self) -> None:
+        summary = build_work_observation_summary(
+            work_id="run-complete-boundary",
+            title="Completed runtime report",
+            report_kind="completion",
+            status="completed",
+            observed_events=[
+                {"event_type": "execution", "status": "observed", "evidence_refs": ["executor-result.json"]},
+                {"event_type": "verification", "status": "observed", "evidence_refs": ["pytest"]},
+            ],
+        )
+
+        rendered = render_completion_report(summary)
+
+        self.assertEqual(validate_work_observation_summary(summary), [])
+        self.assertIn("execution", summary["evidence_boundary"]["not_evidence_until_observed"])
+        self.assertEqual(summary["evidence_boundary"]["active_not_observed_gaps"], [])
+        self.assertIn("Completed: Completed runtime report.", rendered)
+        self.assertIn("Claim rule:", rendered)
+        self.assertNotIn("Still waiting on observed proof", rendered)
+        self.assertNotIn("prepared_not_observed", rendered)
+
+    def test_status_report_renders_only_actual_unobserved_gaps(self) -> None:
+        summary = build_work_observation_summary(
+            work_id="run-ci-gap",
+            title="Runtime report with CI gap",
+            report_kind="status",
+            status="in_progress",
+            observed_events=[
+                {"event_type": "execution", "status": "observed", "evidence_refs": ["executor-result.json"]},
+                {"event_type": "ci", "status": "not_observed", "evidence_refs": ["ci-placeholder"]},
+            ],
+            next_action="record_ci_evidence",
+        )
+
+        rendered = render_status_report(summary)
+
+        self.assertEqual(validate_work_observation_summary(summary), [])
+        self.assertEqual(summary["evidence_boundary"]["active_not_observed_gaps"], ["ci"])
+        self.assertIn("Still waiting on observed proof for: ci.", rendered)
+        self.assertNotIn("Still waiting on observed proof for: prepared_not_observed", rendered)
+        self.assertNotIn("execution, verification, review", rendered)
+        self.assertNotIn("ci-placeholder", rendered)
+
     def test_status_projection_rejects_terminal_completion_when_verification_failed(self) -> None:
         status_payload = {
             "schema_version": "delegated_coding_status/v1",
@@ -338,6 +382,50 @@ class WorkReportingTests(unittest.TestCase):
         self.assertIn("Completion is not observed yet", rendered)
         self.assertIn("pytest-failed", rendered)
         self.assertNotIn("Completed:", rendered)
+
+    def test_runtime_observation_terminal_events_override_in_progress_status(self) -> None:
+        for field, event_status, expected_status in (
+            ("failed_events", "failed", "failed"),
+            ("blocked_events", "blocked", "blocked"),
+        ):
+            with self.subTest(field=field):
+                status_payload = {
+                    "schema_version": "delegated_coding_status/v1",
+                    "run_id": f"run-runtime-{event_status}",
+                    "prepared": {
+                        "workflow": "team",
+                        "harness": "coding-handling",
+                        "status": "prepared_not_observed",
+                        "executor_target": "omx-runtime",
+                    },
+                    "wrapper": {"prompt_dispatched": True, "completion_status": "started"},
+                    "execution": {"observed": False, "status": "not_observed", "evidence_refs": []},
+                    "verification": {"observed": False, "status": "not_observed", "satisfied": False, "evidence_refs": []},
+                    "review": {"required": False, "observed": True, "status": "not_required", "satisfied": True},
+                    "ci": {"required": False, "observed": True, "status": "not_required", "satisfied": True},
+                    "merge": {"required": False, "observed": True, "status": "not_required", "satisfied": True},
+                    "runtime_observation": {
+                        "observed_events": [],
+                        field: ["worker_result"],
+                        "latest": {
+                            "worker_result": {
+                                "event_type": "worker_result",
+                                "status": event_status,
+                                "summary": f"worker result is {event_status}",
+                                "evidence_refs": [f"runtime/runtime_observations.jsonl#{event_status}"],
+                            },
+                        },
+                    },
+                    "next_action": "wait_for_executor_evidence",
+                    "lifecycle_status": "running",
+                    "safe_summary": f"Runtime observation is {event_status}.",
+                }
+
+                summary = build_work_observation_summary_from_status(status_payload, report_kind="status")
+
+                self.assertEqual(validate_work_observation_summary(summary), [])
+                self.assertEqual(summary["status"], expected_status)
+                self.assertIn(f"runtime/runtime_observations.jsonl#{event_status}", summary["observations"]["evidence_refs"])
 
     def test_status_projection_preserves_runtime_latest_event_evidence(self) -> None:
         status_payload = {
@@ -495,6 +583,23 @@ class WorkReportingTests(unittest.TestCase):
         self.assertIn("- DCO: pass (3s) https://github.example/checks/dco.", rendered)
         self.assertIn("- integration tests: pending (1m) https://github.example/checks/integration.", rendered)
 
+    def test_structured_check_completed_without_success_conclusion_is_unknown(self) -> None:
+        rendered = format_check_rollup(
+            [
+                {
+                    "name": "lint",
+                    "status": "completed",
+                    "duration": "5s",
+                    "url": "https://github.example/checks/lint",
+                }
+            ]
+        )
+
+        self.assertIn("Checks: 1 unknown.", rendered)
+        self.assertIn("- lint: unknown (5s) https://github.example/checks/lint.", rendered)
+        self.assertNotIn("1 pass", rendered)
+        self.assertNotIn("lint: pass", rendered)
+
     def test_friendly_korean_progress_report_uses_channel_voice(self) -> None:
         summary = build_work_observation_summary(
             work_id="run-ko-friendly",
@@ -523,6 +628,39 @@ class WorkReportingTests(unittest.TestCase):
         self.assertNotIn("Next:", rendered)
         self.assertNotIn("Evidence boundary", rendered)
         self.assertNotIn("한다", rendered)
+
+    def test_korean_progress_report_voice_is_explicit_and_deterministic(self) -> None:
+        summary = build_work_observation_summary(
+            work_id="run-ko-voice",
+            title="PR #259",
+            report_kind="progress",
+            status="in_progress",
+            safe_summary="CI는 통과했고, 리뷰 결과를 다시 확인 중입니다.",
+            progress_events=[
+                {
+                    "event_type": "status_update",
+                    "status": "observed",
+                    "summary": "CI는 통과했고, 리뷰 결과를 다시 확인 중입니다.",
+                }
+            ],
+            evidence_refs=["https://github.example/checks/tests"],
+            next_action="record_review_evidence",
+        )
+
+        friendly = render_progress_report(summary, locale="ko", voice="friendly")
+        polite = render_progress_report(summary, locale="ko", voice="polite")
+        formal = render_progress_report(summary, locale="ko", voice="formal")
+        default_ko = render_progress_report(summary, locale="ko")
+
+        self.assertIn("PR #259 작업은 진행 중이야.", friendly)
+        self.assertIn("다음은 record_review_evidence 쪽을 볼게.", friendly)
+        self.assertIn("PR #259 작업은 진행 중입니다.", polite)
+        self.assertIn("다음은 record_review_evidence 항목을 확인하겠습니다.", polite)
+        self.assertEqual(formal, polite)
+        self.assertEqual(default_ko, polite)
+        self.assertNotIn("진행 중이야", polite)
+        self.assertNotIn("볼게", polite)
+        self.assertNotIn("Progress:", polite)
 
     def test_user_report_scrubs_awareness_and_native_bridge_context(self) -> None:
         internal_context = """

--- a/tests/test_work_reporting.py
+++ b/tests/test_work_reporting.py
@@ -699,6 +699,26 @@ class WorkReportingTests(unittest.TestCase):
         self.assertNotIn("Background process", rendered)
         self.assertNotIn("Here's the final output", rendered)
 
+    def test_background_check_output_ignores_github_summary_prose(self) -> None:
+        rendered = build_background_completion_report(
+            exit_code=1,
+            command="gh pr checks --watch",
+            output="\n".join(
+                [
+                    "Some checks were not successful",
+                    "1 failing, 0 successful, 0 skipped, 0 pending",
+                    "unit tests\tfail\t2m10s\thttps://github.example/checks/tests",
+                ]
+            ),
+        )
+
+        self.assertIsNotNone(rendered)
+        assert rendered is not None
+        self.assertIn("Checks: 1 fail.", rendered)
+        self.assertIn("- unit tests: fail (2m10s) https://github.example/checks/tests.", rendered)
+        self.assertNotIn("Some checks were not: pass", rendered)
+        self.assertNotIn("1: fail", rendered)
+
     def test_background_completion_does_not_mislabel_plain_command_output_as_checks(self) -> None:
         rendered = build_background_completion_report(
             exit_code=0,

--- a/tests/test_work_reporting.py
+++ b/tests/test_work_reporting.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+import json
+import unittest
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.work_reporting import (
+    build_markdown_export,
+    build_work_observation_summary,
+    build_work_observation_summary_from_status,
+    render_status_report,
+    render_blocker_report,
+    render_completion_report,
+    render_progress_report,
+    validate_markdown_export,
+    validate_work_observation_summary,
+)
+
+
+class WorkReportingTests(unittest.TestCase):
+    def test_plain_text_reports_are_default_and_not_json_or_code_fences(self) -> None:
+        summary = build_work_observation_summary(
+            work_id="run-123",
+            title="Observation reporting vertical slice",
+            report_kind="progress",
+            status="in_progress",
+            workflow="ultragoal",
+            harness="goal-execution",
+            source_message="private user request with token-secret-123",
+            progress_events=[
+                {
+                    "event_type": "workflow_started",
+                    "status": "running",
+                    "summary": "Implementation is underway and scoped to reporting contracts.",
+                    "evidence_refs": ["tests/test_work_reporting.py"],
+                }
+            ],
+            next_action="run_targeted_tests",
+        )
+
+        progress = render_progress_report(summary)
+        completion = render_completion_report({**summary, "report_kind": "completion", "status": "completed"})
+
+        self.assertEqual(validate_work_observation_summary(summary), [])
+        self.assertEqual(summary["user_report"]["default_format"], "plain_text")
+        self.assertFalse(summary["user_report"]["json_default"])
+        self.assertFalse(summary["user_report"]["code_block_default"])
+        status_report = render_status_report(summary)
+
+        for rendered in (progress, completion, status_report):
+            self.assertNotIn("```", rendered)
+            self.assertNotIn("{", rendered)
+            self.assertNotIn("}", rendered)
+            self.assertNotIn("schema_version", rendered)
+            self.assertNotIn("token-secret-123", rendered)
+
+    def test_structured_summary_is_metadata_only_with_evidence_boundaries(self) -> None:
+        secret_message = "ship the reporting feature with private-token-456"
+        summary = build_work_observation_summary(
+            work_id="runtime:abc",
+            title="Runtime observation",
+            report_kind="completion",
+            status="completed",
+            workflow="agent-ops-review",
+            harness="agent-ops-review",
+            source_message=secret_message,
+            evidence_refs=["runtime/run.json", "runtime/runtime_observations.jsonl"],
+            prepared_refs=["coding_runtime_handoff/v1:runtime:abc"],
+            observed_events=[
+                {"event_type": "worker_result", "status": "observed", "evidence_refs": ["runtime/runtime_observations.jsonl"]},
+                {"event_type": "verification", "status": "observed", "evidence_refs": ["pytest"]},
+            ],
+        )
+
+        serialized = json.dumps(summary, sort_keys=True)
+
+        self.assertEqual(validate_work_observation_summary(summary), [])
+        self.assertEqual(summary["schema_version"], "work_observation_summary/v1")
+        self.assertTrue(summary["privacy"]["metadata_only"])
+        self.assertFalse(summary["privacy"]["raw_prompt_stored"])
+        self.assertFalse(summary["privacy"]["raw_logs_stored"])
+        self.assertEqual(summary["source"]["message_length"], len(secret_message))
+        self.assertRegex(summary["source"]["message_sha256"], r"^[0-9a-f]{64}$")
+        self.assertIn("prepared_not_observed", summary["evidence_boundary"]["not_evidence_until_observed"])
+        self.assertIn("review", summary["evidence_boundary"]["not_evidence_until_observed"])
+        self.assertIn("runtime/run.json", summary["observations"]["evidence_refs"])
+        self.assertNotIn(secret_message, serialized)
+        self.assertNotIn("private-token-456", serialized)
+        self.assertNotIn("source_message", serialized)
+
+        mutated = json.loads(json.dumps(summary))
+        mutated["source"]["raw_message_stored"] = True
+        self.assertIn("source raw message must not be stored", validate_work_observation_summary(mutated))
+
+    def test_markdown_export_is_opt_in_secondary_wiki_shape(self) -> None:
+        summary = build_work_observation_summary(
+            work_id="run-456",
+            title="Progress package",
+            report_kind="progress",
+            status="blocked",
+            blockers=["CI evidence has not been observed."],
+            evidence_refs=["runtime/ci.json"],
+            next_action="record_ci_evidence",
+        )
+
+        self.assertNotIn("markdown", summary)
+        self.assertEqual(summary["exports"]["markdown"]["default"], False)
+        self.assertEqual(summary["exports"]["markdown"]["intended_surface"], "wiki_or_markdown")
+
+        export = build_markdown_export(summary)
+        markdown = export["markdown"]
+
+        self.assertEqual(export["schema_version"], "work_report_markdown_export/v1")
+        self.assertEqual(validate_markdown_export(export), [])
+        self.assertEqual(export["export_mode"], "opt_in")
+        self.assertIn("# Progress package", markdown)
+        self.assertIn("## Evidence", markdown)
+        self.assertIn("runtime/ci.json", markdown)
+        self.assertNotIn("```", markdown)
+        self.assertNotIn("schema_version", markdown)
+
+    def test_learning_hints_are_bounded_and_sanitized(self) -> None:
+        long_note = "```raw``` " + "A" * 400
+        summary = build_work_observation_summary(
+            work_id="run-learning",
+            title="Learning candidate",
+            report_kind="completion",
+            status="completed",
+            workflow="workflow-learning",
+            harness="workflow-learning",
+            learning_candidate=True,
+            learning_notes=long_note,
+            evidence_refs=[f"evidence-{index}" for index in range(20)],
+        )
+
+        learning = summary["learning"]
+
+        self.assertTrue(learning["candidate"])
+        self.assertLessEqual(len(learning["notes"]), 180)
+        self.assertNotIn("```", learning["notes"])
+        self.assertEqual(len(learning["evidence_refs"]), 8)
+        self.assertEqual(learning["omitted"]["evidence_ref_count"], 12)
+        self.assertFalse(learning["raw_logs_included"])
+        self.assertFalse(learning["raw_prompt_included"])
+        self.assertEqual(validate_work_observation_summary(summary), [])
+
+    def test_status_integration_keeps_prepared_boundaries_plain(self) -> None:
+        status_payload = {
+            "schema_version": "delegated_coding_status/v1",
+            "run_id": "run-prepared",
+            "prepared": {
+                "workflow": "plan",
+                "harness": "coding-handling",
+                "status": "prepared_not_observed",
+                "executor_target": "codex",
+            },
+            "execution": {"observed": False, "status": "not_observed", "evidence_refs": []},
+            "verification": {"observed": False, "expected": ["pytest"]},
+            "review": {"required": True, "status": "not_observed", "evidence_refs": []},
+            "ci": {"status": "not_observed", "evidence_refs": []},
+            "merge": {"status": "not_observed", "evidence_refs": []},
+            "runtime_observation": {
+                "observed_events": [],
+                "missing_events": ["worker_result", "verification", "review", "ci", "merge"],
+            },
+            "next_action": "dispatch_to_executor",
+            "safe_summary": "Coding handoff is prepared, but execution is not observed.",
+        }
+
+        summary = build_work_observation_summary_from_status(status_payload, report_kind="progress")
+        rendered = render_blocker_report({**summary, "report_kind": "blocker", "status": "blocked"})
+
+        self.assertEqual(validate_work_observation_summary(summary), [])
+        self.assertEqual(summary["status"], "prepared_not_observed")
+        self.assertEqual(summary["observations"]["prepared_refs"], ["delegated_coding_status/v1:run-prepared"])
+        self.assertIn("not observed", rendered.lower())
+        self.assertIn("dispatch_to_executor", summary["next_action"])
+        self.assertIn("execution", summary["evidence_boundary"]["not_evidence_until_observed"])
+        self.assertNotIn("```", rendered)
+        self.assertNotIn("{", rendered)
+
+    def test_status_projection_does_not_complete_or_render_unobserved_refs(self) -> None:
+        status_payload = {
+            "schema_version": "delegated_coding_status/v1",
+            "run_id": "run-overclaim",
+            "prepared": {
+                "workflow": "plan",
+                "harness": "coding-handling",
+                "status": "prepared_not_observed",
+                "executor_target": "codex",
+            },
+            "execution": {"observed": False, "status": "not_observed", "evidence_refs": ["unobserved-exec.log"]},
+            "verification": {"observed": False, "expected": ["pytest"]},
+            "review": {"required": True, "observed": False, "status": "pending", "evidence_refs": ["pending-review.md"]},
+            "ci": {"required": True, "observed": False, "status": "pending", "evidence_refs": ["pending-ci"]},
+            "merge": {"required": True, "observed": False, "status": "not_observed", "evidence_refs": ["pending-merge"]},
+            "next_action": "report_completion_with_evidence",
+            "lifecycle_status": "reportable",
+            "safe_summary": "Terminal labels are inconsistent with observed evidence.",
+        }
+
+        summary = build_work_observation_summary_from_status(status_payload, report_kind="completion")
+        rendered = render_completion_report(summary)
+
+        self.assertEqual(validate_work_observation_summary(summary), [])
+        self.assertEqual(summary["status"], "prepared_not_observed")
+        self.assertEqual(summary["observations"]["evidence_refs"], [])
+        self.assertIn("Completion is not observed yet", rendered)
+        self.assertNotIn("Completed:", rendered)
+        self.assertNotIn("unobserved-exec.log", rendered)
+        self.assertNotIn("pending-review.md", rendered)
+        self.assertNotIn("pending-ci", rendered)
+
+    def test_status_projection_completes_only_with_observed_stage_evidence(self) -> None:
+        status_payload = {
+            "schema_version": "delegated_coding_status/v1",
+            "run_id": "run-complete",
+            "prepared": {
+                "workflow": "plan",
+                "harness": "coding-handling",
+                "status": "prepared_not_observed",
+                "executor_target": "codex",
+            },
+            "execution": {"observed": True, "status": "completed", "evidence_refs": ["executor-result.json"]},
+            "verification": {"observed": True, "expected": ["pytest"]},
+            "review": {"required": False, "observed": True, "status": "not_required", "satisfied": True, "evidence_refs": []},
+            "ci": {"required": False, "observed": True, "status": "not_required", "satisfied": True, "evidence_refs": []},
+            "merge": {"required": False, "observed": True, "status": "not_required", "satisfied": True, "evidence_refs": []},
+            "next_action": "report_completion_with_evidence",
+            "lifecycle_status": "reportable",
+        }
+
+        summary = build_work_observation_summary_from_status(status_payload, report_kind="completion")
+        rendered = render_completion_report(summary)
+
+        self.assertEqual(summary["status"], "completed")
+        self.assertEqual(summary["observations"]["evidence_refs"], ["executor-result.json"])
+        self.assertIn("Completed: Work status for run-complete.", rendered)
+        self.assertIn("executor-result.json", rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_work_reporting.py
+++ b/tests/test_work_reporting.py
@@ -909,6 +909,25 @@ class WorkReportingTests(unittest.TestCase):
         self.assertNotIn("볼게", polite)
         self.assertNotIn("Progress:", polite)
 
+    def test_background_completion_preserves_meaningful_output_when_scrubbing_omh_rails(self) -> None:
+        rendered = build_background_completion_report(
+            exit_code=1,
+            command="gh pr checks --watch",
+            output="\n".join(
+                [
+                    "[OMH Awareness] internal route hint",
+                    "unit tests\tfail\t2m10s\thttps://github.example/checks/tests",
+                ]
+            ),
+        )
+
+        self.assertIsNotNone(rendered)
+        assert rendered is not None
+        self.assertIn("Checks: 1 fail.", rendered)
+        self.assertIn("- unit tests: fail (2m10s) https://github.example/checks/tests.", rendered)
+        self.assertNotIn("OMH Awareness", rendered)
+        self.assertNotIn("internal route hint", rendered)
+
     def test_user_report_scrubs_awareness_and_native_bridge_context(self) -> None:
         internal_context = """
         [OMH Awareness]

--- a/tests/test_work_reporting.py
+++ b/tests/test_work_reporting.py
@@ -337,6 +337,75 @@ class WorkReportingTests(unittest.TestCase):
         self.assertIn("pytest-failed", rendered)
         self.assertNotIn("Completed:", rendered)
 
+    def test_status_projection_preserves_runtime_latest_event_evidence(self) -> None:
+        status_payload = {
+            "schema_version": "delegated_coding_status/v1",
+            "run_id": "run-runtime-latest",
+            "prepared": {
+                "workflow": "team",
+                "harness": "coding-handling",
+                "status": "prepared_not_observed",
+                "executor_target": "omx-runtime",
+            },
+            "wrapper": {"prompt_dispatched": True, "completion_status": "started"},
+            "execution": {"observed": False, "status": "not_observed", "evidence_refs": []},
+            "verification": {"observed": False, "status": "not_observed", "satisfied": False, "evidence_refs": []},
+            "review": {"required": False, "observed": True, "status": "not_required", "satisfied": True, "evidence_refs": []},
+            "ci": {"required": True, "observed": False, "status": "pending", "evidence_refs": []},
+            "merge": {"required": True, "observed": False, "status": "not_observed", "evidence_refs": []},
+            "runtime_observation": {
+                "observed_events": ["worker_result", "verification"],
+                "blocked_events": [],
+                "failed_events": [],
+                "not_observed_events": ["ci"],
+                "missing_events": ["review", "merge"],
+                "latest": {
+                    "worker_result": {
+                        "event_type": "worker_result",
+                        "status": "observed",
+                        "summary": "worker reported completion metadata",
+                        "evidence_refs": ["runtime/runtime_observations.jsonl#worker_result"],
+                    },
+                    "verification": {
+                        "event_type": "verification",
+                        "status": "observed",
+                        "summary": "focused tests passed",
+                        "evidence_refs": ["pytest tests/test_work_reporting.py -v"],
+                    },
+                    "ci": {
+                        "event_type": "ci",
+                        "status": "not_observed",
+                        "summary": "CI is pending",
+                        "evidence_refs": ["ci-placeholder"],
+                    },
+                },
+            },
+            "next_action": "record_ci_evidence",
+            "lifecycle_status": "awaiting_ci",
+            "safe_summary": "Runtime handoff has worker and verification observations; CI is not observed.",
+        }
+
+        summary = build_work_observation_summary_from_status(status_payload, report_kind="progress")
+        rendered = render_progress_report(summary)
+        events = {event["event_type"]: event for event in summary["observations"]["events"]}
+
+        self.assertEqual(validate_work_observation_summary(summary), [])
+        self.assertEqual(summary["status"], "in_progress")
+        self.assertEqual(
+            summary["observations"]["evidence_refs"],
+            ["runtime/runtime_observations.jsonl#worker_result", "pytest tests/test_work_reporting.py -v"],
+        )
+        self.assertEqual(events["worker_result"]["summary"], "worker reported completion metadata")
+        self.assertEqual(events["worker_result"]["evidence_refs"], ["runtime/runtime_observations.jsonl#worker_result"])
+        self.assertEqual(events["verification"]["evidence_refs"], ["pytest tests/test_work_reporting.py -v"])
+        self.assertEqual(events["ci"]["status"], "not_observed")
+        self.assertEqual(events["ci"]["evidence_refs"], [])
+        self.assertIn("ci", summary["observations"]["not_observed_events"])
+        self.assertIn("runtime/runtime_observations.jsonl#worker_result", rendered)
+        self.assertIn("pytest tests/test_work_reporting.py -v", rendered)
+        self.assertNotIn("ci-placeholder", summary["observations"]["evidence_refs"])
+        self.assertNotIn("ci-placeholder", rendered)
+
     def test_not_observed_event_refs_do_not_render_as_evidence(self) -> None:
         summary = build_work_observation_summary(
             work_id="run-event-boundary",

--- a/tests/test_work_reporting.py
+++ b/tests/test_work_reporting.py
@@ -522,6 +522,42 @@ class WorkReportingTests(unittest.TestCase):
         self.assertNotIn("ci-placeholder", summary["observations"]["evidence_refs"])
         self.assertNotIn("ci-placeholder", rendered)
 
+    def test_pending_observation_status_does_not_promote_placeholder_evidence(self) -> None:
+        summary = build_work_observation_summary(
+            work_id="run-pending-ci",
+            title="Pending CI",
+            observed_events=[{"event_type": "ci", "status": "pending", "evidence_refs": ["ci-placeholder"]}],
+        )
+        rendered = render_status_report(summary)
+        ci_event = next(event for event in summary["observations"]["events"] if event["event_type"] == "ci")
+
+        self.assertEqual(validate_work_observation_summary(summary), [])
+        self.assertEqual(ci_event["status"], "not_observed")
+        self.assertEqual(ci_event["evidence_refs"], [])
+        self.assertIn("ci", summary["observations"]["not_observed_events"])
+        self.assertNotIn("ci-placeholder", summary["observations"]["evidence_refs"])
+        self.assertNotIn("ci-placeholder", rendered)
+
+    def test_minimal_completed_status_payload_does_not_report_absent_optional_gates_as_gaps(self) -> None:
+        status_payload = {
+            "run_id": "run-minimal-complete",
+            "prepared": {"status": "prepared_not_observed", "workflow": "plan", "harness": "coding"},
+            "execution": {"observed": True, "status": "completed", "evidence_refs": ["exec"]},
+            "verification": {"observed": True, "status": "passed", "satisfied": True, "evidence_refs": ["pytest"]},
+            "next_action": "report_completion_with_evidence",
+            "lifecycle_status": "reportable",
+        }
+
+        summary = build_work_observation_summary_from_status(status_payload, report_kind="completion")
+        rendered = render_completion_report(summary)
+
+        self.assertEqual(validate_work_observation_summary(summary), [])
+        self.assertEqual(summary["status"], "completed")
+        self.assertNotIn("review", summary["observations"]["not_observed_events"])
+        self.assertNotIn("ci", summary["observations"]["not_observed_events"])
+        self.assertNotIn("merge", summary["observations"]["not_observed_events"])
+        self.assertNotIn("Still waiting on observed proof for", rendered)
+
     def test_empty_successful_background_completion_is_silent(self) -> None:
         rendered = build_background_completion_report(
             output="[Background process proc_b05484479563 finished with exit code 0~ Here's the final output:]",

--- a/tests/test_work_reporting.py
+++ b/tests/test_work_reporting.py
@@ -181,6 +181,67 @@ class WorkReportingTests(unittest.TestCase):
         self.assertNotIn("```", rendered)
         self.assertNotIn("{", rendered)
 
+    def test_status_projection_advances_after_dispatch_even_if_prepared_status_remains(self) -> None:
+        status_payload = {
+            "schema_version": "delegated_coding_status/v1",
+            "run_id": "run-dispatched",
+            "prepared": {
+                "workflow": "plan",
+                "harness": "coding-handling",
+                "status": "prepared_not_observed",
+                "executor_target": "codex",
+            },
+            "wrapper": {"prompt_dispatched": True, "completion_status": "started"},
+            "execution": {"observed": False, "status": "not_observed", "evidence_refs": []},
+            "verification": {"observed": False, "status": "not_observed", "satisfied": False, "expected": ["pytest"]},
+            "review": {"required": False, "observed": True, "status": "not_required", "satisfied": True, "evidence_refs": []},
+            "ci": {"required": False, "observed": True, "status": "not_required", "satisfied": True, "evidence_refs": []},
+            "merge": {"required": False, "observed": True, "status": "not_required", "satisfied": True, "evidence_refs": []},
+            "next_action": "wait_for_executor_evidence",
+            "lifecycle_status": "dispatched",
+            "safe_summary": "A codex coding handoff was dispatched, but executor completion is not observed yet.",
+        }
+
+        summary = build_work_observation_summary_from_status(status_payload, report_kind="progress")
+        rendered = render_progress_report(summary)
+
+        self.assertEqual(validate_work_observation_summary(summary), [])
+        self.assertEqual(summary["status"], "in_progress")
+        self.assertIn("in progress", rendered)
+        self.assertNotIn("prepared but not observed", rendered)
+        self.assertIn("execution", summary["evidence_boundary"]["not_evidence_until_observed"])
+
+    def test_status_projection_advances_after_executor_result_even_if_prepared_status_remains(self) -> None:
+        status_payload = {
+            "schema_version": "delegated_coding_status/v1",
+            "run_id": "run-awaiting-verification",
+            "prepared": {
+                "workflow": "plan",
+                "harness": "coding-handling",
+                "status": "prepared_not_observed",
+                "executor_target": "codex",
+            },
+            "wrapper": {"prompt_dispatched": True, "completion_status": "started"},
+            "execution": {"observed": True, "status": "completed", "evidence_refs": ["executor-result.json"]},
+            "verification": {"observed": False, "status": "not_observed", "satisfied": False, "expected": ["pytest"]},
+            "review": {"required": False, "observed": True, "status": "not_required", "satisfied": True, "evidence_refs": []},
+            "ci": {"required": False, "observed": True, "status": "not_required", "satisfied": True, "evidence_refs": []},
+            "merge": {"required": False, "observed": True, "status": "not_required", "satisfied": True, "evidence_refs": []},
+            "next_action": "record_verification_evidence",
+            "lifecycle_status": "awaiting_verification",
+            "safe_summary": "The codex executor is observed as completed, but verification evidence is not observed yet.",
+        }
+
+        summary = build_work_observation_summary_from_status(status_payload, report_kind="progress")
+        rendered = render_progress_report(summary)
+
+        self.assertEqual(validate_work_observation_summary(summary), [])
+        self.assertEqual(summary["status"], "in_progress")
+        self.assertEqual(summary["observations"]["evidence_refs"], ["executor-result.json"])
+        self.assertIn("in progress", rendered)
+        self.assertIn("executor-result.json", rendered)
+        self.assertNotIn("prepared but not observed", rendered)
+
     def test_status_projection_does_not_complete_or_render_unobserved_refs(self) -> None:
         status_payload = {
             "schema_version": "delegated_coding_status/v1",
@@ -224,7 +285,7 @@ class WorkReportingTests(unittest.TestCase):
                 "executor_target": "codex",
             },
             "execution": {"observed": True, "status": "completed", "evidence_refs": ["executor-result.json"]},
-            "verification": {"observed": True, "expected": ["pytest"]},
+            "verification": {"observed": True, "status": "passed", "satisfied": True, "expected": ["pytest"]},
             "review": {"required": False, "observed": True, "status": "not_required", "satisfied": True, "evidence_refs": []},
             "ci": {"required": False, "observed": True, "status": "not_required", "satisfied": True, "evidence_refs": []},
             "merge": {"required": False, "observed": True, "status": "not_required", "satisfied": True, "evidence_refs": []},
@@ -239,6 +300,40 @@ class WorkReportingTests(unittest.TestCase):
         self.assertEqual(summary["observations"]["evidence_refs"], ["executor-result.json"])
         self.assertIn("Completed: Work status for run-complete.", rendered)
         self.assertIn("executor-result.json", rendered)
+
+    def test_status_projection_rejects_terminal_completion_when_verification_failed(self) -> None:
+        status_payload = {
+            "schema_version": "delegated_coding_status/v1",
+            "run_id": "run-failed-verification",
+            "prepared": {
+                "workflow": "plan",
+                "harness": "coding-handling",
+                "status": "prepared_not_observed",
+                "executor_target": "codex",
+            },
+            "execution": {"observed": True, "status": "completed", "evidence_refs": ["executor-result.json"]},
+            "verification": {
+                "observed": True,
+                "status": "failed",
+                "satisfied": False,
+                "expected": ["pytest"],
+                "evidence_refs": ["pytest-failed"],
+            },
+            "review": {"required": False, "observed": True, "status": "not_required", "satisfied": True, "evidence_refs": []},
+            "ci": {"required": False, "observed": True, "status": "not_required", "satisfied": True, "evidence_refs": []},
+            "merge": {"required": False, "observed": True, "status": "not_required", "satisfied": True, "evidence_refs": []},
+            "next_action": "report_completion_with_evidence",
+            "lifecycle_status": "reportable",
+            "safe_summary": "Verification failed after executor completion.",
+        }
+
+        summary = build_work_observation_summary_from_status(status_payload, report_kind="completion")
+        rendered = render_completion_report(summary)
+
+        self.assertEqual(validate_work_observation_summary(summary), [])
+        self.assertEqual(summary["status"], "failed")
+        self.assertIn("Completion is not observed yet", rendered)
+        self.assertNotIn("Completed:", rendered)
 
 
 if __name__ == "__main__":

--- a/tests/test_work_reporting.py
+++ b/tests/test_work_reporting.py
@@ -332,8 +332,36 @@ class WorkReportingTests(unittest.TestCase):
 
         self.assertEqual(validate_work_observation_summary(summary), [])
         self.assertEqual(summary["status"], "failed")
+        self.assertEqual(summary["observations"]["evidence_refs"], ["executor-result.json", "pytest-failed"])
         self.assertIn("Completion is not observed yet", rendered)
+        self.assertIn("pytest-failed", rendered)
         self.assertNotIn("Completed:", rendered)
+
+    def test_not_observed_event_refs_do_not_render_as_evidence(self) -> None:
+        summary = build_work_observation_summary(
+            work_id="run-event-boundary",
+            title="Runtime event boundary",
+            report_kind="status",
+            status="blocked",
+            observed_events=[
+                {"event_type": "worker_result", "status": "observed", "evidence_refs": ["runtime/result.json"]},
+                {"event_type": "verification", "status": "failed", "evidence_refs": ["pytest-failed"]},
+                {"event_type": "ci", "status": "not_observed", "evidence_refs": ["ci-placeholder"]},
+            ],
+            next_action="record_ci_evidence",
+        )
+        rendered = render_status_report(summary)
+
+        ci_event = next(event for event in summary["observations"]["events"] if event["event_type"] == "ci")
+
+        self.assertEqual(validate_work_observation_summary(summary), [])
+        self.assertEqual(summary["observations"]["evidence_refs"], ["runtime/result.json", "pytest-failed"])
+        self.assertEqual(ci_event["evidence_refs"], [])
+        self.assertIn("ci", summary["observations"]["not_observed_events"])
+        self.assertIn("runtime/result.json", rendered)
+        self.assertIn("pytest-failed", rendered)
+        self.assertNotIn("ci-placeholder", summary["observations"]["evidence_refs"])
+        self.assertNotIn("ci-placeholder", rendered)
 
 
 if __name__ == "__main__":

--- a/tests/test_work_reporting.py
+++ b/tests/test_work_reporting.py
@@ -558,6 +558,45 @@ class WorkReportingTests(unittest.TestCase):
         self.assertNotIn("merge", summary["observations"]["not_observed_events"])
         self.assertNotIn("Still waiting on observed proof for", rendered)
 
+    def test_runtime_observation_only_completion_overrides_legacy_stage_gaps(self) -> None:
+        status_payload = {
+            "run_id": "run-runtime-complete",
+            "prepared": {"status": "prepared_not_observed", "workflow": "team", "harness": "coding"},
+            "execution": {"observed": False, "status": "not_observed", "evidence_refs": []},
+            "verification": {"observed": False, "status": "not_observed", "evidence_refs": []},
+            "runtime_observation": {
+                "observed_events": ["worker_result", "verification"],
+                "blocked_events": [],
+                "failed_events": [],
+                "not_observed_events": [],
+                "missing_events": [],
+                "latest": {
+                    "worker_result": {
+                        "status": "observed",
+                        "summary": "runtime worker completed",
+                        "evidence_refs": ["runtime/result.jsonl#worker_result"],
+                    },
+                    "verification": {
+                        "status": "passed",
+                        "summary": "runtime verification passed",
+                        "evidence_refs": ["runtime/result.jsonl#verification"],
+                    },
+                },
+            },
+            "next_action": "report_runtime_observed",
+            "lifecycle_status": "reportable",
+        }
+
+        summary = build_work_observation_summary_from_status(status_payload, report_kind="completion")
+        rendered = render_completion_report(summary)
+
+        self.assertEqual(validate_work_observation_summary(summary), [])
+        self.assertEqual(summary["status"], "completed")
+        self.assertEqual(summary["observations"]["not_observed_events"], [])
+        self.assertIn("runtime/result.jsonl#worker_result", summary["observations"]["evidence_refs"])
+        self.assertIn("runtime/result.jsonl#verification", summary["observations"]["evidence_refs"])
+        self.assertNotIn("Still waiting on observed proof for", rendered)
+
     def test_empty_successful_background_completion_is_silent(self) -> None:
         rendered = build_background_completion_report(
             output="[Background process proc_b05484479563 finished with exit code 0~ Here's the final output:]",

--- a/tests/test_work_reporting.py
+++ b/tests/test_work_reporting.py
@@ -383,6 +383,69 @@ class WorkReportingTests(unittest.TestCase):
         self.assertIn("pytest-failed", rendered)
         self.assertNotIn("Completed:", rendered)
 
+    def test_runtime_observed_start_counts_as_progress_not_prepared_only(self) -> None:
+        status_payload = {
+            "schema_version": "delegated_coding_status/v1",
+            "run_id": "run-runtime-started",
+            "prepared": {"status": "prepared_not_observed", "workflow": "team", "harness": "coding"},
+            "execution": {"observed": False, "status": "not_observed", "evidence_refs": []},
+            "verification": {"observed": False, "status": "not_observed", "evidence_refs": []},
+            "runtime_observation": {
+                "observed_events": ["runtime_start"],
+                "blocked_events": [],
+                "failed_events": [],
+                "not_observed_events": [],
+                "missing_events": ["worker_result", "verification"],
+                "latest": {
+                    "runtime_start": {
+                        "status": "observed",
+                        "summary": "runtime started",
+                        "evidence_refs": ["runtime/runtime_observations.jsonl#runtime_start"],
+                    }
+                },
+            },
+            "next_action": "wait_for_executor_evidence",
+            "lifecycle_status": "running",
+        }
+
+        summary = build_work_observation_summary_from_status(status_payload, report_kind="progress")
+        rendered = render_progress_report(summary)
+
+        self.assertEqual(validate_work_observation_summary(summary), [])
+        self.assertEqual(summary["status"], "in_progress")
+        self.assertIn("runtime/runtime_observations.jsonl#runtime_start", summary["observations"]["evidence_refs"])
+        self.assertIn("runtime/runtime_observations.jsonl#runtime_start", rendered)
+        self.assertNotIn("prepared but not observed", rendered)
+
+    def test_legacy_completed_status_ignores_absent_runtime_missing_ladder(self) -> None:
+        status_payload = {
+            "schema_version": "delegated_coding_status/v1",
+            "run_id": "run-legacy-complete",
+            "prepared": {"status": "prepared_not_observed", "workflow": "plan", "harness": "coding"},
+            "execution": {"observed": True, "status": "completed", "evidence_refs": ["exec"]},
+            "verification": {"observed": True, "status": "passed", "satisfied": True, "evidence_refs": ["pytest"]},
+            "runtime_observation": {
+                "observed_events": [],
+                "blocked_events": [],
+                "failed_events": [],
+                "not_observed_events": [],
+                "missing_events": ["runtime_start", "worktree_creation", "worker_result", "verification"],
+                "latest": {},
+            },
+            "next_action": "report_completion_with_evidence",
+            "lifecycle_status": "reportable",
+        }
+
+        summary = build_work_observation_summary_from_status(status_payload, report_kind="completion")
+        rendered = render_completion_report(summary)
+
+        self.assertEqual(validate_work_observation_summary(summary), [])
+        self.assertEqual(summary["status"], "completed")
+        self.assertEqual(summary["observations"]["not_observed_events"], [])
+        self.assertNotIn("runtime_start", rendered)
+        self.assertNotIn("worker_result", rendered)
+        self.assertNotIn("Still waiting on observed proof for", rendered)
+
     def test_runtime_observation_terminal_events_override_in_progress_status(self) -> None:
         for field, event_status, expected_status in (
             ("failed_events", "failed", "failed"),

--- a/tests/test_work_reporting.py
+++ b/tests/test_work_reporting.py
@@ -560,6 +560,31 @@ class WorkReportingTests(unittest.TestCase):
         self.assertNotIn("Background process", rendered)
         self.assertNotIn("Here's the final output", rendered)
 
+    def test_background_completion_does_not_mislabel_plain_command_output_as_checks(self) -> None:
+        rendered = build_background_completion_report(
+            exit_code=0,
+            command="pytest tests/test_work_reporting.py",
+            output="1 passed in 0.2s",
+        )
+
+        self.assertIsNotNone(rendered)
+        assert rendered is not None
+        self.assertIn("completed successfully", rendered)
+        self.assertIn("1 passed in 0.2s", rendered)
+        self.assertNotIn("Checks:", rendered)
+        self.assertNotIn("Checks: 1 pass", rendered)
+
+    def test_background_completion_can_summarize_tabular_check_output_without_command_hint(self) -> None:
+        rendered = build_background_completion_report(
+            exit_code=0,
+            output="DCO\tpass\t4s\thttps://github.example/checks/dco",
+        )
+
+        self.assertIsNotNone(rendered)
+        assert rendered is not None
+        self.assertIn("Checks: 1 pass.", rendered)
+        self.assertIn("- DCO: pass (4s) https://github.example/checks/dco.", rendered)
+
     def test_structured_check_rollup_keeps_status_duration_and_links(self) -> None:
         rendered = format_check_rollup(
             [

--- a/tests/test_work_reporting.py
+++ b/tests/test_work_reporting.py
@@ -7,9 +7,11 @@ from _local_package import load_local_package
 
 load_local_package()
 from omh.work_reporting import (
+    build_background_completion_report,
     build_markdown_export,
     build_work_observation_summary,
     build_work_observation_summary_from_status,
+    format_check_rollup,
     render_status_report,
     render_blocker_report,
     render_completion_report,
@@ -431,6 +433,126 @@ class WorkReportingTests(unittest.TestCase):
         self.assertIn("pytest-failed", rendered)
         self.assertNotIn("ci-placeholder", summary["observations"]["evidence_refs"])
         self.assertNotIn("ci-placeholder", rendered)
+
+    def test_empty_successful_background_completion_is_silent(self) -> None:
+        rendered = build_background_completion_report(
+            output="[Background process proc_b05484479563 finished with exit code 0~ Here's the final output:]",
+        )
+
+        self.assertIsNone(rendered)
+
+    def test_background_check_output_renders_compact_rollup_not_watch_transcript(self) -> None:
+        raw_watch_output = "\n".join(
+            [
+                "Refreshing checks status every 10 seconds. Press Ctrl+C to quit.",
+                "DCO\tpass\t4s\thttps://github.example/checks/dco",
+                "unit tests\tpass\t2m10s\thttps://github.example/checks/tests",
+                "Codex review\tpending\t\thttps://github.example/checks/review",
+                "Refreshing checks status every 10 seconds. Press Ctrl+C to quit.",
+                "DCO\tpass\t4s\thttps://github.example/checks/dco",
+                "unit tests\tpass\t2m10s\thttps://github.example/checks/tests",
+                "Codex review\tpending\t\thttps://github.example/checks/review",
+            ]
+        )
+
+        rendered = build_background_completion_report(
+            exit_code=0,
+            command="gh pr checks --watch",
+            output=raw_watch_output,
+        )
+
+        self.assertIsNotNone(rendered)
+        assert rendered is not None
+        self.assertIn("Checks: 1 pending, 2 pass.", rendered)
+        self.assertIn("- DCO: pass (4s) https://github.example/checks/dco.", rendered)
+        self.assertIn("- unit tests: pass (2m10s) https://github.example/checks/tests.", rendered)
+        self.assertIn("- Codex review: pending https://github.example/checks/review.", rendered)
+        self.assertNotIn("Refreshing checks status", rendered)
+        self.assertNotIn("Press Ctrl+C", rendered)
+        self.assertNotIn("Background process", rendered)
+        self.assertNotIn("Here's the final output", rendered)
+
+    def test_structured_check_rollup_keeps_status_duration_and_links(self) -> None:
+        rendered = format_check_rollup(
+            [
+                {
+                    "name": "DCO",
+                    "status": "completed",
+                    "conclusion": "success",
+                    "duration": "3s",
+                    "url": "https://github.example/checks/dco",
+                },
+                {
+                    "name": "integration tests",
+                    "status": "in_progress",
+                    "duration": "1m",
+                    "url": "https://github.example/checks/integration",
+                },
+            ]
+        )
+
+        self.assertIn("Checks: 1 pending, 1 pass.", rendered)
+        self.assertIn("- DCO: pass (3s) https://github.example/checks/dco.", rendered)
+        self.assertIn("- integration tests: pending (1m) https://github.example/checks/integration.", rendered)
+
+    def test_friendly_korean_progress_report_uses_channel_voice(self) -> None:
+        summary = build_work_observation_summary(
+            work_id="run-ko-friendly",
+            title="PR #259",
+            report_kind="progress",
+            status="in_progress",
+            safe_summary="CI는 통과했고, 지금은 리뷰만 다시 확인 중이야.",
+            progress_events=[
+                {
+                    "event_type": "status_update",
+                    "status": "observed",
+                    "summary": "CI는 통과했고, 지금은 리뷰만 다시 확인 중이야.",
+                }
+            ],
+            evidence_refs=["https://github.example/checks/tests"],
+            next_action="record_review_evidence",
+        )
+
+        rendered = render_progress_report(summary, locale="ko", voice="friendly")
+
+        self.assertIn("PR #259 작업은 진행 중이야.", rendered)
+        self.assertIn("CI는 통과했고, 지금은 리뷰만 다시 확인 중이야.", rendered)
+        self.assertIn("확인한 근거: https://github.example/checks/tests.", rendered)
+        self.assertIn("다음은 record_review_evidence 쪽을 볼게.", rendered)
+        self.assertNotIn("Progress:", rendered)
+        self.assertNotIn("Next:", rendered)
+        self.assertNotIn("Evidence boundary", rendered)
+        self.assertNotIn("한다", rendered)
+
+    def test_user_report_scrubs_awareness_and_native_bridge_context(self) -> None:
+        internal_context = """
+        [OMH Awareness]
+        ## OMH Awareness Primer
+        [OMH] Native bridge status context.
+        Evidence boundary: prepared handoffs are not execution, review, CI, merge-readiness, or merge evidence.
+        Latest runtime run: run-raw.
+        """
+        summary = build_work_observation_summary(
+            work_id="run-internal-rails",
+            title="Native bridge context",
+            report_kind="progress",
+            status="in_progress",
+            safe_summary=internal_context,
+            progress_events=[
+                {
+                    "event_type": "status_update",
+                    "status": "observed",
+                    "summary": internal_context,
+                }
+            ],
+        )
+
+        rendered = render_progress_report(summary, locale="ko", voice="friendly")
+
+        self.assertIn("내부 OMH 상태는 확인했고", rendered)
+        self.assertNotIn("[OMH Awareness]", rendered)
+        self.assertNotIn("Native bridge status context", rendered)
+        self.assertNotIn("Evidence boundary: prepared handoffs", rendered)
 
 
 if __name__ == "__main__":

--- a/tests/test_work_reporting.py
+++ b/tests/test_work_reporting.py
@@ -417,6 +417,33 @@ class WorkReportingTests(unittest.TestCase):
         self.assertIn("runtime/runtime_observations.jsonl#runtime_start", rendered)
         self.assertNotIn("prepared but not observed", rendered)
 
+    def test_runtime_explicit_not_observed_events_remain_active_gaps(self) -> None:
+        status_payload = {
+            "schema_version": "delegated_coding_status/v1",
+            "run_id": "run-runtime-gap",
+            "prepared": {"status": "prepared_not_observed", "workflow": "team", "harness": "coding"},
+            "runtime_observation": {
+                "observed_events": [],
+                "blocked_events": [],
+                "failed_events": [],
+                "not_observed_events": ["runtime_start"],
+                "missing_events": ["worktree_creation"],
+                "next_action": "record_runtime_observation:runtime_start",
+                "latest": {"runtime_start": {"status": "not_observed", "summary": "runtime start not observed"}},
+            },
+            "next_action": "wait_for_executor_evidence",
+            "lifecycle_status": "running",
+        }
+
+        summary = build_work_observation_summary_from_status(status_payload, report_kind="status")
+        rendered = render_status_report(summary)
+
+        self.assertEqual(validate_work_observation_summary(summary), [])
+        self.assertIn("runtime_start", summary["observations"]["not_observed_events"])
+        self.assertIn("worktree_creation", summary["observations"]["not_observed_events"])
+        self.assertIn("Still waiting on observed proof for", rendered)
+        self.assertIn("runtime_start", rendered)
+
     def test_legacy_completed_status_ignores_absent_runtime_missing_ladder(self) -> None:
         status_payload = {
             "schema_version": "delegated_coding_status/v1",

--- a/tests/test_work_reporting.py
+++ b/tests/test_work_reporting.py
@@ -570,6 +570,7 @@ class WorkReportingTests(unittest.TestCase):
                 "failed_events": [],
                 "not_observed_events": [],
                 "missing_events": [],
+                "next_action": "report_runtime_observed",
                 "latest": {
                     "worker_result": {
                         "status": "observed",
@@ -583,8 +584,8 @@ class WorkReportingTests(unittest.TestCase):
                     },
                 },
             },
-            "next_action": "report_runtime_observed",
-            "lifecycle_status": "reportable",
+            "next_action": "wait_for_executor_evidence",
+            "lifecycle_status": "awaiting_executor",
         }
 
         summary = build_work_observation_summary_from_status(status_payload, report_kind="completion")

--- a/tests/test_work_reporting.py
+++ b/tests/test_work_reporting.py
@@ -699,6 +699,42 @@ class WorkReportingTests(unittest.TestCase):
         self.assertNotIn("Background process", rendered)
         self.assertNotIn("Here's the final output", rendered)
 
+    def test_check_rollup_loose_parser_uses_status_tokens_not_name_substrings(self) -> None:
+        rendered = build_background_completion_report(
+            exit_code=0,
+            command="gh pr checks --watch",
+            output="\n".join(
+                [
+                    "compass pending https://github.example/checks/compass",
+                    "failover tests pass https://github.example/checks/failover",
+                ]
+            ),
+        )
+
+        self.assertIsNotNone(rendered)
+        assert rendered is not None
+        self.assertIn("- compass: pending https://github.example/checks/compass.", rendered)
+        self.assertIn("- failover tests: pass https://github.example/checks/failover.", rendered)
+        self.assertNotIn("- com: pass", rendered)
+        self.assertNotIn("- over tests: fail", rendered)
+
+    def test_check_name_cleanup_preserves_names_starting_with_x(self) -> None:
+        rendered = format_check_rollup(
+            "\n".join(
+                [
+                    "xcodebuild\tpass\t1m\thttps://github.example/checks/xcodebuild",
+                    "x86 tests\tpass\t2m\thttps://github.example/checks/x86",
+                    "x legacy marker\tfail\t3m\thttps://github.example/checks/legacy",
+                ]
+            )
+        )
+
+        self.assertIn("- xcodebuild: pass (1m) https://github.example/checks/xcodebuild.", rendered)
+        self.assertIn("- x86 tests: pass (2m) https://github.example/checks/x86.", rendered)
+        self.assertIn("- legacy marker: fail (3m) https://github.example/checks/legacy.", rendered)
+        self.assertNotIn("- codebuild", rendered)
+        self.assertNotIn("- 86 tests", rendered)
+
     def test_background_check_output_ignores_github_summary_prose(self) -> None:
         rendered = build_background_completion_report(
             exit_code=1,


### PR DESCRIPTION
## Feature Report

### What Changed

- Added `work_observation_summary/v1`, a metadata-only work reporting contract for observed/progress/completion/blocker state.
- Added plain-text renderers for progress, status, completion, and blocker reports so normal user UX is prose, not JSON or code fences.
- Added an opt-in `work_report_markdown_export/v1` projection and validator for wiki/markdown use without building a full wiki backend.
- Added bounded workflow-learning hints that carry selected sanitized refs, not raw prompt/log content.
- Updated `docs/DIRECTION.md` to make observation-first reporting/reflection a core OMH product direction.

### Why This Exists

The product gap is that Hermes needs to explain what it invoked, what was actually observed, what remains unobserved, and what can be learned afterward. Exhaustively unifying every coding handoff order is less valuable than reliable observation, reporting, and reflection.

This slice gives Hermes/OMH a small deterministic contract that can become the common summary layer above runtime artifacts, wrapper sessions, coding status, markdown/wiki notes, and workflow learning exports.

### User / Operator Impact

- Users get concise plain-text progress/completion/blocker updates by default.
- Operators still have structured metadata for later inspection, export, or learning.
- Prepared handoffs and dishonest terminal labels cannot be promoted into completion reports without observed execution and verification evidence.
- Unobserved review/CI/merge refs are not rendered as user-facing evidence.

### How It Works

- `build_work_observation_summary()` builds the internal metadata-only summary with message hash/length, bounded evidence refs, progress events, observation refs, privacy flags, and claim boundaries.
- `build_work_observation_summary_from_status()` projects existing delegated coding status payloads while filtering evidence refs to observed/satisfied stages.
- `render_progress_report()`, `render_status_report()`, `render_completion_report()`, and `render_blocker_report()` produce plain user text.
- `build_markdown_export()` creates a secondary opt-in markdown/wiki projection; `validate_markdown_export()` keeps it metadata-only.
- `validate_work_observation_summary()` rejects raw-content drift and enforces plain-text/opt-in export defaults.

### Files And Contracts Touched

- `src/work_reporting.py`
  - `work_observation_summary/v1`
  - `work_observation_event_ref/v1`
  - `work_report_markdown_export/v1`
  - `work_report_learning_hint/v1`
- `tests/test_work_reporting.py`
  - plain-text default rendering
  - metadata-only artifact boundaries
  - opt-in markdown/wiki export shape
  - bounded learning hints
  - prepared-vs-observed status projection regressions
- `docs/DIRECTION.md`
  - observation-first reporting direction, non-goals, and UX/export/learning boundaries

## Validation

- [x] `PYTHONPATH=tests python -m unittest discover -s tests -v` (`734` tests passed)
- [x] `python -m compileall -q src tests`
- [x] `PYTHONPATH=tests python -m src.cli docs workflows --check`
- [x] `PYTHONPATH=tests python -m src.cli harness validate`
- [x] `PYTHONPATH=tests python -m src.cli release checklist --json` (plan/checklist rendered with `ok=true`)
- [x] `PYTHONPATH=tests python -m src.cli release hermes-smoke` (plan-mode smoke rendered with `ok=true`)
- [x] `PYTHONPATH=tests python -m src.cli --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
  - Not run: this PR adds a local core reporting contract, not an installed-command or live Hermes integration. Plan-mode release smoke was run instead.
- [x] Relevant workflow-learning review queue smoke, when learning contracts changed:
  - `PYTHONPATH=tests python -m unittest tests/test_workflow_learning.py -v`
- [x] Relevant dry-run or smoke command:
  - `PYTHONPATH=tests python -m unittest tests/test_work_reporting.py -v`
  - `PYTHONPATH=tests python -m unittest tests/test_runtime_artifacts.py -v`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run:
  - Not run: no wrapper, TUI, live Hermes, or CLI user surface was wired in this first slice.

Additional local gates:

- [x] `git diff --check`
- [x] Independent code-reviewer lane: `APPROVE`
- [x] Independent architect lane: `CLEAR`

`uv run` variants were not used because this sandbox could not initialize/fetch the `uv` build environment. Equivalent local Python commands above were used instead.

## Risk

- Moderate: this introduces a new core contract module, but it is not wired into CLI/wrapper runtime paths yet.
- Evidence-boundary risk is covered by regression tests for prepared/unobserved status projection and unobserved stage refs.
- Future callers must keep JSON/code-block output opt-in and plain text as the default user report surface.

## Compatibility / Rollout

- No external dependencies.
- No network calls.
- No full wiki backend or storage migration.
- Existing runtime, wrapper-session, and workflow-learning tests pass unchanged.
- Later wrapper/CLI integration can consume this module without changing existing artifacts.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
  - Local/core contract only; no release channel change in this PR.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
  - This PR adds report contracts and renderers only; it does not claim runtime execution.
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap
  - Live Hermes/TUI smoke was not run because this slice has no live Hermes surface.

## Follow-Up

- Wire the report summary into selected wrapper/session/status commands once the core contract is accepted.
- Add durable wiki storage only after a concrete backend requirement exists.
- Split render/export adapters out of `work_reporting` if those surfaces grow beyond projection helpers.
