### PR TITLE
Harden OMH awareness evaluation routing

### DIFF
--- a/docs/CHAT_WRAPPER_EXAMPLES.md
+++ b/docs/CHAT_WRAPPER_EXAMPLES.md
@@ -267,6 +267,18 @@ intent=unknown; selected=img-summary; confidence=medium
 The wrapper still owns rendering and state recording. The context brief and
 route hint are prompt/context guidance only; they are not workflow execution,
 image generation, scheduled job creation, review, CI, or delivery evidence.
+If a route-hint or managed-skill change has just shipped, a live Hermes Agent
+or gateway may still show the old injected hint until the installed OMH package
+and managed plugin are refreshed with `omh update` or `omh setup`, then the
+Hermes Agent or gateway process is restarted or reloaded.
+
+OMH-owned wrapper and progress reports must render only bounded summaries from
+Codex/background output. They must not echo process completion wrappers such as
+`Background process ... Here's the final output`, raw JSONL `turn.completed` or
+`usage` token objects, token counts, or `Self-improvement review` lines into
+normal chat progress/completion copy. The host process tool may still emit its
+own notification outside OMH control; adapters should treat that as a separate
+Hermes/gateway surface, not as OMH's report body.
 
 Wrappers do not need to wait for plugin load to show the same kind of hint. They
 can call the transport-free backend preview:

--- a/src/coding/codex_progress.py
+++ b/src/coding/codex_progress.py
@@ -15,7 +15,9 @@ from ..context_safety import (
     compact_context_refs,
     compact_visible_text,
     context_budget_payload,
+    is_user_facing_progress_noise,
     raw_output_artifact_ref,
+    sanitize_user_facing_progress_text,
 )
 
 
@@ -38,10 +40,22 @@ _HIDDEN_KEYS = {
 _VISIBLE_MESSAGE_TYPES = {
     "assistant",
     "assistant_message",
+    "agent_message",
     "final",
     "message",
     "response",
     "response_item",
+}
+_TOKEN_USAGE_KEYS = {
+    "cached_input_tokens",
+    "input_tokens",
+    "output_tokens",
+    "reasoning_output_tokens",
+    "total_tokens",
+    "usage",
+}
+_RAW_RUNTIME_EVENT_TYPES = {
+    "turn.completed",
 }
 _TERMINAL_FAILURE_RE = re.compile(r"\b(error|failed|failure|traceback)\b")
 _TERMINAL_SUCCESS_RE = re.compile(r"\b(completed|complete|success|succeeded|passed)\b")
@@ -368,7 +382,7 @@ def _prompt_recommendation(*, session_ref: str, same_session_scope: bool) -> dic
 
 
 def _safe_search_text(event: dict[str, Any]) -> str:
-    if _hidden_event(event):
+    if _hidden_event(event) or _raw_runtime_event(event):
         return ""
     parts: list[str] = []
     _collect_safe_strings(event, parts)
@@ -390,12 +404,14 @@ def _hidden_marker(value: Any) -> bool:
 
 
 def _collect_safe_strings(value: Any, parts: list[str], *, parent_key: str = "") -> None:
-    if parent_key.casefold() in _HIDDEN_KEYS:
+    if parent_key.casefold() in _HIDDEN_KEYS | _TOKEN_USAGE_KEYS:
         return
-    if _hidden_marker(value):
+    if _hidden_marker(value) or _raw_runtime_event(value):
         return
     if isinstance(value, str):
-        parts.append(value[:500])
+        cleaned = sanitize_user_facing_progress_text(value, max_chars=500)
+        if cleaned:
+            parts.append(cleaned)
         return
     if isinstance(value, (int, float, bool)):
         parts.append(str(value))
@@ -406,22 +422,24 @@ def _collect_safe_strings(value: Any, parts: list[str], *, parent_key: str = "")
         return
     if isinstance(value, dict):
         for key, item in value.items():
-            if str(key).casefold() in _HIDDEN_KEYS:
+            if str(key).casefold() in _HIDDEN_KEYS | _TOKEN_USAGE_KEYS:
                 continue
-            if _hidden_marker(item):
+            if _hidden_marker(item) or _raw_runtime_event(item):
                 continue
             parts.append(str(key))
             _collect_safe_strings(item, parts, parent_key=str(key))
 
 
 def _assistant_visible_message(event: dict[str, Any]) -> str:
-    if _hidden_event(event):
+    if _hidden_event(event) or _raw_runtime_event(event):
         return ""
     for key in ("data", "item", "payload"):
         payload = event.get(key)
         if _hidden_marker(payload):
             return ""
     event_type = str(event.get("type") or event.get("event") or event.get("role") or "").casefold()
+    if event_type == "item.completed" and isinstance(event.get("item"), dict):
+        return _assistant_visible_message(event["item"])
     if event_type not in _VISIBLE_MESSAGE_TYPES and str(event.get("role", "")).casefold() != "assistant":
         return ""
     if any(hidden in event_type for hidden in _HIDDEN_KEYS):
@@ -435,6 +453,22 @@ def _assistant_visible_message(event: dict[str, Any]) -> str:
             if key in payload and isinstance(payload[key], str):
                 return _compact_visible_message(payload[key])
     return ""
+
+
+def _raw_runtime_event(value: Any) -> bool:
+    if not isinstance(value, dict):
+        return False
+    event_type = str(value.get("type") or value.get("event") or "").casefold()
+    if event_type in _RAW_RUNTIME_EVENT_TYPES:
+        return True
+    visible_content_keys = {"message", "content", "text", "summary"}
+    if visible_content_keys & {str(key).casefold() for key in value}:
+        return False
+    for nested_key in ("data", "item", "payload"):
+        nested = value.get(nested_key)
+        if isinstance(nested, dict) and not _raw_runtime_event(nested):
+            return False
+    return any(str(key).casefold() in _TOKEN_USAGE_KEYS for key in value)
 
 
 def _normalize_review_status(status: str, *, summary: str = "") -> str:
@@ -498,7 +532,12 @@ def _terminal_success_observed(text: str) -> bool:
 
 
 def _compact_visible_message(value: str) -> str:
-    return compact_visible_text(value, max_chars=MAX_VISIBLE_MESSAGE_CHARS)
+    if is_user_facing_progress_noise(value):
+        return ""
+    return compact_visible_text(
+        sanitize_user_facing_progress_text(value) or value,
+        max_chars=MAX_VISIBLE_MESSAGE_CHARS,
+    )
 
 
 def _progress_events(parsed_events: list[dict[str, Any]], raw_artifact: dict[str, object]) -> tuple[list[dict[str, object]], int]:

--- a/src/coding/context_safety.py
+++ b/src/coding/context_safety.py
@@ -17,6 +17,25 @@ MAX_EVIDENCE_REFS = 8
 MAX_EVIDENCE_REF_CHARS = 160
 MAX_ARTIFACT_REFS = 4
 
+_BACKGROUND_PROCESS_WRAPPER_RE = re.compile(
+    r"\[?\s*\bBackground\s+process\s+\S+\s+finished\s+with\s+exit\s+code\s+\d+~?\s+"
+    r"Here'?s\s+the\s+final\s+output:?\s*\]?",
+    re.IGNORECASE,
+)
+_BACKGROUND_PROCESS_COMPLETION_LINE_RE = re.compile(
+    r"^\[?\s*\bBackground\s+process\s+\S+\s+finished\s+with\s+exit\s+code\s+\d+~?\s*\]?\s*$",
+    re.IGNORECASE,
+)
+_FINAL_OUTPUT_HEADER_LINE_RE = re.compile(r"^Here'?s\s+the\s+final\s+output:?$", re.IGNORECASE)
+_FINAL_OUTPUT_HEADER_PREFIX_RE = re.compile(r"^\[?\s*Here'?s\s+the\s+final\s+output:?\s*\]?\s*", re.IGNORECASE)
+_RAW_CODEX_JSONL_RE = re.compile(
+    r'"type"\s*:\s*"(?:turn|item)\.completed"'
+    r'|"\w*usage\w*"\s*:'
+    r'|"\w*(?:input|output|reasoning|cached)_tokens\w*"\s*:',
+    re.IGNORECASE,
+)
+_SELF_IMPROVEMENT_REVIEW_RE = re.compile(r"\bSelf-improvement\s+review\s*:", re.IGNORECASE)
+
 CODING_PROGRESS_REPORTABLE_EVENTS = (
     "workflow_started",
     "dispatch_to_executor",
@@ -68,6 +87,49 @@ def compact_visible_text(value: Any, *, max_chars: int) -> str:
     return f"{text[: max_chars - 3]}..."
 
 
+def sanitize_user_facing_progress_text(value: Any, *, max_chars: int | None = None) -> str:
+    """Drop raw process/JSONL maintenance noise from chat-facing progress copy."""
+    text = str(value)
+    if not text.strip():
+        return ""
+    clean_lines: list[str] = []
+    for raw_line in text.splitlines() or [text]:
+        line = raw_line.strip()
+        if not line:
+            continue
+        if _raw_jsonl_or_self_review_noise_line(line):
+            continue
+        line = _BACKGROUND_PROCESS_WRAPPER_RE.sub(" ", line).strip()
+        line = _FINAL_OUTPUT_HEADER_PREFIX_RE.sub("", line).strip()
+        if _raw_progress_noise_line(line):
+            continue
+        clean_lines.append(line)
+    cleaned = re.sub(r"\s+", " ", " ".join(clean_lines)).strip()
+    if not cleaned:
+        return ""
+    if max_chars is None:
+        return cleaned
+    return compact_visible_text(cleaned, max_chars=max_chars)
+
+
+def is_user_facing_progress_noise(value: Any) -> bool:
+    text = str(value)
+    return bool(text.strip()) and not sanitize_user_facing_progress_text(text)
+
+
+def _raw_progress_noise_line(line: str) -> bool:
+    return bool(
+        _BACKGROUND_PROCESS_WRAPPER_RE.search(line)
+        or _BACKGROUND_PROCESS_COMPLETION_LINE_RE.search(line)
+        or _FINAL_OUTPUT_HEADER_LINE_RE.search(line)
+        or _raw_jsonl_or_self_review_noise_line(line)
+    )
+
+
+def _raw_jsonl_or_self_review_noise_line(line: str) -> bool:
+    return bool(_RAW_CODEX_JSONL_RE.search(line) or _SELF_IMPROVEMENT_REVIEW_RE.search(line))
+
+
 def compact_context_refs(
     values: Any,
     *,
@@ -109,7 +171,11 @@ def build_progress_event(
         "event_type": _normalize_progress_event_type(event_type),
         "status": _normalize_choice(status, _PROGRESS_EVENT_STATUSES, "observed"),
         "severity": _normalize_choice(severity, _PROGRESS_EVENT_SEVERITIES, "info"),
-        "summary": compact_visible_text(_strip_code_fences(summary), max_chars=MAX_PROGRESS_EVENT_SUMMARY_CHARS),
+        "summary": compact_visible_text(
+            sanitize_user_facing_progress_text(_strip_code_fences(summary))
+            or "Progress observed; raw process output stayed in artifacts.",
+            max_chars=MAX_PROGRESS_EVENT_SUMMARY_CHARS,
+        ),
         "file_refs": compact_files,
         "artifact_refs": compact_artifacts,
         "evidence_refs": compact_evidence,

--- a/src/coding/executor_progress.py
+++ b/src/coding/executor_progress.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from ..local_store import atomic_write_json, ensure_dir, ensure_file, read_json_object, read_jsonl_objects, utc_now
 from ..paths import OmhPaths
+from .context_safety import sanitize_user_facing_progress_text
 
 
 EXECUTOR_PROGRESS_BINDING_SCHEMA_VERSION = "omh_executor_progress_binding/v1"
@@ -303,7 +304,10 @@ def build_progress_event(
         "event_type": event_type,
         "status": status or _status_for_event_type(event_type),
         "severity": severity,
-        "summary": _compact_text(summary or _summary_for_event_type(event_type), 280),
+        "summary": _compact_text(
+            _sanitize_progress_copy(summary) or _summary_for_event_type(event_type),
+            280,
+        ),
         "observed_at": timestamp,
         "evidence_refs": _compact_strings(evidence_refs or binding.get("evidence_refs", [])),
         "signal": _safe_signal(signal or {}),
@@ -351,7 +355,7 @@ def build_safe_progress_signal(
         "codex_artifact_byte_count": progress.get("artifact_byte_count", 0) if profile == "codex" else 0,
         "codex_malformed_event_count": progress.get("malformed_event_count", 0) if profile == "codex" else 0,
         "explicit_event_type": explicit,
-        "explicit_summary": _compact_text(explicit_summary, 280),
+        "explicit_summary": _compact_text(_sanitize_progress_copy(explicit_summary), 280),
         "evidence_ref_count": len(evidence_refs or []),
     }
     return _safe_signal(signal)
@@ -397,7 +401,7 @@ def infer_progress_event_type(signal: dict[str, Any]) -> str:
 def summary_for_signal(signal: dict[str, Any], event_type: str) -> str:
     explicit = str(signal.get("explicit_summary", "")).strip()
     if explicit:
-        return explicit
+        return _sanitize_progress_copy(explicit) or _summary_for_event_type(event_type)
     visible = str(signal.get("assistant_visible_summary", "")).strip()
     if visible and event_type in {
         "repo_exploration",
@@ -409,7 +413,7 @@ def summary_for_signal(signal: dict[str, Any], event_type: str) -> str:
         "executor_blocked",
         "executor_failed",
     }:
-        return _compact_text(visible, 240)
+        return _compact_text(_sanitize_progress_copy(visible) or _summary_for_event_type(event_type), 240)
     return _summary_for_event_type(event_type)
 
 
@@ -961,6 +965,10 @@ def _compact_text(value: str, limit: int) -> str:
     return cleaned[: max(0, limit - 1)].rstrip() + "…"
 
 
+def _sanitize_progress_copy(value: str) -> str:
+    return sanitize_user_facing_progress_text(value)
+
+
 def _clean_object(value: dict[str, Any]) -> dict[str, Any]:
     return {key: item for key, item in value.items() if item not in ("", None, [], {})}
 
@@ -1004,7 +1012,9 @@ def _safe_progress_summary(summary: dict[str, Any] | None, *, codex_profile: boo
         if isinstance(summary.get("observable_activity", []), list)
     ][:8]
     assistant_visible_summary = _compact_text(
-        str(summary.get("latest_assistant_visible_message") or summary.get("chat_summary") or summary.get("summary") or ""),
+        _sanitize_progress_copy(
+            str(summary.get("latest_assistant_visible_message") or summary.get("chat_summary") or summary.get("summary") or "")
+        ),
         240,
     )
     latest_event_type = _compact_text(str(latest.get("event_type", "")), 80)

--- a/src/plugin_bundle/omh/awareness.py
+++ b/src/plugin_bundle/omh/awareness.py
@@ -18,6 +18,17 @@ _DIAGNOSTIC_STATUS_MARKERS = (
     "merge_observed",
     "prepared_not_observed",
 )
+_DIAGNOSTIC_STATUS_LINE_MARKERS = (
+    *_DIAGNOSTIC_STATUS_MARKERS,
+    "selected_workflow=",
+    "mentioned_workflows=",
+    "mentioned_runtime_terms=",
+    "not_executed=",
+    "intent_class=",
+    "status=",
+    "workflow=",
+    "hints=",
+)
 _OMH_DIAGNOSTIC_EVALUATION_CUES = (
     "usage evaluation",
     "usability evaluation",
@@ -31,16 +42,18 @@ _OMH_DIAGNOSTIC_EVALUATION_CUES = (
     "why omh",
     "사용성 평가",
     "사용성평가",
-    "관여",
-    "부족",
+    "omh 관여",
+    "omh관여",
+    "omh 관여도",
+    "omh관여도",
     "안쓴이유",
     "안 쓴 이유",
+    "덜 쓴 이유",
+    "덜쓴 이유",
     "덜 썼",
     "덜썼",
-    "작업한거 분석",
-    "작업한 거 분석",
-    "분석",
-    "평가",
+    "부족했던 점",
+    "부족한 점",
     "라우터 강화",
     "라우터강화",
     "라우터 개선",
@@ -125,14 +138,17 @@ except ImportError:  # pragma: no cover - exercised by standalone plugin hosts.
     def _fallback_diagnostic_omh_evaluation_context(text: str, compact: str) -> bool:
         if not _fallback_diagnostic_status_context(text):
             return False
-        has_omh_subject = bool(re.search(r"(?<![a-z0-9])omh(?![a-z0-9])", text)) or "[omh" in text
-        if not has_omh_subject:
+        user_region = _without_diagnostic_status_lines(text)
+        user_compact = user_region.replace(" ", "")
+        has_user_omh_subject = bool(re.search(r"(?<![a-z0-9])omh(?![a-z0-9])", user_region))
+        has_user_router_subject = bool(_matched_text_cues(("router", "routing", "route hint", "라우터", "라우팅"), user_region, user_compact))
+        if not (has_user_omh_subject or has_user_router_subject):
             return False
         return bool(
             _fallback_matched_omh_quality_cues(
                 _OMH_DIAGNOSTIC_EVALUATION_CUES,
-                text,
-                compact,
+                user_region,
+                user_compact,
             )
         )
 
@@ -239,6 +255,7 @@ except ImportError:  # pragma: no cover - exercised by standalone plugin hosts.
         text = unicodedata.normalize("NFKC", message).casefold()
         compact = text.replace(" ", "")
         diagnostic_evaluation = _fallback_diagnostic_omh_evaluation_context(text, compact)
+        analysis_text = text if diagnostic_evaluation or not _diagnostic_status_context(text) else _without_diagnostic_status_lines(text)
         delivery_workflows = {
             "ultraprocess",
             "ralplan",
@@ -250,9 +267,7 @@ except ImportError:  # pragma: no cover - exercised by standalone plugin hosts.
             "ultrawork",
             "ultraqa",
         }
-        mentioned_workflows = tuple(
-            workflow for workflow in ROUTER_KEYWORD_SKILLS if workflow in text and workflow in delivery_workflows
-        )
+        mentioned_workflows = tuple(workflow for workflow in delivery_workflows if workflow in analysis_text)
         runtime_terms = []
         for term, label in (
             ("codex", "Codex"),
@@ -261,7 +276,7 @@ except ImportError:  # pragma: no cover - exercised by standalone plugin hosts.
             ("one-cycle delivery", "one-cycle delivery"),
             ("one cycle delivery", "one-cycle delivery"),
         ):
-            if term in text and label not in runtime_terms:
+            if term in analysis_text and label not in runtime_terms:
                 runtime_terms.append(label)
         meta_cues = tuple(
             cue
@@ -280,11 +295,9 @@ except ImportError:  # pragma: no cover - exercised by standalone plugin hosts.
                 "로그",
                 "트리거",
                 "오해",
-                "분석",
-                "평가",
                 "라우터",
             )
-            if cue in text
+            if cue in analysis_text
         )
         feedback_cues = tuple(
             cue
@@ -296,29 +309,27 @@ except ImportError:  # pragma: no cover - exercised by standalone plugin hosts.
                 "잘못",
                 "오해",
                 "누락",
-                "관여",
-                "부족",
                 "사용성 평가",
                 "안쓴이유",
                 "안 쓴 이유",
             )
-            if cue in text
+            if cue in analysis_text
         )
-        missing = tuple(cue for cue in ("no requirements", "missing requirements", "요구사항은 없어", "요구사항 없음") if cue in text)
+        missing = tuple(cue for cue in ("no requirements", "missing requirements", "요구사항은 없어", "요구사항 없음") if cue in analysis_text)
         negated_execution = tuple(
             cue
             for cue in ("not asking to implement", "not asking for implementation", "not implement", "do not implement", "don't implement", "without implementation", "no implementation")
-            if cue in text
+            if cue in analysis_text
         )
         execution = tuple(
             cue
             for cue in ("implement", "make a pr", "open a pr", "dispatch", "delegate", "send to codex", "run ultraprocess", "구현", "pr 만들어", "codex로", "맡겨", "실행")
-            if cue in text and not (negated_execution and cue in {"implement", "구현"})
+            if cue in analysis_text and not (negated_execution and cue in {"implement", "구현"})
         )
         routing_context = any(
-            cue in text.split() or cue in text
+            cue in analysis_text.split() or cue in analysis_text
             for cue in ("routing", "route", "workflow", "handoff", "coding", "route hint", "coding handoff", "coding delegate", "라우팅", "워크플로", "코딩")
-        ) or " omh " in f" {text} "
+        ) or " omh " in f" {analysis_text} "
         specific_runtime_reference = any(term != "Codex" for term in runtime_terms)
         workflow_or_specific_runtime = bool(mentioned_workflows or specific_runtime_reference)
         if execution:
@@ -847,11 +858,14 @@ def awareness_context_matches_message(message: str) -> bool:
 def awareness_route_hint(message: str, *, max_hints: int = 2) -> dict[str, object]:
     """Return bounded message-specific workflow hints without exposing raw text."""
     normalized = unicodedata.normalize("NFKC", message).casefold()
-    tokens = set(re.findall(r"[a-z0-9][a-z0-9_-]*", normalized))
+    diagnostic_status = _diagnostic_status_context(normalized)
+    diagnostic_eval = _prefers_diagnostic_workflow_learning_hint(message, classify_workflow_intent(message))
+    routing_normalized = normalized if diagnostic_eval or not diagnostic_status else _without_diagnostic_status_lines(normalized)
+    tokens = set(re.findall(r"[a-z0-9][a-z0-9_-]*", routing_normalized))
     hint_limit = max(max_hints, 0)
     intent = classify_workflow_intent(message)
     omh_quality_intent = classify_omh_quality_intent(message)
-    diagnostic_learning_first = _prefers_diagnostic_workflow_learning_hint(message, intent)
+    diagnostic_learning_first = diagnostic_eval
     hints: list[dict[str, object]] = []
     if normalized.strip() and hint_limit:
         if omh_quality_intent.applies and not diagnostic_learning_first:
@@ -868,7 +882,7 @@ def awareness_route_hint(message: str, *, max_hints: int = 2) -> dict[str, objec
                 continue
             if _rule_suppressed_by_reference_intent(rule, intent):
                 continue
-            phrase_matches = [phrase for phrase in rule["phrases"] if phrase in normalized]
+            phrase_matches = [phrase for phrase in rule["phrases"] if phrase in routing_normalized]
             token_matches = [token for token in rule["tokens"] if token in tokens]
             if not phrase_matches and not token_matches:
                 continue
@@ -1330,22 +1344,46 @@ def _prefers_diagnostic_workflow_learning_hint(message: str, intent: object) -> 
     if bool(getattr(intent, "explicit_execution", False)):
         return False
     text = unicodedata.normalize("NFKC", message).casefold()
-    compact = text.replace(" ", "")
     if not _diagnostic_status_context(text):
         return False
-    if not (re.search(r"(?<![a-z0-9])omh(?![a-z0-9])", text) or "[omh" in text):
+    user_region = _without_diagnostic_status_lines(text)
+    compact = user_region.replace(" ", "")
+    has_user_omh_subject = re.search(r"(?<![a-z0-9])omh(?![a-z0-9])", user_region) is not None
+    has_user_router_subject = bool(_matched_text_cues(("router", "routing", "route hint", "라우터", "라우팅"), user_region, compact))
+    if not (has_user_omh_subject or has_user_router_subject):
         return False
-    return bool(
-        _matched_text_cues(
-            _OMH_DIAGNOSTIC_EVALUATION_CUES,
-            text,
-            compact,
-        )
-    )
+    return bool(_matched_text_cues(_OMH_DIAGNOSTIC_EVALUATION_CUES, user_region, compact))
 
 
 def _diagnostic_status_context(text: str) -> bool:
     return any(marker in text for marker in _DIAGNOSTIC_STATUS_MARKERS)
+
+
+def _without_diagnostic_status_lines(text: str) -> str:
+    kept: list[str] = []
+    for line in text.splitlines() or [text]:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("[omh"):
+            stripped = re.sub(r"^\[omh(?:\s+awareness|\s+route\s+hint)?\]\s*", "", stripped).strip()
+            if not stripped:
+                continue
+        if stripped.startswith(("native bridge status context", "evidence boundary", "latest runtime run")):
+            continue
+        if any(unicodedata.normalize("NFKC", marker).casefold() in stripped for marker in _DIAGNOSTIC_STATUS_LINE_MARKERS):
+            fragments = [fragment.strip() for fragment in re.split(r"[;|]", stripped)]
+            user_fragments = [
+                fragment
+                for fragment in fragments
+                if fragment
+                and not any(unicodedata.normalize("NFKC", marker).casefold() in fragment for marker in _DIAGNOSTIC_STATUS_LINE_MARKERS)
+            ]
+            if user_fragments:
+                kept.append(" ".join(user_fragments))
+            continue
+        kept.append(stripped)
+    return "\n".join(kept)
 
 
 def _matched_text_cues(cues: tuple[str, ...], text: str, compact: str) -> tuple[str, ...]:

--- a/src/plugin_bundle/omh/awareness.py
+++ b/src/plugin_bundle/omh/awareness.py
@@ -4,6 +4,50 @@ import hashlib
 import re
 import unicodedata
 
+_DIAGNOSTIC_STATUS_MARKERS = (
+    "[omh awareness]",
+    "[omh route hint]",
+    "[omh]",
+    "evidence boundary",
+    "not_executed=",
+    "latest_runtime_run",
+    "latest runtime run",
+    "execution_observed",
+    "review_observed",
+    "ci_observed",
+    "merge_observed",
+    "prepared_not_observed",
+)
+_OMH_DIAGNOSTIC_EVALUATION_CUES = (
+    "usage evaluation",
+    "usability evaluation",
+    "usage analysis",
+    "analyze the run",
+    "analyze this run",
+    "router improvement",
+    "router hardening",
+    "route improvement",
+    "evaluate omh",
+    "why omh",
+    "사용성 평가",
+    "사용성평가",
+    "관여",
+    "부족",
+    "안쓴이유",
+    "안 쓴 이유",
+    "덜 썼",
+    "덜썼",
+    "작업한거 분석",
+    "작업한 거 분석",
+    "분석",
+    "평가",
+    "라우터 강화",
+    "라우터강화",
+    "라우터 개선",
+    "플랜으로 잡",
+    "반복해서 강화",
+)
+
 try:  # Keep installed plugin bundles usable even when the full package is absent.
     from ...routing.intent import META_OR_FEEDBACK_INTENTS, classify_omh_quality_intent, classify_workflow_intent
 except ImportError:  # pragma: no cover - exercised by standalone plugin hosts.
@@ -75,6 +119,23 @@ except ImportError:  # pragma: no cover - exercised by standalone plugin hosts.
                 matches.append(cue)
         return tuple(matches)
 
+    def _fallback_diagnostic_status_context(text: str) -> bool:
+        return any(marker in text for marker in _DIAGNOSTIC_STATUS_MARKERS)
+
+    def _fallback_diagnostic_omh_evaluation_context(text: str, compact: str) -> bool:
+        if not _fallback_diagnostic_status_context(text):
+            return False
+        has_omh_subject = bool(re.search(r"(?<![a-z0-9])omh(?![a-z0-9])", text)) or "[omh" in text
+        if not has_omh_subject:
+            return False
+        return bool(
+            _fallback_matched_omh_quality_cues(
+                _OMH_DIAGNOSTIC_EVALUATION_CUES,
+                text,
+                compact,
+            )
+        )
+
     def classify_omh_quality_intent(message: str) -> _FallbackOmhQualityIntent:
         text = unicodedata.normalize("NFKC", message).casefold()
         compact = text.replace(" ", "")
@@ -116,12 +177,15 @@ except ImportError:  # pragma: no cover - exercised by standalone plugin hosts.
                 "fixes",
                 "fixing",
                 "harden",
+                "strengthen",
                 "audit",
                 "find and fix",
                 "개선",
+                "개선해",
                 "고쳐",
                 "찾아",
                 "점검",
+                "강화",
             ),
             text,
             compact,
@@ -132,12 +196,15 @@ except ImportError:  # pragma: no cover - exercised by standalone plugin hosts.
                 "bugs",
                 "failure",
                 "loss",
+                "missing",
                 "regression",
                 "reliability",
                 "quality",
                 "버그",
                 "유사버그",
+                "실패",
                 "손실",
+                "누락",
                 "신뢰성",
                 "품질",
             ),
@@ -145,7 +212,7 @@ except ImportError:  # pragma: no cover - exercised by standalone plugin hosts.
             compact,
         )
         loop_cues = _fallback_matched_omh_quality_cues(
-            ("loop", "continuous", "keep", "keeps", "keeping", "루프", "계속"),
+            ("loop", "continuous", "keep", "keeps", "keeping", "루프", "계속", "반복"),
             text,
             compact,
         )
@@ -170,6 +237,8 @@ except ImportError:  # pragma: no cover - exercised by standalone plugin hosts.
 
     def classify_workflow_intent(message: str) -> _FallbackWorkflowIntent:
         text = unicodedata.normalize("NFKC", message).casefold()
+        compact = text.replace(" ", "")
+        diagnostic_evaluation = _fallback_diagnostic_omh_evaluation_context(text, compact)
         delivery_workflows = {
             "ultraprocess",
             "ralplan",
@@ -196,10 +265,45 @@ except ImportError:  # pragma: no cover - exercised by standalone plugin hosts.
                 runtime_terms.append(label)
         meta_cues = tuple(
             cue
-            for cue in ("test", "developer", "operator", "vocabulary", "route hint", "hud", "log", "trigger", "테스트", "개발자", "용어", "로그", "트리거", "오해")
+            for cue in (
+                "test",
+                "developer",
+                "operator",
+                "vocabulary",
+                "route hint",
+                "hud",
+                "log",
+                "trigger",
+                "테스트",
+                "개발자",
+                "용어",
+                "로그",
+                "트리거",
+                "오해",
+                "분석",
+                "평가",
+                "라우터",
+            )
             if cue in text
         )
-        feedback_cues = tuple(cue for cue in ("why", "wrong route", "missed route", "왜", "잘못", "오해", "누락") if cue in text)
+        feedback_cues = tuple(
+            cue
+            for cue in (
+                "why",
+                "wrong route",
+                "missed route",
+                "왜",
+                "잘못",
+                "오해",
+                "누락",
+                "관여",
+                "부족",
+                "사용성 평가",
+                "안쓴이유",
+                "안 쓴 이유",
+            )
+            if cue in text
+        )
         missing = tuple(cue for cue in ("no requirements", "missing requirements", "요구사항은 없어", "요구사항 없음") if cue in text)
         negated_execution = tuple(
             cue
@@ -219,7 +323,7 @@ except ImportError:  # pragma: no cover - exercised by standalone plugin hosts.
         workflow_or_specific_runtime = bool(mentioned_workflows or specific_runtime_reference)
         if execution:
             intent_class = "delivery_intent"
-        elif missing or (feedback_cues and (routing_context or workflow_or_specific_runtime)):
+        elif diagnostic_evaluation or missing or (feedback_cues and (routing_context or workflow_or_specific_runtime)):
             intent_class = "feedback_signal"
         elif meta_cues and (routing_context or workflow_or_specific_runtime):
             intent_class = "meta_discussion"
@@ -747,11 +851,15 @@ def awareness_route_hint(message: str, *, max_hints: int = 2) -> dict[str, objec
     hint_limit = max(max_hints, 0)
     intent = classify_workflow_intent(message)
     omh_quality_intent = classify_omh_quality_intent(message)
+    diagnostic_learning_first = _prefers_diagnostic_workflow_learning_hint(message, intent)
     hints: list[dict[str, object]] = []
     if normalized.strip() and hint_limit:
-        if omh_quality_intent.applies:
+        if omh_quality_intent.applies and not diagnostic_learning_first:
             hints.append(_omh_quality_improvement_hint(omh_quality_intent))
-        if len(hints) < hint_limit and _prefers_workflow_learning_hint(intent) and not omh_quality_intent.applies:
+        if len(hints) < hint_limit and (
+            diagnostic_learning_first
+            or (_prefers_workflow_learning_hint(intent) and not omh_quality_intent.applies)
+        ):
             hints.append(_workflow_vocabulary_reference_hint(intent))
         for rule in _ROUTE_HINT_RULES:
             if len(hints) >= hint_limit:
@@ -1216,6 +1324,47 @@ def _prefers_workflow_learning_hint(intent: object) -> bool:
             or bool(getattr(intent, "routing_context", False))
         )
     )
+
+
+def _prefers_diagnostic_workflow_learning_hint(message: str, intent: object) -> bool:
+    if bool(getattr(intent, "explicit_execution", False)):
+        return False
+    text = unicodedata.normalize("NFKC", message).casefold()
+    compact = text.replace(" ", "")
+    if not _diagnostic_status_context(text):
+        return False
+    if not (re.search(r"(?<![a-z0-9])omh(?![a-z0-9])", text) or "[omh" in text):
+        return False
+    return bool(
+        _matched_text_cues(
+            _OMH_DIAGNOSTIC_EVALUATION_CUES,
+            text,
+            compact,
+        )
+    )
+
+
+def _diagnostic_status_context(text: str) -> bool:
+    return any(marker in text for marker in _DIAGNOSTIC_STATUS_MARKERS)
+
+
+def _matched_text_cues(cues: tuple[str, ...], text: str, compact: str) -> tuple[str, ...]:
+    matches: list[str] = []
+    for cue in cues:
+        normalized_cue = unicodedata.normalize("NFKC", cue).casefold()
+        if not normalized_cue:
+            continue
+        if any(ord(char) > 127 for char in normalized_cue):
+            if normalized_cue in text or normalized_cue.replace(" ", "") in compact:
+                matches.append(cue)
+            continue
+        parts = re.findall(r"[a-z0-9]+", normalized_cue)
+        if not parts:
+            continue
+        pattern = r"(?<![a-z0-9])" + r"[\s_-]+".join(re.escape(part) for part in parts) + r"(?![a-z0-9])"
+        if re.search(pattern, text):
+            matches.append(cue)
+    return tuple(matches)
 
 
 def _omh_quality_improvement_hint(intent: object) -> dict[str, object]:

--- a/src/routing/chat.py
+++ b/src/routing/chat.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from ..ingress import CHAT_SOURCES, extract_message_text
 from .catalog_questions import is_file_or_text_lookup_question, is_skill_catalog_question
+from .intent import scrub_diagnostic_status_text
 from .policy import (
     CONFIDENCE_LEVELS,
     ROUTE_ACTIONS,
@@ -125,17 +126,18 @@ def route_chat_message(
     if min_confidence not in CONFIDENCE_LEVELS:
         raise ValueError(f"unsupported chat route confidence threshold: {min_confidence}")
 
+    routing_message = scrub_diagnostic_status_text(message)
     definitions = routable_definitions()
-    full_recommendations = recommend_skills(message, limit=len(definitions))
-    explicit_skill = explicit_skill_invocation(message, definitions)
+    full_recommendations = recommend_skills(routing_message, limit=len(definitions))
+    explicit_skill = explicit_skill_invocation(routing_message, definitions)
     task_card = classify_task(message)
     task_card_overrides_explicit = _task_card_overrides_explicit_invocation(task_card)
     if task_card and (not explicit_skill or task_card_overrides_explicit):
         full_recommendations = _prioritize_recommendation(full_recommendations, task_card_recommendation(task_card))
-    catalog_question = is_skill_catalog_question(message)
+    catalog_question = is_skill_catalog_question(routing_message)
     specific_catalog_match = (
         _specific_capability_catalog_match(full_recommendations)
-        if catalog_question and not _is_broad_capability_catalog_question(message)
+        if catalog_question and not _is_broad_capability_catalog_question(routing_message)
         else None
     )
     if specific_catalog_match is not None:
@@ -147,7 +149,7 @@ def route_chat_message(
     candidate_score = _int_value(top["score"])
     candidate_confidence = str(top["confidence"])
     ambiguous = _is_ambiguous(full_recommendations)
-    file_or_text_lookup = is_file_or_text_lookup_question(message)
+    file_or_text_lookup = is_file_or_text_lookup_question(routing_message)
 
     if explicit_skill and not task_card_overrides_explicit:
         selected_skill = explicit_skill

--- a/src/routing/intent.py
+++ b/src/routing/intent.py
@@ -157,6 +157,49 @@ _REFERENCE_CONTEXT_TOKENS = frozenset(
     }
 )
 _NEGATABLE_EXECUTION_CUES = frozenset(_EXECUTION_CUES)
+_DIAGNOSTIC_STATUS_MARKERS = (
+    "[omh awareness]",
+    "[omh route hint]",
+    "[omh]",
+    "evidence boundary",
+    "not_executed=",
+    "latest_runtime_run",
+    "latest runtime run",
+    "execution_observed",
+    "review_observed",
+    "ci_observed",
+    "merge_observed",
+    "prepared_not_observed",
+)
+_OMH_DIAGNOSTIC_EVALUATION_CUES = (
+    "usage evaluation",
+    "usability evaluation",
+    "usage analysis",
+    "analyze the run",
+    "analyze this run",
+    "router improvement",
+    "router hardening",
+    "route improvement",
+    "evaluate omh",
+    "why omh",
+    "사용성 평가",
+    "사용성평가",
+    "관여",
+    "부족",
+    "안쓴이유",
+    "안 쓴 이유",
+    "덜 썼",
+    "덜썼",
+    "작업한거 분석",
+    "작업한 거 분석",
+    "분석",
+    "평가",
+    "라우터 강화",
+    "라우터강화",
+    "라우터 개선",
+    "플랜으로 잡",
+    "반복해서 강화",
+)
 
 
 @dataclass(frozen=True)
@@ -222,7 +265,14 @@ def classify_workflow_intent(message: str) -> WorkflowIntent:
 
     mentioned_workflows = _mentioned_workflows(normalized, tokens)
     mentioned_runtime_terms = _mentioned_runtime_terms(normalized)
-    structural_cues = _structural_cues(message, normalized, tokens)
+    diagnostic_status_context = _diagnostic_status_context(normalized, compact)
+    diagnostic_evaluation_context = _diagnostic_omh_evaluation_context(normalized, compact)
+    structural_cues = _structural_cues(
+        message,
+        normalized,
+        tokens,
+        diagnostic_status_context=diagnostic_status_context,
+    )
     meta_cues = _matched_cues(_META_CUES, normalized, compact)
     feedback_cues = _matched_cues(_FEEDBACK_CUES, normalized, compact)
     planning_cues = _matched_cues(_PLANNING_CUES, normalized, compact)
@@ -233,6 +283,8 @@ def classify_workflow_intent(message: str) -> WorkflowIntent:
         _matched_cues(_EXECUTION_CUES, normalized, compact),
         negated_execution_cues,
     )
+    if diagnostic_evaluation_context:
+        execution_cues = _suppress_diagnostic_status_execution_cues(execution_cues, normalized)
     missing_requirements_cues = _matched_cues(_MISSING_REQUIREMENTS_CUES, normalized, compact)
     routing_context = _routing_context(normalized, tokens)
 
@@ -255,7 +307,11 @@ def classify_workflow_intent(message: str) -> WorkflowIntent:
 
     if explicit_execution:
         intent_class = "delivery_intent"
-    elif missing_requirements_cues or (feedback_cues and (routing_context or workflow_or_specific_runtime)):
+    elif (
+        missing_requirements_cues
+        or diagnostic_evaluation_context
+        or (feedback_cues and (routing_context or workflow_or_specific_runtime))
+    ):
         intent_class = "feedback_signal"
     elif (meta_cues or structural_reference) and (routing_context or workflow_or_specific_runtime):
         intent_class = "meta_discussion"
@@ -492,7 +548,13 @@ def _mentioned_runtime_terms(normalized: str) -> tuple[str, ...]:
     return tuple(mentioned)
 
 
-def _structural_cues(message: str, normalized: str, tokens: set[str]) -> tuple[str, ...]:
+def _structural_cues(
+    message: str,
+    normalized: str,
+    tokens: set[str],
+    *,
+    diagnostic_status_context: bool = False,
+) -> tuple[str, ...]:
     cues: list[str] = []
     if _explicit_workflow_invocation(normalized, tokens):
         cues.append("workflow_marker")
@@ -504,6 +566,8 @@ def _structural_cues(message: str, normalized: str, tokens: set[str]) -> tuple[s
         cues.append("symbolic_negated_execution")
     if _routing_context(normalized, tokens):
         cues.append("routing_context")
+    if diagnostic_status_context:
+        cues.append("diagnostic_status_context")
     return tuple(cues)
 
 
@@ -553,6 +617,25 @@ def _matched_cues(cues: tuple[str, ...], normalized: str, compact: str) -> tuple
     return tuple(matches)
 
 
+def _diagnostic_status_context(normalized: str, compact: str) -> bool:
+    for marker in _DIAGNOSTIC_STATUS_MARKERS:
+        normalized_marker = normalized_phrase(marker)
+        if normalized_marker and (
+            normalized_marker in normalized or normalized_marker.replace(" ", "") in compact
+        ):
+            return True
+    return False
+
+
+def _diagnostic_omh_evaluation_context(normalized: str, compact: str) -> bool:
+    if not _diagnostic_status_context(normalized, compact):
+        return False
+    has_omh_subject = bool(_matched_omh_system_target_cues(normalized)) or "[omh" in normalized
+    if not has_omh_subject:
+        return False
+    return bool(_matched_cues(_OMH_DIAGNOSTIC_EVALUATION_CUES, normalized, compact))
+
+
 def _compact_tuple(values: tuple[str, ...]) -> tuple[str, ...]:
     seen: list[str] = []
     for value in values:
@@ -568,6 +651,20 @@ def _suppress_negated_execution_cues(
     if not negated_execution_cues:
         return execution_cues
     return tuple(cue for cue in execution_cues if cue not in _NEGATABLE_EXECUTION_CUES)
+
+
+def _suppress_diagnostic_status_execution_cues(execution_cues: tuple[str, ...], normalized: str) -> tuple[str, ...]:
+    return tuple(cue for cue in execution_cues if not _diagnostic_status_only_execution_cue(cue, normalized))
+
+
+def _diagnostic_status_only_execution_cue(cue: str, normalized: str) -> bool:
+    if cue == "execute":
+        scrubbed = re.sub(r"\bnot_executed\b", " ", normalized)
+        return not _contains_bounded_english_cue(scrubbed, "execute")
+    if cue == "merge":
+        scrubbed = re.sub(r"\bmerge_observed\b", " ", normalized)
+        return not _contains_bounded_english_cue(scrubbed, "merge")
+    return False
 
 
 def _explicit_workflow_invocation(normalized: str, tokens: set[str]) -> bool:

--- a/src/routing/intent.py
+++ b/src/routing/intent.py
@@ -171,6 +171,17 @@ _DIAGNOSTIC_STATUS_MARKERS = (
     "merge_observed",
     "prepared_not_observed",
 )
+_DIAGNOSTIC_STATUS_LINE_MARKERS = (
+    *_DIAGNOSTIC_STATUS_MARKERS,
+    "selected_workflow=",
+    "mentioned_workflows=",
+    "mentioned_runtime_terms=",
+    "not_executed=",
+    "intent_class=",
+    "status=",
+    "workflow=",
+    "hints=",
+)
 _OMH_DIAGNOSTIC_EVALUATION_CUES = (
     "usage evaluation",
     "usability evaluation",
@@ -184,16 +195,18 @@ _OMH_DIAGNOSTIC_EVALUATION_CUES = (
     "why omh",
     "사용성 평가",
     "사용성평가",
-    "관여",
-    "부족",
+    "omh 관여",
+    "omh관여",
+    "omh 관여도",
+    "omh관여도",
     "안쓴이유",
     "안 쓴 이유",
+    "덜 쓴 이유",
+    "덜쓴 이유",
     "덜 썼",
     "덜썼",
-    "작업한거 분석",
-    "작업한 거 분석",
-    "분석",
-    "평가",
+    "부족했던 점",
+    "부족한 점",
     "라우터 강화",
     "라우터강화",
     "라우터 개선",
@@ -263,30 +276,39 @@ def classify_workflow_intent(message: str) -> WorkflowIntent:
     tokens.update(normalized.split())
     compact = normalized.replace(" ", "")
 
-    mentioned_workflows = _mentioned_workflows(normalized, tokens)
-    mentioned_runtime_terms = _mentioned_runtime_terms(normalized)
     diagnostic_status_context = _diagnostic_status_context(normalized, compact)
     diagnostic_evaluation_context = _diagnostic_omh_evaluation_context(normalized, compact)
+    matching_normalized = (
+        normalized
+        if not diagnostic_status_context or diagnostic_evaluation_context
+        else _without_diagnostic_status_lines(normalized)
+    )
+    matching_compact = matching_normalized.replace(" ", "")
+    matching_tokens = set(routing_tokens(matching_normalized, stopwords=set()))
+    matching_tokens.update(matching_normalized.split())
+
+    mentioned_workflows = _mentioned_workflows(matching_normalized, matching_tokens)
+    mentioned_runtime_terms = _mentioned_runtime_terms(matching_normalized)
     structural_cues = _structural_cues(
         message,
-        normalized,
-        tokens,
+        matching_normalized,
+        matching_tokens,
         diagnostic_status_context=diagnostic_status_context,
     )
-    meta_cues = _matched_cues(_META_CUES, normalized, compact)
-    feedback_cues = _matched_cues(_FEEDBACK_CUES, normalized, compact)
-    planning_cues = _matched_cues(_PLANNING_CUES, normalized, compact)
+    meta_cues = _matched_cues(_META_CUES, matching_normalized, matching_compact)
+    feedback_cues = _matched_cues(_FEEDBACK_CUES, matching_normalized, matching_compact)
+    planning_cues = _matched_cues(_PLANNING_CUES, matching_normalized, matching_compact)
     negated_execution_cues = _compact_tuple(
-        (*_matched_cues(_NEGATED_EXECUTION_CUES, normalized, compact), *_structural_negated_execution_cues(normalized))
+        (*_matched_cues(_NEGATED_EXECUTION_CUES, matching_normalized, matching_compact), *_structural_negated_execution_cues(matching_normalized))
     )
     execution_cues = _suppress_negated_execution_cues(
-        _matched_cues(_EXECUTION_CUES, normalized, compact),
+        _matched_cues(_EXECUTION_CUES, matching_normalized, matching_compact),
         negated_execution_cues,
     )
     if diagnostic_evaluation_context:
         execution_cues = _suppress_diagnostic_status_execution_cues(execution_cues, normalized)
-    missing_requirements_cues = _matched_cues(_MISSING_REQUIREMENTS_CUES, normalized, compact)
-    routing_context = _routing_context(normalized, tokens)
+    missing_requirements_cues = _matched_cues(_MISSING_REQUIREMENTS_CUES, matching_normalized, matching_compact)
+    routing_context = _routing_context(matching_normalized, matching_tokens)
 
     specific_runtime_reference = any(term != "Codex" for term in mentioned_runtime_terms)
     workflow_or_specific_runtime = bool(mentioned_workflows or specific_runtime_reference)
@@ -630,10 +652,49 @@ def _diagnostic_status_context(normalized: str, compact: str) -> bool:
 def _diagnostic_omh_evaluation_context(normalized: str, compact: str) -> bool:
     if not _diagnostic_status_context(normalized, compact):
         return False
-    has_omh_subject = bool(_matched_omh_system_target_cues(normalized)) or "[omh" in normalized
-    if not has_omh_subject:
+    user_region = _without_diagnostic_status_lines(normalized)
+    user_compact = user_region.replace(" ", "")
+    has_user_omh_subject = bool(_matched_omh_system_target_cues(user_region))
+    has_user_router_subject = _routing_context(user_region, set(user_region.split()))
+    if not (has_user_omh_subject or has_user_router_subject):
         return False
-    return bool(_matched_cues(_OMH_DIAGNOSTIC_EVALUATION_CUES, normalized, compact))
+    return bool(_matched_cues(_OMH_DIAGNOSTIC_EVALUATION_CUES, user_region, user_compact))
+
+
+def _without_diagnostic_status_lines(normalized: str) -> str:
+    kept: list[str] = []
+    for line in normalized.splitlines() or [normalized]:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("[omh"):
+            stripped = re.sub(r"^\[omh(?:\s+awareness|\s+route\s+hint)?\]\s*", "", stripped).strip()
+            if not stripped:
+                continue
+        if stripped.startswith(("native bridge status context", "evidence boundary", "latest runtime run")):
+            continue
+        if any(normalized_phrase(marker) in stripped for marker in _DIAGNOSTIC_STATUS_LINE_MARKERS):
+            fragments = [fragment.strip() for fragment in re.split(r"[;|]", stripped)]
+            user_fragments = [
+                fragment
+                for fragment in fragments
+                if fragment and not any(normalized_phrase(marker) in fragment for marker in _DIAGNOSTIC_STATUS_LINE_MARKERS)
+            ]
+            if user_fragments:
+                kept.append(" ".join(user_fragments))
+            continue
+        kept.append(stripped)
+    return "\n".join(kept)
+
+
+def scrub_diagnostic_status_text(message: str) -> str:
+    """Remove pasted/generated OMH status fragments while preserving user text."""
+    normalized = normalized_phrase(message)
+    compact = normalized.replace(" ", "")
+    if not _diagnostic_status_context(normalized, compact):
+        return message
+    scrubbed = _without_diagnostic_status_lines(normalized)
+    return scrubbed or normalized
 
 
 def _compact_tuple(values: tuple[str, ...]) -> tuple[str, ...]:

--- a/src/routing/route_plan.py
+++ b/src/routing/route_plan.py
@@ -242,7 +242,7 @@ def build_workflow_route_plan(
             by_skill.get(selected_skill, {"skill": selected_skill, "score": 0, "confidence": "low", "matched": []}),
         )
 
-    stages = [stage for stage in _STAGE_ORDER if stage in steps_by_stage]
+    stages = _ordered_stages(steps_by_stage, selected_skill=selected_skill)
     if len(stages) < 2:
         return None
     steps = [steps_by_stage[stage].to_dict(index + 1) for index, stage in enumerate(stages)]
@@ -255,6 +255,13 @@ def build_workflow_route_plan(
         "next_action": f"start_with_{steps[0]['skill']}",
         "claim_boundary": CLAIM_BOUNDARY,
     }
+
+
+def _ordered_stages(steps_by_stage: dict[str, _RouteStep], *, selected_skill: str) -> list[str]:
+    stages = [stage for stage in _STAGE_ORDER if stage in steps_by_stage]
+    if selected_skill == "workflow-learning" and "learn" in stages:
+        return ["learn", *(stage for stage in stages if stage != "learn")]
+    return stages
 
 
 def compact_workflow_route_plan(value: object) -> dict[str, object] | None:

--- a/src/routing/task_cards.py
+++ b/src/routing/task_cards.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import re
+
 from .localization import normalized_phrase, routing_tokens
 from .intent import META_OR_FEEDBACK_INTENTS, classify_workflow_intent
 
@@ -91,8 +93,12 @@ _ROUTER_DESIGN_CONTEXT_PHRASES = (
     "워크플로 학습",
     "워크플로우 학습",
     "라우팅 피드백",
+    "omh가 얼마나 관여",
+    "omh를 얼마나 관여",
     "omh 관여",
-    "얼마나 관여",
+    "omh관여",
+    "omh 관여도",
+    "omh관여도",
 )
 _MAINTENANCE_COMMAND_ALIASES = {
     "update": ("update", "upgrade", "refresh", "업데이트", "업뎃", "갱신"),
@@ -283,18 +289,68 @@ def _is_runtime_portability(normalized: str, compact: str, tokens: set[str]) -> 
     return _phrase_hit(("gateway", "bot", "responder", "게이트웨이", "봇", "응답자"), normalized, compact)
 
 
+def _without_diagnostic_status_lines(normalized: str) -> str:
+    markers = (
+        "[omh awareness]",
+        "[omh route hint]",
+        "[omh]",
+        "native bridge status context",
+        "evidence boundary",
+        "latest runtime run",
+        "selected_workflow=",
+        "mentioned_workflows=",
+        "mentioned_runtime_terms=",
+        "not_executed=",
+        "intent_class=",
+        "status=",
+        "workflow=",
+        "hints=",
+    )
+    kept: list[str] = []
+    for line in normalized.splitlines() or [normalized]:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("[omh"):
+            stripped = re.sub(r"^\[omh(?:\s+awareness|\s+route\s+hint)?\]\s*", "", stripped).strip()
+            if not stripped:
+                continue
+        if stripped.startswith(("native bridge status context", "evidence boundary", "latest runtime run")):
+            continue
+        if any(marker in stripped for marker in markers):
+            fragments = [fragment.strip() for fragment in re.split(r"[;|]", stripped)]
+            user_fragments = [fragment for fragment in fragments if fragment and not any(marker in fragment for marker in markers)]
+            if user_fragments:
+                kept.append(" ".join(user_fragments))
+            continue
+        kept.append(stripped)
+    return "\n".join(kept)
+
+
+def _diagnostic_region_router_feedback(normalized: str, compact: str) -> bool:
+    subject = _phrase_hit(("omh", "omh가", "omh를", "omh의", "oh-my-hermes", "oh my hermes", "router", "routing", "route hint", "라우터", "라우팅"), normalized, compact)
+    evaluation = _phrase_hit(("usage evaluation", "usability evaluation", "usage analysis", "router improvement", "router hardening", "route improvement", "evaluate omh", "why omh", "사용성 평가", "사용성평가", "안쓴이유", "안 쓴 이유", "덜 쓴 이유", "덜쓴 이유", "덜 썼", "덜썼", "부족했던 점", "부족한 점", "라우터 강화", "라우터강화", "라우터 개선", "플랜으로 잡", "반복해서 강화"), normalized, compact)
+    return subject and evaluation
+
+
 def _is_router_design_feedback(normalized: str, compact: str, tokens: set[str], intent: object) -> bool:
-    phrase_hit = _phrase_hit(_ROUTER_DESIGN_CONTEXT_PHRASES, normalized, compact)
+    structural_cues = set(getattr(intent, "structural_cues", ()))
+    diagnostic_status_context = "diagnostic_status_context" in structural_cues
+    evaluation_region = _without_diagnostic_status_lines(normalized) if diagnostic_status_context else normalized
+    evaluation_compact = evaluation_region.replace(" ", "")
+    phrase_hit = _phrase_hit(_ROUTER_DESIGN_CONTEXT_PHRASES, evaluation_region, evaluation_compact)
     if phrase_hit:
         return True
-    if "missed route" in normalized or "workflow-learning" in normalized:
+    if "missed route" in evaluation_region or "workflow-learning" in evaluation_region:
         return False
+    if diagnostic_status_context:
+        return _diagnostic_region_router_feedback(evaluation_region, evaluation_compact)
     if (
         getattr(intent, "intent_class", "") in META_OR_FEEDBACK_INTENTS
         and not bool(getattr(intent, "explicit_execution", False))
         and (
-            bool(getattr(intent, "mentioned_workflows", ()))
-            or bool(getattr(intent, "mentioned_runtime_terms", ()))
+            (not diagnostic_status_context and bool(getattr(intent, "mentioned_workflows", ())))
+            or (not diagnostic_status_context and bool(getattr(intent, "mentioned_runtime_terms", ())))
             or bool(getattr(intent, "missing_requirements_cues", ()))
             or _phrase_hit(
                 (
@@ -312,8 +368,8 @@ def _is_router_design_feedback(normalized: str, compact: str, tokens: set[str], 
                     "워크플로우",
                     "코딩 핸드오프",
                 ),
-                normalized,
-                compact,
+                evaluation_region,
+                evaluation_compact,
             )
         )
     ):

--- a/tests/test_chat_router.py
+++ b/tests/test_chat_router.py
@@ -17,6 +17,26 @@ from omh.routing.intent import classify_workflow_intent
 from omh.skills.catalog import primary_harness_for_skill
 
 
+def sionic_omh_usage_evaluation_prompt() -> str:
+    return """이번 Sionic 작업에서 OMH가 얼마나 관여했는지 사용성 평가하고,
+왜 OMH를 덜 썼는지 분석해서 라우터 강화 플랜으로 잡아줘.
+
+[OMH Awareness]
+status=prepared_not_observed; Evidence boundary: pasted status is diagnostic evidence.
+[OMH Route Hint]
+intent=delivery_intent; selected=ultraprocess; confidence=medium.
+mentioned_workflows=ultraprocess.
+not_executed=Codex.
+[omh]
+selected_workflow=ultraprocess
+latest_runtime_run=not_executed=Codex
+execution_observed=false
+review_observed=false
+ci_observed=false
+merge_observed=false
+"""
+
+
 class ChatRouterTests(unittest.TestCase):
     def test_high_confidence_chat_dispatches_to_workflow(self) -> None:
         decision = route_chat_message("risky refactor", source="discord")
@@ -433,6 +453,32 @@ class ChatRouterTests(unittest.TestCase):
                 self.assertEqual(task_card["task_type"], "router_design_feedback")
                 self.assertFalse(decision["explicit"])
                 self.assertNotEqual(decision["selected_skill"], "ultraprocess")
+
+    def test_pasted_omh_awareness_evaluation_routes_learning_before_delivery(self) -> None:
+        message = sionic_omh_usage_evaluation_prompt()
+
+        decision = route_chat_message(message, source="discord", limit=8)
+        task_card = decision["task_card"]
+        intent = classify_workflow_intent(message)
+        route_plan = public_route_payload(decision)["workflow_route_plan"]
+        stages = [step["stage"] for step in route_plan["steps"]]
+        skills = [step["skill"] for step in route_plan["steps"]]
+
+        self.assertEqual(decision["action"], "dispatch")
+        self.assertEqual(decision["selected_skill"], "workflow-learning")
+        self.assertEqual(decision["selected_harness"], "workflow-learning")
+        self.assertEqual(task_card["task_type"], "router_design_feedback")
+        self.assertIn("task_card:router_design_feedback", decision["recommendations"][0]["matched"])
+        self.assertIn(intent.intent_class, {"feedback_signal", "meta_discussion"})
+        self.assertFalse(intent.explicit_execution)
+        self.assertIn("diagnostic_status_context", intent.structural_cues)
+        self.assertIn("ultraprocess", intent.not_executed)
+        self.assertIn("Codex", intent.not_executed)
+        self.assertIn("learn", stages)
+        self.assertIn("deliver", stages)
+        self.assertLess(stages.index("learn"), stages.index("deliver"))
+        self.assertLess(skills.index("workflow-learning"), skills.index("ultraprocess"))
+        self.assertTrue(all(step["status"] == "prepared_not_observed" for step in route_plan["steps"]))
 
     def test_workflow_intent_prefers_structural_cues_over_language_tables(self) -> None:
         intent = classify_workflow_intent("OMH route: `$ultraprocess` ≠ ejecutar; Codex handoff token only.")

--- a/tests/test_chat_router.py
+++ b/tests/test_chat_router.py
@@ -20,6 +20,10 @@ from omh.skills.catalog import primary_harness_for_skill
 def sionic_omh_usage_evaluation_prompt() -> str:
     return """이번 Sionic 작업에서 OMH가 얼마나 관여했는지 사용성 평가하고,
 왜 OMH를 덜 썼는지 분석해서 라우터 강화 플랜으로 잡아줘.
+Sionic은 마크다운 노트뿐 아니라 위키 페이지/site 생성도 포함했어.
+결과창에는 Background process proc_d5eb61ddcf80 finished with exit code 0~
+Here's the final output: 같은 raw output, turn.completed usage, Self-improvement review 줄이 보였고
+이걸 프리티하게 OMH wrapper report로 정리해야 했어.
 
 [OMH Awareness]
 status=prepared_not_observed; Evidence boundary: pasted status is diagnostic evidence.
@@ -499,6 +503,67 @@ class ChatRouterTests(unittest.TestCase):
 
         self.assertIsNone(decision["task_card"])
         self.assertNotIn("task_card:router_design_feedback", decision["recommendations"][0]["matched"])
+
+        domain = route_chat_message("고객 관여도 분석해서 Sionic 위키 페이지 개선해줘.", source="discord")
+        self.assertNotEqual(domain["selected_skill"], "workflow-learning")
+        self.assertIsNone(domain["task_card"])
+
+    def test_domain_work_with_pasted_status_does_not_become_omh_quality_loop(self) -> None:
+        message = """Sionic 위키 페이지 사용성 평가하고 더 보기 좋게 만들어줘.
+
+[omh] v1.0.1 | plugin:ready | target:single | coding-agent:runtime(codex)
+[OMH] Native bridge status context.
+Evidence boundary: prepared handoffs are not execution evidence.
+Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
+"""
+
+        decision = route_chat_message(message, source="discord")
+        intent = classify_workflow_intent(message)
+
+        self.assertNotEqual(decision["selected_skill"], "workflow-learning")
+        self.assertNotEqual(decision["selected_skill"], "agent-ops-review")
+        self.assertIsNone(decision["task_card"])
+        self.assertNotIn("task_card:router_design_feedback", decision["recommendations"][0]["matched"])
+        self.assertNotIn(intent.intent_class, {"feedback_signal", "meta_discussion"})
+
+    def test_status_context_before_user_instruction_is_not_discarded(self) -> None:
+        message = """[omh] v1.0.1 | plugin:ready | target:single | coding-agent:runtime(codex)
+[OMH] Native bridge status context.
+Evidence boundary: prepared handoffs are not execution evidence.
+Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
+
+Sionic 작업 말고 OMH 라우터 강화 플랜으로 잡아줘.
+"""
+
+        decision = route_chat_message(message, source="discord")
+        intent = classify_workflow_intent(message)
+
+        self.assertEqual(decision["selected_skill"], "workflow-learning")
+        self.assertEqual(decision["task_card"]["task_type"], "router_design_feedback")
+        self.assertIn(intent.intent_class, {"feedback_signal", "meta_discussion"})
+
+        same_line = route_chat_message("[OMH] 라우터 강화 플랜으로 잡아줘", source="discord")
+        self.assertEqual(same_line["selected_skill"], "workflow-learning")
+        self.assertEqual(same_line["task_card"]["task_type"], "router_design_feedback")
+
+    def test_bounded_omh_usage_review_cues_survive_without_domain_stealing(self) -> None:
+        status = """
+[OMH Awareness]
+status=prepared_not_observed; Evidence boundary: pasted status is diagnostic evidence.
+selected_workflow=ultraprocess
+"""
+        prefixes = (
+            "이번 작업에서 OMH를 덜 쓴 이유를 분석해줘.",
+            "이번 작업에서 OMH를 덜 썼는지 분석해줘.",
+            "이번 작업에서 OMH 관여도 분석해줘.",
+            "이번 작업에서 OMH가 부족했던 점을 분석해줘.",
+            "status=prepared_not_observed; 이번 작업에서 OMH를 덜 쓴 이유를 분석해줘.",
+        )
+        for prefix in prefixes:
+            with self.subTest(prefix=prefix):
+                decision = route_chat_message(prefix + status, source="discord")
+                self.assertEqual(decision["selected_skill"], "workflow-learning")
+                self.assertEqual(decision["task_card"]["task_type"], "router_design_feedback")
 
     def test_catalog_question_dispatches_to_router_without_shell_approval(self) -> None:
         for message in (

--- a/tests/test_codex_progress.py
+++ b/tests/test_codex_progress.py
@@ -26,6 +26,164 @@ from omh.paths import resolve_paths
 
 
 class CodexProgressTests(unittest.TestCase):
+    def test_background_process_and_usage_noise_do_not_become_user_facing_progress(self) -> None:
+        raw = "\n".join(
+            [
+                json.dumps(
+                    {
+                        "role": "assistant",
+                        "content": (
+                            "Background process proc_d5eb61ddcf80 finished with exit code 0~\n"
+                            "Here's the final output:"
+                        ),
+                    }
+                ),
+                json.dumps(
+                    {
+                        "role": "assistant",
+                        "content": (
+                            "Background process proc_d5eb61ddcf80 finished with exit code 0~ "
+                            "Here's the final output: Targeted tests passed: tests/test_codex_progress.py."
+                        ),
+                    }
+                ),
+                json.dumps(
+                    {
+                        "role": "assistant",
+                        "content": (
+                            "[Background process proc_d5eb61ddcf80 finished with exit code 0~ "
+                            "Here's the final output:] Targeted tests passed: tests/test_codex_progress.py."
+                        ),
+                    }
+                ),
+                json.dumps(
+                    {
+                        "role": "assistant",
+                        "content": "Here's the final output: Targeted tests passed: tests/test_codex_progress.py.",
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "turn.completed",
+                        "usage": {
+                            "input_tokens": 12345,
+                            "output_tokens": 678,
+                            "reasoning_output_tokens": 90,
+                        },
+                    }
+                ),
+                json.dumps({"role": "assistant", "content": "Self-improvement review: Patched noisy report output."}),
+            ]
+        )
+
+        summary = summarize_codex_jsonl_text(raw, evidence_refs=["codex-final-jsonl"], source="codex-final.jsonl")
+        signal = build_safe_progress_signal(executor_profile="codex", codex_progress_summary=summary)
+        rendered = json.dumps({"summary": summary, "signal": signal}, sort_keys=True)
+
+        self.assertEqual(summary["status"], "completed_or_passed_observed")
+        self.assertEqual(summary["latest_assistant_visible_message"], "Targeted tests passed: tests/test_codex_progress.py.")
+        self.assertEqual(summary["latest_progress_event"]["event_type"], "targeted_tests_passed")
+        self.assertEqual(signal["latest_progress_event_type"], "targeted_tests_passed")
+        for forbidden in (
+            "Background process",
+            "Here's the final output",
+            "turn.completed",
+            '"usage"',
+            "input_tokens",
+            "reasoning_output_tokens",
+            "Self-improvement review",
+        ):
+            self.assertNotIn(forbidden, rendered)
+
+    def test_completed_codex_items_still_count_as_observable_progress(self) -> None:
+        raw = "\n".join(
+            [
+                json.dumps(
+                    {
+                        "role": "assistant",
+                        "content": "Tests passed: tests/test_codex_progress.py.",
+                        "usage": {"input_tokens": 1, "output_tokens": 2},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "item.completed",
+                        "item": {
+                            "type": "command_execution",
+                            "command": "python -m unittest tests/test_codex_progress.py",
+                            "aggregated_output": "OK",
+                            "exit_code": 0,
+                            "status": "completed",
+                        },
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "item.completed",
+                        "item": {"type": "agent_message", "text": "Tests passed: tests/test_codex_progress.py."},
+                        "usage": {"input_tokens": 10, "output_tokens": 5},
+                    }
+                ),
+            ]
+        )
+
+        summary = summarize_codex_jsonl_text(raw)
+
+        self.assertEqual(summary["status"], "completed_or_passed_observed")
+        self.assertGreater(summary["activity_counts"]["testing"], 0)
+        self.assertEqual(summary["latest_assistant_visible_message"], "Tests passed: tests/test_codex_progress.py.")
+        self.assertEqual(summary["latest_progress_event"]["event_type"], "targeted_tests_passed")
+
+    def test_executor_progress_reports_sanitize_explicit_background_output(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            binding = write_progress_binding(
+                paths,
+                build_progress_binding(
+                    target_type="run",
+                    target_id="run-noisy-1",
+                    executor_profile="codex",
+                    process_session_id="proc_d5eb61ddcf80",
+                    evidence_refs=["codex-background-output"],
+                    now="2026-06-26T00:00:00Z",
+                ),
+            )
+            noisy = "\n".join(
+                [
+                    "Background process proc_d5eb61ddcf80 finished with exit code 0~",
+                    "Here's the final output:",
+                    '{"type":"turn.completed","usage":{"input_tokens":123,"reasoning_output_tokens":45}}',
+                    "Self-improvement review: Patched output copy.",
+                ]
+            )
+
+            observed = observe_executor_progress(
+                paths,
+                binding,
+                build_safe_progress_signal(
+                    executor_profile="codex",
+                    process_status="completed",
+                    explicit_event_type="executor_completed",
+                    explicit_summary=noisy,
+                    evidence_refs=["codex-background-output"],
+                ),
+                observed_at="2026-06-26T00:00:10Z",
+            )
+
+            rendered = json.dumps(observed, sort_keys=True)
+            self.assertEqual(observed["event"]["event_type"], "executor_completed")
+            self.assertIn("separate result evidence", observed["chat_report"])
+            for forbidden in (
+                "Background process",
+                "Here's the final output",
+                "turn.completed",
+                '"usage"',
+                "input_tokens",
+                "reasoning_output_tokens",
+                "Self-improvement review",
+            ):
+                self.assertNotIn(forbidden, rendered)
+
     def test_summarizes_observable_codex_jsonl_without_raw_or_hidden_text(self) -> None:
         raw = "\n".join(
             [

--- a/tests/test_hook_manifest.py
+++ b/tests/test_hook_manifest.py
@@ -16,6 +16,10 @@ from omh.plugin_bundle.omh.hooks.tool_hooks import pre_tool_call
 def sionic_omh_usage_evaluation_prompt() -> str:
     return """이번 Sionic 작업에서 OMH가 얼마나 관여했는지 사용성 평가하고,
 왜 OMH를 덜 썼는지 분석해서 라우터 강화 플랜으로 잡아줘.
+Sionic은 마크다운 노트뿐 아니라 위키 페이지/site 생성도 포함했어.
+결과창에는 Background process proc_d5eb61ddcf80 finished with exit code 0~
+Here's the final output: 같은 raw output, turn.completed usage, Self-improvement review 줄이 보였고
+이걸 프리티하게 OMH wrapper report로 정리해야 했어.
 
 [OMH Awareness]
 status=prepared_not_observed; Evidence boundary: pasted status is diagnostic evidence.

--- a/tests/test_hook_manifest.py
+++ b/tests/test_hook_manifest.py
@@ -13,6 +13,26 @@ from omh.plugin_bundle.omh.hooks.llm_hooks import pre_llm_call
 from omh.plugin_bundle.omh.hooks.tool_hooks import pre_tool_call
 
 
+def sionic_omh_usage_evaluation_prompt() -> str:
+    return """이번 Sionic 작업에서 OMH가 얼마나 관여했는지 사용성 평가하고,
+왜 OMH를 덜 썼는지 분석해서 라우터 강화 플랜으로 잡아줘.
+
+[OMH Awareness]
+status=prepared_not_observed; Evidence boundary: pasted status is diagnostic evidence.
+[OMH Route Hint]
+intent=delivery_intent; selected=ultraprocess; confidence=medium.
+mentioned_workflows=ultraprocess.
+not_executed=Codex.
+[omh]
+selected_workflow=ultraprocess
+latest_runtime_run=not_executed=Codex
+execution_observed=false
+review_observed=false
+ci_observed=false
+merge_observed=false
+"""
+
+
 class HookManifestTests(unittest.TestCase):
     def test_hook_manifest_projects_plugin_yaml_and_wrapper_events(self) -> None:
         manifest = hook_manifest()
@@ -117,6 +137,27 @@ class HookManifestTests(unittest.TestCase):
         self.assertIn("Codex", payload["not_executed"])
         self.assertIn("selected=workflow-learning", context)
         self.assertIn("mentioned_workflows=ultraprocess", context)
+        self.assertIn("not_executed=ultraprocess, Codex", context)
+        self.assertNotIn("selected=ultraprocess", context)
+        self.assertNotIn(message, context)
+
+    def test_awareness_route_hint_treats_pasted_omh_status_as_diagnostic(self) -> None:
+        message = sionic_omh_usage_evaluation_prompt()
+
+        payload = awareness_route_hint(message, max_hints=3)
+        context_result = pre_llm_call(user_message=message, is_first_turn=False)
+        context = context_result["context"] if context_result else ""
+
+        self.assertEqual(payload["status"], "hinted")
+        self.assertEqual(payload["primary_workflow"], "workflow-learning")
+        self.assertEqual(payload["selected_workflow"], "workflow-learning")
+        self.assertIn(payload["intent_class"], {"meta_discussion", "feedback_signal"})
+        self.assertIn("ultraprocess", payload["mentioned_workflows"])
+        self.assertIn("Codex", payload["mentioned_runtime_terms"])
+        self.assertIn("ultraprocess", payload["not_executed"])
+        self.assertIn("Codex", payload["not_executed"])
+        self.assertEqual(payload["hints"][0]["workflow"], "workflow-learning")
+        self.assertIn("selected=workflow-learning", context)
         self.assertIn("not_executed=ultraprocess, Codex", context)
         self.assertNotIn("selected=ultraprocess", context)
         self.assertNotIn(message, context)

--- a/tests/test_plugin_capabilities.py
+++ b/tests/test_plugin_capabilities.py
@@ -225,6 +225,23 @@ class PluginCapabilitiesTests(unittest.TestCase):
             status, _, stderr = run_cli(["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "setup", "--with-plugin"])
             self.assertEqual(status, 0, stderr)
             plugin_dir = hermes_home / "plugins" / "omh"
+            sionic_prompt_fixture = """이번 Sionic 작업에서 OMH가 얼마나 관여했는지 사용성 평가하고,
+왜 OMH를 덜 썼는지 분석해서 라우터 강화 플랜으로 잡아줘.
+
+[OMH Awareness]
+status=prepared_not_observed; Evidence boundary: pasted status is diagnostic evidence.
+[OMH Route Hint]
+intent=delivery_intent; selected=ultraprocess; confidence=medium.
+mentioned_workflows=ultraprocess.
+not_executed=Codex.
+[omh]
+selected_workflow=ultraprocess
+latest_runtime_run=not_executed=Codex
+execution_observed=false
+review_observed=false
+ci_observed=false
+merge_observed=false
+"""
             script = textwrap.dedent(
                 f"""
                 import importlib.util
@@ -283,6 +300,15 @@ class PluginCapabilitiesTests(unittest.TestCase):
                         "message": "왜 ultraprocess 로그가 떠? Codex handoff 테스트 용어일 뿐이야.",
                         "source": "discord",
                         "limit": 2,
+                        "include_prompt_context": True,
+                    }})
+                )
+                sionic_prompt = {sionic_prompt_fixture!r}
+                context_sionic = json.loads(
+                    context_handler({{
+                        "message": sionic_prompt,
+                        "source": "discord",
+                        "limit": 3,
                         "include_prompt_context": True,
                     }})
                 )
@@ -381,6 +407,13 @@ class PluginCapabilitiesTests(unittest.TestCase):
                     "context_meta_mentioned_workflows": context_meta["route_hint"]["mentioned_workflows"],
                     "context_meta_runtime_terms": context_meta["route_hint"]["mentioned_runtime_terms"],
                     "context_meta_prompt_context": context_meta["prompt_context"],
+                    "context_sionic_primary_workflow": context_sionic["route_hint"]["primary_workflow"],
+                    "context_sionic_intent_class": context_sionic["route_hint"]["intent_class"],
+                    "context_sionic_mentioned_workflows": context_sionic["route_hint"]["mentioned_workflows"],
+                    "context_sionic_runtime_terms": context_sionic["route_hint"]["mentioned_runtime_terms"],
+                    "context_sionic_not_executed": context_sionic["route_hint"]["not_executed"],
+                    "context_sionic_first_hint": context_sionic["route_hint"]["hints"][0]["workflow"],
+                    "context_sionic_prompt_context": context_sionic["prompt_context"],
                     "interaction_schema": interaction["schema_version"],
                     "interaction_degraded": interaction["degraded"],
                     "interaction_source": interaction["source_backend"],
@@ -537,6 +570,15 @@ class PluginCapabilitiesTests(unittest.TestCase):
             self.assertIn("Codex", payload["context_meta_runtime_terms"])
             self.assertIn("selected=workflow-learning", payload["context_meta_prompt_context"])
             self.assertNotIn("selected=ultraprocess", payload["context_meta_prompt_context"])
+            self.assertEqual(payload["context_sionic_primary_workflow"], "workflow-learning")
+            self.assertIn(payload["context_sionic_intent_class"], {"feedback_signal", "meta_discussion"})
+            self.assertIn("ultraprocess", payload["context_sionic_mentioned_workflows"])
+            self.assertIn("Codex", payload["context_sionic_runtime_terms"])
+            self.assertIn("ultraprocess", payload["context_sionic_not_executed"])
+            self.assertIn("Codex", payload["context_sionic_not_executed"])
+            self.assertEqual(payload["context_sionic_first_hint"], "workflow-learning")
+            self.assertIn("selected=workflow-learning", payload["context_sionic_prompt_context"])
+            self.assertNotIn("selected=ultraprocess", payload["context_sionic_prompt_context"])
             self.assertEqual(payload["interaction_schema"], "chat_interaction/v1")
             self.assertTrue(payload["interaction_degraded"])
             self.assertEqual(payload["interaction_source"], "standalone_plugin_bundle_fallback")

--- a/tests/test_plugin_capabilities.py
+++ b/tests/test_plugin_capabilities.py
@@ -227,6 +227,10 @@ class PluginCapabilitiesTests(unittest.TestCase):
             plugin_dir = hermes_home / "plugins" / "omh"
             sionic_prompt_fixture = """이번 Sionic 작업에서 OMH가 얼마나 관여했는지 사용성 평가하고,
 왜 OMH를 덜 썼는지 분석해서 라우터 강화 플랜으로 잡아줘.
+Sionic은 마크다운 노트뿐 아니라 위키 페이지/site 생성도 포함했어.
+결과창에는 Background process proc_d5eb61ddcf80 finished with exit code 0~
+Here's the final output: 같은 raw output, turn.completed usage, Self-improvement review 줄이 보였고
+이걸 프리티하게 OMH wrapper report로 정리해야 했어.
 
 [OMH Awareness]
 status=prepared_not_observed; Evidence boundary: pasted status is diagnostic evidence.


### PR DESCRIPTION
## Feature Report

### What Changed

- Added regression coverage for Sionic-style Korean OMH usage-evaluation prompts that paste `[OMH Awareness]`, `[OMH Route Hint]`, `[omh]`, `not_executed=Codex`, and observed-status fields.
- Treat pasted OMH awareness/status rails as diagnostic context when the actual user request is OMH usage evaluation, routing analysis, or router hardening.
- Route that prompt shape to `workflow-learning` / `router_design_feedback` before `ultraprocess`, including the compact `workflow_route_plan/v1` order.
- Updated `omh_context` awareness hints so canonical and standalone plugin fallback paths select `workflow-learning` first instead of letting pasted `Codex`, `ultraprocess`, or `merge_observed` text steal the route.

### Why This Exists

- The Sionic session review showed that OMH was partially involved, but the follow-up evaluation prompt could be misread as coding delivery because the pasted status block contained `Codex`, `ultraprocess`, `merge`, and `not_executed=Codex`.
- Those pasted blocks are evidence for diagnosis, not execution commands. The router needs to learn/evaluate first, then prepare any coding delivery only after the learning/regression plan exists.

### User / Operator Impact

- Users can paste OMH awareness/status snippets and ask in Korean why OMH was underused or how to improve routing without accidentally triggering a coding-delivery-first hint.
- Clear coding requests still route to `ultraprocess`; existing OMH quality loops that explicitly ask for a process/coding lane remain unchanged.
- Plugin-only Hermes hosts get the same `omh_context` behavior through the standalone fallback awareness implementation.

### How It Works

- `classify_workflow_intent(...)` now recognizes diagnostic OMH status markers and Korean/English evaluation cues, then suppresses execution cues that only came from fields like `not_executed` and `merge_observed`.
- `awareness_route_hint(...)` gives diagnostic OMH evaluation prompts a `workflow-learning` first hint even when the broader OMH quality-improvement guard would otherwise point at `ultraprocess`.
- `build_workflow_route_plan(...)` starts multi-stage plans with `learn` when `workflow-learning` is the selected primary rail, keeping learning before delivery.

### Files And Contracts Touched

- `src/routing/intent.py`: diagnostic status/evaluation intent handling.
- `src/routing/route_plan.py`: learning-first stage order for `workflow-learning` primary routes.
- `src/plugin_bundle/omh/awareness.py`: canonical and standalone fallback `omh_context` hint behavior.
- `tests/test_chat_router.py`: route, intent, not-executed, and route-plan regression.
- `tests/test_hook_manifest.py`: awareness/pre-LLM context regression.
- `tests/test_plugin_capabilities.py`: standalone plugin fallback regression.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_chat_router.py tests/test_hook_manifest.py tests/test_plugin_capabilities.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest tests.test_cli.CliTests.test_context_brief_routes_omh_quality_loops_to_process_before_feedback_triage tests.test_cli.CliTests.test_recommend_omh_quality_loop_routes_to_process_despite_bug_terms -v`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `PYTHONPATH=tests uv run python -m compileall -q src tests`
- [x] `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check`
- [x] `PYTHONPATH=tests uv run python -m omh.cli harness validate`
- [x] `git diff --check`
- [ ] `python3 -m omh.cli release checklist --json` - not run; this is router hardening, not a release checklist change.
- [ ] `python3 -m omh.cli release hermes-smoke` - not run; no install/release surface changed.
- [ ] `omh --help` - not run; no CLI help surface changed.
- [ ] Manual Hermes/TUI check - not run; deterministic router, hook, and standalone plugin tests cover this bounded change.

## Risk

- Main risk is over-classifying OMH quality-improvement prompts as learning-only. Existing CLI regressions keep explicit OMH process/coding quality loops on `ultraprocess`.
- Another risk is route-plan order drift. Existing route-plan tests still preserve research -> plan -> deliver -> review for normal delivery requests.

## Compatibility / Rollout

- Local deterministic behavior only; no new dependencies, network calls, Hermes core changes, or runtime artifact format changes.
- Standalone plugin fallback stays compatible with hosts that load the plugin without the full `omh` package.

## Release / Claims

- [x] Release-channel impact considered: local router/plugin behavior only.
- [x] Runtime/native capability claims are backed by local tests or marked as not observed.
- [x] Known manual Hermes checks are listed; live Hermes/TUI and remote CI are not observed in this PR body.

## Follow-Up

- Consider extracting shared diagnostic cue data if more awareness/status-block learning cases are added.
- CI status should be treated as unobserved until GitHub reports it on this PR.
