### PR TITLE
Route direct coding tasks to one-cycle delivery

### DIFF
--- a/src/routing/policy.py
+++ b/src/routing/policy.py
@@ -1910,6 +1910,15 @@ DELIVERY_CYCLE_GUARD = RoutingGuardRule(
     why="Matched guard/trigger metadata; PR or delivery-cycle requests need the one-cycle process lane rather than research-only routing.",
     activation_status="active",
 )
+DIRECT_CODING_TASK_GUARD = RoutingGuardRule(
+    id="direct_coding_task_before_fallback",
+    rule="Concrete code-edit requests should route to the one-cycle delivery lane instead of falling back to the generic picker.",
+    matched_label="guard:direct_coding_task",
+    preferred_skills=("ultraprocess",),
+    score_boost=44,
+    why="Matched explicit code-edit language; prepare one bounded implementation cycle instead of asking which workflow to use.",
+    activation_status="active",
+)
 CODING_HANDOFF_STATUS_GUARD = RoutingGuardRule(
     id="coding_handoff_status_before_clarify",
     rule="Executor-named coding handoff plus progress/status tracking should route to Ultraprocess instead of generic clarification.",
@@ -2100,6 +2109,7 @@ ROUTING_GUARD_RULES = (
     VISUAL_SUMMARY_GUARD,
     DELIVERABLE_PACKAGE_GUARD,
     DELIVERY_CYCLE_GUARD,
+    DIRECT_CODING_TASK_GUARD,
     CODING_HANDOFF_STATUS_GUARD,
 )
 
@@ -2145,6 +2155,9 @@ def active_routing_guard_rules(
         rules.append(RISKY_REFACTOR_GUARD)
     if _safe_feature_plan_guard_applies(normalized_query, query_tokens):
         rules.append(SAFE_FEATURE_PLAN_GUARD)
+    direct_coding_task_applies = _direct_coding_task_guard_applies(normalized_query, query_tokens)
+    if direct_coding_task_applies:
+        rules.append(DIRECT_CODING_TASK_GUARD)
     if _feedback_before_coding_guard_applies(normalized_query, query_tokens):
         rules.append(FEEDBACK_BEFORE_CODING_GUARD)
     if _product_shaping_guard_applies(normalized_query, query_tokens):
@@ -2267,12 +2280,152 @@ def _product_shaping_guard_applies(normalized_query: str, query_tokens: set[str]
     return product_context and shaping_uncertainty
 
 
+def _direct_coding_task_guard_applies(normalized_query: str, query_tokens: set[str]) -> bool:
+    if _contains_phrase(
+        normalized_query,
+        (
+            "before coding",
+            "before code",
+            "before implementation",
+            "before writing code",
+            "repro plan before coding",
+            "reproduction plan before coding",
+            "구현 전에",
+            "코딩 전에",
+        ),
+    ):
+        return False
+    if _visual_summary_guard_applies(normalized_query, query_tokens):
+        return False
+    if _materials_package_guard_applies(normalized_query, query_tokens):
+        return False
+    if _source_finder_guard_applies(normalized_query, query_tokens):
+        return False
+    if _paper_learning_guard_applies(normalized_query, query_tokens):
+        return False
+    if _github_event_ops_guard_applies(normalized_query, query_tokens):
+        return False
+    if _coding_progress_status_guard_applies(normalized_query, query_tokens):
+        return False
+    if _release_claim_review_guard_applies(normalized_query, query_tokens):
+        return False
+    if _doctor_health_guard_applies(normalized_query, query_tokens):
+        return False
+    if _safe_feature_plan_guard_applies(normalized_query, query_tokens):
+        return False
+    if _risky_refactor_guard_applies(normalized_query, query_tokens):
+        return False
+    if _cleanup_refactor_guard_applies(normalized_query, query_tokens):
+        return False
+
+    action = bool(
+        {
+            "add",
+            "adjust",
+            "build",
+            "change",
+            "delete",
+            "edit",
+            "fix",
+            "implement",
+            "make",
+            "patch",
+            "remove",
+            "rename",
+            "set",
+            "tweak",
+            "update",
+        }
+        & query_tokens
+    ) or _contains_phrase(
+        normalized_query,
+        (
+            "바꿔",
+            "고쳐",
+            "수정",
+            "추가",
+            "구현",
+            "삭제",
+            "제거",
+            "변경",
+            "넣어",
+            "만들어",
+        ),
+    )
+    if not action:
+        return False
+
+    concrete_surface = bool(
+        {
+            "api",
+            "bug",
+            "button",
+            "component",
+            "css",
+            "dark",
+            "docs",
+            "file",
+            "function",
+            "login",
+            "mode",
+            "navbar",
+            "readme",
+            "route",
+            "router",
+            "setting",
+            "settings",
+            "style",
+            "test",
+            "tests",
+            "title",
+            "toggle",
+            "variable",
+        }
+        & query_tokens
+    ) or _contains_phrase(
+        normalized_query,
+        (
+            "button color",
+            "dark mode",
+            "settings button",
+            "navbar",
+            "readme title",
+            "rename this variable",
+            "login bug",
+            "버튼 색",
+            "버그 고쳐",
+            "다크모드",
+            "토글 추가",
+            "readme 제목",
+            "리드미 제목",
+            "변수명",
+        ),
+    )
+    if not concrete_surface:
+        return False
+
+    review_only = _contains_phrase(
+        normalized_query,
+        (
+            "claim matches",
+            "review before release",
+            "before release",
+            "릴리즈 전에",
+            "주장과 실제",
+            "맞는지 검토",
+        ),
+    )
+    return not review_only
+
+
 def _feedback_before_coding_guard_applies(normalized_query: str, query_tokens: set[str]) -> bool:
     if _gateway_intent_guard_applies(normalized_query, query_tokens):
         return False
     if _github_event_ops_guard_applies(normalized_query, query_tokens):
         return False
     if _doctor_health_guard_applies(normalized_query, query_tokens):
+        return False
+    if _direct_coding_task_guard_applies(normalized_query, query_tokens):
         return False
     planning_before_coding = _contains_phrase(
         normalized_query,

--- a/src/routing/recommend.py
+++ b/src/routing/recommend.py
@@ -47,6 +47,7 @@ _FALLBACK_WHY = "No strong catalog metadata match; start with general routing/pl
 _GUARDRAIL_CANDIDATE_INJECTION_IDS = frozenset(
     {
         "coding_progress_status_before_clarify",
+        "direct_coding_task_before_fallback",
         "doctor_health_before_skill_catalog",
         "feedback_before_coding",
         "gateway_intent_before_feedback_triage",

--- a/tests/test_chat_router.py
+++ b/tests/test_chat_router.py
@@ -1004,6 +1004,45 @@ selected_workflow=ultraprocess
                 self.assertEqual(decision["selected_harness"], "goal-execution")
                 self.assertEqual(decision["confidence"], "high")
 
+    def test_direct_small_coding_tasks_route_to_one_cycle_delivery(self) -> None:
+        cases = (
+            "fix the login bug",
+            "implement dark mode toggle",
+            "add a settings button",
+            "change the button color to blue",
+            "make the navbar sticky",
+            "update the README title",
+            "rename this variable",
+            "버튼 색 파란색으로 바꿔줘",
+            "로그인 버그 고쳐줘",
+            "다크모드 토글 추가해줘",
+            "README 제목 수정해줘",
+        )
+
+        for message in cases:
+            with self.subTest(message=message):
+                decision = route_chat_message(message, source="discord")
+
+                self.assertEqual(decision["action"], "dispatch")
+                self.assertEqual(decision["selected_skill"], "ultraprocess")
+                self.assertEqual(decision["selected_harness"], "goal-execution")
+                self.assertEqual(decision["confidence"], "high")
+                self.assertIn("guard:direct_coding_task", decision["recommendations"][0]["matched"])
+
+    def test_direct_coding_guard_preserves_non_coding_and_review_routes(self) -> None:
+        cases = (
+            ("결제 실패 이슈가 자주 나와", "feedback-triage"),
+            ("릴리즈 전에 README claim이 실제 코드와 맞는가 봐줘", "code-review"),
+            ("회의록 요약 이미지 카드 만들어줘", "img-summary"),
+        )
+
+        for message, selected_skill in cases:
+            with self.subTest(message=message):
+                decision = route_chat_message(message, source="discord")
+
+                self.assertEqual(decision["selected_skill"], selected_skill)
+                self.assertNotIn("guard:direct_coding_task", decision["recommendations"][0]["matched"])
+
     def test_multi_workflow_route_plan_exposes_research_plan_delivery_review_order(self) -> None:
         decision = route_chat_message(
             "Research current install friction, make a reviewed plan, implement with Codex, "

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3012,6 +3012,31 @@ class CliTests(unittest.TestCase):
         self.assertTrue({"plan", "ralplan"} & top_names)
         self.assertTrue(any(recommendation["hermes_role"] == "planner" for recommendation in recommendations))
 
+    def test_recommend_direct_small_coding_tasks_use_one_cycle_delivery(self) -> None:
+        cases = (
+            "fix the login bug",
+            "implement dark mode toggle",
+            "change the button color to blue",
+            "README 제목 수정해줘",
+        )
+
+        for message in cases:
+            with self.subTest(message=message):
+                status, stdout, stderr = run_cli(["recommend", message, "--limit", "3"])
+
+                self.assertEqual(stderr, "")
+                self.assertEqual(status, 0)
+                recommendations = json.loads(stdout)["recommendations"]
+                self.assertEqual(recommendations[0]["skill"], "ultraprocess")
+                self.assertEqual(recommendations[0]["next_action"], "start_ultraprocess")
+                self.assertIn("guard:direct_coding_task", recommendations[0]["matched"])
+                self.assertIn("process orchestration", recommendations[0]["evidence_boundary"])
+
+        status, stdout, stderr = run_cli(["recommend", "결제 실패 이슈가 자주 나와", "--limit", "3"])
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        self.assertEqual(json.loads(stdout)["recommendations"][0]["skill"], "feedback-triage")
+
     def test_recommend_json_includes_multi_workflow_route_plan(self) -> None:
         message = "Research current install friction, make a reviewed plan, implement with Codex, and run code review."
         status, stdout, stderr = run_cli(["recommend", message, "--limit", "2", "--json"])


### PR DESCRIPTION
## Feature Report

### What Changed

- Added a `direct_coding_task_before_fallback` routing guard for concrete code-edit requests such as `fix the login bug`, `implement dark mode toggle`, `change the button color to blue`, and Korean equivalents like `README 제목 수정해줘`.
- Injected the guard's preferred `ultraprocess` candidate so low-score but explicit small implementation requests no longer fall back to the generic `oh-my-hermes` picker.
- Added router and CLI regression coverage for direct coding requests and for non-coding/review routes that must not be stolen by the new guard.

### Why This Exists

Hermes chat users often ask short, practical implementation requests without naming a workflow. Before this change, some of those requests routed to feedback triage or the generic picker, which made OMH feel unsure at the moment the user expected a clear one-cycle delivery path.

The fix keeps OMH chat-first: users can say a direct code-edit request naturally, and Hermes can route it to `ultraprocess` without forcing them to learn backend commands.

### User / Operator Impact

- `fix the login bug`, `add a settings button`, `rename this variable`, or `버튼 색 파란색으로 바꿔줘` now select `ultraprocess` with high confidence.
- Product signals such as `결제 실패 이슈가 자주 나와` still route to `feedback-triage`.
- Review asks such as `릴리즈 전에 README claim이 실제 코드와 맞는가 봐줘` still route to `code-review`.
- Visual requests such as `회의록 요약 이미지 카드 만들어줘` still route to `img-summary`.
- Requests that explicitly ask for investigation before coding, such as `make a repro plan before coding`, stay on the planning/triage side instead of jumping to implementation.

### How It Works

- `src/routing/policy.py` defines a new direct-coding guard with explicit action terms plus concrete code surfaces.
- The guard refuses more specific surfaces first, including visual summary, material packaging, source finding, paper learning, GitHub event ops, coding progress status, release claim review, doctor health, safe feature planning, risky refactor, and cleanup refactor.
- The guard also refuses `before coding` / `before implementation` / Korean before-coding phrases so repro-plan requests remain investigative.
- `src/routing/recommend.py` includes the new guard in candidate injection, allowing `ultraprocess` to appear even when catalog metadata alone would not score the terse request highly enough.

### Files And Contracts Touched

- `src/routing/policy.py`: new routing guard and precedence wiring.
- `src/routing/recommend.py`: guardrail candidate injection for direct coding requests.
- `tests/test_chat_router.py`: chat routing coverage for direct coding, non-coding preservation, and review preservation.
- `tests/test_cli.py`: CLI recommendation coverage for direct coding requests and payment-failure preservation.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_chat_router.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_cli.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_keyword_manifest.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` (862 tests)
- [x] `PYTHONPATH=tests uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli harness validate`
- [x] `git diff --check`
- [ ] `python3 -m omh.cli release checklist --json` (not needed for this routing-only change)
- [ ] `python3 -m omh.cli release hermes-smoke` (not run; live Hermes visibility was not changed)
- [ ] `omh --help` (not changed)
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` (not run; install/release path not touched)
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable
- [ ] Relevant dry-run or smoke command: covered by targeted recommend/chat tests above
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run because this PR only changes deterministic routing policy and CLI/chat router tests covered the new contract

## Risk

- Moderate routing-risk surface: terse natural-language matching can accidentally steal neighboring workflows.
- Mitigation: the guard rejects explicit before-coding planning, product feedback, release review, visual summary, and other stronger domain surfaces before applying.

## Compatibility / Rollout

- Backward-compatible additive routing policy.
- No schema changes, no network calls, no Hermes core behavior changes, no runtime artifact migration.
- Existing fallback picker behavior remains for vague or unsupported requests.

## Release / Claims

- [x] Release-channel impact considered: preview/stable behavior improves once this routing policy ships in the installed command package or generated workflow pack.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed: this PR claims only deterministic route selection observed in tests.
- [x] Known manual Hermes checks are listed: live Hermes/TUI rendering was not exercised.

## Follow-Up

- Keep expanding representative chat-first route fixtures when new operator examples reveal ambiguous boundaries.
