### PR TITLE
Polish setup picker redraw

### DIFF
--- a/src/commands/setup.py
+++ b/src/commands/setup.py
@@ -1367,7 +1367,8 @@ def _keyboard_single_choice(
     language: str = "en",
 ) -> str:
     cursor = _default_choice_index(options, default_choice)
-    rendered_rows = 0
+    rendered_option_rows = 0
+    first_render = True
     while True:
         lines = _choice_menu_lines(
             title,
@@ -1378,11 +1379,15 @@ def _keyboard_single_choice(
             use_color=use_color,
             language=language,
         )
-        if rendered_rows:
-            sys.stdout.write(f"\033[{rendered_rows}F\033[J")
-        sys.stdout.write("\n".join(lines) + "\n")
+        option_lines = _choice_menu_option_lines(lines, intro_lines)
+        if first_render:
+            sys.stdout.write("\n".join(lines) + "\n")
+            first_render = False
+        else:
+            sys.stdout.write(f"\033[{rendered_option_rows}F\033[J")
+            sys.stdout.write("\n".join(option_lines) + "\n")
         sys.stdout.flush()
-        rendered_rows = _rendered_terminal_rows(lines)
+        rendered_option_rows = _rendered_terminal_rows(option_lines)
         key = _read_tui_key()
         if key in {"\x03", "\x04"}:
             raise KeyboardInterrupt
@@ -1425,6 +1430,11 @@ def _choice_menu_lines(
         if option["description"]:
             lines.append(f"      {option['description']}")
     return lines
+
+
+def _choice_menu_option_lines(lines: list[str], intro_lines: list[str]) -> list[str]:
+    option_start = 3 + len(intro_lines)
+    return lines[option_start:]
 
 
 def _rendered_terminal_rows(lines: list[str], columns: int | None = None) -> int:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7848,7 +7848,7 @@ class CliTests(unittest.TestCase):
 
         self.assertEqual(_rendered_terminal_rows(lines, columns=20), 6)
 
-    def test_setup_keyboard_menu_repaints_using_wrapped_terminal_rows(self) -> None:
+    def test_setup_keyboard_menu_repaints_only_option_rows(self) -> None:
         options = [
             {"choice": "1", "value": "codex", "label": "Codex", "description": "Short."},
             {
@@ -7866,7 +7866,10 @@ class CliTests(unittest.TestCase):
             default_choice="1",
             use_color=False,
         )
-        expected_rows = setup_commands._rendered_terminal_rows(lines, columns=20)
+        intro_lines = ["Choose who Hermes should suggest for coding work."]
+        option_lines = setup_commands._choice_menu_option_lines(lines, intro_lines)
+        full_rows = setup_commands._rendered_terminal_rows(lines, columns=20)
+        option_rows = setup_commands._rendered_terminal_rows(option_lines, columns=20)
         output = io.StringIO()
 
         with (
@@ -7883,7 +7886,11 @@ class CliTests(unittest.TestCase):
             )
 
         self.assertEqual(value, "hermes")
-        self.assertIn(f"\033[{expected_rows}F\033[J", output.getvalue())
+        rendered = output.getvalue()
+        self.assertLess(option_rows, full_rows)
+        self.assertIn(f"\033[{option_rows}F\033[J", rendered)
+        self.assertNotIn(f"\033[{full_rows}F\033[J", rendered)
+        self.assertEqual(rendered.count("Default coding agent"), 1)
 
     def test_setup_executor_copy_uses_simple_coding_agent_names(self) -> None:
         from omh.commands.language import tr


### PR DESCRIPTION
## Feature Report

### What Changed

- Improved the interactive `omh setup` keyboard picker redraw behavior.
- The first render still prints the full menu, but arrow-key movement now repaints only the option rows instead of clearing and redrawing the title, intro copy, hint, and full option block.
- Updated the setup TUI regression test to lock the smaller repaint region while keeping wrapped-row accounting.

### Why This Exists

- Setup is one of the first places users feel OMH quality. Repainting the entire picker on every arrow key can make the text appear to crawl or jump, especially when options or translated descriptions wrap across multiple terminal rows.
- The change keeps the same choices and keyboard controls while making the interaction feel lighter and less noisy.

### User / Operator Impact

- Users navigating setup with arrow keys should see less screen movement and faster-feeling selection changes.
- Non-interactive setup, JSON output, default executor choices, language selection, plugin setup, and Hermes registration behavior are unchanged.

### How It Works

- `src/commands/setup.py` now separates the stable menu header from the dynamic option rows.
- `_keyboard_single_choice` renders the full menu once, then uses the measured option-row height for subsequent cursor movement redraws.
- `_choice_menu_option_lines` isolates option rows so wrapped terminal rows remain measured accurately.

### Files And Contracts Touched

- `src/commands/setup.py`: setup picker redraw behavior only.
- `tests/test_cli.py`: renamed and strengthened the TUI repaint test to assert option-only redraw and no repeated title rendering.
- Public setup behavior and machine-readable contracts are preserved.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests.test_cli.CliTests.test_setup_choice_menu_uses_cursor_not_checkbox tests.test_cli.CliTests.test_setup_choice_menu_counts_wrapped_terminal_rows tests.test_cli.CliTests.test_setup_keyboard_menu_repaints_only_option_rows tests.test_cli.CliTests.test_setup_interactive_wizard_records_user_choices -v`
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_cli.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `PYTHONPATH=tests uv run python -m compileall -q src tests`
- [x] `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check`
- [x] `PYTHONPATH=tests uv run python -m omh.cli harness validate`
- [x] `git diff --check`
- [ ] Manual arrow-key capture in a real terminal UI session (not run; covered by deterministic TUI output tests)

## Risk

- Low. This only changes redraw scope for the keyboard picker; the selected value, fallback numeric prompt, and non-interactive setup paths are unchanged.
- The main risk is terminal escape-sequence variance, mitigated by continuing to use existing row-width measurement and ANSI clear behavior.

## Compatibility / Rollout

- Backward compatible.
- No release-channel metadata changes.
- Users can still set `OMH_NO_TUI=1` or use non-interactive flags to avoid the keyboard picker entirely.

## Release / Claims

- [x] Release-channel impact considered (`local` UX polish only).
- [x] Runtime/native capability claims are not changed.
- [x] Known manual Hermes checks are listed; no live Hermes smoke is needed for setup TUI redraw logic.

## Follow-Up

- If users still report slow arrow navigation, the next step would be a real terminal capture around `omh setup` on macOS Terminal/iTerm to compare redraw latency outside deterministic tests.