### PR TITLE
Add reply guidance to route explanations

### DIFF
--- a/docs/CHAT_WRAPPER_EXAMPLES.md
+++ b/docs/CHAT_WRAPPER_EXAMPLES.md
@@ -595,7 +595,10 @@ They show how different natural-language messages should produce different
 wrapper-native responses instead of forcing every request into coding.
 Every route payload also includes `route_explanation/v1`, a compact
 why/next/not-yet-evidence card that wrappers can render next to the main
-response without exposing shell commands or raw prompt text.
+response without exposing shell commands or raw prompt text. The same card now
+also carries `recommended_reply`, `primary_action_label`, and
+`primary_action_hint` so a chat surface can show a natural first reply and a
+clear next button without inventing copy or implying execution happened.
 
 ### Startup Product Triage
 
@@ -975,6 +978,7 @@ What gets better for the team:
 | Selected workflow/harness | `chat_response.usage_trace.selected_workflow`, `chat_response.usage_trace.selected_harness` |
 | Workflow pattern card | `chat_response.state.workflow_explanation.workflow_context_card.label`, `.user_examples`, `.first_response_shape`, and `chat_response.usage_trace.workflow_context_id` |
 | Why/next/not-evidence card | `chat_response.state.workflow_explanation.why_this_workflow`, `chat_response.state.workflow_explanation.next_action_label`, `chat_response.state.workflow_explanation.not_evidence_yet` |
+| First reply guidance | `chat_response.state.workflow_explanation.recommended_reply`, `chat_response.state.workflow_explanation.primary_action_label`, `chat_response.state.workflow_explanation.primary_action_hint` |
 | Rendering profile and hints | `chat_response.messenger_rendering.render_profile`, `chat_response.messenger_rendering.transforms_applied`, `chat_response.messenger_rendering.fallback_transforms_applied`, `chat_response.messenger_rendering.preferred_blocks`, `chat_response.messenger_rendering.avoid_blocks`, `chat_response.messenger_rendering.table_policy`, `chat_response.messenger_rendering.prefix_policy` |
 | Button ids | `chat_response.actions[].id` |
 | Thread key | `thread_key` |

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -847,9 +847,10 @@ Before calling the bot integration ready, verify these points:
   `omh chat interact --source slack "<message>"` returns a
   `chat_interaction/v1` envelope with a renderable `chat_response/v1`.
 - The route contains `route_explanation/v1` with the selected workflow, why it
-  was selected, the next action, and a short list of states that are not evidence
-  yet. Special OMH intro, quickstart, status, and catalog routes refresh this
-  card after they override the base route.
+  was selected, the next action, a wrapper-ready `recommended_reply`, a
+  `primary_action_label`, a `primary_action_hint`, and a short list of states
+  that are not evidence yet. Special OMH intro, quickstart, status, and catalog
+  routes refresh this card after they override the base route.
 - Common non-English requests should preserve the user's original text while
   routing through deterministic locale hints when a tested phrase matches. For
   example, Japanese or Chinese payment-failure reports route to

--- a/src/commands/chat.py
+++ b/src/commands/chat.py
@@ -330,6 +330,18 @@ def _print_chat_route_summary(payload: dict[str, object]) -> None:
         print("Why:")
         print(f"  {why}")
 
+    recommended_reply = _text(route_explanation.get("recommended_reply"))
+    if recommended_reply:
+        print()
+        print("Reply:")
+        print(f"  {recommended_reply}")
+
+    primary_action_hint = _text(route_explanation.get("primary_action_hint"))
+    if primary_action_hint:
+        print()
+        print("Action hint:")
+        print(f"  {primary_action_hint}")
+
     recommendations = [item for item in _as_list(route.get("recommendations")) if isinstance(item, dict)]
     if recommendations:
         print()

--- a/src/routing/chat.py
+++ b/src/routing/chat.py
@@ -360,6 +360,7 @@ def route_explanation_payload(route: dict[str, object]) -> dict[str, object]:
     not_evidence_yet = _not_evidence_from_boundary(claim_boundary)
     headline = _route_explanation_headline(action, selected)
     summary = _route_explanation_summary(action, selected, next_action, why)
+    next_action_label = next_action.replace("_", " ") if next_action else ""
     return {
         "schema_version": ROUTE_EXPLANATION_SCHEMA_VERSION,
         "selected_workflow": selected,
@@ -369,7 +370,10 @@ def route_explanation_payload(route: dict[str, object]) -> dict[str, object]:
         "score": _int_value(route.get("score", 0)),
         "why_this_workflow": why,
         "next_action": next_action,
-        "next_action_label": next_action.replace("_", " ") if next_action else "",
+        "next_action_label": next_action_label,
+        "recommended_reply": _route_recommended_reply(action, selected, next_action_label, not_evidence_yet),
+        "primary_action_label": _route_primary_action_label(action, selected, next_action_label),
+        "primary_action_hint": _route_primary_action_hint(action, selected, next_action_label, not_evidence_yet),
         "not_evidence_yet": not_evidence_yet,
         "claim_boundary": claim_boundary,
         "headline": headline,
@@ -613,6 +617,50 @@ def _route_explanation_summary(action: str, selected: str, next_action: str, why
     if action == "clarify":
         return f"The router needs one clarification before dispatch. Best candidate: `{selected}`."
     return f"The router should not dispatch yet. Reason: {why}"
+
+
+def _route_recommended_reply(
+    action: str,
+    selected: str,
+    next_action_label: str,
+    not_evidence_yet: list[str],
+) -> str:
+    if action == "dispatch":
+        not_evidence = _first_not_evidence(not_evidence_yet)
+        suffix = f" This is still not {not_evidence} evidence." if not_evidence else " This is routing guidance, not execution evidence."
+        return f"I will use `{selected}` first and start with {next_action_label}.{suffix}"
+    if action == "clarify":
+        return "I need one clarification before choosing a workflow; no plan or execution has started."
+    return "I will keep this in the router until the target is clear; no workflow or execution has started."
+
+
+def _route_primary_action_label(action: str, selected: str, next_action_label: str) -> str:
+    if action == "dispatch":
+        return f"Open {selected}"
+    if action == "clarify":
+        return "Answer clarification"
+    if next_action_label == "answer file lookup":
+        return "Answer file lookup"
+    return "Clarify request"
+
+
+def _route_primary_action_hint(
+    action: str,
+    selected: str,
+    next_action_label: str,
+    not_evidence_yet: list[str],
+) -> str:
+    if action == "dispatch":
+        not_evidence = _first_not_evidence(not_evidence_yet)
+        suffix = f"; do not claim {not_evidence} until observed" if not_evidence else "; keep evidence claims separate"
+        return f"Route to `{selected}` and run `{next_action_label}`{suffix}."
+    if action == "clarify":
+        return "Ask one blocking question, then reroute with the answer."
+    return "Answer directly or ask for the missing target before dispatching a workflow."
+
+
+def _first_not_evidence(items: list[str]) -> str:
+    return items[0].replace("_", " ") if items else ""
 
 
 def _not_evidence_from_boundary(boundary: str) -> list[str]:

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -4466,6 +4466,8 @@ def workflow_explanation_payload(
     workflow = _usage_workflow(state)
     label = workflow or _usage_label(state, kind=kind, phase=phase, next_action=next_action)
     harness = primary_harness_for_skill(workflow) if workflow else ""
+    next_action_label = next_action.replace("_", " ")
+    not_evidence_yet = _workflow_explanation_not_evidence(state, claim_boundary=claim_boundary)
     payload: dict[str, object] = {
         "schema_version": WORKFLOW_EXPLANATION_SCHEMA_VERSION,
         "selected_workflow": workflow,
@@ -4473,8 +4475,11 @@ def workflow_explanation_payload(
         "selected_harness": harness,
         "why_this_workflow": _workflow_explanation_reason(state, workflow=workflow, label=label),
         "next_action": next_action,
-        "next_action_label": next_action.replace("_", " "),
-        "not_evidence_yet": _workflow_explanation_not_evidence(state, claim_boundary=claim_boundary),
+        "next_action_label": next_action_label,
+        "recommended_reply": _workflow_recommended_reply(workflow, label, next_action_label, not_evidence_yet),
+        "primary_action_label": _workflow_primary_action_label(workflow, label),
+        "primary_action_hint": _workflow_primary_action_hint(workflow, label, next_action_label, not_evidence_yet),
+        "not_evidence_yet": not_evidence_yet,
         "claim_boundary": claim_boundary,
         "rendering_hint": "Show this as a compact why/next/not-evidence card in chat surfaces.",
     }
@@ -4495,6 +4500,34 @@ def _workflow_explanation_reason(state: dict[str, object], *, workflow: str, lab
     if workflow:
         return f"Selected `{workflow}` from the message, workflow metadata, and guardrail policy."
     return f"Using the `{label}` response state for this step."
+
+
+def _workflow_recommended_reply(workflow: str, label: str, next_action_label: str, not_evidence_yet: list[str]) -> str:
+    name = workflow or label
+    not_evidence = _first_not_evidence_item(not_evidence_yet)
+    suffix = f" This is still not {not_evidence} evidence." if not_evidence else " This is guidance, not execution evidence."
+    return f"I will use `{name}` and start with {next_action_label}.{suffix}"
+
+
+def _workflow_primary_action_label(workflow: str, label: str) -> str:
+    name = workflow or label
+    return f"Open {name}"
+
+
+def _workflow_primary_action_hint(
+    workflow: str,
+    label: str,
+    next_action_label: str,
+    not_evidence_yet: list[str],
+) -> str:
+    name = workflow or label
+    not_evidence = _first_not_evidence_item(not_evidence_yet)
+    suffix = f"; do not claim {not_evidence} until observed" if not_evidence else "; keep evidence claims separate"
+    return f"Route to `{name}` and run `{next_action_label}`{suffix}."
+
+
+def _first_not_evidence_item(items: list[str]) -> str:
+    return items[0].replace("_", " ") if items else ""
 
 
 def _workflow_explanation_not_evidence(state: dict[str, object], *, claim_boundary: str) -> list[str]:

--- a/tests/test_chat_router.py
+++ b/tests/test_chat_router.py
@@ -1303,6 +1303,11 @@ selected_workflow=ultraprocess
         self.assertIn("not MCP server installation", explanation["claim_boundary"])
         self.assertIn("API access", explanation["claim_boundary"])
         self.assertIn("connector invocation", explanation["not_evidence_yet"])
+        self.assertIn("toolbelt-readiness", explanation["recommended_reply"])
+        self.assertIn("prepare toolbelt readiness", explanation["recommended_reply"])
+        self.assertEqual(explanation["primary_action_label"], "Open toolbelt-readiness")
+        self.assertIn("do not claim", explanation["primary_action_hint"])
+        self.assertIn("execution", explanation["primary_action_hint"])
         self.assertIn("why / next / not-yet-evidence", explanation["rendering_hint"])
         self.assertNotIn(message, json.dumps(explanation, ensure_ascii=False))
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4056,6 +4056,10 @@ class CliTests(unittest.TestCase):
         self.assertIn("Confidence: high (score 32)", stdout)
         self.assertIn("Why:", stdout)
         self.assertIn("Matched safe feature-change language", stdout)
+        self.assertIn("Reply:", stdout)
+        self.assertIn("I will use `ralplan` first and start with present plan.", stdout)
+        self.assertIn("Action hint:", stdout)
+        self.assertIn("Route to `ralplan` and run `present plan`", stdout)
         self.assertIn("Top recommendations:", stdout)
         self.assertIn("- ralplan: present_plan (high, score 32)", stdout)
         self.assertIn("Route plan:", stdout)
@@ -4071,6 +4075,8 @@ class CliTests(unittest.TestCase):
         route = json.loads(stdout)["route"]
         self.assertEqual(route["selected_skill"], "ralplan")
         self.assertEqual(route["route_explanation"]["next_action"], "present_plan")
+        self.assertEqual(route["route_explanation"]["primary_action_label"], "Open ralplan")
+        self.assertIn("present plan", route["route_explanation"]["recommended_reply"])
 
     def test_chat_route_summary_shows_recorded_runtime_metadata_only(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -1687,6 +1687,8 @@ class RouterContentTests(unittest.TestCase):
         self.assertIn("chat_response.state.workflow_explanation.workflow_context_card", text)
         self.assertIn("first_response_shape", text)
         self.assertIn("chat_response.state.workflow_explanation.not_evidence_yet", text)
+        self.assertIn("chat_response.state.workflow_explanation.recommended_reply", text)
+        self.assertIn("chat_response.state.workflow_explanation.primary_action_hint", text)
         self.assertIn("Telegram can register the `omh` bot command menu", text)
         self.assertIn("Startup Product Triage", text)
         self.assertIn("Real-World QA Check", text)

--- a/tests/test_wrapper_contract.py
+++ b/tests/test_wrapper_contract.py
@@ -938,6 +938,10 @@ class WrapperContractTests(unittest.TestCase):
         self.assertIn("reproduction evidence", explanation["not_evidence_yet"])
         self.assertIn("coding handoff", explanation["not_evidence_yet"])
         self.assertIn("verification", explanation["not_evidence_yet"])
+        self.assertIn("feedback-triage", explanation["recommended_reply"])
+        self.assertIn("triage feedback", explanation["recommended_reply"])
+        self.assertEqual(explanation["primary_action_label"], "Open feedback-triage")
+        self.assertIn("do not claim completed feedback triage", explanation["primary_action_hint"])
 
     def test_review_quality_cards_expose_verification_boundaries(self) -> None:
         cases = (


### PR DESCRIPTION
## Feature Report

### What Changed

- Extended `route_explanation/v1` with wrapper-ready reply guidance:
  - `recommended_reply`
  - `primary_action_label`
  - `primary_action_hint`
- Extended `chat_response.state.workflow_explanation` with the same reply/action guidance fields.
- Updated `omh chat route --summary` so operators see `Reply:` and `Action hint:` without opening JSON.
- Documented the new JSON-to-UI mapping for chat wrapper rendering.

### Why This Exists

OMH could already explain which workflow was selected, why, what the next action was, and what was not evidence yet. The missing piece was the first sentence a Hermes wrapper should say to the user and the primary action copy it should render.

Without stable reply/action fields, each Discord, Slack, Telegram, or Hermes wrapper has to invent copy from lower-level route metadata. That increases the chance of awkward wording or overclaiming, especially around prepared-vs-observed boundaries.

### User / Operator Impact

- A user asking something like `결제 실패 이슈가 자주 나와` can get a clearer first response:
  - `I will use feedback-triage first and start with triage feedback...`
- Operators running `omh chat route --summary` now see exactly how the first chat reply and action hint should read.
- Wrappers can render a more natural button/card without treating routing as workflow execution.
- Existing route selection, scoring, workflow choice, and evidence boundaries remain unchanged.

### How It Works

- `src/routing/chat.py` now derives reply/action guidance from the selected workflow, next action label, and first not-yet-evidence item.
- `src/wrapper/contract.py` adds equivalent fields to generated workflow explanation cards used by `chat_response/v1`.
- `src/commands/chat.py` prints the new reply/action hint in route summaries.
- Tests lock the public JSON fields, CLI summary copy, and docs mapping.

### Files And Contracts Touched

- `src/routing/chat.py`: `route_explanation/v1` fields.
- `src/wrapper/contract.py`: `omh_workflow_explanation/v1` fields.
- `src/commands/chat.py`: route summary human output.
- `docs/CHAT_WRAPPER_EXAMPLES.md`, `docs/INSTALLATION.md`: wrapper rendering guidance.
- `tests/test_chat_router.py`, `tests/test_wrapper_contract.py`, `tests/test_cli.py`, `tests/test_router_content.py`: contract coverage.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_chat_router.py tests/test_wrapper_contract.py tests/test_cli.py tests/test_router_content.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `PYTHONPATH=tests uv run python -m compileall -q src tests`
- [x] `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check`
- [x] `PYTHONPATH=tests uv run python -m omh.cli harness validate`
- [x] `PYTHONPATH=tests uv run python -m omh.cli chat route --summary '결제 실패 이슈가 자주 나와'`
- [x] `PYTHONPATH=tests uv run python -m omh.cli chat route --summary 'I want to safely add a feature to this repo'`
- [x] `PYTHONPATH=tests uv run python -m omh.cli chat interact --source discord --summary '결제 실패 이슈가 자주 나와'`
- [x] `PYTHONPATH=tests uv run python -m omh.cli demo grounded-score --summary`
- [x] `PYTHONPATH=tests uv run python -m omh.cli release product-readiness --version 1.0.1`
- [x] `git diff --check`
- [ ] `python3 -m unittest discover -s tests`
- [ ] `python3 -m compileall src`
- [ ] `python3 -m omh.cli docs workflows --check`
- [ ] `python3 -m omh.cli harness validate`
- [ ] `python3 -m omh.cli release checklist --json`
- [ ] `python3 -m omh.cli release hermes-smoke`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable.
- [ ] Relevant dry-run or smoke command: covered by route summary, chat interaction summary, grounded-score, and product-readiness smoke commands above.
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; this PR changes deterministic wrapper route contracts and CLI summaries, not live Hermes rendering.

## Risk

- Low. This adds fields and summary copy; it does not change route selection or scoring.
- Wrappers that ignore the new fields continue to work.
- Wrappers that use the fields still need to preserve observed evidence boundaries; the copy explicitly says not to claim unobserved states.

## Compatibility / Rollout

- Additive JSON contract change.
- No new dependency, network call, Hermes core patch, executor dispatch, or transport behavior.
- Existing `route_explanation/v1` and `omh_workflow_explanation/v1` consumers remain compatible.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- Consider teaching messenger shims to render `primary_action_label` as the default button label when no workflow-specific button is available.
