### PR TITLE
Add chat card coverage to release readiness

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -122,17 +122,31 @@ into one operator-readable card. It should be ready before a release, but it
 still proves only local deterministic contracts, not live Hermes selection or
 runtime execution.
 
+The wrapper chat-card gate checks the user-facing card corpus:
+
+```sh
+omh demo chat-card-coverage --json
+```
+
+It should report every representative workflow route as a dedicated chat card
+with generic ack count `0`. This catches regressions where Hermes would answer a
+real operator request with a vague acknowledgement instead of an actionable
+workflow card. It is still local deterministic wrapper-contract evidence only:
+it does not prove live Hermes rendering, platform delivery, executor execution,
+review, CI, merge, or plugin loading.
+
 The product readiness rollup sits one level above use cases:
 
 ```sh
 omh release product-readiness --version 1.0.1 --json
 ```
 
-It checks the generated skill content, G1-G10 readiness, parity matrix, and
-release checklist shape in one operator-readable card. It is useful for release
-notes and maintainer handoff, but it is still local deterministic evidence only:
-it does not run the checklist, mutate Hermes, dispatch executors, review code,
-pass CI, merge, deliver messages, or spend provider budget.
+It checks the generated skill content, G1-G10 readiness, wrapper chat-card
+coverage, parity matrix, and release checklist shape in one operator-readable
+card. It is useful for release notes and maintainer handoff, but it is still
+local deterministic evidence only: it does not run the checklist, mutate Hermes,
+dispatch executors, review code, pass CI, merge, deliver messages, or spend
+provider budget.
 
 When the local release story is ready, write an attachable evidence bundle:
 
@@ -142,10 +156,10 @@ omh release evidence-bundle --version 1.0.1 --write --json
 
 The bundle writes `omh_release_evidence_bundle/v1` under
 `.omh/runtime/release-evidence/` with the checklist, product readiness,
-skill-content smoke, use-case readiness, and parity snapshots. It is useful for
-release PRs and notes, but it is still local deterministic evidence only; live
-Hermes smoke, CI, review, merge, delivery, and GitHub release publication must
-be observed separately.
+skill-content smoke, use-case readiness, chat-card coverage, and parity
+snapshots. It is useful for release PRs and notes, but it is still local
+deterministic evidence only; live Hermes smoke, CI, review, merge, delivery, and
+GitHub release publication must be observed separately.
 
 ## Hermes CLI Install Smoke
 

--- a/src/commands/release.py
+++ b/src/commands/release.py
@@ -345,6 +345,12 @@ def _print_release_evidence_bundle_summary(payload: dict[str, object]) -> None:
     print(f"  Artifact: {payload.get('artifact_path')}")
     print(f"  Product readiness: {summary.get('product_readiness_status')} ({summary.get('product_readiness_score')}/100)")
     print(f"  Use-case readiness: {summary.get('use_case_readiness_status')} ({summary.get('use_case_readiness_score')}/100)")
+    if "chat_card_coverage_passing" in summary or "chat_card_coverage_total" in summary:
+        print(
+            "  Chat card coverage: "
+            f"{summary.get('chat_card_coverage_passing')}/{summary.get('chat_card_coverage_total')} "
+            f"(generic ack {summary.get('chat_card_generic_ack_count')})"
+        )
     print(f"  Local artifact store: {summary.get('local_artifact_store')}")
     print("")
     blocking = payload.get("blocking_failures", [])

--- a/src/maintenance/release.py
+++ b/src/maintenance/release.py
@@ -31,6 +31,7 @@ from ..plugin_bundle.omh.tools.capability_tool import (
     standalone_skill_capability_items,
 )
 from ..parity import build_parity_matrix
+from ..quality.chat_card_coverage import build_chat_card_coverage_demo
 from ..release_smoke_core import CommandResult, Runner, bounded_text, expand_home, subprocess_runner
 from ..skill_pack import builtin_skill_templates
 from ..skills.catalog import builtin_definitions
@@ -234,13 +235,23 @@ def release_readiness_checklist(
             "Use-case readiness proves deterministic local use-case contracts only; it does not prove live Hermes chat behavior, connector work, executor work, review, CI, merge, delivery, or billing evidence.",
         ),
         ReleaseChecklistItem(
+            "chat_card_coverage",
+            "Check wrapper chat card coverage",
+            "uv run python -m omh.cli demo chat-card-coverage --json",
+            "contract-quality",
+            True,
+            False,
+            "Chat card coverage reports all dedicated workflow cards passing with generic ack count 0.",
+            "Chat card coverage proves deterministic local wrapper-card contracts only; it does not prove live Hermes chat rendering, platform delivery, executor work, review, CI, merge, or plugin-load evidence.",
+        ),
+        ReleaseChecklistItem(
             "product_readiness",
             "Check product readiness rollup",
             f"{omh_display} release product-readiness --version {release_version} --json",
             "contract-quality",
             True,
             False,
-            "Product readiness reports skill-content, G1-G10 use-case, parity, and release checklist gates as passing.",
+            "Product readiness reports skill-content, G1-G10 use-case, wrapper chat card coverage, parity, and release checklist gates as passing.",
             "Product readiness proves deterministic local package and product contracts only; it does not prove live Hermes chat behavior, connector work, executor work, review, CI, merge, delivery, or billing evidence.",
         ),
         ReleaseChecklistItem(
@@ -250,7 +261,7 @@ def release_readiness_checklist(
             "evidence-packaging",
             True,
             False,
-            "A local `omh_release_evidence_bundle/v1` artifact is written with checklist, product readiness, skill content, use-case readiness, and parity snapshots.",
+            "A local `omh_release_evidence_bundle/v1` artifact is written with checklist, product readiness, skill content, use-case readiness, chat card coverage, and parity snapshots.",
             "The evidence bundle packages local deterministic evidence only; it is not live Hermes runtime use, connector execution, executor dispatch, review, CI, merge, delivery, or release publication evidence.",
         ),
         ReleaseChecklistItem(
@@ -454,6 +465,7 @@ def product_readiness_report(
     omh_display = _shell_word(omh_command)
     skill_content = skill_content_smoke()
     parity = build_parity_matrix()
+    chat_cards = build_chat_card_coverage_demo()
     checklist = release_readiness_checklist(version=release_version, omh_command=omh_command)
 
     checklist_items = checklist.get("items", [])
@@ -468,6 +480,7 @@ def product_readiness_report(
         "harness_validate",
         "skill_content_smoke",
         "use_case_readiness",
+        "chat_card_coverage",
         "product_readiness",
         "release_evidence_bundle",
         "installed_command_smoke",
@@ -483,6 +496,8 @@ def product_readiness_report(
         if count:
             parity_errors.append(f"{status_key}: {count}")
 
+    chat_card_summary = chat_cards.get("summary", {}) if isinstance(chat_cards.get("summary"), Mapping) else {}
+    chat_card_errors = _chat_card_coverage_errors(chat_cards)
     gates = [
         _product_readiness_gate(
             "skill_content",
@@ -513,6 +528,20 @@ def product_readiness_report(
             _string_list(skill_content.get("use_case_readiness_failures")),
             _string_list(skill_content.get("use_case_readiness_warnings")),
             str(skill_content.get("use_case_readiness_boundary", "")),
+        ),
+        _product_readiness_gate(
+            "chat_card_coverage",
+            "Wrapper chat card coverage",
+            "passed" if not chat_card_errors else "failed",
+            True,
+            (
+                f"{chat_card_summary.get('passing_count', 0)}/{chat_card_summary.get('case_count', 0)} "
+                f"dedicated workflow cards; generic ack {chat_card_summary.get('generic_ack_count', 0)}"
+            ),
+            "omh demo chat-card-coverage --json",
+            chat_card_errors,
+            [],
+            str(chat_cards.get("claim_boundary", "")),
         ),
         _product_readiness_gate(
             "parity_contracts",
@@ -1175,6 +1204,36 @@ def _skill_content_product_errors(payload: Mapping[str, object]) -> list[str]:
     return errors
 
 
+def _chat_card_coverage_ready(payload: Mapping[str, object]) -> bool:
+    return not _chat_card_coverage_errors(payload)
+
+
+def _chat_card_coverage_errors(payload: Mapping[str, object]) -> list[str]:
+    errors: list[str] = []
+    summary = payload.get("summary")
+    if not isinstance(summary, Mapping):
+        return ["summary_missing"]
+    if not bool(summary.get("all_passing")):
+        errors.append("not_all_card_coverage_cases_passed")
+    if int(summary.get("generic_ack_count", 0) or 0) != 0:
+        errors.append(f"generic_ack_count: {summary.get('generic_ack_count')}")
+    cases = payload.get("cases")
+    if not isinstance(cases, Sequence) or isinstance(cases, (str, bytes)):
+        errors.append("cases_not_sequence")
+        return errors
+    for case in cases:
+        if not isinstance(case, Mapping) or bool(case.get("passed")):
+            continue
+        case_id = str(case.get("id") or "unknown")
+        issues = case.get("issues")
+        if isinstance(issues, Sequence) and not isinstance(issues, (str, bytes)):
+            issue_text = ", ".join(str(issue) for issue in issues) or "unknown issue"
+        else:
+            issue_text = "unknown issue"
+        errors.append(f"{case_id}: {issue_text}")
+    return errors
+
+
 def _blocking_gate_messages(payload: Mapping[str, object]) -> list[str]:
     gates = payload.get("gates", [])
     if not isinstance(gates, Sequence) or isinstance(gates, (str, bytes)):
@@ -1238,6 +1297,7 @@ def release_evidence_bundle(
     product = product_readiness_report(version=release_version, omh_command=omh_command)
     skill_content = skill_content_smoke()
     use_cases = use_case_readiness(resolved_paths)
+    chat_cards = build_chat_card_coverage_demo()
     parity = build_parity_matrix()
     local_store_status = _release_local_store_status(use_cases)
     required_status = {
@@ -1245,6 +1305,7 @@ def release_evidence_bundle(
         "product_readiness": "passed" if product.get("status") == "ready" else "failed",
         "skill_content": "passed" if skill_content.get("ok") else "failed",
         "use_case_readiness": "passed" if use_cases.get("blocking_failures") == 0 else "failed",
+        "chat_card_coverage": "passed" if _chat_card_coverage_ready(chat_cards) else "failed",
         "parity_contracts": "passed" if _parity_contracts_ready(parity) else "failed",
     }
     blocking_failures = [
@@ -1255,6 +1316,7 @@ def release_evidence_bundle(
     warnings = []
     if local_store_status != "passed":
         warnings.append(f"local_artifact_store: {local_store_status}")
+    chat_card_summary = chat_cards.get("summary", {}) if isinstance(chat_cards.get("summary"), Mapping) else {}
     payload: dict[str, object] = {
         "schema_version": RELEASE_EVIDENCE_BUNDLE_SCHEMA,
         "mode": "live",
@@ -1273,6 +1335,9 @@ def release_evidence_bundle(
             "skill_content_ok": skill_content.get("ok"),
             "use_case_readiness_status": use_cases.get("status"),
             "use_case_readiness_score": use_cases.get("score"),
+            "chat_card_coverage_passing": chat_card_summary.get("passing_count"),
+            "chat_card_coverage_total": chat_card_summary.get("case_count"),
+            "chat_card_generic_ack_count": chat_card_summary.get("generic_ack_count"),
             "local_artifact_store": local_store_status,
             "parity_available": (parity.get("summary") or {}).get("available")
             if isinstance(parity.get("summary"), Mapping)
@@ -1286,6 +1351,7 @@ def release_evidence_bundle(
             "product_readiness": product,
             "skill_content": skill_content,
             "use_case_readiness": use_cases,
+            "chat_card_coverage": chat_cards,
             "parity_contracts": parity,
         },
         "claims": [
@@ -1294,6 +1360,7 @@ def release_evidence_bundle(
             "product_readiness_rollup_ready",
             "skill_content_smoke_ready",
             "g1_to_g10_use_case_readiness_ready",
+            "chat_card_coverage_ready",
             "parity_contract_matrix_ready",
         ],
         "not_evidence_for": [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1941,6 +1941,7 @@ class CliTests(unittest.TestCase):
         self.assertIn("cases artifact --all --json", items["use_case_artifact_bundle"]["command"])
         self.assertIn("cases replay --json", items["use_case_replay"]["command"])
         self.assertIn("cases readiness --json", items["use_case_readiness"]["command"])
+        self.assertIn("demo chat-card-coverage --json", items["chat_card_coverage"]["command"])
         self.assertIn("release product-readiness --version 1.0.0 --json", items["product_readiness"]["command"])
         self.assertIn("release evidence-bundle --version 1.0.0 --write --json", items["release_evidence_bundle"]["command"])
         self.assertIn("skill-content-smoke", items["skill_content_smoke"]["command"])
@@ -2017,6 +2018,7 @@ class CliTests(unittest.TestCase):
         self.assertIn("Score: 100/100", stdout)
         self.assertIn("skill_content: passed", stdout)
         self.assertIn("use_cases: passed", stdout)
+        self.assertIn("chat_card_coverage: passed", stdout)
         self.assertIn("parity_contracts: passed", stdout)
         self.assertIn("release_checklist: passed", stdout)
         self.assertIn("Boundary:", stdout)
@@ -2038,8 +2040,10 @@ class CliTests(unittest.TestCase):
         gates = {gate["id"]: gate for gate in payload["gates"]}
         self.assertEqual(
             set(gates),
-            {"skill_content", "use_cases", "parity_contracts", "release_checklist"},
+            {"skill_content", "use_cases", "chat_card_coverage", "parity_contracts", "release_checklist"},
         )
+        self.assertEqual(gates["chat_card_coverage"]["status"], "passed")
+        self.assertIn("generic ack 0", gates["chat_card_coverage"]["summary"])
         self.assertEqual(gates["parity_contracts"]["status"], "passed")
         self.assertIn("not run the release checklist", payload["boundary"])
 
@@ -2073,6 +2077,7 @@ class CliTests(unittest.TestCase):
             self.assertIn("OMH release evidence bundle for 1.0.1", stdout)
             self.assertIn("Status: ready", stdout)
             self.assertIn("Written: no", stdout)
+            self.assertIn("Chat card coverage: 25/25 (generic ack 0)", stdout)
             self.assertIn("Local artifact store: not_written", stdout)
             self.assertFalse((omh_home / "runtime" / "release-evidence" / "index.json").exists())
 
@@ -2088,6 +2093,8 @@ class CliTests(unittest.TestCase):
             self.assertEqual(payload["status"], "ready")
             self.assertTrue(payload["written"])
             self.assertEqual(payload["summary"]["product_readiness_status"], "ready")
+            self.assertEqual(payload["summary"]["chat_card_coverage_passing"], 25)
+            self.assertEqual(payload["summary"]["chat_card_generic_ack_count"], 0)
             self.assertIn("local_artifact_store: not_written", payload["warnings"])
             self.assertTrue(Path(payload["artifact_path"]).exists())
             self.assertTrue((omh_home / "runtime" / "release-evidence" / "index.json").exists())

--- a/tests/test_release_smoke.py
+++ b/tests/test_release_smoke.py
@@ -40,6 +40,7 @@ class ReleaseSmokeTests(unittest.TestCase):
         self.assertIn("use_case_artifact_bundle", items)
         self.assertIn("use_case_replay", items)
         self.assertIn("use_case_readiness", items)
+        self.assertIn("chat_card_coverage", items)
         self.assertIn("product_readiness", items)
         self.assertIn("release_evidence_bundle", items)
         self.assertIn("live_tap_smoke", items)
@@ -78,8 +79,13 @@ class ReleaseSmokeTests(unittest.TestCase):
         self.assertEqual(items["use_case_readiness"]["command"], "uv run python -m omh.cli cases readiness --json")
         self.assertIn("readiness", items["use_case_readiness"]["evidence_required"])
         self.assertIn("deterministic local use-case contracts", items["use_case_readiness"]["proof_boundary"])
+        self.assertEqual(items["chat_card_coverage"]["command"], "uv run python -m omh.cli demo chat-card-coverage --json")
+        self.assertIn("generic ack count 0", items["chat_card_coverage"]["evidence_required"])
+        self.assertIn("deterministic local wrapper-card contracts", items["chat_card_coverage"]["proof_boundary"])
+        self.assertIn("does not prove live Hermes chat rendering", items["chat_card_coverage"]["proof_boundary"])
         self.assertEqual(items["product_readiness"]["command"], "/tmp/omh release product-readiness --version 1.0.0 --json")
         self.assertIn("skill-content", items["product_readiness"]["evidence_required"])
+        self.assertIn("wrapper chat card coverage", items["product_readiness"]["evidence_required"])
         self.assertIn("product contracts", items["product_readiness"]["proof_boundary"])
         self.assertEqual(items["release_evidence_bundle"]["command"], "/tmp/omh release evidence-bundle --version 1.0.0 --write --json")
         self.assertIn("omh_release_evidence_bundle/v1", items["release_evidence_bundle"]["evidence_required"])
@@ -231,10 +237,15 @@ class ReleaseSmokeTests(unittest.TestCase):
         gates = {gate["id"]: gate for gate in payload["gates"]}
         self.assertEqual(
             set(gates),
-            {"skill_content", "use_cases", "parity_contracts", "release_checklist"},
+            {"skill_content", "use_cases", "chat_card_coverage", "parity_contracts", "release_checklist"},
         )
         self.assertEqual(gates["skill_content"]["status"], "passed")
         self.assertEqual(gates["use_cases"]["status"], "passed")
+        self.assertEqual(gates["chat_card_coverage"]["status"], "passed")
+        self.assertIn("25/25 dedicated workflow cards", gates["chat_card_coverage"]["summary"])
+        self.assertIn("generic ack 0", gates["chat_card_coverage"]["summary"])
+        self.assertEqual(gates["chat_card_coverage"]["command"], "omh demo chat-card-coverage --json")
+        self.assertIn("deterministic local wrapper-card coverage", gates["chat_card_coverage"]["proof_boundary"])
         self.assertEqual(gates["parity_contracts"]["status"], "passed")
         self.assertEqual(gates["release_checklist"]["status"], "passed")
         self.assertIn(
@@ -257,8 +268,13 @@ class ReleaseSmokeTests(unittest.TestCase):
             self.assertFalse(paths.release_evidence_index_path.exists())
             self.assertIn("local_artifact_store: not_written", payload["warnings"])
             self.assertEqual(payload["summary"]["product_readiness_status"], "ready")
+            self.assertEqual(payload["summary"]["chat_card_coverage_passing"], 25)
+            self.assertEqual(payload["summary"]["chat_card_coverage_total"], 25)
+            self.assertEqual(payload["summary"]["chat_card_generic_ack_count"], 0)
             self.assertEqual(payload["evidence"]["product_readiness"]["schema_version"], "omh_product_readiness/v1")
             self.assertEqual(payload["evidence"]["release_checklist"]["schema_version"], "release_readiness_checklist/v1")
+            self.assertEqual(payload["evidence"]["chat_card_coverage"]["schema_version"], "chat_card_coverage/v1")
+            self.assertIn("chat_card_coverage_ready", payload["claims"])
             self.assertIn("executor_dispatch", payload["not_evidence_for"])
 
             written = release_evidence_bundle(version="v1.0.1", omh_command="/tmp/omh command", paths=paths, write=True)


### PR DESCRIPTION
## Feature Report

### What Changed

- Promoted `chat_card_coverage/v1` from a standalone demo QA command into the release readiness path.
- Added `chat_card_coverage` as a required release checklist item.
- Added a product readiness gate that fails if representative chat routes fall back to generic `ack` cards.
- Added chat-card coverage evidence into `omh_release_evidence_bundle/v1` summaries, claims, and nested evidence.
- Updated human-readable release evidence output and release docs so operators can see `25/25` dedicated cards and `generic ack 0` before release.

### Why This Exists

OMH now has enough user-facing wrapper cards that regressions should block release readiness, not hide inside an optional demo. If Hermes receives a natural operator request and OMH falls back to a vague acknowledgement, the product feels less capable even when lower-level router tests still pass.

This change makes the release gate match the user experience: representative workflows must render dedicated chat cards with visible actions, claim boundaries, and not-observed evidence.

### User / Operator Impact

- Maintainers can run `omh release product-readiness --version <version>` and see `chat_card_coverage: passed` in the normal readiness summary.
- Release evidence bundles now carry `chat_card_coverage_passing`, `chat_card_coverage_total`, and `chat_card_generic_ack_count`.
- A release can no longer look locally ready if the checked wrapper corpus regresses to generic acknowledgement cards.

### How It Works

- `src/maintenance/release.py` imports `build_chat_card_coverage_demo()` and evaluates it as a required local deterministic contract.
- Product readiness now includes a `chat_card_coverage` gate with summary copy like `25/25 dedicated workflow cards; generic ack 0`.
- Release evidence bundles include the full `chat_card_coverage/v1` payload and a `chat_card_coverage_ready` claim.
- `src/commands/release.py` prints a compact chat-card coverage line in human evidence-bundle output.

### Files And Contracts Touched

- `release_readiness_checklist/v1`: adds required `chat_card_coverage` item.
- `omh_product_readiness/v1`: adds required `chat_card_coverage` gate.
- `omh_release_evidence_bundle/v1`: adds chat-card summary fields, nested evidence, and claim.
- `docs/RELEASE.md`: documents the wrapper chat-card release gate and its evidence boundary.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_release_smoke.py tests/test_cli.py -v` — 257 tests passed.
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — 888 tests passed.
- [x] `PYTHONPATH=tests uv run python -m compileall -q src tests` — passed.
- [x] `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check` — passed, 48/48 tap skills checked.
- [x] `PYTHONPATH=tests uv run python -m omh.cli harness validate` — passed, 36 harnesses and 50 skills.
- [x] `PYTHONPATH=tests uv run python -m omh.cli release product-readiness --version 1.0.1` — ready; shows `chat_card_coverage: passed`, `25/25`, `generic ack 0`.
- [x] `PYTHONPATH=tests uv run python -m omh.cli release product-readiness --version 1.0.1 --json` — `omh_product_readiness/v1`, status `ready`.
- [x] `PYTHONPATH=tests uv run python -m omh.cli release evidence-bundle --version 1.0.1 --json` — `omh_release_evidence_bundle/v1`, status `ready`, `chat_card_coverage_passing=25`, `chat_card_generic_ack_count=0`.
- [x] `PYTHONPATH=tests uv run python -m omh.cli demo chat-card-coverage` — 25/25 dedicated cards, generic ack 0.
- [x] `git diff --check` — passed.
- [ ] Manual Hermes/TUI check was not run; this PR only changes deterministic local release gate contracts and explicitly does not claim live Hermes rendering.

## Risk

- Narrow. This adds a required local release gate, so future card corpus regressions will block product readiness until fixed.
- The gate is deterministic and metadata-only; it does not call Hermes, platforms, executors, network, CI, or plugin loading.

## Compatibility / Rollout

- Existing release commands remain compatible.
- JSON payloads gain additive fields and one additional product readiness gate.
- Release checklist required item count increases by one.

## Release / Claims

- [x] Release-channel impact considered: this strengthens local release readiness for all channels.
- [x] Runtime/native capability claims are backed by deterministic local evidence or marked as not observed.
- [x] Live Hermes rendering, platform delivery, executor dispatch, review, CI, merge, and plugin-load evidence remain separate and not observed by this PR.

## Follow-Up

- If the chat-card corpus grows, keep `chat_card_coverage/v1` aligned with the highest-risk user-facing routes so release readiness continues to reflect real operator experience.
