### PR TITLE
Polish workflow catalog routing examples

### DIFF
--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -96,9 +96,9 @@ When wrapper metadata reports `omh_target_topology/v1`, skills bind workflow sta
   - The user needs implementation, review, CI, merge, or external publishing evidence that has not been delegated or observed.
 - Strong routing signals: `ralph`, `$ralph`, `finish until done`, `persistent execution`, `self-referential loop`
 - Good example:
-  - Prompt: ralph: handle a execution request that needs explicit evidence boundaries and a clear stop condition.
-  - Expected behavior: Run `ralph` only after naming the target, evidence boundary, and stop condition.
-  - Why: The request matches the catalog use case and keeps observed evidence separate from prepared guidance.
+  - Prompt: ralph: finish the invoice export recovery until the smoke test passes or a blocker is recorded.
+  - Expected behavior: Keep one completion owner, track evidence after every recovery step, and stop only on pass, block, or explicit cancel.
+  - Why: The request needs persistent completion pressure with an observable stop condition.
 - Bad example:
   - Prompt: ralph: treat casual chat or unaccepted work as if this workflow already produced verified results.
   - Expected behavior: Ask a clarification question or route to a narrower workflow instead of forcing `ralph`.
@@ -151,7 +151,7 @@ When wrapper metadata reports `omh_target_topology/v1`, skills bind workflow sta
   - The user expects hidden Hermes code execution rather than explicit executor handoff and observed verification evidence.
 - Strong routing signals: `ultragoal`, `$ultragoal`, `durable goal`, `multi-goal`, `goal ledger`
 - Good example:
-  - Prompt: $ultragoal add per-skill quality rubrics, regenerate skills, test, and open a PR.
+  - Prompt: $ultragoal turn OMH skill quality into a durable goal with rubrics, generated skill sync, tests, and a PR gate.
   - Expected behavior: Create or update a goal ledger, split the story into verifiable checkpoints, and close only after generated docs, skills, and tests match.
   - Why: The task has multiple milestones and a final quality gate that should be inspectable across interruptions.
 - Bad example:
@@ -376,7 +376,7 @@ When wrapper metadata reports `omh_target_topology/v1`, skills bind workflow sta
   - The user asked for immediate read-only analysis and the ambiguity does not change the answer.
 - Strong routing signals: `deep-interview`, `$deep-interview`, `interview`, `don't assume`, `clarify`, `feature shaping`, `ambiguous product request`, `one question`, `온보딩`, `부드럽게`, `모호한 제품 요청`, `기획자`, `개발자 사이`
 - Good example:
-  - Prompt: $deep-interview design channel-specific routing, but do not assume what channels mean.
+  - Prompt: $deep-interview before planning Discord and Slack routing, ask what each channel owns and what evidence counts.
   - Expected behavior: Ask one decision-changing question at a time, then produce goals, non-goals, and acceptance criteria.
   - Why: The request explicitly rejects assumptions and needs product boundaries before implementation.
 - Bad example:
@@ -430,9 +430,9 @@ When wrapper metadata reports `omh_target_topology/v1`, skills bind workflow sta
   - The user needs implementation, review, CI, merge, or external publishing evidence that has not been delegated or observed.
 - Strong routing signals: `team`, `$team`, `swarm`, `parallel agents`, `coordinated workers`
 - Good example:
-  - Prompt: team: handle a execution request that needs explicit evidence boundaries and a clear stop condition.
-  - Expected behavior: Run `team` only after naming the target, evidence boundary, and stop condition.
-  - Why: The request matches the catalog use case and keeps observed evidence separate from prepared guidance.
+  - Prompt: team: coordinate parallel agents for frontend polish, copy polish, and QA with worker ACKs.
+  - Expected behavior: Assign lanes, require worker ACK/result evidence, and keep integration verification separate.
+  - Why: The work benefits from multiple coordinated workers with disjoint ownership.
 - Bad example:
   - Prompt: team: treat casual chat or unaccepted work as if this workflow already produced verified results.
   - Expected behavior: Ask a clarification question or route to a narrower workflow instead of forcing `team`.
@@ -486,7 +486,7 @@ When wrapper metadata reports `omh_target_topology/v1`, skills bind workflow sta
   - The user expects Hermes to secretly execute coding lanes instead of preparing explicit selected-runtime handoffs.
 - Strong routing signals: `ultrawork`, `$ultrawork`, `parallel work`, `parallel implementation`, `high throughput`
 - Good example:
-  - Prompt: $ultrawork implement docs refresh, CLI output polish, and tests as separate accepted lanes.
+  - Prompt: $ultrawork split the accepted docs refresh, CLI output polish, and test updates into parallel implementation lanes.
   - Expected behavior: Create disjoint lane prompts with acceptance criteria, verification commands, and review evidence requirements.
   - Why: The work can be split cleanly and benefits from parallel execution discipline.
 - Bad example:
@@ -668,9 +668,9 @@ When wrapper metadata reports `omh_target_topology/v1`, skills bind workflow sta
   - The user needs implementation, review, CI, merge, or external publishing evidence that has not been delegated or observed.
 - Strong routing signals: `research-brief`, `business-research`, `business research`, `research brief`, `source-backed business research`, `customer feedback trends`, `feedback trends`, `market evidence`, `data search`, `source scan`, `자료 조사`, `데이터 서치`, `근거 조사`, `피드백 추세`, `고객 피드백 추세`
 - Good example:
-  - Prompt: research-brief: handle a research request that needs explicit evidence boundaries and a clear stop condition.
-  - Expected behavior: Run `research-brief` only after naming the target, evidence boundary, and stop condition.
-  - Why: The request matches the catalog use case and keeps observed evidence separate from prepared guidance.
+  - Prompt: research-brief: compare three onboarding analytics vendors using customer notes and confidence gaps.
+  - Expected behavior: Prepare a source-backed brief with evidence, inference, confidence, and retrieval gaps separated.
+  - Why: The user needs business research synthesis, not recurring operations or coding.
 - Bad example:
   - Prompt: research-brief: treat casual chat or unaccepted work as if this workflow already produced verified results.
   - Expected behavior: Ask a clarification question or route to a narrower workflow instead of forcing `research-brief`.
@@ -724,7 +724,7 @@ When wrapper metadata reports `omh_target_topology/v1`, skills bind workflow sta
   - The user asks for coding implementation; prepare a selected executor/runtime handoff after the research plan is accepted.
 - Strong routing signals: `research-department`, `research department`, `research ops department`, `research operations department`, `scout analyst briefer`, `scout analyst brief`, `daily research department`, `competitor research department`, `market research department`, `paper review`, `weekly paper review`, `research paper review`, `paper research`, `notebooklm research`, `obsidian research vault`, `knowledge store`, `knowledge storage`, `synthesis tool`, `knowledge summarizer`, `research inbox`, `source inbox`, `briefing status`, `리서치 부서`, `리서치 조직`, `리서치 운영`, `수집 합성 브리핑`, `지식 저장소`, `요약 도구`, `경쟁사 리서치 부서`
 - Good example:
-  - Prompt: research-department 매일 경쟁사와 시장 뉴스를 수집해서 변화가 있으면 브리핑해줘.
+  - Prompt: Set up a Scout, Analyst, and Briefer research flow for daily competitor and market changes.
   - Expected behavior: Prepare research_department_plan/v1 with Scout/Analyst/Briefer lanes, source inbox buckets, briefing status, knowledge-store and synthesis-tool readiness, and observed-only evidence requirements.
   - Why: The request is recurring, source-backed, and operational; a single research brief would miss the ongoing workflow/status boundary.
 - Bad example:
@@ -852,9 +852,9 @@ When wrapper metadata reports `omh_target_topology/v1`, skills bind workflow sta
   - The user needs implementation, review, CI, merge, or external publishing evidence that has not been delegated or observed.
 - Strong routing signals: `strategy-brief`, `strategy brief`, `strategy memo`, `product strategy`, `strategic options`, `decision note`, `leadership strategy`, `next strategy`, `다음 전략`, `전략 정리`, `전략 메모`, `전략 옵션`, `의사결정`, `리더십 회의`
 - Good example:
-  - Prompt: strategy-brief: handle a strategy request that needs explicit evidence boundaries and a clear stop condition.
-  - Expected behavior: Run `strategy-brief` only after naming the target, evidence boundary, and stop condition.
-  - Why: The request matches the catalog use case and keeps observed evidence separate from prepared guidance.
+  - Prompt: strategy-brief: decide whether our onboarding should prioritize solo founders or enterprise buyers.
+  - Expected behavior: Frame options, tradeoffs, assumptions, rejected paths, and the decision evidence needed.
+  - Why: The request is strategy-shaped and should not jump directly into implementation.
 - Bad example:
   - Prompt: strategy-brief: treat casual chat or unaccepted work as if this workflow already produced verified results.
   - Expected behavior: Ask a clarification question or route to a narrower workflow instead of forcing `strategy-brief`.
@@ -909,7 +909,7 @@ When wrapper metadata reports `omh_target_topology/v1`, skills bind workflow sta
   - The follow-up is implementation work that already has accepted requirements and should become a plan or handoff.
 - Strong routing signals: `meeting-brief`, `meeting brief`, `meeting agenda`, `agenda`, `discussion prompts`, `decisions needed`, `record template`, `meeting topics`, `회의 주제`, `회의 아젠다`, `아젠다`, `회의 준비`, `논의 질문`, `결정할 것`, `기록 템플릿`
 - Good example:
-  - Prompt: meeting-brief for a leadership sync on setup UX, plugin bridge defaults, and release risk.
+  - Prompt: Prepare a meeting agenda for a leadership sync on setup UX, plugin bridge defaults, and release risk.
   - Expected behavior: Prepare agenda topics, prompts, decisions needed, and a record template with unknowns marked.
   - Why: The request is preparation for a meeting and should separate prep from observed outcomes.
 - Bad example:
@@ -966,7 +966,7 @@ When wrapper metadata reports `omh_target_topology/v1`, skills bind workflow sta
   - The user wants current market research rather than triage of supplied signals.
 - Strong routing signals: `feedback-triage`, `customer-feedback-triage`, `feedback triage`, `customer feedback`, `feedback cluster`, `bug or feature`, `feature request triage`, `payment failure feedback`, `feedback trends`, `payment failure`, `payment failure issue`, `payment failure reports`, `고객 피드백`, `피드백`, `피드백 분류`, `피드백을 모아서`, `결제 실패`, `결제 실패 이슈`, `결제 실패 피드백`, `결제 오류`, `고객 불만`, `버그 제보`, `버그 기능 요청`, `기능 요청`
 - Good example:
-  - Prompt: feedback-triage these payment failure reports and feature requests before we plan fixes.
+  - Prompt: Cluster these customer payment failure reports and feature requests before we plan fixes.
   - Expected behavior: Cluster bug signals and feature asks, rank severity or opportunity, and recommend research, planning, or coding as a next workflow.
   - Why: The input is mixed feedback that needs classification before delivery decisions.
 - Bad example:
@@ -1020,9 +1020,9 @@ When wrapper metadata reports `omh_target_topology/v1`, skills bind workflow sta
   - The user needs implementation, review, CI, merge, or external publishing evidence that has not been delegated or observed.
 - Strong routing signals: `ops-review`, `ops review`, `weekly ops review`, `status review`, `operating review`, `release risks`, `risks and blockers`, `priorities`, `weekly status`, `운영 리뷰`, `주간 운영`, `상태 리뷰`, `리스크`, `블로커`, `우선순위`, `릴리즈 리스크`
 - Good example:
-  - Prompt: ops-review: handle a operations request that needs explicit evidence boundaries and a clear stop condition.
-  - Expected behavior: Run `ops-review` only after naming the target, evidence boundary, and stop condition.
-  - Why: The request matches the catalog use case and keeps observed evidence separate from prepared guidance.
+  - Prompt: ops-review: summarize this week’s support queue, release blockers, owner status, and next operating risks.
+  - Expected behavior: Create an operations status review with owners, blockers, evidence gaps, and next actions.
+  - Why: The request is an operating review rather than a one-off plan or coding handoff.
 - Bad example:
   - Prompt: ops-review: treat casual chat or unaccepted work as if this workflow already produced verified results.
   - Expected behavior: Ask a clarification question or route to a narrower workflow instead of forcing `ops-review`.
@@ -1333,7 +1333,7 @@ When wrapper metadata reports `omh_target_topology/v1`, skills bind workflow sta
   - The user needs actual code changes; prepare a selected executor/runtime handoff after the blueprint or plan is accepted.
 - Strong routing signals: `automation-blueprint`, `scheduled ops`, `scheduled operation`, `scheduled operations`, `automation blueprint`, `cron blueprint`, `cron-ready`, `recurring ops`, `recurring workflow`, `every morning`, `every day`, `daily digest`, `weekly digest`, `send to slack`, `send to discord`, `post to telegram`, `only if changed`, `silent if nothing changed`, `schedule this`, `매일`, `매주`, `정기`, `예약`, `반복`, `스케줄`, `슬랙`, `디스코드`, `텔레그램`, `보내`, `공유`, `변화 없으면`, `조용히`
 - Good example:
-  - Prompt: automation-blueprint every morning check competitor news and send a Slack digest only if something changed.
+  - Prompt: automation-blueprint every weekday run an uptime check and send a Slack digest only if status changes.
   - Expected behavior: Prepare hermes_ops_blueprint/v1 with schedule intent, Slack delivery policy, silence rule, research/report skills, missing evidence, and next confirmation.
   - Why: The request is recurring, delivery-shaped, and must stay prepared until host automation and gateway delivery are observed.
 - Bad example:
@@ -1445,9 +1445,9 @@ When wrapper metadata reports `omh_target_topology/v1`, skills bind workflow sta
   - The user needs implementation, review, CI, merge, or external publishing evidence that has not been delegated or observed.
 - Strong routing signals: `idea-to-deploy`, `idea to deploy`, `from idea to deploy`, `plan to deploy`, `idea to launch`, `ship this idea`, `ship this feature`, `launch this feature`, `product delivery loop`, `app delivery loop`, `complete product loop`, `end-to-end app operation`, `완제품 루프`, `아이디어부터 배포`, `기획부터 배포`, `출시까지`, `앱 운영 루프`
 - Good example:
-  - Prompt: idea-to-deploy: handle a delivery request that needs explicit evidence boundaries and a clear stop condition.
-  - Expected behavior: Run `idea-to-deploy` only after naming the target, evidence boundary, and stop condition.
-  - Why: The request matches the catalog use case and keeps observed evidence separate from prepared guidance.
+  - Prompt: idea-to-deploy: turn this onboarding idea into a scoped plan, implementation handoff, QA gate, and release path.
+  - Expected behavior: Prepare the idea-to-release lane while keeping implementation, QA, and deploy evidence observed-only.
+  - Why: The request spans product shaping through deploy readiness instead of a single task.
 - Bad example:
   - Prompt: idea-to-deploy: treat casual chat or unaccepted work as if this workflow already produced verified results.
   - Expected behavior: Ask a clarification question or route to a narrower workflow instead of forcing `idea-to-deploy`.
@@ -1502,9 +1502,9 @@ When wrapper metadata reports `omh_target_topology/v1`, skills bind workflow sta
   - The user needs implementation, review, CI, merge, or external publishing evidence that has not been delegated or observed.
 - Strong routing signals: `cto-loop`, `cto loop`, `cto`, `cto pm`, `pm dev qa security ops`, `roadmap technical tradeoffs`, `technical tradeoff`, `delivery risk`, `release readiness`, `technical leadership loop`, `leadership operating loop`, `engineering leadership`, `CTO 구조`, `PM 구조`, `로드맵`, `아키텍처 트레이드오프`, `기술 리더십`, `출시 준비`
 - Good example:
-  - Prompt: cto-loop: handle a leadership request that needs explicit evidence boundaries and a clear stop condition.
-  - Expected behavior: Run `cto-loop` only after naming the target, evidence boundary, and stop condition.
-  - Why: The request matches the catalog use case and keeps observed evidence separate from prepared guidance.
+  - Prompt: cto-loop: run the PM, dev, QA, security, and ops loop for this risky billing launch.
+  - Expected behavior: Prepare the CTO operating model with role responsibilities, gates, blockers, and status boundaries.
+  - Why: The request needs a leadership operating loop, not just a generic plan.
 - Bad example:
   - Prompt: cto-loop: treat casual chat or unaccepted work as if this workflow already produced verified results.
   - Expected behavior: Ask a clarification question or route to a narrower workflow instead of forcing `cto-loop`.
@@ -1560,9 +1560,9 @@ When wrapper metadata reports `omh_target_topology/v1`, skills bind workflow sta
   - The user needs implementation, review, CI, merge, or external publishing evidence that has not been delegated or observed.
 - Strong routing signals: `deploy-and-monitor`, `deploy and monitor`, `deploy monitor`, `deployment monitoring`, `release monitor`, `post deploy`, `post-deploy`, `rollback`, `rollback gate`, `health check`, `incident watch`, `release health`, `배포 모니터링`, `배포 감시`, `롤백`, `헬스 체크`, `장애 감시`, `릴리즈 모니터링`
 - Good example:
-  - Prompt: deploy-and-monitor: handle a monitoring request that needs explicit evidence boundaries and a clear stop condition.
-  - Expected behavior: Run `deploy-and-monitor` only after naming the target, evidence boundary, and stop condition.
-  - Why: The request matches the catalog use case and keeps observed evidence separate from prepared guidance.
+  - Prompt: deploy-and-monitor: prepare the release monitor, rollback signals, health checks, and post-deploy status card.
+  - Expected behavior: Create release monitoring guidance with deployment, metric, rollback, and observation boundaries.
+  - Why: The request is about deploy readiness and monitoring rather than code review alone.
 - Bad example:
   - Prompt: deploy-and-monitor: treat casual chat or unaccepted work as if this workflow already produced verified results.
   - Expected behavior: Ask a clarification question or route to a narrower workflow instead of forcing `deploy-and-monitor`.
@@ -1618,9 +1618,9 @@ When wrapper metadata reports `omh_target_topology/v1`, skills bind workflow sta
   - The user needs implementation, review, CI, merge, or external publishing evidence that has not been delegated or observed.
 - Strong routing signals: `ultraqa`, `$ultraqa`, `adversarial qa`, `hostile scenarios`, `e2e qa`, `real-world qa`, `qa scenario`, `release qa`, `장애 상황`, `쿠버네티스 장애`, `적절히 진단`, `검증 체크리스트`, `릴리즈 전 gate`
 - Good example:
-  - Prompt: ultraqa: handle a verification request that needs explicit evidence boundaries and a clear stop condition.
-  - Expected behavior: Run `ultraqa` only after naming the target, evidence boundary, and stop condition.
-  - Why: The request matches the catalog use case and keeps observed evidence separate from prepared guidance.
+  - Prompt: $ultraqa test the setup wizard with hostile install paths, stale config, and missing PATH cases.
+  - Expected behavior: Generate adversarial QA scenarios, expected signals, observed results, and fix-or-retry routing.
+  - Why: The request asks for verification pressure and hostile scenarios.
 - Bad example:
   - Prompt: ultraqa: treat casual chat or unaccepted work as if this workflow already produced verified results.
   - Expected behavior: Ask a clarification question or route to a narrower workflow instead of forcing `ultraqa`.
@@ -1794,7 +1794,7 @@ When wrapper metadata reports `omh_target_topology/v1`, skills bind workflow sta
   - The request is broad product critique, strategy, or planning rather than code or evidence review.
 - Strong routing signals: `code-review`, `$code-review`, `review`, `audit`, `find bugs`, `release gate`, `claim audit`, `evidence audit`, `README claim`, `what actually happened`, `code review`, `review gate`, `리뷰`, `코드 리뷰`, `리뷰까지`, `릴리즈 전`, `실제 코드와 맞는가`, `실제로 뭐 했는지`, `검증된 결과`
 - Good example:
-  - Prompt: $code-review check this PR for install/update UX regressions and missing tests.
+  - Prompt: $code-review review this PR for install/update UX regressions and missing tests.
   - Expected behavior: Lead with ranked findings, cite concrete evidence, then list open questions and test gaps.
   - Why: The task is explicitly review-shaped and has a behavioral risk surface.
 - Bad example:
@@ -1850,9 +1850,9 @@ When wrapper metadata reports `omh_target_topology/v1`, skills bind workflow sta
   - The user needs implementation, review, CI, merge, or external publishing evidence that has not been delegated or observed.
 - Strong routing signals: `ai-slop-cleaner`, `$ai-slop-cleaner`, `cleanup`, `deslop`, `refactor`, `risky`, `behavior-preserving refactor`, `risk analysis`, `refactor workflow`, `legacy refactor`, `리팩터링`, `리팩토링`, `위험 분석`, `변경 범위 제한`, `회귀 테스트`
 - Good example:
-  - Prompt: ai-slop-cleaner: handle a maintenance request that needs explicit evidence boundaries and a clear stop condition.
-  - Expected behavior: Run `ai-slop-cleaner` only after naming the target, evidence boundary, and stop condition.
-  - Why: The request matches the catalog use case and keeps observed evidence separate from prepared guidance.
+  - Prompt: $ai-slop-cleaner remove duplicated router branches and lock behavior with regression tests before refactoring.
+  - Expected behavior: Plan cleanup, preserve behavior, delete or simplify code, and prove it with targeted tests.
+  - Why: The request is maintenance cleanup with regression risk.
 - Bad example:
   - Prompt: ai-slop-cleaner: treat casual chat or unaccepted work as if this workflow already produced verified results.
   - Expected behavior: Ask a clarification question or route to a narrower workflow instead of forcing `ai-slop-cleaner`.
@@ -1904,9 +1904,9 @@ When wrapper metadata reports `omh_target_topology/v1`, skills bind workflow sta
   - The user needs implementation, review, CI, merge, or external publishing evidence that has not been delegated or observed.
 - Strong routing signals: `best-practice-research`, `best practice`, `official docs`, `upstream guidance`
 - Good example:
-  - Prompt: best-practice-research: handle a research request that needs explicit evidence boundaries and a clear stop condition.
-  - Expected behavior: Run `best-practice-research` only after naming the target, evidence boundary, and stop condition.
-  - Why: The request matches the catalog use case and keeps observed evidence separate from prepared guidance.
+  - Prompt: best-practice-research: check official docs and upstream examples before we choose the plugin packaging pattern.
+  - Expected behavior: Gather primary-source guidance, compare options, and separate evidence from recommendation.
+  - Why: The request needs citation-backed best-practice research before implementation.
 - Bad example:
   - Prompt: best-practice-research: treat casual chat or unaccepted work as if this workflow already produced verified results.
   - Expected behavior: Ask a clarification question or route to a narrower workflow instead of forcing `best-practice-research`.
@@ -1957,9 +1957,9 @@ When wrapper metadata reports `omh_target_topology/v1`, skills bind workflow sta
   - The user needs implementation, review, CI, merge, or external publishing evidence that has not been delegated or observed.
 - Strong routing signals: `autoresearch-goal`, `research goal`, `durable research`, `critic research`
 - Good example:
-  - Prompt: autoresearch-goal: handle a research request that needs explicit evidence boundaries and a clear stop condition.
-  - Expected behavior: Run `autoresearch-goal` only after naming the target, evidence boundary, and stop condition.
-  - Why: The request matches the catalog use case and keeps observed evidence separate from prepared guidance.
+  - Prompt: autoresearch-goal: keep researching AI agent memory practices until the evidence gaps are closed or logged.
+  - Expected behavior: Run a durable research loop with critic checks, source gaps, and a stop or checkpoint condition.
+  - Why: The request is research that needs persistence and review, not a one-shot brief.
 - Bad example:
   - Prompt: autoresearch-goal: treat casual chat or unaccepted work as if this workflow already produced verified results.
   - Expected behavior: Ask a clarification question or route to a narrower workflow instead of forcing `autoresearch-goal`.
@@ -2010,9 +2010,9 @@ When wrapper metadata reports `omh_target_topology/v1`, skills bind workflow sta
   - The user needs implementation, review, CI, merge, or external publishing evidence that has not been delegated or observed.
 - Strong routing signals: `performance-goal`, `performance goal`, `latency`, `throughput`, `benchmark`
 - Good example:
-  - Prompt: performance-goal: handle a optimization request that needs explicit evidence boundaries and a clear stop condition.
-  - Expected behavior: Run `performance-goal` only after naming the target, evidence boundary, and stop condition.
-  - Why: The request matches the catalog use case and keeps observed evidence separate from prepared guidance.
+  - Prompt: performance-goal: benchmark recommendation latency, optimize hot paths safely, and prove no regressions.
+  - Expected behavior: Create a measurement-led optimization loop with baseline, change, verification, and regression evidence.
+  - Why: The request is performance optimization and needs measured before/after proof.
 - Bad example:
   - Prompt: performance-goal: treat casual chat or unaccepted work as if this workflow already produced verified results.
   - Expected behavior: Ask a clarification question or route to a narrower workflow instead of forcing `performance-goal`.
@@ -2064,9 +2064,9 @@ When wrapper metadata reports `omh_target_topology/v1`, skills bind workflow sta
   - The user needs implementation, review, CI, merge, or external publishing evidence that has not been delegated or observed.
 - Strong routing signals: `wiki`, `project wiki`, `memory`, `notes`
 - Good example:
-  - Prompt: wiki: handle a knowledge request that needs explicit evidence boundaries and a clear stop condition.
-  - Expected behavior: Run `wiki` only after naming the target, evidence boundary, and stop condition.
-  - Why: The request matches the catalog use case and keeps observed evidence separate from prepared guidance.
+  - Prompt: wiki: capture the final router architecture decisions and retrieval hints in the project knowledge base.
+  - Expected behavior: Write durable project knowledge with source context, staleness notes, and follow-up links.
+  - Why: The request is knowledge capture rather than planning or execution.
 - Bad example:
   - Prompt: wiki: treat casual chat or unaccepted work as if this workflow already produced verified results.
   - Expected behavior: Ask a clarification question or route to a narrower workflow instead of forcing `wiki`.
@@ -2117,9 +2117,9 @@ When wrapper metadata reports `omh_target_topology/v1`, skills bind workflow sta
   - The user needs implementation, review, CI, merge, or external publishing evidence that has not been delegated or observed.
 - Strong routing signals: `ask`, `$ask`, `external advisor`, `claude`, `gemini`
 - Good example:
-  - Prompt: ask: handle a review request that needs explicit evidence boundaries and a clear stop condition.
-  - Expected behavior: Run `ask` only after naming the target, evidence boundary, and stop condition.
-  - Why: The request matches the catalog use case and keeps observed evidence separate from prepared guidance.
+  - Prompt: ask: ask Claude as an external advisor to critique this plugin bridge plan before implementation.
+  - Expected behavior: Prepare an advisor prompt, capture the response boundary, and summarize reusable critique.
+  - Why: The user wants outside review before committing to a direction.
 - Bad example:
   - Prompt: ask: treat casual chat or unaccepted work as if this workflow already produced verified results.
   - Expected behavior: Ask a clarification question or route to a narrower workflow instead of forcing `ask`.
@@ -2220,9 +2220,9 @@ When wrapper metadata reports `omh_target_topology/v1`, skills bind workflow sta
   - The user needs implementation, review, CI, merge, or external publishing evidence that has not been delegated or observed.
 - Strong routing signals: `skill`, `$skill`, `skills`, `manage skills`
 - Good example:
-  - Prompt: skill: handle a operator request that needs explicit evidence boundaries and a clear stop condition.
-  - Expected behavior: Run `skill` only after naming the target, evidence boundary, and stop condition.
-  - Why: The request matches the catalog use case and keeps observed evidence separate from prepared guidance.
+  - Prompt: $skill list installed OMH skills and show the catalog metadata for each workflow.
+  - Expected behavior: Manage or inspect the skill catalog without claiming runtime execution or external evidence.
+  - Why: The request is operator skill management, not a user workflow run.
 - Bad example:
   - Prompt: skill: treat casual chat or unaccepted work as if this workflow already produced verified results.
   - Expected behavior: Ask a clarification question or route to a narrower workflow instead of forcing `skill`.

--- a/skills/ai-slop-cleaner/SKILL.md
+++ b/skills/ai-slop-cleaner/SKILL.md
@@ -27,9 +27,9 @@ This is a Hermes-native `ai-slop-cleaner` workflow skill.
 
 Good example:
 
-- Prompt: ai-slop-cleaner: handle a maintenance request that needs explicit evidence boundaries and a clear stop condition.
-- Expected behavior: Run `ai-slop-cleaner` only after naming the target, evidence boundary, and stop condition.
-- Why: The request matches the catalog use case and keeps observed evidence separate from prepared guidance.
+- Prompt: $ai-slop-cleaner remove duplicated router branches and lock behavior with regression tests before refactoring.
+- Expected behavior: Plan cleanup, preserve behavior, delete or simplify code, and prove it with targeted tests.
+- Why: The request is maintenance cleanup with regression risk.
 
 Bad example:
 

--- a/skills/ask/SKILL.md
+++ b/skills/ask/SKILL.md
@@ -27,9 +27,9 @@ This is a Hermes-native `ask` workflow skill.
 
 Good example:
 
-- Prompt: ask: handle a review request that needs explicit evidence boundaries and a clear stop condition.
-- Expected behavior: Run `ask` only after naming the target, evidence boundary, and stop condition.
-- Why: The request matches the catalog use case and keeps observed evidence separate from prepared guidance.
+- Prompt: ask: ask Claude as an external advisor to critique this plugin bridge plan before implementation.
+- Expected behavior: Prepare an advisor prompt, capture the response boundary, and summarize reusable critique.
+- Why: The user wants outside review before committing to a direction.
 
 Bad example:
 

--- a/skills/automation-blueprint/SKILL.md
+++ b/skills/automation-blueprint/SKILL.md
@@ -28,7 +28,7 @@ This is a Hermes-native `automation-blueprint` workflow skill.
 
 Good example:
 
-- Prompt: automation-blueprint every morning check competitor news and send a Slack digest only if something changed.
+- Prompt: automation-blueprint every weekday run an uptime check and send a Slack digest only if status changes.
 - Expected behavior: Prepare hermes_ops_blueprint/v1 with schedule intent, Slack delivery policy, silence rule, research/report skills, missing evidence, and next confirmation.
 - Why: The request is recurring, delivery-shaped, and must stay prepared until host automation and gateway delivery are observed.
 

--- a/skills/autoresearch-goal/SKILL.md
+++ b/skills/autoresearch-goal/SKILL.md
@@ -27,9 +27,9 @@ This is a Hermes-native `autoresearch-goal` workflow skill.
 
 Good example:
 
-- Prompt: autoresearch-goal: handle a research request that needs explicit evidence boundaries and a clear stop condition.
-- Expected behavior: Run `autoresearch-goal` only after naming the target, evidence boundary, and stop condition.
-- Why: The request matches the catalog use case and keeps observed evidence separate from prepared guidance.
+- Prompt: autoresearch-goal: keep researching AI agent memory practices until the evidence gaps are closed or logged.
+- Expected behavior: Run a durable research loop with critic checks, source gaps, and a stop or checkpoint condition.
+- Why: The request is research that needs persistence and review, not a one-shot brief.
 
 Bad example:
 

--- a/skills/best-practice-research/SKILL.md
+++ b/skills/best-practice-research/SKILL.md
@@ -27,9 +27,9 @@ This is a Hermes-native `best-practice-research` workflow skill.
 
 Good example:
 
-- Prompt: best-practice-research: handle a research request that needs explicit evidence boundaries and a clear stop condition.
-- Expected behavior: Run `best-practice-research` only after naming the target, evidence boundary, and stop condition.
-- Why: The request matches the catalog use case and keeps observed evidence separate from prepared guidance.
+- Prompt: best-practice-research: check official docs and upstream examples before we choose the plugin packaging pattern.
+- Expected behavior: Gather primary-source guidance, compare options, and separate evidence from recommendation.
+- Why: The request needs citation-backed best-practice research before implementation.
 
 Bad example:
 

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -28,7 +28,7 @@ This is a Hermes-native `code-review` workflow skill.
 
 Good example:
 
-- Prompt: $code-review check this PR for install/update UX regressions and missing tests.
+- Prompt: $code-review review this PR for install/update UX regressions and missing tests.
 - Expected behavior: Lead with ranked findings, cite concrete evidence, then list open questions and test gaps.
 - Why: The task is explicitly review-shaped and has a behavioral risk surface.
 

--- a/skills/cto-loop/SKILL.md
+++ b/skills/cto-loop/SKILL.md
@@ -27,9 +27,9 @@ This is a Hermes-native `cto-loop` workflow skill.
 
 Good example:
 
-- Prompt: cto-loop: handle a leadership request that needs explicit evidence boundaries and a clear stop condition.
-- Expected behavior: Run `cto-loop` only after naming the target, evidence boundary, and stop condition.
-- Why: The request matches the catalog use case and keeps observed evidence separate from prepared guidance.
+- Prompt: cto-loop: run the PM, dev, QA, security, and ops loop for this risky billing launch.
+- Expected behavior: Prepare the CTO operating model with role responsibilities, gates, blockers, and status boundaries.
+- Why: The request needs a leadership operating loop, not just a generic plan.
 
 Bad example:
 

--- a/skills/deep-interview/SKILL.md
+++ b/skills/deep-interview/SKILL.md
@@ -28,7 +28,7 @@ This is a Hermes-native `deep-interview` workflow skill.
 
 Good example:
 
-- Prompt: $deep-interview design channel-specific routing, but do not assume what channels mean.
+- Prompt: $deep-interview before planning Discord and Slack routing, ask what each channel owns and what evidence counts.
 - Expected behavior: Ask one decision-changing question at a time, then produce goals, non-goals, and acceptance criteria.
 - Why: The request explicitly rejects assumptions and needs product boundaries before implementation.
 

--- a/skills/deploy-and-monitor/SKILL.md
+++ b/skills/deploy-and-monitor/SKILL.md
@@ -27,9 +27,9 @@ This is a Hermes-native `deploy-and-monitor` workflow skill.
 
 Good example:
 
-- Prompt: deploy-and-monitor: handle a monitoring request that needs explicit evidence boundaries and a clear stop condition.
-- Expected behavior: Run `deploy-and-monitor` only after naming the target, evidence boundary, and stop condition.
-- Why: The request matches the catalog use case and keeps observed evidence separate from prepared guidance.
+- Prompt: deploy-and-monitor: prepare the release monitor, rollback signals, health checks, and post-deploy status card.
+- Expected behavior: Create release monitoring guidance with deployment, metric, rollback, and observation boundaries.
+- Why: The request is about deploy readiness and monitoring rather than code review alone.
 
 Bad example:
 

--- a/skills/feedback-triage/SKILL.md
+++ b/skills/feedback-triage/SKILL.md
@@ -28,7 +28,7 @@ This is a Hermes-native `feedback-triage` workflow skill.
 
 Good example:
 
-- Prompt: feedback-triage these payment failure reports and feature requests before we plan fixes.
+- Prompt: Cluster these customer payment failure reports and feature requests before we plan fixes.
 - Expected behavior: Cluster bug signals and feature asks, rank severity or opportunity, and recommend research, planning, or coding as a next workflow.
 - Why: The input is mixed feedback that needs classification before delivery decisions.
 

--- a/skills/idea-to-deploy/SKILL.md
+++ b/skills/idea-to-deploy/SKILL.md
@@ -27,9 +27,9 @@ This is a Hermes-native `idea-to-deploy` workflow skill.
 
 Good example:
 
-- Prompt: idea-to-deploy: handle a delivery request that needs explicit evidence boundaries and a clear stop condition.
-- Expected behavior: Run `idea-to-deploy` only after naming the target, evidence boundary, and stop condition.
-- Why: The request matches the catalog use case and keeps observed evidence separate from prepared guidance.
+- Prompt: idea-to-deploy: turn this onboarding idea into a scoped plan, implementation handoff, QA gate, and release path.
+- Expected behavior: Prepare the idea-to-release lane while keeping implementation, QA, and deploy evidence observed-only.
+- Why: The request spans product shaping through deploy readiness instead of a single task.
 
 Bad example:
 

--- a/skills/meeting-brief/SKILL.md
+++ b/skills/meeting-brief/SKILL.md
@@ -28,7 +28,7 @@ This is a Hermes-native `meeting-brief` workflow skill.
 
 Good example:
 
-- Prompt: meeting-brief for a leadership sync on setup UX, plugin bridge defaults, and release risk.
+- Prompt: Prepare a meeting agenda for a leadership sync on setup UX, plugin bridge defaults, and release risk.
 - Expected behavior: Prepare agenda topics, prompts, decisions needed, and a record template with unknowns marked.
 - Why: The request is preparation for a meeting and should separate prep from observed outcomes.
 

--- a/skills/ops-review/SKILL.md
+++ b/skills/ops-review/SKILL.md
@@ -27,9 +27,9 @@ This is a Hermes-native `ops-review` workflow skill.
 
 Good example:
 
-- Prompt: ops-review: handle a operations request that needs explicit evidence boundaries and a clear stop condition.
-- Expected behavior: Run `ops-review` only after naming the target, evidence boundary, and stop condition.
-- Why: The request matches the catalog use case and keeps observed evidence separate from prepared guidance.
+- Prompt: ops-review: summarize this week’s support queue, release blockers, owner status, and next operating risks.
+- Expected behavior: Create an operations status review with owners, blockers, evidence gaps, and next actions.
+- Why: The request is an operating review rather than a one-off plan or coding handoff.
 
 Bad example:
 

--- a/skills/performance-goal/SKILL.md
+++ b/skills/performance-goal/SKILL.md
@@ -27,9 +27,9 @@ This is a Hermes-native `performance-goal` workflow skill.
 
 Good example:
 
-- Prompt: performance-goal: handle a optimization request that needs explicit evidence boundaries and a clear stop condition.
-- Expected behavior: Run `performance-goal` only after naming the target, evidence boundary, and stop condition.
-- Why: The request matches the catalog use case and keeps observed evidence separate from prepared guidance.
+- Prompt: performance-goal: benchmark recommendation latency, optimize hot paths safely, and prove no regressions.
+- Expected behavior: Create a measurement-led optimization loop with baseline, change, verification, and regression evidence.
+- Why: The request is performance optimization and needs measured before/after proof.
 
 Bad example:
 

--- a/skills/ralph/SKILL.md
+++ b/skills/ralph/SKILL.md
@@ -27,9 +27,9 @@ This is a Hermes-native `ralph` workflow skill.
 
 Good example:
 
-- Prompt: ralph: handle a execution request that needs explicit evidence boundaries and a clear stop condition.
-- Expected behavior: Run `ralph` only after naming the target, evidence boundary, and stop condition.
-- Why: The request matches the catalog use case and keeps observed evidence separate from prepared guidance.
+- Prompt: ralph: finish the invoice export recovery until the smoke test passes or a blocker is recorded.
+- Expected behavior: Keep one completion owner, track evidence after every recovery step, and stop only on pass, block, or explicit cancel.
+- Why: The request needs persistent completion pressure with an observable stop condition.
 
 Bad example:
 

--- a/skills/research-brief/SKILL.md
+++ b/skills/research-brief/SKILL.md
@@ -27,9 +27,9 @@ This is a Hermes-native `research-brief` workflow skill.
 
 Good example:
 
-- Prompt: research-brief: handle a research request that needs explicit evidence boundaries and a clear stop condition.
-- Expected behavior: Run `research-brief` only after naming the target, evidence boundary, and stop condition.
-- Why: The request matches the catalog use case and keeps observed evidence separate from prepared guidance.
+- Prompt: research-brief: compare three onboarding analytics vendors using customer notes and confidence gaps.
+- Expected behavior: Prepare a source-backed brief with evidence, inference, confidence, and retrieval gaps separated.
+- Why: The user needs business research synthesis, not recurring operations or coding.
 
 Bad example:
 

--- a/skills/research-department/SKILL.md
+++ b/skills/research-department/SKILL.md
@@ -29,7 +29,7 @@ This is a Hermes-native `research-department` workflow skill.
 
 Good example:
 
-- Prompt: research-department 매일 경쟁사와 시장 뉴스를 수집해서 변화가 있으면 브리핑해줘.
+- Prompt: Set up a Scout, Analyst, and Briefer research flow for daily competitor and market changes.
 - Expected behavior: Prepare research_department_plan/v1 with Scout/Analyst/Briefer lanes, source inbox buckets, briefing status, knowledge-store and synthesis-tool readiness, and observed-only evidence requirements.
 - Why: The request is recurring, source-backed, and operational; a single research brief would miss the ongoing workflow/status boundary.
 

--- a/skills/skill/SKILL.md
+++ b/skills/skill/SKILL.md
@@ -27,9 +27,9 @@ This is a Hermes-native `skill` workflow skill.
 
 Good example:
 
-- Prompt: skill: handle a operator request that needs explicit evidence boundaries and a clear stop condition.
-- Expected behavior: Run `skill` only after naming the target, evidence boundary, and stop condition.
-- Why: The request matches the catalog use case and keeps observed evidence separate from prepared guidance.
+- Prompt: $skill list installed OMH skills and show the catalog metadata for each workflow.
+- Expected behavior: Manage or inspect the skill catalog without claiming runtime execution or external evidence.
+- Why: The request is operator skill management, not a user workflow run.
 
 Bad example:
 

--- a/skills/strategy-brief/SKILL.md
+++ b/skills/strategy-brief/SKILL.md
@@ -27,9 +27,9 @@ This is a Hermes-native `strategy-brief` workflow skill.
 
 Good example:
 
-- Prompt: strategy-brief: handle a strategy request that needs explicit evidence boundaries and a clear stop condition.
-- Expected behavior: Run `strategy-brief` only after naming the target, evidence boundary, and stop condition.
-- Why: The request matches the catalog use case and keeps observed evidence separate from prepared guidance.
+- Prompt: strategy-brief: decide whether our onboarding should prioritize solo founders or enterprise buyers.
+- Expected behavior: Frame options, tradeoffs, assumptions, rejected paths, and the decision evidence needed.
+- Why: The request is strategy-shaped and should not jump directly into implementation.
 
 Bad example:
 

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -27,9 +27,9 @@ This is a Hermes-native `team` workflow skill.
 
 Good example:
 
-- Prompt: team: handle a execution request that needs explicit evidence boundaries and a clear stop condition.
-- Expected behavior: Run `team` only after naming the target, evidence boundary, and stop condition.
-- Why: The request matches the catalog use case and keeps observed evidence separate from prepared guidance.
+- Prompt: team: coordinate parallel agents for frontend polish, copy polish, and QA with worker ACKs.
+- Expected behavior: Assign lanes, require worker ACK/result evidence, and keep integration verification separate.
+- Why: The work benefits from multiple coordinated workers with disjoint ownership.
 
 Bad example:
 

--- a/skills/ultragoal/SKILL.md
+++ b/skills/ultragoal/SKILL.md
@@ -28,7 +28,7 @@ This is a Hermes-native `ultragoal` workflow skill.
 
 Good example:
 
-- Prompt: $ultragoal add per-skill quality rubrics, regenerate skills, test, and open a PR.
+- Prompt: $ultragoal turn OMH skill quality into a durable goal with rubrics, generated skill sync, tests, and a PR gate.
 - Expected behavior: Create or update a goal ledger, split the story into verifiable checkpoints, and close only after generated docs, skills, and tests match.
 - Why: The task has multiple milestones and a final quality gate that should be inspectable across interruptions.
 

--- a/skills/ultraqa/SKILL.md
+++ b/skills/ultraqa/SKILL.md
@@ -27,9 +27,9 @@ This is a Hermes-native `ultraqa` workflow skill.
 
 Good example:
 
-- Prompt: ultraqa: handle a verification request that needs explicit evidence boundaries and a clear stop condition.
-- Expected behavior: Run `ultraqa` only after naming the target, evidence boundary, and stop condition.
-- Why: The request matches the catalog use case and keeps observed evidence separate from prepared guidance.
+- Prompt: $ultraqa test the setup wizard with hostile install paths, stale config, and missing PATH cases.
+- Expected behavior: Generate adversarial QA scenarios, expected signals, observed results, and fix-or-retry routing.
+- Why: The request asks for verification pressure and hostile scenarios.
 
 Bad example:
 

--- a/skills/ultrawork/SKILL.md
+++ b/skills/ultrawork/SKILL.md
@@ -28,7 +28,7 @@ This is a Hermes-native `ultrawork` workflow skill.
 
 Good example:
 
-- Prompt: $ultrawork implement docs refresh, CLI output polish, and tests as separate accepted lanes.
+- Prompt: $ultrawork split the accepted docs refresh, CLI output polish, and test updates into parallel implementation lanes.
 - Expected behavior: Create disjoint lane prompts with acceptance criteria, verification commands, and review evidence requirements.
 - Why: The work can be split cleanly and benefits from parallel execution discipline.
 

--- a/skills/wiki/SKILL.md
+++ b/skills/wiki/SKILL.md
@@ -27,9 +27,9 @@ This is a Hermes-native `wiki` workflow skill.
 
 Good example:
 
-- Prompt: wiki: handle a knowledge request that needs explicit evidence boundaries and a clear stop condition.
-- Expected behavior: Run `wiki` only after naming the target, evidence boundary, and stop condition.
-- Why: The request matches the catalog use case and keeps observed evidence separate from prepared guidance.
+- Prompt: wiki: capture the final router architecture decisions and retrieval hints in the project knowledge base.
+- Expected behavior: Write durable project knowledge with source context, staleness notes, and follow-up links.
+- Why: The request is knowledge capture rather than planning or execution.
 
 Bad example:
 

--- a/src/routing/chat.py
+++ b/src/routing/chat.py
@@ -139,7 +139,11 @@ def route_chat_message(
     full_recommendations = recommend_skills(routing_message, limit=len(definitions))
     explicit_skill = explicit_skill_invocation(routing_message, definitions)
     task_card = classify_task(message)
-    task_card_overrides_explicit = _task_card_overrides_explicit_invocation(task_card)
+    explicit_prefix = _has_explicit_invocation_prefix(routing_message)
+    task_card_overrides_explicit = _task_card_overrides_explicit_invocation(
+        task_card,
+        explicit_prefix=explicit_prefix,
+    )
     if task_card and (not explicit_skill or task_card_overrides_explicit):
         full_recommendations = _prioritize_recommendation(full_recommendations, task_card_recommendation(task_card))
     catalog_question = is_skill_catalog_question(routing_message)
@@ -283,10 +287,24 @@ def route_chat_message(
     return decision.to_dict()
 
 
-def _task_card_overrides_explicit_invocation(task_card: dict[str, object] | None) -> bool:
+def _has_explicit_invocation_prefix(message: str) -> bool:
+    first = message.strip().split(maxsplit=1)[0].strip(":,").lower()
+    return first.startswith(("$", "/", "./", "@"))
+
+
+def _task_card_overrides_explicit_invocation(
+    task_card: dict[str, object] | None,
+    *,
+    explicit_prefix: bool,
+) -> bool:
     if not isinstance(task_card, dict):
         return False
-    return task_card.get("task_type") in {"router_design_feedback", "omh_cli_maintenance"}
+    task_type = task_card.get("task_type")
+    if task_type == "omh_cli_maintenance":
+        return True
+    if task_type == "router_design_feedback":
+        return not explicit_prefix
+    return False
 
 
 def route_chat_event(

--- a/src/skills/catalog.py
+++ b/src/skills/catalog.py
@@ -352,10 +352,12 @@ class SkillDefinition:
                 ),
             )
         if self.good_example is None:
+            default_good_example = _DEFAULT_GOOD_EXAMPLES.get(self.name)
             object.__setattr__(
                 self,
                 "good_example",
-                SkillExample(
+                default_good_example
+                or SkillExample(
                     prompt=(
                         f"{routing_hint}: handle a {self.category} request that needs "
                         "explicit evidence boundaries and a clear stop condition."
@@ -389,6 +391,90 @@ class SkillDefinition:
                 "recovery_notes",
                 _default_recovery_notes(self.name, self.category, self.hermes_role, self.quality_tier),
             )
+
+
+_DEFAULT_GOOD_EXAMPLES = {
+    "ralph": SkillExample(
+        prompt="ralph: finish the invoice export recovery until the smoke test passes or a blocker is recorded.",
+        expected="Keep one completion owner, track evidence after every recovery step, and stop only on pass, block, or explicit cancel.",
+        why="The request needs persistent completion pressure with an observable stop condition.",
+    ),
+    "team": SkillExample(
+        prompt="team: coordinate parallel agents for frontend polish, copy polish, and QA with worker ACKs.",
+        expected="Assign lanes, require worker ACK/result evidence, and keep integration verification separate.",
+        why="The work benefits from multiple coordinated workers with disjoint ownership.",
+    ),
+    "research-brief": SkillExample(
+        prompt="research-brief: compare three onboarding analytics vendors using customer notes and confidence gaps.",
+        expected="Prepare a source-backed brief with evidence, inference, confidence, and retrieval gaps separated.",
+        why="The user needs business research synthesis, not recurring operations or coding.",
+    ),
+    "strategy-brief": SkillExample(
+        prompt="strategy-brief: decide whether our onboarding should prioritize solo founders or enterprise buyers.",
+        expected="Frame options, tradeoffs, assumptions, rejected paths, and the decision evidence needed.",
+        why="The request is strategy-shaped and should not jump directly into implementation.",
+    ),
+    "ops-review": SkillExample(
+        prompt="ops-review: summarize this week’s support queue, release blockers, owner status, and next operating risks.",
+        expected="Create an operations status review with owners, blockers, evidence gaps, and next actions.",
+        why="The request is an operating review rather than a one-off plan or coding handoff.",
+    ),
+    "idea-to-deploy": SkillExample(
+        prompt="idea-to-deploy: turn this onboarding idea into a scoped plan, implementation handoff, QA gate, and release path.",
+        expected="Prepare the idea-to-release lane while keeping implementation, QA, and deploy evidence observed-only.",
+        why="The request spans product shaping through deploy readiness instead of a single task.",
+    ),
+    "cto-loop": SkillExample(
+        prompt="cto-loop: run the PM, dev, QA, security, and ops loop for this risky billing launch.",
+        expected="Prepare the CTO operating model with role responsibilities, gates, blockers, and status boundaries.",
+        why="The request needs a leadership operating loop, not just a generic plan.",
+    ),
+    "deploy-and-monitor": SkillExample(
+        prompt="deploy-and-monitor: prepare the release monitor, rollback signals, health checks, and post-deploy status card.",
+        expected="Create release monitoring guidance with deployment, metric, rollback, and observation boundaries.",
+        why="The request is about deploy readiness and monitoring rather than code review alone.",
+    ),
+    "ultraqa": SkillExample(
+        prompt="$ultraqa test the setup wizard with hostile install paths, stale config, and missing PATH cases.",
+        expected="Generate adversarial QA scenarios, expected signals, observed results, and fix-or-retry routing.",
+        why="The request asks for verification pressure and hostile scenarios.",
+    ),
+    "ai-slop-cleaner": SkillExample(
+        prompt="$ai-slop-cleaner remove duplicated router branches and lock behavior with regression tests before refactoring.",
+        expected="Plan cleanup, preserve behavior, delete or simplify code, and prove it with targeted tests.",
+        why="The request is maintenance cleanup with regression risk.",
+    ),
+    "best-practice-research": SkillExample(
+        prompt="best-practice-research: check official docs and upstream examples before we choose the plugin packaging pattern.",
+        expected="Gather primary-source guidance, compare options, and separate evidence from recommendation.",
+        why="The request needs citation-backed best-practice research before implementation.",
+    ),
+    "autoresearch-goal": SkillExample(
+        prompt="autoresearch-goal: keep researching AI agent memory practices until the evidence gaps are closed or logged.",
+        expected="Run a durable research loop with critic checks, source gaps, and a stop or checkpoint condition.",
+        why="The request is research that needs persistence and review, not a one-shot brief.",
+    ),
+    "performance-goal": SkillExample(
+        prompt="performance-goal: benchmark recommendation latency, optimize hot paths safely, and prove no regressions.",
+        expected="Create a measurement-led optimization loop with baseline, change, verification, and regression evidence.",
+        why="The request is performance optimization and needs measured before/after proof.",
+    ),
+    "wiki": SkillExample(
+        prompt="wiki: capture the final router architecture decisions and retrieval hints in the project knowledge base.",
+        expected="Write durable project knowledge with source context, staleness notes, and follow-up links.",
+        why="The request is knowledge capture rather than planning or execution.",
+    ),
+    "ask": SkillExample(
+        prompt="ask: ask Claude as an external advisor to critique this plugin bridge plan before implementation.",
+        expected="Prepare an advisor prompt, capture the response boundary, and summarize reusable critique.",
+        why="The user wants outside review before committing to a direction.",
+    ),
+    "skill": SkillExample(
+        prompt="$skill list installed OMH skills and show the catalog metadata for each workflow.",
+        expected="Manage or inspect the skill catalog without claiming runtime execution or external evidence.",
+        why="The request is operator skill management, not a user workflow run.",
+    ),
+}
 
 
 @dataclass(frozen=True)
@@ -763,7 +849,7 @@ _DEFINITIONS = [
             "The user expects hidden Hermes code execution rather than explicit executor handoff and observed verification evidence.",
         ),
         good_example=SkillExample(
-            prompt="$ultragoal add per-skill quality rubrics, regenerate skills, test, and open a PR.",
+            prompt="$ultragoal turn OMH skill quality into a durable goal with rubrics, generated skill sync, tests, and a PR gate.",
             expected="Create or update a goal ledger, split the story into verifiable checkpoints, and close only after generated docs, skills, and tests match.",
             why="The task has multiple milestones and a final quality gate that should be inspectable across interruptions.",
         ),
@@ -1016,7 +1102,7 @@ _DEFINITIONS = [
             "The user asked for immediate read-only analysis and the ambiguity does not change the answer.",
         ),
         good_example=SkillExample(
-            prompt="$deep-interview design channel-specific routing, but do not assume what channels mean.",
+            prompt="$deep-interview before planning Discord and Slack routing, ask what each channel owns and what evidence counts.",
             expected="Ask one decision-changing question at a time, then produce goals, non-goals, and acceptance criteria.",
             why="The request explicitly rejects assumptions and needs product boundaries before implementation.",
         ),
@@ -1090,7 +1176,7 @@ _DEFINITIONS = [
             "The user expects Hermes to secretly execute coding lanes instead of preparing explicit selected-runtime handoffs.",
         ),
         good_example=SkillExample(
-            prompt="$ultrawork implement docs refresh, CLI output polish, and tests as separate accepted lanes.",
+            prompt="$ultrawork split the accepted docs refresh, CLI output polish, and test updates into parallel implementation lanes.",
             expected="Create disjoint lane prompts with acceptance criteria, verification commands, and review evidence requirements.",
             why="The work can be split cleanly and benefits from parallel execution discipline.",
         ),
@@ -1415,7 +1501,7 @@ _DEFINITIONS = [
             "The user asks for coding implementation; prepare a selected executor/runtime handoff after the research plan is accepted.",
         ),
         good_example=SkillExample(
-            prompt="research-department 매일 경쟁사와 시장 뉴스를 수집해서 변화가 있으면 브리핑해줘.",
+            prompt="Set up a Scout, Analyst, and Briefer research flow for daily competitor and market changes.",
             expected="Prepare research_department_plan/v1 with Scout/Analyst/Briefer lanes, source inbox buckets, briefing status, knowledge-store and synthesis-tool readiness, and observed-only evidence requirements.",
             why="The request is recurring, source-backed, and operational; a single research brief would miss the ongoing workflow/status boundary.",
         ),
@@ -1622,7 +1708,7 @@ _DEFINITIONS = [
             "The follow-up is implementation work that already has accepted requirements and should become a plan or handoff.",
         ),
         good_example=SkillExample(
-            prompt="meeting-brief for a leadership sync on setup UX, plugin bridge defaults, and release risk.",
+            prompt="Prepare a meeting agenda for a leadership sync on setup UX, plugin bridge defaults, and release risk.",
             expected="Prepare agenda topics, prompts, decisions needed, and a record template with unknowns marked.",
             why="The request is preparation for a meeting and should separate prep from observed outcomes.",
         ),
@@ -1688,7 +1774,7 @@ _DEFINITIONS = [
             "The user wants current market research rather than triage of supplied signals.",
         ),
         good_example=SkillExample(
-            prompt="feedback-triage these payment failure reports and feature requests before we plan fixes.",
+            prompt="Cluster these customer payment failure reports and feature requests before we plan fixes.",
             expected="Cluster bug signals and feature asks, rank severity or opportunity, and recommend research, planning, or coding as a next workflow.",
             why="The input is mixed feedback that needs classification before delivery decisions.",
         ),
@@ -2222,7 +2308,7 @@ _DEFINITIONS = [
             "The user needs actual code changes; prepare a selected executor/runtime handoff after the blueprint or plan is accepted.",
         ),
         good_example=SkillExample(
-            prompt="automation-blueprint every morning check competitor news and send a Slack digest only if something changed.",
+            prompt="automation-blueprint every weekday run an uptime check and send a Slack digest only if status changes.",
             expected="Prepare hermes_ops_blueprint/v1 with schedule intent, Slack delivery policy, silence rule, research/report skills, missing evidence, and next confirmation.",
             why="The request is recurring, delivery-shaped, and must stay prepared until host automation and gateway delivery are observed.",
         ),
@@ -2642,7 +2728,7 @@ _DEFINITIONS = [
             "The request is broad product critique, strategy, or planning rather than code or evidence review.",
         ),
         good_example=SkillExample(
-            prompt="$code-review check this PR for install/update UX regressions and missing tests.",
+            prompt="$code-review review this PR for install/update UX regressions and missing tests.",
             expected="Lead with ranked findings, cite concrete evidence, then list open questions and test gaps.",
             why="The task is explicitly review-shaped and has a behavioral risk surface.",
         ),

--- a/tests/test_chat_router.py
+++ b/tests/test_chat_router.py
@@ -76,6 +76,21 @@ class ChatRouterTests(unittest.TestCase):
         self.assertTrue(decision["explicit"])
         self.assertEqual(decision["confidence"], "high")
 
+    def test_explicit_skill_invocation_wins_over_router_feedback_card(self) -> None:
+        for message, skill in (
+            ("$deep-interview before planning Discord and Slack routing, ask what each channel owns.", "deep-interview"),
+            ("$code-review review this PR for install/update UX regressions and missing tests.", "code-review"),
+        ):
+            with self.subTest(message=message):
+                decision = route_chat_message(message, source="discord")
+
+                self.assertEqual(decision["action"], "dispatch")
+                self.assertEqual(decision["selected_skill"], skill)
+                self.assertEqual(decision["selected_harness"], primary_harness_for_skill(skill))
+                self.assertTrue(decision["explicit"])
+                self.assertIsNone(decision["task_card"])
+                self.assertEqual(decision["reason"], "Explicit workflow invocation wins over heuristic routing.")
+
     def test_operations_surfaces_dispatch_to_dedicated_harnesses(self) -> None:
         cases = (
             (


### PR DESCRIPTION
## Feature Report

### What Changed

- Replaced generic generated good examples for several workflow surfaces with concrete, operator-readable examples.
- Preserved explicit `$skill` invocations when router-design feedback heuristics would otherwise create a workflow-learning task card.
- Regenerated `docs/WORKFLOWS.md` and the tap-compatible `skills/*/SKILL.md` files from the catalog.
- Added a router regression test proving explicit `$deep-interview` and `$code-review` calls win over heuristic task cards.

### Why This Exists

- Some generated workflow examples were too abstract, such as generic “handle an execution request” prompts, which made the catalog feel less useful in Hermes chat.
- A few direct skill examples could be intercepted by workflow-learning feedback detection, so a user intentionally invoking a skill might see the wrong surface.
- OMH’s chat-first UX depends on examples that are both human-readable and routeable without implying hidden execution evidence.

### User / Operator Impact

- Users browsing generated skills or workflow docs see concrete examples for workflows such as `team`, `ralph`, `research-brief`, `strategy-brief`, `ultraqa`, `ai-slop-cleaner`, and `skill`.
- Direct `$skill` usage remains respected even when the prompt mentions routing, tests, setup, or regressions.
- Operator-facing docs and tap skills stay in sync with the catalog source of truth.

### How It Works

- `SkillDefinition.__post_init__` now checks a `_DEFAULT_GOOD_EXAMPLES` map before falling back to the old generic example template.
- `route_chat_message` records whether the message starts with an explicit invocation prefix (`$`, `/`, `./`, or `@`).
- `omh_cli_maintenance` cards can still override explicit recommendations, but `router_design_feedback` cards only override when the prompt is not explicitly invoking a workflow.
- Generated workflow docs and tap skills are regenerated from `src/skills/catalog.py`.

### Files And Contracts Touched

- `src/skills/catalog.py`: catalog example defaults and targeted good-example copy.
- `src/routing/chat.py`: explicit-prefix-aware task card override logic.
- `tests/test_chat_router.py`: regression coverage for explicit skill invocations.
- `docs/WORKFLOWS.md` and `skills/*/SKILL.md`: generated catalog output.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_chat_router.py tests/test_efficiency.py tests/test_wrapper_contract.py tests/test_router_content.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` (`858` tests passing)
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli harness validate`
- [ ] `python3 -m omh.cli release checklist --json` (not run; this PR does not change release packaging or release claims)
- [ ] `python3 -m omh.cli release hermes-smoke` (not run; no install/runtime smoke surface changed)
- [ ] `omh --help` (not run; no top-level CLI help changed)
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` (not run; no setup/install behavior changed)
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable; routing heuristics only.
- [x] Relevant dry-run or smoke command: catalog route probe over `68` generated examples, `0` as-written mismatches, `1.65ms` average per route.
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; behavior is covered by deterministic router and generated-content tests.

## Risk

- Moderate: changing generated examples touches many skill files, but the generator check verifies they match the catalog.
- Explicit prefix handling is narrow and only relaxes `router_design_feedback` task-card override behavior; maintenance cards still keep their stronger guard.

## Compatibility / Rollout

- Backward compatible with existing workflow names, generated skill paths, and wrapper contracts.
- No runtime artifact schema changes.
- No network, platform SDK, executor dispatch, or Hermes core behavior changes.

## Release / Claims

- [x] Release-channel impact considered (`local` catalog/routing quality improvement)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- Continue adding targeted natural-language route examples for stripped prompts only when they represent real user intent, rather than forcing every example to self-route without its explicit skill name.
