### PR TITLE
Show common chat interaction actions in summaries

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -676,7 +676,9 @@ omh chat interact --source discord --summary "risky refactor"
 
 The default output is the machine-readable `chat_interaction/v1` JSON envelope
 that wrappers should render. Use `--summary` only when an operator wants to
-inspect the same response contract quickly in a terminal.
+inspect the same response contract quickly in a terminal. The summary keeps the
+usual chat actions visible for operator QA; use JSON only when an adapter needs
+the complete machine-readable payload.
 
 If the wrapper can identify the current Hermes agent target, include that as
 metadata rather than asking the user to choose a command:

--- a/src/commands/chat.py
+++ b/src/commands/chat.py
@@ -270,14 +270,15 @@ def _print_chat_interaction_summary(payload: dict[str, object]) -> None:
     if actions:
         print()
         print("Actions:")
-        for action in actions[:8]:
+        action_limit = 12
+        for action in actions[:action_limit]:
             action_id = _text(action.get("id"), "action")
             label = _text(action.get("label"), action_id)
             enabled = bool(action.get("enabled", True))
             state_label = "enabled" if enabled else "disabled"
             print(f"- {action_id}: {label} ({state_label})")
-        if len(actions) > 8:
-            print(f"- ... {len(actions) - 8} more action(s) in --json")
+        if len(actions) > action_limit:
+            print(f"- ... {len(actions) - action_limit} more action(s) in --json")
 
     not_evidence = [
         _text(item)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4357,6 +4357,24 @@ class CliTests(unittest.TestCase):
         self.assertEqual(payload["schema_version"], "chat_interaction/v1")
         self.assertEqual(payload["route"]["selected_skill"], "ralplan")
 
+    def test_chat_interact_summary_shows_common_visual_actions_without_json_escape_hatch(self) -> None:
+        status, stdout, stderr = run_cli(
+            ["chat", "interact", "--source", "discord", "--summary", "make an image explaining the cron feature"],
+            output_json=False,
+        )
+
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        self.assertIn("Workflow: img-summary", stdout)
+        self.assertIn("Actions:", stdout)
+        self.assertIn("- show_visual_prompt_card: Show card (enabled)", stdout)
+        self.assertIn("- choose_image_generator: Choose image tool (enabled)", stdout)
+        self.assertIn("- record_visual_delivery: Record delivery (enabled)", stdout)
+        self.assertIn("- show_visual_status: Show visual status (enabled)", stdout)
+        self.assertNotIn("more action(s) in --json", stdout)
+        self.assertIn("Not evidence yet:", stdout)
+        self.assertIn("- image generation", stdout)
+
     def test_chat_interact_summary_renders_catalog_picker_without_shell_json(self) -> None:
         status, stdout, stderr = run_cli(
             ["chat", "interact", "--source", "discord", "--summary", "what OMH workflows are available?"],


### PR DESCRIPTION
## Feature Report

### What Changed

- Increased the operator-facing `omh chat interact --summary` action display limit from 8 to 12 actions.
- Added CLI coverage proving the `img-summary` chat path shows its normal prompt, generator, delivery, and status actions without forcing operators into `--json`.
- Updated installation docs to clarify that summary mode remains useful for quick operator QA while wrappers should continue to consume JSON.

### Why This Exists

- Chat-first operator flows should make the next useful actions visible in terminal summaries.
- Before this change, `img-summary` could hide common actions such as `record_visual_delivery` and `show_visual_status` behind the `... more action(s) in --json` escape hatch.
- That made the feature feel less ready for Discord/Slack-style QA even though the JSON contract already contained the actions.

### User / Operator Impact

- Operators can run `omh chat interact --source discord --summary "make an image explaining the cron feature"` and see the practical visual-summary action set directly.
- Users still get the same machine-readable `chat_interaction/v1` JSON by default.
- Wrappers/adapters do not need to change; this is summary output polish only.

### How It Works

- `_print_chat_interaction_summary` now uses an explicit `action_limit = 12` before showing a JSON escape-hatch line.
- The test locks the common `img-summary` route so visual prompt, generator choice, delivery recording, and status actions remain visible in summary output.
- No routing, schema, wrapper, or runtime evidence semantics changed.

### Files And Contracts Touched

- `src/commands/chat.py`: operator-readable summary rendering limit.
- `tests/test_cli.py`: regression coverage for the visual-summary action set.
- `docs/INSTALLATION.md`: terminal summary guidance.
- Contract note: `chat_interaction/v1` JSON remains unchanged.

## Validation

- [x] `python3 -m unittest discover -s tests` — observed on this branch before commit as `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` with 879 tests passing.
- [x] `python3 -m compileall src` — observed on this branch before commit as `PYTHONPATH=tests uv run python -m compileall -q src tests`.
- [x] `python3 -m omh.cli docs workflows --check` — observed on this branch before commit as `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check`.
- [x] `python3 -m omh.cli harness validate` — observed on this branch before commit as `PYTHONPATH=tests uv run python -m omh.cli harness validate`.
- [ ] `python3 -m omh.cli release checklist --json` — not run; release surface unchanged.
- [ ] `python3 -m omh.cli release hermes-smoke` — not run; deterministic summary rendering only.
- [ ] `omh --help` — not run; command discovery unchanged.
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` — not run; install/Hermes smoke unchanged.
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable.
- [x] Relevant dry-run or smoke command: `PYTHONPATH=tests uv run python -m unittest tests.test_cli.CliTests.test_chat_interact_summary_shows_common_visual_actions_without_json_escape_hatch -v`; `git diff --check`.
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; no live wrapper rendering or Hermes runtime behavior changed.

## Risk

- Low. This changes only terminal summary rendering and increases the visible action count for operator-readable output.
- The only behavioral risk is slightly longer summaries for workflows with 9-12 common actions, which is intentional for QA readability.

## Compatibility / Rollout

- Backward compatible with existing wrappers because JSON remains the default and unchanged.
- No migration or setup step is required.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`) — no release-channel behavior changed.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed — no new runtime/native claims.
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap — live Hermes/wrapper rendering not observed because this is deterministic CLI summary output only.

## Follow-Up

- None required for this slice. Future wrapper work should continue consuming the JSON envelope rather than parsing summary text.
