### PR TITLE
Clarify route hint summary signals

### DIFF
--- a/docs/CHAT_WRAPPER_EXAMPLES.md
+++ b/docs/CHAT_WRAPPER_EXAMPLES.md
@@ -291,7 +291,7 @@ omh chat route-hint --source discord --summary "make an image explaining the cro
 
 The preview payload also includes `generic_tool_checkpoint.routes`, so adapters
 do not need to parse prose before opening generic tool surfaces. The `--summary`
-form prints the same primary workflow, next action, hint
+form prints the same status, primary workflow, next action, matched cues, hint
 details, checkpoint, and evidence boundary for operator QA. Adapters should
 continue to consume the default JSON payload.
 

--- a/src/commands/chat.py
+++ b/src/commands/chat.py
@@ -381,12 +381,16 @@ def _print_chat_route_hint_summary(payload: dict[str, object]) -> None:
     route_hint = _as_mapping(payload.get("route_hint"))
     state = _as_mapping(response.get("state"))
     state_route_hint = _as_mapping(state.get("route_hint"))
+    hints = [item for item in _as_list(route_hint.get("hints")) if isinstance(item, dict)]
+    primary_hint = hints[0] if hints else {}
+    status = _text(route_hint.get("status") or ("hinted" if hints else "no_hint"), "unknown")
+    fallback_workflow = "none" if status == "no_hint" else "unknown"
     selected_workflow = _text(
         route_hint.get("primary_workflow")
         or route_hint.get("selected_workflow")
         or state_route_hint.get("primary_workflow")
         or state.get("selected_workflow"),
-        "unknown",
+        fallback_workflow,
     )
     next_action = _text(
         route_hint.get("primary_next_action")
@@ -395,13 +399,23 @@ def _print_chat_route_hint_summary(payload: dict[str, object]) -> None:
         "unknown",
     )
     source = _text(payload.get("source"), "generic")
-    hint_count = len([item for item in _as_list(route_hint.get("hints")) if isinstance(item, dict)])
+    hint_count = len(hints)
 
     print("OMH route hint")
     print(f"Source: {source}")
+    print(f"Status: {status}")
     print(f"Workflow: {selected_workflow}")
     print(f"Next action: {next_action}")
     print(f"Hints: {hint_count}")
+
+    matched_cues = _text_items(_as_list(primary_hint.get("matched_cues")))
+    if matched_cues:
+        print(f"Matched cues: {_join_text_items(matched_cues)}")
+    adjacent_workflows = _text_items(
+        _as_list(route_hint.get("adjacent_workflows")) or _as_list(primary_hint.get("adjacent_workflows"))
+    )
+    if adjacent_workflows:
+        print(f"Adjacent workflows: {_join_text_items(adjacent_workflows)}")
 
     headline = _text(response.get("headline"))
     body = _text(response.get("body"))
@@ -412,7 +426,6 @@ def _print_chat_route_hint_summary(payload: dict[str, object]) -> None:
         if body:
             print(body)
 
-    hints = [item for item in _as_list(route_hint.get("hints")) if isinstance(item, dict)]
     if hints:
         print()
         print("Hint details:")
@@ -422,6 +435,9 @@ def _print_chat_route_hint_summary(payload: dict[str, object]) -> None:
             action = _text(hint.get("next_action"), "unknown")
             reason = _text(hint.get("reason"))
             print(f"- {workflow}: {action} ({lane})")
+            hint_cues = _text_items(_as_list(hint.get("matched_cues")))
+            if hint_cues:
+                print(f"  matched: {_join_text_items(hint_cues)}")
             if reason:
                 print(f"  why: {reason}")
 
@@ -478,6 +494,16 @@ def _first_hint_value(route_hint: dict[str, object], key: str) -> object:
     if not hints or not isinstance(hints[0], dict):
         return ""
     return hints[0].get(key, "")
+
+
+def _text_items(items: list[object]) -> list[str]:
+    return [_text(item) for item in items if _text(item)]
+
+
+def _join_text_items(items: list[str], limit: int = 6) -> str:
+    visible = items[:limit]
+    suffix = f", +{len(items) - limit} more" if len(items) > limit else ""
+    return ", ".join(visible) + suffix
 
 
 def _first_recommendation_value(route: dict[str, object], key: str) -> object:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4171,13 +4171,18 @@ class CliTests(unittest.TestCase):
             json.loads(stdout)
         self.assertIn("OMH route hint", stdout)
         self.assertIn("Source: discord", stdout)
+        self.assertIn("Status: hinted", stdout)
         self.assertIn("Workflow: img-summary", stdout)
         self.assertIn("Next action: prepare_visual_prompt_card", stdout)
         self.assertIn("Hints: 2", stdout)
+        self.assertIn("Matched cues: image", stdout)
+        self.assertIn("Adjacent workflows: materials-package, report-package, research-department", stdout)
         self.assertIn("[omh] img-summary looks relevant.", stdout)
         self.assertIn("Hint details:", stdout)
         self.assertIn("- img-summary: prepare_visual_prompt_card (materials_and_visuals)", stdout)
+        self.assertIn("  matched: image", stdout)
         self.assertIn("- automation-blueprint: prepare_scheduled_ops_blueprint (automation_and_status)", stdout)
+        self.assertIn("  matched: cron", stdout)
         self.assertIn("Actions:", stdout)
         self.assertIn("- open_workflow: Open img-summary (enabled)", stdout)
         self.assertIn("Checkpoint:", stdout)
@@ -4195,6 +4200,22 @@ class CliTests(unittest.TestCase):
         payload = json.loads(stdout)
         self.assertEqual(payload["schema_version"], "chat_route_hint/v1")
         self.assertEqual(payload["route_hint"]["primary_workflow"], "img-summary")
+
+    def test_chat_route_hint_summary_renders_no_hint_without_unknown_workflow(self) -> None:
+        status, stdout, stderr = run_cli(["chat", "route-hint", "--source", "slack", "--summary", "zzzzzz"], output_json=False)
+
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        self.assertIn("OMH route hint", stdout)
+        self.assertIn("Source: slack", stdout)
+        self.assertIn("Status: no_hint", stdout)
+        self.assertIn("Workflow: none", stdout)
+        self.assertIn("Next action: open_picker_or_clarify", stdout)
+        self.assertIn("Hints: 0", stdout)
+        self.assertNotIn("Workflow: unknown", stdout)
+        self.assertIn("[omh] no strong workflow hint yet.", stdout)
+        self.assertIn("- open_picker: Open omh (enabled)", stdout)
+        self.assertIn("- clarify: Clarify (enabled)", stdout)
 
     def test_chat_route_hint_can_emit_manual_prompt_context(self) -> None:
         status, stdout, stderr = run_cli(


### PR DESCRIPTION
## Feature Report

### What Changed

- Improved `omh chat route-hint --summary` so it now shows:
  - route-hint status (`hinted` or `no_hint`)
  - matched cues for the primary hint
  - adjacent workflows that may also be relevant
  - matched cue labels for each hint detail
  - `Workflow: none` instead of `Workflow: unknown` when no hint matches
- Added CLI tests for both matched and no-hint summary output.
- Updated wrapper examples docs to describe the richer operator-readable summary.

### Why This Exists

- The previous summary was readable, but still made operators infer why OMH chose a workflow.
- When no route hint matched, `Workflow: unknown` made the fallback state feel like a bug instead of an intentional picker/clarify path.
- The goal is to make router QA easier: an operator should quickly see whether OMH matched a cue, which workflow won, what nearby workflows exist, and what remains only a hint.

### User / Operator Impact

- `omh chat route-hint --source discord --summary "make an image explaining the cron feature"` now makes the visual/cron cues visible before generic image or automation tooling.
- `omh chat route-hint --source slack --summary "zzzzzz"` now clearly reports `Status: no_hint` and `Workflow: none`, then offers picker/clarify actions.
- Wrapper JSON remains unchanged by default, so adapter compatibility is preserved.

### How It Works

- `src/commands/chat.py` reuses existing `matched_cues`, `adjacent_workflows`, and no-hint status fields from the existing route-hint payload.
- The summary renderer adds small formatting helpers for bounded comma-separated cue/workflow lists.
- No new runtime records, route scoring fields, network calls, or wrapper schema changes were added.

### Files And Contracts Touched

- `src/commands/chat.py`: human summary rendering only.
- `tests/test_cli.py`: matched-hint and no-hint summary assertions.
- `docs/CHAT_WRAPPER_EXAMPLES.md`: summary copy updated to mention status and matched cues.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_cli.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `PYTHONPATH=tests uv run python -m compileall -q src tests`
- [x] `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check`
- [x] `PYTHONPATH=tests uv run python -m omh.cli harness validate`
- [ ] `python3 -m omh.cli release checklist --json` - not run; release checklist behavior is unchanged.
- [ ] `python3 -m omh.cli release hermes-smoke` - not run; live Hermes visibility is outside this deterministic CLI summary change.
- [ ] `omh --help` - not run; root help output is unchanged.
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` - not run; install smoke is outside this route-hint summary slice.
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable.
- [x] Relevant dry-run or smoke command: `PYTHONPATH=tests uv run python -m omh.cli chat route-hint --source discord --summary "make an image explaining the cron feature"`
- [x] Relevant dry-run or smoke command: `PYTHONPATH=tests uv run python -m omh.cli chat route-hint --source slack --summary "zzzzzz"`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; this is deterministic local CLI rendering, while live wrapper rendering remains host-owned.
- [x] `git diff --check`

## Risk

- Low. This changes only opt-in summary text and keeps route-hint JSON compatibility intact.
- The summary now exposes existing cue labels, so future cue wording changes may need test updates.

## Compatibility / Rollout

- Backward compatible for wrappers because `omh chat route-hint` still defaults to JSON.
- Operators can use the richer `--summary` immediately for router QA.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`): no release-channel behavior changed.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed: summary remains a route hint only and preserves evidence boundaries.
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap: live Hermes/TUI rendering was not run because this is deterministic local CLI rendering.

## Follow-Up

- If route hints later gain explicit confidence scoring, consider adding it to the summary without changing the default JSON contract shape.
