### PR TITLE
Add grounded score summary output

### DIFF
--- a/docs/APPLICATION_CASES.md
+++ b/docs/APPLICATION_CASES.md
@@ -523,11 +523,17 @@ with:
 omh chat interact --source discord "<message>"
 omh playbook recommend "<message>" --limit 1
 omh coding delegate --executor codex --source discord "<message>"
-omh demo grounded-score
+omh demo grounded-score --summary
+omh demo grounded-score --json
 ```
 
 The purpose of the matrix is to keep Hermes users command-agnostic while giving
 wrapper operators a concrete contract result to render.
+
+`omh demo grounded-score --summary` prints a compact operator-readable rollup;
+`omh demo grounded-score --json` prints the full machine-readable payload.
+The default `omh demo grounded-score` output remains JSON for wrapper
+compatibility.
 
 `omh demo grounded-score` is a deterministic contract-compliance demo over 28
 representative messages. The score is 10/10 only when the expected chat route,

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -622,7 +622,10 @@ omh playbook recommend "every morning check competitor news and send a Slack dig
           </p>
           <p>
             Reproduce the contract-compliance score gate with
-            <code>omh demo grounded-score</code>. A case reaches
+            <code>omh demo grounded-score --summary</code> for an operator-readable
+            rollup, or <code>omh demo grounded-score --json</code> for the full
+            machine-readable payload. The default command still emits JSON for
+            wrapper compatibility. A case reaches
             <code>10/10</code> only when route, response kind, next action,
             playbook confidence, and evidence boundary all match; execution,
             review, CI, and merge never count unless observed.

--- a/src/commands/demo.py
+++ b/src/commands/demo.py
@@ -4,7 +4,7 @@ import argparse
 
 from ..coding_delegation import CODING_EXECUTOR_TARGETS
 from ..demo import DEFAULT_ORCHESTRATION_MESSAGE, build_orchestration_demo
-from ..grounded_score import build_grounded_score_demo
+from ..grounded_score import build_grounded_score_demo, format_grounded_score_summary
 from ..ingress import CHAT_SOURCES
 from ..installer import OmhError
 from .common import _print_json
@@ -28,9 +28,13 @@ def cmd_demo_orchestration(args: argparse.Namespace) -> int:
 
 def cmd_demo_grounded_score(args: argparse.Namespace) -> int:
     try:
-        _print_json(build_grounded_score_demo(source=args.source))
+        payload = build_grounded_score_demo(source=args.source)
     except ValueError as exc:
         raise OmhError(str(exc)) from exc
+    if args.summary:
+        print(format_grounded_score_summary(payload))
+    else:
+        _print_json(payload)
     return 0
 
 
@@ -56,4 +60,7 @@ def _add_demo_commands(sub) -> None:
 
     grounded_score = demo_sub.add_parser("grounded-score")
     grounded_score.add_argument("--source", choices=CHAT_SOURCES, default="discord")
+    output = grounded_score.add_mutually_exclusive_group()
+    output.add_argument("--json", action="store_true", help="Print the full machine-readable JSON payload. This is the default.")
+    output.add_argument("--summary", action="store_true", help="Print a compact human-readable score summary.")
     grounded_score.set_defaults(func=cmd_demo_grounded_score)

--- a/src/quality/grounded_score.py
+++ b/src/quality/grounded_score.py
@@ -372,6 +372,54 @@ def build_grounded_score_demo(*, source: str = "discord") -> dict[str, object]:
     }
 
 
+def format_grounded_score_summary(payload: dict[str, object]) -> str:
+    summary = _nested(payload, "summary")
+    scenario_rows = _dict_rows(payload.get("scenarios", []))
+    total = int(summary.get("scenario_count", len(scenario_rows)) or 0)
+    perfect = sum(1 for scenario in scenario_rows if int(_value(scenario, "score", 0)) == 10)
+    average = summary.get("average_score", 0)
+    minimum = summary.get("minimum_score", 0)
+    maximum = summary.get("maximum_score", 0)
+    all_10 = bool(summary.get("all_10", False))
+    lines = [
+        "OMH grounded score",
+        f"Source: {payload.get('source', 'unknown')}",
+        f"Result: {perfect}/{total} scenarios at 10/10" + (" (all passing)" if all_10 else ""),
+        f"Score range: min {minimum}, avg {average}, max {maximum}",
+        "",
+        "What this proves:",
+    ]
+    for basis in payload.get("score_basis", []):
+        lines.append(f"- {basis}")
+    lines.extend(["", "Scenario rollup:"])
+    for scenario in scenario_rows:
+        observed = _nested(scenario, "observed")
+        skill = observed.get("skill", "unknown")
+        next_action = observed.get("next_action", "unknown")
+        handoff = observed.get("handoff_status", "unknown")
+        score = scenario.get("score", 0)
+        status = "ok" if int(score) == 10 else "needs attention"
+        lines.append(f"- {scenario.get('title', 'Untitled scenario')}: {score}/10 {status}; {skill} -> {next_action}; {handoff}")
+    failed = [scenario for scenario in scenario_rows if int(_value(scenario, "score", 0)) != 10]
+    if failed:
+        lines.extend(["", "Failures:"])
+        for scenario in failed:
+            failed_checks = [
+                str(check.get("name", "unknown"))
+                for check in scenario.get("checks", [])
+                if isinstance(check, dict) and not check.get("passed", False)
+            ]
+            lines.append(f"- {scenario.get('id', 'unknown')}: {', '.join(failed_checks) or 'unknown check failure'}")
+    lines.extend(
+        [
+            "",
+            f"Boundary: {payload.get('claim_boundary', '')}",
+            "Use --json for the full machine-readable payload.",
+        ]
+    )
+    return "\n".join(lines)
+
+
 def _evaluate_grounded_scenario(scenario: GroundedScenario, *, source: str) -> dict[str, object]:
     route = route_chat_message(scenario.message, source=source)
     interaction = build_chat_interaction_payload(scenario.message, source=source)
@@ -497,3 +545,15 @@ def _boundary_observation(delegation: dict[str, object]) -> str:
 def _nested(payload: dict[str, object], key: str) -> dict[str, object]:
     value = payload.get(key)
     return value if isinstance(value, dict) else {}
+
+
+def _dict_rows(value: object) -> list[dict[str, object]]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, dict)]
+
+
+def _value(payload: object, key: str, default: object = "") -> object:
+    if isinstance(payload, dict):
+        return payload.get(key, default)
+    return default

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5227,6 +5227,30 @@ class CliTests(unittest.TestCase):
         self.assertEqual(direct["direct-goal-loop"]["expected"]["invocation_mode"], "direct_skill")
         self.assertEqual(direct["direct-ultraprocess-cycle"]["expected"]["invocation_mode"], "direct_skill")
 
+        status, stdout, stderr = run_cli(["demo", "grounded-score", "--json"])
+
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        explicit_payload = json.loads(stdout)
+        self.assertEqual(explicit_payload["schema_version"], "grounded_score_evaluation/v1")
+        self.assertEqual(explicit_payload["summary"]["scenario_count"], 28)
+
+    def test_demo_grounded_score_summary_is_human_readable(self) -> None:
+        status, stdout, stderr = run_cli(["demo", "grounded-score", "--summary"])
+
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        with self.assertRaises(json.JSONDecodeError):
+            json.loads(stdout)
+        self.assertIn("OMH grounded score", stdout)
+        self.assertIn("Result: 28/28 scenarios at 10/10 (all passing)", stdout)
+        self.assertIn(
+            "Startup SaaS product triage: 10/10 ok; feedback-triage -> triage_feedback; handoff_absent",
+            stdout,
+        )
+        self.assertIn("Boundary: This is deterministic local contract-compliance evaluation", stdout)
+        self.assertIn("Use --json for the full machine-readable payload.", stdout)
+
     def test_coding_delegate_include_message_expands_prompt_for_non_logging_wrappers(self) -> None:
         status, stdout, stderr = run_cli(["coding", "delegate", "--include-message", "risky", "refactor"])
 


### PR DESCRIPTION
## Feature Report

### What Changed

- Added an explicit human-readable `omh demo grounded-score --summary` output for the deterministic grounded operator scenario score gate.
- Added an explicit `--json` flag while keeping the existing default JSON output unchanged for wrappers and scripts.
- Updated application-case docs and site docs so operators can choose summary output for quick scans or JSON for machine-readable rendering.

### Why This Exists

- `omh demo grounded-score` already proved the representative routing corpus, but the default JSON is noisy when an operator just wants to answer "are the examples still all 10/10?".
- The new summary view makes the same evidence easier to read without weakening OMH's prepared-vs-observed boundary or breaking existing JSON consumers.

### User / Operator Impact

- Operators can run `omh demo grounded-score --summary` and immediately see the source, 28/28 pass status, score range, scenario rollup, and evidence boundary.
- Wrapper/backend users can keep using `omh demo grounded-score` or `omh demo grounded-score --json` for the full `grounded_score_evaluation/v1` payload.
- The summary still states that the score is local contract-compliance evidence only, not live Hermes chat, executor work, review, CI, or merge evidence.

### How It Works

- `src/quality/grounded_score.py` now formats the existing grounded-score payload into a compact text report.
- `src/commands/demo.py` adds mutually exclusive `--summary` and `--json` options. JSON remains the default path.
- `tests/test_cli.py` locks both compatibility modes: default/explicit JSON parse as `grounded_score_evaluation/v1`, while `--summary` is non-JSON human text with the expected 28/28 rollup.

### Files And Contracts Touched

- `src/quality/grounded_score.py`: added `format_grounded_score_summary` plus small defensive helpers for scenario rows.
- `src/commands/demo.py`: added demo output mode flags for grounded-score.
- `tests/test_cli.py`: added explicit JSON and summary coverage.
- `docs/APPLICATION_CASES.md`, `site/docs/index.html`: documented summary vs JSON usage.
- Public contract preserved: default `omh demo grounded-score` output remains JSON.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests.test_cli.CliTests.test_demo_grounded_score_keeps_representative_cases_at_10 tests.test_cli.CliTests.test_demo_grounded_score_summary_is_human_readable -v`
- [x] `PYTHONPATH=tests uv run python -m omh.cli demo grounded-score --summary`
- [x] `PYTHONPATH=tests uv run python -m omh.cli demo grounded-score --json | python3 -c 'import json,sys; p=json.load(sys.stdin); print(p["schema_version"], p["summary"]["scenario_count"], p["summary"]["all_10"])'`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `PYTHONPATH=tests uv run python -m compileall -q src tests`
- [x] `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check`
- [x] `PYTHONPATH=tests uv run python -m omh.cli harness validate`
- [x] `PYTHONPATH=tests uv run python -m omh.cli release checklist --json`
- [x] `PYTHONPATH=tests uv run python -m omh.cli release hermes-smoke`
- [x] `PYTHONPATH=tests uv run python -m omh.cli --help`
- [x] `git diff --check`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` (not run; this PR changes local demo formatting only)
- [ ] Manual Hermes/TUI check (not run; this PR does not change live Hermes rendering or installed profile behavior)

## Risk

- Low. The compatibility-sensitive default remains JSON, and the new text view is opt-in.
- The summary is intentionally compact and should not be treated as a replacement for the full payload when a wrapper needs structured fields.

## Compatibility / Rollout

- Backward compatible for existing scripts using `omh demo grounded-score`.
- Operators can adopt `--summary` immediately for manual release or QA scans.

## Release / Claims

- [x] Release-channel impact considered: local/preview contract usability only; no stable release metadata changed.
- [x] Runtime/native capability claims are backed by local deterministic evidence or marked as not observed.
- [x] Known manual Hermes checks are listed: no live Hermes/TUI smoke was needed for this formatting-only demo change.

## Follow-Up

- Consider adding similar summary modes to other large deterministic demo payloads if operators keep reading them manually.