### PR TITLE
Add observation journal for plan-backed handoffs

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -360,9 +360,10 @@ Routing, planning, and delegation have these local surfaces:
    implementation-shaped messages into a deterministic `coding_delegation/v1`
    handoff payload for an executor lane.
 10. Runtime observation recording. `omh runtime observe` lets wrappers or
-   operators append `runtime_observation/v1` evidence for selected runtime
-   handoffs without implying unrecorded worktree, worker, verification, review,
-   CI, or merge steps.
+   operators append observed lifecycle events into
+   `.omh/runtime/journal/events.jsonl` and, for runtime handoffs, maintain
+   `runtime_observation/v1` compatibility without implying unrecorded worktree,
+   worker, verification, review, CI, or merge steps.
 11. Hermes-facing planning artifacts. `omh hermes plan` lets wrappers or
    operators create deterministic `hermes_plan/v1` planning scaffolds under
    `.hermes/plans/` without claiming that execution or review already happened.
@@ -421,12 +422,13 @@ and `coding_delegation.json` as a required pair. The run envelope is
 implementation bookkeeping, not proof that Hermes executed the handoff.
 
 The wrapper contract and lower-level surfaces are local contracts; execution
-evidence still comes from Hermes Agent and the selected executor/runtime. For
-Hermes/OMX/OMO/OMC runtime handoffs, the separate runtime observation ledger is
-the bridge between "prepared" and "observed". A wrapper can record
-`runtime_start` while `worktree_creation`, `worker_dispatch`,
-`worker_result`, `verification`, `review`, `ci`, `merge_readiness`, and
-`merge` remain explicitly missing.
+evidence still comes from Hermes Agent and the selected executor/runtime. The
+append-only observation journal is the bridge between "prepared" and "observed"
+lifecycle status. For Hermes/OMX/OMO/OMC runtime handoffs, the
+legacy-compatible runtime observation ledger is mirrored into that journal. A
+wrapper can record `runtime_start` while `worktree_creation`, `worker_dispatch`,
+`worker_result`, `verification`, `review`, `ci`, `merge_readiness`, and `merge`
+remain explicitly missing.
 
 Hermes planning writes Markdown plans under the configured Hermes home rather
 than runtime JSON under `.omh/runtime/`. The artifact is user-facing: it includes
@@ -436,16 +438,18 @@ default to `not_observed` unless wrapper metadata proves a separate review ran.
 Weak requests create a companion `.hermes/context/` artifact and keep the plan
 `blocked` until Hermes asks the smallest blocking clarification.
 
-The machine-readable planning bridge is stdout JSON, not the Markdown file. Each
-`hermes_plan/v1` payload includes `wrapper_contract` with the current wrapper
-step, decision gate, optional recorded plan artifact path, and coding-delegation
-handoff template. For implementation-shaped draft plans,
-`wrapper_contract.coding_delegate.argv_template` is the adapter contract for
-calling `omh coding delegate --executor codex --record` after plan acceptance
-when the wrapper wants a run-backed Codex handoff and a future
-`runtime.run.run_id`. Blocked or non-coding plans keep
-`coding_delegate.available` false so wrappers do not infer execution from
-presentation text.
+The machine-readable planning bridge is stdout JSON plus the accepted plan
+artifact, not a Discord/channel summary. Each `hermes_plan/v1` payload includes
+`wrapper_contract` with the current wrapper step, decision gate, optional
+recorded plan artifact path, and coding-delegation handoff template. For
+implementation-shaped draft plans, `wrapper_contract.coding_delegate.argv_template`
+is the adapter contract for calling
+`omh coding delegate --executor codex --record --from-plan <accepted-plan.md>`
+after plan acceptance. `omh coding delegate --from-plan` rejects draft plans by
+default and uses the accepted artifact or generated context pack as executor
+context when the wrapper wants a run-backed Codex handoff and a future
+`runtime.run.run_id`. Blocked or non-coding plans keep `coding_delegate.available`
+false so wrappers do not infer execution from presentation text.
 
 `omh chat session` is the recovery layer for adapters that need button/thread
 state to survive restarts. The session id is derived from `thread_key`. Session

--- a/docs/DELEGATION_FIRST_COMPLETENESS.md
+++ b/docs/DELEGATION_FIRST_COMPLETENESS.md
@@ -31,13 +31,13 @@ evidence exists.
 | `omh chat session` | Persists metadata-only chat session decisions, executor/runtime selection, plan acceptance/revision/cancel state, prompt-only handoffs, runtime handoffs, and accepted Codex lifecycle links. | `src/wrapper/sessions.py`, `tests/test_wrapper_sessions.py`, `tests/test_cli.py` |
 | `omh chat session open-executor`, `attach-executor`, `record-executor`, `request-verification` | Backend actions for wrapper-rendered buttons such as Start Codex session, Start Claude Code session, Attach coding session, Refresh status, Record completed, Record blocked, and Ask Hermes to verify. They write `executor_session/v1` metadata after Hermes or the wrapper observes a coding-session event; OMH itself does not launch hidden executors. | `src/wrapper/executor_sessions.py`, `tests/test_wrapper_sessions.py`, `tests/test_cli.py` |
 | `omh chat route` | Deterministically routes plain chat into a workflow decision before wrapper dispatch. | `src/routing/chat.py`, `tests/test_cli.py` |
-| `omh hermes plan` | Produces Hermes-facing plan scaffolds and wrapper contracts under `.hermes/plans`. | `src/hermes_planning.py`, `docs/ARCHITECTURE.md` |
-| `omh coding delegate` | Prepares metadata-only coding handoffs, executor/runtime-choice contracts, prompt-only payloads, and runtime contracts without overclaiming execution. Hermes selection also exposes an optional coding team path with solo, durable-goal, team, and swarm start choices. | `src/coding_delegation.py`, `src/runtime/artifacts.py` |
+| `omh hermes plan` | Produces Hermes-facing plan scaffolds and wrapper contracts under `.hermes/plans`, with accept/revise/cancel lifecycle events. | `src/hermes_planning.py`, `docs/ARCHITECTURE.md` |
+| `omh coding delegate` | Prepares metadata-only coding handoffs, executor/runtime-choice contracts, prompt-only payloads, runtime contracts, and accepted-plan `--from-plan` Codex handoffs without overclaiming execution. Hermes selection also exposes an optional coding team path with solo, durable-goal, team, and swarm start choices. | `src/coding_delegation.py`, `src/runtime/artifacts.py` |
 | `worktree_session_isolation/v1` | Adds deterministic workspace-isolation guidance to coding handoffs and executor-session status: same workspace ok, worktree recommended, or worktree required. | `src/isolation.py`, `src/wrapper/executor_sessions.py`, `tests/test_wrapper_sessions.py` |
 | `omh coding lifecycle` | Tracks Codex-selected handoff dispatch, executor result, verification, and reportable status from existing runtime evidence. | `src/wrapper/lifecycle.py`, `tests/test_coding_lifecycle.py`, `tests/test_cli.py` |
 | `omh memory inspect/pack/apply` | Reviews OMH-local and wrapper-supplied context, creates `memory_review_card/v1`, and attaches only conflict-free `handoff_context_pack/v1` summaries to executor handoffs. | `src/memory.py`, `tests/test_memory.py` |
 | `omh runtime wrapper` | Lets wrappers record what they actually observed after dispatch. | `src/runtime/artifacts.py`, `README.md` |
-| `omh runtime observe` | Records metadata-only `runtime_observation/v1` events for Hermes/OMX/OMO/OMC runtime handoffs: runtime start, worktree creation, worker dispatch/result, verification, review, CI, merge-readiness, and merge. | `src/runtime/artifacts.py`, `src/runtime/records.py`, `tests/test_cli.py`, `tests/test_runtime_artifacts.py` |
+| `omh runtime observe` | Records metadata-only observation journal events for prepared-to-observed lifecycle status, and preserves `runtime_observation/v1` compatibility for Hermes/OMX/OMO/OMC runtime handoffs: runtime start, worktree creation, worker dispatch/result, verification, review, CI, merge-readiness, and merge. | `src/runtime/artifacts.py`, `src/runtime/records.py`, `tests/test_cli.py`, `tests/test_runtime_artifacts.py` |
 | `omh runtime review`, `omh runtime ci`, `omh runtime merge` | Records observed review, CI, merge-readiness, and merge evidence under the run ledger. | `src/runtime/artifacts.py`, `src/runtime/records.py`, `tests/test_cli.py` |
 | `omh runtime validate/export` | Validates and exports local evidence without storing prompt bodies by default. | `src/runtime/artifacts.py`, `tests/test_runtime_artifacts.py` |
 | `examples/wrapper-golden/` | Provides platform-neutral golden chat responses for wrapper button/thread/status UX, including plugin-native `omh_interact` examples. | `examples/wrapper-golden/status-ladder.json`, `examples/wrapper-golden/plugin-interact.json`, `tests/test_wrapper_golden_examples.py` |
@@ -121,8 +121,11 @@ Expected behavior:
   Hermes retained coding-skill prompts, plus an observation contract explaining
   how to record what actually happened later.
 - `omh runtime observe --run <id>` or `omh runtime observe --session <id>`
-  appends one observed, blocked, failed, or not-observed runtime ladder event
-  without upgrading missing events into evidence.
+  appends one observed, blocked, failed, or not-observed lifecycle event without
+  upgrading missing events into evidence.
+- `omh hermes plan-accept <plan.md>` and `omh coding delegate --from-plan
+  <plan.md>` keep executor context file-backed. Discord/channel text is a
+  summary, not the executor plan.
 - `omh chat session open-executor`, `attach-executor`, `record-executor`, and
   `request-verification` are wrapper backend actions. They are meant to sit
   behind chat buttons, write `executor_session/v1`, and update status cards

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -738,7 +738,8 @@ Lower-level debug surfaces remain available when an adapter needs them:
 ```sh
 omh chat route --source discord --record "risky refactor"
 omh hermes plan --source discord --record "risky refactor with review"
-omh coding delegate --executor codex --source discord --record "risky refactor"
+omh hermes plan-accept .hermes/plans/<accepted-plan.md>
+omh coding delegate --executor codex --source discord --record --from-plan .hermes/plans/<accepted-plan.md>
 omh coding delegate --executor claude-code --source discord --record "risky refactor"
 omh runtime delegation-status --run <run-id>
 ```
@@ -753,7 +754,9 @@ The stdout JSON also includes `wrapper_contract`. Wrappers should use that JSON,
 not the Markdown body, to decide the next local action. If
 `wrapper_contract.coding_delegate.available` is `true`, the listed
 `argv_template` is an adapter contract for preparing a lower-level delegation
-after plan acceptance. If it is `false`, follow `next_action` and do not dispatch
+after plan acceptance. Use the accepted plan artifact or generated context pack
+as the executor context; Discord/channel text is only a summary. If
+`coding_delegate.available` is `false`, follow `next_action` and do not dispatch
 coding work.
 
 For hosted bots, run these commands inside the same container, virtual
@@ -789,6 +792,7 @@ delegation flags, and wrapper completion status.
 - setup/install/apply/doctor summaries in `~/.omh/runtime/state.json`
 - workflow run envelopes in `~/.omh/runtime/runs/<run-id>/run.json`
 - append-only run events in `events.jsonl`
+- append-only lifecycle observations in `~/.omh/runtime/journal/events.jsonl`
 - wrapper chat sessions in `~/.omh/runtime/wrapper_sessions/<session-id>/`
 - delegation observation in `delegation.json`
 - prepared coding handoffs in `coding_delegation.json`
@@ -831,6 +835,9 @@ Before calling the bot integration ready, verify these points:
   returns a `coding_delegation/v1` payload and writes `coding_delegation.json`
   with status `prepared_not_observed` when the payload contains a real Codex
   `executor_handoff`.
+- `omh coding delegate --executor codex --record --from-plan <accepted-plan.md>`
+  uses the accepted `hermes_plan/v1` artifact as executor context. Draft plans
+  are rejected unless an operator explicitly passes the override flag.
 - `omh coding lifecycle start --executor codex --record "<message>"` creates a
   prepared Codex handoff lifecycle without storing the raw prompt body by
   default.
@@ -877,8 +884,9 @@ Before calling the bot integration ready, verify these points:
   presentation.
 - For implementation-shaped draft plans, the stdout
   `wrapper_contract.coding_delegate.argv_template` is the handoff bridge to
-  `omh coding delegate --executor codex --record`; run it only after plan
-  acceptance and with the original message preserved when the wrapper wants a
+  `omh coding delegate --executor codex --record --from-plan <accepted-plan.md>`;
+  run it only after plan acceptance and pass the accepted artifact or context
+  pack, not the original Discord/channel summary, when the wrapper wants a
   run-backed Codex handoff.
 - A chat message that strongly names a workflow reaches Hermes with installed
   skill descriptions available after the wrapper dispatches to Hermes.

--- a/skills/oh-my-hermes/references/wrapper-routing.md
+++ b/skills/oh-my-hermes/references/wrapper-routing.md
@@ -53,7 +53,7 @@ artifacts; pass only event summaries and refs into Hermes chat context.
 
 Wrappers can run `omh memory inspect`, `omh memory pack`, and `omh memory apply` to review OMH-local or wrapper-supplied context before preparing a handoff. This emits `memory_review_card/v1` and `handoff_context_pack/v1` artifacts only; it does not read or mutate opaque Hermes internal memory.
 
-For planning-shaped requests, wrappers or operators can run `omh hermes plan` to create a deterministic `hermes_plan/v1` scaffold. The stdout `wrapper_contract` is the adapter contract for follow-on work; use it instead of parsing Markdown.
+For planning-shaped requests, wrappers or operators can run `omh hermes plan` to create a deterministic `hermes_plan/v1` scaffold. The stdout `wrapper_contract` is the adapter contract for follow-on work; after acceptance, pass the accepted plan artifact or generated context pack to `omh coding delegate --from-plan` instead of treating Discord/channel summary text as the executor plan.
 
 ## Backend Boundary
 

--- a/src/coding_delegation.py
+++ b/src/coding_delegation.py
@@ -140,6 +140,7 @@ def build_coding_delegation_payload(
     source_metadata: dict[str, str] | None = None,
     executor_target: str = "generic",
     context_pack: dict[str, object] | None = None,
+    plan_artifact: dict[str, object] | None = None,
 ) -> dict[str, object]:
     message = message.strip()
     if not message:
@@ -235,6 +236,8 @@ def build_coding_delegation_payload(
     metadata = {key: value for key, value in (source_metadata or {}).items() if value}
     if metadata:
         payload["source_metadata"] = metadata
+    if plan_artifact:
+        payload["plan_artifact"] = plan_artifact
     if include_message:
         payload["message"] = message
         payload["delegation_prompt"] = str(delegation.delegation_prompt_template).replace("{message}", message)
@@ -332,6 +335,8 @@ def coding_delegation_record_payload(
             record[key] = payload[key]
     if isinstance(payload.get("isolation_plan"), dict):
         record["isolation_plan"] = payload["isolation_plan"]
+    if isinstance(payload.get("plan_artifact"), dict):
+        record["plan_artifact"] = payload["plan_artifact"]
     return record
 
 

--- a/src/commands/coding.py
+++ b/src/commands/coding.py
@@ -8,12 +8,17 @@ from pathlib import Path
 
 from ..coding_delegation import CODING_EXECUTOR_TARGETS, build_coding_delegation_payload, coding_delegation_record_payload
 from ..executor_readiness import EXECUTOR_READINESS_PROFILES, probe_executor_readiness
+from ..hermes_planning import (
+    build_plan_handoff_context_pack,
+    build_plan_handoff_message,
+    read_hermes_plan_artifact,
+)
 from ..ingress import CHAT_SOURCES, extract_message_text, extract_source_metadata
 from ..installer import OmhError
 from ..memory import read_handoff_context_pack_file
 from ..routing.intent import META_OR_FEEDBACK_INTENTS, classify_workflow_intent
 from ..routing.localization import normalized_phrase, routing_tokens
-from ..runtime.artifacts import create_prepared_coding_delegation_run, write_coding_delegation
+from ..runtime.artifacts import append_journal_observation, create_prepared_coding_delegation_run, write_coding_delegation
 from ..wrapper.lifecycle import (
     CodingLifecycleError,
     record_codex_dispatch,
@@ -28,7 +33,24 @@ from .common import _chat_input_and_metadata, _explicit_source_metadata, _paths,
 def cmd_coding_delegate(args: argparse.Namespace) -> int:
     try:
         source_metadata: dict[str, str] = {}
-        if args.event_json:
+        plan_artifact: dict[str, object] | None = None
+        context_pack = _context_pack(args)
+        executor_target = _resolved_executor_for_delegate(args)
+        if args.from_plan:
+            if args.event_json or args.stdin or args.message:
+                raise ValueError("coding delegate --from-plan cannot be combined with --stdin, --event-json, or message arguments")
+            artifact = read_hermes_plan_artifact(args.from_plan)
+            if artifact.get("schema_version") != "hermes_plan/v1":
+                raise ValueError("coding delegate --from-plan requires a hermes_plan/v1 artifact")
+            plan_status = str(artifact.get("status", ""))
+            if plan_status != "accepted" and not (args.allow_draft_plan or args.force_record):
+                raise ValueError("coding delegate --from-plan requires an accepted plan; use hermes plan-accept or --allow-draft-plan")
+            message = build_plan_handoff_message(artifact)
+            source_metadata.update(_plan_source_metadata(artifact))
+            plan_artifact = _coding_plan_artifact(artifact)
+            if context_pack is None:
+                context_pack = build_plan_handoff_context_pack(artifact, executor_target=executor_target)
+        elif args.event_json:
             raw = (
                 sys.stdin.read()
                 if args.event_json == "-"
@@ -48,21 +70,24 @@ def cmd_coding_delegate(args: argparse.Namespace) -> int:
             limit=args.limit,
             include_message=args.include_message,
             source_metadata=source_metadata,
-            executor_target=_resolved_executor(args, default="generic"),
-            context_pack=_context_pack(args),
+            executor_target=executor_target,
+            context_pack=context_pack,
+            plan_artifact=plan_artifact,
         )
+        if plan_artifact:
+            _apply_plan_handoff_source(payload)
         runtime_skip_reason = ""
         if args.record:
             runtime_skip_reason = _coding_delegate_record_readiness_skip_reason(
                 message,
-                force_record=bool(args.force_record),
+                force_record=bool(args.force_record or args.from_plan),
             )
             if not runtime_skip_reason:
                 runtime_skip_reason = _coding_delegate_runtime_skip_reason(payload)
             if not runtime_skip_reason:
                 runtime_skip_reason = _coding_delegate_record_readiness_skip_reason(
                     message,
-                    force_record=bool(args.force_record),
+                    force_record=bool(args.force_record or args.from_plan),
                     require_dispatchable_requirements=True,
                 )
         if runtime_skip_reason:
@@ -89,7 +114,7 @@ def cmd_coding_delegate(args: argparse.Namespace) -> int:
                     "harness": str(delegation["recommended_harness"]),
                     "trigger": f"coding:{args.source}:{delegation['action']}",
                     "privacy": "metadata_only",
-                    "inputs_summary": f"{args.source} coding delegation request; message_length={len(message)}",
+                    "inputs_summary": _inputs_summary(args.source, message, plan_artifact=plan_artifact),
                     "outputs_summary": f"prepared {delegation['action']} for {delegation['recommended_workflow']}",
                     "verification_summary": "prepared_not_observed; executor work is not observed by omh",
                 },
@@ -98,6 +123,24 @@ def cmd_coding_delegate(args: argparse.Namespace) -> int:
                 paths.runtime_runs_dir / run["run_id"],
                 coding_delegation_record_payload(payload, message, source_metadata=source_metadata),
             )
+            if plan_artifact:
+                append_journal_observation(
+                    paths,
+                    {
+                        "target_type": "run",
+                        "target_id": run["run_id"],
+                        "run_id": run["run_id"],
+                        "workflow": str(delegation["recommended_workflow"]),
+                        "harness": str(delegation["recommended_harness"]),
+                        "phase": "prepared",
+                        "event": "prepared_handoff_created",
+                        "status": "observed",
+                        "source": "coding_delegate_from_plan",
+                        "plan_artifact": plan_artifact.get("path", ""),
+                        "plan_status": plan_artifact.get("status", ""),
+                        "summary": "Prepared coding handoff from accepted Hermes plan artifact.",
+                    },
+                )
             payload["runtime"] = {"run": run, "coding_delegation": record}
     except (OSError, json.JSONDecodeError, ValueError) as exc:
         raise OmhError(str(exc)) from exc
@@ -118,6 +161,62 @@ def _coding_delegate_runtime_skip_reason(payload: dict[str, object]) -> str:
     if payload.get("selected_executor_profile") != "codex" or not isinstance(payload.get("executor_handoff"), dict):
         return "codex_executor_handoff_required_for_runtime_record"
     return ""
+
+
+def _resolved_executor_for_delegate(args: argparse.Namespace) -> str:
+    if getattr(args, "executor", None):
+        return str(args.executor)
+    if getattr(args, "from_plan", None):
+        return "codex"
+    return _resolved_executor(args, default="generic")
+
+
+def _plan_source_metadata(artifact: dict[str, object]) -> dict[str, str]:
+    return {
+        "plan_artifact_path": str(artifact.get("path", "")),
+        "plan_artifact_sha256": str(artifact.get("sha256", "")),
+        "plan_artifact_status": str(artifact.get("status", "")),
+        "plan_task_sha256": str(artifact.get("task_statement_sha256", "")),
+        "plan_task_length": str(artifact.get("task_statement_length", 0)),
+    }
+
+
+def _coding_plan_artifact(artifact: dict[str, object]) -> dict[str, object]:
+    return {
+        "path": str(artifact.get("path", "")),
+        "kind": "hermes_plan",
+        "schema_version": str(artifact.get("schema_version", "hermes_plan/v1")),
+        "status": str(artifact.get("status", "")),
+        "sha256": str(artifact.get("sha256", "")),
+        "task_statement_sha256": str(artifact.get("task_statement_sha256", "")),
+        "task_statement_length": int(artifact.get("task_statement_length", 0) or 0),
+    }
+
+
+def _apply_plan_handoff_source(payload: dict[str, object]) -> None:
+    for key, brief_key in (
+        ("executor_handoff", "execution_brief"),
+        ("runtime_handoff", "runtime_brief"),
+        ("prompt_handoff", ""),
+    ):
+        handoff = payload.get(key)
+        if not isinstance(handoff, dict):
+            continue
+        if brief_key and isinstance(handoff.get(brief_key), dict):
+            handoff[brief_key]["task_source"] = "accepted_plan_artifact"
+        scope = handoff.get("scope")
+        if isinstance(scope, list):
+            scope.insert(0, "Use the accepted Hermes plan artifact as the executor request.")
+        handoff["dispatch_contract"] = str(handoff.get("dispatch_contract", "")) + "; plan_artifact_context_required"
+
+
+def _inputs_summary(source: str, message: str, *, plan_artifact: dict[str, object] | None) -> str:
+    if plan_artifact:
+        return (
+            f"{source} coding delegation from accepted plan artifact; "
+            f"plan_sha256={plan_artifact.get('sha256', '')}; message_length={len(message)}"
+        )
+    return f"{source} coding delegation request; message_length={len(message)}"
 
 
 def _coding_delegate_record_readiness_skip_reason(
@@ -370,6 +469,16 @@ def _add_coding_commands(sub) -> None:
         "--context-pack",
         default=None,
         help="Optional handoff_context_pack/v1 JSON to attach to the prepared executor prompt when conflict-free.",
+    )
+    delegate.add_argument(
+        "--from-plan",
+        default=None,
+        help="Read an accepted hermes_plan/v1 Markdown artifact and use it as executor context.",
+    )
+    delegate.add_argument(
+        "--allow-draft-plan",
+        action="store_true",
+        help="Allow --from-plan to use a draft plan. Intended only for explicit operator overrides.",
     )
     delegate.add_argument("--source-event-id", default="", help="Optional source message/event id to store as metadata.")
     delegate.add_argument("--channel-ref", default="", help="Optional channel reference to store as metadata.")

--- a/src/commands/coding.py
+++ b/src/commands/coding.py
@@ -43,7 +43,7 @@ def cmd_coding_delegate(args: argparse.Namespace) -> int:
             if artifact.get("schema_version") != "hermes_plan/v1":
                 raise ValueError("coding delegate --from-plan requires a hermes_plan/v1 artifact")
             plan_status = str(artifact.get("status", ""))
-            if plan_status != "accepted" and not (args.allow_draft_plan or args.force_record):
+            if plan_status != "accepted" and not args.allow_draft_plan:
                 raise ValueError("coding delegate --from-plan requires an accepted plan; use hermes plan-accept or --allow-draft-plan")
             message = build_plan_handoff_message(artifact)
             source_metadata.update(_plan_source_metadata(artifact))

--- a/src/commands/hermes.py
+++ b/src/commands/hermes.py
@@ -5,7 +5,14 @@ import json
 import sys
 from pathlib import Path
 
-from ..hermes_planning import attach_plan_artifact_to_wrapper_contract, build_hermes_plan_payload, write_hermes_plan
+from ..hermes_planning import (
+    attach_plan_artifact_to_wrapper_contract,
+    build_hermes_plan_payload,
+    read_hermes_plan_artifact,
+    update_hermes_plan_status,
+    write_hermes_plan,
+    write_plan_handoff_context_pack,
+)
 from ..ingress import CHAT_SOURCES, extract_message_text, extract_source_metadata
 from ..installer import OmhError
 from .common import _explicit_source_metadata, _paths, _print_json
@@ -13,6 +20,10 @@ from .common import _explicit_source_metadata, _paths, _print_json
 
 def cmd_hermes_plan(args: argparse.Namespace) -> int:
     try:
+        lifecycle_result = _maybe_handle_plan_lifecycle_alias(args)
+        if lifecycle_result is not None:
+            _print_json(lifecycle_result)
+            return 0
         source_metadata: dict[str, str] = {}
         if args.event_json:
             raw = (
@@ -44,6 +55,55 @@ def cmd_hermes_plan(args: argparse.Namespace) -> int:
     return 0
 
 
+def _maybe_handle_plan_lifecycle_alias(args: argparse.Namespace) -> dict[str, object] | None:
+    words = list(getattr(args, "message", []) or [])
+    if len(words) != 2 or words[0] not in {"accept", "revise", "cancel"}:
+        return None
+    path = Path(words[1]).expanduser()
+    looks_like_path = path.exists() or words[1].endswith(".md") or "/" in words[1]
+    if not looks_like_path:
+        return None
+    if args.stdin or args.event_json or args.record:
+        raise ValueError("omh hermes plan accept/revise/cancel cannot be combined with --stdin, --event-json, or --record")
+    status_by_action = {"accept": "accepted", "revise": "revised", "cancel": "cancelled"}
+    return update_hermes_plan_status(_paths(args), path, status=status_by_action[words[0]])
+
+
+def cmd_hermes_plan_accept(args: argparse.Namespace) -> int:
+    try:
+        paths = _paths(args)
+        result = update_hermes_plan_status(paths, args.path, status="accepted", summary=args.summary or "")
+        if args.write_context_pack:
+            artifact = read_hermes_plan_artifact(args.path)
+            result["context_pack"] = write_plan_handoff_context_pack(
+                paths,
+                artifact,
+                executor_target=args.executor,
+            )
+    except (OSError, ValueError) as exc:
+        raise OmhError(str(exc)) from exc
+    _print_json(result)
+    return 0
+
+
+def cmd_hermes_plan_revise(args: argparse.Namespace) -> int:
+    try:
+        result = update_hermes_plan_status(_paths(args), args.path, status="revised", summary=args.note or "")
+    except (OSError, ValueError) as exc:
+        raise OmhError(str(exc)) from exc
+    _print_json(result)
+    return 0
+
+
+def cmd_hermes_plan_cancel(args: argparse.Namespace) -> int:
+    try:
+        result = update_hermes_plan_status(_paths(args), args.path, status="cancelled", summary=args.reason or "")
+    except (OSError, ValueError) as exc:
+        raise OmhError(str(exc)) from exc
+    _print_json(result)
+    return 0
+
+
 def _add_hermes_commands(sub) -> None:
     hermes = sub.add_parser("hermes", help="Build Hermes-facing plan scaffolds for natural-language work.")
     hermes_sub = hermes.add_subparsers(dest="hermes_command", required=True)
@@ -68,3 +128,20 @@ def _add_hermes_commands(sub) -> None:
     plan.add_argument("--channel-ref", default="", help="Optional channel reference to store as metadata.")
     plan.add_argument("--user-ref", default="", help="Optional user reference to store as metadata.")
     plan.set_defaults(func=cmd_hermes_plan)
+
+    plan_accept = hermes_sub.add_parser("plan-accept", help="Mark a file-backed Hermes plan as accepted.")
+    plan_accept.add_argument("path", help="Path to a hermes_plan/v1 Markdown artifact.")
+    plan_accept.add_argument("--summary", default="", help="Optional metadata-only acceptance summary.")
+    plan_accept.add_argument("--write-context-pack", action="store_true", help="Write a handoff_context_pack/v1 pointer for the accepted plan.")
+    plan_accept.add_argument("--executor", default="codex", choices=("codex", "generic", "claude-code", "hermes", "omx-runtime", "omo-runtime", "omc-runtime"))
+    plan_accept.set_defaults(func=cmd_hermes_plan_accept)
+
+    plan_revise = hermes_sub.add_parser("plan-revise", help="Mark a file-backed Hermes plan as revised.")
+    plan_revise.add_argument("path", help="Path to a hermes_plan/v1 Markdown artifact.")
+    plan_revise.add_argument("--note", default="", help="Optional metadata-only revision note.")
+    plan_revise.set_defaults(func=cmd_hermes_plan_revise)
+
+    plan_cancel = hermes_sub.add_parser("plan-cancel", help="Mark a file-backed Hermes plan as cancelled.")
+    plan_cancel.add_argument("path", help="Path to a hermes_plan/v1 Markdown artifact.")
+    plan_cancel.add_argument("--reason", default="", help="Optional metadata-only cancellation reason.")
+    plan_cancel.set_defaults(func=cmd_hermes_plan_cancel)

--- a/src/commands/runtime.py
+++ b/src/commands/runtime.py
@@ -4,6 +4,7 @@ import argparse
 
 from ..installer import OmhError
 from ..runtime.artifacts import (
+    append_journal_observation,
     CI_STATUSES,
     DELEGATION_RESULTS,
     MERGE_STATUSES,
@@ -15,8 +16,8 @@ from ..runtime.artifacts import (
     create_run,
     export_runtime,
     list_runs,
-    read_state_result,
     show_run,
+    read_state_result,
     summarize_delegated_coding_status,
     validate_runtime,
     write_ci_record,
@@ -51,6 +52,7 @@ def _validate_runtime_names(skill: str, harness: str) -> None:
 def cmd_runtime_status(args: argparse.Namespace) -> int:
     paths = _paths(args)
     state, state_error = read_state_result(paths)
+    journal_events, journal_errors = paths.runtime_journal_events_path, []
     _print_json(
         {
             "schema_version": 1,
@@ -58,6 +60,8 @@ def cmd_runtime_status(args: argparse.Namespace) -> int:
             "state_path": str(paths.runtime_state_path),
             "runs_dir": str(paths.runtime_runs_dir),
             "wrapper_sessions_dir": str(paths.runtime_wrapper_sessions_dir),
+            "journal_path": str(journal_events),
+            "journal_errors": journal_errors,
             "state": state,
             "state_error": state_error,
         }
@@ -66,7 +70,12 @@ def cmd_runtime_status(args: argparse.Namespace) -> int:
 
 
 def cmd_runtime_runs(args: argparse.Namespace) -> int:
-    _print_json({"runs": list_runs(_paths(args), limit=_bounded_limit(args))})
+    paths = _paths(args)
+    runs = [
+        {"run_id": run["run_id"], **run, "lifecycle": show_run(paths, run["run_id"]).get("lifecycle", {})}
+        for run in list_runs(paths, limit=_bounded_limit(args))
+    ]
+    _print_json({"runs": runs})
     return 0
 
 
@@ -279,43 +288,72 @@ def cmd_runtime_observe(args: argparse.Namespace) -> int:
     required_file = target_dir / ("run.json" if target_type == "run" else "session.json")
     if not required_file.exists():
         raise OmhError(f"runtime {target_type} not found: {target_id}")
-    _validate_runtime_observation_target(target_dir, target_type, args.runtime_profile)
+    write_legacy_observation = _validate_runtime_observation_target(target_dir, target_type, args.runtime_profile)
     participants = [item.strip() for item in (args.participants or "").split(",") if item.strip()]
     try:
-        observation = write_runtime_observation(
-            target_dir,
-            {
-                "target_type": target_type,
-                "target_id": target_id,
-                "runtime_profile": args.runtime_profile,
-                "event_type": args.event,
-                "status": args.status,
-                "participants": participants,
-                "worktree_ref": args.worktree_ref or "",
-                "worker_ref": args.worker_ref or "",
-                "evidence_refs": args.evidence_ref or [],
-                "summary": args.summary or "",
-            },
-        )
+        observation_payload = {
+            "target_type": target_type,
+            "target_id": target_id,
+            "runtime_profile": args.runtime_profile,
+            "event_type": args.event,
+            "status": args.status,
+            "participants": participants,
+            "worktree_ref": args.worktree_ref or "",
+            "worker_ref": args.worker_ref or "",
+            "evidence_refs": args.evidence_ref or [],
+            "summary": args.summary or "",
+        }
+        if write_legacy_observation:
+            observation = write_runtime_observation(target_dir, observation_payload)
+            journal_event = None
+        else:
+            observation = {}
+            journal_event = append_journal_observation(
+                paths,
+                {
+                    "target_type": target_type,
+                    "target_id": target_id,
+                    "run_id": target_id if target_type == "run" else "",
+                    "runtime_profile": args.runtime_profile,
+                    "event": args.event,
+                    "status": args.status,
+                    "evidence_refs": args.evidence_ref or [],
+                    "summary": args.summary or "",
+                    "source": "runtime_observe",
+                    "worktree_ref": args.worktree_ref or "",
+                    "worker_ref": args.worker_ref or "",
+                },
+            )
     except ValueError as exc:
         raise OmhError(str(exc)) from exc
     payload: dict[str, object] = {"observation": observation}
+    if journal_event:
+        payload["journal_event"] = journal_event
     if target_type == "run":
         payload["status"] = summarize_delegated_coding_status(paths, target_id)
     _print_json(payload)
     return 0
 
 
-def _validate_runtime_observation_target(target_dir, target_type: str, runtime_profile: str) -> None:
+def _validate_runtime_observation_target(target_dir, target_type: str, runtime_profile: str) -> bool:
     expected_profile = _expected_runtime_profile_for_target(target_dir, target_type)
     if expected_profile is None:
-        return
+        return True
     if not expected_profile:
         if target_type == "wrapper_session":
             raise OmhError("runtime observe requires a runtime_handoff_prepared wrapper session")
+        run = read_json_object(target_dir / "run.json")
+        coding = read_json_object(target_dir / "coding_delegation.json")
+        if (
+            isinstance(run, dict)
+            and run.get("artifact_kind") == "prepared_coding_delegation"
+            and isinstance(coding, dict)
+        ):
+            return False
         raise OmhError("runtime observe cannot record runtime events for this non-runtime handoff run")
     if runtime_profile != expected_profile:
         raise OmhError(f"runtime observation profile mismatch: expected {expected_profile}, got {runtime_profile}")
+    return True
 
 
 def _expected_runtime_profile_for_target(target_dir, target_type: str) -> str | None:
@@ -350,7 +388,15 @@ def cmd_runtime_validate(args: argparse.Namespace) -> int:
 
 
 def cmd_runtime_export(args: argparse.Namespace) -> int:
-    _print_json(export_runtime(_paths(args), redacted=args.redacted, limit=_bounded_limit(args), full=not args.summary))
+    _print_json(
+        export_runtime(
+            _paths(args),
+            redacted=args.redacted,
+            limit=_bounded_limit(args),
+            full=not args.summary,
+            run_id=args.run_id,
+        )
+    )
     return 0
 
 
@@ -477,6 +523,7 @@ def _add_runtime_commands(sub) -> None:
     runtime_export.add_argument("--no-redact", dest="redacted", action="store_false")
     runtime_export.add_argument("--limit", type=int, default=50, help="Maximum recent runs and wrapper sessions to include. Use --all to export all.")
     runtime_export.add_argument("--all", action="store_true", help="Export all runs and wrapper sessions.")
+    runtime_export.add_argument("--run", dest="run_id", default=None, help="Export one runtime run and its journal events.")
     runtime_export.add_argument("--summary", action="store_true", help="Export run/session records without full event payloads.")
     runtime_export.set_defaults(func=cmd_runtime_export)
 

--- a/src/hermes_planning.py
+++ b/src/hermes_planning.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
+import hashlib
 import json
 import re
 import secrets
@@ -9,7 +10,9 @@ from pathlib import Path
 from typing import Any
 
 from .ingress import CHAT_SOURCES, extract_message_text, extract_source_metadata
-from .local_store import atomic_write_text
+from .local_store import atomic_write_json, atomic_write_text, utc_now
+from .memory import validate_handoff_context_pack
+from .observation_journal import append_observation_event
 from .paths import OmhPaths
 from .routing.recommend import recommend_skills
 from .skills.catalog import harness_quality_contract
@@ -17,6 +20,7 @@ from .skills.catalog import harness_quality_contract
 
 SCHEMA_VERSION = "hermes_plan/v1"
 WRAPPER_CONTRACT_VERSION = "hermes_plan_wrapper/v1"
+PLAN_STATUSES = ("draft", "accepted", "revised", "cancelled", "superseded", "blocked")
 _REVIEW_TERMS = (
     "architecture",
     "architect",
@@ -147,6 +151,22 @@ def write_hermes_plan(paths: OmhPaths, payload: dict[str, object]) -> dict[str, 
         context_path = _unique_artifact_path(paths.hermes_home / "context", f"{slug}-context", ".md")
         atomic_write_text(context_path, render_context_markdown(payload, context_path.name), private=True)
         artifact["context_path"] = str(context_path)
+    try:
+        artifact["journal_event"] = append_observation_event(
+            paths,
+            {
+                "target_type": "plan",
+                "target_id": str(path),
+                "event": "plan_artifact_created",
+                "status": "observed",
+                "source": "hermes_plan",
+                "plan_artifact": str(path),
+                "plan_status": str(artifact["status"]),
+                "summary": "Hermes file-backed plan artifact was created.",
+            },
+        )
+    except (OSError, ValueError) as exc:
+        artifact["journal_error"] = str(exc)
     return artifact
 
 
@@ -164,6 +184,139 @@ def attach_plan_artifact_to_wrapper_contract(payload: dict[str, object], artifac
     if artifact.get("context_path"):
         plan_artifact["context_path"] = artifact["context_path"]
     contract["plan_artifact"] = plan_artifact
+
+
+def read_hermes_plan_artifact(path: str | Path) -> dict[str, object]:
+    plan_path = Path(path).expanduser().resolve()
+    text = plan_path.read_text(encoding="utf-8")
+    frontmatter, body = _split_frontmatter(text)
+    status = str(frontmatter.get("status", "draft"))
+    task_statement = _section_text(body, "Task Statement") or _heading_title(body)
+    return {
+        "path": str(plan_path),
+        "name": plan_path.name,
+        "schema_version": str(frontmatter.get("schema_version", "")),
+        "status": status,
+        "source": str(frontmatter.get("source", "")),
+        "task_statement": task_statement,
+        "task_statement_sha256": hashlib.sha256(task_statement.encode("utf-8")).hexdigest() if task_statement else "",
+        "task_statement_length": len(task_statement),
+        "sha256": hashlib.sha256(text.encode("utf-8")).hexdigest(),
+        "body": body,
+        "text": text,
+        "frontmatter": frontmatter,
+    }
+
+
+def update_hermes_plan_status(
+    paths: OmhPaths,
+    path: str | Path,
+    *,
+    status: str,
+    summary: str = "",
+) -> dict[str, object]:
+    if status not in PLAN_STATUSES:
+        raise ValueError(f"unsupported plan status: {status}")
+    plan_path = Path(path).expanduser().resolve()
+    current = read_hermes_plan_artifact(plan_path)
+    if current.get("schema_version") != SCHEMA_VERSION:
+        raise ValueError(f"expected {SCHEMA_VERSION} artifact")
+    original = plan_path.read_text(encoding="utf-8")
+    updated = _replace_frontmatter_status(original, status=status, summary=summary)
+    atomic_write_text(plan_path, updated, private=True)
+    artifact = read_hermes_plan_artifact(plan_path)
+    event_name = {
+        "accepted": "plan_accepted",
+        "revised": "plan_revised",
+        "cancelled": "plan_cancelled",
+    }.get(status, "plan_artifact_created")
+    result: dict[str, object] = {"artifact": _plan_artifact_summary(artifact)}
+    try:
+        result["journal_event"] = append_observation_event(
+            paths,
+            {
+                "target_type": "plan",
+                "target_id": str(plan_path),
+                "event": event_name,
+                "status": "observed",
+                "source": "hermes_plan",
+                "plan_artifact": str(plan_path),
+                "plan_status": status,
+                "summary": summary or f"Hermes plan marked {status}.",
+            },
+        )
+    except (OSError, ValueError) as exc:
+        result["journal_error"] = str(exc)
+    return result
+
+
+def build_plan_handoff_message(artifact: dict[str, object]) -> str:
+    return "\n".join(
+        [
+            "Implement the accepted Hermes plan artifact below.",
+            "",
+            f"Plan artifact: {artifact.get('path', '')}",
+            f"Plan status: {artifact.get('status', '')}",
+            f"Plan sha256: {artifact.get('sha256', '')}",
+            "",
+            "Use this file-backed plan as the executor context. The Discord or chat summary is not the executor plan.",
+            "Preserve prepared-vs-observed boundaries: prepared handoff is not execution, review, CI, merge-readiness, or merge evidence.",
+            "",
+            "----- BEGIN ACCEPTED HERMES PLAN -----",
+            str(artifact.get("text", "")).strip(),
+            "----- END ACCEPTED HERMES PLAN -----",
+        ]
+    )
+
+
+def build_plan_handoff_context_pack(artifact: dict[str, object], *, executor_target: str = "codex") -> dict[str, object]:
+    pack = {
+        "schema_version": "handoff_context_pack/v1",
+        "executor_target": executor_target,
+        "session_id": "",
+        "scope": {"kind": "project", "ref": "default"},
+        "source_refs": [
+            {
+                "source": "hermes_plan",
+                "truth_level": "approved_context",
+                "precedence": 95,
+                "item_count": 1,
+            }
+        ],
+        "included_context": [
+            {
+                "item_id": "accepted-hermes-plan",
+                "key": "plan_artifact",
+                "summary": (
+                    f"Accepted Hermes plan artifact status={artifact.get('status', '')}; "
+                    f"sha256={artifact.get('sha256', '')}."
+                ),
+                "source": "hermes_plan",
+                "truth_level": "approved_context",
+                "scope": {"kind": "project", "ref": "default"},
+            }
+        ],
+        "excluded_context": [],
+        "blocked_by_conflicts": [],
+        "redaction_policy": "metadata_only",
+        "claim_boundary": "Plan context pack points to a file-backed Hermes plan; it is not execution evidence.",
+    }
+    errors = validate_handoff_context_pack(pack, require_conflict_free=True, label="plan context pack")
+    if errors:
+        raise ValueError("; ".join(errors))
+    return pack
+
+
+def write_plan_handoff_context_pack(
+    paths: OmhPaths,
+    artifact: dict[str, object],
+    *,
+    executor_target: str = "codex",
+) -> dict[str, object]:
+    pack = build_plan_handoff_context_pack(artifact, executor_target=executor_target)
+    path = paths.runtime_plan_context_dir / f"{Path(str(artifact.get('path', 'plan'))).stem}-context-pack.json"
+    atomic_write_json(path, pack, private=True)
+    return {"path": str(path), "context_pack": pack}
 
 
 def render_plan_markdown(payload: dict[str, object], artifact_name: str = "plan.md") -> str:
@@ -318,6 +471,132 @@ def render_context_markdown(payload: dict[str, object], artifact_name: str = "co
     )
 
 
+def _split_frontmatter(text: str) -> tuple[dict[str, object], str]:
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return {}, text
+    end_index = None
+    for index, line in enumerate(lines[1:], start=1):
+        if line.strip() == "---":
+            end_index = index
+            break
+    if end_index is None:
+        return {}, text
+    frontmatter: dict[str, object] = {}
+    current_parent = ""
+    for raw in lines[1:end_index]:
+        if not raw.strip():
+            continue
+        if raw.startswith((" ", "\t")) and current_parent:
+            key, _, value = raw.strip().partition(":")
+            parent = frontmatter.setdefault(current_parent, {})
+            if isinstance(parent, dict) and key:
+                parent[key] = _unquote_scalar(value.strip())
+            continue
+        key, _, value = raw.partition(":")
+        if not key:
+            continue
+        current_parent = key.strip()
+        frontmatter[current_parent] = _unquote_scalar(value.strip()) if value.strip() else {}
+    return frontmatter, "\n".join(lines[end_index + 1 :]).lstrip("\n")
+
+
+def _replace_frontmatter_status(text: str, *, status: str, summary: str) -> str:
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return "\n".join(
+            [
+                "---",
+                f"schema_version: {SCHEMA_VERSION}",
+                f"status: {status}",
+                f"{status}_at: {utc_now()}",
+                *_status_note_lines(summary),
+                "---",
+                "",
+                text,
+            ]
+        )
+    end_index = None
+    for index, line in enumerate(lines[1:], start=1):
+        if line.strip() == "---":
+            end_index = index
+            break
+    if end_index is None:
+        return text
+    status_written = False
+    timestamp_key = f"{status}_at"
+    timestamp_written = False
+    note_written = False
+    frontmatter: list[str] = []
+    for line in lines[1:end_index]:
+        stripped = line.strip()
+        if stripped.startswith("status:"):
+            frontmatter.append(f"status: {status}")
+            status_written = True
+        elif stripped.startswith(f"{timestamp_key}:"):
+            frontmatter.append(f"{timestamp_key}: {utc_now()}")
+            timestamp_written = True
+        elif stripped.startswith("status_note:") and summary:
+            frontmatter.append(f"status_note: {_yaml_string(summary)}")
+            note_written = True
+        else:
+            frontmatter.append(line)
+    if not status_written:
+        frontmatter.insert(1 if frontmatter else 0, f"status: {status}")
+    if not timestamp_written:
+        frontmatter.append(f"{timestamp_key}: {utc_now()}")
+    if summary and not note_written:
+        frontmatter.extend(_status_note_lines(summary))
+    return "\n".join(["---", *frontmatter, "---", *lines[end_index + 1 :]]) + "\n"
+
+
+def _status_note_lines(summary: str) -> list[str]:
+    return [f"status_note: {_yaml_string(summary)}"] if summary else []
+
+
+def _section_text(body: str, heading: str) -> str:
+    lines = body.splitlines()
+    marker = f"## {heading}"
+    start = None
+    for index, line in enumerate(lines):
+        if line.strip() == marker:
+            start = index + 1
+            break
+    if start is None:
+        return ""
+    collected: list[str] = []
+    for line in lines[start:]:
+        if line.startswith("## "):
+            break
+        collected.append(line)
+    return "\n".join(collected).strip()
+
+
+def _heading_title(body: str) -> str:
+    for line in body.splitlines():
+        if line.startswith("# "):
+            return line[2:].replace("Hermes Plan:", "", 1).strip()
+    return ""
+
+
+def _plan_artifact_summary(artifact: dict[str, object]) -> dict[str, object]:
+    return {
+        "path": artifact.get("path", ""),
+        "kind": "hermes_plan",
+        "schema_version": artifact.get("schema_version", SCHEMA_VERSION),
+        "status": artifact.get("status", "draft"),
+        "sha256": artifact.get("sha256", ""),
+        "task_statement_sha256": artifact.get("task_statement_sha256", ""),
+        "task_statement_length": artifact.get("task_statement_length", 0),
+    }
+
+
+def _unquote_scalar(value: str) -> str:
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        return value[1:-1]
+    return value
+
+
 def _plan_for(task: str, top: dict[str, object]) -> HermesPlan:
     lowered = task.lower()
     score = _int_value(top.get("score", 0))
@@ -362,7 +641,7 @@ def _plan_for(task: str, top: dict[str, object]) -> HermesPlan:
     workflow = "ralplan" if review_shaped else "plan"
     harness = "planning"
     handoff = (
-        "Use `omh coding delegate --executor codex --record` after this plan is accepted for a run-backed Codex handoff."
+        "Use `omh coding delegate --executor codex --record --from-plan <accepted-plan.md>` after this plan is accepted for a run-backed Codex handoff."
         if coding_shaped
         else "Use the selected Hermes workflow only after the plan is accepted."
     )
@@ -516,6 +795,11 @@ def _wrapper_contract(plan: HermesPlan, *, source: str, source_metadata: dict[st
         "current_step": "ask_clarification" if plan.status == "blocked" else "present_plan",
         "next_action": _wrapper_next_action(plan, coding_available),
         "message_field": "plan.task_statement",
+        "plan_artifact_field": "wrapper_contract.plan_artifact.path",
+        "handoff_context_policy": (
+            "After plan acceptance, read the accepted plan artifact or generated handoff context pack "
+            "and pass that to the coding executor. Discord/channel text is only a summary."
+        ),
         "plan_artifact": {
             "recorded": False,
             "kind": "hermes_plan",
@@ -526,7 +810,7 @@ def _wrapper_contract(plan: HermesPlan, *, source: str, source_metadata: dict[st
             "condition": "plan.status is draft and the wrapper or a human accepts the plan",
             "do_not_delegate_when": [
                 "plan.status is blocked",
-                "the wrapper cannot preserve the original task message",
+                "the wrapper cannot provide an accepted plan artifact or generated context pack",
                 "the wrapper would claim review or execution without evidence",
             ],
         },
@@ -538,7 +822,10 @@ def _wrapper_contract(plan: HermesPlan, *, source: str, source_metadata: dict[st
             "requires_plan_acceptance": coding_available,
             "stdout_schema_version": "coding_delegation/v1",
             "recording_contract": "prepared_not_observed",
-            "input_policy": "Pass the original task message directly; do not parse the Markdown plan body.",
+            "input_policy": (
+                "Use accepted plan artifact content or generated context pack; do not use Discord summary "
+                "as the executor plan."
+            ),
         },
     }
     coding_delegate = contract["coding_delegate"]
@@ -555,9 +842,11 @@ def _wrapper_contract(plan: HermesPlan, *, source: str, source_metadata: dict[st
                         "--source",
                         source,
                         "--record",
+                        "--from-plan",
+                        "{plan_artifact}",
                         *metadata_args,
-                        "{message}",
                     ],
+                    "plan_artifact_arg": "--from-plan",
                     "prompt_template_field": "delegation.delegation_prompt_template",
                     "include_message_flag": "--include-message",
                     "recorded_run_field": "runtime.run.run_id",

--- a/src/hermes_planning.py
+++ b/src/hermes_planning.py
@@ -270,11 +270,19 @@ def build_plan_handoff_message(artifact: dict[str, object]) -> str:
 
 
 def build_plan_handoff_context_pack(artifact: dict[str, object], *, executor_target: str = "codex") -> dict[str, object]:
+    plan_artifact_path = str(artifact.get("path", ""))
     pack = {
         "schema_version": "handoff_context_pack/v1",
         "executor_target": executor_target,
         "session_id": "",
         "scope": {"kind": "project", "ref": "default"},
+        "metadata": {
+            "plan_artifact_path": plan_artifact_path,
+            "plan_artifact_ref": plan_artifact_path,
+            "plan_artifact_status": str(artifact.get("status", "")),
+            "plan_artifact_schema_version": str(artifact.get("schema_version", "")),
+            "plan_artifact_sha256": str(artifact.get("sha256", "")),
+        },
         "source_refs": [
             {
                 "source": "hermes_plan",
@@ -291,6 +299,7 @@ def build_plan_handoff_context_pack(artifact: dict[str, object], *, executor_tar
                     f"Accepted Hermes plan artifact status={artifact.get('status', '')}; "
                     f"sha256={artifact.get('sha256', '')}."
                 ),
+                "artifact_ref": plan_artifact_path,
                 "source": "hermes_plan",
                 "truth_level": "approved_context",
                 "scope": {"kind": "project", "ref": "default"},

--- a/src/memory.py
+++ b/src/memory.py
@@ -63,12 +63,13 @@ _HANDOFF_CONTEXT_PACK_KEYS = {
     "included_context",
     "excluded_context",
     "blocked_by_conflicts",
+    "metadata",
     "redaction_policy",
     "claim_boundary",
 }
 _HANDOFF_CONTEXT_SCOPE_KEYS = {"kind", "ref"}
 _HANDOFF_CONTEXT_SOURCE_REF_KEYS = {"source", "truth_level", "precedence", "item_count"}
-_HANDOFF_CONTEXT_INCLUDED_KEYS = {"item_id", "key", "summary", "source", "truth_level", "scope"}
+_HANDOFF_CONTEXT_INCLUDED_KEYS = {"item_id", "key", "summary", "source", "truth_level", "scope", "artifact_ref"}
 _HANDOFF_CONTEXT_EXCLUDED_KEYS = {"item_id", "source", "reason"}
 _HANDOFF_CONTEXT_CONFLICT_KEYS = {
     "item_id",

--- a/src/observation_journal.py
+++ b/src/observation_journal.py
@@ -11,7 +11,7 @@ try:  # pragma: no cover - non-POSIX fallback is exercised only on platforms wit
 except ImportError:  # pragma: no cover
     fcntl = None  # type: ignore[assignment]
 
-from .local_store import ensure_dir, ensure_file, read_jsonl_objects, utc_now
+from .local_store import ensure_dir, ensure_file, read_json_object, read_jsonl_objects, utc_now
 from .paths import OmhPaths
 
 
@@ -107,6 +107,9 @@ def build_observation_event(event: dict[str, Any]) -> dict[str, Any]:
 
 def append_observation_event(paths: OmhPaths, event: dict[str, Any]) -> dict[str, Any]:
     record = build_observation_event(event)
+    sequence_errors = _validate_observation_event_prerequisites(paths, record, _prior_events_for_record(paths, record))
+    if sequence_errors:
+        raise ValueError(sequence_errors[0])
     ensure_dir(paths.runtime_journal_dir, private=True)
     ensure_file(paths.runtime_journal_events_path, private=True)
     with paths.runtime_journal_events_path.open("a", encoding="utf-8") as handle:
@@ -171,15 +174,16 @@ def validate_observation_event(event: dict[str, Any]) -> list[str]:
 
 def validate_observation_journal(paths: OmhPaths, *, run_id: str | None = None) -> dict[str, Any]:
     events, errors = read_observation_events_result(paths)
-    filtered: list[dict[str, Any]] = []
+    filtered: list[tuple[int, dict[str, Any]]] = []
     for index, event in enumerate(events, start=1):
         if run_id and str(event.get("run_id", "")) != run_id:
             continue
-        filtered.append(event)
+        filtered.append((index, event))
         errors.extend(
             f"{paths.runtime_journal_events_path}:{index}: {error}"
             for error in validate_observation_event(event)
         )
+    errors.extend(_validate_observation_event_sequence(paths, filtered))
     return {
         "schema_version": "omh_observation_journal_validation/v1",
         "path": str(paths.runtime_journal_events_path),
@@ -187,6 +191,148 @@ def validate_observation_journal(paths: OmhPaths, *, run_id: str | None = None) 
         "event_count": len(filtered),
         "errors": errors,
     }
+
+
+def _prior_events_for_record(paths: OmhPaths, record: dict[str, Any]) -> list[dict[str, Any]]:
+    run_id = str(record.get("run_id", ""))
+    if not run_id:
+        return []
+    events, _ = read_observation_events_result(paths)
+    return [event for event in events if isinstance(event, dict) and str(event.get("run_id", "")) == run_id]
+
+
+def _validate_observation_event_sequence(paths: OmhPaths, indexed_events: list[tuple[int, dict[str, Any]]]) -> list[str]:
+    errors: list[str] = []
+    prior_by_run: dict[str, list[dict[str, Any]]] = {}
+    for index, event in indexed_events:
+        run_id = str(event.get("run_id", ""))
+        prior = prior_by_run.setdefault(run_id, [])
+        for error in _validate_observation_event_prerequisites(paths, event, prior):
+            errors.append(f"{paths.runtime_journal_events_path}:{index}: {error}")
+        prior.append(event)
+    return errors
+
+
+def _validate_observation_event_prerequisites(
+    paths: OmhPaths,
+    event: dict[str, Any],
+    prior_events: list[dict[str, Any]],
+) -> list[str]:
+    run_id = str(event.get("run_id", ""))
+    if not run_id or str(event.get("target_type", "")) != "run":
+        return []
+    event_name = canonical_observation_event(str(event.get("event", "")))
+    if event_name not in _ORDERED_LIFECYCLE_EVENTS or str(event.get("status", "observed")) == "not_observed":
+        return []
+    state = _lifecycle_prerequisite_state(prior_events)
+    review_required = _journal_review_required(paths, run_id)
+    errors: list[str] = []
+    if event_name == "executor_result_observed":
+        _require_prerequisites(event_name, state, ["executor_dispatch_observed"], errors)
+    elif event_name == "verification_result_observed":
+        _require_prerequisites(
+            event_name,
+            state,
+            ["executor_dispatch_observed", "executor_result_observed"],
+            errors,
+        )
+    elif event_name == "review_result_observed":
+        _require_prerequisites(event_name, state, ["verification_result_observed"], errors)
+    elif event_name == "ci_result_observed":
+        required = ["verification_result_observed"]
+        if review_required or state["review_seen"]:
+            required.append("review_result_observed")
+        _require_prerequisites(event_name, state, required, errors)
+    elif event_name == "merge_gate_observed":
+        required = [
+            "executor_dispatch_observed",
+            "executor_result_observed",
+            "verification_result_observed",
+        ]
+        if review_required or state["review_seen"]:
+            required.append("review_result_observed")
+        if state["review_result_observed"] or state["ci_seen"]:
+            required.append("ci_result_observed")
+        _require_prerequisites(event_name, state, required, errors)
+    elif event_name == "merge_observed":
+        required = [
+            "executor_dispatch_observed",
+            "executor_result_observed",
+            "verification_result_observed",
+        ]
+        if review_required or state["review_seen"]:
+            required.append("review_result_observed")
+        if state["review_result_observed"] or state["ci_seen"]:
+            required.append("ci_result_observed")
+        required.append("merge_gate_observed")
+        _require_prerequisites(event_name, state, required, errors)
+    return errors
+
+
+_ORDERED_LIFECYCLE_EVENTS = {
+    "executor_result_observed",
+    "verification_result_observed",
+    "review_result_observed",
+    "ci_result_observed",
+    "merge_gate_observed",
+    "merge_observed",
+}
+
+
+def _lifecycle_prerequisite_state(events: list[dict[str, Any]]) -> dict[str, bool]:
+    state = {
+        "executor_dispatch_observed": False,
+        "executor_result_observed": False,
+        "verification_result_observed": False,
+        "review_result_observed": False,
+        "ci_result_observed": False,
+        "merge_gate_observed": False,
+        "review_seen": False,
+        "ci_seen": False,
+    }
+    for event in events:
+        event_name = canonical_observation_event(str(event.get("event", "")))
+        status = str(event.get("status", "observed"))
+        if event_name == "review_result_observed":
+            state["review_seen"] = True
+        elif event_name == "ci_result_observed":
+            state["ci_seen"] = True
+        if status != "observed":
+            continue
+        if event_name in state:
+            state[event_name] = True
+    return state
+
+
+def _require_prerequisites(
+    event_name: str,
+    state: dict[str, bool],
+    required_events: list[str],
+    errors: list[str],
+) -> None:
+    missing = [required for required in required_events if not state.get(required, False)]
+    if missing:
+        errors.append(f"{event_name} requires {_join_required_events(missing)}")
+
+
+def _join_required_events(events: list[str]) -> str:
+    if len(events) <= 1:
+        return events[0] if events else ""
+    if len(events) == 2:
+        return f"{events[0]} and {events[1]}"
+    return f"{', '.join(events[:-1])}, and {events[-1]}"
+
+
+def _journal_review_required(paths: OmhPaths, run_id: str) -> bool:
+    try:
+        coding = read_json_object(paths.runtime_runs_dir / run_id / "coding_delegation.json")
+    except (OSError, json.JSONDecodeError, ValueError):
+        return False
+    if not isinstance(coding, dict):
+        return False
+    handoff = coding.get("executor_handoff")
+    review = handoff.get("review") if isinstance(handoff, dict) and isinstance(handoff.get("review"), dict) else {}
+    return bool(review.get("required", coding.get("review_required", False)))
 
 
 def project_run_lifecycle(

--- a/src/observation_journal.py
+++ b/src/observation_journal.py
@@ -1,0 +1,398 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import secrets
+from pathlib import Path
+from typing import Any
+
+try:  # pragma: no cover - non-POSIX fallback is exercised only on platforms without fcntl.
+    import fcntl
+except ImportError:  # pragma: no cover
+    fcntl = None  # type: ignore[assignment]
+
+from .local_store import ensure_dir, ensure_file, read_jsonl_objects, utc_now
+from .paths import OmhPaths
+
+
+OBSERVATION_EVENT_SCHEMA_VERSION = "omh_observation_event/v1"
+LIFECYCLE_PROJECTION_SCHEMA_VERSION = "omh_lifecycle_projection/v1"
+OBSERVATION_PRIVACY = "metadata_only"
+OBSERVATION_STATUSES = ("observed", "blocked", "failed", "not_observed")
+CANONICAL_OBSERVATION_EVENTS = (
+    "prepared_handoff_created",
+    "plan_artifact_created",
+    "plan_accepted",
+    "plan_revised",
+    "plan_cancelled",
+    "runtime_start_observed",
+    "worktree_creation_observed",
+    "executor_dispatch_observed",
+    "executor_result_observed",
+    "verification_result_observed",
+    "review_result_observed",
+    "ci_result_observed",
+    "merge_gate_observed",
+    "merge_observed",
+    "blocked",
+    "failed",
+    "cancelled",
+)
+OBSERVATION_EVENT_ALIASES = {
+    "coding_handoff_prepared": "prepared_handoff_created",
+    "handoff_prepared": "prepared_handoff_created",
+    "runtime_start": "runtime_start_observed",
+    "worktree_creation": "worktree_creation_observed",
+    "worker_dispatch": "executor_dispatch_observed",
+    "executor_dispatch": "executor_dispatch_observed",
+    "worker_result": "executor_result_observed",
+    "executor_result": "executor_result_observed",
+    "verification": "verification_result_observed",
+    "review": "review_result_observed",
+    "ci": "ci_result_observed",
+    "merge_readiness": "merge_gate_observed",
+    "merge_gate": "merge_gate_observed",
+    "merge": "merge_observed",
+}
+PROJECTION_ORDER = (
+    "prepared_not_observed",
+    "runtime_start_observed",
+    "worktree_creation_observed",
+    "dispatch_observed",
+    "execution_observed",
+    "verification_observed",
+    "review_observed",
+    "ci_observed",
+    "merge_gate_observed",
+    "merge_observed",
+)
+
+
+def canonical_observation_event(event: str) -> str:
+    value = str(event).strip()
+    return OBSERVATION_EVENT_ALIASES.get(value, value)
+
+
+def build_observation_event(event: dict[str, Any]) -> dict[str, Any]:
+    canonical = canonical_observation_event(str(event.get("event", "")))
+    observed_at = str(event.get("observed_at") or event.get("updated_at") or utc_now())
+    evidence_refs = _evidence_refs(event)
+    record: dict[str, Any] = {
+        "schema_version": OBSERVATION_EVENT_SCHEMA_VERSION,
+        "event_id": str(event.get("event_id") or _event_id(observed_at, event)),
+        "target_type": str(event.get("target_type") or ("run" if event.get("run_id") else "runtime")),
+        "target_id": str(event.get("target_id") or event.get("run_id") or event.get("session_id") or ""),
+        "run_id": str(event.get("run_id") or ""),
+        "workflow": str(event.get("workflow") or event.get("skill") or ""),
+        "harness": str(event.get("harness") or ""),
+        "phase": str(event.get("phase") or ""),
+        "event": canonical,
+        "status": str(event.get("status") or "observed"),
+        "observed_at": observed_at,
+        "source": str(event.get("source") or ""),
+        "actor": str(event.get("actor") or ""),
+        "runtime_profile": str(event.get("runtime_profile") or ""),
+        "evidence_refs": evidence_refs,
+        "summary": _bounded_summary(event.get("summary", "")),
+        "privacy": OBSERVATION_PRIVACY,
+    }
+    for key in ("plan_artifact", "plan_status", "worktree_ref", "worker_ref"):
+        if event.get(key):
+            record[key] = str(event[key])
+    errors = validate_observation_event(record)
+    if errors:
+        raise ValueError(errors[0])
+    return record
+
+
+def append_observation_event(paths: OmhPaths, event: dict[str, Any]) -> dict[str, Any]:
+    record = build_observation_event(event)
+    ensure_dir(paths.runtime_journal_dir, private=True)
+    ensure_file(paths.runtime_journal_events_path, private=True)
+    with paths.runtime_journal_events_path.open("a", encoding="utf-8") as handle:
+        if fcntl is not None:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        try:
+            handle.write(json.dumps(record, sort_keys=True) + "\n")
+            handle.flush()
+        finally:
+            if fcntl is not None:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    return record
+
+
+def read_observation_events_result(paths: OmhPaths) -> tuple[list[dict[str, Any]], list[str]]:
+    return read_jsonl_objects(paths.runtime_journal_events_path)
+
+
+def read_observation_events(
+    paths: OmhPaths,
+    *,
+    run_id: str | None = None,
+    target_type: str | None = None,
+    target_id: str | None = None,
+    limit: int | None = None,
+) -> list[dict[str, Any]]:
+    events, _ = read_observation_events_result(paths)
+    if run_id is not None:
+        events = [event for event in events if str(event.get("run_id", "")) == run_id]
+    if target_type is not None:
+        events = [event for event in events if str(event.get("target_type", "")) == target_type]
+    if target_id is not None:
+        events = [event for event in events if str(event.get("target_id", "")) == target_id]
+    return _apply_limit(events, limit)
+
+
+def validate_observation_event(event: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if event.get("schema_version") != OBSERVATION_EVENT_SCHEMA_VERSION:
+        errors.append(f"observation_event schema_version must be {OBSERVATION_EVENT_SCHEMA_VERSION}")
+    for key in ("event_id", "target_type", "target_id", "run_id", "event", "status", "observed_at", "privacy"):
+        if not isinstance(event.get(key), str):
+            errors.append(f"observation_event {key} must be a string")
+    if event.get("event") not in CANONICAL_OBSERVATION_EVENTS:
+        errors.append(f"observation_event event is unsupported: {event.get('event')!r}")
+    if event.get("status") not in OBSERVATION_STATUSES:
+        errors.append(f"observation_event status is unsupported: {event.get('status')!r}")
+    if event.get("privacy") != OBSERVATION_PRIVACY:
+        errors.append("observation_event privacy must be metadata_only")
+    if not isinstance(event.get("evidence_refs"), list):
+        errors.append("observation_event evidence_refs must be a list")
+    else:
+        for index, value in enumerate(event.get("evidence_refs", [])):
+            if not isinstance(value, str):
+                errors.append(f"observation_event evidence_refs[{index}] must be a string")
+    if not isinstance(event.get("summary"), str):
+        errors.append("observation_event summary must be a string")
+    if event.get("target_type") == "run" and not event.get("run_id"):
+        errors.append("observation_event target_type=run requires run_id")
+    return errors
+
+
+def validate_observation_journal(paths: OmhPaths, *, run_id: str | None = None) -> dict[str, Any]:
+    events, errors = read_observation_events_result(paths)
+    filtered: list[dict[str, Any]] = []
+    for index, event in enumerate(events, start=1):
+        if run_id and str(event.get("run_id", "")) != run_id:
+            continue
+        filtered.append(event)
+        errors.extend(
+            f"{paths.runtime_journal_events_path}:{index}: {error}"
+            for error in validate_observation_event(event)
+        )
+    return {
+        "schema_version": "omh_observation_journal_validation/v1",
+        "path": str(paths.runtime_journal_events_path),
+        "ok": not errors,
+        "event_count": len(filtered),
+        "errors": errors,
+    }
+
+
+def project_run_lifecycle(
+    events: list[dict[str, Any]],
+    *,
+    run_id: str = "",
+    workflow: str = "",
+    harness: str = "",
+    phase: str = "",
+) -> dict[str, Any]:
+    projection: dict[str, Any] = {
+        "schema_version": LIFECYCLE_PROJECTION_SCHEMA_VERSION,
+        "run_id": run_id,
+        "workflow": workflow,
+        "harness": harness,
+        "phase": phase,
+        "prepared_handoff": False,
+        "plan_artifact": "",
+        "plan_status": "",
+        "prompt_dispatched": False,
+        "runtime_start_observed": False,
+        "worktree_observed": False,
+        "execution_observed": False,
+        "verification_observed": False,
+        "review_observed": False,
+        "ci_observed": False,
+        "merge_gate_observed": False,
+        "merge_observed": False,
+        "blocked": False,
+        "failed": False,
+        "cancelled": False,
+        "observation_status": "unknown",
+        "journal_event_count": 0,
+        "latest_event_id": "",
+        "latest_event": {},
+    }
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        event_run_id = str(event.get("run_id", ""))
+        if run_id and event_run_id and event_run_id != run_id:
+            continue
+        _fold_event(projection, event)
+    if projection["journal_event_count"] == 0 and projection["prepared_handoff"]:
+        projection["observation_status"] = "prepared_not_observed"
+    return projection
+
+
+def observation_status_from_projection(projection: dict[str, Any], fallback: str = "unknown") -> str:
+    status = str(projection.get("observation_status") or "")
+    return status if status and status != "unknown" else fallback
+
+
+def merge_lifecycle_projection(legacy: dict[str, Any], journal: dict[str, Any]) -> dict[str, Any]:
+    merged = {**legacy, **journal}
+    for key in (
+        "prepared_handoff",
+        "prompt_dispatched",
+        "runtime_start_observed",
+        "worktree_observed",
+        "execution_observed",
+        "verification_observed",
+        "review_observed",
+        "ci_observed",
+        "merge_gate_observed",
+        "merge_observed",
+        "blocked",
+        "failed",
+        "cancelled",
+    ):
+        merged[key] = bool(legacy.get(key)) or bool(journal.get(key))
+    for key in ("run_id", "workflow", "harness", "phase", "plan_artifact", "plan_status"):
+        merged[key] = journal.get(key) or legacy.get(key, "")
+    merged["observation_status"] = _max_status(
+        str(legacy.get("observation_status", "unknown")),
+        str(journal.get("observation_status", "unknown")),
+    )
+    merged["journal_event_count"] = int(journal.get("journal_event_count", 0) or 0)
+    merged["latest_event_id"] = str(journal.get("latest_event_id", ""))
+    merged["latest_event"] = journal.get("latest_event", {})
+    return merged
+
+
+def _fold_event(projection: dict[str, Any], event: dict[str, Any]) -> None:
+    status = str(event.get("status", "observed"))
+    event_name = canonical_observation_event(str(event.get("event", "")))
+    projection["journal_event_count"] = int(projection.get("journal_event_count", 0)) + 1
+    projection["latest_event_id"] = str(event.get("event_id", ""))
+    projection["latest_event"] = {
+        "event": event_name,
+        "status": status,
+        "summary": str(event.get("summary", "")),
+        "observed_at": str(event.get("observed_at", "")),
+    }
+    if event.get("workflow") and not projection.get("workflow"):
+        projection["workflow"] = str(event.get("workflow", ""))
+    if event.get("harness") and not projection.get("harness"):
+        projection["harness"] = str(event.get("harness", ""))
+    if event.get("phase"):
+        projection["phase"] = str(event.get("phase", ""))
+    if event.get("plan_artifact"):
+        projection["plan_artifact"] = str(event.get("plan_artifact", ""))
+    if event.get("plan_status"):
+        projection["plan_status"] = str(event.get("plan_status", ""))
+    if event_name == "plan_accepted":
+        projection["plan_status"] = "accepted"
+    elif event_name == "plan_revised":
+        projection["plan_status"] = "revised"
+    elif event_name == "plan_cancelled":
+        projection["plan_status"] = "cancelled"
+    if status == "blocked":
+        projection["blocked"] = True
+        projection["observation_status"] = "blocked"
+    elif status == "failed":
+        projection["failed"] = True
+        projection["observation_status"] = "failed"
+    if status != "observed":
+        return
+    if event_name == "prepared_handoff_created":
+        projection["prepared_handoff"] = True
+        _advance_status(projection, "prepared_not_observed")
+    elif event_name == "runtime_start_observed":
+        projection["runtime_start_observed"] = True
+        _advance_status(projection, "runtime_start_observed")
+    elif event_name == "worktree_creation_observed":
+        projection["worktree_observed"] = True
+        _advance_status(projection, "worktree_creation_observed")
+    elif event_name == "executor_dispatch_observed":
+        projection["prompt_dispatched"] = True
+        _advance_status(projection, "dispatch_observed")
+    elif event_name == "executor_result_observed":
+        projection["execution_observed"] = True
+        _advance_status(projection, "execution_observed")
+    elif event_name == "verification_result_observed":
+        projection["verification_observed"] = True
+        _advance_status(projection, "verification_observed")
+    elif event_name == "review_result_observed":
+        projection["review_observed"] = True
+        _advance_status(projection, "review_observed")
+    elif event_name == "ci_result_observed":
+        projection["ci_observed"] = True
+        _advance_status(projection, "ci_observed")
+    elif event_name == "merge_gate_observed":
+        projection["merge_gate_observed"] = True
+        _advance_status(projection, "merge_gate_observed")
+    elif event_name == "merge_observed":
+        projection["merge_observed"] = True
+        _advance_status(projection, "merge_observed")
+    elif event_name == "blocked":
+        projection["blocked"] = True
+        projection["observation_status"] = "blocked"
+    elif event_name == "failed":
+        projection["failed"] = True
+        projection["observation_status"] = "failed"
+    elif event_name == "cancelled":
+        projection["cancelled"] = True
+        projection["observation_status"] = "cancelled"
+
+
+def _event_id(observed_at: str, event: dict[str, Any]) -> str:
+    base = json.dumps(
+        {
+            "observed_at": observed_at,
+            "run_id": event.get("run_id", ""),
+            "target_id": event.get("target_id", ""),
+            "event": event.get("event", ""),
+            "summary": event.get("summary", ""),
+        },
+        sort_keys=True,
+    )
+    digest = hashlib.sha256(base.encode("utf-8")).hexdigest()[:10]
+    return f"{observed_at.replace(':', '').replace('-', '').replace('.', '')}-{digest}-{secrets.token_hex(2)}"
+
+
+def _evidence_refs(event: dict[str, Any]) -> list[str]:
+    refs = event.get("evidence_refs", event.get("evidence_ref", []))
+    if isinstance(refs, str):
+        refs = [refs]
+    if not isinstance(refs, list):
+        return []
+    return [str(ref) for ref in refs if str(ref)]
+
+
+def _bounded_summary(value: Any, limit: int = 500) -> str:
+    text = " ".join(str(value or "").split())
+    return text[:limit]
+
+
+def _apply_limit(events: list[dict[str, Any]], limit: int | None) -> list[dict[str, Any]]:
+    if limit is None:
+        return events
+    if limit < 1:
+        return []
+    return events[-limit:]
+
+
+def _advance_status(projection: dict[str, Any], candidate: str) -> None:
+    projection["observation_status"] = _max_status(str(projection.get("observation_status", "unknown")), candidate)
+
+
+def _max_status(current: str, candidate: str) -> str:
+    if candidate in {"blocked", "failed", "cancelled"}:
+        return candidate
+    if current in {"blocked", "failed", "cancelled"}:
+        return current
+    try:
+        return candidate if PROJECTION_ORDER.index(candidate) >= PROJECTION_ORDER.index(current) else current
+    except ValueError:
+        return candidate if current == "unknown" else current

--- a/src/paths.py
+++ b/src/paths.py
@@ -47,6 +47,18 @@ class OmhPaths:
         return self.runtime_dir / "worktrees.jsonl"
 
     @property
+    def runtime_journal_dir(self) -> Path:
+        return self.runtime_dir / "journal"
+
+    @property
+    def runtime_journal_events_path(self) -> Path:
+        return self.runtime_journal_dir / "events.jsonl"
+
+    @property
+    def runtime_plan_context_dir(self) -> Path:
+        return self.runtime_dir / "plan-context"
+
+    @property
     def release_evidence_dir(self) -> Path:
         return self.runtime_dir / "release-evidence"
 

--- a/src/plugin_bundle/omh/runtime_reader.py
+++ b/src/plugin_bundle/omh/runtime_reader.py
@@ -12,6 +12,22 @@ HUD_SCHEMA_VERSION = "omh_hud/v1"
 HUD_PRESETS = {"minimal", "focused", "full"}
 HUD_REQUIRED_TOOLS = PROVIDED_TOOLS
 HUD_REQUIRED_HOOKS = PROVIDED_HOOKS
+OBSERVATION_EVENT_SCHEMA_VERSION = "omh_observation_event/v1"
+JOURNAL_EVENT_ALIASES = {
+    "coding_handoff_prepared": "prepared_handoff_created",
+    "handoff_prepared": "prepared_handoff_created",
+    "runtime_start": "runtime_start_observed",
+    "worktree_creation": "worktree_creation_observed",
+    "worker_dispatch": "executor_dispatch_observed",
+    "executor_dispatch": "executor_dispatch_observed",
+    "worker_result": "executor_result_observed",
+    "executor_result": "executor_result_observed",
+    "verification": "verification_result_observed",
+    "review": "review_result_observed",
+    "ci": "ci_result_observed",
+    "merge_readiness": "merge_gate_observed",
+    "merge": "merge_observed",
+}
 
 
 def _expand_path(value: str | Path) -> Path:
@@ -34,6 +50,24 @@ def _read_json(path: Path) -> dict[str, Any]:
     return data if isinstance(data, dict) else {}
 
 
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return []
+    records: list[dict[str, Any]] = []
+    for line in lines:
+        if not line.strip():
+            continue
+        try:
+            data = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(data, dict):
+            records.append(data)
+    return records
+
+
 def _bool_from_record(record: dict[str, Any], key: str = "observed") -> bool:
     return bool(record.get(key, False)) if record else False
 
@@ -46,7 +80,7 @@ def _summarize_run(run_dir: Path) -> dict[str, Any]:
     review = _read_json(run_dir / "review.json")
     ci = _read_json(run_dir / "ci.json")
     merge = _read_json(run_dir / "merge.json")
-    return {
+    legacy = {
         "run_id": str(run.get("run_id", run_dir.name)),
         "workflow": str(coding.get("recommended_workflow") or run.get("skill", "unknown")),
         "harness": str(coding.get("recommended_harness") or run.get("harness", "unknown")),
@@ -65,6 +99,12 @@ def _summarize_run(run_dir: Path) -> dict[str, Any]:
         "merge_observed": _bool_from_record(merge),
         "merge_status": str(merge.get("status", "not_observed" if merge else "unknown")),
     }
+    lifecycle = _journal_projection_for_run(run_dir, legacy)
+    _apply_lifecycle_to_run_summary(legacy, lifecycle)
+    legacy["lifecycle"] = lifecycle
+    legacy["journal_event_count"] = lifecycle["journal_event_count"]
+    legacy["latest_event"] = lifecycle["latest_event"]
+    return legacy
 
 
 def _executor_target_from_coding(coding: dict[str, Any]) -> str:
@@ -82,6 +122,130 @@ def _executor_target_from_coding(coding: dict[str, Any]) -> str:
             return value
     value = str(coding.get("selected_executor_profile") or coding.get("executor_profile") or "").strip()
     return value
+
+
+def _journal_projection_for_run(run_dir: Path, legacy: dict[str, Any]) -> dict[str, Any]:
+    run_id = str(legacy.get("run_id", run_dir.name))
+    runtime_dir = run_dir.parents[1]
+    events = [
+        event
+        for event in _read_jsonl(runtime_dir / "journal" / "events.jsonl")
+        if event.get("schema_version") == OBSERVATION_EVENT_SCHEMA_VERSION
+        and str(event.get("run_id", "")) == run_id
+    ]
+    projection: dict[str, Any] = {
+        "schema_version": "omh_lifecycle_projection/v1",
+        "run_id": run_id,
+        "workflow": str(legacy.get("workflow", "")),
+        "harness": str(legacy.get("harness", "")),
+        "phase": str(legacy.get("phase", "")),
+        "prepared_handoff": bool(legacy.get("prepared_handoff", False)),
+        "plan_artifact": "",
+        "plan_status": "",
+        "prompt_dispatched": bool(legacy.get("prompt_dispatched", False)),
+        "runtime_start_observed": False,
+        "worktree_observed": False,
+        "execution_observed": bool(legacy.get("execution_observed", False)),
+        "verification_observed": bool(legacy.get("verification_observed", False)),
+        "review_observed": bool(legacy.get("review_observed", False)),
+        "ci_observed": bool(legacy.get("ci_observed", False)),
+        "merge_gate_observed": False,
+        "merge_observed": bool(legacy.get("merge_observed", False)),
+        "observation_status": str(legacy.get("observation_status", "unknown")),
+        "journal_event_count": len(events),
+        "latest_event_id": "",
+        "latest_event": {},
+    }
+    for event in events:
+        name = JOURNAL_EVENT_ALIASES.get(str(event.get("event", "")), str(event.get("event", "")))
+        status = str(event.get("status", "observed"))
+        projection["latest_event_id"] = str(event.get("event_id", ""))
+        projection["latest_event"] = {
+            "event": name,
+            "status": status,
+            "summary": str(event.get("summary", "")),
+            "observed_at": str(event.get("observed_at", "")),
+        }
+        if event.get("plan_artifact"):
+            projection["plan_artifact"] = str(event.get("plan_artifact", ""))
+        if event.get("plan_status"):
+            projection["plan_status"] = str(event.get("plan_status", ""))
+        if status != "observed":
+            if status in {"blocked", "failed"}:
+                projection["observation_status"] = status
+            continue
+        if name == "prepared_handoff_created":
+            projection["prepared_handoff"] = True
+            projection["observation_status"] = _later_status(projection["observation_status"], "prepared_not_observed")
+        elif name == "runtime_start_observed":
+            projection["runtime_start_observed"] = True
+            projection["observation_status"] = _later_status(projection["observation_status"], "runtime_start_observed")
+        elif name == "worktree_creation_observed":
+            projection["worktree_observed"] = True
+            projection["observation_status"] = _later_status(projection["observation_status"], "worktree_creation_observed")
+        elif name == "executor_dispatch_observed":
+            projection["prompt_dispatched"] = True
+            projection["observation_status"] = _later_status(projection["observation_status"], "dispatch_observed")
+        elif name == "executor_result_observed":
+            projection["execution_observed"] = True
+            projection["observation_status"] = _later_status(projection["observation_status"], "execution_observed")
+        elif name == "verification_result_observed":
+            projection["verification_observed"] = True
+            projection["observation_status"] = _later_status(projection["observation_status"], "verification_observed")
+        elif name == "review_result_observed":
+            projection["review_observed"] = True
+            projection["observation_status"] = _later_status(projection["observation_status"], "review_observed")
+        elif name == "ci_result_observed":
+            projection["ci_observed"] = True
+            projection["observation_status"] = _later_status(projection["observation_status"], "ci_observed")
+        elif name == "merge_gate_observed":
+            projection["merge_gate_observed"] = True
+            projection["observation_status"] = _later_status(projection["observation_status"], "merge_gate_observed")
+        elif name == "merge_observed":
+            projection["merge_observed"] = True
+            projection["observation_status"] = _later_status(projection["observation_status"], "merge_observed")
+    return projection
+
+
+def _apply_lifecycle_to_run_summary(summary: dict[str, Any], lifecycle: dict[str, Any]) -> None:
+    for key in (
+        "prepared_handoff",
+        "prompt_dispatched",
+        "execution_observed",
+        "verification_observed",
+        "review_observed",
+        "ci_observed",
+        "merge_observed",
+    ):
+        summary[key] = bool(summary.get(key, False)) or bool(lifecycle.get(key, False))
+    if lifecycle.get("observation_status") and lifecycle.get("observation_status") != "unknown":
+        summary["observation_status"] = str(lifecycle["observation_status"])
+    if lifecycle.get("plan_artifact"):
+        summary["plan_artifact"] = lifecycle["plan_artifact"]
+    if lifecycle.get("plan_status"):
+        summary["plan_status"] = lifecycle["plan_status"]
+
+
+def _later_status(current: str, candidate: str) -> str:
+    order = [
+        "unknown",
+        "prepared_not_observed",
+        "runtime_start_observed",
+        "worktree_creation_observed",
+        "dispatch_observed",
+        "execution_observed",
+        "verification_observed",
+        "review_observed",
+        "ci_observed",
+        "merge_gate_observed",
+        "merge_observed",
+    ]
+    if current in {"blocked", "failed", "cancelled"}:
+        return current
+    try:
+        return candidate if order.index(candidate) >= order.index(current) else current
+    except ValueError:
+        return candidate
 
 
 def read_omh_hud(
@@ -505,6 +669,7 @@ def read_omh_status(omh_home: str | Path | None = None, limit: int = 5) -> dict[
         "schema_version": STATUS_SCHEMA_VERSION,
         "omh_home": str(home),
         "runtime_dir": str(runtime_dir),
+        "journal_path": str(runtime_dir / "journal" / "events.jsonl"),
         "runtime_state_present": bool(state),
         "latest_run_id": str(state.get("last_run_id", "")) if state else "",
         "plugin_session_end": _read_json(runtime_dir / "plugin-session-end.json"),

--- a/src/runtime/artifacts.py
+++ b/src/runtime/artifacts.py
@@ -19,6 +19,13 @@ from ..local_store import (
     read_jsonl_objects,
     utc_now,
 )
+from ..observation_journal import (
+    append_observation_event,
+    merge_lifecycle_projection,
+    project_run_lifecycle,
+    read_observation_events_result,
+    validate_observation_journal,
+)
 from ..paths import OmhPaths
 from .records import (
     DELEGATION_RESULTS,
@@ -135,7 +142,23 @@ def create_prepared_coding_delegation_run(paths: OmhPaths, metadata: dict[str, A
         "phase": "prepared",
         "observation_status": "prepared_not_observed",
     }
-    return create_run(paths, prepared_metadata)
+    run = create_run(paths, prepared_metadata)
+    append_observation_event(
+        paths,
+        {
+            "target_type": "run",
+            "target_id": run["run_id"],
+            "run_id": run["run_id"],
+            "workflow": run.get("skill", ""),
+            "harness": run.get("harness", ""),
+            "phase": "prepared",
+            "event": "prepared_handoff_created",
+            "status": "observed",
+            "source": "omh-runtime",
+            "summary": "Prepared coding handoff recorded; execution is not observed.",
+        },
+    )
+    return run
 
 
 def append_event(run_dir: Path, event: dict[str, Any]) -> dict[str, Any]:
@@ -297,7 +320,109 @@ def write_runtime_observation(target_dir: Path, observation: dict[str, Any]) -> 
             },
         },
     )
+    _append_runtime_observation_to_journal(target_dir, record)
     return record
+
+
+def append_journal_observation(paths: OmhPaths, observation: dict[str, Any]) -> dict[str, Any]:
+    return append_observation_event(paths, observation)
+
+
+def _append_runtime_observation_to_journal(target_dir: Path, record: dict[str, Any]) -> None:
+    try:
+        runtime_dir = target_dir.parents[1]
+        paths = OmhPaths(omh_home=runtime_dir.parent, hermes_home=Path("~/.hermes").expanduser())
+        append_observation_event(
+            paths,
+            {
+                "target_type": record.get("target_type", ""),
+                "target_id": record.get("target_id", ""),
+                "run_id": record.get("target_id", "") if record.get("target_type") == "run" else "",
+                "event": record.get("event_type", ""),
+                "status": record.get("status", "observed"),
+                "observed_at": record.get("updated_at", ""),
+                "runtime_profile": record.get("runtime_profile", ""),
+                "evidence_refs": record.get("evidence_refs", []),
+                "summary": record.get("summary", ""),
+                "source": "runtime_observation",
+                "worktree_ref": record.get("worktree_ref", ""),
+                "worker_ref": record.get("worker_ref", ""),
+            },
+        )
+    except (IndexError, OSError, ValueError):
+        return
+
+
+def _journal_events_for_run_result(paths: OmhPaths, run_id: str) -> tuple[list[dict[str, Any]], list[str]]:
+    events, errors = read_observation_events_result(paths)
+    return [event for event in events if str(event.get("run_id", "")) == run_id], errors
+
+
+def _lifecycle_projection_from_shown(shown: dict[str, Any]) -> dict[str, Any]:
+    run = _object_or_empty(shown.get("run"))
+    run_id = str(run.get("run_id", ""))
+    legacy = _legacy_lifecycle_projection(shown)
+    journal = project_run_lifecycle(
+        _list_or_empty(shown.get("journal_events")),
+        run_id=run_id,
+        workflow=str(run.get("skill", "")),
+        harness=str(run.get("harness", "")),
+        phase=str(run.get("phase", "")),
+    )
+    return merge_lifecycle_projection(legacy, journal)
+
+
+def _legacy_lifecycle_projection(shown: dict[str, Any]) -> dict[str, Any]:
+    run = _object_or_empty(shown.get("run"))
+    coding = _object_or_empty(shown.get("coding_delegation"))
+    delegation = _object_or_empty(shown.get("delegation"))
+    wrapper = _object_or_empty(shown.get("wrapper"))
+    review = _object_or_empty(shown.get("review"))
+    ci = _object_or_empty(shown.get("ci"))
+    merge = _object_or_empty(shown.get("merge"))
+    plan_artifact = _object_or_empty(coding.get("plan_artifact"))
+    prepared = run.get("artifact_kind") == "prepared_coding_delegation" and bool(coding)
+    observation_status = str(run.get("observation_status", "unknown"))
+    if merge.get("observed"):
+        observation_status = "merge_observed"
+    elif ci.get("observed"):
+        observation_status = "ci_observed"
+    elif review.get("observed"):
+        observation_status = "review_observed"
+    elif wrapper.get("verification_observed"):
+        observation_status = "verification_observed"
+    elif delegation.get("observed"):
+        observation_status = "execution_observed"
+    elif wrapper.get("prompt_dispatched"):
+        observation_status = "dispatch_observed"
+    elif prepared:
+        observation_status = "prepared_not_observed"
+    return {
+        "schema_version": "omh_lifecycle_projection/v1",
+        "run_id": str(run.get("run_id", "")),
+        "workflow": str(coding.get("recommended_workflow") or run.get("skill", "")),
+        "harness": str(coding.get("recommended_harness") or run.get("harness", "")),
+        "phase": str(run.get("phase", "")),
+        "prepared_handoff": prepared,
+        "plan_artifact": str(plan_artifact.get("path", "")),
+        "plan_status": str(plan_artifact.get("status", "")),
+        "prompt_dispatched": bool(wrapper.get("prompt_dispatched", False)),
+        "runtime_start_observed": False,
+        "worktree_observed": False,
+        "execution_observed": bool(delegation.get("observed", False)),
+        "verification_observed": bool(wrapper.get("verification_observed", False)),
+        "review_observed": bool(review.get("observed", False)),
+        "ci_observed": bool(ci.get("observed", False)),
+        "merge_gate_observed": bool(merge.get("ready", False)),
+        "merge_observed": bool(merge.get("merged", False)),
+        "blocked": delegation.get("result") == "blocked" or wrapper.get("completion_status") == "blocked",
+        "failed": delegation.get("result") == "failed" or wrapper.get("completion_status") == "failed",
+        "cancelled": False,
+        "observation_status": observation_status,
+        "journal_event_count": 0,
+        "latest_event_id": "",
+        "latest_event": {},
+    }
 
 
 def _apply_limit(records: list[dict[str, Any]], limit: int | None) -> list[dict[str, Any]]:
@@ -352,10 +477,12 @@ def show_run(paths: OmhPaths, run_id: str) -> dict[str, Any]:
     evidence_dir = run_dir / "evidence"
     events, event_errors = read_events_result(run_dir)
     observations, observation_errors = read_runtime_observations_result(run_dir)
+    journal_events, journal_errors = _journal_events_for_run_result(paths, run_id)
     result = {
         "run": run,
         "events": events,
         "runtime_observations": observations,
+        "journal_events": journal_events,
         "routing": read_json_object(run_dir / "routing.json"),
         "coding_delegation": read_json_object(run_dir / "coding_delegation.json"),
         "delegation": read_json_object(run_dir / "delegation.json"),
@@ -369,6 +496,9 @@ def show_run(paths: OmhPaths, run_id: str) -> dict[str, Any]:
         result["event_errors"] = event_errors
     if observation_errors:
         result["runtime_observation_errors"] = observation_errors
+    if journal_errors:
+        result["journal_errors"] = journal_errors
+    result["lifecycle"] = _lifecycle_projection_from_shown(result)
     return result
 
 
@@ -413,6 +543,7 @@ def summarize_delegated_coding_status(paths: OmhPaths, run_id: str) -> dict[str,
     ci_record = _object_or_empty(shown.get("ci"))
     merge_record = _object_or_empty(shown.get("merge"))
     runtime_observations = runtime_observations_for_target(_list_or_empty(shown.get("runtime_observations")), "run", run_id)
+    lifecycle = _object_or_empty(shown.get("lifecycle"))
     handoff = _object_or_empty(coding.get("executor_handoff"))
     review = _object_or_empty(handoff.get("review"))
 
@@ -420,11 +551,11 @@ def summarize_delegated_coding_status(paths: OmhPaths, run_id: str) -> dict[str,
     action = str(coding.get("action", "unknown"))
     handoff_available = bool(handoff)
     executor_target = str(handoff.get("executor_target") or coding.get("executor_profile") or "generic")
-    execution_observed = bool(delegation.get("observed", False))
+    execution_observed = bool(delegation.get("observed", False)) or bool(lifecycle.get("execution_observed", False))
     execution_status = str(delegation.get("result") or ("not_observed" if prepared else "unknown"))
-    prompt_dispatched = bool(wrapper.get("prompt_dispatched", False))
+    prompt_dispatched = bool(wrapper.get("prompt_dispatched", False)) or bool(lifecycle.get("prompt_dispatched", False))
     response_observed = bool(wrapper.get("hermes_response_observed", False))
-    verification_observed = bool(wrapper.get("verification_observed", False))
+    verification_observed = bool(wrapper.get("verification_observed", False)) or bool(lifecycle.get("verification_observed", False))
     completion_status = str(wrapper.get("completion_status") or "unknown")
     verification_status = _verification_status_summary(
         observed=verification_observed,
@@ -522,6 +653,7 @@ def summarize_delegated_coding_status(paths: OmhPaths, run_id: str) -> dict[str,
         },
         "merge": merge_status,
         "runtime_observation": summarize_runtime_observation_status(runtime_observations),
+        "lifecycle": lifecycle,
         "next_action": next_action,
         "progress_reporting_policy": build_coding_progress_reporting_policy(next_action=next_action),
         "safe_summary": _delegated_status_summary(
@@ -1247,11 +1379,15 @@ def validate_runtime(paths: OmhPaths, run_id: str | None = None) -> dict[str, An
         )
     results = [validate_run_dir(run_dir) for run_dir in run_dirs]
     session_results = [validate_wrapper_session_dir(session_dir) for session_dir in session_dirs]
+    journal_result = validate_observation_journal(paths, run_id=run_id)
     _add_duplicate_wrapper_run_link_errors(session_results, session_dirs)
     return {
-        "ok": all(result["ok"] for result in results) and all(result["ok"] for result in session_results),
+        "ok": all(result["ok"] for result in results)
+        and all(result["ok"] for result in session_results)
+        and bool(journal_result["ok"]),
         "runs": results,
         "wrapper_sessions": session_results,
+        "journal": journal_result,
     }
 
 
@@ -1335,9 +1471,20 @@ def _redact(value: Any) -> Any:
     return value
 
 
-def export_runtime(paths: OmhPaths, redacted: bool = True, *, limit: int | None = None, full: bool = True) -> dict[str, Any]:
-    runs = list_runs(paths, limit=limit)
+def export_runtime(
+    paths: OmhPaths,
+    redacted: bool = True,
+    *,
+    limit: int | None = None,
+    full: bool = True,
+    run_id: str | None = None,
+) -> dict[str, Any]:
+    runs = [read_json_object(paths.runtime_runs_dir / run_id / "run.json")] if run_id else list_runs(paths, limit=limit)
+    runs = [run for run in runs if isinstance(run, dict)]
     wrapper_sessions = list_wrapper_session_records(paths, limit=limit)
+    journal_events, journal_errors = read_observation_events_result(paths)
+    if run_id:
+        journal_events = [event for event in journal_events if str(event.get("run_id", "")) == run_id]
     payload = {
         "schema_version": SCHEMA_VERSION,
         "runtime_dir": str(paths.runtime_dir),
@@ -1345,13 +1492,20 @@ def export_runtime(paths: OmhPaths, redacted: bool = True, *, limit: int | None 
         "export": {
             "full": full,
             "limit": limit,
+            "run_id": run_id or "",
             "run_count": len(runs),
             "wrapper_session_count": len(wrapper_sessions),
+            "journal_event_count": len(journal_events),
         },
         "runs": [show_run(paths, run["run_id"]) for run in runs] if full else runs,
         "wrapper_sessions": (
             [show_wrapper_session_record(paths, session["session_id"]) for session in wrapper_sessions] if full else wrapper_sessions
         ),
+        "journal": {
+            "path": str(paths.runtime_journal_events_path),
+            "events": journal_events if full else [],
+            "errors": journal_errors,
+        },
     }
     if redacted:
         payload = _redact(payload)

--- a/src/runtime/artifacts.py
+++ b/src/runtime/artifacts.py
@@ -544,6 +544,7 @@ def summarize_delegated_coding_status(paths: OmhPaths, run_id: str) -> dict[str,
     merge_record = _object_or_empty(shown.get("merge"))
     runtime_observations = runtime_observations_for_target(_list_or_empty(shown.get("runtime_observations")), "run", run_id)
     lifecycle = _object_or_empty(shown.get("lifecycle"))
+    legacy_runtime_observation = summarize_runtime_observation_status(runtime_observations)
     handoff = _object_or_empty(coding.get("executor_handoff"))
     review = _object_or_empty(handoff.get("review"))
 
@@ -552,7 +553,10 @@ def summarize_delegated_coding_status(paths: OmhPaths, run_id: str) -> dict[str,
     handoff_available = bool(handoff)
     executor_target = str(handoff.get("executor_target") or coding.get("executor_profile") or "generic")
     execution_observed = bool(delegation.get("observed", False)) or bool(lifecycle.get("execution_observed", False))
-    execution_status = str(delegation.get("result") or ("not_observed" if prepared else "unknown"))
+    execution_status = str(
+        delegation.get("result")
+        or ("completed" if lifecycle.get("execution_observed") else "not_observed" if prepared else "unknown")
+    )
     prompt_dispatched = bool(wrapper.get("prompt_dispatched", False)) or bool(lifecycle.get("prompt_dispatched", False))
     response_observed = bool(wrapper.get("hermes_response_observed", False))
     verification_observed = bool(wrapper.get("verification_observed", False)) or bool(lifecycle.get("verification_observed", False))
@@ -565,10 +569,13 @@ def summarize_delegated_coding_status(paths: OmhPaths, run_id: str) -> dict[str,
     review_required = bool(review.get("required", coding.get("review_required", False)))
     review_workflow = review.get("workflow") if review else coding.get("review_workflow")
     review_status = _review_status_summary(review_required, review_workflow, review, review_record)
+    review_status = _apply_lifecycle_review_status(review_status, lifecycle)
     ci_required = bool(ci_record) or review_status["status"] == "passed"
     ci_status = _ci_status_summary(ci_required, ci_record)
+    ci_status = _apply_lifecycle_ci_status(ci_status, lifecycle, review_status)
     merge_required = bool(merge_record) or ci_status["status"] == "passed"
     merge_status = _merge_status_summary(merge_required, merge_record)
+    merge_status = _apply_lifecycle_merge_status(merge_status, lifecycle)
     harness_quality = _object_or_empty(coding.get("harness_quality") or handoff.get("harness_quality"))
     harness_progress = _delegated_harness_progress(
         harness_quality,
@@ -592,6 +599,11 @@ def summarize_delegated_coding_status(paths: OmhPaths, run_id: str) -> dict[str,
         review_status=review_status,
         ci_status=ci_status,
         merge_status=merge_status,
+    )
+    runtime_observation_status = _delegated_runtime_observation_status(
+        legacy_runtime_observation,
+        lifecycle,
+        next_action=next_action,
     )
     integrity_warnings = _delegated_status_integrity_warnings(
         run=run,
@@ -652,7 +664,7 @@ def summarize_delegated_coding_status(paths: OmhPaths, run_id: str) -> dict[str,
             "summary": merge_status["summary"],
         },
         "merge": merge_status,
-        "runtime_observation": summarize_runtime_observation_status(runtime_observations),
+        "runtime_observation": runtime_observation_status,
         "lifecycle": lifecycle,
         "next_action": next_action,
         "progress_reporting_policy": build_coding_progress_reporting_policy(next_action=next_action),
@@ -1107,6 +1119,146 @@ def _merge_status_summary(required: bool, record: dict[str, Any]) -> dict[str, A
     }
 
 
+def _apply_lifecycle_review_status(status: dict[str, Any], lifecycle: dict[str, Any]) -> dict[str, Any]:
+    if not lifecycle.get("review_observed") or status.get("observed"):
+        return status
+    return {
+        **status,
+        "observed": True,
+        "status": "passed",
+        "satisfied": True,
+        "summary": str(_object_or_empty(lifecycle.get("latest_event")).get("summary") or status.get("summary", "")),
+    }
+
+
+def _apply_lifecycle_ci_status(
+    status: dict[str, Any],
+    lifecycle: dict[str, Any],
+    review_status: dict[str, Any],
+) -> dict[str, Any]:
+    if not lifecycle.get("ci_observed") or status.get("observed"):
+        return status
+    return {
+        **status,
+        "required": bool(status.get("required")) or review_status.get("status") == "passed",
+        "observed": True,
+        "status": "passed",
+        "satisfied": True,
+        "summary": str(_object_or_empty(lifecycle.get("latest_event")).get("summary") or status.get("summary", "")),
+    }
+
+
+def _apply_lifecycle_merge_status(status: dict[str, Any], lifecycle: dict[str, Any]) -> dict[str, Any]:
+    if status.get("observed"):
+        return status
+    latest = _object_or_empty(lifecycle.get("latest_event"))
+    if lifecycle.get("merge_observed"):
+        return {
+            **status,
+            "required": True,
+            "observed": True,
+            "ready": True,
+            "merged": True,
+            "status": "merged",
+            "satisfied": True,
+            "summary": str(latest.get("summary") or status.get("summary", "")),
+        }
+    if lifecycle.get("merge_gate_observed"):
+        return {
+            **status,
+            "required": True,
+            "observed": True,
+            "ready": True,
+            "merged": False,
+            "status": "ready",
+            "satisfied": True,
+            "summary": str(latest.get("summary") or status.get("summary", "")),
+        }
+    return status
+
+
+def _delegated_runtime_observation_status(
+    legacy_status: dict[str, Any],
+    lifecycle: dict[str, Any],
+    *,
+    next_action: str,
+) -> dict[str, Any]:
+    if int(lifecycle.get("journal_event_count", 0) or 0) <= 0:
+        return legacy_status
+    observed_events = _runtime_events_from_lifecycle(lifecycle)
+    latest = _object_or_empty(lifecycle.get("latest_event"))
+    blocked_events = []
+    failed_events = []
+    latest_event = _runtime_event_from_journal_event(str(latest.get("event", "")))
+    latest_status = str(latest.get("status", ""))
+    if latest_event and latest_status == "blocked":
+        blocked_events.append(latest_event)
+    elif latest_event and latest_status == "failed":
+        failed_events.append(latest_event)
+    missing_events = _runtime_missing_events_for_next_action(next_action)
+    return {
+        "schema_version": "runtime_observation_status/v1",
+        "record_schema": RUNTIME_OBSERVATION_SCHEMA_VERSION,
+        "applicable": True,
+        "source": "lifecycle_projection",
+        "observed_events": observed_events,
+        "blocked_events": blocked_events,
+        "failed_events": failed_events,
+        "not_observed_events": [],
+        "missing_events": missing_events,
+        "unsatisfied_events": missing_events,
+        "latest": {"event": latest_event, **latest} if latest_event else latest,
+        "next_action": next_action,
+        "claim_boundary": (
+            "Runtime observation status is projected from the merged lifecycle journal for prepared Codex runs. "
+            "It remains metadata-only evidence."
+        ),
+    }
+
+
+def _runtime_events_from_lifecycle(lifecycle: dict[str, Any]) -> list[str]:
+    events: list[str] = []
+    for lifecycle_key, event_type in (
+        ("runtime_start_observed", "runtime_start"),
+        ("worktree_observed", "worktree_creation"),
+        ("prompt_dispatched", "worker_dispatch"),
+        ("execution_observed", "worker_result"),
+        ("verification_observed", "verification"),
+        ("review_observed", "review"),
+        ("ci_observed", "ci"),
+        ("merge_gate_observed", "merge_readiness"),
+        ("merge_observed", "merge"),
+    ):
+        if lifecycle.get(lifecycle_key):
+            events.append(event_type)
+    return events
+
+
+def _runtime_missing_events_for_next_action(next_action: str) -> list[str]:
+    return {
+        "dispatch_to_executor": ["worker_dispatch"],
+        "wait_for_executor_evidence": ["worker_result"],
+        "record_verification_evidence": ["verification"],
+        "record_review_evidence": ["review"],
+        "record_ci_evidence": ["ci"],
+        "record_merge_readiness": ["merge_readiness"],
+    }.get(next_action, [])
+
+
+def _runtime_event_from_journal_event(event_name: str) -> str:
+    return {
+        "runtime_start_observed": "runtime_start",
+        "worktree_creation_observed": "worktree_creation",
+        "executor_dispatch_observed": "worker_dispatch",
+        "executor_result_observed": "worker_result",
+        "verification_result_observed": "verification",
+        "review_result_observed": "review",
+        "ci_result_observed": "ci",
+        "merge_gate_observed": "merge_readiness",
+        "merge_observed": "merge",
+    }.get(event_name, "")
+
+
 def _delegated_status_next_action(
     *,
     prepared: bool,
@@ -1481,7 +1633,10 @@ def export_runtime(
 ) -> dict[str, Any]:
     runs = [read_json_object(paths.runtime_runs_dir / run_id / "run.json")] if run_id else list_runs(paths, limit=limit)
     runs = [run for run in runs if isinstance(run, dict)]
-    wrapper_sessions = list_wrapper_session_records(paths, limit=limit)
+    if run_id:
+        wrapper_sessions = _wrapper_session_records_for_run(paths, run_id, limit=limit)
+    else:
+        wrapper_sessions = list_wrapper_session_records(paths, limit=limit)
     journal_events, journal_errors = read_observation_events_result(paths)
     if run_id:
         journal_events = [event for event in journal_events if str(event.get("run_id", "")) == run_id]
@@ -1513,6 +1668,15 @@ def export_runtime(
     else:
         payload["redacted"] = False
     return payload
+
+
+def _wrapper_session_records_for_run(paths: OmhPaths, run_id: str, *, limit: int | None = None) -> list[dict[str, Any]]:
+    sessions: list[dict[str, Any]] = []
+    for session_dir in _wrapper_session_dirs_for_run(paths, run_id):
+        session = read_json_object(session_dir / "session.json")
+        if isinstance(session, dict):
+            sessions.append(session)
+    return _apply_limit(sessions, limit)
 
 
 def _read_jsonl_events(path: Path) -> list[dict[str, Any]]:

--- a/src/runtime/records.py
+++ b/src/runtime/records.py
@@ -96,6 +96,11 @@ CODING_SOURCE_METADATA_KEYS = (
     "user_ref",
     "timestamp",
     "render_profile",
+    "plan_artifact_path",
+    "plan_artifact_sha256",
+    "plan_artifact_status",
+    "plan_task_sha256",
+    "plan_task_length",
     *TARGET_SOURCE_METADATA_KEYS,
 )
 CODING_RECOMMENDATION_KEYS = ("skill", "score", "confidence", "matched")
@@ -135,7 +140,17 @@ CODING_DELEGATION_RECORD_KEYS = (
     "isolation_plan",
     "acceptance_criteria",
     "verification",
+    "plan_artifact",
     "status",
+)
+CODING_PLAN_ARTIFACT_KEYS = (
+    "path",
+    "kind",
+    "schema_version",
+    "status",
+    "sha256",
+    "task_statement_sha256",
+    "task_statement_length",
 )
 ISOLATION_STRATEGIES = ("same_workspace_ok", "worktree_recommended", "worktree_required")
 ISOLATION_STATUSES = ("prepared_not_observed",)
@@ -668,6 +683,9 @@ def build_coding_delegation_record(delegation: dict[str, Any]) -> dict[str, Any]
     isolation_plan = _compact_isolation_plan(delegation.get("isolation_plan"))
     if isolation_plan:
         record["isolation_plan"] = isolation_plan
+    plan_artifact = _compact_plan_artifact(delegation.get("plan_artifact"))
+    if plan_artifact:
+        record["plan_artifact"] = plan_artifact
     if not record["message_sha256"] and message_text:
         record["message_sha256"] = hashlib.sha256(message_text.encode("utf-8")).hexdigest()
     errors = validate_coding_delegation_record(record)
@@ -1316,6 +1334,20 @@ def _compact_context_pack_blocked(value: Any) -> dict[str, Any]:
     }
 
 
+def _compact_plan_artifact(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    return {
+        "path": str(value.get("path", "")),
+        "kind": str(value.get("kind", "hermes_plan")),
+        "schema_version": str(value.get("schema_version", "")),
+        "status": str(value.get("status", "")),
+        "sha256": str(value.get("sha256", "")),
+        "task_statement_sha256": str(value.get("task_statement_sha256", "")),
+        "task_statement_length": int(value.get("task_statement_length", 0) or 0),
+    }
+
+
 def _compact_context_scope(value: Any) -> dict[str, str]:
     if not isinstance(value, dict):
         return {}
@@ -1724,7 +1756,39 @@ def validate_coding_delegation_record(delegation: dict[str, Any]) -> list[str]:
         errors.extend(validate_isolation_plan(delegation["isolation_plan"], "coding_delegation isolation_plan"))
     if "harness_quality" in delegation:
         errors.extend(validate_harness_quality(delegation["harness_quality"], "coding_delegation harness_quality"))
+    if "plan_artifact" in delegation:
+        errors.extend(validate_coding_plan_artifact(delegation["plan_artifact"]))
     errors.extend(validate_coding_handoff_combination(delegation, "coding_delegation"))
+    return errors
+
+
+def validate_coding_plan_artifact(value: Any) -> list[str]:
+    errors: list[str] = []
+    if not isinstance(value, dict):
+        return ["coding_delegation plan_artifact must be an object"]
+    extra_keys = sorted(set(value) - set(CODING_PLAN_ARTIFACT_KEYS))
+    _require(not extra_keys, errors, f"coding_delegation plan_artifact has unsupported keys: {extra_keys}")
+    for key in ("path", "kind", "schema_version", "status", "sha256", "task_statement_sha256"):
+        _require(isinstance(value.get(key), str), errors, f"coding_delegation plan_artifact.{key} must be a string")
+    _require(value.get("kind") == "hermes_plan", errors, "coding_delegation plan_artifact.kind must be hermes_plan")
+    _require(
+        value.get("schema_version") == "hermes_plan/v1",
+        errors,
+        "coding_delegation plan_artifact.schema_version must be hermes_plan/v1",
+    )
+    if value.get("sha256"):
+        _require(_is_sha256(str(value.get("sha256", ""))), errors, "coding_delegation plan_artifact.sha256 must be a sha256 hex digest")
+    if value.get("task_statement_sha256"):
+        _require(
+            _is_sha256(str(value.get("task_statement_sha256", ""))),
+            errors,
+            "coding_delegation plan_artifact.task_statement_sha256 must be a sha256 hex digest",
+        )
+    _require(
+        isinstance(value.get("task_statement_length"), int),
+        errors,
+        "coding_delegation plan_artifact.task_statement_length must be an integer",
+    )
     return errors
 
 

--- a/src/skills/render.py
+++ b/src/skills/render.py
@@ -398,7 +398,7 @@ artifacts; pass only event summaries and refs into Hermes chat context.
 
 Wrappers can run `omh memory inspect`, `omh memory pack`, and `omh memory apply` to review OMH-local or wrapper-supplied context before preparing a handoff. This emits `{MEMORY_REVIEW_SCHEMA}` and `{HANDOFF_CONTEXT_PACK_SCHEMA}` artifacts only; it does not read or mutate opaque Hermes internal memory.
 
-For planning-shaped requests, wrappers or operators can run `omh hermes plan` to create a deterministic `hermes_plan/v1` scaffold. The stdout `wrapper_contract` is the adapter contract for follow-on work; use it instead of parsing Markdown.
+For planning-shaped requests, wrappers or operators can run `omh hermes plan` to create a deterministic `hermes_plan/v1` scaffold. The stdout `wrapper_contract` is the adapter contract for follow-on work; after acceptance, pass the accepted plan artifact or generated context pack to `omh coding delegate --from-plan` instead of treating Discord/channel summary text as the executor plan.
 
 ## Backend Boundary
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5405,6 +5405,93 @@ class CliTests(unittest.TestCase):
             self.assertEqual(status, 0)
             run_id = json.loads(stdout)["runtime"]["run"]["run_id"]
 
+            status, _, stderr = run_cli(
+                home_args
+                + [
+                    "runtime",
+                    "observe",
+                    "--run",
+                    run_id,
+                    "--runtime-profile",
+                    "hermes",
+                    "--event",
+                    "verification",
+                    "--summary",
+                    "local verification passed",
+                    "--evidence-ref",
+                    "tests/test_runtime_artifacts.py",
+                ]
+            )
+            self.assertEqual(status, 2)
+            self.assertIn("verification_result_observed requires executor_dispatch_observed and executor_result_observed", stderr)
+
+            status, _, stderr = run_cli(
+                home_args
+                + [
+                    "runtime",
+                    "observe",
+                    "--run",
+                    run_id,
+                    "--runtime-profile",
+                    "hermes",
+                    "--event",
+                    "merge",
+                    "--summary",
+                    "merged without prerequisites",
+                ]
+            )
+            self.assertEqual(status, 2)
+            self.assertIn("merge_observed requires executor_dispatch_observed", stderr)
+
+            status, stdout, stderr = run_cli(
+                home_args
+                + [
+                    "runtime",
+                    "observe",
+                    "--run",
+                    run_id,
+                    "--runtime-profile",
+                    "hermes",
+                    "--event",
+                    "worker_dispatch",
+                    "--summary",
+                    "executor dispatch observed",
+                    "--evidence-ref",
+                    "executor-session.json",
+                ]
+            )
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            observed = json.loads(stdout)
+            self.assertEqual(observed["observation"], {})
+            self.assertEqual(observed["journal_event"]["event"], "executor_dispatch_observed")
+            self.assertTrue(observed["status"]["lifecycle"]["prompt_dispatched"])
+
+            status, stdout, stderr = run_cli(
+                home_args
+                + [
+                    "runtime",
+                    "observe",
+                    "--run",
+                    run_id,
+                    "--runtime-profile",
+                    "hermes",
+                    "--event",
+                    "worker_result",
+                    "--summary",
+                    "executor reported completion",
+                    "--evidence-ref",
+                    "executor-result.json",
+                ]
+            )
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            observed = json.loads(stdout)
+            self.assertEqual(observed["observation"], {})
+            self.assertEqual(observed["journal_event"]["event"], "executor_result_observed")
+            self.assertTrue(observed["status"]["execution"]["observed"])
+            self.assertEqual(observed["status"]["next_action"], "record_verification_evidence")
+
             status, stdout, stderr = run_cli(
                 home_args
                 + [
@@ -5436,7 +5523,7 @@ class CliTests(unittest.TestCase):
             shown = json.loads(stdout)
             self.assertEqual(shown["lifecycle"]["latest_event"]["event"], "verification_result_observed")
             self.assertTrue(shown["lifecycle"]["verification_observed"])
-            self.assertEqual(shown["lifecycle"]["journal_event_count"], 2)
+            self.assertEqual(shown["lifecycle"]["journal_event_count"], 4)
 
             status, stdout, stderr = run_cli(home_args + ["runtime", "validate"])
             self.assertEqual(stderr, "")
@@ -6686,6 +6773,30 @@ class CliTests(unittest.TestCase):
             self.assertEqual(status, 2)
             self.assertIn("requires an accepted plan", stderr)
 
+            status, _, stderr = run_cli(
+                base + ["coding", "delegate", "--from-plan", str(plan_path), "--record", "--force-record"]
+            )
+            self.assertEqual(status, 2)
+            self.assertIn("requires an accepted plan", stderr)
+
+            status, stdout, stderr = run_cli(
+                base
+                + [
+                    "coding",
+                    "delegate",
+                    "--from-plan",
+                    str(plan_path),
+                    "--record",
+                    "--allow-draft-plan",
+                    "--include-message",
+                ]
+            )
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            draft_payload = json.loads(stdout)
+            self.assertEqual(draft_payload["plan_artifact"]["status"], "draft")
+            self.assertEqual(draft_payload["runtime"]["coding_delegation"]["plan_artifact"]["status"], "draft")
+
             invalid_plan = root / "not-a-plan.md"
             invalid_plan.write_text("---\nschema_version: other/v1\nstatus: accepted\n---\n# Not a Hermes plan\n", encoding="utf-8")
             status, _, stderr = run_cli(base + ["hermes", "plan", "accept", str(invalid_plan)])
@@ -6722,6 +6833,11 @@ class CliTests(unittest.TestCase):
             self.assertEqual(payload["executor_handoff"]["execution_brief"]["task_source"], "accepted_plan_artifact")
             self.assertIn("plan_artifact_context_required", payload["executor_handoff"]["dispatch_contract"])
             self.assertEqual(payload["executor_handoff"]["context_pack"]["included_context"][0]["key"], "plan_artifact")
+            self.assertEqual(payload["executor_handoff"]["context_pack"]["metadata"]["plan_artifact_path"], str(plan_path.resolve()))
+            self.assertEqual(
+                payload["executor_handoff"]["context_pack"]["included_context"][0]["artifact_ref"],
+                str(plan_path.resolve()),
+            )
             self.assertEqual(payload["plan_artifact"]["path"], str(plan_path.resolve()))
             self.assertEqual(payload["plan_artifact"]["status"], "accepted")
             self.assertEqual(payload["source_metadata"]["plan_artifact_path"], str(plan_path.resolve()))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5383,6 +5383,66 @@ class CliTests(unittest.TestCase):
             self.assertEqual(status, 0)
             self.assertTrue(json.loads(stdout)["ok"])
 
+    def test_runtime_observe_records_journal_events_for_prepared_codex_runs(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / ".omh"
+            home_args = ["--omh-home", str(omh_home), "--hermes-home", str(root / ".hermes")]
+
+            status, stdout, stderr = run_cli(
+                home_args
+                + [
+                    "coding",
+                    "delegate",
+                    "--record",
+                    "--force-record",
+                    "--executor",
+                    "codex",
+                    "implement safe runtime feature in src/runtime/artifacts.py without overclaiming",
+                ]
+            )
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            run_id = json.loads(stdout)["runtime"]["run"]["run_id"]
+
+            status, stdout, stderr = run_cli(
+                home_args
+                + [
+                    "runtime",
+                    "observe",
+                    "--run",
+                    run_id,
+                    "--runtime-profile",
+                    "hermes",
+                    "--event",
+                    "verification",
+                    "--summary",
+                    "local verification passed",
+                    "--evidence-ref",
+                    "tests/test_runtime_artifacts.py",
+                ]
+            )
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            observed = json.loads(stdout)
+            self.assertEqual(observed["observation"], {})
+            self.assertEqual(observed["journal_event"]["event"], "verification_result_observed")
+            self.assertTrue(observed["status"]["lifecycle"]["verification_observed"])
+            self.assertFalse((omh_home / "runtime" / "runs" / run_id / "runtime_observations.jsonl").exists())
+
+            status, stdout, stderr = run_cli(home_args + ["runtime", "show", run_id])
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            shown = json.loads(stdout)
+            self.assertEqual(shown["lifecycle"]["latest_event"]["event"], "verification_result_observed")
+            self.assertTrue(shown["lifecycle"]["verification_observed"])
+            self.assertEqual(shown["lifecycle"]["journal_event_count"], 2)
+
+            status, stdout, stderr = run_cli(home_args + ["runtime", "validate"])
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            self.assertTrue(json.loads(stdout)["ok"])
+
     def test_chat_session_executor_actions_track_codex_without_user_cli_commands(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -6497,14 +6557,18 @@ class CliTests(unittest.TestCase):
         self.assertEqual(plan["deep_interview"]["after_answer_next_action"], "accept_or_revise_plan")
         self.assertTrue(plan["acceptance_criteria"])
         self.assertTrue(plan["verification_plan"])
-        self.assertIn("omh coding delegate --executor codex --record", plan["execution_handoff"])
+        self.assertIn("omh coding delegate --executor codex --record --from-plan <accepted-plan.md>", plan["execution_handoff"])
         contract = payload["wrapper_contract"]
         self.assertEqual(contract["schema_version"], "hermes_plan_wrapper/v1")
         self.assertEqual(contract["current_step"], "present_plan")
         self.assertEqual(contract["next_action"], "prepare_coding_delegation_after_plan_acceptance")
         self.assertEqual(contract["message_field"], "plan.task_statement")
+        self.assertEqual(contract["plan_artifact_field"], "wrapper_contract.plan_artifact.path")
+        self.assertIn("accepted plan artifact", contract["handoff_context_policy"])
+        self.assertIn("Discord/channel text is only a summary", contract["handoff_context_policy"])
         self.assertFalse(contract["plan_artifact"]["recorded"])
         self.assertTrue(contract["decision_gate"]["required"])
+        self.assertIn("accepted plan artifact", contract["decision_gate"]["do_not_delegate_when"][1])
         self.assertEqual(contract["quality_gate"]["readiness"], "ready_for_acceptance")
         self.assertEqual(contract["harness_quality"]["schema_version"], "harness_quality/v1")
         self.assertEqual(contract["harness_quality"]["harness"], "planning")
@@ -6515,9 +6579,13 @@ class CliTests(unittest.TestCase):
         self.assertTrue(coding_delegate["requires_plan_acceptance"])
         self.assertEqual(coding_delegate["stdout_schema_version"], "coding_delegation/v1")
         self.assertEqual(coding_delegate["recording_contract"], "prepared_not_observed")
-        self.assertIn("{message}", coding_delegate["argv_template"])
+        self.assertIn("accepted plan artifact", coding_delegate["input_policy"])
+        self.assertIn("--from-plan", coding_delegate["argv_template"])
+        self.assertIn("{plan_artifact}", coding_delegate["argv_template"])
+        self.assertNotIn("{message}", coding_delegate["argv_template"])
         self.assertIn("--executor", coding_delegate["argv_template"])
         self.assertIn("codex", coding_delegate["argv_template"])
+        self.assertEqual(coding_delegate["plan_artifact_arg"], "--from-plan")
         self.assertEqual(coding_delegate["recorded_run_field"], "runtime.run.run_id")
         self.assertNotIn("command_template", coding_delegate)
 
@@ -6532,7 +6600,7 @@ class CliTests(unittest.TestCase):
         coding_delegate = payload["wrapper_contract"]["coding_delegate"]
         self.assertTrue(coding_delegate["available"])
         self.assertNotIn("command_template", coding_delegate)
-        self.assertEqual(coding_delegate["argv_template"][-1], "{message}")
+        self.assertEqual(coding_delegate["argv_template"][-1], "{plan_artifact}")
         self.assertIn("--executor", coding_delegate["argv_template"])
         self.assertIn("codex", coding_delegate["argv_template"])
         self.assertNotIn(hostile, json.dumps(coding_delegate))
@@ -6588,6 +6656,90 @@ class CliTests(unittest.TestCase):
             self.assertIn("review_gate:", text)
             self.assertIn("## Acceptance Criteria", text)
             self.assertIn("## Verification Plan", text)
+
+    def test_accepted_plan_artifact_is_coding_delegate_context(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / ".omh"
+            hermes_home = root / ".hermes"
+            base = ["--omh-home", str(omh_home), "--hermes-home", str(hermes_home)]
+
+            status, stdout, stderr = run_cli(
+                base
+                + [
+                    "hermes",
+                    "plan",
+                    "--record",
+                    "implement",
+                    "durable",
+                    "observation",
+                    "journal",
+                    "with",
+                    "tests",
+                ]
+            )
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            plan_path = Path(json.loads(stdout)["artifact"]["path"])
+
+            status, _, stderr = run_cli(base + ["coding", "delegate", "--from-plan", str(plan_path), "--record"])
+            self.assertEqual(status, 2)
+            self.assertIn("requires an accepted plan", stderr)
+
+            invalid_plan = root / "not-a-plan.md"
+            invalid_plan.write_text("---\nschema_version: other/v1\nstatus: accepted\n---\n# Not a Hermes plan\n", encoding="utf-8")
+            status, _, stderr = run_cli(base + ["hermes", "plan", "accept", str(invalid_plan)])
+            self.assertEqual(status, 2)
+            self.assertIn("expected hermes_plan/v1 artifact", stderr)
+            status, _, stderr = run_cli(base + ["coding", "delegate", "--from-plan", str(invalid_plan), "--record"])
+            self.assertEqual(status, 2)
+            self.assertIn("requires a hermes_plan/v1 artifact", stderr)
+
+            status, stdout, stderr = run_cli(base + ["hermes", "plan", "accept", str(plan_path)])
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            accepted = json.loads(stdout)
+            self.assertEqual(accepted["artifact"]["status"], "accepted")
+            self.assertEqual(accepted["journal_event"]["event"], "plan_accepted")
+            self.assertEqual(accepted["journal_event"]["target_type"], "plan")
+            self.assertIn("status: accepted", plan_path.read_text(encoding="utf-8").split("---", 2)[1])
+
+            status, stdout, stderr = run_cli(base + ["hermes", "plan-accept", str(plan_path), "--write-context-pack"])
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            context_pack_path = Path(json.loads(stdout)["context_pack"]["path"])
+            self.assertTrue(context_pack_path.exists())
+
+            status, stdout, stderr = run_cli(
+                base + ["coding", "delegate", "--from-plan", str(plan_path), "--record", "--include-message"]
+            )
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            payload = json.loads(stdout)
+            self.assertIn("BEGIN ACCEPTED HERMES PLAN", payload["message"])
+            self.assertIn("Discord or chat summary is not the executor plan", payload["message"])
+            self.assertEqual(payload["selected_executor_profile"], "codex")
+            self.assertEqual(payload["executor_handoff"]["execution_brief"]["task_source"], "accepted_plan_artifact")
+            self.assertIn("plan_artifact_context_required", payload["executor_handoff"]["dispatch_contract"])
+            self.assertEqual(payload["executor_handoff"]["context_pack"]["included_context"][0]["key"], "plan_artifact")
+            self.assertEqual(payload["plan_artifact"]["path"], str(plan_path.resolve()))
+            self.assertEqual(payload["plan_artifact"]["status"], "accepted")
+            self.assertEqual(payload["source_metadata"]["plan_artifact_path"], str(plan_path.resolve()))
+
+            run_id = payload["runtime"]["run"]["run_id"]
+            record = payload["runtime"]["coding_delegation"]
+            self.assertEqual(record["plan_artifact"]["path"], str(plan_path.resolve()))
+            self.assertEqual(record["plan_artifact"]["status"], "accepted")
+            self.assertEqual(record["source_metadata"]["plan_artifact_status"], "accepted")
+            self.assertEqual(record["executor_handoff"]["execution_brief"]["task_source"], "accepted_plan_artifact")
+
+            status, stdout, stderr = run_cli(base + ["runtime", "show", run_id])
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            shown = json.loads(stdout)
+            self.assertEqual(shown["lifecycle"]["plan_status"], "accepted")
+            self.assertTrue(shown["lifecycle"]["prepared_handoff"])
+            self.assertEqual(shown["lifecycle"]["observation_status"], "prepared_not_observed")
 
     def test_hermes_plan_records_context_for_weak_request(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_plugin_distribution.py
+++ b/tests/test_plugin_distribution.py
@@ -331,12 +331,38 @@ class PluginDistributionTests(unittest.TestCase):
             self.assertEqual(probe_payload["capability_gap_roadmap"]["schema_version"], "omh_capability_gap_roadmap/v1")
             self.assertIn("plugin_runtime_observed", {item["name"] for item in probe_payload["capabilities"]})
 
+            status, stdout, stderr = run_cli(
+                [
+                    "--omh-home",
+                    str(omh_home),
+                    "--hermes-home",
+                    str(hermes_home),
+                    "runtime",
+                    "observe",
+                    "--run",
+                    run_id,
+                    "--runtime-profile",
+                    "hermes",
+                    "--event",
+                    "worker_result",
+                    "--summary",
+                    "executor completed the prepared handoff",
+                ]
+            )
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            self.assertEqual(json.loads(stdout)["journal_event"]["event"], "executor_result_observed")
+
             handler = ctx.tools["omh_status"]["args"][2]
             payload = json.loads(handler({"omh_home": str(omh_home), "limit": 1}))
             self.assertEqual(payload["schema_version"], "omh_status/v1")
             self.assertEqual(payload["runs"][0]["run_id"], run_id)
             self.assertTrue(payload["runs"][0]["prepared_handoff"])
-            self.assertFalse(payload["runs"][0]["execution_observed"])
+            self.assertTrue(payload["runs"][0]["execution_observed"])
+            self.assertEqual(payload["runs"][0]["observation_status"], "execution_observed")
+            self.assertEqual(payload["runs"][0]["latest_event"]["event"], "executor_result_observed")
+            self.assertTrue(payload["runs"][0]["lifecycle"]["execution_observed"])
+            self.assertGreaterEqual(payload["runs"][0]["journal_event_count"], 2)
             self.assertIn("not execution evidence", payload["evidence_boundary"]["prepared_handoff"])
 
             recommend_handler = ctx.tools["omh_recommend"]["args"][2]

--- a/tests/test_plugin_distribution.py
+++ b/tests/test_plugin_distribution.py
@@ -344,6 +344,28 @@ class PluginDistributionTests(unittest.TestCase):
                     "--runtime-profile",
                     "hermes",
                     "--event",
+                    "worker_dispatch",
+                    "--summary",
+                    "executor session opened for the prepared handoff",
+                ]
+            )
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            self.assertEqual(json.loads(stdout)["journal_event"]["event"], "executor_dispatch_observed")
+
+            status, stdout, stderr = run_cli(
+                [
+                    "--omh-home",
+                    str(omh_home),
+                    "--hermes-home",
+                    str(hermes_home),
+                    "runtime",
+                    "observe",
+                    "--run",
+                    run_id,
+                    "--runtime-profile",
+                    "hermes",
+                    "--event",
                     "worker_result",
                     "--summary",
                     "executor completed the prepared handoff",

--- a/tests/test_runtime_artifacts.py
+++ b/tests/test_runtime_artifacts.py
@@ -16,6 +16,7 @@ from omh.paths import resolve_paths
 from omh.chat_router import route_chat_message, routing_record_payload
 from omh.coding_delegation import build_coding_delegation_payload, coding_delegation_record_payload
 from omh.runtime_artifacts import (
+    append_journal_observation,
     create_prepared_coding_delegation_run,
     create_run,
     export_runtime,
@@ -87,6 +88,10 @@ class RuntimeArtifactTests(unittest.TestCase):
             self.assertEqual(run["phase"], "prepared")
             self.assertEqual(run["observation_status"], "prepared_not_observed")
             self.assertEqual(validate_run_record(run), [])
+            shown = show_run(paths, run["run_id"])
+            self.assertTrue(shown["lifecycle"]["prepared_handoff"])
+            self.assertEqual(shown["lifecycle"]["observation_status"], "prepared_not_observed")
+            self.assertEqual(shown["lifecycle"]["latest_event"]["event"], "prepared_handoff_created")
 
     def test_create_run_does_not_collide_for_rapid_same_harness_records(self) -> None:
         with TemporaryDirectory() as tmp:
@@ -504,6 +509,110 @@ class RuntimeArtifactTests(unittest.TestCase):
             self.assertEqual(not_observed_summary["observed_events"], [])
             self.assertEqual(not_observed_summary["next_action"], "record_runtime_observation:runtime_start")
             self.assertIn("runtime_start", not_observed_summary["unsatisfied_events"])
+
+    def test_journal_events_project_run_lifecycle_without_legacy_observation_file(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            run = create_prepared_coding_delegation_run(
+                paths,
+                {"skill": "ai-slop-cleaner", "harness": "coding-handling"},
+            )
+            run_dir = paths.runtime_runs_dir / run["run_id"]
+            message = "implement safe runtime feature in src/runtime/artifacts.py without overclaiming"
+            payload = build_coding_delegation_payload(
+                message,
+                source="discord",
+                executor_target="codex",
+            )
+            write_coding_delegation(
+                run_dir,
+                coding_delegation_record_payload(payload, message),
+            )
+
+            append_journal_observation(
+                paths,
+                {
+                    "target_type": "run",
+                    "target_id": run["run_id"],
+                    "run_id": run["run_id"],
+                    "event": "executor_dispatch",
+                    "status": "observed",
+                    "summary": "wrapper dispatched the accepted handoff",
+                    "evidence_refs": ["executor-session.json"],
+                },
+            )
+            append_journal_observation(
+                paths,
+                {
+                    "target_type": "run",
+                    "target_id": run["run_id"],
+                    "run_id": run["run_id"],
+                    "event": "executor_result",
+                    "status": "observed",
+                    "summary": "executor reported completion",
+                    "evidence_refs": ["executor-result.json"],
+                },
+            )
+
+            shown = show_run(paths, run["run_id"])
+            status = summarize_delegated_coding_status(paths, run["run_id"])
+            exported = export_runtime(paths, redacted=False, run_id=run["run_id"])
+
+            self.assertFalse((run_dir / "runtime_observations.jsonl").exists())
+            self.assertEqual(shown["lifecycle"]["journal_event_count"], 3)
+            self.assertTrue(shown["lifecycle"]["prompt_dispatched"])
+            self.assertTrue(shown["lifecycle"]["execution_observed"])
+            self.assertEqual(shown["lifecycle"]["observation_status"], "execution_observed")
+            self.assertEqual(shown["lifecycle"]["latest_event"]["event"], "executor_result_observed")
+            self.assertTrue(status["execution"]["observed"])
+            self.assertTrue(status["wrapper"]["prompt_dispatched"])
+            self.assertEqual(exported["export"]["journal_event_count"], 3)
+            self.assertEqual({event["run_id"] for event in exported["journal"]["events"]}, {run["run_id"]})
+            self.assertTrue(validate_runtime(paths, run["run_id"])["ok"])
+
+    def test_validate_runtime_rejects_malformed_journal_records(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            run = create_prepared_coding_delegation_run(
+                paths,
+                {"skill": "ai-slop-cleaner", "harness": "coding-handling"},
+            )
+            message = "implement safe runtime feature in src/runtime/artifacts.py without overclaiming"
+            payload = build_coding_delegation_payload(
+                message,
+                source="discord",
+                executor_target="codex",
+            )
+            write_coding_delegation(
+                paths.runtime_runs_dir / run["run_id"],
+                coding_delegation_record_payload(payload, message),
+            )
+            with paths.runtime_journal_events_path.open("a", encoding="utf-8") as handle:
+                handle.write(
+                    json.dumps(
+                        {
+                            "schema_version": "omh_observation_event/v1",
+                            "event_id": "bad-event",
+                            "target_type": "run",
+                            "target_id": run["run_id"],
+                            "run_id": run["run_id"],
+                            "event": "not-supported",
+                            "status": "observed",
+                            "observed_at": "2026-06-24T00:00:00Z",
+                            "privacy": "metadata_only",
+                            "evidence_refs": [],
+                            "summary": "invalid event",
+                        },
+                        sort_keys=True,
+                    )
+                    + "\n"
+                )
+
+            result = validate_runtime(paths, run["run_id"])
+
+            self.assertFalse(result["ok"])
+            self.assertFalse(result["journal"]["ok"])
+            self.assertIn("observation_event event is unsupported", "\n".join(result["journal"]["errors"]))
 
     def test_validate_runtime_requires_coding_delegation_for_prepared_runs(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_runtime_artifacts.py
+++ b/tests/test_runtime_artifacts.py
@@ -570,6 +570,130 @@ class RuntimeArtifactTests(unittest.TestCase):
             self.assertEqual({event["run_id"] for event in exported["journal"]["events"]}, {run["run_id"]})
             self.assertTrue(validate_runtime(paths, run["run_id"])["ok"])
 
+    def test_delegated_status_uses_journal_lifecycle_for_runtime_observation_projection(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            run = create_prepared_coding_delegation_run(
+                paths,
+                {
+                    "skill": "coding",
+                    "harness": "delegate",
+                    "trigger": "test",
+                    "privacy": "metadata_only",
+                    "inputs_summary": "prepared handoff",
+                    "outputs_summary": "prepared",
+                    "verification_summary": "prepared_not_observed",
+                },
+            )
+            run_dir = paths.runtime_runs_dir / run["run_id"]
+            message = "implement safe runtime feature in src/runtime/artifacts.py without overclaiming"
+            payload = build_coding_delegation_payload(message, source="discord", executor_target="codex")
+            write_coding_delegation(run_dir, coding_delegation_record_payload(payload, message))
+
+            for event, summary in (
+                ("executor_dispatch", "wrapper dispatched the handoff"),
+                ("executor_result", "executor reported completion"),
+                ("verification", "verification passed"),
+            ):
+                append_journal_observation(
+                    paths,
+                    {
+                        "target_type": "run",
+                        "target_id": run["run_id"],
+                        "run_id": run["run_id"],
+                        "event": event,
+                        "status": "observed",
+                        "summary": summary,
+                    },
+                )
+
+            status = summarize_delegated_coding_status(paths, run["run_id"])
+
+            self.assertEqual(status["next_action"], "record_review_evidence")
+            self.assertEqual(status["runtime_observation"]["source"], "lifecycle_projection")
+            self.assertEqual(status["runtime_observation"]["next_action"], "record_review_evidence")
+            self.assertEqual(
+                status["runtime_observation"]["observed_events"],
+                ["worker_dispatch", "worker_result", "verification"],
+            )
+            self.assertNotIn("runtime_start", status["runtime_observation"]["missing_events"])
+
+    def test_validate_runtime_rejects_out_of_order_journal_lifecycle_events(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            run = create_prepared_coding_delegation_run(
+                paths,
+                {
+                    "skill": "coding",
+                    "harness": "delegate",
+                    "trigger": "test",
+                    "privacy": "metadata_only",
+                    "inputs_summary": "prepared handoff",
+                    "outputs_summary": "prepared",
+                    "verification_summary": "prepared_not_observed",
+                },
+            )
+            run_dir = paths.runtime_runs_dir / run["run_id"]
+            message = "implement safe runtime feature in src/runtime/artifacts.py without overclaiming"
+            payload = build_coding_delegation_payload(message, source="discord", executor_target="codex")
+            write_coding_delegation(run_dir, coding_delegation_record_payload(payload, message))
+
+            append_journal_observation(
+                paths,
+                {
+                    "target_type": "run",
+                    "target_id": run["run_id"],
+                    "run_id": run["run_id"],
+                    "event": "executor_dispatch",
+                    "status": "observed",
+                    "summary": "dispatch observed",
+                },
+            )
+            append_journal_observation(
+                paths,
+                {
+                    "target_type": "run",
+                    "target_id": run["run_id"],
+                    "run_id": run["run_id"],
+                    "event": "executor_result",
+                    "status": "observed",
+                    "summary": "executor result observed",
+                },
+            )
+            with paths.runtime_journal_events_path.open("a", encoding="utf-8") as handle:
+                handle.write(
+                    json.dumps(
+                        {
+                            "schema_version": "omh_observation_event/v1",
+                            "event_id": "bad-merge",
+                            "target_type": "run",
+                            "target_id": run["run_id"],
+                            "run_id": run["run_id"],
+                            "workflow": "coding",
+                            "harness": "delegate",
+                            "phase": "prepared",
+                            "event": "merge_observed",
+                            "status": "observed",
+                            "observed_at": "2026-06-24T00:00:00Z",
+                            "source": "test",
+                            "actor": "",
+                            "runtime_profile": "hermes",
+                            "evidence_refs": [],
+                            "summary": "merge without verification",
+                            "privacy": "metadata_only",
+                        },
+                        sort_keys=True,
+                    )
+                    + "\n"
+                )
+
+            result = validate_runtime(paths, run["run_id"])
+
+            self.assertFalse(result["ok"])
+            self.assertFalse(result["journal"]["ok"])
+            errors = "\n".join(result["journal"]["errors"])
+            self.assertIn("merge_observed requires verification_result_observed", errors)
+
     def test_validate_runtime_rejects_malformed_journal_records(self) -> None:
         with TemporaryDirectory() as tmp:
             paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")

--- a/tests/test_wrapper_sessions.py
+++ b/tests/test_wrapper_sessions.py
@@ -1401,6 +1401,50 @@ class WrapperSessionTests(unittest.TestCase):
             self.assertEqual(len(exported["wrapper_sessions"]), 1)
             self.assertNotIn(message, json.dumps(exported))
 
+    def test_export_runtime_run_scope_includes_only_linked_wrapper_sessions(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+
+            first = create_or_resume_wrapper_session(
+                paths,
+                "risky refactor first scoped runtime fix in src/runtime/artifacts.py",
+                source="discord",
+                source_metadata={"channel_ref": "c1", "source_event_id": "thread-one"},
+            )
+            first_id = str(first["session"]["session_id"])
+            record_plan_decision(paths, first_id, "accept")
+            select_wrapper_session_executor(paths, first_id, "codex")
+            first_handoff = prepare_wrapper_session_handoff(
+                paths,
+                first_id,
+                "risky refactor first scoped runtime fix in src/runtime/artifacts.py",
+            )
+            first_run_id = str(first_handoff["session"]["current_run_id"])
+
+            second = create_or_resume_wrapper_session(
+                paths,
+                "risky refactor second unrelated runtime fix in src/runtime/artifacts.py",
+                source="discord",
+                source_metadata={"channel_ref": "c2", "source_event_id": "thread-two"},
+            )
+            second_id = str(second["session"]["session_id"])
+            record_plan_decision(paths, second_id, "accept")
+            select_wrapper_session_executor(paths, second_id, "codex")
+            second_handoff = prepare_wrapper_session_handoff(
+                paths,
+                second_id,
+                "risky refactor second unrelated runtime fix in src/runtime/artifacts.py",
+            )
+            second_run_id = str(second_handoff["session"]["current_run_id"])
+
+            exported = export_runtime(paths, redacted=False, run_id=first_run_id)
+
+            self.assertNotEqual(first_run_id, second_run_id)
+            self.assertEqual(exported["export"]["run_id"], first_run_id)
+            self.assertEqual(exported["export"]["wrapper_session_count"], 1)
+            self.assertEqual(exported["wrapper_sessions"][0]["session"]["session_id"], first_id)
+            self.assertNotIn(second_id, json.dumps(exported))
+
     def test_runtime_validation_rejects_wrong_linked_run_type(self) -> None:
         with TemporaryDirectory() as tmp:
             paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")


### PR DESCRIPTION
## Summary

This PR implements the full Observation Journal and file-backed plan handoff path that came out of the Ralplan artifact for OMH's prepared-vs-observed lifecycle gap.

The main user-visible change is that OMH no longer treats a Discord/channel summary or original chat message as the coding plan after a reviewed plan exists. `omh hermes plan` can now produce a durable file-backed plan, the plan can be accepted/revised/cancelled, and `omh coding delegate --from-plan <accepted-plan.md>` uses the accepted plan artifact as executor context for a run-backed Codex handoff.

The compact HUD/status line is intentionally unchanged. The new lifecycle detail lives in runtime/status/native bridge metadata via an append-only observation journal.

## What changed

- Added `src/observation_journal.py` for metadata-only `omh_observation_event/v1` events and `omh_lifecycle_projection/v1` projections.
- Added runtime journal paths under `.omh/runtime/journal/events.jsonl`.
- Updated runtime runs/status/export/validate to merge legacy runtime artifacts with journal-derived lifecycle state.
- Updated plugin runtime reader so native `omh_status` can surface journal event count/latest event/lifecycle booleans.
- Added Hermes plan lifecycle commands:
  - `omh hermes plan-accept <plan.md>`
  - `omh hermes plan-revise <plan.md>`
  - `omh hermes plan-cancel <plan.md>`
- Added accepted-plan executor handoff support:
  - `omh coding delegate --from-plan <accepted-plan.md> --record`
  - rejects draft plans by default unless explicitly overridden.
  - records plan artifact metadata in the coding delegation record.
- Updated wrapper contract docs/guidance so wrappers pass accepted plan artifacts or generated context packs, not Discord summaries, into coding delegates.
- Updated tests for file-backed handoff contract, plan acceptance, journal projection, runtime validation, export/status, and plugin distribution.

## Why

The observed failure was that OMH could prepare a Ralplan file, but the lower-level coding handoff contract still told wrappers to pass the original user/Discord message as the implementation prompt. That made the plan artifact decorative and recreated the feeling that "the Discord summary is the plan."

This PR makes the durable plan artifact the source of truth after acceptance and adds the observation journal bridge for later lifecycle evidence.

## Boundary behavior

- Prepared handoff remains `prepared_not_observed`.
- Journal events can record dispatch, executor result, verification, review, CI, merge gate, and merge as separate observed lifecycle steps.
- HUD remains compact; lifecycle detail is available in runtime/status/native bridge data.
- Live mid-run progress reporting is **not** included here; it is tracked separately in #262.

## Verification observed

- `git diff --check`
- `PYTHONPATH=tests uv run python -m unittest tests.test_runtime_artifacts tests.test_cli tests.test_plugin_distribution -v` — 259 tests passed.
- `uv run python -m compileall -q src tests` — passed.
- `PYTHONPATH=tests uv run python -m src.cli docs workflows --check` — passed.
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — 770 tests passed.
- After Hermes review fix for doc command spelling:
  - `PYTHONPATH=tests uv run python -m src.cli docs workflows --check` — passed.
  - `PYTHONPATH=tests uv run python -m unittest tests.test_cli.CliTests.test_accepted_plan_artifact_is_coding_delegate_context tests.test_cli.CliTests.test_hermes_plan_returns_review_gated_scaffold tests.test_runtime_artifacts.RuntimeArtifactTests.test_journal_events_project_run_lifecycle_without_legacy_observation_file -v` — 3 tests passed.

## Review notes

Hermes review found and fixed one issue before opening the PR: documentation initially referenced `omh hermes plan accept`, but the implemented CLI command is `omh hermes plan-accept`. The docs now match the command surface.

## Risks / rollout

- Broad runtime/status surface change; existing legacy runtime artifacts are still readable and merged with journal projections.
- Installed Hermes profiles need `omh update`/setup refresh and Hermes restart/reload before chat-visible plugin/status changes can be claimed.
- Live executor progress reporting remains a follow-up product gap tracked in #262.
