### PR TITLE
Preserve route reasons in chat interaction cards

### DIFF
--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -3431,6 +3431,7 @@ def _finish_interaction(payload: dict[str, object], target_notice: dict[str, obj
             payload["target_topology"] = topology
     response = payload.get("chat_response")
     if isinstance(response, dict):
+        response = _chat_response_with_route_explanation(response, _nested(payload, "route"))
         if target_notice:
             response = _chat_response_with_target_notice(response, target_notice)
         payload["chat_response"] = _chat_response_with_render_profile(
@@ -3439,6 +3440,42 @@ def _finish_interaction(payload: dict[str, object], target_notice: dict[str, obj
             source_metadata=_nested(payload, "source_metadata"),
         )
     return payload
+
+
+def _chat_response_with_route_explanation(
+    response: dict[str, object], route_payload: dict[str, object]
+) -> dict[str, object]:
+    route_explanation = _nested(route_payload, "route_explanation")
+    if not route_explanation:
+        return response
+    updated = dict(response)
+    state = dict(_nested(updated, "state"))
+    workflow_explanation = dict(_nested(state, "workflow_explanation"))
+    if not workflow_explanation:
+        return response
+
+    existing_reason = str(workflow_explanation.get("why_this_workflow") or "").strip()
+    route_reason = str(route_explanation.get("why_this_workflow") or "").strip()
+    if route_reason:
+        if existing_reason and existing_reason not in route_reason:
+            reason = f"{route_reason} {existing_reason}"
+        else:
+            reason = route_reason
+        workflow_explanation["why_this_workflow"] = reason
+        state["workflow_explanation_reason"] = reason
+    for source_key, target_key in (
+        ("action", "route_action"),
+        ("next_action", "route_next_action"),
+        ("recommended_reply", "route_recommended_reply"),
+        ("primary_action_label", "route_primary_action_label"),
+        ("primary_action_hint", "route_primary_action_hint"),
+    ):
+        value = route_explanation.get(source_key)
+        if value:
+            workflow_explanation[target_key] = value
+    state["workflow_explanation"] = workflow_explanation
+    updated["state"] = state
+    return updated
 
 
 def _chat_response_with_target_notice(response: dict[str, object], target_notice: dict[str, object]) -> dict[str, object]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4357,6 +4357,12 @@ class CliTests(unittest.TestCase):
         self.assertEqual(response["state"]["selected_workflow"], "ralplan")
         self.assertIn("because it needs a safe plan first", response["headline"])
         self.assertIn("not execution evidence", response["claim_boundary"])
+        explanation = response["state"]["workflow_explanation"]
+        self.assertIn("safe feature-change language", explanation["why_this_workflow"])
+        self.assertEqual(explanation["next_action"], "accept_or_revise_plan")
+        self.assertEqual(explanation["route_next_action"], "present_plan")
+        self.assertIn("present plan", explanation["route_recommended_reply"])
+        self.assertIn("accept or revise plan", explanation["recommended_reply"])
         actions = {action["id"]: action for action in response["actions"]}
         self.assertTrue(actions["accept_plan"]["enabled"])
         self.assertTrue(actions["revise_plan"]["enabled"])

--- a/tests/test_wrapper_contract.py
+++ b/tests/test_wrapper_contract.py
@@ -943,6 +943,24 @@ class WrapperContractTests(unittest.TestCase):
         self.assertEqual(explanation["primary_action_label"], "Open feedback-triage")
         self.assertIn("do not claim completed feedback triage", explanation["primary_action_hint"])
 
+    def test_plan_interaction_keeps_route_specific_reason_in_workflow_explanation(self) -> None:
+        payload = build_chat_interaction_payload("I want to safely add a feature to this repo", source="discord")
+
+        response = payload["chat_response"]
+        explanation = response["state"]["workflow_explanation"]
+
+        self.assertEqual(payload["mode"], "plan")
+        self.assertEqual(payload["route"]["selected_skill"], "ralplan")
+        self.assertEqual(response["kind"], "plan")
+        self.assertEqual(explanation["selected_workflow"], "ralplan")
+        self.assertIn("safe feature-change language", explanation["why_this_workflow"])
+        self.assertEqual(explanation["next_action"], "accept_or_revise_plan")
+        self.assertEqual(explanation["route_next_action"], "present_plan")
+        self.assertIn("accept or revise plan", explanation["recommended_reply"])
+        self.assertIn("present plan", explanation["route_recommended_reply"])
+        self.assertIn("do not claim plan acceptance", explanation["primary_action_hint"])
+        self.assertIn("do not claim execution", explanation["route_primary_action_hint"])
+
     def test_review_quality_cards_expose_verification_boundaries(self) -> None:
         cases = (
             (


### PR DESCRIPTION
## Feature Report

### What Changed

- Preserved route-specific workflow reasoning inside the primary `chat_response.state.workflow_explanation` payload that Discord/Slack-style wrappers render first.
- Added route-scoped fields (`route_next_action`, `route_recommended_reply`, `route_primary_action_hint`, and related action metadata) so cards can distinguish route intent from the response-level next action.
- Locked the behavior with CLI and wrapper-contract tests for the safe feature request path.

### Why This Exists

- `omh chat route` already knew why a request matched a workflow, but `omh chat interact` could still show a generic explanation in the visible card.
- For messages like `I want to safely add a feature to this repo`, Hermes should explain that the safe feature-change language triggered `ralplan`, not only that metadata and guardrails selected it.
- Wrapper cards also need to keep evidence boundaries clear: presenting a plan is not plan acceptance, executor dispatch, implementation, verification, review, CI, or merge evidence.

### User / Operator Impact

- When a user asks Hermes for safe feature work, the visible card now says why OMH chose the reviewed-plan path.
- Wrappers can render both the user-facing next action (`accept_or_revise_plan`) and the route-level recommendation (`present_plan`) without collapsing them into one ambiguous state.
- Existing image-summary and workflow fallback guidance remains visible because route reasons are added while preserving the workflow's own explanation text.

### How It Works

- `_finish_interaction()` now enriches `chat_response` with the nested `route.route_explanation` before target notices and render profiles are applied.
- `_chat_response_with_route_explanation()` prepends route-specific rationale to the existing workflow explanation, then copies route action metadata under `route_*` keys.
- Response-level fields remain authoritative for the current card state, while `route_*` fields remain advisory context from the router.

### Files And Contracts Touched

- `src/wrapper/contract.py`: adds the route-to-chat-response enrichment helper.
- `tests/test_wrapper_contract.py`: adds a regression for preserving the route-specific reason in plan cards.
- `tests/test_cli.py`: asserts safe feature `chat interact` output exposes both response-level and route-level next-action copy.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `PYTHONPATH=tests uv run python -m compileall -q src tests`
- [x] `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check`
- [x] `PYTHONPATH=tests uv run python -m omh.cli harness validate`
- [ ] `python3 -m omh.cli release checklist --json`
- [ ] `python3 -m omh.cli release hermes-smoke`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable; no workflow-learning contract changed.
- [x] Relevant dry-run or smoke command: `PYTHONPATH=tests uv run python -m omh.cli chat interact --source discord --summary "I want to safely add a feature to this repo"`
- [x] Relevant dry-run or smoke command: `PYTHONPATH=tests uv run python -m omh.cli demo grounded-score --summary`
- [x] Relevant dry-run or smoke command: `PYTHONPATH=tests uv run python -m omh.cli release product-readiness --version 1.0.1`
- [x] Relevant dry-run or smoke command: `git diff --check`
- [x] Manual Hermes/TUI check, or explicit reason it was not run: not run; this PR changes deterministic local wrapper payload shaping only, not live Hermes runtime loading or TUI rendering.

## Risk

- Risk is narrow: the change only adds explanatory fields and preserves existing response-level action semantics.
- Route-derived fields are advisory and must not be interpreted as execution, review, CI, merge, delivery, or plugin-load evidence.

## Compatibility / Rollout

- Backward compatible for existing consumers of `chat_response.state.workflow_explanation`: existing keys remain present.
- New `route_*` fields give wrappers more context without requiring immediate renderer changes.
- No release-channel behavior, installer behavior, or Hermes core behavior changes.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`): no release-channel change.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap.

## Follow-Up

- Consider a future renderer pass that visually separates route-level reason, card-level next action, and evidence boundary in messenger-native cards.
