### PR TITLE
Tighten operator status and setup routing

### DIFF
--- a/src/routing/policy.py
+++ b/src/routing/policy.py
@@ -1241,6 +1241,19 @@ _CODING_PROGRESS_STATUS_PHRASES = (
     "진행됐는지",
     "진행되었는지",
 )
+_CODING_SESSION_STATUS_ONLY_PHRASES = (
+    "session looks stuck",
+    "coding session looks stuck",
+    "codex session looks stuck",
+    "claude code session looks stuck",
+    "what is it doing",
+    "what did the coding agent do",
+    "what did codex do",
+    "what did claude code do",
+    "did the coding agent finish",
+    "is codex done",
+    "is claude code done",
+)
 _CODING_PROGRESS_STATUS_TOKENS = _normalized_token_set(
     {
         "codex",
@@ -1329,6 +1342,7 @@ _RELEASE_CLAIM_REVIEW_TOKENS = _normalized_token_set(
 _VOICE_OPERATOR_PHRASES = (
     "voice operator",
     "voice-first",
+    "voice note",
     "mobile command",
     "from mobile",
     "on mobile",
@@ -2631,6 +2645,8 @@ def _delivery_cycle_terms(normalized_query: str, query_tokens: set[str]) -> bool
 def _coding_handoff_status_guard_applies(normalized_query: str, query_tokens: set[str]) -> bool:
     if _visual_summary_guard_applies(normalized_query, query_tokens):
         return False
+    if _coding_session_status_only_guard_applies(normalized_query, query_tokens):
+        return False
     explicit_phrase = _contains_phrase(normalized_query, _CODING_HANDOFF_PHRASES)
     executor = bool(_CODING_HANDOFF_EXECUTOR_TOKENS & query_tokens) or _contains_phrase(
         normalized_query,
@@ -2651,9 +2667,9 @@ def _github_event_ops_guard_applies(normalized_query: str, query_tokens: set[str
     )
     event_or_pr_prep = _contains_phrase(
         normalized_query,
-        ("opened", "failed ci", "ci failed", "label", "review", "to pr", "into a pr", "pr 만들", "pr로", "들어온"),
+        ("opened", "failed ci", "ci failed", "failing ci", "ci failing", "label", "review", "to pr", "into a pr", "pr 만들", "pr로", "들어온"),
     )
-    event_context = _contains_phrase(normalized_query, ("opened", "failed ci", "ci failed", "label", "들어온"))
+    event_context = _contains_phrase(normalized_query, ("opened", "failed ci", "ci failed", "failing ci", "ci failing", "label", "들어온"))
     return issue_or_pr and event_or_pr_prep and (github_context or event_context)
 
 
@@ -2700,6 +2716,8 @@ def _agent_board_guard_applies(normalized_query: str, query_tokens: set[str]) ->
 
 
 def _coding_progress_status_guard_applies(normalized_query: str, query_tokens: set[str]) -> bool:
+    if _coding_session_status_only_guard_applies(normalized_query, query_tokens):
+        return True
     if _contains_phrase(normalized_query, _CODING_PROGRESS_STATUS_PHRASES):
         return True
     executor = _contains_phrase(
@@ -2711,6 +2729,14 @@ def _coding_progress_status_guard_applies(normalized_query: str, query_tokens: s
         ("progress", "status", "running", "where", "어디까지", "진행", "상태"),
     )
     return executor and progress
+
+
+def _coding_session_status_only_guard_applies(normalized_query: str, query_tokens: set[str]) -> bool:
+    executor = _contains_phrase(
+        normalized_query,
+        ("codex", "claude code", "coding agent", "executor", "코덱스", "클로드", "코딩 에이전트"),
+    )
+    return executor and _contains_phrase(normalized_query, _CODING_SESSION_STATUS_ONLY_PHRASES)
 
 
 def _release_claim_review_guard_applies(normalized_query: str, query_tokens: set[str]) -> bool:
@@ -2746,6 +2772,12 @@ def _doctor_health_guard_applies(normalized_query: str, query_tokens: set[str]) 
             "skills still look stale",
             "skills look stale",
             "hermes skills still",
+            "hermes cannot see the skills",
+            "hermes can't see the skills",
+            "cannot see the skills",
+            "can't see the skills",
+            "setup says done but hermes cannot see",
+            "setup says done but hermes can't see",
             "install looks broken",
             "setup looks broken",
             "registration looks broken",

--- a/src/routing/recommend.py
+++ b/src/routing/recommend.py
@@ -47,12 +47,14 @@ _FALLBACK_WHY = "No strong catalog metadata match; start with general routing/pl
 _GUARDRAIL_CANDIDATE_INJECTION_IDS = frozenset(
     {
         "coding_progress_status_before_clarify",
+        "doctor_health_before_skill_catalog",
         "feedback_before_coding",
         "github_event_ops_before_generic_planning",
         "safe_feature_change_before_generic_plan",
         "img_summary_before_materials_or_delivery",
         "paper_learning_before_materials_or_research_ops",
         "source_finder_before_generic_web_research",
+        "voice_operator_before_generic_clarification",
         "missed_workflow_research_recovery",
         "missed_workflow_operating_record_recovery",
         "product_shaping_before_ops_review",

--- a/tests/test_chat_router.py
+++ b/tests/test_chat_router.py
@@ -204,6 +204,22 @@ class ChatRouterTests(unittest.TestCase):
                 "agent-ops-review",
             ),
             (
+                "PR 42 has failing CI, summarize the risk and next fix path.",
+                "github-event-ops",
+            ),
+            (
+                "The Claude Code session looks stuck; what is it doing and what should I do next?",
+                "agent-ops-review",
+            ),
+            (
+                "Voice note: release risky. check fast and ask before action.",
+                "voice-operator",
+            ),
+            (
+                "omh setup says done but Hermes cannot see the skills.",
+                "doctor",
+            ),
+            (
                 "decide whether our onboarding should prioritize solo founders or enterprise buyers.",
                 "strategy-brief",
             ),


### PR DESCRIPTION
## Summary
- Route failing PR/CI status requests to `github-event-ops` instead of generic clarification.
- Route executor stuck-session questions such as Claude Code status checks to `agent-ops-review` while keeping explicit open/dispatch requests on the delivery path.
- Route voice-note operator requests to `voice-operator` and setup visibility failures to `doctor`.

## Why
Operators were asking Hermes natural questions like “PR 42 has failing CI” or “Claude Code looks stuck” and some of those requests still fell into generic planning or a fresh delivery workflow. This PR tightens the chat-first routing layer so Hermes can answer status and recovery questions without forcing users to know backend OMH commands.

## How
- Adds executor-gated status-only phrases so stuck Codex/Claude Code session questions become manager-facing status review, not a new handoff.
- Extends GitHub event routing for “failing CI” phrasing.
- Adds voice-note and setup visibility health guard coverage to guardrail candidate injection.
- Locks the behavior with grounded operator examples in `tests/test_chat_router.py`.

## Verification
- `PYTHONPATH=tests uv run python -m unittest tests/test_chat_router.py tests/test_keyword_manifest.py -v`
- `PYTHONPATH=tests uv run python -m unittest tests/test_router_content.py -v`
- `PYTHONPATH=tests uv run python -m unittest tests/test_cli.py -v`
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- `PYTHONPATH=tests uv run python -m compileall -q src tests`
- `uv run python -m omh.cli docs workflows --check`
- `uv run python -m omh.cli harness validate`
- `git diff --check`
- route probe: `samples=10 iterations=40 avg_ms=3.018 p95_ms=4.452 max_ms=4.641`

## Risks / Notes
- Live Discord/Slack/Hermes wrapper rendering was not exercised in this PR.
- The guard intentionally keeps generic “What should I do next?” as clarification unless an executor/session context is present.
