### PR TITLE
Improve multilingual safe feature routing

### DIFF
--- a/src/routing/localization.py
+++ b/src/routing/localization.py
@@ -37,7 +37,10 @@ _CANONICAL_PAYMENT_FAILURE = (
 _CANONICAL_RISKY_REFACTOR = (
     "dangerous refactor risky refactor unsafe refactor reviewed plan consensus planning acceptance criteria"
 )
-_CANONICAL_SAFE_FEATURE = "safely add a feature to this repo feature add safe plan"
+_CANONICAL_SAFE_FEATURE = (
+    "safely add feature safe feature change reviewed consensus acceptance criteria "
+    "risk verification command before executor handoff"
+)
 _CANONICAL_ISSUE_TO_PR = "issue to pr pr-ready issue plan acceptance criteria coding handoff request-to-handoff"
 _CANONICAL_WEB_RESEARCH = (
     "web research web search search the web current sources source-backed research "
@@ -153,6 +156,18 @@ _ALIASES: tuple[LocaleAlias, ...] = (
         "risky_refactor",
         ("riskantes refactoring", "gefährliches refactoring", "gefaehrliches refactoring", "riskante refaktorierung"),
         _CANONICAL_RISKY_REFACTOR,
+    ),
+    LocaleAlias(
+        "ko",
+        "safe_feature",
+        (
+            "안전하게 기능 추가",
+            "기능 안전하게 추가",
+            "기능 추가를 안전하게",
+            "새 기능 안전하게 넣",
+            "안전하게 새 기능",
+        ),
+        _CANONICAL_SAFE_FEATURE,
     ),
     LocaleAlias(
         "ja",

--- a/src/routing/policy.py
+++ b/src/routing/policy.py
@@ -2314,13 +2314,27 @@ def _safe_feature_plan_guard_applies(normalized_query: str, query_tokens: set[st
     )
     feature_change = bool({"feature", "features", "기능"} & query_tokens) and (
         bool({"add", "implement", "change", "build", "추가", "구현"} & query_tokens)
-        or _contains_phrase(normalized_query, ("add a feature", "feature change", "기능 추가"))
+        or _contains_phrase(normalized_query, ("add a feature", "feature change", "기능 추가", "기능 안전하게 넣"))
     )
     scope_or_handoff = bool({"repo", "repository", "handoff", "plan", "codebase", "executor"} & query_tokens) or _contains_phrase(
         normalized_query,
         ("this repo", "this repository", "before handoff", "request-to-handoff", "코드베이스", "핸드오프"),
     )
-    return safe_signal and feature_change and scope_or_handoff
+    return safe_signal and feature_change and (
+        scope_or_handoff
+        or _contains_phrase(
+            normalized_query,
+            (
+                "safely add a feature",
+                "add a feature safely",
+                "feature safely",
+                "safe feature",
+                "안전하게 기능",
+                "안전한 기능",
+                "기능 안전하게",
+            ),
+        )
+    )
 
 
 def _persistent_completion_guard_applies(normalized_query: str, query_tokens: set[str]) -> bool:

--- a/tests/test_chat_router.py
+++ b/tests/test_chat_router.py
@@ -51,6 +51,28 @@ class ChatRouterTests(unittest.TestCase):
         self.assertEqual(decision["confidence"], "high")
         self.assertIn("User message:\nrisky refactor", decision["routing_prompt"])
 
+    def test_safe_feature_chat_routes_to_reviewed_plan_across_common_phrasings(self) -> None:
+        cases = (
+            ("safely add a feature", None),
+            ("add a feature safely", None),
+            ("안전하게 기능 추가하고 싶어", "locale:ko:safe_feature"),
+            ("새 기능 안전하게 넣고 싶어", "locale:ko:safe_feature"),
+            ("Quiero agregar una función de forma segura a este repo", "locale:es:safe_feature"),
+            ("Je veux ajouter une fonctionnalité en toute sécurité à ce repo", "locale:fr:safe_feature"),
+            ("Ich möchte sicher eine Funktion hinzufügen", "locale:de:safe_feature"),
+        )
+
+        for message, locale_match in cases:
+            with self.subTest(message=message):
+                decision = route_chat_message(message, source="discord")
+
+                self.assertEqual(decision["action"], "dispatch")
+                self.assertEqual(decision["selected_skill"], "ralplan")
+                self.assertEqual(decision["selected_harness"], "planning")
+                self.assertIn("guard:safe_feature_change", decision["recommendations"][0]["matched"])
+                if locale_match is not None:
+                    self.assertIn(locale_match, decision["recommendations"][0]["matched"])
+
     def test_low_signal_chat_falls_back_to_router(self) -> None:
         decision = route_chat_message("zzzzunknownphrase", source="slack")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3100,6 +3100,10 @@ class CliTests(unittest.TestCase):
             ("支付失败问题经常出现", "feedback-triage", "locale:zh:payment_failure"),
             ("危険なリファクタリングだと思います", "ralplan", "locale:ja:risky_refactor"),
             ("这个重构很危险", "ralplan", "locale:zh:risky_refactor"),
+            ("안전하게 기능 추가하고 싶어", "ralplan", "locale:ko:safe_feature"),
+            ("Quiero agregar una función de forma segura a este repo", "ralplan", "locale:es:safe_feature"),
+            ("Je veux ajouter une fonctionnalité en toute sécurité à ce repo", "ralplan", "locale:fr:safe_feature"),
+            ("Ich möchte sicher eine Funktion hinzufügen", "ralplan", "locale:de:safe_feature"),
             ("Quiero convertir este issue en un PR", "plan", "locale:es:issue_to_pr"),
             ("Je veux transformer cette issue en PR", "plan", "locale:fr:issue_to_pr"),
             ("Ich möchte dieses Issue für einen PR vorbereiten", "plan", "locale:de:issue_to_pr"),
@@ -3521,7 +3525,7 @@ class CliTests(unittest.TestCase):
                 self.assertIn("process orchestration", top["evidence_boundary"])
                 self.assertIn("prepared_not_observed", top["wrapper_guidance"])
 
-    def test_chat_interact_multilingual_feature_request_uses_plan_surface(self) -> None:
+    def test_chat_interact_multilingual_safe_feature_request_uses_reviewed_plan_surface(self) -> None:
         status, stdout, stderr = run_cli(
             ["chat", "interact", "--source", "hermes", "Ajoute une fonctionnalité en toute sécurité à ce dépôt"]
         )
@@ -3531,7 +3535,8 @@ class CliTests(unittest.TestCase):
         payload = json.loads(stdout)
         self.assertEqual(payload["mode"], "plan")
         self.assertEqual(payload["chat_response"]["kind"], "plan")
-        self.assertEqual(payload["chat_response"]["state"]["selected_workflow"], "plan")
+        self.assertEqual(payload["route"]["selected_skill"], "ralplan")
+        self.assertEqual(payload["chat_response"]["state"]["selected_workflow"], "ralplan")
         self.assertIn("Accept plan", {action["label"] for action in payload["chat_response"]["actions"]})
 
     def test_chat_interact_render_profile_override_is_preserved(self) -> None:

--- a/tests/test_workflow_learning.py
+++ b/tests/test_workflow_learning.py
@@ -58,7 +58,7 @@ class WorkflowLearningTests(unittest.TestCase):
         self.assertEqual(trace["privacy"]["mode"], "metadata_only")
         self.assertFalse(trace["privacy"]["raw_prompt_stored"])
         self.assertEqual(trace["source"]["message_length"], len(message))
-        self.assertEqual(trace["workflow"]["selected_workflow"], "plan")
+        self.assertEqual(trace["workflow"]["selected_workflow"], "ralplan")
         self.assertIn("plan acceptance", trace["reasoning_summary"]["not_evidence_yet"])
         self.assertNotIn(message, serialized)
         self.assertNotIn("secret-token-123", serialized)


### PR DESCRIPTION
## Feature Report

### What Changed

- Routes short and multilingual safe feature-change requests to `ralplan` instead of generic `plan`.
- Adds Korean safe-feature aliases and retunes the safe-feature locale canonical text toward reviewed planning signals: acceptance criteria, risk, verification command, and executor handoff boundary.
- Locks chat, CLI recommend, chat-interact, and workflow-learning trace expectations around the reviewed-plan route.

### Why This Exists

- Real chat users often say things like “safely add a feature”, “add a feature safely”, or equivalent Korean/French/Spanish/German phrasing without explicitly saying “repo” or “handoff”.
- Before this change, some of those requests routed to generic `plan`, and Korean natural phrasing could fall back to the router. That made safe implementation requests less consistently review-gated than the English canonical example.

### User / Operator Impact

- Hermes can now route common safe feature requests from Discord/Slack-style chat directly into reviewed planning.
- Users get the safer first workflow for implementation-adjacent requests: plan acceptance before executor handoff, not a vague generic plan or fallback picker.
- Workflow-learning traces now record the reviewed-plan route for safe feature requests while still storing metadata only.

### How It Works

- `src/routing/localization.py` changes the `safe_feature` canonical text so locale aliases boost reviewed-planning evidence rather than generic `plan` scoring.
- `src/routing/policy.py` relaxes the safe-feature guard so explicit safe feature-change phrasing does not require a repo/handoff token before preferring `ralplan`.
- Tests cover short English phrasing, natural Korean phrasing, and Spanish/French/German locale aliases.

### Files And Contracts Touched

- `src/routing/localization.py`: safe-feature canonical text and Korean alias coverage.
- `src/routing/policy.py`: safe-feature guard acceptance for common chat phrasing.
- `tests/test_chat_router.py`: chat route regression cases.
- `tests/test_cli.py`: recommend/chat-interact expectations.
- `tests/test_workflow_learning.py`: metadata trace selected workflow expectation.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_chat_router.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_cli.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_workflow_learning.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `PYTHONPATH=tests uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli harness validate`
- [x] `git diff --check`
- [x] Relevant dry-run or smoke command: direct multilingual chat route smoke covering 25 payment/refactor/safe-feature/issue/web-search samples.
- [x] Manual Hermes/TUI check, or explicit reason it was not run: not run; this is deterministic local router behavior and does not change live Hermes UI rendering.

## Risk

- Narrow routing behavior change: safe feature-change phrases that previously selected generic `plan` now select `ralplan`. This is intentional because the product contract treats safe implementation requests as review-gated before executor handoff.

## Compatibility / Rollout

- No schema, command, or artifact migration required.
- Existing explicit `$plan` or `/plan` invocations still override heuristic routing.

## Release / Claims

- [x] Release-channel impact considered (`preview` routing quality improvement; no installer/update behavior change).
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap.

## Follow-Up

- Continue expanding locale fixture coverage only when real chat phrases reveal missed routes; avoid turning OMH into translation API behavior.
