### PR TITLE
Restore loop wording and README spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,24 +126,35 @@ understand first; the rest live in [Workflow Reference](docs/WORKFLOWS.md) and
 
 - **Deep Interview** (`deep-interview`) - clarify the one missing decision
   before planning. Use when the request is still fuzzy.
+
 - **Ralplan** (`ralplan`) - turn repo facts, sources, risks, acceptance
   criteria, and verification commands into a reviewed plan.
+
 - **Ultragoal** (`ultragoal`) - keep an ambitious goal tied to checkpoints and
   completion gates instead of a one-shot answer.
+
 - **Ultra Process** (`ultraprocess`) - run one delivery cycle: research ->
   ralplan -> implementation path -> code review -> docs/status sync.
-- **Loop Engineering** (`loop`) - iterate through research, plan, handoff,
+
+- **Loop** (`loop`) - iterate through research, plan, handoff,
   feedback, and repeat when the right implementation must be discovered.
+
 - **Web Research** (`web-research`) - gather current, source-backed evidence
   for market, docs, competitor, implementation, or best-practice questions.
+
 - **Paper Learning** (`paper-learning`) - explain a supplied paper or paper PDF
   at very easy, moderate, or expert level without dropping section coverage.
+
 - **Source Finder** (`source-finder`) - prepare typed source candidates:
   papers, datasets, repos, docs, public decks, and similar inputs.
+
 - **Idea To Deploy** (`idea-to-deploy`) - prepare scoped coding work for Codex, Claude Code, Hermes, or another runtime without claiming execution.
+
 - **Workflow Learning** (`workflow-learning`) - turn missed routes or weak
   workflows into traces, evals, review queues, regression cases, and patch
   proposals.
+
+<br>
 
 ## What You Get
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -89,21 +89,30 @@ with these 10 modes; then use [WORKFLOWS.md](WORKFLOWS.md) and
 
 - **Deep Interview** (`deep-interview`) - clarify the one missing decision
   before planning.
+
 - **Ralplan** (`ralplan`) - turn facts, sources, risks, acceptance criteria,
   and verification commands into a reviewed plan.
+
 - **Ultragoal** (`ultragoal`) - give ambitious work durable checkpoints and
   completion gates.
+
 - **Ultra Process** (`ultraprocess`) - run one delivery cycle from research to
   plan, implementation path, review, and docs/status sync.
-- **Loop Engineering** (`loop`) - iterate when the correct next implementation
+
+- **Loop** (`loop`) - iterate when the correct next implementation
   must be discovered through bounded cycles.
+
 - **Web Research** (`web-research`) - keep current research source-backed.
+
 - **Paper Learning** (`paper-learning`) - explain a supplied paper or paper PDF
   by level while preserving section coverage.
+
 - **Source Finder** (`source-finder`) - prepare typed source candidates before
   research or synthesis starts.
+
 - **Idea To Deploy** (`idea-to-deploy`) - prepare scoped coding work for the
   selected runtime without claiming unobserved execution.
+
 - **Workflow Learning** (`workflow-learning`) - turn weak workflow attempts into
   traces, evals, review queues, regression cases, and patch proposals.
 

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -185,7 +185,7 @@
             <figure class="loop-image-frame loop-image-frame--spotlight">
               <img
                 src="../assets/omh-loop-engineering.png"
-                alt="Loop Engineering poster showing a goal-driven research, plan, handoff, feedback, and repeat cycle for OMH"
+                alt="Loop poster showing a goal-driven research, plan, handoff, feedback, and repeat cycle for OMH"
               >
             </figure>
           </a>
@@ -255,8 +255,8 @@
               <code>ultraprocess</code>
             </a>
             <a class="mode-card mode-card--docs" href="loop/">
-              <span class="mode-card__label">Loop engineering</span>
-              <h3>Loop Engineering</h3>
+              <span class="mode-card__label">Loop</span>
+              <h3>Loop</h3>
               <p>Research, plan, handoff, feedback, repeat.</p>
               <strong>Best when the next right move must be discovered.</strong>
               <code>loop</code>

--- a/site/index.html
+++ b/site/index.html
@@ -252,8 +252,8 @@ omh doctor</code>
             <code>ultraprocess</code>
           </article>
           <article class="mode-card">
-            <span class="mode-card__label">Loop engineering</span>
-            <h3>Loop Engineering</h3>
+            <span class="mode-card__label">Loop</span>
+            <h3>Loop</h3>
             <p>Research, plan, handoff, feedback, repeat.</p>
             <strong>Best when the next right move must be discovered.</strong>
             <code>loop</code>
@@ -316,11 +316,11 @@ omh doctor</code>
             <figure>
               <img
                 src="assets/omh-loop-engineering.png"
-                alt="Loop Engineering poster showing a goal-driven research, plan, handoff, feedback, and repeat cycle for OMH"
+                alt="Loop poster showing a goal-driven research, plan, handoff, feedback, and repeat cycle for OMH"
               >
             </figure>
             <div>
-              <span>Loop engineering</span>
+              <span>Loop</span>
               <h3>Goal-driven iteration with visible stop and resume states.</h3>
               <p>
                 Loop gives Hermes a north star, then keeps each cycle grounded

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -1337,7 +1337,7 @@ class RouterContentTests(unittest.TestCase):
         self.assertIn("planner", site)
         self.assertIn("Prepared is not observed", site)
         self.assertIn("Workflow surfaces that look like the work they support.", site)
-        self.assertIn("Loop engineering", site)
+        self.assertIn("Loop</span>", site)
         self.assertIn("Prompt cards with source structure and domain scene separated.", site)
         self.assertIn('href="docs/image-gen/"', site)
         self.assertIn('href="docs/hermes-agent-architecture/">Hermes Deepdive</a>', site)


### PR DESCRIPTION
## Summary
- restore the public representative mode label from `Loop Engineering` to the simpler `Loop`
- add blank spacing between README/docs representative workflow bullets so the section scans less tightly
- restore the visual break before `What You Get`
- update the site/docs card copy and contract test to match the simpler public label

## Why
The previous merge made the mode list compact, but the top-level wording still felt over-framed. The public overview should use the direct skill name people actually see and call: `loop`. Deeper docs can still explain loop engineering, but the first-read surface should stay simple.

## User-Facing Change
Readers now see:
- `Loop` in the README, docs overview, and site representative cards
- more breathing room between the representative workflow bullets
- the restored break before the `What You Get` section

## Implementation Notes
- `README.md` and `docs/README.md` keep the 10-mode list but add blank lines between entries.
- `site/index.html` and `site/docs/index.html` use `Loop` for the visible label/title and image alt text.
- `tests/test_router_content.py` now locks the public site contract to the simpler label.

## Verification
- `PYTHONPATH=tests uv run python -m unittest tests/test_router_content.py -v`
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check`
- `uv run python -m compileall -q src tests`
- `git diff --check`

## Risk
Low. This is a copy/layout correction with one matching public-content test update. No runtime behavior changes.
