### PR TITLE
Align safe feature routing with reviewed plans

### DIFF
--- a/src/routing/policy.py
+++ b/src/routing/policy.py
@@ -1092,7 +1092,15 @@ _CODING_PROGRESS_STATUS_PHRASES = (
     "coding progress",
     "codex progress",
     "codex status",
+    "codex work session",
+    "track the codex work session",
+    "track codex work session",
     "coding agent status",
+    "coding agent session",
+    "what changed in the coding agent session",
+    "what changed in coding agent session",
+    "tell me what changed",
+    "work session and tell me what changed",
     "where is codex",
     "codex 작업",
     "codex 작업이 어디까지",
@@ -1530,6 +1538,15 @@ RISKY_REFACTOR_GUARD = RoutingGuardRule(
     why="Matched guard/trigger metadata; risky code-change requests should get a reviewed plan before cleanup.",
     activation_status="active",
 )
+SAFE_FEATURE_PLAN_GUARD = RoutingGuardRule(
+    id="safe_feature_change_before_generic_plan",
+    rule="Safe feature-change requests should route to ralplan before generic planning.",
+    matched_label="guard:safe_feature_change",
+    preferred_skills=("ralplan",),
+    score_boost=32,
+    why="Matched safe feature-change language; prepare a reviewed plan before executor handoff.",
+    activation_status="active",
+)
 FEEDBACK_BEFORE_CODING_GUARD = RoutingGuardRule(
     id="feedback_before_coding",
     rule="Product feedback and bug reports should route through triage/investigation before coding handoff unless code work is explicit.",
@@ -1826,6 +1843,7 @@ PAPER_LEARNING_GUARD = RoutingGuardRule(
 )
 ROUTING_GUARD_RULES = (
     RISKY_REFACTOR_GUARD,
+    SAFE_FEATURE_PLAN_GUARD,
     FEEDBACK_BEFORE_CODING_GUARD,
     PRODUCT_SHAPING_GUARD,
     PERSISTENT_COMPLETION_GUARD,
@@ -1900,6 +1918,8 @@ def active_routing_guard_rules(
     rules: list[RoutingGuardRule] = []
     if _risky_refactor_guard_applies(normalized_query, query_tokens):
         rules.append(RISKY_REFACTOR_GUARD)
+    if _safe_feature_plan_guard_applies(normalized_query, query_tokens):
+        rules.append(SAFE_FEATURE_PLAN_GUARD)
     if _product_shaping_guard_applies(normalized_query, query_tokens):
         rules.append(PRODUCT_SHAPING_GUARD)
     if _persistent_completion_guard_applies(normalized_query, query_tokens):
@@ -2030,6 +2050,22 @@ def _workflow_learning_guard_applies(normalized_query: str, query_tokens: set[st
 
 def _omh_quality_improvement_guard_applies(normalized_query: str) -> bool:
     return classify_omh_quality_intent(normalized_query).applies
+
+
+def _safe_feature_plan_guard_applies(normalized_query: str, query_tokens: set[str]) -> bool:
+    safe_signal = bool({"safe", "safely", "safety", "안전", "안전하게"} & query_tokens) or _contains_phrase(
+        normalized_query,
+        ("safe feature", "safely add a feature", "safe plan", "안전하게 기능", "안전한 기능"),
+    )
+    feature_change = bool({"feature", "features", "기능"} & query_tokens) and (
+        bool({"add", "implement", "change", "build", "추가", "구현"} & query_tokens)
+        or _contains_phrase(normalized_query, ("add a feature", "feature change", "기능 추가"))
+    )
+    scope_or_handoff = bool({"repo", "repository", "handoff", "plan", "codebase", "executor"} & query_tokens) or _contains_phrase(
+        normalized_query,
+        ("this repo", "this repository", "before handoff", "request-to-handoff", "코드베이스", "핸드오프"),
+    )
+    return safe_signal and feature_change and scope_or_handoff
 
 
 def _persistent_completion_guard_applies(normalized_query: str, query_tokens: set[str]) -> bool:

--- a/src/routing/recommend.py
+++ b/src/routing/recommend.py
@@ -46,6 +46,7 @@ _FALLBACK_SKILLS = ("oh-my-hermes", "plan", "deep-interview")
 _FALLBACK_WHY = "No strong catalog metadata match; start with general routing/planning guidance."
 _GUARDRAIL_CANDIDATE_INJECTION_IDS = frozenset(
     {
+        "safe_feature_change_before_generic_plan",
         "img_summary_before_materials_or_delivery",
         "paper_learning_before_materials_or_research_ops",
         "source_finder_before_generic_web_research",

--- a/src/workflows/hermes_planning.py
+++ b/src/workflows/hermes_planning.py
@@ -618,8 +618,10 @@ def _unquote_scalar(value: str) -> str:
 def _plan_for(task: str, top: dict[str, object]) -> HermesPlan:
     lowered = task.lower()
     score = _int_value(top.get("score", 0))
+    top_skill = str(top.get("skill", ""))
     weak = len(task.split()) <= 2 and (score == 0 or any(term in lowered for term in _CLARIFY_TERMS))
     review_shaped = any(term in lowered for term in _REVIEW_TERMS)
+    reviewed_plan_shaped = review_shaped or top_skill == "ralplan"
     coding_shaped = _is_coding_shaped(task)
 
     if weak:
@@ -656,7 +658,7 @@ def _plan_for(task: str, top: dict[str, object]) -> HermesPlan:
             stop_condition="A clarified task statement is available for planning.",
         )
 
-    workflow = "ralplan" if review_shaped else "plan"
+    workflow = "ralplan" if reviewed_plan_shaped else "plan"
     harness = "planning"
     handoff = (
         "Use `omh coding delegate --executor codex --record --from-plan <accepted-plan.md>` after this plan is accepted for a run-backed Codex handoff."
@@ -668,9 +670,9 @@ def _plan_for(task: str, top: dict[str, object]) -> HermesPlan:
         task_statement=task,
         recommended_workflow=workflow,
         recommended_harness=harness,
-        planning_mode="review-gated" if review_shaped else "structured",
+        planning_mode="review-gated" if reviewed_plan_shaped else "structured",
         clarified_assumptions=("The task statement is sufficient for a first deterministic planning scaffold.",),
-        goals=_goals(coding_shaped, review_shaped),
+        goals=_goals(coding_shaped, reviewed_plan_shaped),
         non_goals=(
             "Do not execute code or mutate Hermes core from the planning command.",
             "Do not claim architect or critic approval without wrapper evidence.",
@@ -681,8 +683,8 @@ def _plan_for(task: str, top: dict[str, object]) -> HermesPlan:
             "Make acceptance criteria and verification visible before execution.",
             "Separate planned work from observed implementation evidence.",
         ),
-        options=_options("reviewed" if review_shaped else "structured"),
-        chosen_direction=_chosen_direction(coding_shaped, review_shaped),
+        options=_options("reviewed" if reviewed_plan_shaped else "structured"),
+        chosen_direction=_chosen_direction(coding_shaped, reviewed_plan_shaped),
         rejection_rationale=(
             "Direct execution is rejected until the plan names success criteria and verification.",
             "Claimed multi-role consensus is rejected unless wrapper metadata proves those reviews ran.",
@@ -711,7 +713,7 @@ def _plan_for(task: str, top: dict[str, object]) -> HermesPlan:
             status="draft",
             top=top,
             coding_shaped=coding_shaped,
-            review_shaped=review_shaped,
+            review_shaped=reviewed_plan_shaped,
         ),
         deep_interview=_deep_interview_contract(
             task,

--- a/tests/test_chat_router.py
+++ b/tests/test_chat_router.py
@@ -172,6 +172,10 @@ class ChatRouterTests(unittest.TestCase):
                 "doctor",
             ),
             (
+                "Track the Codex work session and tell me what changed.",
+                "agent-ops-review",
+            ),
+            (
                 "finish the invoice export recovery until the smoke test passes or a blocker is recorded.",
                 "ralph",
             ),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -373,7 +373,7 @@ class CliTests(unittest.TestCase):
             self.assertEqual(trace["schema_version"], "workflow_learning_trace/v1")
             self.assertEqual(trace["privacy"]["mode"], "metadata_only")
             self.assertFalse(trace["privacy"]["raw_prompt_stored"])
-            self.assertEqual(trace["workflow"]["selected_workflow"], "plan")
+            self.assertEqual(trace["workflow"]["selected_workflow"], "ralplan")
             self.assertEqual(record["interaction"]["chat_response"]["state"]["learning_trace_ref"], record["learning_trace_ref"])
             self.assertNotIn(message, json.dumps(trace))
 
@@ -3033,7 +3033,7 @@ class CliTests(unittest.TestCase):
         )
         self.assertIn("routing guidance only", route_plan["claim_boundary"])
 
-    def test_recommend_safe_feature_routes_to_plan_with_wrapper_copy(self) -> None:
+    def test_recommend_safe_feature_routes_to_ralplan_with_wrapper_copy(self) -> None:
         message = "I want to safely add a feature to this repo"
         status, stdout, stderr = run_cli(["recommend", message, "--limit", "2"])
 
@@ -3041,7 +3041,7 @@ class CliTests(unittest.TestCase):
         self.assertEqual(status, 0)
         recommendations = json.loads(stdout)["recommendations"]
         top = recommendations[0]
-        self.assertEqual(top["skill"], "plan")
+        self.assertEqual(top["skill"], "ralplan")
         self.assertEqual(top["confidence"], "high")
         self.assertEqual(top["next_action"], "present_plan")
         self.assertIn("not execution evidence", top["evidence_boundary"])
@@ -4105,9 +4105,13 @@ class CliTests(unittest.TestCase):
         payload = json.loads(stdout)
         self.assertEqual(payload["mode"], "plan")
         self.assertEqual(payload["next_action"], "present_plan")
-        self.assertEqual(payload["route"]["selected_skill"], "plan")
+        self.assertEqual(payload["route"]["selected_skill"], "ralplan")
+        self.assertEqual(payload["plan"]["plan"]["recommended_workflow"], "ralplan")
+        self.assertEqual(payload["plan"]["plan"]["planning_mode"], "review-gated")
         response = payload["chat_response"]
         self.assertEqual(response["kind"], "plan")
+        self.assertTrue(response["headline"].startswith("[omh] ralplan - "))
+        self.assertEqual(response["state"]["selected_workflow"], "ralplan")
         self.assertIn("because it needs a safe plan first", response["headline"])
         self.assertIn("not execution evidence", response["claim_boundary"])
         actions = {action["id"]: action for action in response["actions"]}
@@ -5069,7 +5073,7 @@ class CliTests(unittest.TestCase):
         self.assertEqual(payload["schema_version"], "orchestration_demo/v1")
         self.assertEqual(payload["executor_target"], "choose")
         self.assertEqual([step["id"] for step in payload["steps"]], ["recommend", "chat", "plan", "handoff", "status_card"])
-        self.assertEqual(payload["steps"][0]["payload"]["recommendations"][0]["skill"], "plan")
+        self.assertEqual(payload["steps"][0]["payload"]["recommendations"][0]["skill"], "ralplan")
         handoff_payload = payload["steps"][3]["payload"]
         self.assertEqual(handoff_payload["chat_response"]["state"]["next_action"], "choose_executor")
         self.assertEqual(handoff_payload["executor_handoff"], {})


### PR DESCRIPTION
## Summary

This PR improves OMH's first-use and coding-session routing feel:

- The flagship safe feature prompt now routes to `ralplan` instead of generic `plan`.
- Hermes plan/chat response state preserves that reviewed-plan workflow, so the visible prefix becomes `[omh] ralplan`.
- English coding-session status requests such as “Track the Codex work session and tell me what changed” now route to `agent-ops-review` instead of clarification.

## Why

OMH docs and wrapper examples already present safe feature work as a reviewed plan-first flow. The router had started selecting `ralplan`, but the plan response still rendered as generic `plan`, which made the user-visible surface feel inconsistent. Coding session progress questions also needed a clearer operator-status route without requiring users to know backend commands.

## What changed

- Added a narrow `safe_feature_change_before_generic_plan` guard for safe feature-change requests with repo/handoff/planning scope.
- Allowed that guard to inject `ralplan` into recommendation candidates even when raw trigger scoring only found `plan`.
- Updated Hermes planning so a top `ralplan` recommendation stays `ralplan` in the generated plan payload and chat response.
- Expanded coding progress/status phrase coverage for English session-tracking prompts.
- Updated tests for learning traces, orchestration demo output, chat interact output, and operator-surface examples.

## Boundary notes

This is still routing and planning metadata only. It does not dispatch Codex, Claude Code, Hermes coding, or any executor; it does not claim implementation, review, CI, or merge evidence.

## Verification

Observed locally:

```sh
PYTHONPATH=tests uv run python -m unittest discover -s tests
uv run python -m compileall -q src tests
uv run python -m omh.cli docs workflows --check
uv run python -m omh.cli harness validate
git diff --check
```

Manual routing/output smoke:

```text
I want to safely add a feature to this repo -> ralplan
chat headline -> [omh] ralplan - I routed this to `ralplan` because it needs a safe plan first.
Track the Codex work session and tell me what changed -> agent-ops-review
400 routes in 1.0906s avg_ms=2.73
```

## Risks

The safe-feature guard is intentionally scoped to explicit safety plus feature-change plus repo/handoff/planning context. Plain “add a feature” remains generic planning, and “feature request” can still clarify.
