### PR TITLE
Tighten routing for executor status and gateway policies

### DIFF
--- a/src/routing/policy.py
+++ b/src/routing/policy.py
@@ -1270,8 +1270,14 @@ _CODING_SESSION_STATUS_ONLY_PHRASES = (
     "did the coding agent finish",
     "says done",
     "said done",
+    "tests passed",
+    "pr is open",
+    "pr opened",
+    "what is still missing",
+    "what's still missing",
     "what evidence is still missing",
     "evidence is still missing",
+    "still missing",
     "is codex done",
     "is claude code done",
 )
@@ -1972,7 +1978,7 @@ CODING_PROGRESS_STATUS_GUARD = RoutingGuardRule(
     rule="Executor or coding-agent progress/status requests should route to agent-ops-review before generic clarification.",
     matched_label="guard:coding_progress_status",
     preferred_skills=("agent-ops-review",),
-    score_boost=28,
+    score_boost=56,
     why="Matched guard/trigger metadata; coding progress questions should render a manager-facing status card with observed gaps.",
     activation_status="active",
 )
@@ -2459,8 +2465,6 @@ def _durable_research_goal_guard_applies(normalized_query: str, query_tokens: se
 
 
 def _loop_goal_guard_applies(normalized_query: str, query_tokens: set[str]) -> bool:
-    if is_explicit_one_off_request(normalized_query, query_tokens):
-        return False
     explicit_loop = _contains_phrase(
         normalized_query,
         ("loopable", "loop engineering", "goal loop", "루프", "반복해서"),
@@ -2474,7 +2478,9 @@ def _loop_goal_guard_applies(normalized_query: str, query_tokens: set[str]) -> b
         normalized_query,
         ("star worthy", "star-worthy", "first-run friction", "10k star", "100k star"),
     )
-    return explicit_loop or (repeated_improvement and (product_or_oss_goal or north_star))
+    if is_explicit_one_off_request(normalized_query, query_tokens) and not (explicit_loop or repeated_improvement or north_star):
+        return False
+    return explicit_loop or (repeated_improvement and (product_or_oss_goal or north_star)) or (north_star and product_or_oss_goal)
 
 
 def _scheduled_ops_blueprint_guard_applies(normalized_query: str, query_tokens: set[str]) -> bool:
@@ -2655,13 +2661,14 @@ def _web_research_guard_applies(normalized_query: str, query_tokens: set[str]) -
         "web",
         "search",
         "sources",
-        "source",
         "citation",
         "citations",
         "links",
         "official",
         "upstream",
     } & query_tokens:
+        return True
+    if "source" in query_tokens and not _contains_phrase(normalized_query, ("open source", "open-source")):
         return True
     if {"latest", "current", "freshness"} & query_tokens:
         freshness_context = bool(
@@ -2919,8 +2926,43 @@ def _agent_board_guard_applies(normalized_query: str, query_tokens: set[str]) ->
 
 def _gateway_intent_guard_applies(normalized_query: str, query_tokens: set[str]) -> bool:
     platform = bool({"discord", "slack", "telegram", "whatsapp", "signal", "gateway", "platform"} & query_tokens)
-    policy = bool({"thread", "delivery", "silent", "attachment", "status", "origin"} & query_tokens)
-    return platform and policy and _deliverable_gateway_context_applies(normalized_query, query_tokens)
+    policy = bool(
+        {
+            "thread",
+            "delivery",
+            "silent",
+            "silently",
+            "quiet",
+            "quietly",
+            "attachment",
+            "file",
+            "status",
+            "origin",
+            "update",
+            "updates",
+        }
+        & query_tokens
+    )
+    gateway_context = _deliverable_gateway_context_applies(normalized_query, query_tokens) or bool(
+        {
+            "message",
+            "messages",
+            "thread",
+            "attachment",
+            "file",
+            "voice",
+            "origin",
+            "delivery",
+            "status",
+            "update",
+            "updates",
+        }
+        & query_tokens
+    ) or _contains_phrase(
+        normalized_query,
+        ("file attachment", "sent an attachment", "update the thread", "thread quietly", "voice note"),
+    )
+    return platform and policy and gateway_context
 
 
 def _hermes_coding_team_guard_applies(normalized_query: str, query_tokens: set[str]) -> bool:
@@ -2931,6 +2973,8 @@ def _hermes_coding_team_guard_applies(normalized_query: str, query_tokens: set[s
 
 
 def _coding_progress_status_guard_applies(normalized_query: str, query_tokens: set[str]) -> bool:
+    if _github_event_ops_guard_applies(normalized_query, query_tokens):
+        return False
     if _coding_session_status_only_guard_applies(normalized_query, query_tokens):
         return True
     if _contains_phrase(normalized_query, _CODING_PROGRESS_STATUS_PHRASES):

--- a/src/routing/task_cards.py
+++ b/src/routing/task_cards.py
@@ -93,6 +93,11 @@ _ROUTER_DESIGN_CONTEXT_PHRASES = (
     "워크플로 학습",
     "워크플로우 학습",
     "라우팅 피드백",
+    "라우터 강화",
+    "라우터강화",
+    "라우터 개선",
+    "라우터개선",
+    "플랜으로 잡",
     "omh가 얼마나 관여",
     "omh를 얼마나 관여",
     "omh 관여",
@@ -215,6 +220,48 @@ _CODE_CLEANUP_TARGET_TOKENS = frozenset(
         "회귀",
         "구현",
     )
+)
+_EXECUTOR_STATUS_CONTEXT_PHRASES = (
+    "codex",
+    "claude code",
+    "coding agent",
+    "executor",
+    "코덱스",
+    "클로드",
+    "코딩 에이전트",
+)
+_EXECUTOR_STATUS_SIGNAL_PHRASES = (
+    "latest status",
+    "current status",
+    "status of",
+    "handoff status",
+    "coding handoff",
+    "tests passed",
+    "pr is open",
+    "pr opened",
+    "what is still missing",
+    "what's still missing",
+    "what evidence is still missing",
+    "progress",
+    "running",
+    "session",
+    "진행상태",
+    "진행 상황",
+)
+_EXECUTOR_STATUS_META_EXCLUSION_PHRASES = (
+    "developer test",
+    "developer note",
+    "setup test",
+    "token only",
+    "not asking to implement",
+    "vocabulary",
+    "route:",
+    "routing",
+    "router",
+    "용어",
+    "라우팅",
+    "라우터",
+    "라우터 강화",
 )
 
 
@@ -354,6 +401,11 @@ def _without_diagnostic_status_lines(normalized: str) -> str:
             stripped = re.sub(r"^\[omh(?:\s+awareness|\s+route\s+hint)?\]\s*", "", stripped).strip()
             if not stripped:
                 continue
+        stripped = re.sub(r"\bnative bridge status context\.?", "", stripped).strip()
+        stripped = re.sub(r"\bevidence boundary:[^.]*\.?", "", stripped).strip()
+        stripped = re.sub(r"\blatest runtime run:[^.]*\.?", "", stripped).strip()
+        if not stripped:
+            continue
         if stripped.startswith(("native bridge status context", "evidence boundary", "latest runtime run")):
             continue
         if any(marker in stripped for marker in markers):
@@ -378,6 +430,8 @@ def _is_router_design_feedback(normalized: str, compact: str, tokens: set[str], 
     evaluation_region = _without_diagnostic_status_lines(normalized) if diagnostic_status_context else normalized
     evaluation_compact = evaluation_region.replace(" ", "")
     if _is_code_cleanup_request(evaluation_region, tokens):
+        return False
+    if _is_executor_status_question(evaluation_region, evaluation_compact, tokens):
         return False
     phrase_hit = _phrase_hit(_ROUTER_DESIGN_CONTEXT_PHRASES, evaluation_region, evaluation_compact)
     if phrase_hit:
@@ -422,6 +476,16 @@ def _is_router_design_feedback(normalized: str, compact: str, tokens: set[str], 
     ):
         return True
     return False
+
+
+def _is_executor_status_question(evaluation_region: str, evaluation_compact: str, tokens: set[str]) -> bool:
+    if _phrase_hit(_EXECUTOR_STATUS_META_EXCLUSION_PHRASES, evaluation_region, evaluation_compact):
+        return False
+    executor_context = _phrase_hit(_EXECUTOR_STATUS_CONTEXT_PHRASES, evaluation_region, evaluation_compact)
+    status_signal = _phrase_hit(_EXECUTOR_STATUS_SIGNAL_PHRASES, evaluation_region, evaluation_compact) or bool(
+        {"status", "progress", "running", "session", "handoff"} & tokens
+    )
+    return executor_context and status_signal
 
 
 def _is_code_cleanup_request(evaluation_region: str, tokens: set[str]) -> bool:

--- a/tests/test_chat_router.py
+++ b/tests/test_chat_router.py
@@ -244,6 +244,14 @@ class ChatRouterTests(unittest.TestCase):
                 "agent-ops-review",
             ),
             (
+                "The coding agent says tests passed and PR is open; what is still missing?",
+                "agent-ops-review",
+            ),
+            (
+                "What is the latest status of the Codex handoff?",
+                "agent-ops-review",
+            ),
+            (
                 "I installed it but omh is not found in a new terminal.",
                 "doctor",
             ),
@@ -264,7 +272,15 @@ class ChatRouterTests(unittest.TestCase):
                 "gateway-intent-card",
             ),
             (
+                "Slack message has a file attachment and should update the thread quietly.",
+                "gateway-intent-card",
+            ),
+            (
                 "Make this OSS star-worthy by repeatedly reducing first-run friction.",
+                "loop",
+            ),
+            (
+                "Make a 100k star open source project from this repo.",
                 "loop",
             ),
             (


### PR DESCRIPTION
## Summary
- Routes executor status/completion questions to `agent-ops-review` when users ask about Codex, Claude Code, or a coding agent being done, having tests pass, opening a PR, or needing missing evidence.
- Routes messenger platform attachment/thread/silent-update policy questions to `gateway-intent-card` instead of treating them as deliverable file packaging.
- Keeps north-star OSS goals such as "100k star open source project" in `loop` and prevents the `source` token inside "open source" from triggering web research.
- Preserves `workflow-learning` for router-design and vocabulary feedback, including pasted one-line OMH status contexts.

## Why
Real chat users do not phrase these as backend commands. They ask things like "what is the latest status of the Codex handoff?", "the coding agent says tests passed and PR is open; what is still missing?", or "Slack message has a file attachment and should update the thread quietly." These should produce the operator-facing OMH card that matches the real boundary instead of drifting into generic delivery, file packaging, web research, or workflow-learning.

## What Changed
- Strengthened coding progress routing for observed-gap/status questions while explicitly letting GitHub issue/PR event ops win when the request is a GitHub event flow.
- Added executor-status exclusions to the task-card router so "Codex handoff status" is not mistaken for router-design feedback, while meta/vocabulary tests still stay in `workflow-learning`.
- Made diagnostic status stripping preserve user instructions when wrapper status and the user request appear on one line.
- Expanded gateway-intent matching for platform message, attachment, file, thread, update, and quiet/silent delivery policy.
- Adjusted web-research matching so `open source` does not count as a source lookup by itself.
- Added chat-router regression examples for these cases.

## User Impact
- "What is the latest status of the Codex handoff?" now routes to `agent-ops-review`.
- "The coding agent says tests passed and PR is open; what is still missing?" now routes to `agent-ops-review`.
- "Slack message has a file attachment and should update the thread quietly." now routes to `gateway-intent-card`.
- "Make a 100k star open source project from this repo." now routes to `loop`.
- "OMH developer test: Codex handoff vocabulary, not asking to implement." remains `workflow-learning`.

## Verification
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — 858 tests OK.
- `PYTHONPATH=tests uv run python -m unittest tests/test_chat_router.py -v` — 43 tests OK.
- `PYTHONPATH=tests uv run python -m compileall -q src tests` — OK.
- `uv run python -m omh.cli docs workflows --check` — OK.
- `uv run python -m omh.cli harness validate` — OK.
- `git diff --check` — OK.
- Route probe: 7 samples x 50 iterations, avg 3.279ms, p95 4.044ms, max 5.077ms.

## Risk
- Moderate routing-policy surface area. This PR uses targeted exclusions and regression tests around broad words such as handoff, source, status, attachment, review, and route.
- No live Hermes/Discord/Slack rendering was exercised; this is deterministic local routing behavior.
