### PR TITLE
Add learning candidate cards for Hermes learn

### DIFF
--- a/src/omh/learning_candidate.py
+++ b/src/omh/learning_candidate.py
@@ -1,0 +1,3 @@
+from __future__ import annotations
+
+from .workflows.learning_candidate import *  # noqa: F401,F403

--- a/src/routing/chat.py
+++ b/src/routing/chat.py
@@ -18,6 +18,7 @@ from .policy import (
 from .recommend import recommend_skills
 from .route_plan import build_workflow_route_plan, compact_workflow_route_plan
 from .task_cards import classify_task, task_card_recommendation
+from ..learning_candidate import build_learning_candidate_card
 from ..skills.catalog import SkillDefinition, primary_harness_for_skill, routable_definitions
 
 
@@ -102,6 +103,7 @@ class ChatRouteDecision:
     routing_prompt: str
     task_card: dict[str, object] | None
     workflow_route_plan: dict[str, object] | None
+    learning_candidate_card: dict[str, object] | None
     recommendations: tuple[dict[str, object], ...]
 
     def to_dict(self) -> dict[str, object]:
@@ -223,6 +225,28 @@ def route_chat_message(
         reason = f"Best match confidence {candidate_confidence} is below {min_confidence}; clarify before dispatch."
 
     selected_harness = primary_harness_for_skill(selected_skill)
+    learning_candidate_card = build_learning_candidate_card(
+        message,
+        source=source,
+        selected_workflow=selected_skill,
+        selected_harness=selected_harness,
+    )
+    if learning_candidate_card:
+        selected_skill = str(learning_candidate_card.get("recommended_workflow", selected_skill))
+        selected_harness = primary_harness_for_skill(selected_skill)
+        candidate_skill = selected_skill
+        candidate_harness = selected_harness
+        candidate_score = max(candidate_score, 12)
+        candidate_confidence = "high"
+        action = "dispatch"
+        ambiguous = False
+        reason = "Explicit learning signal; prepare a reviewable learning candidate card without running Hermes /learn."
+        learning_candidate_card = build_learning_candidate_card(
+            message,
+            source=source,
+            selected_workflow=selected_skill,
+            selected_harness=selected_harness,
+        )
     workflow_route_plan = build_workflow_route_plan(
         message,
         full_recommendations,
@@ -248,6 +272,7 @@ def route_chat_message(
         routing_prompt=_routing_prompt(action, selected_skill, candidate_skill, reason, message),
         task_card=task_card,
         workflow_route_plan=workflow_route_plan,
+        learning_candidate_card=learning_candidate_card,
         recommendations=recommendations,
     )
     return decision.to_dict()
@@ -288,6 +313,8 @@ def public_route_payload(decision: dict[str, object], *, include_message: bool =
         route.pop("routing_prompt", None)
     if not route.get("task_card"):
         route.pop("task_card", None)
+    if not route.get("learning_candidate_card"):
+        route.pop("learning_candidate_card", None)
     workflow_route_plan = compact_workflow_route_plan(route.get("workflow_route_plan"))
     if workflow_route_plan:
         route["workflow_route_plan"] = workflow_route_plan
@@ -342,6 +369,9 @@ def routing_record_payload(
     task_card = decision.get("task_card")
     if isinstance(task_card, dict) and task_card:
         payload["task_card"] = task_card
+    learning_candidate_card = decision.get("learning_candidate_card")
+    if isinstance(learning_candidate_card, dict) and learning_candidate_card:
+        payload["learning_candidate_card"] = learning_candidate_card
     return payload
 
 

--- a/src/system/ingress.py
+++ b/src/system/ingress.py
@@ -6,12 +6,16 @@ from typing import Any
 CHAT_SOURCES = ("generic", "discord", "slack", "telegram", "hermes")
 SOURCE_METADATA_KEYS = (
     "source_event_id",
+    "project_ref",
     "channel_ref",
+    "thread_ref",
     "user_ref",
     "timestamp",
     "agent_ref",
     "target_ref",
     "runtime_ref",
+    "workflow_ref",
+    "executor_ref",
     "hermes_home",
     "agent_count",
     "target_count",
@@ -42,6 +46,7 @@ _SOURCE_METADATA_PATHS: dict[str, tuple[tuple[str, ...], ...]] = {
         ("event", "id"),
         ("event", "client_msg_id"),
     ),
+    "project_ref": (("project_ref",), ("project", "id"), ("repository", "full_name"), ("repo", "full_name")),
     "channel_ref": (
         ("channel",),
         ("channel_id",),
@@ -50,6 +55,7 @@ _SOURCE_METADATA_PATHS: dict[str, tuple[tuple[str, ...], ...]] = {
         ("event", "channel"),
         ("channel", "id"),
     ),
+    "thread_ref": (("thread_ref",), ("thread", "id"), ("message", "thread_ts"), ("event", "thread_ts")),
     "user_ref": (
         ("user",),
         ("user_id",),
@@ -70,6 +76,8 @@ _SOURCE_METADATA_PATHS: dict[str, tuple[tuple[str, ...], ...]] = {
     "agent_ref": (("agent_ref",), ("agent", "id"), ("bot", "id"), ("message", "agent", "id"), ("event", "agent", "id")),
     "target_ref": (("target_ref",), ("target", "id"), ("workspace", "id"), ("team", "id"), ("guild_id",)),
     "runtime_ref": (("runtime_ref",), ("runtime", "id"), ("hermes", "runtime_id"), ("hermes_runtime", "id")),
+    "workflow_ref": (("workflow_ref",), ("workflow", "id"), ("workflow", "name")),
+    "executor_ref": (("executor_ref",), ("executor", "id"), ("executor", "profile")),
     "hermes_home": (("hermes_home",), ("runtime", "hermes_home"), ("hermes", "home")),
     "agent_count": (("agent_count",), ("agents_count",), ("target", "agent_count"), ("runtime", "agent_count"), ("hermes", "agent_count")),
     "target_count": (("target_count",), ("targets_count",), ("runtime", "target_count"), ("hermes", "target_count")),

--- a/src/workflows/learning_candidate.py
+++ b/src/workflows/learning_candidate.py
@@ -1,0 +1,511 @@
+from __future__ import annotations
+
+import hashlib
+import re
+from typing import Any, Iterable
+
+
+LEARNING_CANDIDATE_CARD_SCHEMA_VERSION = "learning_candidate_card/v1"
+LEARNING_CANDIDATE_SCOPE_SCHEMA_VERSION = "learning_candidate_scope/v1"
+LEARNING_CANDIDATE_TARGETS = ("skill_candidate", "memory_candidate", "session_only", "review_first")
+LEARNING_CANDIDATE_STATUS = "prepared_not_observed"
+
+_EXPLICIT_LEARN_SIGNALS = (
+    "/learn",
+    "learn this",
+    "remember this pattern",
+    "remember this",
+    "make a skill from this",
+    "create a skill from this",
+    "turn this into a skill",
+    "save this as a skill",
+    "use this next time",
+    "next time",
+    "from now on",
+    "다음부터 이렇게",
+    "다음부터",
+    "앞으로는",
+    "이걸 학습해",
+    "이거 학습해",
+    "학습해",
+    "이 패턴 기억해",
+    "기억해",
+    "방금 한 방식 skill로 남겨",
+    "방금 한 방식 스킬로 남겨",
+    "skill로 남겨",
+    "스킬로 남겨",
+)
+_SKILL_FORCING_SIGNALS = (
+    "make a skill from this",
+    "create a skill from this",
+    "turn this into a skill",
+    "save this as a skill",
+    "remember this pattern",
+    "이 패턴 기억해",
+    "방금 한 방식 skill로 남겨",
+    "방금 한 방식 스킬로 남겨",
+    "skill로 남겨",
+    "스킬로 남겨",
+)
+_BRIDGE_FORCING_SIGNALS = _SKILL_FORCING_SIGNALS + (
+    "/learn",
+    "learn this",
+    "이걸 학습해",
+    "이거 학습해",
+)
+_PROCEDURE_TOKENS = (
+    "workflow",
+    "runbook",
+    "procedure",
+    "checklist",
+    "steps",
+    "step",
+    "pattern",
+    "command",
+    "commands",
+    "tooling",
+    "tool",
+    "script",
+    "verify",
+    "verification",
+    "test",
+    "tests",
+    "lint",
+    "when ",
+    "whenever",
+    "after ",
+    "before ",
+    "if ",
+    "then ",
+    "run ",
+    "use ",
+    "do ",
+    "워크플로",
+    "워크플로우",
+    "런북",
+    "절차",
+    "방식",
+    "패턴",
+    "단계",
+    "명령",
+    "커맨드",
+    "검증",
+    "테스트",
+    "도구",
+    "실행",
+    "때 ",
+    "하면",
+    "먼저",
+)
+_COMMAND_TOKENS = (
+    "git ",
+    "gh ",
+    "uv ",
+    "python ",
+    "pytest",
+    "ruff",
+    "mypy",
+    "npm ",
+    "pnpm ",
+    "yarn ",
+    "make ",
+    "omh ",
+    "omx ",
+    "hermes ",
+)
+_PREFERENCE_TOKENS = (
+    "i prefer",
+    "my preference",
+    "prefer ",
+    "always ",
+    "never ",
+    "default to",
+    "use korean",
+    "in korean",
+    "concise",
+    "brief",
+    "tone",
+    "format",
+    "style",
+    "선호",
+    "좋아",
+    "싫어",
+    "항상",
+    "절대",
+    "한국어",
+    "짧게",
+    "간결",
+    "말투",
+    "형식",
+    "포맷",
+)
+_CROSS_CHANNEL_TOKENS = (
+    "cross-channel",
+    "cross channel",
+    "other channel",
+    "different channel",
+    "channel ",
+    "thread ",
+    "slack channel",
+    "discord channel",
+    "dm ",
+    "다른 채널",
+    "채널",
+    "스레드",
+)
+_CONFLICT_TOKENS = (
+    "conflict",
+    "conflicting",
+    "contradict",
+    "contradicts",
+    "ambiguous",
+    "not sure",
+    "maybe",
+    "might",
+    "충돌",
+    "모순",
+    "애매",
+    "확실하지",
+)
+_TRANSIENT_STATE_TOKENS = (
+    "blocked on ci",
+    "ci is failing",
+    "current pr",
+    "this pr",
+    "this branch",
+    "current branch",
+    "this run",
+    "current run",
+    "this task",
+    "current task",
+    "이번 pr",
+    "현재 pr",
+    "이번 작업",
+    "현재 작업",
+    "이번 런",
+)
+
+_TRANSIENT_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    (
+        "channel_or_thread_ref",
+        re.compile(
+            r"(?i)\b(?:slack|discord)?\s*(?:channel|thread|dm)\s+[#@]?[A-Za-z0-9_.:-]{2,120}\b|#[A-Za-z][A-Za-z0-9_-]{1,80}\b"
+        ),
+    ),
+    ("pull_request_number", re.compile(r"(?i)\b(?:pr|pull request)\s*#?\d+\b")),
+    ("commit_sha", re.compile(r"(?i)\b(?:commit|sha)\s+[0-9a-f]{7,40}\b|\b[0-9a-f]{12,40}\b")),
+    (
+        "run_id",
+        re.compile(r"(?i)\b\d{8}t\d{6,}z[-A-Za-z0-9_.:]*\b|\brun[_:-][A-Za-z0-9_.:-]{6,}\b"),
+    ),
+    ("process_id", re.compile(r"(?i)\b(?:pid|process id)\s*[:#]?\s*\d+\b|\bproc_[A-Za-z0-9_:-]{6,}\b")),
+    ("branch_ref", re.compile(r"(?i)\bbranch\s+[A-Za-z0-9._/-]{3,120}\b")),
+    ("task_state_ref", re.compile(r"(?i)\b(?:task|job)\s*#?[A-Za-z0-9_.:-]{4,120}\b")),
+)
+
+
+def build_learning_candidate_card(
+    message: str,
+    *,
+    source: str = "generic",
+    source_metadata: dict[str, str] | None = None,
+    selected_workflow: str = "",
+    selected_harness: str = "",
+    thread_key: str = "",
+    executor_runtime: str = "",
+) -> dict[str, object] | None:
+    signal = detect_learning_signal(message)
+    if signal is None:
+        return None
+
+    sanitized, redactions = sanitize_learning_text(message)
+    persistence_target = classify_learning_persistence_target(message, sanitized=sanitized, signal=signal, redactions=redactions)
+    recommended_workflow = _recommended_workflow(persistence_target)
+    summary = _candidate_summary(persistence_target, sanitized)
+    card = {
+        "schema_version": LEARNING_CANDIDATE_CARD_SCHEMA_VERSION,
+        "card_id": _card_id(source, sanitized, persistence_target),
+        "status": LEARNING_CANDIDATE_STATUS,
+        "learning_signal": signal,
+        "persistence_target": persistence_target,
+        "recommended_workflow": recommended_workflow,
+        "primary_action": _primary_action(persistence_target),
+        "summary": summary,
+        "scope": build_learning_candidate_scope(
+            source=source,
+            source_metadata=source_metadata or {},
+            selected_workflow=selected_workflow or recommended_workflow,
+            selected_harness=selected_harness,
+            thread_key=thread_key,
+            executor_runtime=executor_runtime,
+        ),
+        "sanitization": {
+            "transient_identifier_categories": redactions,
+            "prompt_uses_sanitized_observed_facts": True,
+            "excluded_from_prompt_and_summary": [
+                "pull request numbers",
+                "commit SHAs",
+                "run IDs",
+                "process IDs",
+                "one-off channel/thread/task state",
+            ],
+        },
+        "review": {
+            "required": persistence_target in {"memory_candidate", "review_first"},
+            "review_workflow": "memory-curation-review" if persistence_target in {"memory_candidate", "review_first"} else "",
+            "human_gate": "review_before_persistence",
+        },
+        "claim_boundary": (
+            "This card and any /learn prompt are prepared_not_observed; they are not skill creation evidence, "
+            "memory mutation evidence, workflow execution evidence, review evidence, CI evidence, or merge evidence."
+        ),
+        "not_observed": [
+            "Hermes /learn execution",
+            "skill creation",
+            "memory write",
+            "future behavior change",
+            "review approval",
+        ],
+        "available_actions": _available_actions(persistence_target),
+    }
+    if persistence_target == "skill_candidate":
+        card["learn_prompt"] = build_copy_ready_learn_prompt(sanitized)
+    return card
+
+
+def build_learning_candidate_scope(
+    *,
+    source: str,
+    source_metadata: dict[str, str],
+    selected_workflow: str,
+    selected_harness: str = "",
+    thread_key: str = "",
+    executor_runtime: str = "",
+) -> dict[str, object]:
+    return {
+        "schema_version": LEARNING_CANDIDATE_SCOPE_SCHEMA_VERSION,
+        "source": source,
+        "project_ref": source_metadata.get("project_ref", ""),
+        "channel_ref": source_metadata.get("channel_ref", ""),
+        "thread_ref": source_metadata.get("thread_ref", "") or thread_key,
+        "target_ref": source_metadata.get("target_ref", ""),
+        "workflow": source_metadata.get("workflow_ref", "") or selected_workflow,
+        "harness": selected_harness,
+        "executor_runtime": executor_runtime
+        or source_metadata.get("executor_ref", "")
+        or source_metadata.get("runtime_ref", ""),
+    }
+
+
+def detect_learning_signal(message: str) -> dict[str, object] | None:
+    normalized = _fold(message)
+    workflow_learning_context = "workflow learning" in normalized or "learn from this workflow" in normalized
+    if workflow_learning_context and not any(_fold(phrase) in normalized for phrase in _BRIDGE_FORCING_SIGNALS):
+        return None
+    for phrase in _EXPLICIT_LEARN_SIGNALS:
+        if _fold(phrase) in normalized:
+            signal_type = "skill_request" if phrase in _SKILL_FORCING_SIGNALS else "explicit_learn_request"
+            if phrase in {"next time", "from now on", "다음부터", "다음부터 이렇게", "앞으로는"}:
+                signal_type = "user_correction"
+            if phrase == "/learn":
+                signal_type = "hermes_learn_bridge"
+            return {
+                "type": signal_type,
+                "matched": phrase,
+                "source": "user_message",
+            }
+    return None
+
+
+def classify_learning_persistence_target(
+    message: str,
+    *,
+    sanitized: str | None = None,
+    signal: dict[str, object] | None = None,
+    redactions: list[str] | None = None,
+) -> str:
+    text = sanitized if sanitized is not None else sanitize_learning_text(message)[0]
+    folded = _fold(message)
+    sanitized_folded = _fold(text)
+    signal = signal or detect_learning_signal(message) or {}
+    redactions = redactions if redactions is not None else sanitize_learning_text(message)[1]
+
+    if _contains_any(folded, _CROSS_CHANNEL_TOKENS) or _contains_any(folded, _CONFLICT_TOKENS):
+        return "review_first"
+
+    has_procedure = _contains_any(sanitized_folded, _PROCEDURE_TOKENS) or _contains_any(sanitized_folded, _COMMAND_TOKENS)
+    has_preference = _contains_any(sanitized_folded, _PREFERENCE_TOKENS)
+    has_transient = bool(redactions) or _contains_any(folded, _TRANSIENT_STATE_TOKENS)
+
+    if has_transient and not has_procedure:
+        return "session_only"
+    if str(signal.get("matched", "")) in _SKILL_FORCING_SIGNALS:
+        return "skill_candidate"
+    if has_procedure:
+        return "skill_candidate"
+    if has_preference:
+        return "memory_candidate"
+    if has_transient:
+        return "session_only"
+    return "review_first"
+
+
+def sanitize_learning_text(message: str) -> tuple[str, list[str]]:
+    text = _strip_learning_signal(message)
+    redactions: list[str] = []
+    for category, pattern in _TRANSIENT_PATTERNS:
+        if pattern.search(text):
+            redactions.append(category)
+            text = pattern.sub(_replacement_for_category(category), text)
+    text = _normalize_space(text)
+    text = _trim_trailing_one_off_state(text)
+    return text[:900].strip(), _unique(redactions)
+
+
+def build_copy_ready_learn_prompt(sanitized_observed_facts: str) -> dict[str, object]:
+    observed = sanitized_observed_facts.strip() or "The user explicitly requested a reusable learning artifact, but the durable procedure details need review."
+    copy_text = "\n".join(
+        [
+            "/learn",
+            "Use observed facts only. Create a reusable Hermes skill from the procedure below.",
+            "",
+            "Observed reusable procedure:",
+            observed,
+            "",
+            "The skill must include:",
+            "- Trigger conditions for when Hermes should use it.",
+            "- Exact steps in order, using only reusable facts from the observed procedure.",
+            "- Pitfalls and false positives to avoid.",
+            "- Verification commands or checks when applicable.",
+            "- When not to use the skill.",
+            "",
+            "Exclude transient IDs and one-off state: PR numbers, commit SHAs, run IDs, process IDs, channel/thread/task state, branch-specific status, and temporary review or CI state.",
+            "Preserve the evidence boundary: this copied prompt is prepared_not_observed and is not proof that a Hermes skill was created.",
+        ]
+    )
+    return {
+        "schema_version": "hermes_learn_prompt/v1",
+        "status": LEARNING_CANDIDATE_STATUS,
+        "command": "/learn",
+        "copy_text": copy_text,
+        "claim_boundary": "Copy-ready prompt only; Hermes Agent /learn owns any skill creation evidence.",
+    }
+
+
+def validate_learning_candidate_card(card: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if card.get("schema_version") != LEARNING_CANDIDATE_CARD_SCHEMA_VERSION:
+        errors.append("schema_version must be learning_candidate_card/v1")
+    if card.get("status") != LEARNING_CANDIDATE_STATUS:
+        errors.append("status must be prepared_not_observed")
+    if card.get("persistence_target") not in LEARNING_CANDIDATE_TARGETS:
+        errors.append("persistence_target is unsupported")
+    scope = card.get("scope")
+    if not isinstance(scope, dict) or scope.get("schema_version") != LEARNING_CANDIDATE_SCOPE_SCHEMA_VERSION:
+        errors.append("scope must be learning_candidate_scope/v1")
+    if card.get("persistence_target") == "skill_candidate":
+        prompt = card.get("learn_prompt")
+        if not isinstance(prompt, dict) or prompt.get("command") != "/learn":
+            errors.append("skill_candidate must include a /learn prompt")
+    if "prepared_not_observed" not in str(card.get("claim_boundary", "")):
+        errors.append("claim_boundary must preserve prepared_not_observed")
+    return errors
+
+
+def _recommended_workflow(target: str) -> str:
+    if target in {"memory_candidate", "review_first"}:
+        return "memory-curation-review"
+    if target == "session_only":
+        return "oh-my-hermes"
+    return "workflow-learning"
+
+
+def _primary_action(target: str) -> str:
+    if target == "skill_candidate":
+        return "copy_learn_prompt"
+    if target in {"memory_candidate", "review_first"}:
+        return "prepare_memory_curation_review"
+    return "show_learning_candidate"
+
+
+def _available_actions(target: str) -> list[str]:
+    actions = ["show_learning_candidate", "show_status"]
+    if target == "skill_candidate":
+        actions.insert(0, "copy_learn_prompt")
+    if target in {"memory_candidate", "review_first"}:
+        actions.insert(0, "prepare_memory_curation_review")
+        actions.append("show_memory_status")
+    return actions
+
+
+def _candidate_summary(target: str, sanitized: str) -> str:
+    fact = sanitized.strip()
+    if target == "skill_candidate":
+        return _truncate(f"Reusable skill candidate from observed procedure: {fact}", 360)
+    if target == "memory_candidate":
+        return _truncate(f"Durable user preference candidate for memory review: {fact}", 360)
+    if target == "session_only":
+        return "Session-only learning signal; do not persist transient task, PR, run, process, branch, or channel state."
+    return "Review-first learning signal; cross-channel, conflicting, or underspecified context needs memory curation review before persistence."
+
+
+def _strip_learning_signal(message: str) -> str:
+    text = message.strip()
+    for phrase in sorted(_EXPLICIT_LEARN_SIGNALS, key=len, reverse=True):
+        pattern = re.compile(r"\s+".join(re.escape(part) for part in phrase.split()), re.IGNORECASE)
+        match = pattern.search(text)
+        if match is None:
+            continue
+        stripped = (text[: match.start()] + text[match.end() :]).strip(" :-\n\t")
+        return stripped or text
+    return text
+
+
+def _replacement_for_category(category: str) -> str:
+    return {
+        "channel_or_thread_ref": "channel/thread context",
+        "pull_request_number": "pull request",
+        "commit_sha": "commit",
+        "run_id": "run",
+        "process_id": "process",
+        "branch_ref": "branch",
+        "task_state_ref": "task",
+    }.get(category, "transient state")
+
+
+def _trim_trailing_one_off_state(text: str) -> str:
+    return re.sub(r"(?i)\b(?:for now|right now|only for this task|only for this run|이번만|이번 작업만)\b", "", text).strip(" .:-")
+
+
+def _contains_any(text: str, needles: Iterable[str]) -> bool:
+    return any(needle and needle in text for needle in needles)
+
+
+def _fold(text: str) -> str:
+    return " ".join(text.strip().lower().split())
+
+
+def _normalize_space(text: str) -> str:
+    return " ".join(text.replace("\n", " ").split())
+
+
+def _unique(values: Iterable[str]) -> list[str]:
+    result: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        if value not in seen:
+            result.append(value)
+            seen.add(value)
+    return result
+
+
+def _truncate(text: str, limit: int) -> str:
+    if len(text) <= limit:
+        return text
+    return text[: max(0, limit - 3)].rstrip() + "..."
+
+
+def _card_id(source: str, sanitized: str, target: str) -> str:
+    seed = "|".join((source.strip().lower(), sanitized.strip().lower(), target))
+    digest = hashlib.sha256(seed.encode("utf-8")).hexdigest()[:12]
+    return f"learning-candidate-{digest}"

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -13,6 +13,7 @@ from ..context import build_context_brief
 from ..executors import executor_label
 from ..goal_loop import build_loop_start_card
 from ..hermes_planning import build_hermes_plan_payload, is_coding_shaped_task
+from ..learning_candidate import build_learning_candidate_card
 from ..memory import memory_recall_pack_for_handoff
 from ..operator_productivity import build_agent_operator_productivity_card
 from ..paths import OmhPaths, resolve_paths
@@ -184,6 +185,8 @@ VISIBLE_ACTIONS = (
     "prepare_patch_proposal",
     "show_patch_proposal",
     "copy_patch_handoff",
+    "show_learning_candidate",
+    "copy_learn_prompt",
     "add_regression_case",
     "audit_learning_readiness",
     "export_learning_bundle",
@@ -570,6 +573,17 @@ def build_chat_interaction_payload(
     base["route"] = route_payload
     if isinstance(route_payload.get("task_card"), dict):
         base["task_card"] = route_payload["task_card"]
+    learning_candidate_card = build_learning_candidate_card(
+        message,
+        source=source,
+        source_metadata=metadata,
+        selected_workflow=str(route_payload.get("selected_skill", "")),
+        selected_harness=str(route_payload.get("selected_harness", "")),
+        thread_key=str(base["thread_key"]),
+    )
+    if learning_candidate_card:
+        base["learning_candidate_card"] = learning_candidate_card
+        route_payload["learning_candidate_card"] = learning_candidate_card
 
     if _is_omh_intro_question(message) and resolved_mode in {"route", "plan", "clarify"}:
         base["mode"] = "route"
@@ -882,6 +896,14 @@ def build_chat_response_from_route(
         if task_card and str(task_card.get("task_type", "")) != "router_design_feedback":
             return _chat_response_from_task_card(
                 task_card,
+                decision=decision,
+                thread_key=thread_key,
+                workflow_explanation_reason=workflow_explanation_reason,
+            )
+        learning_candidate_card = decision.get("learning_candidate_card")
+        if isinstance(learning_candidate_card, dict) and learning_candidate_card:
+            return _chat_response_from_learning_candidate_card(
+                learning_candidate_card,
                 decision=decision,
                 thread_key=thread_key,
                 workflow_explanation_reason=workflow_explanation_reason,
@@ -1315,6 +1337,80 @@ def _route_task_card(decision: dict[str, object]) -> dict[str, object]:
 def _task_card_state(decision: dict[str, object]) -> dict[str, object]:
     task_card = _route_task_card(decision)
     return {"task_card": task_card} if task_card else {}
+
+
+def _chat_response_from_learning_candidate_card(
+    card: dict[str, object],
+    *,
+    decision: dict[str, object],
+    thread_key: str,
+    workflow_explanation_reason: str,
+) -> dict[str, object]:
+    target = str(card.get("persistence_target", "review_first"))
+    primary_action = str(card.get("primary_action", "show_learning_candidate"))
+    summary = str(card.get("summary", "")).strip()
+    prompt = card.get("learn_prompt")
+    has_prompt = isinstance(prompt, dict) and bool(prompt.get("copy_text"))
+    if target == "skill_candidate":
+        headline = "I can prepare this for Hermes /learn."
+        body = (
+            "This is a reusable skill candidate. I prepared a sanitized copy-ready /learn prompt for Hermes Agent; "
+            "OMH has not run /learn, created a skill, or changed memory. "
+            f"Candidate: {summary}"
+        )
+    elif target == "memory_candidate":
+        headline = "I can queue this as a memory candidate."
+        body = (
+            "This looks like a durable user preference, so it should go through memory curation review before anything is saved. "
+            f"Candidate: {summary}"
+        )
+    elif target == "session_only":
+        headline = "This should stay session-only."
+        body = (
+            "The request points at transient task, PR, run, process, branch, or channel state. I will show it as a learning signal "
+            "without preparing persistence. "
+            f"Candidate: {summary}"
+        )
+    else:
+        headline = "This learning request needs review first."
+        body = (
+            "The request is ambiguous, conflicting, or cross-channel. Route it through memory curation review before persistence. "
+            f"Candidate: {summary}"
+        )
+
+    actions: list[dict[str, object]] = []
+    if has_prompt:
+        actions.append(_action("copy_learn_prompt", "Copy /learn prompt", "primary", payload=prompt))
+    actions.append(_action("show_learning_candidate", "Show candidate", "primary" if not actions else "secondary", payload=card))
+    if target in {"memory_candidate", "review_first"}:
+        actions.append(_action("prepare_memory_curation_review", "Review memory", "primary" if not has_prompt else "secondary", payload=card))
+        actions.append(_action("show_memory_status", "Show memory status", "secondary"))
+    actions.append(_action("show_status", "Show status", "secondary"))
+
+    return _chat_response(
+        kind="learning_candidate",
+        headline=headline,
+        body=body,
+        phase="learning_candidate_prepared",
+        next_action=primary_action,
+        thread_key=thread_key,
+        actions=actions,
+        claim_boundary=str(card.get("claim_boundary", "Learning candidate is prepared_not_observed.")),
+        extra_state={
+            "route_action": decision.get("action", "dispatch"),
+            "confidence": decision.get("confidence", "high"),
+            "selected_workflow": card.get("recommended_workflow", decision.get("selected_skill", "")),
+            "workflow_explanation_reason": workflow_explanation_reason,
+            "learning_candidate_card_schema": card.get("schema_version", ""),
+            "learning_candidate_target": target,
+            "learning_candidate_status": card.get("status", "prepared_not_observed"),
+            "primary_learning_action": primary_action,
+            "learning_candidate_card": card,
+            "scope": card.get("scope", {}),
+            "artifact_schemas": ["learning_candidate_card/v1", "hermes_learn_prompt/v1"],
+            "evidence_not_observed": card.get("not_observed", []),
+        },
+    )
 
 
 def _chat_response_from_task_card(
@@ -2114,6 +2210,8 @@ def _resolve_mode(mode: str, route: dict[str, object], *, message: str = "") -> 
     action = str(route.get("action", "fallback"))
     if action != "dispatch":
         return _ROUTE_TO_MODE.get(action, "clarify")
+    if isinstance(route.get("learning_candidate_card"), dict):
+        return "route"
     if isinstance(route.get("task_card"), dict):
         return "route"
     selected = str(route.get("selected_skill", ""))

--- a/tests/test_chat_router.py
+++ b/tests/test_chat_router.py
@@ -458,6 +458,110 @@ class ChatRouterTests(unittest.TestCase):
                 self.assertFalse(decision["explicit"])
                 self.assertNotEqual(decision["selected_skill"], "ultraprocess")
 
+    def test_explicit_learn_request_prepares_skill_candidate_card(self) -> None:
+        decision = route_chat_message(
+            "learn this: when opening PRs, run git diff --check before gh pr create",
+            source="discord",
+        )
+        card = decision["learning_candidate_card"]
+        prompt = card["learn_prompt"]["copy_text"]
+
+        self.assertEqual(decision["action"], "dispatch")
+        self.assertEqual(decision["selected_skill"], "workflow-learning")
+        self.assertEqual(card["schema_version"], "learning_candidate_card/v1")
+        self.assertEqual(card["status"], "prepared_not_observed")
+        self.assertEqual(card["persistence_target"], "skill_candidate")
+        self.assertEqual(card["primary_action"], "copy_learn_prompt")
+        self.assertIn("/learn", prompt)
+        self.assertIn("Use observed facts only", prompt)
+        self.assertIn("reusable Hermes skill", prompt)
+        self.assertIn("Trigger conditions", prompt)
+        self.assertIn("Exact steps", prompt)
+        self.assertIn("Pitfalls", prompt)
+        self.assertIn("Verification commands", prompt)
+        self.assertIn("When not to use", prompt)
+        self.assertIn("prepared_not_observed", card["claim_boundary"])
+        self.assertIn("skill creation", card["not_observed"])
+        self.assertIn("memory write", card["not_observed"])
+
+    def test_user_correction_becomes_memory_candidate_not_skill_prompt(self) -> None:
+        decision = route_chat_message("다음부터 이렇게 답해줘: 짧게 한국어로 요약해", source="discord")
+        card = decision["learning_candidate_card"]
+
+        self.assertEqual(decision["action"], "dispatch")
+        self.assertEqual(decision["selected_skill"], "memory-curation-review")
+        self.assertEqual(card["persistence_target"], "memory_candidate")
+        self.assertEqual(card["primary_action"], "prepare_memory_curation_review")
+        self.assertEqual(card["review"]["review_workflow"], "memory-curation-review")
+        self.assertNotIn("learn_prompt", card)
+        self.assertIn("Durable user preference", card["summary"])
+
+    def test_learning_classification_separates_memory_skill_and_session_state(self) -> None:
+        skill = route_chat_message(
+            "이 패턴 기억해: after CI fails, run gh pr checks --watch before pushing fixes",
+            source="discord",
+        )["learning_candidate_card"]
+        memory = route_chat_message(
+            "from now on prefer concise Korean final summaries",
+            source="discord",
+        )["learning_candidate_card"]
+        session = route_chat_message("learn this: PR #123 is blocked on CI", source="discord")["learning_candidate_card"]
+
+        self.assertEqual(skill["persistence_target"], "skill_candidate")
+        self.assertIn("learn_prompt", skill)
+        self.assertEqual(memory["persistence_target"], "memory_candidate")
+        self.assertNotIn("learn_prompt", memory)
+        self.assertEqual(session["persistence_target"], "session_only")
+        self.assertNotIn("learn_prompt", session)
+
+    def test_learning_channel_term_collision_routes_to_review_first(self) -> None:
+        decision = route_chat_message(
+            "in channel #ops, learn this pattern from PR #123 for the other thread",
+            source="discord",
+        )
+        card = decision["learning_candidate_card"]
+        serialized = json.dumps(card)
+
+        self.assertEqual(decision["selected_skill"], "memory-curation-review")
+        self.assertEqual(card["persistence_target"], "review_first")
+        self.assertEqual(card["primary_action"], "prepare_memory_curation_review")
+        self.assertIn("channel_or_thread_ref", card["sanitization"]["transient_identifier_categories"])
+        self.assertIn("pull_request_number", card["sanitization"]["transient_identifier_categories"])
+        self.assertNotIn("#ops", serialized)
+        self.assertNotIn("#123", serialized)
+
+    def test_learning_candidate_excludes_transient_pr_state_from_summary_and_prompt(self) -> None:
+        message = (
+            "make a skill from this: for PR #123 on commit abcdef123456 and run_abc123def456 "
+            "with pid 9876, run git diff --check before gh pr create"
+        )
+
+        card = route_chat_message(message, source="discord")["learning_candidate_card"]
+        serialized = json.dumps(card)
+
+        self.assertEqual(card["persistence_target"], "skill_candidate")
+        self.assertIn("pull_request_number", card["sanitization"]["transient_identifier_categories"])
+        self.assertIn("commit_sha", card["sanitization"]["transient_identifier_categories"])
+        self.assertIn("run_id", card["sanitization"]["transient_identifier_categories"])
+        self.assertIn("process_id", card["sanitization"]["transient_identifier_categories"])
+        self.assertNotIn("#123", serialized)
+        self.assertNotIn("abcdef123456", serialized)
+        self.assertNotIn("run_abc123def456", serialized)
+        self.assertNotIn("9876", serialized)
+        self.assertIn("git diff --check", card["learn_prompt"]["copy_text"])
+
+    def test_skill_forcing_transient_only_request_stays_session_only(self) -> None:
+        card = route_chat_message("make a skill from this: PR #123 is blocked on CI", source="discord")[
+            "learning_candidate_card"
+        ]
+        serialized = json.dumps(card)
+
+        self.assertEqual(card["persistence_target"], "session_only")
+        self.assertEqual(card["primary_action"], "show_learning_candidate")
+        self.assertNotIn("learn_prompt", card)
+        self.assertNotIn("#123", serialized)
+        self.assertIn("do not persist transient task", card["summary"])
+
     def test_pasted_omh_awareness_evaluation_routes_learning_before_delivery(self) -> None:
         message = sionic_omh_usage_evaluation_prompt()
 

--- a/tests/test_wrapper_contract.py
+++ b/tests/test_wrapper_contract.py
@@ -551,6 +551,79 @@ class WrapperContractTests(unittest.TestCase):
                 self.assertIn("automatic skill patch", response["state"]["evidence_not_observed"])
                 self.assertNotIn(message, serialized)
 
+    def test_chat_interaction_renders_learning_candidate_card_with_learn_prompt(self) -> None:
+        message = (
+            "make a skill from this: for PR #123 on commit abcdef123456 and run_abc123def456, "
+            "run git diff --check before gh pr create"
+        )
+
+        payload = build_chat_interaction_payload(
+            message,
+            source="discord",
+            source_metadata={
+                "project_ref": "omhm",
+                "channel_ref": "C-learning",
+                "thread_ref": "T-learning",
+                "target_ref": "hermes-agent",
+                "workflow_ref": "workflow-learning",
+                "executor_ref": "codex",
+            },
+        )
+        response = payload["chat_response"]
+        card = payload["learning_candidate_card"]
+        actions = {action["id"]: action for action in response["actions"]}
+        serialized = json.dumps(payload)
+
+        self.assertEqual(payload["mode"], "route")
+        self.assertEqual(payload["next_action"], "copy_learn_prompt")
+        self.assertEqual(response["kind"], "learning_candidate")
+        self.assertEqual(card["schema_version"], "learning_candidate_card/v1")
+        self.assertEqual(card["persistence_target"], "skill_candidate")
+        self.assertEqual(card["scope"]["project_ref"], "omhm")
+        self.assertEqual(card["scope"]["channel_ref"], "C-learning")
+        self.assertEqual(card["scope"]["thread_ref"], "T-learning")
+        self.assertEqual(card["scope"]["target_ref"], "hermes-agent")
+        self.assertEqual(card["scope"]["workflow"], "workflow-learning")
+        self.assertEqual(card["scope"]["executor_runtime"], "codex")
+        self.assertEqual(response["state"]["learning_candidate_status"], "prepared_not_observed")
+        self.assertIn("prepared_not_observed", response["claim_boundary"])
+        self.assertIn("copy_learn_prompt", actions)
+        self.assertEqual(actions["copy_learn_prompt"]["payload"]["command"], "/learn")
+        self.assertIn("Use observed facts only", actions["copy_learn_prompt"]["payload"]["copy_text"])
+        self.assertIn("reusable Hermes skill", actions["copy_learn_prompt"]["payload"]["copy_text"])
+        self.assertNotIn("#123", serialized)
+        self.assertNotIn("abcdef123456", serialized)
+        self.assertNotIn("run_abc123def456", serialized)
+
+    def test_chat_interaction_memory_candidate_uses_review_action_without_learn_prompt(self) -> None:
+        payload = build_chat_interaction_payload(
+            "다음부터 이렇게 답해줘: 짧게 한국어로 요약해",
+            source="discord",
+        )
+        response = payload["chat_response"]
+        actions = {action["id"]: action for action in response["actions"]}
+        card = payload["learning_candidate_card"]
+
+        self.assertEqual(payload["mode"], "route")
+        self.assertEqual(payload["next_action"], "prepare_memory_curation_review")
+        self.assertEqual(response["kind"], "learning_candidate")
+        self.assertEqual(card["persistence_target"], "memory_candidate")
+        self.assertNotIn("learn_prompt", card)
+        self.assertNotIn("copy_learn_prompt", actions)
+        self.assertIn("prepare_memory_curation_review", actions)
+        self.assertIn("memory curation review", response["body"])
+
+    def test_learning_candidate_scope_does_not_treat_agent_ref_as_executor_runtime(self) -> None:
+        payload = build_chat_interaction_payload(
+            "learn this: when opening PRs, run git diff --check before gh pr create",
+            source="discord",
+            source_metadata={"agent_ref": "hermes-chat-target"},
+        )
+
+        card = payload["learning_candidate_card"]
+
+        self.assertEqual(card["scope"]["executor_runtime"], "")
+
     def test_route_mode_exposes_visible_omh_usage_trace_for_web_research(self) -> None:
         payload = build_chat_interaction_payload(
             "web-research로 Hermes Agent와 Oh My Codex/OpenCode 계열을 비교해서 OMHM 포지셔닝 근거를 찾아줘.",


### PR DESCRIPTION
## Summary

Adds OMH learning candidate cards around Hermes Agent `/learn` without reimplementing `/learn` itself. OMH now detects explicit learning requests, classifies the persistence target, and prepares a scoped, sanitized, copy-ready `/learn` prompt only when the request is a reusable skill candidate.

## Motivation

Hermes Agent already owns the actual `/learn` skill-distillation flow. The product gap in OMH was earlier in the loop: deciding whether a user correction or workflow pattern should become a skill, a memory candidate, session-only context, or a review-first memory-curation item. Without that layer, transient PR/run/channel details can leak into durable learning, and cross-channel term collisions can be over-persisted.

## What changed

- Added `learning_candidate_card/v1` and `hermes_learn_prompt/v1` payload builders.
- Routed explicit learning signals such as `/learn`, `learn this`, `make a skill from this`, `다음부터`, `이걸 학습해`, and `스킬로 남겨` into a reviewable card.
- Classifies learning requests as:
  - `skill_candidate` for reusable procedures/workflows/runbooks/tooling steps.
  - `memory_candidate` for durable user preferences.
  - `session_only` for transient PR/run/process/branch/task state.
  - `review_first` for ambiguous, conflicting, or cross-channel context.
- Adds scope metadata from wrapper ingress where available: project, channel, thread, target, workflow, executor/runtime.
- Sanitizes card summaries and `/learn` prompts to remove PR numbers, commit SHAs, run IDs, process IDs, branch refs, and one-off channel/task state.
- Surfaces wrapper actions `show_learning_candidate` and `copy_learn_prompt` while keeping the evidence boundary explicit.

## Boundary

This PR does not run Hermes `/learn`, create skills, mutate memory, add a learning ledger, or claim future behavior has changed. Cards and prompts remain `prepared_not_observed` until Hermes Agent or a user actually runs `/learn` and approves any resulting skill write.

## Verification

Observed locally:

- `PYTHONPATH=tests uv run python -m unittest tests.test_chat_router tests.test_wrapper_contract -v`
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- `uv run python -m compileall -q src tests`
- `uv run python -m omh.cli docs workflows --check`
- `git diff --check`
- `printf '%s\n' '다음부터 이 PR QA 절차는 스킬로 남겨' | uv run python -m omh.cli chat interact --source discord --stdin --limit 3`
  - Observed `learning_candidate_card/v1`, `hermes_learn_prompt/v1`, `copy_learn_prompt`, `prepared_not_observed`, and messenger-safe rendering metadata.

Observed on GitHub PR checks:

- DCO: PASS
- CI `test (3.11)`: PASS
- CI `test (3.12)`: PASS

## Risks / follow-up

- The CLI/wrapper rendering path is dogfooded, but a live Discord adapter button/action rendering pass is still not observed in a running gateway surface.
- The heavier `.omh/learning` ledger idea is intentionally excluded from this A+B PR.
