### PR TITLE
Tighten routed workflow precedence

### DIFF
--- a/src/routing/policy.py
+++ b/src/routing/policy.py
@@ -438,8 +438,10 @@ _VISUAL_SUMMARY_MODALITY_TOKENS = _normalized_token_set(
         "圖片",
         "图片",
     }
-)
-_VISUAL_SUMMARY_CARD_TOKENS = _normalized_token_set({"card", "poster", "one-pager", "카드", "포스터", "海报", "海報"})
+) - {"one", "pager"}
+_VISUAL_SUMMARY_CARD_TOKENS = _normalized_token_set(
+    {"card", "poster", "one-pager", "카드", "포스터", "海报", "海報"}
+) - {"one", "pager"}
 _VISUAL_SUMMARY_CAPABILITY_TOKENS = _normalized_token_set(
     {
         "support",
@@ -1434,6 +1436,13 @@ _CODING_HANDOFF_PHRASES = (
     "진행 상태 추적",
 )
 _SCHEDULED_OPS_PHRASES = (
+    "automation blueprint",
+    "scheduled ops blueprint",
+    "ops blueprint",
+    "cron blueprint",
+    "schedule blueprint",
+    "hermes cron spec",
+    "cron spec",
     "every morning",
     "every day",
     "every week",
@@ -1450,6 +1459,15 @@ _SCHEDULED_OPS_PHRASES = (
     "변화 없으면",
     "바뀐 게 없으면",
     "조용히",
+)
+_EXPLICIT_SCHEDULED_OPS_BLUEPRINT_PHRASES = (
+    "automation blueprint",
+    "scheduled ops blueprint",
+    "ops blueprint",
+    "cron blueprint",
+    "schedule blueprint",
+    "hermes cron spec",
+    "cron spec",
 )
 _ONE_OFF_TOKENS = _normalized_token_set(
     {
@@ -1791,17 +1809,21 @@ def active_routing_guard_rules(
     )
     if paper_learning_applies:
         rules.append(PAPER_LEARNING_GUARD)
+    scheduled_ops_blueprint_applies = (
+        not delivery_cycle_applies and _scheduled_ops_blueprint_guard_applies(normalized_query, query_tokens)
+    )
+    explicit_scheduled_ops_blueprint = _explicit_scheduled_ops_blueprint_requested(normalized_query, query_tokens)
     research_department_applies = (
         not delivery_cycle_applies
         and not paper_learning_applies
+        and not explicit_scheduled_ops_blueprint
         and _research_department_guard_applies(normalized_query, query_tokens)
     )
     if research_department_applies:
         rules.append(RESEARCH_DEPARTMENT_GUARD)
     if (
-        not delivery_cycle_applies
-        and _scheduled_ops_blueprint_guard_applies(normalized_query, query_tokens)
-        and not research_department_applies
+        scheduled_ops_blueprint_applies
+        and (explicit_scheduled_ops_blueprint or not research_department_applies)
     ):
         rules.append(SCHEDULED_OPS_BLUEPRINT_GUARD)
     source_finder_applies = (
@@ -1891,6 +1913,16 @@ def _scheduled_ops_blueprint_guard_applies(normalized_query: str, query_tokens: 
     if _SCHEDULED_OPS_CADENCE_TOKENS & query_tokens and _SCHEDULED_OPS_CONTEXT_TOKENS & query_tokens:
         return True
     return _contains_phrase(normalized_query, _SCHEDULED_OPS_PHRASES)
+
+
+def _explicit_scheduled_ops_blueprint_requested(normalized_query: str, query_tokens: set[str]) -> bool:
+    if _contains_phrase(normalized_query, _EXPLICIT_SCHEDULED_OPS_BLUEPRINT_PHRASES):
+        return True
+    blueprint = "blueprint" in query_tokens
+    scheduled_context = bool(_SCHEDULED_OPS_STRONG_TOKENS & query_tokens) or bool(
+        _SCHEDULED_OPS_CADENCE_TOKENS & query_tokens
+    )
+    return blueprint and scheduled_context
 
 
 def _paper_learning_guard_applies(normalized_query: str, query_tokens: set[str]) -> bool:
@@ -2217,6 +2249,8 @@ def _coding_progress_status_guard_applies(normalized_query: str, query_tokens: s
 
 
 def _release_claim_review_guard_applies(normalized_query: str, query_tokens: set[str]) -> bool:
+    if _reliability_review_context_applies(normalized_query, query_tokens):
+        return False
     if _contains_phrase(normalized_query, _RELEASE_CLAIM_REVIEW_PHRASES):
         return True
     review_intent = bool(_RELEASE_CLAIM_REVIEW_TOKENS & query_tokens)
@@ -2226,6 +2260,22 @@ def _release_claim_review_guard_applies(normalized_query: str, query_tokens: set
     )
     compare_or_verify = _contains_phrase(normalized_query, ("match", "matches", "verify", "review", "맞는지", "검토", "통과"))
     return review_intent and claim_or_release and compare_or_verify
+
+
+def _reliability_review_context_applies(normalized_query: str, query_tokens: set[str]) -> bool:
+    reliability = bool({"reliability", "slo", "postmortem", "incident"} & query_tokens) or _contains_phrase(
+        normalized_query,
+        (
+            "reliability review",
+            "service reliability",
+            "slo review",
+            "incident review",
+            "incident postmortem",
+            "error budget",
+        ),
+    )
+    review = bool({"review", "check", "검토"} & query_tokens)
+    return reliability and review
 
 
 def _executor_runtime_readiness_guard_applies(normalized_query: str, query_tokens: set[str]) -> bool:

--- a/tests/test_chat_router.py
+++ b/tests/test_chat_router.py
@@ -104,6 +104,11 @@ class ChatRouterTests(unittest.TestCase):
                 "reliability-review",
             ),
             (
+                "Can OMH run a release reliability review before launch?",
+                "reliability-review",
+                "reliability-review",
+            ),
+            (
                 "엑셀 매출 리포트를 PDF로 만들고 렌더 QA까지 준비해줘",
                 "materials-package",
                 "materials-package",
@@ -112,6 +117,11 @@ class ChatRouterTests(unittest.TestCase):
                 "every morning check competitor news and send a Slack digest only if something changed",
                 "research-department",
                 "research-department",
+            ),
+            (
+                "Can OMH make an automation blueprint for a daily research digest?",
+                "automation-blueprint",
+                "scheduled-ops-blueprint",
             ),
         )
 
@@ -765,6 +775,7 @@ selected_workflow=ultraprocess
             "codex로 이 기능 구현 맡겨줘",
             "이 이슈를 Codex로 구현하게 맡기고 진행상태 추적해줘",
             "$ultraprocess로 이 repo 변경을 PR-ready까지 준비해줘",
+            "Can OMH do one full research plan implementation review cycle?",
         )
 
         for message in cases:


### PR DESCRIPTION
## Feature Report

### What Changed

- Tightens three chat-first routing collisions found by live route probes:
  - Explicit “automation blueprint” requests now route to `automation-blueprint` even when the request also mentions recurring research.
  - “Release reliability review” requests now stay on `reliability-review` instead of being pulled into `code-review` by release/review wording.
  - One-cycle delivery requests such as “one full research plan implementation review cycle” now route to `ultraprocess` instead of `img-summary`.

### Why This Exists

- The previous router behavior was technically deterministic but felt surprising to an operator asking natural capability questions.
- `one-pager` visual support leaked a bare `one` token into visual-summary modality matching, so ordinary “one full cycle” wording looked like image work.
- Recurring research and scheduled automation intentionally overlap, but an explicit blueprint request should respect the user's named surface.

### User / Operator Impact

- Hermes can answer “Can OMH make an automation blueprint for a daily research digest?” with the scheduled ops blueprint workflow instead of a research department lane.
- Hermes can answer “Can OMH run a release reliability review before launch?” with a reliability review card.
- Hermes can answer “Can OMH do one full research plan implementation review cycle?” with the one-cycle delivery lane.
- Visual requests like “one-page visual card” still route to `img-summary`.

### How It Works

- `src/routing/policy.py` adds an explicit scheduled blueprint detector and lets it override recurring research-department precedence only when the user names the blueprint surface.
- `src/routing/policy.py` excludes reliability-review context from the release-claim code-review guard.
- `src/routing/policy.py` removes bare `one` and `pager` from visual token sets while preserving explicit one-pager phrases.
- `tests/test_chat_router.py` adds regression prompts for the three corrected collisions.

### Files And Contracts Touched

- `src/routing/policy.py`: guard precedence and visual token boundaries.
- `tests/test_chat_router.py`: regression coverage for scheduled ops, reliability review, and one-cycle delivery.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_chat_router.py tests/test_efficiency.py tests/test_wrapper_contract.py tests/test_router_content.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli harness validate`
- [x] `git diff --check`
- [x] Route probe benchmark: 400 `route_chat_message` calls at 2.28 ms/call.
- [ ] `python3 -m omh.cli release checklist --json` — not run; no release packaging changed.
- [ ] `python3 -m omh.cli release hermes-smoke` — not run; no live Hermes registration behavior changed.
- [ ] `omh --help` — not run; no command surface changed.
- [ ] Manual Hermes/TUI check: not run; deterministic router and wrapper contracts were covered by unit tests.

## Risk

- Low. This is policy-only routing logic with regression tests.
- The scheduled ops change is deliberately narrow: generic recurring competitor/news monitoring still routes to `research-department`; explicit blueprint requests route to `automation-blueprint`.
- The visual-token change removes only bare `one`/`pager`; explicit visual phrases remain covered.

## Compatibility / Rollout

- Backward compatible with existing payload schemas and wrapper contracts.
- No command, setup, plugin, runtime artifact, or generated docs contract changed.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`): router behavior improves when released.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed: no runtime claims added.
- [x] Known manual Hermes checks are listed: live Hermes/TUI check not run because this PR changes deterministic routing policy only.

## Follow-Up

- Continue adding route-probe regressions from real chat transcripts where users ask what OMH can do instead of invoking skills directly.
