### PR TITLE
Tighten operator surface routing

### DIFF
--- a/src/routing/policy.py
+++ b/src/routing/policy.py
@@ -895,6 +895,11 @@ _EXECUTOR_RUNTIME_READINESS_PHRASES = (
     "runtime readiness",
     "codex readiness",
     "claude code readiness",
+    "can this task run in codex",
+    "can this run in codex",
+    "can this run in claude",
+    "run in codex or claude",
+    "run in codex, claude",
     "codex or claude",
     "codex and claude",
     "codex vs claude",
@@ -1048,6 +1053,9 @@ _AGENT_BOARD_PHRASES = (
     "multi agent board",
     "multiple hermes agents",
     "multiple hermes profiles",
+    "coordinate pm cto qa",
+    "coordinate pm cto qa and release agents",
+    "coordinate release agents",
     "roles and board",
     "role board",
     "task board",
@@ -1174,6 +1182,11 @@ _VOICE_OPERATOR_PHRASES = (
     "voice operator",
     "voice-first",
     "mobile command",
+    "from mobile",
+    "on mobile",
+    "from phone",
+    "mobile request",
+    "mobile note",
     "spoken request",
     "short voice",
     "hands free",
@@ -1676,6 +1689,15 @@ RELEASE_CLAIM_REVIEW_GUARD = RoutingGuardRule(
     why="Matched guard/trigger metadata; release claim checks need review boundaries instead of plain file lookup.",
     activation_status="active",
 )
+DOCTOR_HEALTH_GUARD = RoutingGuardRule(
+    id="doctor_health_before_skill_catalog",
+    rule="OMH install, setup, update, stale skill, or registration health confusion should route to doctor.",
+    matched_label="guard:doctor_health",
+    preferred_skills=("doctor",),
+    score_boost=30,
+    why="Matched guard/trigger metadata; setup/update health confusion should run diagnostics before skill catalog management.",
+    activation_status="active",
+)
 VOICE_OPERATOR_GUARD = RoutingGuardRule(
     id="voice_operator_before_generic_clarification",
     rule="Voice, mobile, or terse accessibility-sensitive requests should route to voice-operator before generic clarification.",
@@ -1749,6 +1771,7 @@ ROUTING_GUARD_RULES = (
     AGENT_BOARD_GUARD,
     CODING_PROGRESS_STATUS_GUARD,
     RELEASE_CLAIM_REVIEW_GUARD,
+    DOCTOR_HEALTH_GUARD,
     EXECUTOR_RUNTIME_READINESS_GUARD,
     VOICE_OPERATOR_GUARD,
     VISUAL_SUMMARY_GUARD,
@@ -1842,7 +1865,12 @@ def active_routing_guard_rules(
         rules.append(MISSED_WORKFLOW_WEB_RESEARCH_GUARD)
     if _github_event_ops_guard_applies(normalized_query, query_tokens):
         rules.append(GITHUB_EVENT_OPS_GUARD)
-    if _materials_package_guard_applies(normalized_query, query_tokens) and not paper_learning_applies:
+    deliverable_package_applies = _deliverable_package_guard_applies(normalized_query, query_tokens)
+    if (
+        _materials_package_guard_applies(normalized_query, query_tokens)
+        and not paper_learning_applies
+        and not deliverable_package_applies
+    ):
         rules.append(MATERIALS_PACKAGE_GUARD)
     if _memory_curation_guard_applies(normalized_query, query_tokens):
         rules.append(MEMORY_CURATION_GUARD)
@@ -1852,13 +1880,15 @@ def active_routing_guard_rules(
         rules.append(CODING_PROGRESS_STATUS_GUARD)
     if _release_claim_review_guard_applies(normalized_query, query_tokens):
         rules.append(RELEASE_CLAIM_REVIEW_GUARD)
+    if _doctor_health_guard_applies(normalized_query, query_tokens):
+        rules.append(DOCTOR_HEALTH_GUARD)
     if _executor_runtime_readiness_guard_applies(normalized_query, query_tokens):
         rules.append(EXECUTOR_RUNTIME_READINESS_GUARD)
     if _voice_operator_guard_applies(normalized_query, query_tokens):
         rules.append(VOICE_OPERATOR_GUARD)
     if _visual_summary_guard_applies(normalized_query, query_tokens):
         rules.append(VISUAL_SUMMARY_GUARD)
-    if _deliverable_package_guard_applies(normalized_query, query_tokens):
+    if deliverable_package_applies:
         rules.append(DELIVERABLE_PACKAGE_GUARD)
     if _coding_handoff_status_guard_applies(normalized_query, query_tokens):
         rules.append(CODING_HANDOFF_STATUS_GUARD)
@@ -2231,7 +2261,10 @@ def _agent_board_guard_applies(normalized_query: str, query_tokens: set[str]) ->
     )
     board_or_roles = bool({"board", "kanban", "role", "roles", "보드", "역할", "칸반"} & query_tokens)
     team_context = bool(_AGENT_BOARD_CONTEXT_TOKENS & query_tokens)
-    return team_context and multi_agent and board_or_roles
+    coordination = bool({"coordinate", "assign", "handoff", "route", "조율", "배정", "분배"} & query_tokens)
+    named_roles = len({"pm", "cto", "qa", "security", "ops", "release"} & query_tokens) >= 2
+    agents = bool({"agent", "agents", "에이전트"} & query_tokens)
+    return (team_context and multi_agent and board_or_roles) or (coordination and agents and named_roles)
 
 
 def _coding_progress_status_guard_applies(normalized_query: str, query_tokens: set[str]) -> bool:
@@ -2260,6 +2293,81 @@ def _release_claim_review_guard_applies(normalized_query: str, query_tokens: set
     )
     compare_or_verify = _contains_phrase(normalized_query, ("match", "matches", "verify", "review", "맞는지", "검토", "통과"))
     return review_intent and claim_or_release and compare_or_verify
+
+
+def _doctor_health_guard_applies(normalized_query: str, query_tokens: set[str]) -> bool:
+    code_change_context = {"implementation", "router"} & query_tokens and {
+        "fix",
+        "code",
+        "change",
+        "수정",
+        "구현",
+    } & query_tokens
+    if code_change_context:
+        return False
+    if _contains_phrase(
+        normalized_query,
+        (
+            "after omh update",
+            "omh update says setup",
+            "setup is next",
+            "skills still look stale",
+            "skills look stale",
+            "hermes skills still",
+            "install looks broken",
+            "setup looks broken",
+            "registration looks broken",
+            "omh가 이상",
+            "설치가 이상",
+            "셋업이 이상",
+            "스킬이 안 보여",
+            "스킬이 stale",
+        ),
+    ):
+        return True
+    omh_context = _contains_phrase(normalized_query, ("omh", "oh-my-hermes", "oh my hermes", "hermes skills"))
+    maintenance = bool(
+        {
+            "install",
+            "setup",
+            "update",
+            "doctor",
+            "health",
+            "registration",
+            "stale",
+            "skills",
+            "path",
+            "설치",
+            "셋업",
+            "업데이트",
+            "닥터",
+            "스킬",
+            "등록",
+            "상태",
+        }
+        & query_tokens
+    )
+    confusion = _contains_phrase(
+        normalized_query,
+        (
+            "still",
+            "stale",
+            "missing",
+            "not found",
+            "broken",
+            "doesn't work",
+            "not working",
+            "says setup",
+            "look stale",
+            "looks stale",
+            "안 보여",
+            "안됨",
+            "안 돼",
+            "이상",
+            "깨짐",
+        ),
+    )
+    return omh_context and maintenance and confusion
 
 
 def _reliability_review_context_applies(normalized_query: str, query_tokens: set[str]) -> bool:
@@ -2293,13 +2401,29 @@ def _executor_runtime_readiness_guard_applies(normalized_query: str, query_token
         normalized_query,
         ("which", "choose", "compare", "vs", "중 어떤", "어떤", "골라", "선택", "정해", "할까", "넘길지"),
     )
-    return runtime_intent and named_executor and selection
+    run_capability = _contains_phrase(
+        normalized_query,
+        (
+            "can this task run",
+            "can this run",
+            "run in codex",
+            "run in claude",
+            "run with codex",
+            "run with claude",
+        ),
+    )
+    return runtime_intent and named_executor and (selection or run_capability)
 
 
 def _voice_operator_guard_applies(normalized_query: str, query_tokens: set[str]) -> bool:
     if _contains_phrase(normalized_query, _VOICE_OPERATOR_PHRASES):
         return True
     if _VOICE_OPERATOR_TOKENS & query_tokens and _CAPABILITY_INTENT_TOKENS & query_tokens:
+        return True
+    if _VOICE_OPERATOR_TOKENS & query_tokens and _contains_phrase(
+        normalized_query,
+        ("from mobile", "on mobile", "from phone", "mobile request", "mobile note"),
+    ):
         return True
     return bool(_VOICE_OPERATOR_TOKENS & query_tokens) and _contains_phrase(
         normalized_query,

--- a/tests/test_chat_router.py
+++ b/tests/test_chat_router.py
@@ -134,6 +134,40 @@ class ChatRouterTests(unittest.TestCase):
                 self.assertEqual(decision["selected_harness"], harness)
                 self.assertEqual(decision["confidence"], "high")
 
+    def test_operator_surface_good_examples_route_without_skill_names(self) -> None:
+        cases = (
+            (
+                "can this task run in Codex, Claude Code, or Hermes coding?",
+                "executor-runtime-readiness",
+            ),
+            (
+                "coordinate PM, CTO, QA, and release agents on this launch checklist.",
+                "agent-board",
+            ),
+            (
+                "release before lunch, check risky parts from mobile.",
+                "voice-operator",
+            ),
+            (
+                "turn this research into PPT and PDF with attachment status.",
+                "deliverable-package",
+            ),
+            (
+                "after omh update says setup is next but Hermes skills still look stale.",
+                "doctor",
+            ),
+        )
+
+        for message, skill in cases:
+            with self.subTest(message=message):
+                decision = route_chat_message(message, source="discord")
+
+                self.assertEqual(decision["action"], "dispatch")
+                self.assertEqual(decision["selected_skill"], skill)
+                self.assertEqual(decision["selected_harness"], primary_harness_for_skill(skill))
+                self.assertEqual(decision["recommendations"][0]["skill"], skill)
+                self.assertEqual(decision["confidence"], "high")
+
     def test_visual_summary_chat_dispatches_to_img_summary(self) -> None:
         cases = (
             "이미지 요약 카드 만들어줘",
@@ -403,6 +437,8 @@ class ChatRouterTests(unittest.TestCase):
 
         self.assertIsNone(decision["task_card"])
         self.assertNotIn("task_card:omh_cli_maintenance", decision["recommendations"][0]["matched"])
+        self.assertNotEqual(decision["selected_skill"], "doctor")
+        self.assertNotIn("guard:doctor_health", decision["recommendations"][0]["matched"])
 
         explanation = route_chat_message("omh update 설명해줘", source="discord")
         self.assertIsNone(explanation["task_card"])


### PR DESCRIPTION
## Feature Report

### What Changed

- Tightened natural-language routing for operator-facing OMH surfaces that were still losing to nearby generic workflows.
- Added deterministic coverage for executor runtime readiness, agent board coordination, voice/mobile requests, deliverable attachment status, and OMH install/update health confusion.
- Added regression tests that lock these phrases without requiring users to type exact skill names.

### Why This Exists

Hermes users usually ask in chat, not by memorizing every OMH skill name. Recent routing probes showed several good operator examples still landed on adjacent surfaces: executor/runtime questions could become generic `ask`, PM/CTO/QA coordination could become `cto-loop`, mobile requests could become cleanup, deliverable status could become plain materials packaging, and stale update/setup confusion could become skill catalog handling.

### User / Operator Impact

After this change, a user can ask natural questions such as:

- `can this task run in Codex, Claude Code, or Hermes coding?` -> `executor-runtime-readiness`
- `coordinate PM, CTO, QA, and release agents on this launch checklist` -> `agent-board`
- `release before lunch, check risky parts from mobile` -> `voice-operator`
- `turn this research into PPT and PDF with attachment status` -> `deliverable-package`
- `after omh update says setup is next but Hermes skills still look stale` -> `doctor`

The router still preserves the opposite boundary: `fix the omh update router implementation` stays implementation-oriented and is not swallowed by diagnostics.

### How It Works

- `src/routing/policy.py` adds narrow guard phrases and semantic checks for the five operator surfaces.
- `deliverable-package` now wins over `materials-package` only when delivery or attachment status is part of the request.
- A new doctor-health guard captures install/setup/update/stale-skill confusion while explicitly avoiding router implementation requests.
- `tests/test_chat_router.py` adds regression coverage for the natural operator examples and the doctor false-positive boundary.

### Files And Contracts Touched

- `src/routing/policy.py`
- `tests/test_chat_router.py`

No schema, artifact, plugin, or runtime execution contract changed. Routing remains advisory metadata and does not claim execution, review, CI, or merge evidence.

## Validation

Observed locally:

- `PYTHONPATH=tests uv run python -m unittest tests/test_chat_router.py tests/test_efficiency.py tests/test_wrapper_contract.py tests/test_router_content.py -v` -> 159 tests passed
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` -> 857 tests passed
- `uv run python -m compileall -q src tests` -> passed
- `uv run python -m omh.cli docs workflows --check` -> passed
- `uv run python -m omh.cli harness validate` -> passed
- `git diff --check` -> passed
- Focused routing probe confirmed all five corrected examples select the intended workflow.
- Routing speed sample: 400 route calls in 1.0577s, about 2.64 ms/call.

## Risk

The main risk is over-routing maintenance or coordination wording. The added conditions are intentionally narrow and include a regression that keeps code-change requests out of `doctor`.

## Compatibility / Rollout

Backward compatible. Existing explicit skill invocations and existing chat routes continue to work; this only strengthens natural-language selection for already-supported surfaces.

## Release / Claims

This PR improves deterministic chat routing. It does not add runtime execution, live messenger rendering, platform transport, or new evidence claims.

## Follow-Up

Continue probing representative catalog examples and real Hermes chat transcripts for adjacent-surface misses, especially where one request can reasonably map to both packaging and delivery workflows.