### PR TITLE
Add web research chat card

### DIFF
--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -1277,6 +1277,48 @@ def build_chat_response_from_route(
                     ],
                 },
             )
+        if selected == "web-research" or policy_next_action == "run_hermes_research":
+            evidence_boundary = str(policy.get("evidence_boundary", "")) or "A web research card is not source retrieval evidence."
+            body = (
+                "I will keep this as Hermes-side research: define the source boundaries, freshness window, source diversity, "
+                "citation confidence, and retrieval gaps before turning findings into a plan, report, or coding handoff. "
+                "I will not claim sources were fetched or verified until observed."
+            )
+            return _chat_response(
+                kind="web_research",
+                headline="I can gather source-backed current evidence for this.",
+                body=body,
+                phase="web_research_prepared",
+                next_action="run_hermes_research",
+                thread_key=thread_key,
+                actions=[
+                    _action("run_hermes_research", "Start research", "primary"),
+                    _action("record_source_observation", "Record source observation", "secondary"),
+                    _action("prepare_source_finder_plan", "Prepare source finder", "secondary"),
+                    _action("prepare_research_department_plan", "Prepare research ops", "secondary"),
+                    _action("prepare_report_package", "Prepare report", "secondary"),
+                    _action("show_status", "Show status", "secondary"),
+                ],
+                claim_boundary=evidence_boundary,
+                extra_state={
+                    "route_action": action,
+                    "confidence": decision.get("confidence", "low"),
+                    "selected_workflow": selected,
+                    "workflow_explanation_reason": workflow_explanation_reason,
+                    "policy_next_action": policy_next_action,
+                    "artifact_schema": "web_research_brief/v1",
+                    "observation_schema": "source_observation/v1",
+                    "research_scope": "source_backed_current_evidence",
+                    "evidence_not_observed": [
+                        "source retrieval",
+                        "source access",
+                        "citation verification",
+                        "source diversity",
+                        "freshness confirmation",
+                        "downstream plan or handoff",
+                    ],
+                },
+            )
         if selected == "agent-ops-review" or policy_next_action == "prepare_agent_ops_review":
             evidence_boundary = str(policy.get("evidence_boundary", "")) or "An agent ops review card is not runtime evidence."
             card = build_agent_operator_productivity_card(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4457,7 +4457,7 @@ class CliTests(unittest.TestCase):
             ("research the repo, plan, implement, code-review, sync docs, and prepare a PR", "ultraprocess", "handoff", "choose_executor"),
             ("Hermes가 기억하는 맥락을 점검하고 정리해줘", "memory-curation-review", "ack", "prepare_memory_curation_review"),
             ("GitHub issue 들어온 걸 PR 만들 수 있게 정리해줘", "github-event-ops", "ack", "prepare_github_event_ops_card"),
-            ("리서치 요청했는데 OMH를 안 썼어", "web-research", "ack", "run_hermes_research"),
+            ("리서치 요청했는데 OMH를 안 썼어", "web-research", "web_research", "run_hermes_research"),
             ("회의록 요약을 부탁했는데 OMH 안 쓰고 일반 답변했어", "operating-rhythm", "ack", "prepare_operating_record"),
             ("Hermes가 기억하고 있는 프로젝트 맥락이 오래된 것 같아 정리해줘", "memory-curation-review", "ack", "prepare_memory_curation_review"),
             ("첨부한 엑셀을 월간 보고서 PDF랑 PPT로 만들 수 있게 정리해줘", "materials-package", "ack", "prepare_material_package"),

--- a/tests/test_wrapper_contract.py
+++ b/tests/test_wrapper_contract.py
@@ -638,7 +638,8 @@ class WrapperContractTests(unittest.TestCase):
         self.assertEqual(trace["schema_version"], "omh_usage_trace/v1")
         self.assertEqual(trace["visible_prefix"], "[omh] web-research")
         self.assertEqual(trace["selected_harness"], "research")
-        self.assertEqual(trace["evidence_state"], "routing_not_execution")
+        self.assertEqual(trace["evidence_state"], "prepared_not_observed")
+        self.assertEqual(response["kind"], "web_research")
         explanation = response["state"]["workflow_explanation"]
         self.assertEqual(explanation["schema_version"], "omh_workflow_explanation/v1")
         self.assertEqual(explanation["selected_workflow"], "web-research")
@@ -652,9 +653,17 @@ class WrapperContractTests(unittest.TestCase):
         self.assertEqual(trace["workflow_context_id"], "research_and_ops")
         self.assertIn("why_this_workflow", explanation)
         self.assertEqual(explanation["next_action"], "run_hermes_research")
-        self.assertTrue(explanation["not_evidence_yet"])
+        self.assertIn("source retrieval", explanation["not_evidence_yet"])
+        self.assertIn("citation verification", explanation["not_evidence_yet"])
+        self.assertNotIn("implementation", explanation["not_evidence_yet"])
         self.assertTrue(response["headline"].startswith("[omh] web-research - "))
-        self.assertEqual(response["plain_headline"], "I know which workflow should handle this.")
+        self.assertEqual(response["plain_headline"], "I can gather source-backed current evidence for this.")
+        self.assertIn("source boundaries", response["body"])
+        self.assertIn("citation confidence", response["body"])
+        actions = {action["id"]: action for action in response["actions"]}
+        self.assertTrue(actions["run_hermes_research"]["enabled"])
+        self.assertTrue(actions["record_source_observation"]["enabled"])
+        self.assertTrue(actions["prepare_report_package"]["enabled"])
         self.assertEqual(rendering["schema_version"], "omh_messenger_rendering/v1")
         self.assertIn("markdown_table", rendering["avoid_blocks"])
         self.assertEqual(rendering["table_policy"], "convert_tables_to_bullets_for_messenger")
@@ -1760,12 +1769,6 @@ class WrapperContractTests(unittest.TestCase):
                 "code-review",
                 "prepare_review_or_followup_handoff",
                 "review path",
-            ),
-            (
-                "web search latest secure login UX evidence",
-                "web-research",
-                "run_hermes_research",
-                "source-backed research lane",
             ),
             (
                 "route Discord Slack Telegram threads with delivery policy",


### PR DESCRIPTION
## Summary

This PR gives `web-research` a dedicated wrapper chat response instead of routing it through the generic `ack` copy. Hermes chat surfaces can now explain source boundaries, freshness windows, source diversity, citation confidence, and retrieval gaps before any downstream plan, report, or coding handoff.

## Why

Before this change, a web research request rendered like a generic route acknowledgement:

- `kind=ack`
- headline: `I know which workflow should handle this.`
- not-evidence copy focused on generic `implementation` / `verification`

That made source-backed research feel like a vague workflow selection rather than a prepared research boundary. The user-facing gap was especially visible in Discord/Slack-style chat where Hermes needs to say what research can start, what action comes next, and what has not been observed yet.

## What Changed

- Added a `web_research` chat response in `src/wrapper/contract.py`.
- Added source-specific visible actions:
  - `run_hermes_research`
  - `record_source_observation`
  - `prepare_source_finder_plan`
  - `prepare_research_department_plan`
  - `prepare_report_package`
  - `show_status`
- Added source-specific evidence boundaries for retrieval, source access, citation verification, source diversity, freshness confirmation, and downstream plan/handoff status.
- Updated wrapper and CLI tests so `web-research` is no longer treated as a generic ack card.

## Boundary

This does not add network access, LLM calls, source fetching, citation verification, or downstream execution. It only improves the deterministic wrapper contract and the human-readable chat card. Source retrieval remains `prepared_not_observed` until a wrapper or runtime records matching observation evidence.

## Verification

Observed locally:

```sh
PYTHONPATH=tests uv run python -m unittest tests/test_wrapper_contract.py tests/test_cli.py tests/test_chat_router.py -v
PYTHONPATH=tests uv run python -m unittest discover -s tests -v
PYTHONPATH=tests uv run python -m compileall -q src tests
PYTHONPATH=tests uv run python -m omh.cli docs workflows --check
PYTHONPATH=tests uv run python -m omh.cli harness validate
git diff --check
```

Manual smoke:

```sh
PYTHONPATH=tests uv run python -m omh.cli chat interact --source discord --summary "search latest browser agent benchmarks with sources"
PYTHONPATH=tests uv run python -m omh.cli chat interact --source discord --summary "web-research로 Hermes Agent와 Oh My Codex/OpenCode 계열을 비교해서 OMHM 포지셔닝 근거를 찾아줘."
```

Both manual smokes rendered `[omh] web-research` with `kind=web_research`, source-specific actions, and source retrieval/citation/freshness evidence gaps.

## Risks

- Live Discord, Slack, Telegram, or Hermes wrapper rendering was not exercised in this local PR.
- Future research cards should stay explicit about source retrieval and citation evidence before claiming downstream plans or handoffs.
