### PR TITLE
Improve chat coding-agent progress UX

### DIFF
--- a/docs/PLAYBOOKS.md
+++ b/docs/PLAYBOOKS.md
@@ -99,9 +99,9 @@ omh playbook recommend "I want to safely add a feature to this repo"
 
 The top playbook is `request-to-handoff`. A wrapper can show why that flagship
 path was chosen, name the responsible role, keep handoff disabled until plan
-acceptance, then show executor selection, `Send to executor`, prompt handoff,
-and `Show status` actions based on the configured executor profile. `Send to
-Codex` is only a compatibility alias when the Codex lifecycle profile is
+acceptance, then show coding-agent selection, `Open in Codex`, prompt handoff,
+and `Show status` actions based on the configured coding-agent profile. `Open
+in Codex` is only a compatibility alias when the Codex lifecycle profile is
 selected.
 
 The user-facing improvement is simple: the user describes the work naturally,

--- a/src/quality/grounded_score.py
+++ b/src/quality/grounded_score.py
@@ -311,7 +311,7 @@ GROUNDED_SCENARIOS: tuple[GroundedScenario, ...] = (
         "Codex 작업이 진행중인지 확인하고 지금 어떤 상태인지 알려줘",
         "ultraprocess",
         "handoff",
-        "choose_executor",
+        "send_to_executor",
         "clarify",
         False,
         expected_playbook="ultraprocess",

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -207,6 +207,26 @@ _SKILL_PICKER_TOKENS = frozenset({"omh", "ohmy", "skills"})
 _SKILL_PICKER_HELP_TOKENS = frozenset({"", "help", "menu", "list", "commands", "workflows", "skills"})
 _COMMAND_PREVIEW_PREFIXES = ("./", "/")
 _COMMAND_PREVIEW_ALIAS = "omh"
+_MESSAGE_EXECUTOR_HINTS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("claude-code", ("claude code", "claude-code", "claudecode", "클로드 코드", "클로드코드")),
+    ("codex", ("codex", "코덱스")),
+    ("omc-runtime", ("omc", "oh my claude", "oh-my-claude", "oh my claude code", "oh-my-claude-code")),
+    ("omo-runtime", ("omo", "oh my openagent", "oh-my-openagent", "openagent runtime")),
+    ("omx-runtime", ("omx", "oh my codex", "oh-my-" + "codex", "omx runtime")),
+    (
+        "hermes",
+        (
+            "hermes coding",
+            "hermes runtime",
+            "hermes itself",
+            "with hermes",
+            "헤르메스가 코딩",
+            "헤르메스로 구현",
+            "헤르메스 자체",
+            "헤르메스 런타임",
+        ),
+    ),
+)
 _SKILL_PICKER_ENTRIES = (
     ("oh-my-hermes", "Route for me", "Let Hermes choose the safest workflow.", "./omh <request>"),
     ("deep-interview", "Deep Interview", "Clarify fuzzy goals before planning.", "./deep-interview <request>"),
@@ -631,7 +651,7 @@ def build_chat_interaction_payload(
         base["next_action"] = str(_nested(base["chat_response"], "state").get("next_action", "show_command_preview"))
         return _finish_interaction(base, target_notice)
 
-    resolved_executor_target, executor_resolution = _resolve_delegate_executor_target(executor_target, paths)
+    resolved_executor_target, executor_resolution = _resolve_delegate_executor_target(executor_target, paths, message=message)
 
     if resolved_mode == "delegate":
         delegation = build_coding_delegation_payload(
@@ -715,8 +735,9 @@ def build_chat_interaction_payload(
     return _finish_interaction(base, target_notice)
 
 
-def _resolve_delegate_executor_target(executor_target: str, paths: OmhPaths | None) -> tuple[str, dict[str, object]]:
+def _resolve_delegate_executor_target(executor_target: str, paths: OmhPaths | None, *, message: str = "") -> tuple[str, dict[str, object]]:
     requested = str(executor_target or "choose").strip() or "choose"
+    message_hint = _executor_target_from_message(message)
     setup_default = "choose"
     setup_available = False
     if paths is not None:
@@ -733,6 +754,9 @@ def _resolve_delegate_executor_target(executor_target: str, paths: OmhPaths | No
     if requested != "choose":
         resolved = requested
         source = "explicit"
+    elif message_hint:
+        resolved = message_hint
+        source = "message_mention"
     elif setup_available:
         resolved = setup_default
         source = "setup_profile"
@@ -744,11 +768,20 @@ def _resolve_delegate_executor_target(executor_target: str, paths: OmhPaths | No
         "schema_version": "executor_resolution/v1",
         "source": source,
         "requested_executor_target": requested,
+        "message_executor_target": message_hint,
         "default_executor": setup_default,
         "resolved_executor_target": resolved,
         "explicit_override": requested != "choose",
         "claim_boundary": "Executor default resolution is routing preference only; it is not dispatch, execution, review, CI, or merge evidence.",
     }
+
+
+def _executor_target_from_message(message: str) -> str:
+    lowered = f" {message.lower()} "
+    for target, hints in _MESSAGE_EXECUTOR_HINTS:
+        if any(hint in lowered for hint in hints):
+            return target
+    return ""
 
 
 def _attach_coding_owner_handoff(
@@ -783,6 +816,13 @@ def _attach_coding_owner_handoff(
         else None,
     )
     delegation["executor_resolution"] = executor_resolution
+    delegation["route_context"] = {
+        "schema_version": "coding_route_context/v1",
+        "selected_skill": route_payload.get("selected_skill", ""),
+        "reason": route_payload.get("reason", ""),
+        "coding_status_request": _route_is_coding_status_request(route_payload),
+        "claim_boundary": "Route context explains why the wrapper shaped this handoff; it is not dispatch or runtime evidence.",
+    }
     base["delegation"] = delegation
     base["executor_resolution"] = executor_resolution
     base["next_action"] = _delegation_next_action(delegation)
@@ -816,6 +856,32 @@ def _route_requires_coding_owner(route_payload: dict[str, object], route_respons
         return True
     if selected in _CODING_OWNER_WHEN_CODE_SHAPED:
         return is_coding_shaped_task(message)
+    return False
+
+
+def _route_is_coding_status_request(route_payload: dict[str, object]) -> bool:
+    reason = str(route_payload.get("reason", "")).lower()
+    if "coding progress questions" in reason or "progress/status" in reason:
+        return True
+    for recommendation in route_payload.get("recommendations", []):
+        if not isinstance(recommendation, dict):
+            continue
+        matched = {str(item) for item in recommendation.get("matched", []) if str(item)}
+        if {"guard:coding_progress_status", "guard:coding_handoff_status"} & matched:
+            return True
+    return False
+
+
+def _delegation_is_coding_status_request(delegation_payload: dict[str, object]) -> bool:
+    route_context = _nested(delegation_payload, "route_context")
+    if route_context.get("coding_status_request"):
+        return True
+    for recommendation in delegation_payload.get("recommendations", []):
+        if not isinstance(recommendation, dict):
+            continue
+        matched = {str(item) for item in recommendation.get("matched", []) if str(item)}
+        if "trigger:session" in matched and {"trigger:codex", "trigger:claude", "trigger:coding"} & matched:
+            return True
     return False
 
 
@@ -1510,6 +1576,18 @@ def _label_for_action(action_id: str) -> str:
     return action_id.replace("_", " ").title()
 
 
+def _open_coding_agent_label(profile: str | None) -> str:
+    if profile == "codex":
+        return "Open in Codex"
+    if profile == "claude-code":
+        return "Open in Claude Code"
+    if profile == "hermes":
+        return "Open Hermes coding"
+    if profile:
+        return f"Open {executor_label(profile)}"
+    return "Open coding agent"
+
+
 def build_chat_response_from_plan(plan_payload: dict[str, object], *, thread_key: str = "") -> dict[str, object]:
     plan = _nested(plan_payload, "plan")
     contract = _nested(plan_payload, "wrapper_contract")
@@ -1528,7 +1606,7 @@ def build_chat_response_from_plan(plan_payload: dict[str, object], *, thread_key
     coding_delegate = _nested(contract, "coding_delegate")
     if coding_delegate.get("available"):
         if coding_delegate.get("executor_choice_required"):
-            actions.append(_action("choose_executor", "Choose executor", "secondary"))
+            actions.append(_action("choose_executor", "Choose coding agent", "secondary"))
         actions.append(_action("prepare_handoff", "Prepare handoff", "secondary", enabled=False))
     selected = str(plan.get("recommended_workflow", "plan"))
     executor_resolution = _nested(coding_delegate, "executor_resolution")
@@ -1579,18 +1657,43 @@ def build_chat_response_from_delegation(delegation_payload: dict[str, object], *
         handoff = _nested(delegation_payload, "executor_handoff")
         executor = str(handoff.get("selected_executor_profile") or handoff.get("executor_target") or "executor")
         label = executor_label(executor)
+        status_request = _delegation_is_coding_status_request(delegation_payload)
+        actions = [
+            _action("send_to_executor", _open_coding_agent_label(executor), "primary", payload={"selected_executor_profile": executor})
+        ]
+        if executor == "codex":
+            actions.append(_action("send_to_codex", "Open in Codex", "secondary", payload={"compatibility_alias": True}))
+        if status_request:
+            actions.append(
+                _action(
+                    "attach_executor_session",
+                    f"Attach existing {label} session",
+                    "secondary",
+                    enabled=False,
+                    payload={
+                        "selected_executor_profile": executor,
+                        "disabled_reason": "A wrapper session id is required before OMH can attach observed coding-session evidence.",
+                    },
+                )
+            )
+        actions.append(_action("show_status", "Show status", "secondary"))
         return _chat_response(
             kind="handoff",
-            headline="A coding-agent handoff is ready.",
-            body=f"I can send this to {label}, but I will not claim implementation until executor evidence is observed.",
+            headline=(
+                f"{label} is selected; session evidence is not attached yet."
+                if status_request
+                else "A coding-agent handoff is ready."
+            ),
+            body=(
+                f"I can open {label} with the prepared handoff or attach an existing {label} session. "
+                "Until wrapper evidence records dispatch, progress, result, or verification, I cannot say what the coding agent has done."
+                if status_request
+                else f"I can open {label} with this prepared handoff, but I will not claim implementation until coding-agent evidence is observed."
+            ),
             phase="handoff_prepared",
             next_action="send_to_executor",
             thread_key=thread_key,
-            actions=[
-                _action("send_to_executor", "Send to executor", "primary", payload={"selected_executor_profile": executor}),
-                _action("send_to_codex", "Send to Codex", "secondary", payload={"compatibility_alias": True}),
-                _action("show_status", "Show status", "secondary"),
-            ],
+            actions=actions,
             claim_boundary="Prepared handoff is not execution evidence.",
             extra_state={
                 "delegation_action": action,
@@ -1605,24 +1708,51 @@ def build_chat_response_from_delegation(delegation_payload: dict[str, object], *
                 "prepared_handoff_boundary": "Prepared handoff is not execution evidence.",
                 "executor_readiness": delegation_payload.get("executor_readiness", {}),
                 "executor_resolution": executor_resolution,
+                "coding_status_request": status_request,
+                "route_context": delegation_payload.get("route_context", {}),
             },
         )
     if action == "delegate" and delegation_payload.get("prompt_handoff"):
         prompt_handoff = _nested(delegation_payload, "prompt_handoff")
         selected = str(prompt_handoff.get("selected_executor_profile") or "executor")
+        label = executor_label(selected)
+        status_request = _delegation_is_coding_status_request(delegation_payload)
+        actions = [
+            _action("show_prompt_handoff", f"Show {label} prompt", "primary", payload={"selected_executor_profile": selected}),
+            _action("copy_prompt_handoff", f"Copy {label} prompt", "secondary", payload={"selected_executor_profile": selected}),
+            _action("choose_executor", "Change coding agent", "secondary"),
+        ]
+        if status_request:
+            actions.append(
+                _action(
+                    "attach_executor_session",
+                    f"Attach existing {label} session",
+                    "secondary",
+                    enabled=False,
+                    payload={
+                        "selected_executor_profile": selected,
+                        "disabled_reason": "A wrapper session id is required before OMH can attach observed coding-session evidence.",
+                    },
+                )
+            )
+        actions.append(_action("show_status", "Show status", "secondary"))
         return _chat_response(
             kind="handoff",
-            headline="A prompt handoff is ready.",
-            body=f"I prepared a copyable {selected} prompt. This is not dispatch, execution, review, CI, or merge evidence.",
+            headline=(
+                f"{label} is selected; session evidence is not attached yet."
+                if status_request
+                else "A prompt handoff is ready."
+            ),
+            body=(
+                f"I can show or copy the {label} prompt, then the wrapper can attach an observed {label} session. "
+                "Until dispatch, progress, result, or verification evidence is recorded, I cannot say what the coding agent has done."
+                if status_request
+                else f"I prepared a copyable {selected} prompt. This is not dispatch, execution, review, CI, or merge evidence."
+            ),
             phase="prompt_handoff_prepared",
             next_action="show_prompt_handoff",
             thread_key=thread_key,
-            actions=[
-                _action("show_prompt_handoff", "Show prompt", "primary", payload={"selected_executor_profile": selected}),
-                _action("copy_prompt_handoff", "Copy prompt", "secondary", payload={"selected_executor_profile": selected}),
-                _action("choose_executor", "Change executor", "secondary"),
-                _action("show_status", "Show status", "secondary"),
-            ],
+            actions=actions,
             claim_boundary="Prompt handoff is prepared only; OMH has not dispatched it to an executor.",
             extra_state={
                 "delegation_action": action,
@@ -1637,6 +1767,8 @@ def build_chat_response_from_delegation(delegation_payload: dict[str, object], *
                 "prepared_handoff_boundary": "Prompt handoff is prepared only; OMH has not dispatched it to an executor.",
                 "executor_readiness": delegation_payload.get("executor_readiness", {}),
                 "executor_resolution": executor_resolution,
+                "coding_status_request": status_request,
+                "route_context": delegation_payload.get("route_context", {}),
             },
         )
     if action == "delegate" and delegation_payload.get("runtime_handoff"):
@@ -1673,7 +1805,7 @@ def build_chat_response_from_delegation(delegation_payload: dict[str, object], *
                 _action("prepare_worktree", "Prepare worktree", "secondary", enabled=False, payload={"selected_executor_profile": selected}),
                 _action("start_team", "Start team", "secondary", enabled=False, payload={"selected_executor_profile": selected}),
                 _action("start_swarm", "Start swarm", "secondary", enabled=False, payload={"selected_executor_profile": selected}),
-                _action("choose_executor", "Change runtime", "secondary"),
+                _action("choose_executor", "Change coding agent", "secondary"),
                 _action("show_status", "Show status", "secondary"),
             ],
             claim_boundary=(
@@ -1705,13 +1837,13 @@ def build_chat_response_from_delegation(delegation_payload: dict[str, object], *
     if action == "delegate" and _nested(delegation_payload, "executor_selection").get("choice_required"):
         return _chat_response(
             kind="handoff",
-            headline="Choose who should own the coding work.",
-            body="I can keep this with Hermes, prepare an oh-my runtime handoff, prepare a prompt for another coding agent, or prepare a Codex lifecycle handoff.",
+            headline="Choose the coding agent.",
+            body="Pick Codex, Claude Code, Hermes, or an oh-my runtime path before this becomes a prepared coding handoff.",
             phase="executor_choice_required",
             next_action="choose_executor",
             thread_key=thread_key,
-            actions=[_action("choose_executor", "Choose executor", "primary"), _action("show_status", "Show status", "secondary")],
-            claim_boundary="Executor choice is not dispatch or implementation evidence.",
+            actions=[_action("choose_executor", "Choose coding agent", "primary"), _action("show_status", "Show status", "secondary")],
+            claim_boundary="Coding-agent choice is not dispatch or implementation evidence.",
             extra_state={
                 "delegation_action": action,
                 "intent": delegation.get("intent", "unknown"),
@@ -1721,7 +1853,7 @@ def build_chat_response_from_delegation(delegation_payload: dict[str, object], *
                 "executor_choice_required": True,
                 "dispatchable": False,
                 "executor_options": _nested(delegation_payload, "executor_selection").get("options", []),
-                "prepared_handoff_boundary": "Executor choice is not dispatch or implementation evidence.",
+                "prepared_handoff_boundary": "Coding-agent choice is not dispatch or implementation evidence.",
                 "executor_readiness": delegation_payload.get("executor_readiness", {}),
                 "executor_resolution": executor_resolution,
             },
@@ -1773,11 +1905,12 @@ def build_chat_response_from_status(status_payload: dict[str, Any], *, thread_ke
     kind, headline, body, claim_boundary = _status_copy(status_payload, next_action)
     actions = [_action("show_status", "Show status", "secondary")]
     if next_action == "choose_executor":
-        actions.insert(0, _action("choose_executor", "Choose executor", "primary"))
+        actions.insert(0, _action("choose_executor", "Choose coding agent", "primary"))
     if next_action == "dispatch_to_executor":
-        actions.insert(0, _action("send_to_executor", "Send to executor", "primary"))
+        selected = str(_nested(status_payload, "prepared").get("executor_target", "") or _nested(status_payload, "prepared").get("selected_executor_profile", ""))
+        actions.insert(0, _action("send_to_executor", _open_coding_agent_label(selected), "primary"))
         if str(_nested(status_payload, "prepared").get("executor_target", "")) == "codex":
-            actions.insert(1, _action("send_to_codex", "Send to Codex", "secondary", payload={"compatibility_alias": True}))
+            actions.insert(1, _action("send_to_codex", "Open in Codex", "secondary", payload={"compatibility_alias": True}))
     if next_action == "show_prompt_handoff":
         selected = str(_nested(status_payload, "prepared").get("selected_executor_profile", "") or "")
         actions.insert(

--- a/src/wrapper/sessions.py
+++ b/src/wrapper/sessions.py
@@ -962,13 +962,13 @@ def _session_chat_response(session: dict[str, Any]) -> dict[str, object]:
     if status == "executor_choice_required":
         return response(
             kind="handoff",
-            headline="Choose who should own the coding work.",
-            body="Hermes can keep shaping the work, prepare a prompt-only handoff, or prepare a Codex lifecycle handoff.",
+            headline="Choose the coding agent.",
+            body="Pick Codex, Claude Code, Hermes, or a runtime path before this becomes a prepared coding handoff.",
             phase="executor_choice_required",
             next_action="choose_executor",
             thread_key=thread_key,
-            actions=[_action("choose_executor", "Choose executor", "primary"), _action("cancel", "Cancel", "secondary")],
-            claim_boundary="Choosing an executor is not dispatch or implementation evidence.",
+            actions=[_action("choose_executor", "Choose coding agent", "primary"), _action("cancel", "Cancel", "secondary")],
+            claim_boundary="Choosing a coding agent is not dispatch or implementation evidence.",
         )
     if status == "executor_selected":
         selected = str(session.get("selected_executor_profile") or "Hermes")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4183,7 +4183,7 @@ class CliTests(unittest.TestCase):
             ("회의록 요약을 부탁했는데 OMH 안 쓰고 일반 답변했어", "operating-rhythm", "ack", "prepare_operating_record"),
             ("Hermes가 기억하고 있는 프로젝트 맥락이 오래된 것 같아 정리해줘", "memory-curation-review", "ack", "prepare_memory_curation_review"),
             ("첨부한 엑셀을 월간 보고서 PDF랑 PPT로 만들 수 있게 정리해줘", "materials-package", "ack", "prepare_material_package"),
-            ("Codex 작업이 어디까지 진행됐는지 알려줘", "ultraprocess", "handoff", "choose_executor"),
+            ("Codex 작업이 어디까지 진행됐는지 알려줘", "ultraprocess", "handoff", "send_to_executor"),
             ("Claude Code로 넘길지 Codex로 넘길지 정해줘", "executor-runtime-readiness", "ack", "prepare_executor_runtime_readiness"),
             ("우리 팀 Hermes agent 여러 명이 같이 일할 때 역할과 보드를 잡아줘", "agent-board", "ack", "prepare_agent_board_card"),
             ("릴리즈 전에 README 주장과 실제 기능이 맞는지 검토해줘", "code-review", "ack", "prepare_review_or_followup_handoff"),

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -53,7 +53,7 @@ class OrchestrationDemoTests(unittest.TestCase):
         self.assertFalse(status["prepared"]["handoff_available"])
         self.assertNotEqual(status["run_id"], "demo-prepared-codex-handoff")
         self.assertEqual(status_step["chat_response"]["state"]["phase"], "executor_choice_required")
-        self.assertIn("Choose executor", [action["label"] for action in status_step["chat_response"]["actions"]])
+        self.assertIn("Choose coding agent", [action["label"] for action in status_step["chat_response"]["actions"]])
 
     def test_codex_demo_keeps_codex_specific_alias_only_when_selected(self) -> None:
         demo = build_orchestration_demo(executor_target="codex")
@@ -67,7 +67,7 @@ class OrchestrationDemoTests(unittest.TestCase):
         self.assertEqual(status["prepared"]["executor_target"], "codex")
         self.assertEqual(status["prepared"]["handoff_schema_version"], "coding_executor_handoff/v1")
         self.assertTrue(status["prepared"]["handoff_available"])
-        self.assertIn("Send to Codex", [action["label"] for action in status_step["chat_response"]["actions"]])
+        self.assertIn("Open in Codex", [action["label"] for action in status_step["chat_response"]["actions"]])
 
     def test_prompt_and_runtime_demo_profiles_are_not_collapsed_to_codex(self) -> None:
         cases = (

--- a/tests/test_wrapper_contract.py
+++ b/tests/test_wrapper_contract.py
@@ -1381,28 +1381,82 @@ class WrapperContractTests(unittest.TestCase):
 
     def test_ultraprocess_interaction_exposes_process_actions(self) -> None:
         cases = (
-            "research the repo, plan, implement, code-review, sync docs, and prepare a PR",
-            "이 이슈를 Codex로 구현하게 맡기고 진행상태 추적해줘",
+            (
+                "research the repo, plan, implement, code-review, sync docs, and prepare a PR",
+                "choose_executor",
+                True,
+                "choose_executor",
+                "Choose coding agent",
+            ),
+            (
+                "이 이슈를 Codex로 구현하게 맡기고 진행상태 추적해줘",
+                "send_to_executor",
+                False,
+                "send_to_executor",
+                "Open in Codex",
+            ),
         )
 
-        for message in cases:
+        for message, next_action, choice_required, primary_action, primary_label in cases:
             with self.subTest(message=message):
                 payload = build_chat_interaction_payload(message, source="discord")
 
                 self.assertEqual(payload["mode"], "route")
-                self.assertEqual(payload["next_action"], "choose_executor")
+                self.assertEqual(payload["next_action"], next_action)
                 self.assertEqual(payload["chat_response"]["kind"], "handoff")
                 self.assertEqual(payload["chat_response"]["state"]["selected_workflow"], "ultraprocess")
-                self.assertTrue(payload["chat_response"]["state"]["executor_choice_required"])
-                self.assertTrue(payload["delegation"]["executor_selection"]["choice_required"])
+                self.assertEqual(payload["chat_response"]["state"]["executor_choice_required"], choice_required)
+                self.assertEqual(payload["delegation"]["executor_selection"]["choice_required"], choice_required)
                 explanation = payload["chat_response"]["state"]["workflow_explanation"]
                 self.assertEqual(explanation["selected_workflow"], "ultraprocess")
                 self.assertEqual(explanation["workflow_context_id"], "intent_to_plan")
                 self.assertIn("ultraprocess", explanation["workflow_context_card"]["representative_workflows"])
-                self.assertIn("executor/runtime dispatch", explanation["not_evidence_yet"])
+                self.assertIn(
+                    "executor/runtime dispatch" if choice_required else "execution",
+                    explanation["not_evidence_yet"],
+                )
                 actions = {action["id"]: action for action in payload["chat_response"]["actions"]}
-                self.assertTrue(actions["choose_executor"]["enabled"])
-                self.assertIn("not dispatch", payload["chat_response"]["claim_boundary"])
+                self.assertTrue(actions[primary_action]["enabled"])
+                self.assertEqual(actions[primary_action]["label"], primary_label)
+                if choice_required:
+                    self.assertIn("not dispatch", payload["chat_response"]["claim_boundary"])
+                else:
+                    self.assertIn("not execution evidence", payload["chat_response"]["claim_boundary"])
+
+    def test_codex_status_question_surfaces_session_evidence_boundary(self) -> None:
+        payload = build_chat_interaction_payload("Codex 작업이 어디까지 진행됐는지 알려줘", source="discord")
+
+        actions = {action["id"]: action for action in payload["chat_response"]["actions"]}
+        state = payload["chat_response"]["state"]
+        self.assertEqual(payload["route"]["selected_skill"], "ultraprocess")
+        self.assertEqual(payload["next_action"], "send_to_executor")
+        self.assertEqual(payload["executor_resolution"]["source"], "message_mention")
+        self.assertEqual(payload["executor_resolution"]["resolved_executor_target"], "codex")
+        self.assertEqual(state["selected_executor_profile"], "codex")
+        self.assertTrue(state["coding_status_request"])
+        self.assertTrue(state["route_context"]["coding_status_request"])
+        self.assertIn("session evidence is not attached yet", payload["chat_response"]["headline"])
+        self.assertEqual(actions["send_to_executor"]["label"], "Open in Codex")
+        self.assertEqual(actions["send_to_codex"]["label"], "Open in Codex")
+        self.assertFalse(actions["attach_executor_session"]["enabled"])
+        self.assertIn("wrapper session id", actions["attach_executor_session"]["payload"]["disabled_reason"])
+
+    def test_claude_code_status_question_surfaces_prompt_session_boundary(self) -> None:
+        payload = build_chat_interaction_payload("Claude Code session looks stuck", source="discord")
+
+        actions = {action["id"]: action for action in payload["chat_response"]["actions"]}
+        state = payload["chat_response"]["state"]
+        self.assertEqual(payload["route"]["selected_skill"], "ultraprocess")
+        self.assertEqual(payload["next_action"], "show_prompt_handoff")
+        self.assertEqual(payload["executor_resolution"]["source"], "message_mention")
+        self.assertEqual(payload["executor_resolution"]["resolved_executor_target"], "claude-code")
+        self.assertEqual(state["selected_executor_profile"], "claude-code")
+        self.assertTrue(state["coding_status_request"])
+        self.assertIn("session evidence is not attached yet", payload["chat_response"]["headline"])
+        self.assertEqual(actions["show_prompt_handoff"]["label"], "Show Claude Code prompt")
+        self.assertEqual(actions["copy_prompt_handoff"]["label"], "Copy Claude Code prompt")
+        self.assertEqual(actions["choose_executor"]["label"], "Change coding agent")
+        self.assertFalse(actions["attach_executor_session"]["enabled"])
 
     def test_visual_summary_interaction_exposes_prompt_card_actions(self) -> None:
         cases = (
@@ -1540,7 +1594,7 @@ class WrapperContractTests(unittest.TestCase):
             (
                 "Codex 작업이 어디까지 진행됐는지 알려줘",
                 "ultraprocess",
-                "choose_executor",
+                "send_to_executor",
                 "handoff",
             ),
             (


### PR DESCRIPTION
## Feature Report

### What Changed

- Improved chat-first coding-agent progress UX for explicit Codex and Claude Code status requests.
- Added deterministic message-level coding-agent hints so requests that name Codex, Claude Code, Hermes, or runtime paths do not fall back to generic executor selection.
- Reworded wrapper-visible actions from generic executor language to user-facing coding-agent language such as `Open in Codex`, `Show Claude Code prompt`, `Attach existing Codex session`, and `Choose coding agent`.
- Updated the representative grounded-score scenario and playbook copy to match the new status-request behavior.

### Why This Exists

- In Hermes chat, users do not want to approve or type backend `omh` commands just to ask whether a Codex or Claude Code task is running.
- Before this change, explicit questions like “Codex 작업이 어디까지 진행됐는지 알려줘” could still surface a generic “choose executor” UX, which made OMH feel unaware of the named coding agent.
- OMH still must not claim dispatch, progress, result, verification, CI, or merge evidence until wrapper/runtime evidence is recorded.

### User / Operator Impact

- If a user asks about a Codex session, Hermes can show that Codex is selected and offer `Open in Codex`, attach-session, and status actions.
- If a user asks about Claude Code progress, Hermes can show the Claude Code prompt path and the missing session-evidence boundary.
- If a user asks for generic implementation without naming an agent, OMH still asks them to choose Codex, Claude Code, Hermes, or a runtime path first.
- The visible copy is easier to understand: “coding agent” replaces the colder “executor” language on the main user path.

### How It Works

- `src/wrapper/contract.py` now resolves explicit coding-agent mentions from the incoming message before falling back to setup defaults.
- Coding handoff payloads include a `coding_route_context/v1` metadata block that explains route context without treating it as runtime evidence.
- Status/progress requests get specialized response copy and actions while preserving `prepared_not_observed` boundaries.
- `src/wrapper/sessions.py` mirrors the friendlier coding-agent wording for session state copy.
- Tests cover Codex progress, Claude Code progress, generic delivery-cycle fallback, demo labels, and grounded-score expectations.

### Files And Contracts Touched

- `src/wrapper/contract.py`: message-level coding-agent hints, status-request detection, action labels, and route context metadata.
- `src/wrapper/sessions.py`: session copy for coding-agent choice.
- `src/quality/grounded_score.py`: representative status scenario expectation.
- `tests/test_wrapper_contract.py`, `tests/test_cli.py`, `tests/test_demo.py`: updated and expanded contract coverage.
- `docs/PLAYBOOKS.md`: public playbook language updated from executor wording to coding-agent wording.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `PYTHONPATH=tests uv run python -m compileall -q src tests`
- [x] `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check`
- [x] `PYTHONPATH=tests uv run python -m omh.cli harness validate`
- [ ] `PYTHONPATH=tests uv run python -m omh.cli release checklist --json` — not run; release checklist was not part of this wrapper UX slice.
- [ ] `PYTHONPATH=tests uv run python -m omh.cli release hermes-smoke` — not run; no live Hermes release smoke in this slice.
- [ ] `omh --help` — not run; no top-level CLI parser change.
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` — not run; install smoke was not part of this wrapper UX slice.
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable.
- [x] Relevant dry-run or smoke command: sampled six chat messages through `build_chat_interaction_payload`; average 6.24ms, max 10.08ms.
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; this PR changes deterministic wrapper payloads and does not attach live Codex/Claude Code sessions.

## Risk

- Moderate: wrapper payload labels and next actions are user-visible, so downstream adapters that assert old labels may need to update.
- Runtime evidence risk remains low because the change only prepares/labels actions and does not dispatch or observe coding-agent work.

## Compatibility / Rollout

- Existing action ids are preserved where compatibility matters, including `send_to_codex` as a Codex alias.
- The visible labels change toward coding-agent language, but the machine-readable contract remains deterministic.
- Generic coding requests still fall back to coding-agent selection, so this does not make Codex the implicit default.

## Release / Claims

- [x] Release-channel impact considered (`preview` behavior improvement, no package release performed in this PR)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Known manual Hermes checks are listed, including live session attachment not observed

## Follow-Up

- Live adapter validation can confirm how Discord/Slack surfaces render the attach-session button and status copy.
- Future runtime integration can turn disabled attach-session actions into adapter-owned attach flows once a wrapper session id is available.