### PR TITLE
Add chat route summary output

### DIFF
--- a/docs/APPLICATION_CASES.md
+++ b/docs/APPLICATION_CASES.md
@@ -534,6 +534,9 @@ wrapper operators a concrete contract result to render.
 `omh chat interact --summary` prints a compact operator-readable view of the
 same wrapper response, actions, evidence gaps, and claim boundary. The default
 `omh chat interact` output remains JSON for adapter compatibility.
+When only the lower-level router needs inspection, `omh chat route --summary`
+prints why the workflow was selected, the next action, route-plan steps, and
+the same evidence boundary while keeping default `chat route` output as JSON.
 
 `omh demo grounded-score --summary` prints a compact operator-readable rollup;
 `omh demo grounded-score --json` prints the full machine-readable payload.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -758,12 +758,17 @@ Lower-level debug surfaces remain available when an adapter needs them:
 
 ```sh
 omh chat route --source discord --record "risky refactor"
+omh chat route --source discord --summary "risky refactor"
 omh hermes plan --source discord --record "risky refactor with review"
 omh hermes plan-accept .hermes/plans/<accepted-plan.md>
 omh coding delegate --executor codex --source discord --record --from-plan .hermes/plans/<accepted-plan.md>
 omh coding delegate --executor claude-code --source discord --record "risky refactor"
 omh runtime delegation-status --run <run-id>
 ```
+
+`omh chat route --summary` is for operator inspection of the lower-level route
+decision. It does not replace the default JSON payload that adapters should
+consume.
 
 `omh hermes plan --record` writes a draft `hermes_plan/v1` Markdown artifact
 under `.hermes/plans/`. Each plan includes a deterministic `quality_gate` and

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -355,14 +355,16 @@ hermes skills install rlaope/oh-my-hermes/skills/oh-my-hermes --yes</code>
             <code>plugin tool: omh_interact
 omh chat interact --source discord "risky refactor"
 omh chat interact --source slack "diagnose installation health"
-omh chat interact --source discord --summary "risky refactor"</code>
+omh chat interact --source discord --summary "risky refactor"
+omh chat route --source discord --summary "risky refactor"</code>
           </div>
           <p>
             <code>omh_interact</code> is the plugin-native path: it returns the
             same chat envelope and records a metadata-only wrapper session with
             producer provenance. The CLI examples are adapter backend
-            equivalents. The <code>--summary</code> form is for operator
-            inspection; wrappers should keep using the JSON envelope or plugin
+            equivalents. The <code>chat interact --summary</code> and
+            <code>chat route --summary</code> forms are for operator
+            inspection; wrappers should keep using the JSON envelopes or plugin
             tool output. Fixture-backed examples cover both shell-free workflow
             picker responses and plugin-produced planning cards. A response can be
             an answer, a clarification request, policy-specific workflow

--- a/src/commands/chat.py
+++ b/src/commands/chat.py
@@ -43,6 +43,8 @@ from .runtime import _validate_runtime_names
 
 
 def cmd_chat_route(args: argparse.Namespace) -> int:
+    if bool(getattr(args, "summary", False)) and bool(getattr(args, "json", False)):
+        raise OmhError("--summary and --json cannot be used together")
     message = _chat_message(args)
     try:
         decision = route_chat_message(message, source=args.source, limit=args.limit, min_confidence=args.min_confidence)
@@ -78,7 +80,10 @@ def cmd_chat_route(args: argparse.Namespace) -> int:
             ),
         )
         payload["runtime"] = {"run": run, "routing": routing}
-    _print_json(payload)
+    if bool(getattr(args, "summary", False)):
+        _print_chat_route_summary(payload)
+    else:
+        _print_json(payload)
     return 0
 
 
@@ -292,6 +297,85 @@ def _print_chat_interaction_summary(payload: dict[str, object]) -> None:
 
     print()
     print("Use --json for the full machine-readable payload.")
+
+
+def _print_chat_route_summary(payload: dict[str, object]) -> None:
+    route = _as_mapping(payload.get("route"))
+    route_explanation = _as_mapping(route.get("route_explanation"))
+    selected_workflow = _text(route.get("selected_skill") or route_explanation.get("selected_workflow"), "unknown")
+    selected_harness = _text(route.get("selected_harness") or route_explanation.get("selected_harness"), "unknown")
+    action = _text(route.get("action") or route_explanation.get("action"), "unknown")
+    source = _text(route.get("source"), "generic")
+    confidence = _text(route.get("confidence") or route_explanation.get("confidence"), "unknown")
+    score = _text(route.get("score") or route_explanation.get("score"), "0")
+    next_action = _text(route_explanation.get("next_action") or _first_recommendation_value(route, "next_action"), "unknown")
+
+    print("OMH chat route")
+    print(f"Source: {source}")
+    print(f"Workflow: {selected_workflow}")
+    print(f"Harness: {selected_harness}")
+    print(f"Action: {action}")
+    print(f"Next action: {next_action}")
+    print(f"Confidence: {confidence} (score {score})")
+
+    why = _text(route_explanation.get("why_this_workflow") or route.get("reason"))
+    if why:
+        print()
+        print("Why:")
+        print(f"  {why}")
+
+    recommendations = [item for item in _as_list(route.get("recommendations")) if isinstance(item, dict)]
+    if recommendations:
+        print()
+        print("Top recommendations:")
+        for item in recommendations[:5]:
+            skill = _text(item.get("skill"), "unknown")
+            item_next = _text(item.get("next_action"), "unknown")
+            item_confidence = _text(item.get("confidence"), "unknown")
+            item_score = _text(item.get("score"), "0")
+            print(f"- {skill}: {item_next} ({item_confidence}, score {item_score})")
+
+    route_plan = _as_mapping(route.get("workflow_route_plan"))
+    steps = [item for item in _as_list(route_plan.get("steps")) if isinstance(item, dict)]
+    if steps:
+        print()
+        print("Route plan:")
+        for step in steps[:6]:
+            order = _text(step.get("order"), "?")
+            stage = _text(step.get("stage"), "stage")
+            skill = _text(step.get("skill"), "workflow")
+            status = _text(step.get("status"), "prepared_not_observed")
+            print(f"- {order}. {stage}: {skill} ({status})")
+
+    not_evidence = [_text(item) for item in _as_list(route_explanation.get("not_evidence_yet")) if _text(item)]
+    if not_evidence:
+        print()
+        print("Not evidence yet:")
+        for item in not_evidence[:6]:
+            print(f"- {item}")
+
+    boundary = _text(route_explanation.get("claim_boundary") or _first_recommendation_value(route, "evidence_boundary"))
+    if boundary:
+        print()
+        print("Boundary:")
+        print(f"  {boundary}")
+
+    run = _as_mapping(_as_mapping(payload.get("runtime")).get("run"))
+    if run:
+        print()
+        print("Runtime record:")
+        print(f"  run_id: {_text(run.get('run_id'), 'unknown')}")
+        print("  status: recorded metadata only")
+
+    print()
+    print("Use --json for the full machine-readable route payload.")
+
+
+def _first_recommendation_value(route: dict[str, object], key: str) -> object:
+    recommendations = _as_list(route.get("recommendations"))
+    if not recommendations or not isinstance(recommendations[0], dict):
+        return ""
+    return recommendations[0].get(key, "")
 
 
 def _add_target_metadata_options(parser: argparse.ArgumentParser) -> None:
@@ -630,6 +714,16 @@ def _add_chat_commands(sub) -> None:
     route.add_argument("--source-event-id", default="", help="Optional source message/event id to store as metadata.")
     route.add_argument("--channel-ref", default="", help="Optional channel reference to store as metadata.")
     route.add_argument("--user-ref", default="", help="Optional user reference to store as metadata.")
+    route.add_argument(
+        "--summary",
+        action="store_true",
+        help="Print a compact human-readable route summary instead of the default JSON payload.",
+    )
+    route.add_argument(
+        "--json",
+        action="store_true",
+        help="Print the full machine-readable JSON route payload. This is the default.",
+    )
     route.set_defaults(func=cmd_chat_route)
 
     route_hint = chat_sub.add_parser(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4011,6 +4011,66 @@ class CliTests(unittest.TestCase):
         self.assertIn("{message}", route["routing_prompt_template"])
         self.assertNotIn("risky refactor", json.dumps(route))
 
+    def test_chat_route_summary_renders_operator_readable_route(self) -> None:
+        message = "I want to safely add a feature to this repo"
+        status, stdout, stderr = run_cli(["chat", "route", "--source", "discord", "--summary", message], output_json=False)
+
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        with self.assertRaises(json.JSONDecodeError):
+            json.loads(stdout)
+        self.assertIn("OMH chat route", stdout)
+        self.assertIn("Source: discord", stdout)
+        self.assertIn("Workflow: ralplan", stdout)
+        self.assertIn("Harness: planning", stdout)
+        self.assertIn("Action: dispatch", stdout)
+        self.assertIn("Next action: present_plan", stdout)
+        self.assertIn("Confidence: high (score 32)", stdout)
+        self.assertIn("Why:", stdout)
+        self.assertIn("Matched safe feature-change language", stdout)
+        self.assertIn("Top recommendations:", stdout)
+        self.assertIn("- ralplan: present_plan (high, score 32)", stdout)
+        self.assertIn("Route plan:", stdout)
+        self.assertIn("- 1. triage: feedback-triage (prepared_not_observed)", stdout)
+        self.assertIn("Boundary:", stdout)
+        self.assertIn("A recommendation or draft plan is not execution evidence.", stdout)
+        self.assertIn("Use --json for the full machine-readable route payload.", stdout)
+
+        status, stdout, stderr = run_cli(["chat", "route", "--source", "discord", "--json", message], output_json=False)
+
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        route = json.loads(stdout)["route"]
+        self.assertEqual(route["selected_skill"], "ralplan")
+        self.assertEqual(route["route_explanation"]["next_action"], "present_plan")
+
+    def test_chat_route_summary_shows_recorded_runtime_metadata_only(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+            status, stdout, stderr = run_cli(
+                base + ["chat", "route", "--source", "discord", "--record", "--summary", "payment failures keep coming up"],
+                output_json=False,
+            )
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            self.assertIn("Workflow: feedback-triage", stdout)
+            self.assertIn("Next action: triage_feedback", stdout)
+            self.assertIn("Runtime record:", stdout)
+            self.assertIn("run_id: ", stdout)
+            self.assertIn("status: recorded metadata only", stdout)
+
+    def test_chat_route_rejects_conflicting_output_modes(self) -> None:
+        status, stdout, stderr = run_cli(
+            ["chat", "route", "--source", "discord", "--summary", "--json", "risky refactor"],
+            output_json=False,
+        )
+
+        self.assertNotEqual(status, 0)
+        self.assertEqual(stdout, "")
+        self.assertIn("--summary and --json cannot be used together", stderr)
+
     def test_chat_route_dispatches_image_capability_questions_to_img_summary(self) -> None:
         cases = (
             "이미지 생성 기능 뭐 있어?",


### PR DESCRIPTION
## Feature Report

### What Changed

- Added `omh chat route --summary`, a compact human-readable renderer for the lower-level route contract.
- Kept default `omh chat route` output as JSON and added explicit `--json` as the machine-readable form.
- Documented `chat route --summary` as an operator inspection surface, separate from wrapper JSON consumption.

### Why This Exists

- `omh chat interact --summary` made wrapper interaction QA readable, but the lower-level `chat route` command still required operators to inspect a large JSON payload for the selected workflow, next action, route-plan steps, and claim boundary.
- Router strengthening needs fast human inspection without weakening the deterministic JSON contract wrappers already consume.

### User / Operator Impact

- Operators can now run `omh chat route --source discord --summary "payment failures keep coming up"` and immediately see the selected workflow, harness, action, confidence, route explanation, evidence gaps, and boundary.
- `--record --summary` also shows the metadata-only runtime record id without implying execution evidence.
- Wrappers remain compatible because JSON is still the default and `--json` remains available explicitly.

### How It Works

- `src/commands/chat.py` now renders a route summary only when `--summary` is passed.
- The renderer consumes existing `route_explanation/v1`, recommendations, workflow route plan, and runtime metadata fields; it does not re-route, dispatch, or mutate anything beyond existing `--record` behavior.
- `--summary` and `--json` are mutually exclusive to prevent ambiguous operator output.

### Files And Contracts Touched

- `src/commands/chat.py`: adds the route summary renderer and output-mode flags for `chat route`.
- `tests/test_cli.py`: locks readable route output, JSON compatibility, metadata-only record copy, and conflicting flag rejection.
- `docs/INSTALLATION.md`, `docs/APPLICATION_CASES.md`, `site/docs/index.html`: document route summary as operator inspection only.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `PYTHONPATH=tests uv run python -m compileall -q src tests`
- [x] `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check`
- [x] `PYTHONPATH=tests uv run python -m omh.cli harness validate`
- [ ] `python3 -m omh.cli release checklist --json`
- [ ] `python3 -m omh.cli release hermes-smoke`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable; learning contracts were not changed.
- [x] Relevant dry-run or smoke command: `PYTHONPATH=tests uv run python -m omh.cli chat route --source discord --summary "I want to safely add a feature to this repo"`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; this PR only adds deterministic CLI/operator rendering while preserving route JSON contracts.

## Risk

- Low. The default route output remains JSON, and the summary is derived from existing route payload fields.
- Future route payload shape changes could require summary copy updates; tests now lock representative safe-feature, product-feedback, and recorded-route cases.

## Compatibility / Rollout

- Backward-compatible for adapters and wrappers because `omh chat route` still emits JSON unless `--summary` is explicitly passed.
- Operators can use the new summary mode immediately for manual route QA without changing wrapper code.

## Release / Claims

- [x] Release-channel impact considered (`preview` feature, no package channel mutation in this PR)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- Continue auditing other backend-heavy commands for places where operator summaries improve real-world QA without changing wrapper-facing JSON contracts.
