### PR TITLE
Polish orchestration demo executor choice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,10 +22,11 @@ dist/
 *.egg-info/
 *.whl
 
-# Local Hermes artifacts
+# Local agent/runtime artifacts
 .hermes/
 .omh/
 .omc/
+.loop/
 
 # Local resolver artifacts
 uv.lock

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Use OMH request-to-handoff for: I want to safely add a feature to this repo.
 | OMH context brief | Hermes or a wrapper can fetch a compact OMH mental model, generic-tool checkpoint, and route hint before falling back to ordinary chat/tools. |
 | Catalog-aware list | `omh list` groups installed workflows by lane, and `omh list --json` includes descriptions, routing hints, examples, and evidence boundaries for wrappers or operators. |
 | Route hint cards | Wrappers can preview the nearest OMH workflow with `chat_route_hint/v1`, even before plugin load is observed. |
+| Deterministic demos | `omh demo orchestration` shows the local recommend -> chat -> plan -> handoff -> status path; `--executor` can demonstrate Codex, Claude Code, or Hermes paths without treating prepared handoffs as execution. |
 | Plugin runtime evidence | Hosts or wrappers can record plugin load/use with `omh plugin observe-host`, and plugin tools/hooks can self-record the same metadata when the host passes observation context; active-ready and historical events stay separate from install smoke. |
 | Coding agent paths | Hermes can prepare work for Codex, Claude Code, Hermes itself, or another runtime without pretending the work already ran. |
 | Workspace isolation | Hermes can show whether the current workspace is ok, recommend or require a worktree, use `omh worktree prepare` to create one, and use `omh worktree bind` to render open/attach/record actions for the selected coding agent. |

--- a/docs/CHAT_WRAPPER_EXAMPLES.md
+++ b/docs/CHAT_WRAPPER_EXAMPLES.md
@@ -24,6 +24,7 @@ uv run python -m omh.cli chat native-command --source discord
 uv run python -m omh.cli chat native-command --source slack
 uv run python -m omh.cli chat native-command --source telegram
 uv run python -m omh.cli demo orchestration
+uv run python -m omh.cli demo orchestration --executor hermes
 ```
 
 The first command renders the fixture event in
@@ -33,6 +34,13 @@ the full deterministic path:
 ```text
 recommend -> chat response -> Hermes plan -> selected executor/runtime handoff -> status card
 ```
+
+By default `omh demo orchestration` leaves the coding owner unselected and shows
+the `choose_executor` state. Add `--executor codex`, `--executor claude-code`,
+or `--executor hermes` when the demo should show the selected Codex lifecycle,
+Claude Code prompt handoff, or Hermes runtime handoff path. In every case the
+status card remains prepared-only until separate dispatch or runtime evidence
+is observed.
 
 ## Messenger-Native OMH Entry
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,7 +28,7 @@ repo-local contract for Codex agents working here.
 | See task cards and Discord-style wrapper responses | [Chat Wrapper Examples](CHAT_WRAPPER_EXAMPLES.md) |
 | Render workflow quality gates in wrappers | [Harness Quality Contract](HARNESS_QUALITY.md) |
 | Install Hermes-native skills or bootstrap managed skills | [Installation](INSTALLATION.md) |
-| Run deterministic backend demos | [Chat Wrapper Examples](CHAT_WRAPPER_EXAMPLES.md#commands-used) and [fixture shims](../examples) |
+| Run deterministic backend demos, including executor-choice and selected runtime handoff status | [Chat Wrapper Examples](CHAT_WRAPPER_EXAMPLES.md#commands-used) and [fixture shims](../examples) |
 | See the G1-G10 implemented feature surfaces and demo cards | [Application Cases](APPLICATION_CASES.md) |
 | Check generated skill and harness metadata | [Workflow Reference](WORKFLOWS.md) |
 | Prepare or verify a release | [Release](RELEASE.md) |

--- a/src/commands/demo.py
+++ b/src/commands/demo.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 
+from ..coding_delegation import CODING_EXECUTOR_TARGETS
 from ..demo import DEFAULT_ORCHESTRATION_MESSAGE, build_orchestration_demo
 from ..grounded_score import build_grounded_score_demo
 from ..ingress import CHAT_SOURCES
@@ -12,7 +13,14 @@ from .common import _print_json
 def cmd_demo_orchestration(args: argparse.Namespace) -> int:
     message = " ".join(args.message).strip() or DEFAULT_ORCHESTRATION_MESSAGE
     try:
-        _print_json(build_orchestration_demo(message, source=args.source, limit=args.limit))
+        _print_json(
+            build_orchestration_demo(
+                message,
+                source=args.source,
+                limit=args.limit,
+                executor_target=args.executor,
+            )
+        )
     except ValueError as exc:
         raise OmhError(str(exc)) from exc
     return 0
@@ -38,6 +46,12 @@ def _add_demo_commands(sub) -> None:
     )
     orchestration.add_argument("--source", choices=CHAT_SOURCES, default="discord")
     orchestration.add_argument("--limit", type=int, default=3)
+    orchestration.add_argument(
+        "--executor",
+        choices=CODING_EXECUTOR_TARGETS,
+        default="choose",
+        help="Executor/runtime profile to demonstrate. Defaults to an explicit choice-required handoff.",
+    )
     orchestration.set_defaults(func=cmd_demo_orchestration)
 
     grounded_score = demo_sub.add_parser("grounded-score")

--- a/src/surfaces/demo.py
+++ b/src/surfaces/demo.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import hashlib
 from typing import Any
 
+from ..coding_delegation import CODING_EXECUTOR_TARGETS
+from ..executors import executor_label
 from ..harness_quality import build_harness_progress
 from ..hermes_planning import build_hermes_plan_payload
 from ..ingress import CHAT_SOURCES
@@ -19,6 +21,7 @@ def build_orchestration_demo(
     *,
     source: str = "discord",
     limit: int = 3,
+    executor_target: str = "choose",
 ) -> dict[str, object]:
     task = message.strip()
     if not task:
@@ -27,11 +30,13 @@ def build_orchestration_demo(
         raise ValueError(f"unsupported demo source: {source}")
     if limit < 1:
         raise ValueError("demo orchestration --limit must be at least 1")
+    if executor_target not in CODING_EXECUTOR_TARGETS:
+        raise ValueError(f"unsupported demo orchestration executor: {executor_target}")
 
     recommendations = recommend_skills(task, limit=limit)
     chat = build_chat_interaction_payload(task, source=source, limit=limit)
     plan = build_hermes_plan_payload(task, source=source, limit=limit)
-    handoff = build_chat_interaction_payload(task, source=source, mode="delegate", limit=limit, executor_target="codex")
+    handoff = build_chat_interaction_payload(task, source=source, mode="delegate", limit=limit, executor_target=executor_target)
     status_payload = _prepared_status_from_handoff(handoff, source=source)
     status = build_chat_status_interaction(status_payload, source=source)
 
@@ -39,10 +44,11 @@ def build_orchestration_demo(
         "schema_version": ORCHESTRATION_DEMO_SCHEMA_VERSION,
         "scenario": "recommend_chat_plan_handoff_status",
         "source": source,
+        "executor_target": executor_target,
         "message_sha256": hashlib.sha256(task.encode("utf-8")).hexdigest(),
         "message_length": len(task),
         "redaction_policy": "metadata_only",
-        "summary": "Deterministic local Hermes chat orchestration demo with routing, planning, handoff, and status contracts.",
+        "summary": _demo_summary(executor_target),
         "steps": [
             {
                 "id": "recommend",
@@ -112,22 +118,42 @@ def _prepared_status_from_handoff(handoff: dict[str, object], *, source: str) ->
     delegation_payload = _nested(handoff, "delegation")
     delegation = _nested(delegation_payload, "delegation")
     executor_handoff = _nested(delegation_payload, "executor_handoff")
+    runtime_handoff = _nested(delegation_payload, "runtime_handoff")
+    prompt_handoff = _nested(delegation_payload, "prompt_handoff")
+    selected_handoff = executor_handoff or runtime_handoff or prompt_handoff
+    selected_executor = str(
+        selected_handoff.get("selected_executor_profile")
+        or selected_handoff.get("executor_target")
+        or delegation_payload.get("selected_executor_profile")
+        or _nested(handoff, "executor_resolution").get("resolved_executor_target")
+        or "choose"
+    )
+    choice_required = bool(_nested(delegation_payload, "executor_selection").get("choice_required", False))
     harness_quality = _nested(delegation_payload, "harness_quality")
     ladder = [str(step) for step in harness_quality.get("evidence_ladder", []) if isinstance(step, str)]
     progress = build_harness_progress(harness_quality, {ladder[0]: "complete"} if ladder else {})
     review_required = bool(delegation.get("review_required", False))
     review_status = "not_observed" if review_required else "not_required"
+    next_action = _status_next_action_from_handoff(
+        handoff,
+        selected_handoff=bool(selected_handoff),
+        choice_required=choice_required,
+    )
     return {
         "schema_version": "delegated_coding_status/v1",
-        "run_id": "demo-prepared-codex-handoff",
+        "run_id": _demo_run_id(selected_executor),
         "source": source,
         "source_metadata": {},
         "prepared": {
-            "available": bool(executor_handoff),
-            "handoff_available": bool(executor_handoff),
-            "executor_target": executor_handoff.get("executor_target", "codex") if executor_handoff else "codex",
-            "handoff_schema_version": executor_handoff.get("schema_version", "") if executor_handoff else "",
-            "status": executor_handoff.get("status", "prepared_not_observed") if executor_handoff else "not_available",
+            "available": bool(selected_handoff),
+            "handoff_available": bool(selected_handoff),
+            "choice_required": choice_required,
+            "executor_target": selected_executor,
+            "selected_executor_profile": selected_handoff.get("selected_executor_profile", selected_executor)
+            if selected_handoff
+            else "",
+            "handoff_schema_version": selected_handoff.get("schema_version", "") if selected_handoff else "",
+            "status": selected_handoff.get("status", "prepared_not_observed") if selected_handoff else "not_available",
             "action": delegation.get("action", "fallback"),
             "workflow": delegation.get("recommended_workflow", "oh-my-hermes"),
             "harness": delegation.get("recommended_harness", "coding-handling"),
@@ -154,14 +180,62 @@ def _prepared_status_from_handoff(handoff: dict[str, object], *, source: str) ->
         "harness_quality": harness_quality,
         "harness_progress": progress,
         "integrity": {"ok": True, "warnings": []},
-        "next_action": "dispatch_to_executor" if executor_handoff else "route_coding_request",
-        "safe_summary": "A selected executor/runtime handoff is prepared, but wrapper dispatch is not observed yet.",
+        "next_action": next_action,
+        "safe_summary": _safe_status_summary(
+            selected_executor,
+            selected_handoff=bool(selected_handoff),
+            choice_required=choice_required,
+        ),
         "overclaim_guard": [
             "Prepared coding delegation is not execution evidence.",
             "Hermes should not claim it implemented code from this demo artifact.",
             "Review, verification, CI, and merge status require separate observed evidence.",
         ],
     }
+
+
+def _demo_summary(executor_target: str) -> str:
+    if executor_target == "choose":
+        return (
+            "Deterministic local Hermes chat orchestration demo with routing, planning, executor choice, "
+            "handoff, and status contracts."
+        )
+    return (
+        "Deterministic local Hermes chat orchestration demo with routing, planning, selected executor/runtime "
+        f"handoff for {executor_label(executor_target)}, and status contracts."
+    )
+
+
+def _demo_run_id(executor_target: str) -> str:
+    normalized = executor_target.strip() or "choose"
+    if normalized == "choose":
+        return "demo-prepared-executor-choice"
+    return f"demo-prepared-{normalized}-handoff"
+
+
+def _status_next_action_from_handoff(
+    handoff: dict[str, object],
+    *,
+    selected_handoff: bool,
+    choice_required: bool,
+) -> str:
+    if choice_required:
+        return "choose_executor"
+    chat_next_action = str(handoff.get("next_action", ""))
+    if chat_next_action == "send_to_executor":
+        return "dispatch_to_executor"
+    if chat_next_action in {"show_prompt_handoff", "show_runtime_handoff"}:
+        return chat_next_action
+    return "dispatch_to_executor" if selected_handoff else "route_coding_request"
+
+
+def _safe_status_summary(executor_target: str, *, selected_handoff: bool, choice_required: bool) -> str:
+    if choice_required:
+        return "A coding handoff path is not selected yet; no executor/runtime dispatch is observed."
+    if selected_handoff:
+        label = executor_label(executor_target)
+        return f"A {label} handoff is prepared, but wrapper dispatch or runtime start is not observed yet."
+    return "No coding executor/runtime handoff is prepared or observed yet."
 
 
 def _public_recommendation(item: dict[str, object]) -> dict[str, object]:

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -280,11 +280,29 @@ _STATUS_COPY = {
         "I will ask for the missing outcome before sending anything to an executor.",
         "No execution has started.",
     ),
+    "choose_executor": (
+        "handoff",
+        "Choose who should own the coding work.",
+        "A coding handoff path is not selected yet; no executor/runtime dispatch is observed.",
+        "Executor choice is not dispatch or implementation evidence.",
+    ),
     "dispatch_to_executor": (
         "handoff",
         "An executor handoff is ready.",
         "I have prepared the handoff, but executor/runtime dispatch is not observed yet.",
         "Preparation is not execution evidence.",
+    ),
+    "show_prompt_handoff": (
+        "handoff",
+        "A prompt handoff is ready.",
+        "The selected prompt handoff is prepared, but OMH has not dispatched it to an executor.",
+        "Prompt handoff is prepared only; OMH has not dispatched it to an executor.",
+    ),
+    "show_runtime_handoff": (
+        "handoff",
+        "A runtime handoff is ready.",
+        "The selected runtime handoff is prepared, but runtime start is not observed yet.",
+        "Runtime handoff is prepared only; runtime start requires observed runtime evidence.",
     ),
     "wait_for_executor_evidence": (
         "status",
@@ -1494,10 +1512,43 @@ def build_chat_response_from_status(status_payload: dict[str, Any], *, thread_ke
     next_action = str(status_payload.get("next_action", "show_status"))
     kind, headline, body, claim_boundary = _status_copy(status_payload, next_action)
     actions = [_action("show_status", "Show status", "secondary")]
+    if next_action == "choose_executor":
+        actions.insert(0, _action("choose_executor", "Choose executor", "primary"))
     if next_action == "dispatch_to_executor":
         actions.insert(0, _action("send_to_executor", "Send to executor", "primary"))
         if str(_nested(status_payload, "prepared").get("executor_target", "")) == "codex":
             actions.insert(1, _action("send_to_codex", "Send to Codex", "secondary", payload={"compatibility_alias": True}))
+    if next_action == "show_prompt_handoff":
+        selected = str(_nested(status_payload, "prepared").get("selected_executor_profile", "") or "")
+        actions.insert(
+            0,
+            _action(
+                "show_prompt_handoff",
+                "Show prompt",
+                "primary",
+                payload={"selected_executor_profile": selected},
+            ),
+        )
+        actions.insert(
+            1,
+            _action(
+                "copy_prompt_handoff",
+                "Copy prompt",
+                "secondary",
+                payload={"selected_executor_profile": selected},
+            ),
+        )
+    if next_action == "show_runtime_handoff":
+        selected = str(_nested(status_payload, "prepared").get("selected_executor_profile", "") or "")
+        actions.insert(
+            0,
+            _action(
+                "show_runtime_handoff",
+                "Show runtime",
+                "primary",
+                payload={"selected_executor_profile": selected},
+            ),
+        )
     return _chat_response(
         kind=kind,
         headline=headline,
@@ -1762,6 +1813,10 @@ def _status_copy(status_payload: dict[str, Any], next_action: str) -> tuple[str,
             "I have prepared the coding handoff, but executor/runtime dispatch is not observed yet.",
             claim_boundary,
         )
+    if next_action in {"show_prompt_handoff", "show_runtime_handoff"}:
+        label = _status_executor_label(status_payload)
+        suffix = f" ({label})" if label else ""
+        return kind, f"{headline}{suffix}", body, claim_boundary
     return kind, headline, body, claim_boundary
 
 
@@ -3352,7 +3407,10 @@ def _action_from_spec(spec: dict[str, object]) -> dict[str, object]:
 def _phase_for_next_action(next_action: str) -> str:
     return {
         "prepare_coding_delegation": "preparing",
+        "choose_executor": "executor_choice_required",
         "dispatch_to_executor": "handoff_prepared",
+        "show_prompt_handoff": "prompt_handoff_prepared",
+        "show_runtime_handoff": "runtime_handoff_prepared",
         "wait_for_executor_evidence": "dispatched",
         "surface_executor_blocker": "blocked",
         "surface_review_blocker": "blocked",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5065,15 +5065,28 @@ class CliTests(unittest.TestCase):
         self.assertEqual(status, 0)
         payload = json.loads(stdout)
         self.assertEqual(payload["schema_version"], "orchestration_demo/v1")
+        self.assertEqual(payload["executor_target"], "choose")
         self.assertEqual([step["id"] for step in payload["steps"]], ["recommend", "chat", "plan", "handoff", "status_card"])
         self.assertEqual(payload["steps"][0]["payload"]["recommendations"][0]["skill"], "plan")
+        handoff_payload = payload["steps"][3]["payload"]
+        self.assertEqual(handoff_payload["chat_response"]["state"]["next_action"], "choose_executor")
+        self.assertEqual(handoff_payload["executor_handoff"], {})
+        status_card = payload["steps"][4]["payload"]["status_card"]
+        self.assertEqual(status_card["schema_version"], "status_card/v1")
+        self.assertEqual(status_card["next_action"], "choose_executor")
+        self.assertIn("executor_result", payload["not_observed"])
+        self.assertNotIn(message, json.dumps(payload))
+
+        status, stdout, stderr = run_cli(["demo", "orchestration", "--executor", "codex"])
+
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        payload = json.loads(stdout)
+        self.assertEqual(payload["executor_target"], "codex")
         handoff = payload["steps"][3]["payload"]["executor_handoff"]
         self.assertEqual(handoff["status"], "prepared_not_observed")
         status_card = payload["steps"][4]["payload"]["status_card"]
-        self.assertEqual(status_card["schema_version"], "status_card/v1")
         self.assertEqual(status_card["next_action"], "dispatch_to_executor")
-        self.assertIn("executor_result", payload["not_observed"])
-        self.assertNotIn(message, json.dumps(payload))
 
     def test_demo_grounded_score_keeps_representative_cases_at_10(self) -> None:
         status, stdout, stderr = run_cli(["demo", "grounded-score"])

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import json
+import unittest
+
+from _cli_harness import run_cli
+from _local_package import load_local_package
+
+load_local_package()
+
+from omh.demo import build_orchestration_demo
+
+
+def _step(payload: dict[str, object], step_id: str) -> dict[str, object]:
+    steps = payload["steps"]
+    if not isinstance(steps, list):
+        raise AssertionError("demo steps must be a list")
+    for item in steps:
+        if isinstance(item, dict) and item.get("id") == step_id:
+            return item
+    raise AssertionError(f"missing demo step: {step_id}")
+
+
+def _payload(step: dict[str, object]) -> dict[str, object]:
+    payload = step["payload"]
+    if not isinstance(payload, dict):
+        raise AssertionError("demo step payload must be an object")
+    return payload
+
+
+class OrchestrationDemoTests(unittest.TestCase):
+    def test_default_demo_requires_executor_choice_without_codex_run_id(self) -> None:
+        demo = build_orchestration_demo()
+
+        self.assertEqual(demo["schema_version"], "orchestration_demo/v1")
+        self.assertEqual(demo["executor_target"], "choose")
+        self.assertIn("executor choice", demo["summary"])
+
+        handoff_step = _payload(_step(demo, "handoff"))
+        handoff_response = handoff_step["chat_response"]
+        self.assertIsInstance(handoff_response, dict)
+        self.assertEqual(handoff_response["state"]["next_action"], "choose_executor")
+        self.assertEqual(handoff_response["state"]["selected_executor_profile"], None)
+        self.assertEqual(handoff_step["executor_handoff"], {})
+
+        status_step = _payload(_step(demo, "status_card"))
+        status = status_step["status"]
+        self.assertIsInstance(status, dict)
+        self.assertEqual(status["run_id"], "demo-prepared-executor-choice")
+        self.assertEqual(status["next_action"], "choose_executor")
+        self.assertEqual(status["prepared"]["executor_target"], "choose")
+        self.assertTrue(status["prepared"]["choice_required"])
+        self.assertFalse(status["prepared"]["handoff_available"])
+        self.assertNotEqual(status["run_id"], "demo-prepared-codex-handoff")
+        self.assertEqual(status_step["chat_response"]["state"]["phase"], "executor_choice_required")
+        self.assertIn("Choose executor", [action["label"] for action in status_step["chat_response"]["actions"]])
+
+    def test_codex_demo_keeps_codex_specific_alias_only_when_selected(self) -> None:
+        demo = build_orchestration_demo(executor_target="codex")
+
+        status_step = _payload(_step(demo, "status_card"))
+        status = status_step["status"]
+        self.assertIsInstance(status, dict)
+        self.assertEqual(demo["executor_target"], "codex")
+        self.assertEqual(status["run_id"], "demo-prepared-codex-handoff")
+        self.assertEqual(status["next_action"], "dispatch_to_executor")
+        self.assertEqual(status["prepared"]["executor_target"], "codex")
+        self.assertEqual(status["prepared"]["handoff_schema_version"], "coding_executor_handoff/v1")
+        self.assertTrue(status["prepared"]["handoff_available"])
+        self.assertIn("Send to Codex", [action["label"] for action in status_step["chat_response"]["actions"]])
+
+    def test_prompt_and_runtime_demo_profiles_are_not_collapsed_to_codex(self) -> None:
+        cases = (
+            ("claude-code", "coding_prompt_handoff/v1", "show_prompt_handoff", "prompt_handoff_prepared"),
+            ("hermes", "coding_runtime_handoff/v1", "show_runtime_handoff", "runtime_handoff_prepared"),
+        )
+
+        for executor, schema_version, next_action, phase in cases:
+            with self.subTest(executor=executor):
+                demo = build_orchestration_demo(executor_target=executor)
+                status_step = _payload(_step(demo, "status_card"))
+                status = status_step["status"]
+                self.assertIsInstance(status, dict)
+                self.assertEqual(demo["executor_target"], executor)
+                self.assertEqual(status["run_id"], f"demo-prepared-{executor}-handoff")
+                self.assertEqual(status["next_action"], next_action)
+                self.assertEqual(status["prepared"]["executor_target"], executor)
+                self.assertEqual(status["prepared"]["selected_executor_profile"], executor)
+                self.assertEqual(status["prepared"]["handoff_schema_version"], schema_version)
+                self.assertTrue(status["prepared"]["handoff_available"])
+                self.assertEqual(status_step["chat_response"]["state"]["phase"], phase)
+                self.assertNotEqual(status["run_id"], "demo-prepared-codex-handoff")
+
+    def test_cli_demo_orchestration_accepts_executor_choice(self) -> None:
+        status, stdout, stderr = run_cli(["demo", "orchestration", "--executor", "hermes"], output_json=False)
+
+        self.assertEqual(status, 0, stderr)
+        self.assertEqual(stderr, "")
+        payload = json.loads(stdout)
+        self.assertEqual(payload["executor_target"], "hermes")
+        status_step = _payload(_step(payload, "status_card"))
+        self.assertEqual(status_step["status"]["prepared"]["executor_target"], "hermes")
+        self.assertEqual(status_step["status"]["next_action"], "show_runtime_handoff")


### PR DESCRIPTION
## Feature Report

### What Changed

This PR polishes the deterministic OMH orchestration demo so first-use/product demo surfaces no longer imply Codex is the implicit coding owner.

- `omh demo orchestration` now defaults to an explicit `choose_executor` state instead of a prepared Codex handoff.
- Added `omh demo orchestration --executor codex|claude-code|hermes` so the demo can show all first-class coding surfaces:
  - Codex executor lifecycle handoff
  - Claude Code prompt handoff
  - Hermes runtime handoff
- Status-card copy now covers executor choice, prompt handoff, and runtime handoff without overclaiming dispatch or execution.
- Added docs examples for the executor-selectable orchestration demo.
- Ignored local `.loop/` artifacts so loop runner state does not appear as accidental repo noise.

### Why

The previous demo was a high-visibility first-use surface but hardcoded `executor_target="codex"` and `demo-prepared-codex-handoff`. That conflicted with OMH's product direction: Codex, Claude Code, and Hermes runtime/handoff paths should all be first-class development surfaces.

For a 10K-star polish loop, the demo should teach the right mental model immediately: OMH prepares routing, planning, selected coding-owner handoff, and status cards while preserving prepared-vs-observed boundaries.

### Boundary Notes

- Executor choice is not dispatch or implementation evidence.
- Prompt handoff is prepared only; OMH has not dispatched it to an executor.
- Runtime handoff is prepared only; runtime start requires observed runtime evidence.
- The demo remains deterministic and local.

### Verification

Observed locally:

```sh
PYTHONPATH=tests uv run python -m unittest tests/test_demo.py -v
PYTHONPATH=tests uv run python -m unittest tests/test_cli.py -v
PYTHONPATH=tests uv run python -m unittest tests/test_router_content.py tests/test_wrapper_contract.py -v
PYTHONPATH=tests uv run python -m unittest discover -s tests -v
uv run python -m compileall -q src tests
git diff --check
PYTHONPATH=tests uv run python -m omh.cli docs workflows --check
PYTHONPATH=tests uv run python -m omh.cli demo orchestration --executor codex
PYTHONPATH=tests uv run python -m omh.cli demo orchestration --executor claude-code
PYTHONPATH=tests uv run python -m omh.cli demo orchestration --executor hermes
```

Results:

- `tests/test_demo.py`: pass, 4 tests
- `tests/test_cli.py`: pass, 219 tests
- `tests/test_router_content.py tests/test_wrapper_contract.py`: pass, 97 tests
- full unittest discovery: pass, 832 tests
- compileall: pass
- docs workflows check: pass
- smoke outputs show expected schemas/actions:
  - Codex: `coding_executor_handoff/v1`, `dispatch_to_executor`
  - Claude Code: `coding_prompt_handoff/v1`, `show_prompt_handoff`
  - Hermes: `coding_runtime_handoff/v1`, `show_runtime_handoff`

### Not Tested

- Live Hermes/Discord wrapper rendering.
- GitHub CI, pending this PR.
