### PR TITLE
Route multilingual content requests to workflow lanes

### DIFF
--- a/src/routing/localization.py
+++ b/src/routing/localization.py
@@ -46,6 +46,18 @@ _CANONICAL_WEB_RESEARCH = (
     "web research web search search the web current sources source-backed research "
     "citations links freshness source diversity retrieval gap"
 )
+_CANONICAL_VISUAL_SUMMARY = (
+    "img-summary visual summary image card summary image explainer image visual prompt card "
+    "image generation prompt explain feature cron workflow poster infographic"
+)
+_CANONICAL_PAPER_LEARNING = (
+    "paper-learning paper pdf research paper explain summarize easy moderate expert "
+    "section walkthrough coverage ledger without dropping details"
+)
+_CANONICAL_SOURCE_FINDER = (
+    "source-finder find source candidates papers datasets github repository public pdf links "
+    "presentation materials acquisition status downstream workflow"
+)
 
 
 @dataclass(frozen=True)
@@ -326,6 +338,210 @@ _ALIASES: tuple[LocaleAlias, ...] = (
             "neueste quellen",
         ),
         _CANONICAL_WEB_RESEARCH,
+    ),
+    LocaleAlias(
+        "ja",
+        "visual_summary",
+        (
+            "画像を作って",
+            "画像で説明",
+            "説明する画像",
+            "要約画像",
+            "インフォグラフィック",
+            "ポスターを作って",
+        ),
+        _CANONICAL_VISUAL_SUMMARY,
+    ),
+    LocaleAlias(
+        "zh",
+        "visual_summary",
+        (
+            "解释 cron 功能的图片",
+            "解释功能的图片",
+            "说明图片",
+            "說明圖片",
+            "摘要图片",
+            "摘要圖片",
+            "信息图",
+            "資訊圖",
+            "海报",
+            "海報",
+        ),
+        _CANONICAL_VISUAL_SUMMARY,
+    ),
+    LocaleAlias(
+        "es",
+        "visual_summary",
+        (
+            "haz una imagen",
+            "hacer una imagen",
+            "crea una imagen",
+            "crear una imagen",
+            "imagen que explique",
+            "imagen explicando",
+            "infografía",
+            "infografia",
+            "póster",
+            "poster",
+        ),
+        _CANONICAL_VISUAL_SUMMARY,
+    ),
+    LocaleAlias(
+        "fr",
+        "visual_summary",
+        (
+            "fais une image",
+            "faire une image",
+            "crée une image",
+            "cree une image",
+            "image qui explique",
+            "image explicative",
+            "infographie",
+            "affiche",
+        ),
+        _CANONICAL_VISUAL_SUMMARY,
+    ),
+    LocaleAlias(
+        "de",
+        "visual_summary",
+        (
+            "erstelle ein bild",
+            "mach ein bild",
+            "bild das",
+            "bild, das",
+            "bild erklären",
+            "bild erklaren",
+            "infografik",
+            "poster",
+        ),
+        _CANONICAL_VISUAL_SUMMARY,
+    ),
+    LocaleAlias(
+        "ja",
+        "paper_learning",
+        (
+            "論文pdfをやさしく説明",
+            "論文pdfを簡単に説明",
+            "この論文pdfを説明",
+            "この論文をやさしく説明",
+            "この論文を要約",
+        ),
+        _CANONICAL_PAPER_LEARNING,
+    ),
+    LocaleAlias(
+        "zh",
+        "paper_learning",
+        (
+            "解释这篇论文 pdf",
+            "解釋這篇論文 pdf",
+            "简单解释这篇论文",
+            "簡單解釋這篇論文",
+            "总结这篇论文",
+            "總結這篇論文",
+        ),
+        _CANONICAL_PAPER_LEARNING,
+    ),
+    LocaleAlias(
+        "es",
+        "paper_learning",
+        (
+            "explicame este paper",
+            "explícame este paper",
+            "explica este paper",
+            "explica este artículo",
+            "explica este articulo",
+            "resumir este paper",
+            "paper en un nivel fácil",
+            "paper en un nivel facil",
+        ),
+        _CANONICAL_PAPER_LEARNING,
+    ),
+    LocaleAlias(
+        "fr",
+        "paper_learning",
+        (
+            "explique ce pdf de recherche",
+            "explique cet article",
+            "explique ce papier",
+            "résume ce papier",
+            "resume ce papier",
+            "simplement ce papier",
+        ),
+        _CANONICAL_PAPER_LEARNING,
+    ),
+    LocaleAlias(
+        "de",
+        "paper_learning",
+        (
+            "erkläre dieses paper",
+            "erklaere dieses paper",
+            "erkläre dieses pdf",
+            "erklaere dieses pdf",
+            "dieses paper einfach",
+            "dieses paper zusammenfassen",
+        ),
+        _CANONICAL_PAPER_LEARNING,
+    ),
+    LocaleAlias(
+        "ja",
+        "source_finder",
+        (
+            "論文とデータセットを探",
+            "githubリポジトリを探",
+            "公開pdfを探",
+            "発表資料を探",
+        ),
+        _CANONICAL_SOURCE_FINDER,
+    ),
+    LocaleAlias(
+        "zh",
+        "source_finder",
+        (
+            "找论文和数据集",
+            "找論文和資料集",
+            "查找 github 仓库",
+            "查找 github 倉庫",
+            "公开 pdf 链接",
+            "公開 pdf 連結",
+        ),
+        _CANONICAL_SOURCE_FINDER,
+    ),
+    LocaleAlias(
+        "es",
+        "source_finder",
+        (
+            "encuentra el paper y el dataset",
+            "encuentra papers y datasets",
+            "buscar paper y dataset",
+            "encuentra el repositorio github",
+            "encuentra fuentes descargables",
+        ),
+        _CANONICAL_SOURCE_FINDER,
+    ),
+    LocaleAlias(
+        "fr",
+        "source_finder",
+        (
+            "trouve le dépôt github",
+            "trouve le depot github",
+            "trouve le pdf public",
+            "trouve les papers et datasets",
+            "trouve des sources téléchargeables",
+            "trouve des sources telechargeables",
+        ),
+        _CANONICAL_SOURCE_FINDER,
+    ),
+    LocaleAlias(
+        "de",
+        "source_finder",
+        (
+            "finde paper und dataset",
+            "finde papers und datasets",
+            "finde das github repository",
+            "finde öffentliche pdfs",
+            "finde offentliche pdfs",
+        ),
+        _CANONICAL_SOURCE_FINDER,
     ),
 )
 

--- a/tests/test_chat_router.py
+++ b/tests/test_chat_router.py
@@ -73,6 +73,32 @@ class ChatRouterTests(unittest.TestCase):
                 if locale_match is not None:
                     self.assertIn(locale_match, decision["recommendations"][0]["matched"])
 
+    def test_multilingual_chat_routes_content_workflows_without_external_translation(self) -> None:
+        cases = (
+            ("haz una imagen que explique la función cron", "img-summary", "locale:es:visual_summary"),
+            ("erstelle ein Bild, das die Cron-Funktion erklärt", "img-summary", "locale:de:visual_summary"),
+            ("cron機能を説明する画像を作って", "img-summary", "locale:ja:visual_summary"),
+            ("生成一张解释 cron 功能的图片", "img-summary", "locale:zh:visual_summary"),
+            ("explícame este paper en un nivel fácil", "paper-learning", "locale:es:paper_learning"),
+            ("explique ce PDF de recherche simplement", "paper-learning", "locale:fr:paper_learning"),
+            ("erkläre dieses Paper einfach", "paper-learning", "locale:de:paper_learning"),
+            ("この論文PDFをやさしく説明して", "paper-learning", "locale:ja:paper_learning"),
+            ("encuentra el paper y el dataset para este tema", "source-finder", "locale:es:source_finder"),
+            ("trouve le dépôt GitHub et le PDF public", "source-finder", "locale:fr:source_finder"),
+            ("finde paper und dataset zu diesem thema", "source-finder", "locale:de:source_finder"),
+        )
+
+        for message, skill, locale_match in cases:
+            with self.subTest(message=message):
+                decision = route_chat_message(message, source="discord")
+
+                self.assertEqual(decision["action"], "dispatch")
+                self.assertEqual(decision["selected_skill"], skill)
+                self.assertEqual(decision["selected_harness"], primary_harness_for_skill(skill))
+                self.assertEqual(decision["recommendations"][0]["skill"], skill)
+                self.assertEqual(decision["confidence"], "high")
+                self.assertIn(locale_match, decision["recommendations"][0]["matched"])
+
     def test_low_signal_chat_falls_back_to_router(self) -> None:
         decision = route_chat_message("zzzzunknownphrase", source="slack")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3132,6 +3132,17 @@ class CliTests(unittest.TestCase):
             ("Quiero convertir este issue en un PR", "github-event-ops", "locale:es:issue_to_pr"),
             ("Je veux transformer cette issue en PR", "github-event-ops", "locale:fr:issue_to_pr"),
             ("Ich möchte dieses Issue für einen PR vorbereiten", "github-event-ops", "locale:de:issue_to_pr"),
+            ("haz una imagen que explique la función cron", "img-summary", "locale:es:visual_summary"),
+            ("erstelle ein Bild, das die Cron-Funktion erklärt", "img-summary", "locale:de:visual_summary"),
+            ("cron機能を説明する画像を作って", "img-summary", "locale:ja:visual_summary"),
+            ("生成一张解释 cron 功能的图片", "img-summary", "locale:zh:visual_summary"),
+            ("explícame este paper en un nivel fácil", "paper-learning", "locale:es:paper_learning"),
+            ("explique ce PDF de recherche simplement", "paper-learning", "locale:fr:paper_learning"),
+            ("erkläre dieses Paper einfach", "paper-learning", "locale:de:paper_learning"),
+            ("この論文PDFをやさしく説明して", "paper-learning", "locale:ja:paper_learning"),
+            ("encuentra el paper y el dataset para este tema", "source-finder", "locale:es:source_finder"),
+            ("trouve le dépôt GitHub et le PDF public", "source-finder", "locale:fr:source_finder"),
+            ("finde paper und dataset zu diesem thema", "source-finder", "locale:de:source_finder"),
         )
 
         for message, expected_skill, locale_match in cases:

--- a/tests/test_keyword_manifest.py
+++ b/tests/test_keyword_manifest.py
@@ -22,6 +22,9 @@ class KeywordManifestTests(unittest.TestCase):
         self.assertEqual(manifest["conflict_policy"]["tied_scores"], "clarify")
         self.assertIn("ja", manifest["locale_policy"]["supported_alias_locales"])
         self.assertIn("payment_failure", manifest["locale_policy"]["alias_labels"])
+        self.assertIn("visual_summary", manifest["locale_policy"]["alias_labels"])
+        self.assertIn("paper_learning", manifest["locale_policy"]["alias_labels"])
+        self.assertIn("source_finder", manifest["locale_policy"]["alias_labels"])
 
     def test_keyword_manifest_includes_guard_rules_and_skill_triggers(self) -> None:
         manifest = keyword_detector_manifest()


### PR DESCRIPTION
## Feature Report

### What Changed

- Added deterministic locale aliases for Spanish, French, German, Japanese, and Chinese content-workflow requests.
- Routes common non-English visual card, paper explanation, and source acquisition requests to `img-summary`, `paper-learning`, and `source-finder`.
- Added CLI, chat-router, and keyword manifest coverage so the alias labels remain wrapper-visible.

### Why This Exists

- Live QA showed non-English requests such as `haz una imagen que explique la función cron`, `explique ce PDF de recherche simplement`, and `trouve le dépôt GitHub et le PDF public` could fall into unrelated lanes like automation, materials, or clarify.
- OMH should stay natural-language first for common operator requests without depending on translation APIs or LLM routing.

### User / Operator Impact

- A user can ask Hermes in common Spanish, French, German, Japanese, or Chinese phrasing for an image explainer, paper/PDF learning, or source lookup and get the expected OMH workflow.
- Wrapper operators get stable matched markers such as `locale:es:visual_summary`, `locale:fr:paper_learning`, and `locale:de:source_finder` for display/debugging.
- Unsupported phrasing still follows the existing clarify/fallback path instead of being over-claimed as translated.

### How It Works

- `src/routing/localization.py` extends the existing local alias registry with canonical scoring text for three workflow labels.
- The implementation remains deterministic and offline: no translation API, LLM call, network call, or platform SDK is added.
- Tests assert both `omh recommend`-style routing and chat wrapper routing resolve to the same workflow lanes.

### Files And Contracts Touched

- `src/routing/localization.py`: alias labels and canonical hint text for `visual_summary`, `paper_learning`, and `source_finder`.
- `tests/test_cli.py`: recommend-path multilingual regression cases.
- `tests/test_chat_router.py`: wrapper chat dispatch regression cases.
- `tests/test_keyword_manifest.py`: manifest visibility for new alias labels.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `PYTHONPATH=tests uv run python -m compileall -q src tests`
- [x] `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check`
- [x] `PYTHONPATH=tests uv run python -m omh.cli harness validate`
- [ ] `python3 -m omh.cli release checklist --json` - not run; release packaging was not changed.
- [ ] `python3 -m omh.cli release hermes-smoke` - not run; Hermes live install behavior was not changed.
- [ ] `omh --help` - not run; command surface was not changed.
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` - not run; install/smoke behavior was not changed.
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: N/A; learning contracts were not changed.
- [x] Relevant dry-run or smoke command: `PYTHONPATH=tests uv run python -m omh.cli chat interact --source discord --summary "haz una imagen que explique la función cron"` routed to `img-summary`; `... "explique ce PDF de recherche simplement"` routed to `paper-learning`; `... "trouve le dépôt GitHub et le PDF public"` routed to `source-finder`.
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; this PR changes local deterministic routing only and wrapper rendering remains covered by unit tests.

## Risk

- Moderate routing risk: locale aliases can over-route if too broad. The phrases were kept intent-specific and are guarded by existing routing thresholds.
- Chinese image aliases intentionally avoid broad phrases like generic `generate image` so unrelated image coding requests are less likely to be stolen.

## Compatibility / Rollout

- No schema changes.
- No generated skill changes.
- No install, plugin, release, or runtime ledger changes.
- Existing English/Korean routing remains untouched.

## Release / Claims

- [x] Release-channel impact considered (`preview` behavior improves after workflow/package update; no installer release required).
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap.

## Follow-Up

- Continue adding locale aliases only from observed real misses.
- Consider improving `paper-learning` summary copy separately so non-coding workflows do not mention review/CI in the generic “not evidence yet” text.