### PR TITLE
Fix Korean file lookup routing

### DIFF
--- a/src/routing/catalog_questions.py
+++ b/src/routing/catalog_questions.py
@@ -360,6 +360,26 @@ _PATH_REFERENCE_MARKERS = (
     "readme",
     "section",
 )
+_FILE_LOOKUP_ACTION_MARKERS = (
+    "find",
+    "show",
+    "open",
+    "read",
+    "search",
+    "look up",
+    "lookup",
+    "locate",
+    "찾아",
+    "찾아줘",
+    "보여",
+    "보여줘",
+    "열어",
+    "열어줘",
+    "읽어",
+    "읽어줘",
+    "검색",
+    "어디",
+)
 _CATALOG_COLLISION_MARKERS = _CATALOG_COLLECTION_WORDS + ("명령어",)
 _OPERATOR_ACTION_QUESTION_MARKERS = (
     "how can i",
@@ -431,12 +451,31 @@ def _is_file_or_text_search_question(search_texts: tuple[str, ...]) -> bool:
     if _contains_catalog_token(search_texts, _WORKFLOW_REVIEW_INTENT_MARKERS):
         return False
     if _contains_catalog_token(search_texts, _PATH_REFERENCE_MARKERS):
+        if _contains_file_lookup_action(search_texts):
+            return True
         return _contains_catalog_token(search_texts, _CONTEXT_MARKERS) or _contains_catalog_token(
             search_texts, _CATALOG_COLLISION_MARKERS
         ) or _contains_catalog_token(search_texts, _NAMED_WORKFLOW_MARKERS)
     return _contains_catalog_token(search_texts, _FILE_OR_TEXT_MARKERS) and _contains_catalog_token(
         search_texts, _CATALOG_COLLISION_MARKERS
     )
+
+
+def _contains_file_lookup_action(search_texts: tuple[str, ...]) -> bool:
+    for text in search_texts:
+        word_text = _word_search_text(text)
+        for marker in _FILE_LOOKUP_ACTION_MARKERS:
+            if marker.isascii():
+                if f" {marker} " in word_text:
+                    return True
+            elif marker in text:
+                return True
+    return False
+
+
+def _word_search_text(text: str) -> str:
+    cleaned = "".join(character if character.isalnum() else " " for character in text)
+    return f" {' '.join(cleaned.split())} "
 
 
 def _is_named_workflow_catalog_question(search_texts: tuple[str, ...]) -> bool:

--- a/src/routing/chat.py
+++ b/src/routing/chat.py
@@ -566,11 +566,11 @@ def _route_next_action(route: dict[str, object], recommendation: dict[str, objec
 
 
 def _route_claim_boundary(route: dict[str, object], recommendation: dict[str, object]) -> str:
+    if _is_file_lookup_reason(str(route.get("reason", ""))):
+        return "No OMH workflow, execution, or file inspection has started."
     boundary = str(recommendation.get("evidence_boundary", "")).strip()
     if boundary:
         return boundary
-    if _is_file_lookup_reason(str(route.get("reason", ""))):
-        return "No OMH workflow, execution, or file inspection has started."
     if str(route.get("action", "")) == "dispatch":
         return "Routing guidance is not workflow execution evidence."
     return "No execution has started."
@@ -665,6 +665,11 @@ def _first_not_evidence(items: list[str]) -> str:
 
 def _not_evidence_from_boundary(boundary: str) -> list[str]:
     text = boundary.lower()
+    if "file inspection" in text:
+        items = ["file inspection"]
+        if "execution" in text:
+            items.append("execution")
+        return items
     items: list[str] = []
     for marker, label in (
         ("plan acceptance", "plan acceptance"),

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -4572,6 +4572,11 @@ def _workflow_explanation_not_evidence(state: dict[str, object], *, claim_bounda
     if isinstance(explicit, list) and explicit:
         return [str(item) for item in explicit if str(item)]
     text = claim_boundary.lower()
+    if "file inspection" in text:
+        items = ["file inspection"]
+        if "execution" in text:
+            items.append("execution")
+        return items
     items: list[str] = []
     for marker, label in (
         ("plan acceptance", "plan acceptance"),

--- a/tests/test_chat_router.py
+++ b/tests/test_chat_router.py
@@ -1059,6 +1059,8 @@ selected_workflow=ultraprocess
             "search docs/WORKFLOWS.md for loop",
             "show img-summary in README.md",
             "what does OMH do in docs/ARCHITECTURE.md?",
+            "README 파일 찾아줘",
+            "README 보여줘",
         ):
             with self.subTest(message=message):
                 decision = route_chat_message(message, source="discord")
@@ -1074,6 +1076,20 @@ selected_workflow=ultraprocess
                 public_payload = public_route_payload(decision)
                 self.assertIn("file or text lookup", public_payload["routing_instruction"])
                 self.assertNotIn("ask one concise clarification", public_payload["routing_instruction"])
+                explanation = public_payload["route_explanation"]
+                self.assertIn("file inspection", explanation["claim_boundary"])
+                self.assertIn("file inspection", explanation["not_evidence_yet"])
+                self.assertNotIn("review", explanation["not_evidence_yet"])
+
+    def test_korean_file_lookup_does_not_steal_readme_edit_requests(self) -> None:
+        lookup = route_chat_message("README 파일 찾아줘", source="discord")
+        edit = route_chat_message("README 제목 수정해줘", source="discord")
+
+        self.assertEqual(lookup["action"], "fallback")
+        self.assertEqual(lookup["selected_skill"], "oh-my-hermes")
+        self.assertIn("File or text lookup", lookup["reason"])
+        self.assertNotEqual(edit["reason"], lookup["reason"])
+        self.assertNotEqual(edit["action"], "fallback")
 
     def test_web_search_chat_dispatches_to_research_harness(self) -> None:
         cases = (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4287,7 +4287,7 @@ class CliTests(unittest.TestCase):
         self.assertIn("--summary and --json cannot be used together", stderr)
 
     def test_chat_route_file_lookup_does_not_emit_workflow_clarification(self) -> None:
-        status, stdout, stderr = run_cli(["chat", "route", "--source", "discord", "search", "docs/WORKFLOWS.md", "for", "loop"])
+        status, stdout, stderr = run_cli(["chat", "route", "--source", "discord", "README", "파일", "찾아줘"])
 
         self.assertEqual(stderr, "")
         self.assertEqual(status, 0)
@@ -4299,10 +4299,12 @@ class CliTests(unittest.TestCase):
         self.assertIn("file or text lookup", route["clarification"])
         self.assertIn("file or text lookup", route["routing_instruction"])
         self.assertNotIn("ask one concise clarification", route["routing_instruction"])
+        self.assertIn("file inspection", route["route_explanation"]["not_evidence_yet"])
+        self.assertNotIn("review", route["route_explanation"]["not_evidence_yet"])
         self.assertNotEqual(route["recommendations"][0]["skill"], route["selected_skill"])
 
     def test_chat_interact_file_lookup_fallback_uses_lookup_card(self) -> None:
-        status, stdout, stderr = run_cli(["chat", "interact", "--source", "discord", "search", "docs/WORKFLOWS.md", "for", "loop"])
+        status, stdout, stderr = run_cli(["chat", "interact", "--source", "discord", "README", "파일", "찾아줘"])
 
         self.assertEqual(stderr, "")
         self.assertEqual(status, 0)
@@ -4314,6 +4316,9 @@ class CliTests(unittest.TestCase):
         self.assertEqual(response["kind"], "clarification")
         self.assertIn("file or text lookup", response["body"])
         self.assertEqual(response["state"]["lookup_kind"], "file_or_text")
+        explanation = response["state"]["workflow_explanation"]
+        self.assertIn("file inspection", explanation["not_evidence_yet"])
+        self.assertNotIn("review", explanation["not_evidence_yet"])
         self.assertNotIn("choose the right workflow", response["body"])
 
     def test_chat_route_and_interact_guard_short_omh_maintenance_command(self) -> None:

--- a/tests/test_wrapper_contract.py
+++ b/tests/test_wrapper_contract.py
@@ -1484,20 +1484,26 @@ class WrapperContractTests(unittest.TestCase):
                 self.assertNotIn("capability_summary", payload["chat_response"]["state"])
 
     def test_file_lookup_fallback_card_uses_lookup_copy(self) -> None:
-        payload = build_chat_interaction_payload("search docs/WORKFLOWS.md for loop", source="discord")
+        for message in ("search docs/WORKFLOWS.md for loop", "README 파일 찾아줘"):
+            with self.subTest(message=message):
+                payload = build_chat_interaction_payload(message, source="discord")
 
-        self.assertEqual(payload["mode"], "clarify")
-        self.assertEqual(payload["route"]["action"], "fallback")
-        self.assertEqual(payload["next_action"], "answer_file_lookup")
-        response = payload["chat_response"]
-        self.assertEqual(response["kind"], "clarification")
-        self.assertIn("file or text lookup", response["body"])
-        self.assertIn("file or text lookup", response["state"]["routing_instruction"])
-        self.assertEqual(response["state"]["lookup_kind"], "file_or_text")
-        self.assertNotIn("choose the right workflow", response["body"])
-        actions = {action["id"]: action for action in response["actions"]}
-        self.assertIn("answer:file_lookup", actions)
-        self.assertTrue(actions["answer:file_lookup"]["enabled"])
+                self.assertEqual(payload["mode"], "clarify")
+                self.assertEqual(payload["route"]["action"], "fallback")
+                self.assertEqual(payload["next_action"], "answer_file_lookup")
+                response = payload["chat_response"]
+                self.assertEqual(response["kind"], "clarification")
+                self.assertIn("file or text lookup", response["body"])
+                self.assertIn("file or text lookup", response["state"]["routing_instruction"])
+                self.assertEqual(response["state"]["lookup_kind"], "file_or_text")
+                explanation = response["state"]["workflow_explanation"]
+                self.assertIn("file inspection", explanation["claim_boundary"])
+                self.assertIn("file inspection", explanation["not_evidence_yet"])
+                self.assertNotIn("review", explanation["not_evidence_yet"])
+                self.assertNotIn("choose the right workflow", response["body"])
+                actions = {action["id"]: action for action in response["actions"]}
+                self.assertIn("answer:file_lookup", actions)
+                self.assertTrue(actions["answer:file_lookup"]["enabled"])
 
     def test_interaction_route_explanation_matches_special_route_overrides(self) -> None:
         payload = build_chat_interaction_payload("What is OMH and how should I use it?", source="discord")


### PR DESCRIPTION
## Feature Report

### What Changed

- Korean file/text lookup requests such as `README 파일 찾아줘` and `README 보여줘` now stay in the file lookup fallback path instead of drifting into workflow recommendation or review/coding candidates.
- Path-reference lookup verbs are detected with word-boundary-safe English handling, so `README` no longer accidentally matches the English verb `read`.
- File lookup route explanations now report `file inspection` as the missing evidence instead of inheriting unrelated `review` or `implementation` evidence boundaries from the top recommendation candidate.

### Why This Exists

- A chat user asking Hermes to find or show a file should not be told to choose a workflow or accidentally see a code-review/ultraprocess-style boundary.
- The previous heuristic handled English path lookup examples but missed common Korean phrasing around `README 파일 찾아줘`.
- A first-response card must say what has not happened yet: no file was actually inspected, and no workflow execution started.

### User / Operator Impact

- Korean chat requests for file lookup feel direct and less surprising.
- Editing requests like `README 제목 수정해줘` still route to the implementation workflow path, so lookup improvements do not steal actual code/document edit tasks.
- Wrapper cards now show clearer evidence language: `file inspection` and `execution` are not observed yet.

### How It Works

- `src/routing/catalog_questions.py` adds path-reference lookup action detection for Korean and English lookup verbs.
- English lookup verbs are checked against normalized word boundaries to avoid substring matches inside filenames like `README`.
- `src/routing/chat.py` prioritizes file lookup boundaries before recommendation-derived evidence boundaries.
- `src/wrapper/contract.py` mirrors the same `file inspection` not-yet-evidence wording inside the visible chat response workflow explanation.

### Files And Contracts Touched

- `src/routing/catalog_questions.py`: lookup action detection and safe word matching.
- `src/routing/chat.py`: file lookup claim boundary and route explanation evidence ladder.
- `src/wrapper/contract.py`: workflow explanation evidence wording for file inspection.
- `tests/test_chat_router.py`, `tests/test_cli.py`, `tests/test_wrapper_contract.py`: regression coverage for Korean file lookup, README edit routing, CLI output, and wrapper card evidence wording.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests.test_chat_router.ChatRouterTests.test_file_lookup_does_not_dispatch_to_workflow_keyword tests.test_chat_router.ChatRouterTests.test_korean_file_lookup_does_not_steal_readme_edit_requests tests.test_wrapper_contract.WrapperContractTests.test_file_lookup_fallback_card_uses_lookup_copy tests.test_cli.CliTests.test_chat_route_file_lookup_does_not_emit_workflow_clarification tests.test_cli.CliTests.test_chat_interact_file_lookup_fallback_uses_lookup_card -v`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `PYTHONPATH=tests uv run python -m compileall -q src tests`
- [x] `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check`
- [x] `PYTHONPATH=tests uv run python -m omh.cli harness validate`
- [ ] `python3 -m omh.cli release checklist --json`
- [ ] `python3 -m omh.cli release hermes-smoke`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable; no workflow-learning contract changed.
- [x] Relevant dry-run or smoke command: `PYTHONPATH=tests uv run python -m omh.cli chat interact --source discord --summary "README 파일 찾아줘"`
- [x] Relevant dry-run or smoke command: `PYTHONPATH=tests uv run python -m omh.cli chat route --source discord --summary "README 제목 수정해줘"`
- [x] Relevant dry-run or smoke command: `PYTHONPATH=tests uv run python -m omh.cli demo grounded-score --summary`
- [x] Relevant dry-run or smoke command: `PYTHONPATH=tests uv run python -m omh.cli release product-readiness --version 1.0.1`
- [x] Relevant dry-run or smoke command: `git diff --check`
- [x] Manual Hermes/TUI check, or explicit reason it was not run: not run; this PR changes deterministic local routing and wrapper payload shaping only, not live Hermes runtime loading or TUI rendering.

## Risk

- Risk is narrow and limited to file/text lookup classification and evidence wording.
- The new Korean lookup action detection intentionally avoids overriding review/edit requests that contain release/review intent or explicit edit language.

## Compatibility / Rollout

- Backward compatible for existing file lookup paths.
- Adds better Korean coverage without changing public schema versions.
- No installer, release channel, plugin, or Hermes core behavior changes.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`): no release-channel change.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap.

## Follow-Up

- Continue collecting real chat examples where direct lookup, direct editing, and workflow routing are easy to confuse across Korean and English phrasing.
