### PR TITLE
Project OMH usability capability families

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,18 +96,17 @@ Use OMH request-to-handoff for: I want to safely add a feature to this repo.
 ## Why OMH
 
 - **Hermes stays the surface** - users ask in plain language, and Hermes can
-  answer with the right workflow, role, next action, or handoff.
-- **Skills install into the workflow you already use** - OMH adds
-  Hermes-visible skills and setup repair without asking teams to adopt another
-  dashboard.
-- **Research and planning feel first-class** - source finding, paper learning,
-  web research, briefs, interviews, plans, and strategy work have dedicated
-  Hermes-facing paths.
+  answer with a family, workflow, role, next action, or handoff.
+- **Discovery starts with outcomes** - planning, learning, material creation,
+  coding delegation, and operations appear as capability families before users
+  need to know skill names.
+- **Research and planning are first-class** - source finding, paper learning,
+  web research, briefs, interviews, plans, and strategy work stay in
+  Hermes-facing paths instead of defaulting to coding.
 - **Coding is delegated deliberately** - Codex, Claude Code, Hermes, or another
-  selected executor can receive a scoped handoff with non-goals, acceptance
-  criteria, and verification expectations.
-- **Prepared is not observed** - OMH keeps planned handoffs, generated prompts,
-  status cards, execution, review, CI, and merge evidence separate.
+  selected executor receives a scoped handoff only after the request is clear.
+- **Prepared is not observed** - plans, generated prompts, status cards,
+  dispatch, execution, review, CI, and merge evidence stay separate.
 - **Local and inspectable** - skills, manifests, plans, sessions, and status
   records stay in user-owned local directories.
 
@@ -121,16 +120,11 @@ Use OMH request-to-handoff for: I want to safely add a feature to this repo.
 
 | Need | OMH helps Hermes do this | Example |
 | --- | --- | --- |
-| `deep-interview` / `ralplan` / `ultragoal` / `loop` / `ultraprocess` | Shape fuzzy intent into an interview, plan, goal loop, or one PR-ready delivery cycle. | "Make onboarding feel smoother." |
-| `feedback-triage` / `research-brief` / `strategy-brief` | Keep product signals, source-backed research, and decisions in non-coding workflows. | "Payment failures keep coming up." |
-| `source-finder` / `research-department` / `web-research` / `research-brief` / `report-package` | Prepare typed source candidates, Scout -> Analyst -> Briefer research operations, source-backed evidence, and briefing status boundaries. | "Find papers, datasets, and repos for this topic." |
-| `paper-learning` | Explain a supplied paper or paper PDF at very easy, moderate, or expert level while preserving a coverage ledger. | "Explain this arXiv paper without dropping details." |
-| `operating-rhythm` / `report-package` / `reliability-review` | Record cadence, reports, and reliability reviews as local artifacts with evidence boundaries. | "Turn the sprint retro and incident review into durable records." |
-| `automation-blueprint` / `web-research` / `report-package` | Prepare recurring research or ops blueprints with schedule, delivery, and silence policy. | "Every morning, check competitor news and send a digest only if something changed." |
-| `materials-package` / `report-package` | Shape decks, PDFs, spreadsheets, documents, HWP, Markdown, and upload-ready packages. | "Turn the revenue spreadsheet into an Excel and PDF package." |
-| `img-summary` | Turn notes, PRs, issues, research, or reports into image-card prompts for a connected image tool. | "Make a PR summary card for reviewers." |
-| `idea-to-deploy` / coding runtime handoff / executor selection | Prepare work for Codex, Claude Code, Hermes, or another runtime without hiding execution. | "Turn this issue into a PR-ready plan and hand it to implementation." |
-| `agent-ops-review` | Show a manager view of AI-agent research, coding, review, blockers, next actions, and throughput levers. | "As a manager, show the quality and progress of agent work." |
+| Plan and decide | Clarify fuzzy goals, produce reviewed plans, choose loopable work, and keep decisions explicit. | "Make onboarding feel smoother." |
+| Learn and gather | Find sources, explain papers, triage signals, and prepare source-backed briefs before synthesis or handoff. | "Find papers, datasets, and repos for this topic." |
+| Create materials and visuals | Shape decks, PDFs, spreadsheets, reports, deliverable packages, and image-card prompts before generation is claimed. | "Make a PR summary card for reviewers." |
+| Delegate coding and ship | Prepare scoped handoffs for Codex, Claude Code, Hermes, or another runtime, then track dispatch, review, CI, and merge evidence separately. | "Turn this issue into a PR-ready plan and hand it to implementation." |
+| Operate and observe | Show setup health, recurring ops plans, workflow learning, memory review, agent ops status, and repair next steps. | "Why did this route to plan? Make it a regression." |
 
 ## What You Get
 

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -47,6 +47,22 @@ Friendly section aliases such as `roles`, `agents`, `patterns`, `tools`, and
 `evidence` are accepted as input; JSON responses keep the canonical section
 names shown below.
 
+The summary also includes `capability_families`, the user-facing front door for
+normal chat surfaces:
+
+| Family | What Hermes should show first |
+| --- | --- |
+| Plan and decide | Clarify goals, prepare plans, and make loop or decision paths explicit. |
+| Learn and gather | Find sources, explain papers, triage signals, and prepare source-backed briefs. |
+| Create materials and visuals | Shape files, reports, packages, and image-card prompts before generation is claimed. |
+| Delegate coding and ship | Prepare scoped handoffs for Codex, Claude Code, Hermes, or another runtime after scope is clear. |
+| Operate and observe | Show setup health, automation, workflow learning, memory review, status, and repair next steps. |
+
+Capability families are the public, user-facing front door. The older lanes and
+groups remain in the manifest as compatibility context for wrappers, tests, and
+existing plugin surfaces; they should not be introduced to normal users before
+the family layer.
+
 ## Sections
 
 | Section | Purpose |

--- a/src/capabilities/__init__.py
+++ b/src/capabilities/__init__.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
-from .registry import capability_snapshot, filtered_capability_snapshot, inspect_capability, list_capabilities
-
 __all__ = [
     "capability_snapshot",
     "filtered_capability_snapshot",
     "inspect_capability",
     "list_capabilities",
 ]
+
+
+def __getattr__(name: str):
+    if name in __all__:
+        from . import registry
+
+        return getattr(registry, name)
+    raise AttributeError(name)

--- a/src/capabilities/families.py
+++ b/src/capabilities/families.py
@@ -1,0 +1,329 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Iterable, cast
+
+from ..plugin_bundle.omh.awareness import awareness_lane_examples, awareness_primer_payload
+from ..skills.catalog import installable_skill_names
+
+CAPABILITY_FAMILY_SCHEMA_VERSION = "omh_capability_families/v1"
+
+CONCEPTUAL_WORKFLOW_SURFACES = {
+    "request-to-handoff",
+    "executor selection",
+    "coding runtime handoff",
+}
+
+_FAMILY_DEFINITIONS = (
+    {
+        "id": "plan_and_decide",
+        "label": "Plan and decide",
+        "owner_role": "planner",
+        "source_lanes": ("intent_to_plan",),
+        "use_for": "Ambiguous goals, planning, decisions, and loopable work before execution.",
+        "primary_workflows": ("deep-interview", "ralplan", "ultragoal", "loop", "strategy-brief"),
+        "next_action": "clarify_or_prepare_plan",
+        "example_prompt": "Make onboarding feel smoother.",
+        "not_evidence_until_observed": ("plan acceptance", "executor dispatch", "verification"),
+        "route_summary": "Clarify the goal, choose the planning depth, and show the next concrete action.",
+    },
+    {
+        "id": "learn_and_gather",
+        "label": "Learn and gather",
+        "owner_role": "researcher",
+        "source_lanes": ("research_and_ops",),
+        "use_for": "Source finding, web research, papers, customer signals, and briefings.",
+        "primary_workflows": ("source-finder", "web-research", "paper-learning", "research-department", "feedback-triage"),
+        "next_action": "gather_source_backed_evidence",
+        "example_prompt": "Find papers, datasets, and repos for this topic.",
+        "not_evidence_until_observed": ("source retrieval", "source verification", "decision approval"),
+        "route_summary": "Name the source/synthesis split before summarizing or planning from the material.",
+    },
+    {
+        "id": "create_materials_and_visuals",
+        "label": "Create materials and visuals",
+        "owner_role": "operator",
+        "source_lanes": ("materials_and_visuals",),
+        "use_for": "Decks, PDFs, spreadsheets, reports, image cards, and shareable packages.",
+        "primary_workflows": ("materials-package", "report-package", "deliverable-package", "img-summary"),
+        "next_action": "prepare_material_or_visual_card",
+        "example_prompt": "Make a PR summary card for reviewers.",
+        "not_evidence_until_observed": ("file export", "image generation", "visual QA", "delivery"),
+        "route_summary": "Prepare the copy, prompt, package, or QA contract before claiming generated output.",
+    },
+    {
+        "id": "delegate_coding_and_ship",
+        "label": "Delegate coding and ship",
+        "owner_role": "handoff-guide",
+        "source_lanes": ("coding_handoff",),
+        "use_for": "Scoped coding handoffs, executor choice, review, QA, CI, and merge readiness.",
+        "primary_workflows": ("idea-to-deploy", "ultraprocess", "code-review", "team", "ultrawork", "ultraqa"),
+        "executor_choices": ("Codex", "Claude Code", "Hermes", "generic runtime"),
+        "next_action": "prepare_scoped_coding_handoff",
+        "example_prompt": "Turn this issue into a PR-ready plan and hand it to implementation.",
+        "not_evidence_until_observed": ("executor dispatch", "implementation", "review", "CI", "merge"),
+        "route_summary": "Choose the coding owner only after scope is concrete, then track observed evidence separately.",
+    },
+    {
+        "id": "operate_and_observe",
+        "label": "Operate and observe",
+        "owner_role": "tracker",
+        "source_lanes": ("automation_and_status",),
+        "use_for": "Setup repair, status, automation, workflow learning, memory review, and ops cards.",
+        "primary_workflows": ("doctor", "automation-blueprint", "agent-ops-review", "workflow-learning", "memory-curation-review"),
+        "next_action": "show_status_or_prepare_operating_card",
+        "example_prompt": "Why did this route to plan? Make it a regression.",
+        "not_evidence_until_observed": ("schedule creation", "connector I/O", "runtime load", "skill patch approval"),
+        "route_summary": "Show status, repair, schedule, or learning shape without claiming runtime actions happened.",
+    },
+)
+
+_WORKFLOW_FAMILY_OVERRIDES = {
+    "oh-my-hermes": "plan_and_decide",
+    "deep-interview": "plan_and_decide",
+    "plan": "plan_and_decide",
+    "ralplan": "plan_and_decide",
+    "ralph": "plan_and_decide",
+    "ultragoal": "plan_and_decide",
+    "loop": "plan_and_decide",
+    "performance-goal": "plan_and_decide",
+    "strategy-brief": "plan_and_decide",
+    "source-finder": "learn_and_gather",
+    "web-research": "learn_and_gather",
+    "best-practice-research": "learn_and_gather",
+    "autoresearch-goal": "learn_and_gather",
+    "research-brief": "learn_and_gather",
+    "research-department": "learn_and_gather",
+    "paper-learning": "learn_and_gather",
+    "feedback-triage": "learn_and_gather",
+    "meeting-brief": "learn_and_gather",
+    "materials-package": "create_materials_and_visuals",
+    "report-package": "create_materials_and_visuals",
+    "deliverable-package": "create_materials_and_visuals",
+    "img-summary": "create_materials_and_visuals",
+    "wiki": "create_materials_and_visuals",
+    "idea-to-deploy": "delegate_coding_and_ship",
+    "ultraprocess": "delegate_coding_and_ship",
+    "code-review": "delegate_coding_and_ship",
+    "team": "delegate_coding_and_ship",
+    "ultrawork": "delegate_coding_and_ship",
+    "ultraqa": "delegate_coding_and_ship",
+    "ai-slop-cleaner": "delegate_coding_and_ship",
+    "executor-runtime-readiness": "delegate_coding_and_ship",
+    "request-to-handoff": "delegate_coding_and_ship",
+    "executor selection": "delegate_coding_and_ship",
+    "coding runtime handoff": "delegate_coding_and_ship",
+    "cto-loop": "delegate_coding_and_ship",
+    "deploy-and-monitor": "delegate_coding_and_ship",
+    "github-event-ops": "delegate_coding_and_ship",
+    "automation-blueprint": "operate_and_observe",
+    "agent-board": "operate_and_observe",
+    "gateway-intent-card": "operate_and_observe",
+    "voice-operator": "operate_and_observe",
+    "toolbelt-readiness": "operate_and_observe",
+    "ops-observability-card": "operate_and_observe",
+    "agent-ops-review": "operate_and_observe",
+    "memory-curation-review": "operate_and_observe",
+    "workflow-learning": "operate_and_observe",
+    "doctor": "operate_and_observe",
+    "skill": "operate_and_observe",
+    "ask": "operate_and_observe",
+    "cancel": "operate_and_observe",
+    "operating-rhythm": "operate_and_observe",
+    "ops-review": "operate_and_observe",
+    "reliability-review": "operate_and_observe",
+}
+
+
+def capability_family_projection(available_workflows: Iterable[str] | None = None) -> dict[str, object]:
+    """Return the user-facing OMH capability-family projection."""
+    awareness = awareness_primer_payload()
+    lane_by_id = {
+        str(lane.get("id")): lane
+        for lane in _dict_list(awareness.get("lanes", []))
+    }
+    available = _available_workflows(available_workflows)
+    families = [
+        _family_payload(definition, lane_by_id, available)
+        for definition in _FAMILY_DEFINITIONS
+    ]
+    workflow_to_family = _workflow_to_family(families, lane_by_id, available)
+    return {
+        "schema_version": CAPABILITY_FAMILY_SCHEMA_VERSION,
+        "determinism": "static_projection_no_runtime_clock",
+        "purpose": (
+            "User-facing front-door families for explaining OMH without making normal users learn backend commands."
+        ),
+        "families": families,
+        "workflow_to_family": workflow_to_family,
+        "family_order": [str(family["id"]) for family in families],
+        "claim_boundary": (
+            "Capability families are routing and handoff guidance only; prepared cards, prompts, or handoffs "
+            "are not observed execution, generation, review, CI, merge, delivery, or Hermes plugin-use evidence."
+        ),
+    }
+
+
+def capability_family_cards(available_workflows: Iterable[str] | None = None) -> list[dict[str, object]]:
+    """Return compact cards for picker, quickstart, and README-like surfaces."""
+    return deepcopy(_dict_list(capability_family_projection(available_workflows).get("families", [])))
+
+
+def family_for_workflow(workflow: str, available_workflows: Iterable[str] | None = None) -> dict[str, object]:
+    """Return the family card for one workflow or an empty dict when unknown."""
+    key = str(workflow or "").strip()
+    if not key:
+        return {}
+    projection = capability_family_projection(available_workflows)
+    workflow_to_family = _string_mapping(projection.get("workflow_to_family", {}))
+    family_id = workflow_to_family.get(key)
+    if not family_id:
+        family_id = workflow_to_family.get(key.casefold())
+    if not family_id:
+        return {}
+    for family in _dict_list(projection.get("families", [])):
+        if family.get("id") == family_id:
+            return deepcopy(family)
+    return {}
+
+
+def family_id_for_workflow(workflow: str) -> str:
+    """Return just the family id for compact skill capability metadata."""
+    family = family_for_workflow(workflow)
+    return str(family.get("id", ""))
+
+
+def _available_workflows(available_workflows: Iterable[str] | None) -> set[str]:
+    if available_workflows is None:
+        return set(installable_skill_names()) | CONCEPTUAL_WORKFLOW_SURFACES | {"oh-my-hermes"}
+    return {str(item) for item in available_workflows if str(item)} | CONCEPTUAL_WORKFLOW_SURFACES | {"oh-my-hermes"}
+
+
+def _family_payload(
+    definition: dict[str, object],
+    lane_by_id: dict[str, dict[str, object]],
+    available: set[str],
+) -> dict[str, object]:
+    source_lanes = _string_tuple(definition.get("source_lanes", ()))
+    source_workflows = _source_workflows(source_lanes, lane_by_id, available)
+    family_id = str(definition["id"])
+    primary_workflows = [
+        workflow
+        for workflow in _dedupe([*_string_tuple(definition.get("primary_workflows", ())), *source_workflows])
+        if workflow in available and _workflow_belongs_to_family(workflow, family_id, source_lanes)
+    ]
+    payload = {
+        "id": family_id,
+        "label": str(definition["label"]),
+        "owner_role": str(definition["owner_role"]),
+        "source_lanes": list(source_lanes),
+        "use_for": str(definition["use_for"]),
+        "primary_workflows": primary_workflows,
+        "next_action": str(definition["next_action"]),
+        "example_prompt": str(definition["example_prompt"]),
+        "route_summary": str(definition["route_summary"]),
+        "not_evidence_until_observed": list(_string_tuple(definition.get("not_evidence_until_observed", ()))),
+        "source_examples": [
+            example
+            for lane_id in source_lanes
+            for example in awareness_lane_examples(lane_id)
+        ][:4],
+    }
+    executor_choices = _string_tuple(definition.get("executor_choices", ()))
+    if executor_choices:
+        payload["executor_choices"] = list(executor_choices)
+    return payload
+
+
+def _source_workflows(
+    source_lanes: tuple[str, ...],
+    lane_by_id: dict[str, dict[str, object]],
+    available: set[str],
+) -> list[str]:
+    workflows: list[str] = []
+    for lane_id in source_lanes:
+        lane = lane_by_id.get(lane_id, {})
+        for workflow in _string_list(lane.get("skills", [])):
+            if workflow in available:
+                workflows.append(workflow)
+    return workflows
+
+
+def _workflow_to_family(
+    families: list[dict[str, object]],
+    lane_by_id: dict[str, dict[str, object]],
+    available: set[str],
+) -> dict[str, str]:
+    mapping: dict[str, str] = {}
+    family_ids = {str(family["id"]) for family in families}
+    for workflow, family_id in sorted(_WORKFLOW_FAMILY_OVERRIDES.items()):
+        if workflow in available and family_id in family_ids:
+            mapping[workflow] = family_id
+            mapping[workflow.casefold()] = family_id
+    for family in families:
+        family_id = str(family["id"])
+        for workflow in _string_list(family.get("primary_workflows", [])):
+            mapping.setdefault(workflow, family_id)
+            mapping.setdefault(workflow.casefold(), family_id)
+    for lane in lane_by_id.values():
+        lane_id = str(lane.get("id", ""))
+        default_family = _default_family_for_source_lane(lane_id)
+        if not default_family:
+            continue
+        for workflow in _string_list(lane.get("skills", [])):
+            if workflow in available:
+                mapping.setdefault(workflow, default_family)
+                mapping.setdefault(workflow.casefold(), default_family)
+    return mapping
+
+
+def _workflow_belongs_to_family(workflow: str, family_id: str, source_lanes: tuple[str, ...]) -> bool:
+    override = _WORKFLOW_FAMILY_OVERRIDES.get(workflow)
+    if override:
+        return override == family_id
+    return any(_default_family_for_source_lane(lane_id) == family_id for lane_id in source_lanes)
+
+
+def _default_family_for_source_lane(lane_id: str) -> str:
+    for definition in _FAMILY_DEFINITIONS:
+        if lane_id in _string_tuple(definition.get("source_lanes", ())):
+            return str(definition["id"])
+    return ""
+
+
+def _dedupe(values: Iterable[object]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        text = str(value)
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        result.append(text)
+    return result
+
+
+def _dict_list(value: object) -> list[dict[str, object]]:
+    if not isinstance(value, list):
+        return []
+    return [cast(dict[str, object], item) for item in value if isinstance(item, dict)]
+
+
+def _string_list(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value if str(item)]
+
+
+def _string_tuple(value: object) -> tuple[str, ...]:
+    if isinstance(value, tuple):
+        return tuple(str(item) for item in value if str(item))
+    if isinstance(value, list):
+        return tuple(str(item) for item in value if str(item))
+    return ()
+
+
+def _string_mapping(value: object) -> dict[str, str]:
+    if not isinstance(value, dict):
+        return {}
+    return {str(key): str(item) for key, item in value.items() if str(key) and str(item)}

--- a/src/capabilities/registry.py
+++ b/src/capabilities/registry.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from copy import deepcopy
 
 from .agents import agent_role_capabilities
+from .families import capability_family_projection
 from .hooks import hook_manifest
 from .keywords import keyword_detector_manifest
 from .orchestration import orchestration_patterns
@@ -73,6 +74,7 @@ def capability_snapshot() -> dict[str, object]:
     playbooks = playbook_capabilities()
     tools = tool_requirements_manifest()
     awareness = awareness_primer_payload()
+    families = capability_family_projection()
     snapshot = {
         "schema_version": CAPABILITY_MANIFEST_SCHEMA_VERSION,
         "manifest_id": "omh_capabilities",
@@ -87,7 +89,9 @@ def capability_snapshot() -> dict[str, object]:
             "orchestration_patterns": len(patterns),
             "playbooks": len(playbooks),
             "tool_requirements": len(tools["items"]),
+            "capability_families": len(families["families"]),
         },
+        "capability_families": families,
         "omh_awareness": awareness,
         "agent_roles": agent_roles,
         "skills": skills,
@@ -115,6 +119,7 @@ def capability_summary() -> dict[str, object]:
     skills = {str(item.get("id")): item for item in snapshot["skills"] if isinstance(item, dict)}
     playbooks = {str(item.get("id")): item for item in snapshot["playbooks"] if isinstance(item, dict)}
     lanes = awareness.get("lanes", []) if isinstance(awareness, dict) else []
+    families = snapshot.get("capability_families", {})
     return {
         "schema_version": "omh_capability_summary/v1",
         "manifest_id": snapshot["manifest_id"],
@@ -125,6 +130,8 @@ def capability_summary() -> dict[str, object]:
         ),
         "chat_rule": awareness.get("chat_rule", "") if isinstance(awareness, dict) else "",
         "totals": snapshot["summary"],
+        "capability_families": families.get("families", []) if isinstance(families, dict) else [],
+        "workflow_to_family": families.get("workflow_to_family", {}) if isinstance(families, dict) else {},
         "lanes": [
             _summary_lane(lane, skills, playbooks)
             for lane in lanes
@@ -132,9 +139,9 @@ def capability_summary() -> dict[str, object]:
         ],
         "workflow_context_cards": awareness.get("workflow_context_cards", []) if isinstance(awareness, dict) else [],
         "direct_response_guidance": [
-            "When a user asks what OMH can do, summarize these lanes and offer the workflow picker.",
-            "When a request matches a lane, name the likely workflow and the first safe next action.",
-            "When a request crosses lanes, name the adjacent workflow before preparing handoff or status.",
+            "When a user asks what OMH can do, summarize capability families and offer the workflow picker.",
+            "When a request matches a family, name the likely workflow and the first safe next action.",
+            "When a request crosses families, name the adjacent workflow before preparing handoff or status.",
             "Use friendly section aliases for input, but keep canonical names in machine-readable output.",
         ],
         "section_aliases": dict(sorted(CAPABILITY_SECTION_ALIASES.items())),

--- a/src/commands/capabilities.py
+++ b/src/commands/capabilities.py
@@ -43,6 +43,19 @@ def cmd_capabilities_summary(args: argparse.Namespace) -> int:
         return 0
     print("OMH capability summary")
     print("Use this when Hermes needs to explain what OMH can do without shell catalog approval.")
+    families = payload.get("capability_families", [])
+    if isinstance(families, list) and families:
+        print("Capability families")
+        print("Families are the user-facing front door; legacy lanes remain compatibility context.")
+        for family in families:
+            if not isinstance(family, dict):
+                continue
+            workflows = family.get("primary_workflows", [])
+            workflow_text = ", ".join(str(item) for item in workflows[:5]) if isinstance(workflows, list) else ""
+            print(f"- {family.get('label', '')} ({family.get('owner_role', '')})")
+            print(f"  Use for: {family.get('use_for', '')}")
+            print(f"  Workflows: {workflow_text}")
+        print("Legacy lanes")
     for lane in payload["lanes"]:
         skills = lane["primary_skills"]
         playbooks = lane["representative_playbooks"]

--- a/src/plugin_bundle/omh/context_brief.py
+++ b/src/plugin_bundle/omh/context_brief.py
@@ -40,6 +40,7 @@ def build_context_brief(
         "chat_rule": primer["chat_rule"],
         "first_turn_rule": primer["first_turn_rule"],
         "all_skill_context_rule": primer["all_skill_context_rule"],
+        "capability_families": _capability_family_cards(),
         "lanes": primer["lanes"],
         "workflow_context_cards": primer["workflow_context_cards"],
         "workflow_cues": primer["workflow_cues"],
@@ -84,6 +85,16 @@ def build_context_brief(
     if catalog_hint:
         payload["catalog_question"] = catalog_hint
     return payload
+
+
+def _capability_family_cards() -> list[dict[str, object]]:
+    try:
+        from omh.capabilities.families import capability_family_cards
+    except ImportError:
+        from .tools.capability_tool import standalone_capability_family_cards
+
+        return standalone_capability_family_cards()
+    return capability_family_cards()
 
 
 def bounded_context_hint_limit(value: object, *, default: int) -> int:

--- a/src/plugin_bundle/omh/tools/capability_tool.py
+++ b/src/plugin_bundle/omh/tools/capability_tool.py
@@ -48,6 +48,111 @@ LANE_OWNER_ROLES = {
     "automation_and_status": "tracker",
     "coding_handoff": "handoff-guide",
 }
+STANDALONE_CAPABILITY_FAMILIES = (
+    {
+        "id": "plan_and_decide",
+        "label": "Plan and decide",
+        "owner_role": "planner",
+        "source_lanes": ("intent_to_plan",),
+        "use_for": "Ambiguous goals, planning, decisions, and loopable work before execution.",
+        "primary_workflows": (
+            "deep-interview",
+            "ralplan",
+            "ultragoal",
+            "loop",
+            "strategy-brief",
+            "oh-my-hermes",
+            "plan",
+            "ralph",
+            "performance-goal",
+        ),
+        "next_action": "clarify_or_prepare_plan",
+        "example_prompt": "Make onboarding feel smoother.",
+        "route_summary": "Clarify the goal, choose the planning depth, and show the next concrete action.",
+        "not_evidence_until_observed": ("plan acceptance", "executor dispatch", "verification"),
+    },
+    {
+        "id": "learn_and_gather",
+        "label": "Learn and gather",
+        "owner_role": "researcher",
+        "source_lanes": ("research_and_ops",),
+        "use_for": "Source finding, web research, papers, customer signals, and briefings.",
+        "primary_workflows": (
+            "source-finder",
+            "web-research",
+            "paper-learning",
+            "research-department",
+            "feedback-triage",
+            "best-practice-research",
+            "autoresearch-goal",
+            "research-brief",
+            "meeting-brief",
+        ),
+        "next_action": "gather_source_backed_evidence",
+        "example_prompt": "Find papers, datasets, and repos for this topic.",
+        "route_summary": "Name the source/synthesis split before summarizing or planning from the material.",
+        "not_evidence_until_observed": ("source retrieval", "source verification", "decision approval"),
+    },
+    {
+        "id": "create_materials_and_visuals",
+        "label": "Create materials and visuals",
+        "owner_role": "operator",
+        "source_lanes": ("materials_and_visuals",),
+        "use_for": "Decks, PDFs, spreadsheets, reports, image cards, and shareable packages.",
+        "primary_workflows": ("materials-package", "report-package", "deliverable-package", "img-summary", "wiki"),
+        "next_action": "prepare_material_or_visual_card",
+        "example_prompt": "Make a PR summary card for reviewers.",
+        "route_summary": "Prepare the copy, prompt, package, or QA contract before claiming generated output.",
+        "not_evidence_until_observed": ("file export", "image generation", "visual QA", "delivery"),
+    },
+    {
+        "id": "delegate_coding_and_ship",
+        "label": "Delegate coding and ship",
+        "owner_role": "handoff-guide",
+        "source_lanes": ("coding_handoff",),
+        "use_for": "Scoped coding handoffs, executor choice, review, QA, CI, and merge readiness.",
+        "primary_workflows": (
+            "idea-to-deploy",
+            "ultraprocess",
+            "code-review",
+            "team",
+            "ultrawork",
+            "ultraqa",
+            "cto-loop",
+            "deploy-and-monitor",
+            "ai-slop-cleaner",
+            "request-to-handoff",
+            "executor selection",
+            "coding runtime handoff",
+        ),
+        "executor_choices": ("Codex", "Claude Code", "Hermes", "generic runtime"),
+        "next_action": "prepare_scoped_coding_handoff",
+        "example_prompt": "Turn this issue into a PR-ready plan and hand it to implementation.",
+        "route_summary": "Choose the coding owner only after scope is concrete, then track observed evidence separately.",
+        "not_evidence_until_observed": ("executor dispatch", "implementation", "review", "CI", "merge"),
+    },
+    {
+        "id": "operate_and_observe",
+        "label": "Operate and observe",
+        "owner_role": "tracker",
+        "source_lanes": ("automation_and_status",),
+        "use_for": "Setup repair, status, automation, workflow learning, memory review, and ops cards.",
+        "primary_workflows": (
+            "doctor",
+            "automation-blueprint",
+            "agent-ops-review",
+            "workflow-learning",
+            "memory-curation-review",
+            "skill",
+            "ask",
+            "cancel",
+        ),
+        "next_action": "show_status_or_prepare_operating_card",
+        "example_prompt": "Why did this route to plan? Make it a regression.",
+        "route_summary": "Show status, repair, schedule, or learning shape without claiming runtime actions happened.",
+        "not_evidence_until_observed": ("schedule creation", "connector I/O", "runtime load", "skill patch approval"),
+    },
+)
 STANDALONE_LANE_PLAYBOOK_IDS = {
     "intent_to_plan": ("request-to-handoff", "safe-feature-change"),
     "research_and_ops": ("source-finder", "research-department", "source-backed-research", "feedback-triage"),
@@ -171,12 +276,16 @@ def _standalone_capability_summary() -> dict[str, object]:
             "skills": len(skills),
             "playbooks": len(playbooks),
             "agent_roles": len(_standalone_items(sections["agent_roles"])),
+            "capability_families": len(STANDALONE_CAPABILITY_FAMILIES),
         },
+        "capability_families": _standalone_capability_families(),
+        "workflow_to_family": _standalone_workflow_to_family(),
         "lanes": lanes,
         "workflow_context_cards": awareness.get("workflow_context_cards", []),
         "direct_response_guidance": [
-            "When a user asks what OMH can do, summarize these lanes and offer the workflow picker.",
-            "When a request matches a lane, name the likely workflow and the first safe next action.",
+            "When a user asks what OMH can do, summarize capability families and offer the workflow picker.",
+            "When a request matches a family, name the likely workflow and the first safe next action.",
+            "When a request crosses families, name the adjacent workflow before preparing handoff or status.",
             "Use friendly section aliases for input, but keep canonical names in machine-readable output.",
         ],
         "section_aliases": dict(sorted(STANDALONE_CAPABILITY_SECTION_ALIASES.items())),
@@ -214,6 +323,61 @@ def _standalone_summary_lane(
         )[:8],
         "examples": awareness_lane_examples(lane_id),
     }
+
+
+def standalone_capability_family_cards() -> list[dict[str, object]]:
+    return _standalone_capability_families()
+
+
+def _standalone_capability_families() -> list[dict[str, object]]:
+    families: list[dict[str, object]] = []
+    for family in STANDALONE_CAPABILITY_FAMILIES:
+        source_lanes = [str(lane) for lane in family.get("source_lanes", ()) if str(lane)]
+        payload = {
+            **family,
+            "source_lanes": source_lanes,
+            "primary_workflows": list(family.get("primary_workflows", ())),
+            "not_evidence_until_observed": list(family.get("not_evidence_until_observed", ())),
+            "source_examples": [
+                example
+                for lane_id in source_lanes
+                for example in awareness_lane_examples(lane_id)
+            ][:4],
+        }
+        if family.get("executor_choices"):
+            payload["executor_choices"] = list(family.get("executor_choices", ()))
+        families.append(payload)
+    return families
+
+
+def _standalone_workflow_to_family() -> dict[str, str]:
+    mapping: dict[str, str] = {}
+    for family in STANDALONE_CAPABILITY_FAMILIES:
+        family_id = str(family.get("id", ""))
+        for workflow in family.get("primary_workflows", ()):
+            text = str(workflow)
+            if text and family_id:
+                mapping[text] = family_id
+                mapping[text.casefold()] = family_id
+    for lane in awareness_primer_payload().get("lanes", []):
+        if not isinstance(lane, dict):
+            continue
+        family_id = _standalone_default_family_for_source_lane(str(lane.get("id", "")))
+        if not family_id:
+            continue
+        for workflow in lane.get("skills", []):
+            text = str(workflow)
+            if text:
+                mapping.setdefault(text, family_id)
+                mapping.setdefault(text.casefold(), family_id)
+    return dict(sorted(mapping.items()))
+
+
+def _standalone_default_family_for_source_lane(lane_id: str) -> str:
+    for family in STANDALONE_CAPABILITY_FAMILIES:
+        if lane_id in family.get("source_lanes", ()):
+            return str(family.get("id", ""))
+    return ""
 
 
 def _standalone_compact_playbook(playbook: dict[str, object]) -> dict[str, object]:

--- a/src/surfaces/quickstart.py
+++ b/src/surfaces/quickstart.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from ..version import __version__
+from ..capabilities.families import capability_family_cards
 from ..doctor import doctor_ok, recommended_next_action, run_doctor
 from ..paths import OmhPaths
 from ..probe import probe_capabilities
@@ -40,9 +41,10 @@ def build_quickstart_card(paths: OmhPaths, *, source: str = "hermes") -> dict[st
         },
         "first_five_minutes": [
             "Restart or reload Hermes Agent after setup.",
-            "Ask Hermes: Use OMH request-to-handoff for: I want to safely add a feature to this repo.",
-            "If you want to choose manually, type ./omh or ask Hermes what OMH workflows are available.",
+            "Ask Hermes what OMH can do, or paste a plain request and let Hermes route it.",
+            "For coding work, ask for request-to-handoff after the scope is clear.",
         ],
+        "first_use_family_cards": capability_family_cards(),
         "chat_prompts": [
             {
                 "label": "safe feature work",

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -8,6 +8,7 @@ from ..ingress import CHAT_SOURCES, compact_source_metadata, extract_message_tex
 from ..routing.catalog_questions import is_skill_catalog_question as _is_skill_catalog_question
 from ..routing.chat import public_route_payload, route_chat_message
 from ..coding_delegation import CODING_EXECUTOR_TARGETS, build_coding_delegation_payload
+from ..capabilities.families import capability_family_cards
 from ..context import build_context_brief
 from ..executors import executor_label
 from ..goal_loop import build_loop_start_card
@@ -2470,6 +2471,7 @@ def _skill_picker_response(decision: dict[str, object], *, thread_key: str = "",
                     "selection_mode": "single_select",
                     "options": picker["options"],
                     "featured_options": picker["featured_options"],
+                    "capability_families": picker["capability_families"],
                     "groups": picker["groups"],
                 },
             ),
@@ -2482,6 +2484,8 @@ def _skill_picker_response(decision: dict[str, object], *, thread_key: str = "",
 
 
 def _skill_picker_body(*, catalog_question: bool) -> str:
+    family_heading = "Capability families:" if catalog_question else "Families:"
+    family_lines = _skill_picker_family_body_lines()
     if catalog_question:
         return "\n".join(
             [
@@ -2489,14 +2493,11 @@ def _skill_picker_body(*, catalog_question: bool) -> str:
                 "",
                 "Start here:",
                 "- Route for me: let Hermes choose the safest workflow from your message.",
-                "- Choose workflow: pick from the grouped OMH workflow lanes.",
+                "- Choose workflow: pick from the OMH capability families.",
                 "- Search workflows: find the exact skill when you already know the job.",
                 "",
-                "Common lanes:",
-                "- Intent to plan: deep-interview, ralplan, ultragoal, loop, ultraprocess.",
-                "- Company/product ops: feedback-triage, research-brief, strategy-brief, research-department, paper-learning.",
-                "- Deliverables/visuals: materials-package, report-package, img-summary.",
-                "- Coding/runtime: request-to-handoff, idea-to-deploy, code-review, executor selection.",
+                family_heading,
+                *family_lines,
             ]
         )
     return "\n".join(
@@ -2506,13 +2507,22 @@ def _skill_picker_body(*, catalog_question: bool) -> str:
             "Best default:",
             "- Route for me: paste the request and let Hermes choose the workflow.",
             "",
-            "Manual lanes:",
-            "- Plan or loop: deep-interview, ralplan, ultragoal, loop, ultraprocess.",
-            "- Ops or research: feedback-triage, research-brief, paper-learning, strategy-brief.",
-            "- Deliverables or visuals: materials-package, report-package, img-summary.",
-            "- Coding: request-to-handoff, idea-to-deploy, code-review, executor selection.",
+            family_heading,
+            *family_lines,
         ]
     )
+
+
+def _skill_picker_family_body_lines() -> list[str]:
+    lines = []
+    for family in capability_family_cards():
+        workflows = _as_string_list(family.get("primary_workflows", []))[:4]
+        workflow_text = ", ".join(workflows)
+        executor_choices = _as_string_list(family.get("executor_choices", []))[:3]
+        if executor_choices:
+            workflow_text = f"{workflow_text}; executors: {', '.join(executor_choices)}"
+        lines.append(f"- {family.get('label', '')}: {workflow_text}.")
+    return lines
 
 
 def _skill_picker_state(message: str, *, source: str) -> dict[str, object]:
@@ -2543,6 +2553,7 @@ def _skill_picker_state(message: str, *, source: str) -> dict[str, object]:
         if option["id"] == _ROUTER_SKILL
     ]
     groups = _skill_picker_groups(options)
+    family_cards = _skill_picker_family_cards(options)
     return {
         "schema_version": SKILL_PICKER_SCHEMA_VERSION,
         "trigger": _first_token(message),
@@ -2550,15 +2561,49 @@ def _skill_picker_state(message: str, *, source: str) -> dict[str, object]:
         "selection_mode": "single_select",
         "options": options,
         "featured_options": featured_options,
+        "capability_families": family_cards,
         "groups": groups,
         "rendering_hints": {
             "discord": "Render Route for me first, then grouped sections; keep the full options list only as a compatibility fallback.",
             "slack": "Render Route for me first, then grouped sections or a grouped static select in the current thread.",
             "hermes_tui": "Render grouped sections with short direct invocations; keep real skill names unchanged.",
         },
-        "recommended_rendering": "Show the featured Route for me option first, then the groups. Use search_skills for the full installed catalog.",
+        "recommended_rendering": "Show the featured Route for me option first, then capability families. Use groups/options as compatibility fallback.",
         "claim_boundary": "This picker records routing intent only; selected workflows still need their own plan, handoff, or observed evidence.",
     }
+
+
+def _skill_picker_family_cards(options: list[dict[str, object]]) -> list[dict[str, object]]:
+    option_ids = {str(option["id"]) for option in options}
+    cards = []
+    for family in capability_family_cards(option_ids):
+        workflows = [
+            workflow
+            for workflow in _as_string_list(family.get("primary_workflows", []))
+            if workflow in option_ids or workflow in {"request-to-handoff", "executor selection", "coding runtime handoff"}
+        ]
+        if not workflows:
+            continue
+        card = _compact_family_card(family)
+        card["primary_workflows"] = workflows
+        cards.append(card)
+    return cards
+
+
+def _compact_family_cards(families: list[dict[str, object]]) -> list[dict[str, object]]:
+    return [_compact_family_card(family) for family in families]
+
+
+def _compact_family_card(family: dict[str, object]) -> dict[str, object]:
+    card = {
+        "id": str(family.get("id", "")),
+        "label": str(family.get("label", "")),
+        "primary_workflows": _as_string_list(family.get("primary_workflows", []))[:8],
+    }
+    executor_choices = _as_string_list(family.get("executor_choices", []))
+    if executor_choices:
+        card["executor_choices"] = executor_choices
+    return card
 
 
 def _skill_picker_groups(options: list[dict[str, object]]) -> list[dict[str, object]]:
@@ -2617,6 +2662,7 @@ def _context_primer_state() -> dict[str, object]:
             "OMH is a Hermes workflow layer. It helps Hermes route natural-language work into skills, plans, "
             "deliverables, coding handoffs, loops, and status updates without treating prepared guidance as observed work."
         ),
+        "capability_families": _compact_family_cards(capability_family_cards(installed)),
         "workflow_groups": groups,
         "workflow_context_cards": workflow_context_cards(),
         "routing_rule": "Use Route for me when the user did not choose a workflow; use explicit workflow names when the user did.",
@@ -2654,6 +2700,7 @@ def _catalog_capability_summary() -> dict[str, object]:
     return {
         "schema_version": summary.get("schema_version", "omh_capability_summary/v1"),
         "purpose": summary.get("purpose", ""),
+        "capability_families": _compact_family_cards(_as_dict_list(summary.get("capability_families", []))),
         "lanes": compact_lanes,
         "workflow_context_cards": _as_dict_list(summary.get("workflow_context_cards", [])),
         "direct_response_guidance": _as_string_list(summary.get("direct_response_guidance", [])),

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -10,6 +10,7 @@ from _local_package import load_local_package
 
 load_local_package()
 
+from omh.capabilities.families import capability_family_projection, family_for_workflow
 from omh.capabilities.registry import capability_snapshot, capability_summary, inspect_capability, list_capabilities
 from omh.capabilities.schema import normalize_capability_section
 from omh.skills.catalog import builtin_definitions, installable_skill_names
@@ -60,6 +61,44 @@ class CapabilityManifestTests(unittest.TestCase):
         self.assertFalse(generated_skills - lane_skills)
         self.assertLessEqual(lane_skills - catalog_surfaces, conceptual_surfaces)
 
+    def test_capability_families_are_user_facing_front_door_projection(self) -> None:
+        projection = capability_family_projection()
+        families = {family["id"]: family for family in projection["families"]}
+
+        self.assertEqual(projection["schema_version"], "omh_capability_families/v1")
+        self.assertEqual(
+            [family["label"] for family in projection["families"]],
+            [
+                "Plan and decide",
+                "Learn and gather",
+                "Create materials and visuals",
+                "Delegate coding and ship",
+                "Operate and observe",
+            ],
+        )
+        self.assertIn("deep-interview", families["plan_and_decide"]["primary_workflows"])
+        self.assertIn("paper-learning", families["learn_and_gather"]["primary_workflows"])
+        self.assertIn("img-summary", families["create_materials_and_visuals"]["primary_workflows"])
+        self.assertIn("ultraprocess", families["delegate_coding_and_ship"]["primary_workflows"])
+        self.assertIn("doctor", families["operate_and_observe"]["primary_workflows"])
+        self.assertEqual(projection["workflow_to_family"]["img-summary"], "create_materials_and_visuals")
+        self.assertEqual(projection["workflow_to_family"]["paper-learning"], "learn_and_gather")
+        self.assertEqual(projection["workflow_to_family"]["ultraprocess"], "delegate_coding_and_ship")
+        self.assertEqual(family_for_workflow("code-review")["id"], "delegate_coding_and_ship")
+        self.assertEqual(family_for_workflow("workflow-learning")["id"], "operate_and_observe")
+        self.assertIn("Codex", families["delegate_coding_and_ship"]["executor_choices"])
+        self.assertIn("Claude Code", families["delegate_coding_and_ship"]["executor_choices"])
+        self.assertIn("Hermes", families["delegate_coding_and_ship"]["executor_choices"])
+        self.assertIn("executor dispatch", families["delegate_coding_and_ship"]["not_evidence_until_observed"])
+        self.assertIn("not observed execution", projection["claim_boundary"])
+        seen_workflows: dict[str, str] = {}
+        for family in projection["families"]:
+            family_id = family["id"]
+            for workflow in family["primary_workflows"]:
+                self.assertNotIn(workflow, seen_workflows, f"{workflow} appears in multiple families")
+                seen_workflows[workflow] = family_id
+                self.assertEqual(projection["workflow_to_family"][workflow], family_id)
+
     def test_capability_sections_have_expected_ids(self) -> None:
         listing = list_capabilities()
         sections = {section["section"]: section["ids"] for section in listing["sections"]}
@@ -79,16 +118,22 @@ class CapabilityManifestTests(unittest.TestCase):
 
     def test_capability_summary_is_human_facing_catalog_context(self) -> None:
         summary = capability_summary()
+        families = {family["id"]: family for family in summary["capability_families"]}
         lanes = {lane["id"]: lane for lane in summary["lanes"]}
         context_cards = {card["id"]: card for card in summary["workflow_context_cards"]}
 
         self.assertEqual(summary["schema_version"], "omh_capability_summary/v1")
         self.assertIn("without requiring shell catalog approval", summary["purpose"])
         self.assertIn("Normal users talk to Hermes", summary["chat_rule"])
-        self.assertIn("workflow picker", " ".join(summary["direct_response_guidance"]))
+        self.assertIn("capability families", " ".join(summary["direct_response_guidance"]))
         self.assertEqual(summary["section_aliases"]["roles"], "agent_roles")
         self.assertEqual(summary["section_aliases"]["tools"], "tool_requirements")
         self.assertIn("Prepared OMH capability", summary["evidence_boundary"])
+        self.assertEqual(families["plan_and_decide"]["label"], "Plan and decide")
+        self.assertIn("paper-learning", families["learn_and_gather"]["primary_workflows"])
+        self.assertIn("img-summary", families["create_materials_and_visuals"]["primary_workflows"])
+        self.assertIn("Claude Code", families["delegate_coding_and_ship"]["executor_choices"])
+        self.assertEqual(summary["workflow_to_family"]["code-review"], "delegate_coding_and_ship")
         self.assertEqual(lanes["intent_to_plan"]["owner_role"], "planner")
         self.assertIn("loop", lanes["intent_to_plan"]["primary_skills"])
         self.assertIn("img-summary", lanes["materials_and_visuals"]["primary_skills"])
@@ -180,6 +225,7 @@ class CapabilityManifestTests(unittest.TestCase):
 
         self.assertEqual(status, 0, stderr)
         self.assertIn("OMH capability summary", stdout)
+        self.assertIn("Families are the user-facing front door", stdout)
         self.assertIn("Materials and visual summaries", stdout)
 
         status, stdout, stderr = run_cli(["capabilities", "summary", "--json"], output_json=False)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -114,6 +114,13 @@ class CliTests(unittest.TestCase):
         self.assertFalse(payload["message"]["raw_prompt_stored"])
         self.assertNotIn("secret-token-123", stdout)
 
+    def test_context_brief_does_not_mask_capability_family_projection_errors(self) -> None:
+        from omh.plugin_bundle.omh.context_brief import build_context_brief
+
+        with patch("omh.capabilities.families.capability_family_cards", side_effect=RuntimeError("projection boom")):
+            with self.assertRaisesRegex(RuntimeError, "projection boom"):
+                build_context_brief("what can OMH do?")
+
         status, stdout, stderr = run_cli(
             [
                 "context",
@@ -841,6 +848,10 @@ class CliTests(unittest.TestCase):
             self.assertEqual(payload["schema_version"], "omh_quickstart_card/v1")
             self.assertEqual(payload["status"], "ready")
             self.assertEqual(payload["source"], "discord")
+            family_cards = {family["id"]: family for family in payload["first_use_family_cards"]}
+            self.assertIn("paper-learning", family_cards["learn_and_gather"]["primary_workflows"])
+            self.assertIn("img-summary", family_cards["create_materials_and_visuals"]["primary_workflows"])
+            self.assertIn("Claude Code", family_cards["delegate_coding_and_ship"]["executor_choices"])
             self.assertEqual(payload["local_status"]["plugin_bridge"]["status"], "ready_locally")
             self.assertFalse(payload["local_status"]["plugin_runtime_observed"])
             self.assertFalse(payload["local_status"]["plugin_runtime_active"])
@@ -4106,7 +4117,7 @@ class CliTests(unittest.TestCase):
                 picker = payload["chat_response"]["state"]["skill_picker"]
                 self.assertEqual(picker["schema_version"], "omh_skill_picker/v1")
                 self.assertIn("Best default:", payload["chat_response"]["body"])
-                self.assertIn("Manual lanes:", payload["chat_response"]["body"])
+                self.assertIn("Families:", payload["chat_response"]["body"])
                 self.assertIn("Route for me:", payload["chat_response"]["body"])
                 rendering_blocks = payload["chat_response"]["messenger_rendering"]["body_blocks"]
                 self.assertGreaterEqual(
@@ -4116,12 +4127,17 @@ class CliTests(unittest.TestCase):
                 option_ids = {option["id"] for option in picker["options"]}
                 self.assertTrue({"oh-my-hermes", "deep-interview", "ralplan", "loop", "ultraprocess"} <= option_ids)
                 self.assertEqual(picker["featured_options"][0]["id"], "oh-my-hermes")
+                families = {family["id"]: family for family in picker["capability_families"]}
+                self.assertIn("paper-learning", families["learn_and_gather"]["primary_workflows"])
+                self.assertIn("img-summary", families["create_materials_and_visuals"]["primary_workflows"])
+                self.assertIn("Claude Code", families["delegate_coding_and_ship"]["executor_choices"])
                 groups = {group["id"]: group for group in picker["groups"]}
                 self.assertIn("loop", groups["intent_to_plan"]["option_ids"])
                 self.assertIn("img-summary", groups["deliverables_and_visuals"]["option_ids"])
                 self.assertIn("code-review", groups["coding_and_runtime"]["option_ids"])
                 action_payload = next(action for action in payload["chat_response"]["actions"] if action["id"] == "choose_skill")["payload"]
                 self.assertEqual(action_payload["featured_options"][0]["id"], "oh-my-hermes")
+                self.assertIn("capability_families", action_payload)
                 self.assertIn("groups", action_payload)
                 self.assertIn("choose_skill", {action["id"] for action in payload["chat_response"]["actions"]})
 
@@ -4164,7 +4180,7 @@ class CliTests(unittest.TestCase):
                 self.assertTrue(payload["chat_response"]["state"]["catalog_question"])
                 self.assertIn("shell command", payload["chat_response"]["body"])
                 self.assertIn("Start here:", payload["chat_response"]["body"])
-                self.assertIn("Common lanes:", payload["chat_response"]["body"])
+                self.assertIn("Capability families:", payload["chat_response"]["body"])
                 self.assertIn("Route for me:", payload["chat_response"]["body"])
                 rendering_blocks = payload["chat_response"]["messenger_rendering"]["body_blocks"]
                 self.assertGreaterEqual(
@@ -4173,15 +4189,21 @@ class CliTests(unittest.TestCase):
                 )
                 picker = payload["chat_response"]["state"]["skill_picker"]
                 self.assertEqual(picker["featured_options"][0]["id"], "oh-my-hermes")
+                picker_families = {family["id"]: family for family in picker["capability_families"]}
+                self.assertIn("paper-learning", picker_families["learn_and_gather"]["primary_workflows"])
+                self.assertIn("img-summary", picker_families["create_materials_and_visuals"]["primary_workflows"])
                 picker_groups = {group["id"]: group for group in picker["groups"]}
                 self.assertIn("feedback-triage", picker_groups["company_product_ops"]["option_ids"])
                 self.assertIn("img-summary", picker_groups["deliverables_and_visuals"]["option_ids"])
                 capability_summary = payload["chat_response"]["state"]["capability_summary"]
                 self.assertEqual(capability_summary["schema_version"], "omh_capability_summary/v1")
+                summary_families = {family["id"]: family for family in capability_summary["capability_families"]}
                 lanes = {lane["id"]: lane for lane in capability_summary["lanes"]}
                 self.assertIn("intent_to_plan", lanes)
                 self.assertIn("materials_and_visuals", lanes)
                 self.assertIn("coding_handoff", lanes)
+                self.assertIn("paper-learning", summary_families["learn_and_gather"]["primary_workflows"])
+                self.assertIn("Claude Code", summary_families["delegate_coding_and_ship"]["executor_choices"])
                 self.assertIn("img-summary", lanes["materials_and_visuals"]["primary_skills"])
                 self.assertIn("request-to-handoff", {item["id"] for item in lanes["intent_to_plan"]["representative_playbooks"]})
                 self.assertNotIn("run_local_operator_check", json.dumps(payload))

--- a/tests/test_plugin_capabilities.py
+++ b/tests/test_plugin_capabilities.py
@@ -14,6 +14,8 @@ from _local_package import load_local_package
 
 load_local_package()
 
+from omh.capabilities.families import capability_family_projection
+from omh.capabilities.registry import capability_summary
 from omh.capabilities.schema import CAPABILITY_SECTIONS
 from omh.plugin_bundle.omh.metadata import PROVIDED_HOOKS, PROVIDED_TOOLS
 from test_plugin_distribution import FakeHermesContext, load_installed_plugin
@@ -49,9 +51,16 @@ class PluginCapabilitiesTests(unittest.TestCase):
 
             summary = json.loads(handler({"action": "summary"}))
             summary_lanes = {lane["id"]: lane for lane in summary["lanes"]}
+            summary_families = {family["id"]: family for family in summary["capability_families"]}
             self.assertEqual(summary["schema_version"], "omh_capability_summary/v1")
             self.assertFalse(summary.get("degraded", False))
             self.assertIn("without requiring shell catalog approval", summary["purpose"])
+            self.assertEqual(summary_families["plan_and_decide"]["label"], "Plan and decide")
+            self.assertIn("paper-learning", summary_families["learn_and_gather"]["primary_workflows"])
+            self.assertIn("img-summary", summary_families["create_materials_and_visuals"]["primary_workflows"])
+            self.assertIn("Claude Code", summary_families["delegate_coding_and_ship"]["executor_choices"])
+            self.assertEqual(summary["workflow_to_family"]["paper-learning"], "learn_and_gather")
+            self.assertEqual(summary["workflow_to_family"]["code-review"], "delegate_coding_and_ship")
             self.assertIn("img-summary", summary_lanes["materials_and_visuals"]["primary_skills"])
             self.assertIn("roles", summary["section_aliases"])
             summary_cards = {card["id"]: card for card in summary["workflow_context_cards"]}
@@ -398,6 +407,14 @@ class PluginCapabilitiesTests(unittest.TestCase):
                     "sensitive_probe_serialized": json.dumps(sensitive_probe, sort_keys=True),
                     "sensitive_probe_public": sensitive_probe.get("plugin_host_observation"),
                     "summary_lanes": [lane["id"] for lane in summary["lanes"]],
+                    "summary_families": summary["capability_families"],
+                    "summary_guidance": summary["direct_response_guidance"],
+                    "summary_family_workflows": [
+                        workflow
+                        for family in summary["capability_families"]
+                        for workflow in family["primary_workflows"]
+                    ],
+                    "summary_workflow_to_family": summary["workflow_to_family"],
                     "summary_visual_skills": [
                         lane["primary_skills"]
                         for lane in summary["lanes"]
@@ -475,6 +492,28 @@ class PluginCapabilitiesTests(unittest.TestCase):
             self.assertEqual(payload["source"], "standalone_plugin_bundle_fallback")
             self.assertEqual(payload["summary_schema"], "omh_capability_summary/v1")
             self.assertEqual(payload["summary_source"], "standalone_plugin_bundle_fallback")
+            self.assertEqual(
+                len(payload["summary_family_workflows"]),
+                len(set(payload["summary_family_workflows"])),
+            )
+            canonical_families = {
+                family["id"]: family
+                for family in capability_family_projection()["families"]
+            }
+            standalone_families = {
+                family["id"]: family
+                for family in payload["summary_families"]
+            }
+            self.assertEqual(standalone_families.keys(), canonical_families.keys())
+            for family_id, canonical_family in canonical_families.items():
+                with self.subTest(family_id=family_id):
+                    standalone_family = standalone_families[family_id]
+                    self.assertEqual(standalone_family, canonical_family)
+            self.assertEqual(payload["summary_guidance"], capability_summary()["direct_response_guidance"])
+            self.assertEqual(payload["summary_workflow_to_family"]["paper-learning"], "learn_and_gather")
+            self.assertEqual(payload["summary_workflow_to_family"]["code-review"], "delegate_coding_and_ship")
+            self.assertEqual(payload["summary_workflow_to_family"]["request-to-handoff"], "delegate_coding_and_ship")
+            self.assertEqual(payload["summary_workflow_to_family"]["ask"], "operate_and_observe")
             self.assertEqual(payload["recommend_schema"], "omh_recommend_result/v1")
             self.assertEqual(payload["recommend_source"], "standalone_plugin_bundle_fallback")
             self.assertEqual(payload["recommend_status"], "recommended")

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -1120,9 +1120,11 @@ class RouterContentTests(unittest.TestCase):
         self.assertIn("`web-research`, `doctor`", readme)
         self.assertIn("`idea-to-deploy`, `ultragoal`, `loop`, and `ultraprocess`", readme)
         self.assertIn("`ultraprocess`", readme)
-        self.assertIn("`deep-interview` / `ralplan` / `ultragoal` / `loop` / `ultraprocess`", readme)
-        self.assertIn("`source-finder` / `research-department` / `web-research` / `research-brief` / `report-package`", readme)
-        self.assertIn("`automation-blueprint` / `web-research` / `report-package`", readme)
+        self.assertIn("Plan and decide", readme)
+        self.assertIn("Learn and gather", readme)
+        self.assertIn("Create materials and visuals", readme)
+        self.assertIn("Delegate coding and ship", readme)
+        self.assertIn("Operate and observe", readme)
         self.assertIn("## Request Flow", readme)
         self.assertIn("plain request", readme)
         self.assertIn("choose workflow lane", readme)
@@ -1176,6 +1178,17 @@ class RouterContentTests(unittest.TestCase):
         self.assertNotIn("## What Gets Recorded", readme)
         self.assertNotIn("omh docs workflows --json", readme)
         self.assertNotIn("Useful local and wrapper-debug commands", readme)
+        core_workflows = readme.split("## Core Workflows", 1)[1].split("## What You Get", 1)[0]
+        for label in (
+            "Plan and decide",
+            "Learn and gather",
+            "Create materials and visuals",
+            "Delegate coding and ship",
+            "Operate and observe",
+        ):
+            self.assertIn(label, core_workflows)
+        self.assertNotIn("| `deep-interview` / `ralplan`", core_workflows)
+        self.assertIn("Codex, Claude Code, Hermes", core_workflows)
         self.assertIn("Install Path A: Hermes-Native Skill Tap", installation)
         self.assertIn("Agent Install Protocol", installation)
         self.assertIn("hermes_native_setup/v1", installation)

--- a/tests/test_wrapper_contract.py
+++ b/tests/test_wrapper_contract.py
@@ -824,7 +824,7 @@ class WrapperContractTests(unittest.TestCase):
         self.assertEqual(payload["route"]["selected_skill"], "oh-my-hermes")
         self.assertEqual(payload["chat_response"]["kind"], "skill_picker")
         self.assertIn("Best default:", payload["chat_response"]["body"])
-        self.assertIn("Manual lanes:", payload["chat_response"]["body"])
+        self.assertIn("Families:", payload["chat_response"]["body"])
         self.assertIn("Route for me:", payload["chat_response"]["body"])
         rendering_blocks = payload["chat_response"]["messenger_rendering"]["body_blocks"]
         self.assertGreaterEqual(
@@ -839,6 +839,17 @@ class WrapperContractTests(unittest.TestCase):
         self.assertIn("source-finder", option_ids)
         self.assertIn("paper-learning", option_ids)
         self.assertEqual(picker["featured_options"][0]["id"], "oh-my-hermes")
+        picker_families = {family["id"]: family for family in picker["capability_families"]}
+        self.assertEqual(picker_families["plan_and_decide"]["label"], "Plan and decide")
+        self.assertIn("paper-learning", picker_families["learn_and_gather"]["primary_workflows"])
+        self.assertIn("img-summary", picker_families["create_materials_and_visuals"]["primary_workflows"])
+        self.assertIn("Claude Code", picker_families["delegate_coding_and_ship"]["executor_choices"])
+        picker_family_workflows = [
+            workflow
+            for family in picker["capability_families"]
+            for workflow in family["primary_workflows"]
+        ]
+        self.assertEqual(len(picker_family_workflows), len(set(picker_family_workflows)))
         picker_groups = {group["id"]: group for group in picker["groups"]}
         self.assertTrue({"intent_to_plan", "company_product_ops", "deliverables_and_visuals", "coding_and_runtime"} <= picker_groups.keys())
         self.assertIn("loop", picker_groups["intent_to_plan"]["option_ids"])
@@ -851,6 +862,8 @@ class WrapperContractTests(unittest.TestCase):
         self.assertIn("search_skills", actions)
         self.assertEqual(actions["choose_skill"]["payload"]["schema_version"], "omh_skill_picker/v1")
         self.assertEqual(actions["choose_skill"]["payload"]["featured_options"][0]["id"], "oh-my-hermes")
+        action_families = {family["id"]: family for family in actions["choose_skill"]["payload"]["capability_families"]}
+        self.assertIn("code-review", action_families["delegate_coding_and_ship"]["primary_workflows"])
         action_groups = {group["id"]: group for group in actions["choose_skill"]["payload"]["groups"]}
         self.assertIn("feedback-triage", action_groups["company_product_ops"]["option_ids"])
         self.assertIn("source-finder", action_groups["company_product_ops"]["option_ids"])
@@ -894,7 +907,7 @@ class WrapperContractTests(unittest.TestCase):
                 self.assertIn("shell command", payload["chat_response"]["body"])
                 self.assertIn("planning, ops, deliverables, coding handoffs, loops, and status", payload["chat_response"]["body"])
                 self.assertIn("Start here:", payload["chat_response"]["body"])
-                self.assertIn("Common lanes:", payload["chat_response"]["body"])
+                self.assertIn("Capability families:", payload["chat_response"]["body"])
                 self.assertIn("Route for me:", payload["chat_response"]["body"])
                 rendering_blocks = payload["chat_response"]["messenger_rendering"]["body_blocks"]
                 self.assertGreaterEqual(
@@ -913,6 +926,10 @@ class WrapperContractTests(unittest.TestCase):
                 primer = payload["chat_response"]["state"]["context_primer"]
                 self.assertEqual(primer["schema_version"], "omh_context_primer/v1")
                 self.assertIn("Hermes workflow layer", primer["summary"])
+                primer_families = {family["id"]: family for family in primer["capability_families"]}
+                self.assertIn("ralplan", primer_families["plan_and_decide"]["primary_workflows"])
+                self.assertIn("img-summary", primer_families["create_materials_and_visuals"]["primary_workflows"])
+                self.assertIn("Codex", primer_families["delegate_coding_and_ship"]["executor_choices"])
                 groups = {group["id"]: group for group in primer["workflow_groups"]}
                 self.assertTrue({"intent_to_plan", "company_product_ops", "deliverables_and_visuals", "coding_and_runtime"} <= groups.keys())
                 self.assertIn("img-summary", groups["deliverables_and_visuals"]["workflows"])
@@ -929,9 +946,12 @@ class WrapperContractTests(unittest.TestCase):
                 self.assertIn("Prepared plans", primer["evidence_rule"])
                 capability_summary = payload["chat_response"]["state"]["capability_summary"]
                 self.assertEqual(capability_summary["schema_version"], "omh_capability_summary/v1")
+                summary_families = {family["id"]: family for family in capability_summary["capability_families"]}
                 lanes = {lane["id"]: lane for lane in capability_summary["lanes"]}
                 summary_cards = {card["id"]: card for card in capability_summary["workflow_context_cards"]}
                 self.assertTrue({"intent_to_plan", "materials_and_visuals", "coding_handoff"} <= lanes.keys())
+                self.assertIn("paper-learning", summary_families["learn_and_gather"]["primary_workflows"])
+                self.assertIn("Claude Code", summary_families["delegate_coding_and_ship"]["executor_choices"])
                 self.assertIn("img-summary", lanes["materials_and_visuals"]["primary_skills"])
                 self.assertIn("ultraprocess", lanes["intent_to_plan"]["primary_skills"])
                 self.assertIn("feedback-triage", summary_cards["research_and_ops"]["representative_workflows"])


### PR DESCRIPTION
## Feature Report

### What Changed

- Adds `omh_capability_families/v1`, a five-family front door for OMH: Plan and decide, Learn and gather, Create materials and visuals, Delegate coding and ship, and Operate and observe.
- Wires the family projection into capability summaries, quickstart JSON, wrapper picker/context/catalog surfaces, README Core Workflows, and `docs/CAPABILITIES.md`.
- Keeps legacy lanes/groups/options as compatibility fallback while making normal user discovery outcome-first.
- Adds standalone plugin fallback parity for family cards and `workflow_to_family`.

### Why This Exists

- OMH had too many backend workflow names exposed in README and picker surfaces, making first-use discovery feel command-heavy.
- The user-facing story needed to group paper learning, source finding, image-card prompts, materials, planning, coding delegation, and operations into a smaller set of understandable units.
- Wrapper/plugin surfaces needed a contract that keeps Hermes command-agnostic while preserving prepared-vs-observed evidence boundaries.

### User / Operator Impact

- Users can ask Hermes what OMH can do and see five outcome-focused capability families before learning exact skill names.
- Coding delegation explicitly names Codex, Claude Code, Hermes, and generic runtimes as executor choices without implying hidden execution.
- Operators still have legacy workflow lanes and skill IDs for compatibility, debugging, and exact routing.

### How It Works

- `src/capabilities/families.py` defines the canonical family projection, workflow-to-family mapping, executor choices, and claim boundary.
- `capability_summary()` and `capability_snapshot()` include `capability_families` and `workflow_to_family`.
- Wrapper picker prose and payloads are generated from `capability_family_cards()` so body text and structured state stay aligned.
- Plugin standalone mode mirrors canonical family ids, labels, workflows, and evidence boundary fields, with tests that fail on drift.
- Quickstart exposes `first_use_family_cards` and keeps the first-use steps short.

### Files And Contracts Touched

- `src/capabilities/families.py` introduces `omh_capability_families/v1`.
- `src/capabilities/registry.py`, `src/commands/capabilities.py`, `src/surfaces/quickstart.py`, and `src/wrapper/contract.py` expose family cards in public surfaces.
- `src/plugin_bundle/omh/context_brief.py` and `src/plugin_bundle/omh/tools/capability_tool.py` expose plugin/standalone family metadata.
- `README.md` and `docs/CAPABILITIES.md` document the concise user-facing family model.
- Tests lock family ordering, uniqueness, mapping parity, wrapper picker payloads, standalone plugin fallback parity, quickstart output, and README Core Workflows copy.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` (809 tests)
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_cli.py -v` (216 tests)
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_router_content.py tests/test_wrapper_contract.py tests/test_plugin_capabilities.py tests/test_capabilities.py -v` (110 tests)
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `git diff --check`
- [ ] `python3 -m omh.cli harness validate` - not run; this PR changes discovery/context surfaces, and targeted contract plus full unittest coverage covered the touched public contracts.
- [ ] `python3 -m omh.cli release checklist --json` - not run; no release-channel metadata change.
- [ ] `python3 -m omh.cli release hermes-smoke` - not run; no live Hermes profile mutation in this PR.
- [ ] `omh --help` - not run; quickstart/help copy covered by CLI tests.
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` - not run; live install smoke outside this PR scope.
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable.
- [ ] Relevant dry-run or smoke command: `uv run python -m omh.cli docs workflows --check`.
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; tmux/team runtime is unavailable in this Codex App environment, and live Hermes/TUI plugin runtime was not mutated.

## Risk

- Moderate: family cards are now a public discovery contract across README, wrapper, plugin, and quickstart surfaces.
- Mitigation: regression tests lock family uniqueness, workflow mapping, standalone parity, wrapper payloads, and compact context budgets.

## Compatibility / Rollout

- Legacy workflow lanes, groups, options, and direct skill IDs remain available as compatibility fallback.
- Standalone plugin mode remains degraded/metadata-only and now exposes family metadata plus `workflow_to_family`.
- No Hermes core patching, no network/API calls, and no hidden executor dispatch are introduced.

## Release / Claims

- [x] Release-channel impact considered (`local`): no release channel metadata change.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] Known manual Hermes checks are listed, including live Hermes/TUI gaps above.

## Follow-Up

- Consider generating the standalone plugin family table from canonical data during plugin bundling to remove the remaining duplicated table, while keeping current parity tests as a guard.