### PR TITLE
Add chat interaction summary output

### DIFF
--- a/docs/APPLICATION_CASES.md
+++ b/docs/APPLICATION_CASES.md
@@ -521,6 +521,7 @@ with:
 
 ```sh
 omh chat interact --source discord "<message>"
+omh chat interact --source discord --summary "<message>"
 omh playbook recommend "<message>" --limit 1
 omh coding delegate --executor codex --source discord "<message>"
 omh demo grounded-score --summary
@@ -529,6 +530,10 @@ omh demo grounded-score --json
 
 The purpose of the matrix is to keep Hermes users command-agnostic while giving
 wrapper operators a concrete contract result to render.
+
+`omh chat interact --summary` prints a compact operator-readable view of the
+same wrapper response, actions, evidence gaps, and claim boundary. The default
+`omh chat interact` output remains JSON for adapter compatibility.
 
 `omh demo grounded-score --summary` prints a compact operator-readable rollup;
 `omh demo grounded-score --json` prints the full machine-readable payload.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -671,7 +671,12 @@ Minimal wrapper calls:
 omh chat interact --source discord --event-json event.json
 omh chat interact --source slack "risky refactor"
 printf '%s' "$SLACK_TEXT" | omh chat interact --source slack --stdin
+omh chat interact --source discord --summary "risky refactor"
 ```
+
+The default output is the machine-readable `chat_interaction/v1` JSON envelope
+that wrappers should render. Use `--summary` only when an operator wants to
+inspect the same response contract quickly in a terminal.
 
 If the wrapper can identify the current Hermes agent target, include that as
 metadata rather than asking the user to choose a command:

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -354,13 +354,16 @@ hermes skills install rlaope/oh-my-hermes/skills/oh-my-hermes --yes</code>
           <div class="command" role="region" aria-label="Chat interaction command" tabindex="0">
             <code>plugin tool: omh_interact
 omh chat interact --source discord "risky refactor"
-omh chat interact --source slack "diagnose installation health"</code>
+omh chat interact --source slack "diagnose installation health"
+omh chat interact --source discord --summary "risky refactor"</code>
           </div>
           <p>
             <code>omh_interact</code> is the plugin-native path: it returns the
             same chat envelope and records a metadata-only wrapper session with
             producer provenance. The CLI examples are adapter backend
-            equivalents. Fixture-backed examples cover both shell-free workflow
+            equivalents. The <code>--summary</code> form is for operator
+            inspection; wrappers should keep using the JSON envelope or plugin
+            tool output. Fixture-backed examples cover both shell-free workflow
             picker responses and plugin-produced planning cards. A response can be
             an answer, a clarification request, policy-specific workflow
             guidance for research, strategy, feedback triage, meeting prep, a

--- a/src/commands/chat.py
+++ b/src/commands/chat.py
@@ -100,6 +100,8 @@ def cmd_chat_route_hint(args: argparse.Namespace) -> int:
 
 
 def cmd_chat_interact(args: argparse.Namespace) -> int:
+    if bool(getattr(args, "summary", False)) and bool(getattr(args, "json", False)):
+        raise OmhError("--summary and --json cannot be used together")
     try:
         if args.run_id:
             status = summarize_delegated_coding_status(_paths(args), args.run_id)
@@ -126,7 +128,10 @@ def cmd_chat_interact(args: argparse.Namespace) -> int:
         raise OmhError(f"runtime run not found: {args.run_id}") from exc
     except (OSError, json.JSONDecodeError, ValueError) as exc:
         raise OmhError(str(exc)) from exc
-    _print_json(payload)
+    if bool(getattr(args, "summary", False)):
+        _print_chat_interaction_summary(payload)
+    else:
+        _print_json(payload)
     return 0
 
 
@@ -206,6 +211,87 @@ def _context_pack(args: argparse.Namespace) -> dict[str, object] | None:
 
 def _has_target_metadata(source_metadata: dict[str, str]) -> bool:
     return any(source_metadata.get(key) for key in TARGET_METADATA_KEYS)
+
+
+def _as_mapping(value: object) -> dict[str, object]:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: object) -> list[object]:
+    return value if isinstance(value, list) else []
+
+
+def _text(value: object, default: str = "") -> str:
+    if value is None:
+        return default
+    text = str(value).strip()
+    return text or default
+
+
+def _print_chat_interaction_summary(payload: dict[str, object]) -> None:
+    response = _as_mapping(payload.get("chat_response"))
+    route = _as_mapping(payload.get("route"))
+    state = _as_mapping(response.get("state"))
+    route_explanation = _as_mapping(route.get("route_explanation"))
+    source = _text(payload.get("source"), "generic")
+    selected_workflow = _text(
+        state.get("selected_workflow")
+        or route.get("selected_skill")
+        or route_explanation.get("selected_workflow")
+        or response.get("kind"),
+        "unknown",
+    )
+    next_action = _text(payload.get("next_action") or state.get("next_action") or route.get("action"), "unknown")
+    print("OMH chat interaction")
+    print(f"Source: {source}")
+    print(f"Workflow: {selected_workflow}")
+    print(f"Next action: {next_action}")
+
+    headline = _text(response.get("headline") or response.get("plain_headline"))
+    body = _text(response.get("body") or response.get("plain_body"))
+    if headline or body:
+        print()
+        if headline:
+            print(headline)
+        if body:
+            print(body)
+
+    actions = [action for action in _as_list(response.get("actions")) if isinstance(action, dict)]
+    if actions:
+        print()
+        print("Actions:")
+        for action in actions[:8]:
+            action_id = _text(action.get("id"), "action")
+            label = _text(action.get("label"), action_id)
+            enabled = bool(action.get("enabled", True))
+            state_label = "enabled" if enabled else "disabled"
+            print(f"- {action_id}: {label} ({state_label})")
+        if len(actions) > 8:
+            print(f"- ... {len(actions) - 8} more action(s) in --json")
+
+    not_evidence = [
+        _text(item)
+        for item in (
+            _as_list(state.get("evidence_not_observed"))
+            or _as_list(route_explanation.get("not_evidence_yet"))
+            or _as_list(response.get("not_evidence_yet"))
+        )
+        if _text(item)
+    ]
+    if not_evidence:
+        print()
+        print("Not evidence yet:")
+        for item in not_evidence[:6]:
+            print(f"- {item}")
+
+    boundary = _text(response.get("claim_boundary") or route_explanation.get("claim_boundary"))
+    if boundary:
+        print()
+        print("Boundary:")
+        print(f"  {boundary}")
+
+    print()
+    print("Use --json for the full machine-readable payload.")
 
 
 def _add_target_metadata_options(parser: argparse.ArgumentParser) -> None:
@@ -611,6 +697,16 @@ def _add_chat_commands(sub) -> None:
     interact.add_argument("--source-event-id", default="", help="Optional source message/event id to store as metadata.")
     interact.add_argument("--channel-ref", default="", help="Optional channel reference to store as metadata.")
     interact.add_argument("--user-ref", default="", help="Optional user reference to store as metadata.")
+    interact.add_argument(
+        "--summary",
+        action="store_true",
+        help="Print a compact human-readable operator summary instead of the default JSON envelope.",
+    )
+    interact.add_argument(
+        "--json",
+        action="store_true",
+        help="Print the full machine-readable JSON envelope. This is the default.",
+    )
     _add_render_profile_option(interact)
     _add_target_metadata_options(interact)
     interact.set_defaults(func=cmd_chat_interact)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4192,6 +4192,60 @@ class CliTests(unittest.TestCase):
         self.assertTrue(response["state"]["coding_delegate_available"])
         self.assertNotIn(message, json.dumps(payload))
 
+    def test_chat_interact_summary_renders_operator_readable_plan(self) -> None:
+        message = "I want to safely add a feature to this repo"
+        status, stdout, stderr = run_cli(["chat", "interact", "--source", "discord", "--summary", message], output_json=False)
+
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        with self.assertRaises(json.JSONDecodeError):
+            json.loads(stdout)
+        self.assertIn("OMH chat interaction", stdout)
+        self.assertIn("Source: discord", stdout)
+        self.assertIn("Workflow: ralplan", stdout)
+        self.assertIn("Next action: present_plan", stdout)
+        self.assertIn("[omh] ralplan - I routed this to `ralplan`", stdout)
+        self.assertIn("Actions:", stdout)
+        self.assertIn("- accept_plan: Accept plan (enabled)", stdout)
+        self.assertIn("- prepare_handoff: Prepare handoff (disabled)", stdout)
+        self.assertIn("Boundary:", stdout)
+        self.assertIn("A draft plan is not execution evidence.", stdout)
+        self.assertIn("Use --json for the full machine-readable payload.", stdout)
+
+        status, stdout, stderr = run_cli(["chat", "interact", "--source", "discord", "--json", message], output_json=False)
+
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        payload = json.loads(stdout)
+        self.assertEqual(payload["schema_version"], "chat_interaction/v1")
+        self.assertEqual(payload["route"]["selected_skill"], "ralplan")
+
+    def test_chat_interact_summary_renders_catalog_picker_without_shell_json(self) -> None:
+        status, stdout, stderr = run_cli(
+            ["chat", "interact", "--source", "discord", "--summary", "what OMH workflows are available?"],
+            output_json=False,
+        )
+
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        self.assertIn("OMH chat interaction", stdout)
+        self.assertIn("Workflow: oh-my-hermes", stdout)
+        self.assertIn("Next action: choose_skill", stdout)
+        self.assertIn("[omh] oh-my-hermes - Here are the OMH workflows.", stdout)
+        self.assertIn("- choose_skill: Choose workflow (enabled)", stdout)
+        self.assertIn("- search_skills: Search workflows (enabled)", stdout)
+        self.assertIn("Use --json for the full machine-readable payload.", stdout)
+
+    def test_chat_interact_rejects_conflicting_output_modes(self) -> None:
+        status, stdout, stderr = run_cli(
+            ["chat", "interact", "--source", "discord", "--summary", "--json", "risky refactor"],
+            output_json=False,
+        )
+
+        self.assertNotEqual(status, 0)
+        self.assertEqual(stdout, "")
+        self.assertIn("--summary and --json cannot be used together", stderr)
+
     def test_chat_interact_routes_grounded_operator_examples(self) -> None:
         cases = (
             ("결제 실패 이슈가 자주 나와", "feedback-triage", "ack", "triage_feedback"),


### PR DESCRIPTION
## Feature Report

### What Changed

- Added `omh chat interact --summary`, a compact human-readable renderer for the existing `chat_interaction/v1` response contract.
- Kept default `omh chat interact` output as JSON and added explicit `--json` as the machine-readable form.
- Documented when to use `--summary` in wrapper/operator docs and site docs.

### Why This Exists

- Real QA of OMH chat routing currently requires reading large JSON payloads even when the operator only needs to confirm the selected workflow, next action, actions, evidence gaps, and claim boundary.
- Hermes/wrapper integrations still need the full JSON envelope, but humans need a quick inspection surface while testing Discord/Slack-style routing behavior.

### User / Operator Impact

- Operators can now run `omh chat interact --source discord --summary "I want to safely add a feature to this repo"` and see the same response in a readable terminal format.
- The summary shows workflow, next action, visible actions, not-yet-evidence items, and the boundary line without exposing raw prompt text.
- Wrappers and plugins remain compatible because JSON is still the default and `--json` remains available explicitly.

### How It Works

- `src/commands/chat.py` now renders a summary only when `--summary` is passed.
- The renderer reads the already-built `chat_response`, `route`, and route explanation payloads; it does not re-route, record evidence, or mutate runtime state.
- `--summary` and `--json` are mutually exclusive to avoid ambiguous operator output modes.

### Files And Contracts Touched

- `src/commands/chat.py`: adds the summary renderer and output-mode flags for `chat interact`.
- `tests/test_cli.py`: locks plan summary output, catalog picker summary output, JSON compatibility, and conflicting flag rejection.
- `docs/INSTALLATION.md`, `docs/APPLICATION_CASES.md`, `site/docs/index.html`: explain summary as operator inspection only.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `PYTHONPATH=tests uv run python -m compileall -q src tests`
- [x] `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check`
- [x] `PYTHONPATH=tests uv run python -m omh.cli harness validate`
- [ ] `python3 -m omh.cli release checklist --json`
- [ ] `python3 -m omh.cli release hermes-smoke`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable; learning contracts were not changed.
- [x] Relevant dry-run or smoke command: `PYTHONPATH=tests uv run python -m omh.cli chat interact --source discord --summary "I want to safely add a feature to this repo"`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; this PR only adds a deterministic CLI/operator rendering mode and preserves wrapper JSON contracts.

## Risk

- Low. The default output remains JSON, and the summary renderer consumes existing payload fields without changing routing or wrapper contracts.
- The main risk is future copy drift between `chat_response` fields and the summary renderer; tests now lock representative plan and catalog picker outputs.

## Compatibility / Rollout

- Backward-compatible for adapters and wrappers because `omh chat interact` still emits JSON unless `--summary` is explicitly passed.
- `--json` is accepted as an explicit no-op JSON mode for scripts that prefer visible output intent.

## Release / Claims

- [x] Release-channel impact considered (`preview` feature, no package channel mutation in this PR)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- Consider adding similar `--summary` output to `omh chat route` if operator testing shows the lower-level route command is still too raw.
