### PR TITLE
Remove README Why OMH section

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,25 +93,6 @@ Use OMH request-to-handoff for: I want to safely add a feature to this repo.
 
 <br>
 
-## Why OMH
-
-- **Hermes stays the surface** - users ask in plain language, and Hermes can
-  answer with a family, workflow, role, next action, or handoff.
-- **Discovery starts with outcomes** - planning, learning, material creation,
-  coding delegation, and operations appear as capability families before users
-  need to know skill names.
-- **Research and planning are first-class** - source finding, paper learning,
-  web research, briefs, interviews, plans, and strategy work stay in
-  Hermes-facing paths instead of defaulting to coding.
-- **Coding is delegated deliberately** - Codex, Claude Code, Hermes, or another
-  selected executor receives a scoped handoff only after the request is clear.
-- **Prepared is not observed** - plans, generated prompts, status cards,
-  dispatch, execution, review, CI, and merge evidence stay separate.
-- **Local and inspectable** - skills, manifests, plans, sessions, and status
-  records stay in user-owned local directories.
-
-<br>
-
 ## Core Workflows
 
 <p align="center">

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -1165,8 +1165,9 @@ class RouterContentTests(unittest.TestCase):
         self.assertNotIn("omh update --channel preview", update_section)
         self.assertIn("omh setup", readme)
         self.assertIn("omh doctor", readme)
-        self.assertLess(readme.index("## Quick Start"), readme.index("## Why OMH"))
-        quick_start = readme.split("## Quick Start", 1)[1].split("## Why OMH", 1)[0]
+        self.assertNotIn("## Why OMH", readme)
+        self.assertLess(readme.index("## Quick Start"), readme.index("## Core Workflows"))
+        quick_start = readme.split("## Quick Start", 1)[1].split("## Core Workflows", 1)[0]
         self.assertIn("curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes/main/install.sh | sh", quick_start)
         self.assertIn("omh setup", quick_start)
         self.assertLess(quick_start.index("omh setup"), quick_start.index("omh doctor"))


### PR DESCRIPTION
## Summary
- removes the `Why OMH` section from the README
- leaves the Core Workflows images and representative workflow list intact

## Why
The README no longer needs the outcome-positioning bullet block between the GitHub Follow note and Core Workflows.

## Verification
- [x] `git diff --check -- README.md`

## Risk / Rollout
- Narrow README copy deletion only.
- No runtime behavior changes.
