### PR TITLE
Improve operator route guard coverage

### DIFF
--- a/src/routing/policy.py
+++ b/src/routing/policy.py
@@ -791,6 +791,132 @@ _PRODUCT_SHAPING_UNCERTAINTY_TOKENS = _normalized_token_set(
         "모호",
     }
 )
+_FEEDBACK_TRIAGE_PHRASES = (
+    "customer feedback",
+    "customer notes",
+    "customer reports",
+    "customers report",
+    "customers say",
+    "user feedback",
+    "user reports",
+    "users report",
+    "users say",
+    "app keeps crashing",
+    "keeps crashing after login",
+    "checkout is broken",
+    "checkout keeps failing",
+    "payment failures keep coming up",
+    "payment failure keeps coming up",
+    "what to build next from customer notes",
+    "decide what to build next from customer notes",
+    "decide what to build next from these customer notes",
+    "고객 피드백",
+    "고객 노트",
+    "고객 제보",
+    "사용자 제보",
+    "사용자 피드백",
+    "결제 실패 이슈",
+    "결제 실패가 자주",
+    "체크아웃이 깨",
+    "체크아웃 실패",
+    "로그인 후 크래시",
+)
+_FEEDBACK_TRIAGE_SOURCE_TOKENS = _normalized_token_set(
+    {
+        "customer",
+        "customers",
+        "user",
+        "users",
+        "feedback",
+        "notes",
+        "report",
+        "reports",
+        "reported",
+        "signal",
+        "signals",
+        "고객",
+        "사용자",
+        "피드백",
+        "제보",
+        "노트",
+        "신호",
+    }
+)
+_FEEDBACK_TRIAGE_PRODUCT_TOKENS = _normalized_token_set(
+    {
+        "app",
+        "product",
+        "checkout",
+        "payment",
+        "billing",
+        "login",
+        "signup",
+        "onboarding",
+        "cart",
+        "subscription",
+        "앱",
+        "제품",
+        "체크아웃",
+        "결제",
+        "청구",
+        "로그인",
+        "가입",
+        "온보딩",
+    }
+)
+_FEEDBACK_TRIAGE_ISSUE_TOKENS = _normalized_token_set(
+    {
+        "bug",
+        "bugs",
+        "issue",
+        "issues",
+        "broken",
+        "breaks",
+        "crash",
+        "crashes",
+        "crashing",
+        "fail",
+        "fails",
+        "failed",
+        "failing",
+        "failure",
+        "failures",
+        "error",
+        "errors",
+        "problem",
+        "problems",
+        "버그",
+        "이슈",
+        "깨",
+        "고장",
+        "크래시",
+        "실패",
+        "에러",
+        "문제",
+    }
+)
+_FEEDBACK_TRIAGE_DECISION_TOKENS = _normalized_token_set(
+    {
+        "decide",
+        "choose",
+        "prioritize",
+        "rank",
+        "build",
+        "next",
+        "roadmap",
+        "investigate",
+        "reproduce",
+        "triage",
+        "결정",
+        "선택",
+        "우선순위",
+        "다음",
+        "로드맵",
+        "조사",
+        "재현",
+        "트리아지",
+    }
+)
 _WORKFLOW_LEARNING_PHRASES = (
     "learn from this workflow",
     "learn from this workflow run",
@@ -1097,6 +1223,12 @@ _CODING_PROGRESS_STATUS_PHRASES = (
     "track codex work session",
     "coding agent status",
     "coding agent session",
+    "what did the coding agent do",
+    "what did the coding agent do while i was away",
+    "what has the coding agent done",
+    "what did codex do",
+    "what did claude code do",
+    "did the coding agent finish",
     "what changed in the coding agent session",
     "what changed in coding agent session",
     "tell me what changed",
@@ -1131,6 +1263,14 @@ _CODING_PROGRESS_STATUS_TOKENS = _normalized_token_set(
 )
 _GITHUB_EVENT_OPS_PHRASES = (
     "github issue to pr",
+    "issue to pr",
+    "issue into a pr",
+    "issue should become a pr",
+    "issue should become pr",
+    "this issue should become a pr",
+    "turn this issue into a pr",
+    "make this issue into a pr",
+    "convert this issue into a pr",
     "issue opened",
     "pr opened",
     "github issue",
@@ -1552,9 +1692,9 @@ FEEDBACK_BEFORE_CODING_GUARD = RoutingGuardRule(
     rule="Product feedback and bug reports should route through triage/investigation before coding handoff unless code work is explicit.",
     matched_label="guard:feedback_before_coding",
     preferred_skills=("feedback-triage",),
-    score_boost=0,
-    why="Product feedback and bug reports should get triage/investigation before coding handoff.",
-    activation_status="cataloged",
+    score_boost=34,
+    why="Matched customer or product signal language; triage the signal and investigation path before planning fixes.",
+    activation_status="active",
 )
 PRODUCT_SHAPING_GUARD = RoutingGuardRule(
     id="product_shaping_before_ops_review",
@@ -1920,6 +2060,8 @@ def active_routing_guard_rules(
         rules.append(RISKY_REFACTOR_GUARD)
     if _safe_feature_plan_guard_applies(normalized_query, query_tokens):
         rules.append(SAFE_FEATURE_PLAN_GUARD)
+    if _feedback_before_coding_guard_applies(normalized_query, query_tokens):
+        rules.append(FEEDBACK_BEFORE_CODING_GUARD)
     if _product_shaping_guard_applies(normalized_query, query_tokens):
         rules.append(PRODUCT_SHAPING_GUARD)
     if _persistent_completion_guard_applies(normalized_query, query_tokens):
@@ -2032,6 +2174,22 @@ def _product_shaping_guard_applies(normalized_query: str, query_tokens: set[str]
     product_context = bool(_PRODUCT_SHAPING_CONTEXT_TOKENS & query_tokens)
     shaping_uncertainty = bool(_PRODUCT_SHAPING_UNCERTAINTY_TOKENS & query_tokens)
     return product_context and shaping_uncertainty
+
+
+def _feedback_before_coding_guard_applies(normalized_query: str, query_tokens: set[str]) -> bool:
+    if _github_event_ops_guard_applies(normalized_query, query_tokens):
+        return False
+    if _doctor_health_guard_applies(normalized_query, query_tokens):
+        return False
+    if _explicit_delivery_or_implementation_requested(normalized_query, query_tokens):
+        return False
+    if _contains_phrase(normalized_query, _FEEDBACK_TRIAGE_PHRASES):
+        return True
+    source_signal = bool(_FEEDBACK_TRIAGE_SOURCE_TOKENS & query_tokens)
+    product_context = bool(_FEEDBACK_TRIAGE_PRODUCT_TOKENS & query_tokens)
+    issue_signal = bool(_FEEDBACK_TRIAGE_ISSUE_TOKENS & query_tokens)
+    decision_signal = bool(_FEEDBACK_TRIAGE_DECISION_TOKENS & query_tokens)
+    return (source_signal and (issue_signal or decision_signal)) or (product_context and issue_signal)
 
 
 def _workflow_learning_guard_applies(normalized_query: str, query_tokens: set[str]) -> bool:
@@ -2788,6 +2946,25 @@ def _delivery_cycle_guard_applies(normalized_query: str, query_tokens: set[str])
             "계획 구현 리뷰 문서",
             "기획 구현 리뷰 문서",
             "pr까지",
+        ),
+    )
+
+
+def _explicit_delivery_or_implementation_requested(normalized_query: str, query_tokens: set[str]) -> bool:
+    if _delivery_cycle_terms(normalized_query, query_tokens):
+        return True
+    return _contains_phrase(
+        normalized_query,
+        (
+            "write the code",
+            "implement the fix",
+            "fix the code",
+            "open the pr",
+            "merge the pr",
+            "코드 작성",
+            "수정 구현",
+            "pr 열",
+            "pr 머지",
         ),
     )
 

--- a/src/routing/recommend.py
+++ b/src/routing/recommend.py
@@ -46,6 +46,9 @@ _FALLBACK_SKILLS = ("oh-my-hermes", "plan", "deep-interview")
 _FALLBACK_WHY = "No strong catalog metadata match; start with general routing/planning guidance."
 _GUARDRAIL_CANDIDATE_INJECTION_IDS = frozenset(
     {
+        "coding_progress_status_before_clarify",
+        "feedback_before_coding",
+        "github_event_ops_before_generic_planning",
         "safe_feature_change_before_generic_plan",
         "img_summary_before_materials_or_delivery",
         "paper_learning_before_materials_or_research_ops",

--- a/tests/test_chat_router.py
+++ b/tests/test_chat_router.py
@@ -184,6 +184,26 @@ class ChatRouterTests(unittest.TestCase):
                 "research-brief",
             ),
             (
+                "Help me decide what to build next from these customer notes.",
+                "feedback-triage",
+            ),
+            (
+                "The app keeps crashing after login.",
+                "feedback-triage",
+            ),
+            (
+                "Users say checkout is broken.",
+                "feedback-triage",
+            ),
+            (
+                "This issue should become a PR.",
+                "github-event-ops",
+            ),
+            (
+                "What did the coding agent do while I was away?",
+                "agent-ops-review",
+            ),
+            (
                 "decide whether our onboarding should prioritize solo founders or enterprise buyers.",
                 "strategy-brief",
             ),

--- a/tests/test_keyword_manifest.py
+++ b/tests/test_keyword_manifest.py
@@ -32,7 +32,7 @@ class KeywordManifestTests(unittest.TestCase):
         self.assertIn("risky_refactor_before_cleanup", rules)
         self.assertIn("planning/review", rules["risky_refactor_before_cleanup"])
         self.assertEqual(catalog["risky_refactor_before_cleanup"]["activation_status"], "active")
-        self.assertEqual(catalog["feedback_before_coding"]["activation_status"], "cataloged")
+        self.assertEqual(catalog["feedback_before_coding"]["activation_status"], "active")
         self.assertIn("ultragoal", skills)
         self.assertIn("$ultragoal", skills["ultragoal"]["triggers"])
         self.assertEqual(skills["ops-observability-card"]["exposure"], "harness_only")


### PR DESCRIPTION
## Summary
- Activates the existing `feedback_before_coding` guard so customer/product signals route to `feedback-triage` instead of fallback, generic clarify, or unrelated wiki capture.
- Expands natural-language issue-to-PR and coding-agent status guard coverage for chat-first operator messages.
- Adds regression coverage for the exact recovered operator examples: issue-to-PR, app crash, broken checkout, customer notes prioritization, and coding-agent catch-up status.

## Why
Real Hermes users often ask in plain chat rather than naming a workflow. The audit found several high-value operator prompts that still missed the intended OMH surface:

- `This issue should become a PR` clarified instead of routing to GitHub event ops.
- `The app keeps crashing after login` clarified instead of product signal triage.
- `Users say checkout is broken` fell back to the generic router.
- `Help me decide what to build next from these customer notes` routed to wiki.
- `What did the coding agent do while I was away?` clarified instead of showing agent ops status.

This PR makes those requests feel like OMH is actually present in the chat workflow, while keeping execution and evidence claims unchanged.

## What changed
- Added feedback-triage phrases/tokens for customer notes, user reports, product crashes, checkout/payment/login failures, and prioritization from customer signals.
- Turned `feedback_before_coding` from cataloged metadata into an active guard with candidate injection.
- Added issue-to-PR phrase variants for `github-event-ops`.
- Added coding-agent catch-up/status phrase variants for `agent-ops-review`.
- Guarded against false positives by excluding GitHub event ops, doctor/setup health, and explicit implementation/delivery requests from feedback triage.
- Updated keyword manifest expectations now that the feedback guard is active.

## User impact
After this change, Hermes wrappers can route the above natural-language messages directly to the right OMH card or workflow without asking the user to manually choose a skill or approve shell commands. Product bug reports now start at triage/investigation, issue-to-PR asks start with a GitHub event ops card, and coding-agent catch-up questions render a manager-facing status workflow.

## Verification
- `PYTHONPATH=tests uv run python -m unittest tests/test_chat_router.py -v`
- `PYTHONPATH=tests uv run python -m unittest tests/test_keyword_manifest.py -v`
- `PYTHONPATH=tests uv run python -m unittest tests/test_chat_router.py tests/test_cli.py tests/test_router_content.py -v`
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — 858 tests passing
- `PYTHONPATH=tests uv run python -m compileall -q src tests`
- `uv run python -m omh.cli docs workflows --check`
- `uv run python -m omh.cli harness validate`
- `git diff --check`
- Route performance probe: `samples=12`, `iterations=40`, `avg_ms=2.385`, `p95_ms=2.479`, `max_ms=2.507`

## Boundary
This is routing metadata only. It does not claim product investigation, GitHub webhook delivery, executor dispatch, coding execution, review, CI, merge, or live Hermes wrapper rendering.