### PR TITLE
Add chat route hint summary output

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ understand first; the rest live in [Workflow Reference](docs/WORKFLOWS.md) and
 | Chat workflow picker | Hermes can answer "what can OMH do?" without making the user approve shell commands. |
 | OMH context brief | Hermes or a wrapper can fetch a compact OMH mental model, generic-tool checkpoint, and route hint before falling back to ordinary chat/tools. |
 | Catalog-aware list | `omh list` groups installed workflows by lane, and `omh list --json` includes descriptions, routing hints, examples, and evidence boundaries for wrappers or operators. |
-| Route hint cards | Wrappers can preview the nearest OMH workflow with `chat_route_hint/v1`, even before plugin load is observed. |
+| Route hint cards | Wrappers can preview the nearest OMH workflow with `chat_route_hint/v1`, and operators can inspect the same hint with `omh chat route-hint --summary`. |
 | Deterministic demos | `omh demo orchestration` shows the local recommend -> chat -> plan -> handoff -> status path; `--executor` can demonstrate Codex, Claude Code, or Hermes paths without treating prepared handoffs as execution. |
 | Plugin runtime evidence | Hosts or wrappers can record plugin load/use with `omh plugin observe-host`, and plugin tools/hooks can self-record the same metadata when the host passes observation context; active-ready and historical events stay separate from install smoke. |
 | Coding agent paths | Hermes can prepare work for Codex, Claude Code, Hermes itself, or another runtime without pretending the work already ran. |

--- a/docs/CHAT_WRAPPER_EXAMPLES.md
+++ b/docs/CHAT_WRAPPER_EXAMPLES.md
@@ -20,6 +20,7 @@ uv run python examples/slack-adapter-shim.py --plugin-interact examples/wrapper-
 uv run python examples/discord-adapter-shim.py --route-hint examples/wrapper-events/discord-route-hint-visual.json
 uv run python examples/slack-adapter-shim.py --route-hint examples/wrapper-events/slack-route-hint-missed-route.json
 uv run python -m omh.cli chat route-hint --source discord "make an image explaining the cron feature"
+uv run python -m omh.cli chat route-hint --source discord --summary "make an image explaining the cron feature"
 uv run python -m omh.cli chat native-command --source discord
 uv run python -m omh.cli chat native-command --source slack
 uv run python -m omh.cli chat native-command --source telegram
@@ -285,11 +286,16 @@ can call the transport-free backend preview:
 
 ```sh
 omh chat route-hint --source discord "make an image explaining the cron feature"
+omh chat route-hint --source discord --summary "make an image explaining the cron feature"
 ```
 
 The preview payload also includes `generic_tool_checkpoint.routes`, so adapters
-do not need to parse prose before opening generic tool surfaces. The current
-OMH-first map is:
+do not need to parse prose before opening generic tool surfaces. The `--summary`
+form prints the same primary workflow, next action, hint
+details, checkpoint, and evidence boundary for operator QA. Adapters should
+continue to consume the default JSON payload.
+
+The current OMH-first map is:
 
 - image tools -> `img-summary` / `prepare_visual_prompt_card`
 - file tools -> `materials-package` / `prepare_material_package`

--- a/src/commands/chat.py
+++ b/src/commands/chat.py
@@ -88,6 +88,8 @@ def cmd_chat_route(args: argparse.Namespace) -> int:
 
 
 def cmd_chat_route_hint(args: argparse.Namespace) -> int:
+    if bool(getattr(args, "summary", False)) and bool(getattr(args, "json", False)):
+        raise OmhError("--summary and --json cannot be used together")
     try:
         event_or_message, source_metadata = _chat_input_and_metadata(args)
         message = extract_message_text(event_or_message) if isinstance(event_or_message, dict) else str(event_or_message)
@@ -100,7 +102,10 @@ def cmd_chat_route_hint(args: argparse.Namespace) -> int:
         )
     except (OSError, json.JSONDecodeError, ValueError) as exc:
         raise OmhError(str(exc)) from exc
-    _print_json(payload)
+    if bool(getattr(args, "summary", False)):
+        _print_chat_route_hint_summary(payload)
+    else:
+        _print_json(payload)
     return 0
 
 
@@ -369,6 +374,110 @@ def _print_chat_route_summary(payload: dict[str, object]) -> None:
 
     print()
     print("Use --json for the full machine-readable route payload.")
+
+
+def _print_chat_route_hint_summary(payload: dict[str, object]) -> None:
+    response = _as_mapping(payload.get("chat_response"))
+    route_hint = _as_mapping(payload.get("route_hint"))
+    state = _as_mapping(response.get("state"))
+    state_route_hint = _as_mapping(state.get("route_hint"))
+    selected_workflow = _text(
+        route_hint.get("primary_workflow")
+        or route_hint.get("selected_workflow")
+        or state_route_hint.get("primary_workflow")
+        or state.get("selected_workflow"),
+        "unknown",
+    )
+    next_action = _text(
+        route_hint.get("primary_next_action")
+        or state_route_hint.get("primary_next_action")
+        or state.get("next_action"),
+        "unknown",
+    )
+    source = _text(payload.get("source"), "generic")
+    hint_count = len([item for item in _as_list(route_hint.get("hints")) if isinstance(item, dict)])
+
+    print("OMH route hint")
+    print(f"Source: {source}")
+    print(f"Workflow: {selected_workflow}")
+    print(f"Next action: {next_action}")
+    print(f"Hints: {hint_count}")
+
+    headline = _text(response.get("headline"))
+    body = _text(response.get("body"))
+    if headline or body:
+        print()
+        if headline:
+            print(headline)
+        if body:
+            print(body)
+
+    hints = [item for item in _as_list(route_hint.get("hints")) if isinstance(item, dict)]
+    if hints:
+        print()
+        print("Hint details:")
+        for hint in hints[:5]:
+            workflow = _text(hint.get("workflow"), "unknown")
+            lane = _text(hint.get("lane"), "unknown")
+            action = _text(hint.get("next_action"), "unknown")
+            reason = _text(hint.get("reason"))
+            print(f"- {workflow}: {action} ({lane})")
+            if reason:
+                print(f"  why: {reason}")
+
+    actions = [action for action in _as_list(response.get("actions")) if isinstance(action, dict)]
+    if actions:
+        print()
+        print("Actions:")
+        for action in actions[:6]:
+            action_id = _text(action.get("id"), "action")
+            label = _text(action.get("label"), action_id)
+            enabled = bool(action.get("enabled", True))
+            state_label = "enabled" if enabled else "disabled"
+            print(f"- {action_id}: {label} ({state_label})")
+
+    checkpoint = _as_mapping(payload.get("generic_tool_checkpoint"))
+    checkpoint_body = _text(checkpoint.get("body"))
+    if checkpoint_body:
+        print()
+        print("Checkpoint:")
+        print(f"  {checkpoint_body}")
+
+    not_evidence = [
+        _text(item)
+        for item in (
+            _as_list(route_hint.get("not_executed"))
+            or _as_list(_first_hint_value(route_hint, "not_evidence_yet"))
+            or _as_list(checkpoint.get("not_evidence_yet"))
+        )
+        if _text(item)
+    ]
+    if not_evidence:
+        print()
+        print("Not evidence yet:")
+        for item in not_evidence[:6]:
+            print(f"- {item}")
+
+    prompt_context = _text(payload.get("prompt_context"))
+    if prompt_context:
+        print()
+        print("Prompt context: included")
+
+    boundary = _text(payload.get("claim_boundary") or response.get("claim_boundary") or route_hint.get("claim_boundary"))
+    if boundary:
+        print()
+        print("Boundary:")
+        print(f"  {boundary}")
+
+    print()
+    print("Use --json for the full machine-readable route hint payload.")
+
+
+def _first_hint_value(route_hint: dict[str, object], key: str) -> object:
+    hints = _as_list(route_hint.get("hints"))
+    if not hints or not isinstance(hints[0], dict):
+        return ""
+    return hints[0].get(key, "")
 
 
 def _first_recommendation_value(route: dict[str, object], key: str) -> object:
@@ -751,6 +860,16 @@ def _add_chat_commands(sub) -> None:
         "--prompt-context",
         action="store_true",
         help="Also include the compact plugin-style prompt context string for wrappers that inject context manually.",
+    )
+    route_hint.add_argument(
+        "--summary",
+        action="store_true",
+        help="Print a compact human-readable route-hint summary instead of the default JSON payload.",
+    )
+    route_hint.add_argument(
+        "--json",
+        action="store_true",
+        help="Print the full machine-readable JSON route-hint payload. This is the default.",
     )
     route_hint.set_defaults(func=cmd_chat_route_hint)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4161,6 +4161,41 @@ class CliTests(unittest.TestCase):
         self.assertTrue(payload["wrapper_contract"]["does_not_require_plugin_load"])
         self.assertNotIn(message, json.dumps(payload))
 
+    def test_chat_route_hint_summary_renders_operator_readable_hint(self) -> None:
+        message = "make an image explaining the cron feature"
+        status, stdout, stderr = run_cli(["chat", "route-hint", "--source", "discord", "--summary", message], output_json=False)
+
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        with self.assertRaises(json.JSONDecodeError):
+            json.loads(stdout)
+        self.assertIn("OMH route hint", stdout)
+        self.assertIn("Source: discord", stdout)
+        self.assertIn("Workflow: img-summary", stdout)
+        self.assertIn("Next action: prepare_visual_prompt_card", stdout)
+        self.assertIn("Hints: 2", stdout)
+        self.assertIn("[omh] img-summary looks relevant.", stdout)
+        self.assertIn("Hint details:", stdout)
+        self.assertIn("- img-summary: prepare_visual_prompt_card (materials_and_visuals)", stdout)
+        self.assertIn("- automation-blueprint: prepare_scheduled_ops_blueprint (automation_and_status)", stdout)
+        self.assertIn("Actions:", stdout)
+        self.assertIn("- open_workflow: Open img-summary (enabled)", stdout)
+        self.assertIn("Checkpoint:", stdout)
+        self.assertIn("Before generic tools, check OMH prep/status/learning", stdout)
+        self.assertIn("Not evidence yet:", stdout)
+        self.assertIn("- image generation", stdout)
+        self.assertIn("Boundary:", stdout)
+        self.assertIn("not workflow execution", stdout)
+        self.assertIn("Use --json for the full machine-readable route hint payload.", stdout)
+
+        status, stdout, stderr = run_cli(["chat", "route-hint", "--source", "discord", "--json", message], output_json=False)
+
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        payload = json.loads(stdout)
+        self.assertEqual(payload["schema_version"], "chat_route_hint/v1")
+        self.assertEqual(payload["route_hint"]["primary_workflow"], "img-summary")
+
     def test_chat_route_hint_can_emit_manual_prompt_context(self) -> None:
         status, stdout, stderr = run_cli(
             ["chat", "route-hint", "--source", "discord", "--prompt-context", "missed route: OMH was not used"]
@@ -4173,6 +4208,27 @@ class CliTests(unittest.TestCase):
         self.assertIn("[OMH Route Hint]", payload["prompt_context"])
         self.assertIn("selected=workflow-learning", payload["prompt_context"])
         self.assertIn("Prompt context is for Hermes routing guidance only", payload["prompt_context_boundary"])
+
+        status, stdout, stderr = run_cli(
+            ["chat", "route-hint", "--source", "discord", "--summary", "--prompt-context", "missed route: OMH was not used"],
+            output_json=False,
+        )
+
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        self.assertIn("Workflow: workflow-learning", stdout)
+        self.assertIn("Next action: record_missed_route", stdout)
+        self.assertIn("Prompt context: included", stdout)
+
+    def test_chat_route_hint_rejects_conflicting_output_modes(self) -> None:
+        status, stdout, stderr = run_cli(
+            ["chat", "route-hint", "--source", "discord", "--summary", "--json", "make an image"],
+            output_json=False,
+        )
+
+        self.assertNotEqual(status, 0)
+        self.assertEqual(stdout, "")
+        self.assertIn("--summary and --json cannot be used together", stderr)
 
     def test_chat_route_file_lookup_does_not_emit_workflow_clarification(self) -> None:
         status, stdout, stderr = run_cli(["chat", "route", "--source", "discord", "search", "docs/WORKFLOWS.md", "for", "loop"])


### PR DESCRIPTION
## Feature Report

### What Changed

- Added `omh chat route-hint --summary` as a compact, human-readable route-hint view for operators.
- Kept the default `omh chat route-hint` output as `chat_route_hint/v1` JSON for wrappers, adapters, and shims.
- Added conflict handling for `--summary --json`, focused CLI coverage, and docs/README copy for the operator QA path.

### Why This Exists

- Route-hint JSON is the right contract for wrappers, but it is too noisy when an operator wants to quickly check whether OMH would point Hermes toward `img-summary`, `automation-blueprint`, `workflow-learning`, or another workflow before generic tool fallback.
- Recent Discord/Hermes usage showed that missed OMH awareness is easier to debug when the nearest workflow, next action, checkpoint, and evidence boundary are visible without parsing raw JSON.

### User / Operator Impact

- Operators can now run `omh chat route-hint --source discord --summary "make an image explaining the cron feature"` and immediately see the primary workflow, next action, hint details, wrapper actions, checkpoint, and what is not evidence yet.
- Wrapper authors can keep consuming JSON unchanged, so existing Discord/Slack/Telegram shim behavior is not disturbed.

### How It Works

- `src/commands/chat.py` now routes `cmd_chat_route_hint` through a summary renderer only when `--summary` is set.
- The renderer reads existing `chat_response`, `route_hint`, `generic_tool_checkpoint`, `prompt_context`, and claim-boundary fields without creating new runtime evidence.
- `--json` remains available as an explicit machine-readable mode and is mutually exclusive with `--summary`.

### Files And Contracts Touched

- `src/commands/chat.py`: route-hint output mode handling and summary renderer.
- `tests/test_cli.py`: summary rendering, JSON compatibility, prompt-context summary, and conflicting-mode coverage.
- `docs/CHAT_WRAPPER_EXAMPLES.md`: route-hint summary examples and adapter guidance.
- `README.md`: operator-facing route-hint capability mention.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_cli.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `PYTHONPATH=tests uv run python -m compileall -q src tests`
- [x] `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check`
- [x] `PYTHONPATH=tests uv run python -m omh.cli harness validate`
- [ ] `python3 -m omh.cli release checklist --json` - not run; no release-channel or packaging behavior changed.
- [ ] `python3 -m omh.cli release hermes-smoke` - not run; this change is local CLI rendering and wrapper guidance only.
- [ ] `omh --help` - not run; no root help surface changed.
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` - not run; install smoke is outside this route-hint summary slice.
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable; no workflow-learning artifact schema changed.
- [x] Relevant dry-run or smoke command: `PYTHONPATH=tests uv run python -m omh.cli chat route-hint --source discord --summary "make an image explaining the cron feature"`
- [x] Relevant dry-run or smoke command: `PYTHONPATH=tests uv run python -m omh.cli chat route-hint --source discord --json "make an image explaining the cron feature" | python3 -c 'import json,sys; data=json.load(sys.stdin); print(data["schema_version"], data["route_hint"]["primary_workflow"])'`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; summary output is deterministic local CLI rendering, while live Hermes wrapper rendering remains host-owned.
- [x] `git diff --check`

## Risk

- Low. The default route-hint JSON behavior stays unchanged, and the new summary path is opt-in.
- The main compatibility risk would be accidental output-mode ambiguity, covered by the `--summary --json` rejection test.

## Compatibility / Rollout

- Backward compatible for adapters because JSON remains the default route-hint output.
- Operators can start using `--summary` immediately for local QA without wrapper changes.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`): no release-channel behavior changed.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed: summary text explicitly preserves route-hint and not-evidence boundaries.
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap: live Hermes/TUI rendering was not run because this is deterministic local CLI rendering.

## Follow-Up

- Consider adding a similar operator summary for future route-hint contract variants if wrappers gain more fallback-specific hints.
