### PR TITLE
Add route explanation cards

### DIFF
--- a/docs/CHAT_WRAPPER_EXAMPLES.md
+++ b/docs/CHAT_WRAPPER_EXAMPLES.md
@@ -574,6 +574,9 @@ User-facing effect:
 The following examples were run through `omh chat interact --source discord`.
 They show how different natural-language messages should produce different
 wrapper-native responses instead of forcing every request into coding.
+Every route payload also includes `route_explanation/v1`, a compact
+why/next/not-yet-evidence card that wrappers can render next to the main
+response without exposing shell commands or raw prompt text.
 
 ### Startup Product Triage
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -834,6 +834,10 @@ Before calling the bot integration ready, verify these points:
 - `omh chat interact --source discord "<message>"` or
   `omh chat interact --source slack "<message>"` returns a
   `chat_interaction/v1` envelope with a renderable `chat_response/v1`.
+- The route contains `route_explanation/v1` with the selected workflow, why it
+  was selected, the next action, and a short list of states that are not evidence
+  yet. Special OMH intro, quickstart, status, and catalog routes refresh this
+  card after they override the base route.
 - Common non-English requests should preserve the user's original text while
   routing through deterministic locale hints when a tested phrase matches. For
   example, Japanese or Chinese payment-failure reports route to

--- a/src/routing/chat.py
+++ b/src/routing/chat.py
@@ -25,6 +25,7 @@ from ..skills.catalog import SkillDefinition, primary_harness_for_skill, routabl
 FILE_LOOKUP_REASON = (
     "File or text lookup request; answer directly or ask for the target file instead of dispatching to a workflow keyword."
 )
+ROUTE_EXPLANATION_SCHEMA_VERSION = "route_explanation/v1"
 _ROUTER_SKILL = "oh-my-hermes"
 _SPECIFIC_CAPABILITY_CATALOG_MIN_SCORE = 6
 _SPECIFIC_CAPABILITY_CATALOG_SKILLS = frozenset(
@@ -343,7 +344,38 @@ def public_route_payload(decision: dict[str, object], *, include_message: bool =
         route["workflow_route_plan"] = workflow_route_plan
     else:
         route.pop("workflow_route_plan", None)
+    route["route_explanation"] = route_explanation_payload(route)
     return route
+
+
+def route_explanation_payload(route: dict[str, object]) -> dict[str, object]:
+    """Build a compact human-facing explanation without storing the raw message."""
+    action = str(route.get("action", "fallback"))
+    selected = str(route.get("selected_skill", ""))
+    harness = str(route.get("selected_harness", "")) or primary_harness_for_skill(selected)
+    recommendation = _selected_recommendation(route)
+    next_action = _route_next_action(route, recommendation)
+    claim_boundary = _route_claim_boundary(route, recommendation)
+    why = _route_explanation_reason(route)
+    not_evidence_yet = _not_evidence_from_boundary(claim_boundary)
+    headline = _route_explanation_headline(action, selected)
+    summary = _route_explanation_summary(action, selected, next_action, why)
+    return {
+        "schema_version": ROUTE_EXPLANATION_SCHEMA_VERSION,
+        "selected_workflow": selected,
+        "selected_harness": harness,
+        "action": action,
+        "confidence": str(route.get("confidence", "low")),
+        "score": _int_value(route.get("score", 0)),
+        "why_this_workflow": why,
+        "next_action": next_action,
+        "next_action_label": next_action.replace("_", " ") if next_action else "",
+        "not_evidence_yet": not_evidence_yet,
+        "claim_boundary": claim_boundary,
+        "headline": headline,
+        "summary": summary,
+        "rendering_hint": "Show this as the compact why / next / not-yet-evidence card in chat surfaces.",
+    }
 
 
 def explicit_skill_invocation(message: str, definitions: list[SkillDefinition] | None = None) -> str | None:
@@ -500,6 +532,120 @@ def _compact_recommendations(recommendations: object) -> list[dict[str, object]]
             }
         )
     return compact
+
+
+def _selected_recommendation(route: dict[str, object]) -> dict[str, object]:
+    selected = str(route.get("selected_skill", ""))
+    recommendations = route.get("recommendations", [])
+    if not isinstance(recommendations, list):
+        return {}
+    first: dict[str, object] = {}
+    for item in recommendations:
+        if not isinstance(item, dict):
+            continue
+        if not first:
+            first = item
+        if str(item.get("skill", "")) == selected:
+            return item
+    return first
+
+
+def _route_next_action(route: dict[str, object], recommendation: dict[str, object]) -> str:
+    action = str(route.get("action", "fallback"))
+    if action == "dispatch":
+        return str(recommendation.get("next_action") or "dispatch_to_workflow")
+    if action == "fallback" and _is_file_lookup_reason(str(route.get("reason", ""))):
+        return "answer_file_lookup"
+    if action == "clarify":
+        return "answer_clarification"
+    return "ask_one_clarification"
+
+
+def _route_claim_boundary(route: dict[str, object], recommendation: dict[str, object]) -> str:
+    boundary = str(recommendation.get("evidence_boundary", "")).strip()
+    if boundary:
+        return boundary
+    if _is_file_lookup_reason(str(route.get("reason", ""))):
+        return "No OMH workflow, execution, or file inspection has started."
+    if str(route.get("action", "")) == "dispatch":
+        return "Routing guidance is not workflow execution evidence."
+    return "No execution has started."
+
+
+def _route_explanation_reason(route: dict[str, object]) -> str:
+    reason = str(route.get("reason", "")).strip()
+    if reason:
+        return _human_route_reason(reason)
+    clarification = str(route.get("clarification", "")).strip()
+    if clarification:
+        return clarification
+    return "Selected from catalog metadata, trigger phrases, and deterministic guardrail policy."
+
+
+def _human_route_reason(reason: str) -> str:
+    for prefix in (
+        "Matched guard/trigger metadata; ",
+        "Matched high-level task abstraction before workflow routing. ",
+    ):
+        if reason.startswith(prefix):
+            return _capitalize_sentence(reason[len(prefix) :])
+    return reason
+
+
+def _capitalize_sentence(value: str) -> str:
+    text = value.strip()
+    if not text:
+        return ""
+    return text[:1].upper() + text[1:]
+
+
+def _route_explanation_headline(action: str, selected: str) -> str:
+    if action == "dispatch":
+        return f"Use `{selected}` for this request."
+    if action == "clarify":
+        return "Ask one question before choosing a workflow."
+    return "Keep this in the router until the target is clear."
+
+
+def _route_explanation_summary(action: str, selected: str, next_action: str, why: str) -> str:
+    if action == "dispatch":
+        return f"`{selected}` is selected because {why} Next action: `{next_action}`."
+    if action == "clarify":
+        return f"The router needs one clarification before dispatch. Best candidate: `{selected}`."
+    return f"The router should not dispatch yet. Reason: {why}"
+
+
+def _not_evidence_from_boundary(boundary: str) -> list[str]:
+    text = boundary.lower()
+    items: list[str] = []
+    for marker, label in (
+        ("plan acceptance", "plan acceptance"),
+        ("dispatch", "executor/runtime dispatch"),
+        ("execution", "execution"),
+        ("implementation", "implementation"),
+        ("image", "image generation"),
+        ("file", "file generation/export"),
+        ("download", "download"),
+        ("search", "source retrieval"),
+        ("api", "API access"),
+        ("credential", "credential validation"),
+        ("connector", "connector invocation"),
+        ("delivery", "delivery"),
+        ("attachment", "attachment"),
+        ("review", "review"),
+        ("verification", "verification"),
+        ("ci", "CI"),
+        ("merge", "merge"),
+    ):
+        if marker in text and label not in items:
+            items.append(label)
+    if items:
+        return items
+    if "prepared" in text:
+        return ["execution", "verification", "delivery"]
+    if "no execution" in text:
+        return ["execution"]
+    return ["completion claim without observed evidence"]
 
 
 def _int_value(value: object, default: int = 0) -> int:

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -6,7 +6,7 @@ from typing import Any
 from ..context_safety import compact_progress_events
 from ..ingress import CHAT_SOURCES, compact_source_metadata, extract_message_text, extract_source_metadata
 from ..routing.catalog_questions import is_skill_catalog_question as _is_skill_catalog_question
-from ..routing.chat import public_route_payload, route_chat_message
+from ..routing.chat import public_route_payload, route_chat_message, route_explanation_payload
 from ..coding_delegation import CODING_EXECUTOR_TARGETS, build_coding_delegation_payload
 from ..capabilities.families import capability_family_cards
 from ..context import build_context_brief
@@ -2471,6 +2471,7 @@ def _catalog_question_route_payload(route_payload: dict[str, object]) -> dict[st
             "threshold": "high",
         }
     )
+    updated["route_explanation"] = route_explanation_payload(updated)
     return updated
 
 
@@ -2504,6 +2505,7 @@ def _omh_status_route_payload(route_payload: dict[str, object]) -> dict[str, obj
             "threshold": "high",
         }
     )
+    updated["route_explanation"] = route_explanation_payload(updated)
     return updated
 
 
@@ -2537,6 +2539,7 @@ def _omh_quickstart_route_payload(route_payload: dict[str, object]) -> dict[str,
             "threshold": "high",
         }
     )
+    updated["route_explanation"] = route_explanation_payload(updated)
     return updated
 
 
@@ -2570,6 +2573,7 @@ def _omh_intro_route_payload(route_payload: dict[str, object]) -> dict[str, obje
             "threshold": "high",
         }
     )
+    updated["route_explanation"] = route_explanation_payload(updated)
     return updated
 
 

--- a/tests/test_chat_router.py
+++ b/tests/test_chat_router.py
@@ -1260,6 +1260,26 @@ selected_workflow=ultraprocess
         expanded = public_route_payload(decision, include_message=True)
         self.assertIn(message, str(expanded["routing_prompt"]))
 
+    def test_public_route_payload_includes_human_route_explanation(self) -> None:
+        message = "FAL_KEY 없어서 이미지 생성이 막히면 어떻게 연결해야 해?"
+        decision = route_chat_message(message, source="discord")
+
+        public = public_route_payload(decision)
+        explanation = public["route_explanation"]
+
+        self.assertEqual(explanation["schema_version"], "route_explanation/v1")
+        self.assertEqual(explanation["selected_workflow"], "toolbelt-readiness")
+        self.assertEqual(explanation["selected_harness"], "toolbelt-readiness")
+        self.assertEqual(explanation["action"], "dispatch")
+        self.assertEqual(explanation["next_action"], "prepare_toolbelt_readiness")
+        self.assertNotIn("Matched guard/trigger metadata", explanation["why_this_workflow"])
+        self.assertTrue(str(explanation["why_this_workflow"]).startswith("Missing tool"))
+        self.assertIn("not MCP server installation", explanation["claim_boundary"])
+        self.assertIn("API access", explanation["claim_boundary"])
+        self.assertIn("connector invocation", explanation["not_evidence_yet"])
+        self.assertIn("why / next / not-yet-evidence", explanation["rendering_hint"])
+        self.assertNotIn(message, json.dumps(explanation, ensure_ascii=False))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_wrapper_contract.py
+++ b/tests/test_wrapper_contract.py
@@ -1195,6 +1195,22 @@ class WrapperContractTests(unittest.TestCase):
         self.assertIn("answer:file_lookup", actions)
         self.assertTrue(actions["answer:file_lookup"]["enabled"])
 
+    def test_interaction_route_explanation_matches_special_route_overrides(self) -> None:
+        payload = build_chat_interaction_payload("What is OMH and how should I use it?", source="discord")
+
+        route = payload["route"]
+        explanation = route["route_explanation"]
+        self.assertEqual(route["selected_skill"], "oh-my-hermes")
+        self.assertEqual(
+            route["routing_instruction"],
+            "Show the OMH context brief and offer the workflow picker as the next action.",
+        )
+        self.assertEqual(explanation["schema_version"], "route_explanation/v1")
+        self.assertEqual(explanation["selected_workflow"], "oh-my-hermes")
+        self.assertEqual(explanation["next_action"], "show_context_brief")
+        self.assertIn("Context brief output", explanation["claim_boundary"])
+        self.assertIn("execution", explanation["not_evidence_yet"])
+
     def test_partial_dot_slash_invocation_exposes_omh_command_preview_only(self) -> None:
         cases = {
             "./": "./omh",


### PR DESCRIPTION
## Feature Report

### What Changed

- Added `route_explanation/v1` to public chat route payloads.
- The new card gives wrappers a compact human-facing explanation: selected workflow, why it was selected, the next action, and what is not evidence yet.
- Refreshed the card after wrapper-specific route overrides for OMH intro, quickstart, status, and catalog routes so special responses do not keep stale base-route explanations.
- Documented the new wrapper-visible route explanation contract in chat wrapper examples and installation integration checks.

### Why This Exists

- OMH routing already selected good workflows, but the lower-level route payload forced wrappers to piece together `reason`, recommendation policy, evidence boundary, and routing instruction themselves.
- In Discord/Slack/Hermes-style chat, users need to see the simple explanation: why this workflow, what to do next, and what is still not observed evidence.
- This keeps normal users away from backend CLI detail while preserving OMH's prepared-vs-observed boundary.

### User / Operator Impact

- Wrappers can render a small why/next/not-yet-evidence card next to the normal chat response.
- A missing image generator/API key/tool request can show `toolbelt-readiness`, the setup-oriented next action, and the fact that API access/connector invocation are not observed yet.
- OMH intro/status/quickstart/catalog answers now keep route explanation in sync after the wrapper replaces the generic route payload.
- Raw prompt text is not stored in the route explanation card.

### How It Works

- `src/routing/chat.py` now builds `route_explanation/v1` from the selected route and compact recommendation policy.
- The card derives `next_action` and `claim_boundary` from the selected recommendation, falls back safely for clarify/fallback/file-lookup routes, and extracts short not-yet-evidence labels from the claim boundary.
- Internal route-reason prefixes such as `Matched guard/trigger metadata` are stripped from the human-facing explanation.
- `src/wrapper/contract.py` recomputes the card after special route payload overrides.

### Files And Contracts Touched

- `src/routing/chat.py`: new `route_explanation/v1` builder and public payload attachment.
- `src/wrapper/contract.py`: special wrapper route overrides refresh route explanation after mutation.
- `tests/test_chat_router.py`: public payload metadata-only and human-readable explanation coverage.
- `tests/test_wrapper_contract.py`: special OMH intro override keeps explanation synchronized.
- `docs/CHAT_WRAPPER_EXAMPLES.md`, `docs/INSTALLATION.md`: wrapper/operator contract docs.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` passed, 868 tests OK.
- [x] `PYTHONPATH=tests uv run python -m compileall -q src tests` passed.
- [x] `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check` passed, 48 tap skills checked.
- [x] `PYTHONPATH=tests uv run python -m omh.cli harness validate` passed, 36 harnesses and 50 skills validated.
- [ ] `python3 -m omh.cli release checklist --json` not run; this PR changes wrapper route metadata only, not release packaging.
- [ ] `python3 -m omh.cli release hermes-smoke` not run; no install/runtime surface changed.
- [ ] `omh --help` not run; no top-level command help changed.
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` not run; setup/install behavior unchanged.
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable.
- [x] Relevant dry-run or smoke command: `PYTHONPATH=tests uv run python -m omh.cli demo grounded-score` kept all 28 scenarios at 10/10.
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; route explanation is deterministic local wrapper metadata, and live messenger rendering remains host-owned.
- [x] `git diff --check` passed.

## Risk

- Low risk: the change is additive to public route payloads and does not alter route selection.
- Main risk is wrapper consumers treating the new `route_explanation/v1` as execution evidence. The card explicitly includes claim boundaries and not-yet-evidence labels.

## Compatibility / Rollout

- Backward compatible for existing JSON consumers because existing fields stay intact.
- Wrappers can adopt `route_explanation/v1` opportunistically; older wrappers can ignore it.
- No Hermes core patching, network calls, transport SDKs, or executor dispatch behavior were added.

## Release / Claims

- [x] Release-channel impact considered: local/preview wrapper contract improvement only.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] Known manual Hermes checks are listed, including the live rendering gap above.

## Follow-Up

- Consider rendering `route_explanation/v1` in future golden messenger fixtures if adapters need a visual card-level example.
