### PR TITLE
Add noncoding evidence cards for source workflows

### DIFF
--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -1178,6 +1178,105 @@ def build_chat_response_from_route(
                     ),
                 },
             )
+        if selected == "paper-learning" or policy_next_action == "prepare_paper_learning":
+            evidence_boundary = str(policy.get("evidence_boundary", "")) or "A paper-learning card is not paper validation evidence."
+            body = (
+                "I will prepare a paper-learning card: explanation level, source/PDF state, section coverage, "
+                "key claims, figures or equations to revisit, and a coverage ledger. I will not claim full extraction, "
+                "citation checking, math validation, reproduction, or peer review until those are observed."
+            )
+            return _chat_response(
+                kind="paper_learning",
+                headline="I can explain this paper with the right depth.",
+                body=body,
+                phase="paper_learning_prepared",
+                next_action="prepare_paper_learning",
+                thread_key=thread_key,
+                actions=[
+                    _action("choose_explanation_level", "Choose level", "primary"),
+                    _action("show_paper_source_requirements", "Show source needs", "secondary"),
+                    _action("record_paper_metadata", "Record metadata", "secondary"),
+                    _action("record_paper_excerpt_observed", "Record excerpt", "secondary"),
+                    _action("record_file_text_extraction_observed", "Record text extraction", "secondary"),
+                    _action("show_paper_learning", "Show paper learning", "secondary"),
+                    _action("continue_next_section", "Next section", "secondary"),
+                    _action("revise_explanation_level", "Revise level", "secondary"),
+                    _action("show_coverage_ledger", "Coverage ledger", "secondary"),
+                    _action("record_user_review", "Record user review", "secondary"),
+                    _action("show_status", "Show status", "secondary"),
+                ],
+                claim_boundary=evidence_boundary,
+                extra_state={
+                    "route_action": action,
+                    "confidence": decision.get("confidence", "low"),
+                    "selected_workflow": selected,
+                    "workflow_explanation_reason": workflow_explanation_reason,
+                    "policy_next_action": policy_next_action,
+                    "artifact_schema": "paper_learning_card/v1",
+                    "source_state_schema": "paper_source_state/v1",
+                    "coverage_ledger_schema": "paper_coverage_ledger/v1",
+                    "default_level": "choose",
+                    "evidence_not_observed": [
+                        "full PDF extraction",
+                        "figure OCR",
+                        "external citation checking",
+                        "math validation",
+                        "code reproduction",
+                        "peer review",
+                        "proof that paper claims are true",
+                    ],
+                },
+            )
+        if selected == "source-finder" or policy_next_action == "prepare_source_finder_plan":
+            evidence_boundary = str(policy.get("evidence_boundary", "")) or "A source-finder plan is not source retrieval evidence."
+            body = (
+                "I will prepare a source-finder plan: typed candidate categories, search/acquisition status, "
+                "missing provenance, license or access checks, and the best downstream workflow. I will not claim "
+                "web search, download, clone, extraction, verification, or downstream processing until observed."
+            )
+            return _chat_response(
+                kind="source_finder",
+                headline="I can turn this into a source acquisition plan.",
+                body=body,
+                phase="source_finder_prepared",
+                next_action="prepare_source_finder_plan",
+                thread_key=thread_key,
+                actions=[
+                    _action("show_source_candidates", "Show candidates", "primary"),
+                    _action("record_source_candidate", "Record candidate", "secondary"),
+                    _action("record_source_link_observed", "Record source link", "secondary"),
+                    _action("record_download_observed", "Record download", "secondary"),
+                    _action("record_file_hash", "Record file hash", "secondary"),
+                    _action("record_text_extraction_observed", "Record text extraction", "secondary"),
+                    _action("record_license_check", "Record license check", "secondary"),
+                    _action("choose_source", "Choose source", "secondary"),
+                    _action("route_to_downstream_workflow", "Route downstream", "secondary"),
+                    _action("show_acquisition_status", "Show acquisition status", "secondary"),
+                    _action("show_status", "Show status", "secondary"),
+                ],
+                claim_boundary=evidence_boundary,
+                extra_state={
+                    "route_action": action,
+                    "confidence": decision.get("confidence", "low"),
+                    "selected_workflow": selected,
+                    "workflow_explanation_reason": workflow_explanation_reason,
+                    "policy_next_action": policy_next_action,
+                    "artifact_schema": "source_finder_plan/v1",
+                    "candidate_schema": "source_candidate_set/v1",
+                    "acquisition_status_schema": "source_acquisition_status/v1",
+                    "downstream_workflow_required": True,
+                    "evidence_not_observed": [
+                        "web search",
+                        "download",
+                        "repository clone",
+                        "file extraction",
+                        "file hash verification",
+                        "license verification",
+                        "source correctness verification",
+                        "downstream processing",
+                    ],
+                },
+            )
         if selected == "agent-ops-review" or policy_next_action == "prepare_agent_ops_review":
             evidence_boundary = str(policy.get("evidence_boundary", "")) or "An agent ops review card is not runtime evidence."
             card = build_agent_operator_productivity_card(

--- a/tests/test_wrapper_contract.py
+++ b/tests/test_wrapper_contract.py
@@ -1527,6 +1527,54 @@ class WrapperContractTests(unittest.TestCase):
                 self.assertIn("image_generation_setup/v1", explanation["why_this_workflow"])
                 self.assertIn("visual QA", explanation["not_evidence_yet"])
 
+    def test_paper_learning_interaction_uses_learning_evidence_not_coding_gates(self) -> None:
+        payload = build_chat_interaction_payload("explique ce PDF de recherche simplement", source="discord")
+
+        self.assertEqual(payload["mode"], "route")
+        self.assertEqual(payload["next_action"], "prepare_paper_learning")
+        self.assertEqual(payload["chat_response"]["kind"], "paper_learning")
+        self.assertIn("paper-learning card", payload["chat_response"]["body"])
+        self.assertNotIn("CI", payload["chat_response"]["body"])
+        self.assertEqual(payload["chat_response"]["state"]["selected_workflow"], "paper-learning")
+        self.assertEqual(payload["chat_response"]["state"]["artifact_schema"], "paper_learning_card/v1")
+        self.assertEqual(payload["chat_response"]["state"]["source_state_schema"], "paper_source_state/v1")
+        self.assertEqual(payload["chat_response"]["state"]["coverage_ledger_schema"], "paper_coverage_ledger/v1")
+        actions = {action["id"]: action for action in payload["chat_response"]["actions"]}
+        self.assertTrue(actions["choose_explanation_level"]["enabled"])
+        self.assertTrue(actions["show_paper_learning"]["enabled"])
+        self.assertTrue(actions["record_file_text_extraction_observed"]["enabled"])
+        self.assertIn("full PDF extraction", payload["chat_response"]["claim_boundary"])
+        self.assertIn("figure OCR", payload["chat_response"]["state"]["evidence_not_observed"])
+        explanation = payload["chat_response"]["state"]["workflow_explanation"]
+        self.assertEqual(explanation["selected_workflow"], "paper-learning")
+        self.assertIn("full PDF extraction", explanation["not_evidence_yet"])
+        self.assertNotIn("review", explanation["not_evidence_yet"])
+        self.assertNotIn("CI", explanation["not_evidence_yet"])
+
+    def test_source_finder_interaction_uses_acquisition_evidence_not_coding_gates(self) -> None:
+        payload = build_chat_interaction_payload("trouve le dépôt GitHub et le PDF public", source="discord")
+
+        self.assertEqual(payload["mode"], "route")
+        self.assertEqual(payload["next_action"], "prepare_source_finder_plan")
+        self.assertEqual(payload["chat_response"]["kind"], "source_finder")
+        self.assertIn("source-finder plan", payload["chat_response"]["body"])
+        self.assertNotIn("CI", payload["chat_response"]["body"])
+        self.assertEqual(payload["chat_response"]["state"]["selected_workflow"], "source-finder")
+        self.assertEqual(payload["chat_response"]["state"]["artifact_schema"], "source_finder_plan/v1")
+        self.assertEqual(payload["chat_response"]["state"]["candidate_schema"], "source_candidate_set/v1")
+        self.assertEqual(payload["chat_response"]["state"]["acquisition_status_schema"], "source_acquisition_status/v1")
+        actions = {action["id"]: action for action in payload["chat_response"]["actions"]}
+        self.assertTrue(actions["show_source_candidates"]["enabled"])
+        self.assertTrue(actions["record_source_link_observed"]["enabled"])
+        self.assertTrue(actions["route_to_downstream_workflow"]["enabled"])
+        self.assertIn("web search", payload["chat_response"]["claim_boundary"])
+        self.assertIn("download", payload["chat_response"]["state"]["evidence_not_observed"])
+        explanation = payload["chat_response"]["state"]["workflow_explanation"]
+        self.assertEqual(explanation["selected_workflow"], "source-finder")
+        self.assertIn("web search", explanation["not_evidence_yet"])
+        self.assertNotIn("review", explanation["not_evidence_yet"])
+        self.assertNotIn("CI", explanation["not_evidence_yet"])
+
     def test_generic_catalog_question_still_uses_picker(self) -> None:
         payload = build_chat_interaction_payload("OMH 기능 뭐 있어?", source="discord")
 


### PR DESCRIPTION
## Feature Report

### What Changed

- Added dedicated wrapper chat responses for `paper-learning` and `source-finder`.
- Exposed workflow-specific actions, artifact schema names, and evidence gaps for paper explanation and source acquisition requests.
- Added wrapper contract tests to ensure these noncoding workflows do not fall back to generic coding-oriented evidence copy.

### Why This Exists

- After improving multilingual routing, `paper-learning` and `source-finder` could route correctly but still render through the generic acknowledgement path.
- That made the user-facing "not evidence yet" section less precise and risked mixing coding-gate language like review/CI into noncoding research/material workflows.
- OMH should make Hermes feel natural in chat: the workflow card should name the next useful action and the exact evidence that is still missing.

### User / Operator Impact

- A paper/PDF explanation request now shows a `paper-learning` card with actions such as choosing explanation level, recording metadata, recording text extraction, showing the explanation, and showing the coverage ledger.
- A source acquisition request now shows a `source-finder` card with actions such as showing candidates, recording links/downloads/hashes/text extraction/license checks, choosing a source, and routing downstream.
- The "Not evidence yet" section is now domain-specific: PDF extraction, figure OCR, citation checking, math validation, source search, download, clone, license verification, and downstream processing stay separate from observed evidence.

### How It Works

- `src/wrapper/contract.py` now has explicit branches for `prepare_paper_learning` and `prepare_source_finder_plan`, parallel to the existing `img-summary` response path.
- The branches are metadata-only wrapper contracts. They do not perform web search, file download, PDF extraction, LLM calls, source verification, or downstream execution.
- `workflow_explanation.not_evidence_yet` now reads from explicit workflow-specific evidence gaps instead of inferring generic coding gates from the claim boundary.

### Files And Contracts Touched

- `src/wrapper/contract.py`: adds `paper_learning` and `source_finder` chat response kinds, actions, schemas, and evidence gaps.
- `tests/test_wrapper_contract.py`: locks paper/source responses so they stay noncoding and evidence-specific.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_wrapper_contract.py tests/test_cli.py tests/test_chat_router.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `PYTHONPATH=tests uv run python -m compileall -q src tests`
- [x] `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check`
- [x] `PYTHONPATH=tests uv run python -m omh.cli harness validate`
- [x] `git diff --check`
- [x] Relevant dry-run or smoke command: `PYTHONPATH=tests uv run python -m omh.cli chat interact --source discord --summary "explique ce PDF de recherche simplement"`; `PYTHONPATH=tests uv run python -m omh.cli chat interact --source discord --summary "trouve le dépôt GitHub et le PDF public"`; `PYTHONPATH=tests uv run python -m omh.cli chat interact --source discord --summary "haz una imagen que explique la función cron"`.
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; this PR changes deterministic wrapper payload rendering and summary output only.

## Risk

- Moderate UX-contract risk: wrappers may key off response `kind`. Existing generic ack remains available for other workflows, and this only specializes two already-public workflows.
- No runtime side effects are added. The response remains prepared-not-observed metadata.

## Compatibility / Rollout

- No install, plugin, release, or generated skill changes.
- No schema migration is required; this adds richer state fields for existing workflows.
- Existing `img-summary`, coding handoff, and generic ack behavior remain unchanged.

## Release / Claims

- [x] Release-channel impact considered (`preview` behavior improves after workflow/package update; no installer release required).
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] Known manual Hermes checks are listed.

## Follow-Up

- Continue specializing high-use noncoding workflows when live chat summaries show generic or confusing evidence copy.
- Consider a shared helper for simple prepared-only workflow cards if more branches start duplicating the same structure.