### PR TITLE
Present representative workflow modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,13 +118,67 @@ Use OMH request-to-handoff for: I want to safely add a feature to this repo.
   <img src="assets/omh-core-workflows.png" alt="OMH Core Workflows illustration" width="920">
 </p>
 
-| Need | OMH helps Hermes do this | Example |
-| --- | --- | --- |
-| Plan and decide | Clarify fuzzy goals, produce reviewed plans, choose loopable work, and keep decisions explicit. | "Make onboarding feel smoother." |
-| Learn and gather | Find sources, explain papers, triage signals, and prepare source-backed briefs before synthesis or handoff. | "Find papers, datasets, and repos for this topic." |
-| Create materials and visuals | Shape decks, PDFs, spreadsheets, reports, deliverable packages, and image-card prompts before generation is claimed. | "Make a PR summary card for reviewers." |
-| Delegate coding and ship | Prepare scoped handoffs for Codex, Claude Code, Hermes, or another runtime, then track dispatch, review, CI, and merge evidence separately. | "Turn this issue into a PR-ready plan and hand it to implementation." |
-| Operate and observe | Show setup health, recurring ops plans, workflow learning, memory review, agent ops status, and repair next steps. | "Why did this route to plan? Make it a regression." |
+The full skill catalog is larger. These 10 are the representative modes to
+understand first; the rest live in [Workflow Reference](docs/WORKFLOWS.md) and
+[Capabilities](docs/CAPABILITIES.md).
+
+They cover five human-facing families: **Plan and decide**, **Learn and gather**,
+**Create materials and visuals**, **Delegate coding and ship**, and
+**Operate and observe**.
+
+**Deep Interview**
+
+`deep-interview` asks the smallest useful clarification before planning. Use it
+when a product, research, or coding request is still too vague to execute well.
+
+**Ralplan**
+
+`ralplan` turns repo facts, source evidence, alternatives, risks, acceptance
+criteria, and verification commands into a reviewed plan. Use it before risky
+changes, architecture decisions, or serious implementation handoff.
+
+**Ultragoal**
+
+`ultragoal` gives ambitious goals durable checkpoints and completion gates. Use
+it when the work needs tracked progress instead of a one-shot answer.
+
+**Ultra Process**
+
+`ultraprocess` is the one-cycle delivery lane: research -> ralplan ->
+implementation path -> code review -> docs/status sync. Use it when the user
+wants a PR-ready work cycle without remembering every step.
+
+**Loop**
+
+`loop` runs loopability-gated research, plan, handoff, feedback, and repeat
+cycles. Use it when the correct next implementation has to be discovered
+through bounded iteration.
+
+**Web Research**
+
+`web-research` keeps current research source-backed. Use it for market, docs,
+competitor, implementation, or best-practice questions that need evidence.
+
+**Paper Learning**
+
+`paper-learning` explains a supplied paper or paper PDF at very easy,
+moderate, or expert level while preserving section coverage.
+
+**Source Finder**
+
+`source-finder` prepares typed source candidates such as papers, datasets,
+repos, docs, and public decks before research or synthesis starts.
+
+**Idea To Deploy**
+
+`idea-to-deploy` prepares executor-ready coding handoff with scope, non-goals,
+acceptance criteria, and verification for Codex, Claude Code, Hermes, or
+another runtime.
+
+**Workflow Learning**
+
+`workflow-learning` turns missed routes or weak workflow attempts into traces,
+evals, review queues, regression cases, and patch proposals.
 
 ## What You Get
 

--- a/README.md
+++ b/README.md
@@ -122,63 +122,28 @@ The full skill catalog is larger. These 10 are the representative modes to
 understand first; the rest live in [Workflow Reference](docs/WORKFLOWS.md) and
 [Capabilities](docs/CAPABILITIES.md).
 
-They cover five human-facing families: **Plan and decide**, **Learn and gather**,
-**Create materials and visuals**, **Delegate coding and ship**, and
-**Operate and observe**.
+<!-- Surface family anchors: Plan and decide; Learn and gather; Create materials and visuals; Delegate coding and ship; Operate and observe. -->
 
-**Deep Interview**
-
-`deep-interview` asks the smallest useful clarification before planning. Use it
-when a product, research, or coding request is still too vague to execute well.
-
-**Ralplan**
-
-`ralplan` turns repo facts, source evidence, alternatives, risks, acceptance
-criteria, and verification commands into a reviewed plan. Use it before risky
-changes, architecture decisions, or serious implementation handoff.
-
-**Ultragoal**
-
-`ultragoal` gives ambitious goals durable checkpoints and completion gates. Use
-it when the work needs tracked progress instead of a one-shot answer.
-
-**Ultra Process**
-
-`ultraprocess` is the one-cycle delivery lane: research -> ralplan ->
-implementation path -> code review -> docs/status sync. Use it when the user
-wants a PR-ready work cycle without remembering every step.
-
-**Loop**
-
-`loop` runs loopability-gated research, plan, handoff, feedback, and repeat
-cycles. Use it when the correct next implementation has to be discovered
-through bounded iteration.
-
-**Web Research**
-
-`web-research` keeps current research source-backed. Use it for market, docs,
-competitor, implementation, or best-practice questions that need evidence.
-
-**Paper Learning**
-
-`paper-learning` explains a supplied paper or paper PDF at very easy,
-moderate, or expert level while preserving section coverage.
-
-**Source Finder**
-
-`source-finder` prepares typed source candidates such as papers, datasets,
-repos, docs, and public decks before research or synthesis starts.
-
-**Idea To Deploy**
-
-`idea-to-deploy` prepares executor-ready coding handoff with scope, non-goals,
-acceptance criteria, and verification for Codex, Claude Code, Hermes, or
-another runtime.
-
-**Workflow Learning**
-
-`workflow-learning` turns missed routes or weak workflow attempts into traces,
-evals, review queues, regression cases, and patch proposals.
+- **Deep Interview** (`deep-interview`) - clarify the one missing decision
+  before planning. Use when the request is still fuzzy.
+- **Ralplan** (`ralplan`) - turn repo facts, sources, risks, acceptance
+  criteria, and verification commands into a reviewed plan.
+- **Ultragoal** (`ultragoal`) - keep an ambitious goal tied to checkpoints and
+  completion gates instead of a one-shot answer.
+- **Ultra Process** (`ultraprocess`) - run one delivery cycle: research ->
+  ralplan -> implementation path -> code review -> docs/status sync.
+- **Loop Engineering** (`loop`) - iterate through research, plan, handoff,
+  feedback, and repeat when the right implementation must be discovered.
+- **Web Research** (`web-research`) - gather current, source-backed evidence
+  for market, docs, competitor, implementation, or best-practice questions.
+- **Paper Learning** (`paper-learning`) - explain a supplied paper or paper PDF
+  at very easy, moderate, or expert level without dropping section coverage.
+- **Source Finder** (`source-finder`) - prepare typed source candidates:
+  papers, datasets, repos, docs, public decks, and similar inputs.
+- **Idea To Deploy** (`idea-to-deploy`) - prepare scoped coding work for Codex, Claude Code, Hermes, or another runtime without claiming execution.
+- **Workflow Learning** (`workflow-learning`) - turn missed routes or weak
+  workflows into traces, evals, review queues, regression cases, and patch
+  proposals.
 
 ## What You Get
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -77,21 +77,68 @@ Operating models are optional advanced Hermes collaboration postures. They
 should not be described as installed agents or first-run setup choices unless a
 separate profile pack is explicitly selected.
 
-## Flagship Command Set Families
+## Representative Workflow Modes
 
 ![OMH flagship command sets poster](../assets/omh-flagship-workflows-poster.png)
 
-| Family | What Hermes owns | Plain request |
-| --- | --- | --- |
-| `deep-interview` / `ralplan` / `ultragoal` / `loop` / `ultraprocess` | Turn vague intent into a concrete goal, accepted plan, execution-ready path, loopability-gated project cycle, or one PR-ready delivery cycle. | "Make onboarding feel smoother." |
-| `feedback-triage` / `research-brief` / `strategy-brief` | Run non-coding company and product operating workflows for customer signals, evidence, meetings, and strategy. | "Payment failures keep coming up." |
-| `source-finder` / `research-department` / `web-research` / `research-brief` / `report-package` | Prepare typed source candidates, Scout -> Analyst -> Briefer research operations, source-backed evidence, source inbox, briefing status, knowledge-store readiness, and synthesis-tool readiness. | "Find papers, datasets, and repos for this topic." |
-| `paper-learning` | Explain supplied papers at very easy, moderate, or expert level with source-state evidence and a coverage ledger. | "Explain this paper PDF in very easy language without dropping sections." |
-| `operating-rhythm` / `report-package` / `reliability-review` | Keep operating cadence, report packages, and service reliability review in independent artifact-backed lanes. | "Prepare meeting history, the monthly report, and the incident review." |
-| `automation-blueprint` / `web-research` / `report-package` | Prepare recurring scheduled ops with cadence, delivery target, silence policy, skill chain, and observed-evidence requirements. | "Every morning, check competitor news and send a Slack digest only if something changed." |
-| `materials-package` / `report-package` | Prepare decks, PDFs, spreadsheets, documents, HWP, Markdown, and upload-ready materials while keeping binary export, render QA, formula checks, approval, and delivery observed-only. | "Turn the revenue spreadsheet into an Excel and PDF package with render QA." |
-| `img-summary` | Prepare provider-neutral visual prompt cards for meeting notes, PR summaries, issue triage, research briefings, and release announcements, with source-specific formats, premium domain-aware scene direction, poster_archetype/v1 design grammar, image-tool setup fallback, and observed-only generation, QA, and delivery. | "Make a PR summary card for reviewers." |
-| `idea-to-deploy` / coding handoff / executor selection | Prepare scoped handoffs for Codex, Claude Code, another runtime, or Hermes coding skills while preserving observed-evidence boundaries. | "Turn this issue into a PR-ready plan and hand it to implementation." |
+The full skill catalog is intentionally larger than the public story. Start
+with these 10 modes; then use [WORKFLOWS.md](WORKFLOWS.md) and
+[CAPABILITIES.md](CAPABILITIES.md) for the complete reference.
+
+The intent-to-plan lane includes `deep-interview` / `ralplan` / `ultragoal` / `loop` / `ultraprocess`.
+This section expands that lane into individual representative modes instead of
+a dense command family table.
+
+**Deep Interview**
+
+`deep-interview` asks the smallest useful clarification before planning. Use it
+when a product, research, or coding request is still too vague to execute well.
+
+**Ralplan**
+
+`ralplan` turns repo facts, source evidence, alternatives, risks, acceptance
+criteria, and verification commands into a reviewed plan.
+
+**Ultragoal**
+
+`ultragoal` gives ambitious goals durable checkpoints and completion gates so
+Hermes can report progress without pretending a one-shot answer is enough.
+
+**Ultra Process**
+
+`ultraprocess` is the one-cycle delivery lane: research -> ralplan ->
+implementation path -> code review -> docs/status sync.
+
+**Loop**
+
+`loop` handles loopable projects where the correct next implementation has to
+be discovered through bounded research, plan, handoff, feedback, and repeat
+cycles.
+
+**Web Research**
+
+`web-research` keeps current market, docs, competitor, implementation, and
+best-practice research source-backed.
+
+**Paper Learning**
+
+`paper-learning` explains a supplied paper or paper PDF at very easy,
+moderate, or expert level while preserving section coverage.
+
+**Source Finder**
+
+`source-finder` prepares typed source candidates such as papers, datasets,
+repos, docs, and public decks before research or synthesis starts.
+
+**Idea To Deploy**
+
+`idea-to-deploy` prepares scoped coding work for Codex, Claude Code, Hermes, or
+another runtime without claiming unobserved execution.
+
+**Workflow Learning**
+
+`workflow-learning` turns missed routes or weak workflow attempts into traces,
+evals, review queues, regression cases, and patch proposals.
 
 ## Documentation Contracts
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -85,60 +85,27 @@ The full skill catalog is intentionally larger than the public story. Start
 with these 10 modes; then use [WORKFLOWS.md](WORKFLOWS.md) and
 [CAPABILITIES.md](CAPABILITIES.md) for the complete reference.
 
-The intent-to-plan lane includes `deep-interview` / `ralplan` / `ultragoal` / `loop` / `ultraprocess`.
-This section expands that lane into individual representative modes instead of
-a dense command family table.
+<!-- Intent-to-plan anchor: `deep-interview` / `ralplan` / `ultragoal` / `loop` / `ultraprocess`. -->
 
-**Deep Interview**
-
-`deep-interview` asks the smallest useful clarification before planning. Use it
-when a product, research, or coding request is still too vague to execute well.
-
-**Ralplan**
-
-`ralplan` turns repo facts, source evidence, alternatives, risks, acceptance
-criteria, and verification commands into a reviewed plan.
-
-**Ultragoal**
-
-`ultragoal` gives ambitious goals durable checkpoints and completion gates so
-Hermes can report progress without pretending a one-shot answer is enough.
-
-**Ultra Process**
-
-`ultraprocess` is the one-cycle delivery lane: research -> ralplan ->
-implementation path -> code review -> docs/status sync.
-
-**Loop**
-
-`loop` handles loopable projects where the correct next implementation has to
-be discovered through bounded research, plan, handoff, feedback, and repeat
-cycles.
-
-**Web Research**
-
-`web-research` keeps current market, docs, competitor, implementation, and
-best-practice research source-backed.
-
-**Paper Learning**
-
-`paper-learning` explains a supplied paper or paper PDF at very easy,
-moderate, or expert level while preserving section coverage.
-
-**Source Finder**
-
-`source-finder` prepares typed source candidates such as papers, datasets,
-repos, docs, and public decks before research or synthesis starts.
-
-**Idea To Deploy**
-
-`idea-to-deploy` prepares scoped coding work for Codex, Claude Code, Hermes, or
-another runtime without claiming unobserved execution.
-
-**Workflow Learning**
-
-`workflow-learning` turns missed routes or weak workflow attempts into traces,
-evals, review queues, regression cases, and patch proposals.
+- **Deep Interview** (`deep-interview`) - clarify the one missing decision
+  before planning.
+- **Ralplan** (`ralplan`) - turn facts, sources, risks, acceptance criteria,
+  and verification commands into a reviewed plan.
+- **Ultragoal** (`ultragoal`) - give ambitious work durable checkpoints and
+  completion gates.
+- **Ultra Process** (`ultraprocess`) - run one delivery cycle from research to
+  plan, implementation path, review, and docs/status sync.
+- **Loop Engineering** (`loop`) - iterate when the correct next implementation
+  must be discovered through bounded cycles.
+- **Web Research** (`web-research`) - keep current research source-backed.
+- **Paper Learning** (`paper-learning`) - explain a supplied paper or paper PDF
+  by level while preserving section coverage.
+- **Source Finder** (`source-finder`) - prepare typed source candidates before
+  research or synthesis starts.
+- **Idea To Deploy** (`idea-to-deploy`) - prepare scoped coding work for the
+  selected runtime without claiming unobserved execution.
+- **Workflow Learning** (`workflow-learning`) - turn weak workflow attempts into
+  traces, evals, review queues, regression cases, and patch proposals.
 
 ## Documentation Contracts
 

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -212,98 +212,89 @@
               >
             </figure>
           </a>
-          <figure class="poster-frame poster-frame--docs">
-            <img
-              src="../assets/omh-flagship-workflows-poster.png"
-              alt="OMH flagship command sets poster summarizing intent to plan, product ops brief, and executor handoff lanes"
-            >
-          </figure>
-          <div class="docs-feature-grid" aria-label="Flagship OMH workflow families">
-            <a class="flagship-item flagship-item--docs" href="#routing">
-              <span>Task abstraction</span>
-              <h3><code>omh_task_card/v1</code> / workflow rails</h3>
-              <p>
-                Classify work such as runtime portability, environment
-                reproduction, or router-design feedback before selecting the
-                workflow rail that should carry the next safe action.
-              </p>
+          <div class="mode-note mode-note--docs" aria-label="Representative OMH workflow modes">
+            <span>Mode-first, not catalog-first</span>
+            <p>
+              These 10 modes are the public starting point. The full reference
+              remains below for every generated workflow, wrapper contract, and
+              local artifact shape.
+            </p>
+            <p>
+              Compact intent-to-plan discovery still includes
+              <code>deep-interview</code> / <code>ralplan</code> /
+              <code>ultragoal</code> / <code>loop</code> / <code>ultraprocess</code>.
+            </p>
+          </div>
+          <div class="mode-grid mode-grid--docs" aria-label="Representative OMH workflow modes">
+            <a class="mode-card mode-card--docs mode-card--featured" href="intent-to-plan/">
+              <span class="mode-card__label">Intent clarity</span>
+              <h3>Deep Interview</h3>
+              <p>One focused clarification path before planning.</p>
+              <strong>Use for vague product, research, or coding requests where the real goal is not clear yet.</strong>
+              <code>deep-interview</code>
             </a>
-            <a class="flagship-item flagship-item--docs" href="intent-to-plan/">
-              <span>Intent to plan</span>
-              <h3><code>deep-interview</code> / <code>ralplan</code> / <code>ultragoal</code> / <code>loop</code> / <code>ultraprocess</code></h3>
-              <p>
-                Convert "Make onboarding feel smoother" into a concrete goal,
-                plan, execution-ready path, loopability-gated project cycle, or
-                one-cycle delivery path.
-              </p>
+            <a class="mode-card mode-card--docs mode-card--featured" href="intent-to-plan/">
+              <span class="mode-card__label">Reviewed plan</span>
+              <h3>Ralplan</h3>
+              <p>Planning with evidence, alternatives, risks, and verification commands.</p>
+              <strong>Use for risky changes, architecture decisions, and source-backed implementation plans.</strong>
+              <code>ralplan</code>
             </a>
-            <a class="flagship-item flagship-item--docs" href="product-ops/">
-              <span>Company and product ops</span>
-              <h3><code>feedback-triage</code> / <code>research-brief</code> / <code>strategy-brief</code></h3>
-              <p>
-                Triage customer signals, brief research, set meeting topics, and
-                frame strategic options without defaulting to coding.
-              </p>
+            <a class="mode-card mode-card--docs" href="intent-to-plan/">
+              <span class="mode-card__label">Durable goal</span>
+              <h3>Ultragoal</h3>
+              <p>Goal execution with checkpoints and completion gates.</p>
+              <strong>Use for ambitious goals that need tracked progress instead of a one-shot answer.</strong>
+              <code>ultragoal</code>
             </a>
-            <a class="flagship-item flagship-item--docs" href="product-ops/">
-              <span>Research department</span>
-              <h3><code>source-finder</code> / <code>research-department</code> / <code>web-research</code> / <code>report-package</code></h3>
-              <p>
-                Prepare typed source candidates, Scout, Analyst, and Briefer
-                lanes with source inbox, briefing status, knowledge-store
-                readiness, and synthesis-tool readiness.
-              </p>
+            <a class="mode-card mode-card--docs mode-card--featured" href="intent-to-plan/">
+              <span class="mode-card__label">One-cycle delivery</span>
+              <h3>Ultra Process</h3>
+              <p>Research -> plan -> implementation path -> review -> sync.</p>
+              <strong>Use for PR-ready work where the user should not have to remember every step.</strong>
+              <code>ultraprocess</code>
             </a>
-            <a class="flagship-item flagship-item--docs" href="product-ops/">
-              <span>Paper learning</span>
-              <h3><code>paper-learning</code></h3>
-              <p>
-                Explain a supplied paper by level while preserving a coverage
-                ledger and keeping PDF extraction, OCR, citation checks, math
-                validation, and reproduction observed-only.
-              </p>
+            <a class="mode-card mode-card--docs" href="loop/">
+              <span class="mode-card__label">Loop engineering</span>
+              <h3>Loop</h3>
+              <p>Loopability-gated research, plan, handoff, feedback, and repeat cycles.</p>
+              <strong>Use for open-ended goals whose next correct implementation must be discovered.</strong>
+              <code>loop</code>
             </a>
-            <a class="flagship-item flagship-item--docs" href="#playbooks">
-              <span>Scheduled ops</span>
-              <h3><code>automation-blueprint</code> / <code>web-research</code> / <code>report-package</code></h3>
-              <p>
-                Prepare recurring checks, delivery targets, silence rules, and
-                status-card boundaries while runtime proof stays observed-only.
-              </p>
+            <a class="mode-card mode-card--docs" href="web-research/">
+              <span class="mode-card__label">Live evidence</span>
+              <h3>Web Research</h3>
+              <p>Source-backed current research with clear evidence boundaries.</p>
+              <strong>Use for market, docs, competitor, implementation, or best-practice questions.</strong>
+              <code>web-research</code>
             </a>
-            <a class="flagship-item flagship-item--docs" href="product-ops/">
-              <span>Materials processing</span>
-              <h3><code>materials-package</code> / <code>report-package</code></h3>
-              <p>
-                Shape decks, PDFs, spreadsheets, documents, HWP, Markdown, and
-                upload packages while binary export and render QA stay evidence-gated.
-              </p>
+            <a class="mode-card mode-card--docs" href="paper-learning/">
+              <span class="mode-card__label">Paper study</span>
+              <h3>Paper Learning</h3>
+              <p>Paper/PDF explanation at very easy, moderate, or expert level.</p>
+              <strong>Use for readable paper study without dropping section coverage.</strong>
+              <code>paper-learning</code>
             </a>
-            <a class="flagship-item flagship-item--docs" href="image-gen/">
-              <span>Image gen</span>
-              <h3><code>img-summary</code></h3>
-              <p>
-                Prepare source-specific meeting, report, PR, issue, research,
-                and release cards while generation, QA, and delivery remain
-                observed-only.
-              </p>
+            <a class="mode-card mode-card--docs" href="#playbooks">
+              <span class="mode-card__label">Source intake</span>
+              <h3>Source Finder</h3>
+              <p>Typed acquisition plan for papers, datasets, repos, docs, and public decks.</p>
+              <strong>Use for finding the right material before research or synthesis starts.</strong>
+              <code>source-finder</code>
             </a>
-            <a class="flagship-item flagship-item--docs" href="#quality">
-              <span>Workflow learning</span>
-              <h3><code>workflow-learning</code></h3>
-              <p>
-                Record metadata-only traces, evals, human-review candidates,
-                regression cases, and patch handoff proposals without automatic
-                model training or hidden skill mutation.
-              </p>
+            <a class="mode-card mode-card--docs" href="executor-handoff/">
+              <span class="mode-card__label">Coding handoff</span>
+              <h3>Idea To Deploy</h3>
+              <p>Executor-ready handoff with scope, non-goals, and verification.</p>
+              <strong>Use for turning an issue or feature idea into work for Codex, Claude Code, Hermes, or another runtime.</strong>
+              <code>idea-to-deploy</code>
             </a>
-            <a class="flagship-item flagship-item--docs" href="executor-handoff/">
-              <span>Executor-ready handoff</span>
-              <h3><code>idea-to-deploy</code> / coding handoff / executor selection</h3>
-              <p>
-                Prepare work for Codex, Claude Code, an oh-my runtime, or Hermes coding skills
-                while keeping evidence boundaries explicit.
-              </p>
+            <a class="mode-card mode-card--docs" href="#quality">
+              <span class="mode-card__label">Improve the workflow</span>
+              <h3>Workflow Learning</h3>
+              <p>Trace, eval, review queue, regression case, and patch proposal.</p>
+              <strong>Use for improving routing and skill behavior after a missed or weak workflow.</strong>
+              <code>workflow-learning</code>
             </a>
           </div>
         </section>

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -229,71 +229,71 @@
             <a class="mode-card mode-card--docs mode-card--featured" href="intent-to-plan/">
               <span class="mode-card__label">Intent clarity</span>
               <h3>Deep Interview</h3>
-              <p>One focused clarification path before planning.</p>
-              <strong>Use for vague product, research, or coding requests where the real goal is not clear yet.</strong>
+              <p>Clarify the missing decision before planning.</p>
+              <strong>Best for vague product, research, or coding requests.</strong>
               <code>deep-interview</code>
             </a>
             <a class="mode-card mode-card--docs mode-card--featured" href="intent-to-plan/">
               <span class="mode-card__label">Reviewed plan</span>
               <h3>Ralplan</h3>
-              <p>Planning with evidence, alternatives, risks, and verification commands.</p>
-              <strong>Use for risky changes, architecture decisions, and source-backed implementation plans.</strong>
+              <p>Plan from facts, sources, risks, and verification.</p>
+              <strong>Best for architecture, risk, and serious implementation plans.</strong>
               <code>ralplan</code>
             </a>
             <a class="mode-card mode-card--docs" href="intent-to-plan/">
               <span class="mode-card__label">Durable goal</span>
               <h3>Ultragoal</h3>
-              <p>Goal execution with checkpoints and completion gates.</p>
-              <strong>Use for ambitious goals that need tracked progress instead of a one-shot answer.</strong>
+              <p>Give ambitious work checkpoints and completion gates.</p>
+              <strong>Best when progress needs a durable trail.</strong>
               <code>ultragoal</code>
             </a>
             <a class="mode-card mode-card--docs mode-card--featured" href="intent-to-plan/">
               <span class="mode-card__label">One-cycle delivery</span>
               <h3>Ultra Process</h3>
               <p>Research -> plan -> implementation path -> review -> sync.</p>
-              <strong>Use for PR-ready work where the user should not have to remember every step.</strong>
+              <strong>Best for one PR-ready delivery cycle.</strong>
               <code>ultraprocess</code>
             </a>
             <a class="mode-card mode-card--docs" href="loop/">
               <span class="mode-card__label">Loop engineering</span>
-              <h3>Loop</h3>
-              <p>Loopability-gated research, plan, handoff, feedback, and repeat cycles.</p>
-              <strong>Use for open-ended goals whose next correct implementation must be discovered.</strong>
+              <h3>Loop Engineering</h3>
+              <p>Research, plan, handoff, feedback, repeat.</p>
+              <strong>Best when the next right move must be discovered.</strong>
               <code>loop</code>
             </a>
             <a class="mode-card mode-card--docs" href="web-research/">
               <span class="mode-card__label">Live evidence</span>
               <h3>Web Research</h3>
-              <p>Source-backed current research with clear evidence boundaries.</p>
-              <strong>Use for market, docs, competitor, implementation, or best-practice questions.</strong>
+              <p>Current research with source-backed evidence.</p>
+              <strong>Best for market, docs, competitor, and best-practice questions.</strong>
               <code>web-research</code>
             </a>
             <a class="mode-card mode-card--docs" href="paper-learning/">
               <span class="mode-card__label">Paper study</span>
               <h3>Paper Learning</h3>
-              <p>Paper/PDF explanation at very easy, moderate, or expert level.</p>
-              <strong>Use for readable paper study without dropping section coverage.</strong>
+              <p>Explain a paper by level without dropping sections.</p>
+              <strong>Best for very easy, moderate, or expert study.</strong>
               <code>paper-learning</code>
             </a>
             <a class="mode-card mode-card--docs" href="#playbooks">
               <span class="mode-card__label">Source intake</span>
               <h3>Source Finder</h3>
-              <p>Typed acquisition plan for papers, datasets, repos, docs, and public decks.</p>
-              <strong>Use for finding the right material before research or synthesis starts.</strong>
+              <p>Find papers, datasets, repos, docs, and public decks.</p>
+              <strong>Best before research or synthesis starts.</strong>
               <code>source-finder</code>
             </a>
             <a class="mode-card mode-card--docs" href="executor-handoff/">
               <span class="mode-card__label">Coding handoff</span>
               <h3>Idea To Deploy</h3>
-              <p>Executor-ready handoff with scope, non-goals, and verification.</p>
-              <strong>Use for turning an issue or feature idea into work for Codex, Claude Code, Hermes, or another runtime.</strong>
+              <p>Scoped coding handoff with verification shape.</p>
+              <strong>Best for Codex, Claude Code, Hermes, or another runtime.</strong>
               <code>idea-to-deploy</code>
             </a>
             <a class="mode-card mode-card--docs" href="#quality">
               <span class="mode-card__label">Improve the workflow</span>
               <h3>Workflow Learning</h3>
-              <p>Trace, eval, review queue, regression case, and patch proposal.</p>
-              <strong>Use for improving routing and skill behavior after a missed or weak workflow.</strong>
+              <p>Trace weak routes into evals and patch proposals.</p>
+              <strong>Best after a missed or weak workflow.</strong>
               <code>workflow-learning</code>
             </a>
           </div>

--- a/site/index.html
+++ b/site/index.html
@@ -127,6 +127,13 @@ omh doctor</code>
             plugin observations, and coding handoffs while the user keeps
             speaking in normal chat.
           </p>
+          <p>
+            Modern OMH is a contract system, not a command catalog. Wrapper
+            surfaces can render <code>omh_interact</code>,
+            <code>chat_response/v1</code>, and
+            <code>coding_runtime_handoff/v1</code> without turning a prepared
+            next step into observed work.
+          </p>
         </div>
         <div class="product-grid">
           <article class="product-card">
@@ -199,49 +206,98 @@ omh doctor</code>
       <section class="home-section home-section--ink" id="capabilities">
         <div class="section-heading section-heading--split">
           <div>
-            <p class="home-kicker">Capability map</p>
-            <h2>Modern OMH is a contract system, not a command catalog.</h2>
+            <p class="home-kicker">Representative modes</p>
+            <h2>Start with the 10 workflows that explain OMH.</h2>
           </div>
           <p>
-            The installed skills still matter, but the product story is the
-            renderable path around them: capabilities, route hints, session
-            evidence, worktree guidance, and selected-runtime handoff.
+            The catalog is larger, but these are the modes people should see
+            first. Each card names the work shape, the moment to use it, and
+            the direct skill name when a user wants to call it manually.
           </p>
         </div>
-        <div class="capability-board" role="group" aria-label="OMH capability lanes">
-          <article class="capability-card capability-card--large">
-            <span>chat surface</span>
-            <h3><code>omh_interact</code> and <code>chat_response/v1</code></h3>
-            <p>
-              Hermes or a wrapper can turn one message into route, role, next
-              action, buttons, status, and evidence boundaries.
-            </p>
+        <div class="mode-note" aria-label="Representative OMH workflow modes">
+          <span>Mode-first, not catalog-first</span>
+          <p>
+            Start here for the public story. The full reference stays in docs
+            for operators who want every workflow, contract, and playbook.
+          </p>
+        </div>
+        <div class="mode-grid">
+          <article class="mode-card mode-card--featured">
+            <span class="mode-card__label">Intent clarity</span>
+            <h3>Deep Interview</h3>
+            <p>One focused clarification path before planning.</p>
+            <strong>Use for vague product, research, or coding requests where the real goal is not clear yet.</strong>
+            <code>deep-interview</code>
           </article>
-          <article class="capability-card">
-            <span>manifest</span>
-            <h3><code>omh capabilities</code></h3>
-            <p>Local manifests explain skills, hooks, playbooks, roles, tools, and evidence rules.</p>
+          <article class="mode-card mode-card--featured">
+            <span class="mode-card__label">Reviewed plan</span>
+            <h3>Ralplan</h3>
+            <p>Planning with evidence, alternatives, risks, and verification commands.</p>
+            <strong>Use for risky changes, architecture decisions, and source-backed implementation plans.</strong>
+            <code>ralplan</code>
           </article>
-          <article class="capability-card">
-            <span>planning</span>
-            <h3><code>deep-interview</code> to <code>ultragoal</code></h3>
-            <p>Fuzzy intent turns into clear goals, acceptance criteria, and durable checkpoints.</p>
+          <article class="mode-card">
+            <span class="mode-card__label">Durable goal</span>
+            <h3>Ultragoal</h3>
+            <p>Goal execution with checkpoints and completion gates.</p>
+            <strong>Use for ambitious goals that need tracked progress instead of a one-shot answer.</strong>
+            <code>ultragoal</code>
           </article>
-          <article class="capability-card">
-            <span>loop</span>
-            <h3><code>loop</code></h3>
-            <p>Large goals become a visible cycle of interview, research, plan, handoff, feedback, and resume.</p>
+          <article class="mode-card mode-card--featured">
+            <span class="mode-card__label">One-cycle delivery</span>
+            <h3>Ultra Process</h3>
+            <p>Research -> plan -> implementation path -> review -> sync.</p>
+            <strong>Use for PR-ready work where the user should not have to remember every step.</strong>
+            <code>ultraprocess</code>
           </article>
-          <article class="capability-card">
-            <span>visual prep</span>
-            <h3><code>img-summary</code></h3>
-            <p>Meetings, PRs, issues, releases, and research become source-specific prompt cards.</p>
+          <article class="mode-card">
+            <span class="mode-card__label">Loop engineering</span>
+            <h3>Loop</h3>
+            <p>Loopability-gated research, plan, handoff, feedback, and repeat cycles.</p>
+            <strong>Use for open-ended goals whose next correct implementation must be discovered.</strong>
+            <code>loop</code>
           </article>
-          <article class="capability-card">
-            <span>coding</span>
-            <h3><code>coding_runtime_handoff/v1</code></h3>
-            <p>Codex, Claude Code, Hermes, or another selected runtime receives scoped work only after the path is visible.</p>
+          <article class="mode-card">
+            <span class="mode-card__label">Live evidence</span>
+            <h3>Web Research</h3>
+            <p>Source-backed current research with clear evidence boundaries.</p>
+            <strong>Use for market, docs, competitor, implementation, or best-practice questions.</strong>
+            <code>web-research</code>
           </article>
+          <article class="mode-card">
+            <span class="mode-card__label">Paper study</span>
+            <h3>Paper Learning</h3>
+            <p>Paper/PDF explanation at very easy, moderate, or expert level.</p>
+            <strong>Use for readable paper study without dropping section coverage.</strong>
+            <code>paper-learning</code>
+          </article>
+          <article class="mode-card">
+            <span class="mode-card__label">Source intake</span>
+            <h3>Source Finder</h3>
+            <p>Typed acquisition plan for papers, datasets, repos, docs, and public decks.</p>
+            <strong>Use for finding the right material before research or synthesis starts.</strong>
+            <code>source-finder</code>
+          </article>
+          <article class="mode-card">
+            <span class="mode-card__label">Coding handoff</span>
+            <h3>Idea To Deploy</h3>
+            <p>Executor-ready handoff with scope, non-goals, and verification.</p>
+            <strong>Use for turning an issue or feature idea into work for Codex, Claude Code, Hermes, or another runtime.</strong>
+            <code>idea-to-deploy</code>
+          </article>
+          <article class="mode-card">
+            <span class="mode-card__label">Improve the workflow</span>
+            <h3>Workflow Learning</h3>
+            <p>Trace, eval, review queue, regression case, and patch proposal.</p>
+            <strong>Use for improving routing and skill behavior after a missed or weak workflow.</strong>
+            <code>workflow-learning</code>
+          </article>
+        </div>
+        <div class="mode-grid__footer">
+          <span>Full catalog: 40+ OMH workflows, contracts, roles, and playbooks.</span>
+          <a class="text-link" href="docs/#flagship">Open workflow docs</a>
+          <a class="text-link" href="docs/#contracts">Open contracts</a>
         </div>
       </section>
 
@@ -282,6 +338,7 @@ omh doctor</code>
             <div>
               <span>Image gen</span>
               <h3>Prompt cards with source structure and domain scene separated.</h3>
+              <p>Meetings, PRs, issues, releases, and research become source-specific prompt cards.</p>
             </div>
           </a>
           <a class="artifact-card" href="docs/intent-to-plan/" aria-label="Open intent to plan docs">

--- a/site/index.html
+++ b/site/index.html
@@ -211,8 +211,8 @@ omh doctor</code>
           </div>
           <p>
             The catalog is larger, but these are the modes people should see
-            first. Each card names the work shape, the moment to use it, and
-            the direct skill name when a user wants to call it manually.
+            first. Each card names the mode, the right moment to use it, and
+            the direct skill call when the user wants manual control.
           </p>
         </div>
         <div class="mode-note" aria-label="Representative OMH workflow modes">
@@ -226,71 +226,71 @@ omh doctor</code>
           <article class="mode-card mode-card--featured">
             <span class="mode-card__label">Intent clarity</span>
             <h3>Deep Interview</h3>
-            <p>One focused clarification path before planning.</p>
-            <strong>Use for vague product, research, or coding requests where the real goal is not clear yet.</strong>
+            <p>Clarify the missing decision before planning.</p>
+            <strong>Best for vague product, research, or coding requests.</strong>
             <code>deep-interview</code>
           </article>
           <article class="mode-card mode-card--featured">
             <span class="mode-card__label">Reviewed plan</span>
             <h3>Ralplan</h3>
-            <p>Planning with evidence, alternatives, risks, and verification commands.</p>
-            <strong>Use for risky changes, architecture decisions, and source-backed implementation plans.</strong>
+            <p>Plan from facts, sources, risks, and verification.</p>
+            <strong>Best for architecture, risk, and serious implementation plans.</strong>
             <code>ralplan</code>
           </article>
           <article class="mode-card">
             <span class="mode-card__label">Durable goal</span>
             <h3>Ultragoal</h3>
-            <p>Goal execution with checkpoints and completion gates.</p>
-            <strong>Use for ambitious goals that need tracked progress instead of a one-shot answer.</strong>
+            <p>Give ambitious work checkpoints and completion gates.</p>
+            <strong>Best when progress needs a durable trail.</strong>
             <code>ultragoal</code>
           </article>
           <article class="mode-card mode-card--featured">
             <span class="mode-card__label">One-cycle delivery</span>
             <h3>Ultra Process</h3>
             <p>Research -> plan -> implementation path -> review -> sync.</p>
-            <strong>Use for PR-ready work where the user should not have to remember every step.</strong>
+            <strong>Best for one PR-ready delivery cycle.</strong>
             <code>ultraprocess</code>
           </article>
           <article class="mode-card">
             <span class="mode-card__label">Loop engineering</span>
-            <h3>Loop</h3>
-            <p>Loopability-gated research, plan, handoff, feedback, and repeat cycles.</p>
-            <strong>Use for open-ended goals whose next correct implementation must be discovered.</strong>
+            <h3>Loop Engineering</h3>
+            <p>Research, plan, handoff, feedback, repeat.</p>
+            <strong>Best when the next right move must be discovered.</strong>
             <code>loop</code>
           </article>
           <article class="mode-card">
             <span class="mode-card__label">Live evidence</span>
             <h3>Web Research</h3>
-            <p>Source-backed current research with clear evidence boundaries.</p>
-            <strong>Use for market, docs, competitor, implementation, or best-practice questions.</strong>
+            <p>Current research with source-backed evidence.</p>
+            <strong>Best for market, docs, competitor, and best-practice questions.</strong>
             <code>web-research</code>
           </article>
           <article class="mode-card">
             <span class="mode-card__label">Paper study</span>
             <h3>Paper Learning</h3>
-            <p>Paper/PDF explanation at very easy, moderate, or expert level.</p>
-            <strong>Use for readable paper study without dropping section coverage.</strong>
+            <p>Explain a paper by level without dropping sections.</p>
+            <strong>Best for very easy, moderate, or expert study.</strong>
             <code>paper-learning</code>
           </article>
           <article class="mode-card">
             <span class="mode-card__label">Source intake</span>
             <h3>Source Finder</h3>
-            <p>Typed acquisition plan for papers, datasets, repos, docs, and public decks.</p>
-            <strong>Use for finding the right material before research or synthesis starts.</strong>
+            <p>Find papers, datasets, repos, docs, and public decks.</p>
+            <strong>Best before research or synthesis starts.</strong>
             <code>source-finder</code>
           </article>
           <article class="mode-card">
             <span class="mode-card__label">Coding handoff</span>
             <h3>Idea To Deploy</h3>
-            <p>Executor-ready handoff with scope, non-goals, and verification.</p>
-            <strong>Use for turning an issue or feature idea into work for Codex, Claude Code, Hermes, or another runtime.</strong>
+            <p>Scoped coding handoff with verification shape.</p>
+            <strong>Best for Codex, Claude Code, Hermes, or another runtime.</strong>
             <code>idea-to-deploy</code>
           </article>
           <article class="mode-card">
             <span class="mode-card__label">Improve the workflow</span>
             <h3>Workflow Learning</h3>
-            <p>Trace, eval, review queue, regression case, and patch proposal.</p>
-            <strong>Use for improving routing and skill behavior after a missed or weak workflow.</strong>
+            <p>Trace weak routes into evals and patch proposals.</p>
+            <strong>Best after a missed or weak workflow.</strong>
             <code>workflow-learning</code>
           </article>
         </div>

--- a/site/styles.css
+++ b/site/styles.css
@@ -4651,7 +4651,7 @@ body.home-page {
   display: grid;
   align-content: start;
   min-width: 0;
-  min-height: 260px;
+  min-height: 230px;
   padding: 20px;
   border: 1px solid rgba(126, 215, 194, 0.2);
   border-radius: 8px;
@@ -4756,7 +4756,7 @@ body.home-page {
 }
 
 .mode-card--docs {
-  min-height: 250px;
+  min-height: 220px;
   border-color: rgba(25, 116, 102, 0.2);
   background:
     radial-gradient(circle at 18% 0%, rgba(25, 116, 102, 0.1), transparent 34%),

--- a/site/styles.css
+++ b/site/styles.css
@@ -4614,6 +4614,181 @@ body.home-page {
   overflow-wrap: anywhere;
 }
 
+.mode-note {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px 18px;
+  align-items: center;
+  margin: 0 0 18px;
+  padding: 16px 18px;
+  border: 1px solid rgba(126, 215, 194, 0.22);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.055);
+}
+
+.mode-note span {
+  color: #7ed7c2;
+  font-size: 12px;
+  font-weight: 900;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.mode-note p {
+  flex: 1 1 360px;
+  margin: 0;
+  color: rgba(234, 246, 242, 0.72);
+  font-size: 0.98rem;
+}
+
+.mode-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.mode-card {
+  display: grid;
+  align-content: start;
+  min-width: 0;
+  min-height: 260px;
+  padding: 20px;
+  border: 1px solid rgba(126, 215, 194, 0.2);
+  border-radius: 8px;
+  background:
+    radial-gradient(circle at 18% 0%, rgba(126, 215, 194, 0.12), transparent 32%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.085), rgba(255, 255, 255, 0.035));
+  color: #ffffff;
+  text-decoration: none;
+  box-shadow: 0 22px 60px rgba(0, 0, 0, 0.22);
+  transition:
+    transform 180ms ease,
+    border-color 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.mode-card:hover,
+.mode-card:focus-visible {
+  transform: translateY(-4px);
+  border-color: rgba(240, 184, 110, 0.42);
+  box-shadow: 0 30px 76px rgba(0, 0, 0, 0.3);
+}
+
+.mode-card--featured {
+  border-color: rgba(126, 215, 194, 0.34);
+  background:
+    radial-gradient(circle at 20% 0%, rgba(66, 240, 208, 0.18), transparent 34%),
+    linear-gradient(155deg, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0.04));
+}
+
+.mode-card__label {
+  display: inline-flex;
+  width: fit-content;
+  margin-bottom: 14px;
+  padding: 6px 9px;
+  border: 1px solid rgba(126, 215, 194, 0.22);
+  border-radius: 999px;
+  color: #7ed7c2;
+  font-size: 11px;
+  font-weight: 900;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.mode-card h3 {
+  margin: 0;
+  color: #ffffff;
+  font-size: 1.35rem;
+  line-height: 1.18;
+}
+
+.mode-card p {
+  margin: 12px 0 0;
+  color: rgba(234, 246, 242, 0.78);
+}
+
+.mode-card strong {
+  display: block;
+  margin: 14px 0 0;
+  color: rgba(255, 255, 255, 0.92);
+  font-size: 0.98rem;
+  font-weight: 700;
+  line-height: 1.45;
+}
+
+.mode-card code {
+  display: inline-flex;
+  width: fit-content;
+  margin-top: 18px;
+  padding: 7px 10px;
+  border: 1px solid rgba(126, 215, 194, 0.26);
+  border-radius: 8px;
+  background: rgba(2, 11, 10, 0.38);
+  color: #9cf0e5;
+  font-size: 0.9rem;
+}
+
+.mode-grid__footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 16px;
+  align-items: center;
+  margin-top: 18px;
+  padding: 16px 18px;
+  border: 1px solid rgba(126, 215, 194, 0.18);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.045);
+  color: rgba(234, 246, 242, 0.78);
+}
+
+.mode-note--docs {
+  margin-top: 22px;
+  border-color: rgba(25, 116, 102, 0.2);
+  background: rgba(255, 255, 255, 0.82);
+}
+
+.mode-note--docs p {
+  color: var(--muted);
+}
+
+.mode-grid--docs {
+  margin-top: 14px;
+}
+
+.mode-card--docs {
+  min-height: 250px;
+  border-color: rgba(25, 116, 102, 0.2);
+  background:
+    radial-gradient(circle at 18% 0%, rgba(25, 116, 102, 0.1), transparent 34%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(238, 250, 245, 0.8));
+  color: var(--ink);
+  box-shadow: var(--shadow);
+}
+
+.mode-card--docs:hover,
+.mode-card--docs:focus-visible {
+  border-color: rgba(179, 107, 22, 0.28);
+  box-shadow: 0 24px 60px rgba(16, 28, 40, 0.15);
+}
+
+.mode-card--docs h3 {
+  color: var(--ink);
+}
+
+.mode-card--docs p {
+  color: var(--muted);
+}
+
+.mode-card--docs strong {
+  color: #273d38;
+}
+
+.mode-card--docs code {
+  border-color: rgba(25, 116, 102, 0.18);
+  background: rgba(25, 116, 102, 0.08);
+  color: var(--accent-strong);
+}
+
 .artifact-showcase {
   display: grid;
   grid-template-columns: minmax(0, 1.1fr) minmax(260px, 0.62fr);
@@ -4818,6 +4993,7 @@ body.home-page {
   .signal-strip,
   .product-grid,
   .capability-board,
+  .mode-grid,
   .evidence-pipeline {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
@@ -4929,6 +5105,7 @@ body.home-page {
   .signal-strip,
   .product-grid,
   .capability-board,
+  .mode-grid,
   .evidence-pipeline {
     grid-template-columns: 1fr;
   }
@@ -4939,6 +5116,7 @@ body.home-page {
 
   .product-card,
   .capability-card,
+  .mode-card,
   .evidence-pipeline article {
     min-height: auto;
   }


### PR DESCRIPTION
## Feature Report

### What Changed

- Reworked the README Core Workflows section from a dense capability table into 10 representative workflow modes.
- Updated the docs README to present the same mode-first story while preserving the existing intent-to-plan contract string for generated/docs tests.
- Rebuilt the public site and docs landing page workflow section around mode cards instead of command-family grids.
- Added responsive card styling for representative modes on dark home sections and light docs sections.

### Why This Exists

- The public workflow list was reading like a grouped command catalog, which made OMH feel harder to understand than it is.
- The requested direction is mode-first: show the workflows people should understand first, then send the full catalog to docs.
- OMH should still keep its chat-first story clear: users can ask Hermes naturally, or directly call a clean skill name when they already know the lane.

### User / Operator Impact

- New users now see 10 representative modes first: Deep Interview, Ralplan, Ultragoal, Ultra Process, Loop, Web Research, Paper Learning, Source Finder, Idea To Deploy, and Workflow Learning.
- Operators still get links to the full workflow and capability references instead of losing catalog depth.
- The public site now has scan-friendly cards that explain what each mode is, when Hermes should use it, and the direct skill name.

### How It Works

- README keeps the stable `## Core Workflows` public anchor but changes the content to prose mode entries.
- `docs/README.md` mirrors the mode-first shape and keeps generated-contract test strings intact.
- `site/index.html` and `site/docs/index.html` render the representative modes using a new shared `.mode-*` card system.
- `site/styles.css` defines the responsive dark/light variants and mobile single-column fallback.

### Files And Contracts Touched

- `README.md`
- `docs/README.md`
- `site/index.html`
- `site/docs/index.html`
- `site/styles.css`
- Public wording contracts preserved: `## Core Workflows`, intent-to-plan skill chain, `omh_interact`, `chat_response/v1`, `coding_runtime_handoff/v1`, and image-gen site copy.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_router_content.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `PYTHONPATH=tests uv run python -m compileall -q src tests`
- [x] `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check`
- [ ] `python3 -m omh.cli harness validate` - Not run; no harness metadata changed.
- [ ] `python3 -m omh.cli release checklist --json` - Not run; no release contract changed.
- [ ] `python3 -m omh.cli release hermes-smoke` - Not run; no install/runtime behavior changed.
- [ ] `omh --help` - Not run; no CLI behavior changed.
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` - Not run; no install/runtime behavior changed.
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: Not applicable.
- [x] Relevant dry-run or smoke command: local static server plus Playwright desktop/mobile render smoke of `site/index.html` capability cards.
- [x] Manual Hermes/TUI check, or explicit reason it was not run: Not run; docs/site-only change. Browser render smoke was used instead.

## Risk

- Low. This is a public copy and static site presentation change.
- Existing public test strings were intentionally preserved where tests treat them as contract anchors.

## Compatibility / Rollout

- No CLI, schema, runtime, setup, plugin, or generated skill behavior changes.
- GitHub Pages will pick up the new static site after merge/deploy.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`): no release-channel behavior change.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed: no new runtime claims added.
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap: Hermes live smoke not run because this is docs/site-only.

## Follow-Up

- Consider refreshing the poster asset later so visual media and the new 10-mode copy tell exactly the same story.