### PR TITLE
Improve file lookup route reply copy

### DIFF
--- a/src/routing/chat.py
+++ b/src/routing/chat.py
@@ -358,7 +358,7 @@ def route_explanation_payload(route: dict[str, object]) -> dict[str, object]:
     claim_boundary = _route_claim_boundary(route, recommendation)
     why = _route_explanation_reason(route)
     not_evidence_yet = _not_evidence_from_boundary(claim_boundary)
-    headline = _route_explanation_headline(action, selected)
+    headline = _route_explanation_headline(action, selected, next_action)
     summary = _route_explanation_summary(action, selected, next_action, why)
     next_action_label = next_action.replace("_", " ") if next_action else ""
     return {
@@ -603,11 +603,13 @@ def _capitalize_sentence(value: str) -> str:
     return text[:1].upper() + text[1:]
 
 
-def _route_explanation_headline(action: str, selected: str) -> str:
+def _route_explanation_headline(action: str, selected: str, next_action: str) -> str:
     if action == "dispatch":
         return f"Use `{selected}` for this request."
     if action == "clarify":
         return "Ask one question before choosing a workflow."
+    if next_action == "answer_file_lookup":
+        return "Answer as a file or text lookup."
     return "Keep this in the router until the target is clear."
 
 
@@ -616,6 +618,8 @@ def _route_explanation_summary(action: str, selected: str, next_action: str, why
         return f"`{selected}` is selected because {why} Next action: `{next_action}`."
     if action == "clarify":
         return f"The router needs one clarification before dispatch. Best candidate: `{selected}`."
+    if next_action == "answer_file_lookup":
+        return f"Answer directly as a file or text lookup; do not dispatch a workflow. Reason: {why}"
     return f"The router should not dispatch yet. Reason: {why}"
 
 
@@ -631,6 +635,8 @@ def _route_recommended_reply(
         return f"I will use `{selected}` first and start with {next_action_label}.{suffix}"
     if action == "clarify":
         return "I need one clarification before choosing a workflow; no plan or execution has started."
+    if next_action_label == "answer file lookup":
+        return "I will answer this as a file or text lookup; no file inspection or workflow execution has started."
     return "I will keep this in the router until the target is clear; no workflow or execution has started."
 
 

--- a/tests/test_chat_router.py
+++ b/tests/test_chat_router.py
@@ -1077,6 +1077,10 @@ selected_workflow=ultraprocess
                 self.assertIn("file or text lookup", public_payload["routing_instruction"])
                 self.assertNotIn("ask one concise clarification", public_payload["routing_instruction"])
                 explanation = public_payload["route_explanation"]
+                self.assertEqual(explanation["headline"], "Answer as a file or text lookup.")
+                self.assertIn("Answer directly as a file or text lookup", explanation["summary"])
+                self.assertIn("I will answer this as a file or text lookup", explanation["recommended_reply"])
+                self.assertNotIn("target is clear", explanation["recommended_reply"])
                 self.assertIn("file inspection", explanation["claim_boundary"])
                 self.assertIn("file inspection", explanation["not_evidence_yet"])
                 self.assertNotIn("review", explanation["not_evidence_yet"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4299,8 +4299,12 @@ class CliTests(unittest.TestCase):
         self.assertIn("file or text lookup", route["clarification"])
         self.assertIn("file or text lookup", route["routing_instruction"])
         self.assertNotIn("ask one concise clarification", route["routing_instruction"])
-        self.assertIn("file inspection", route["route_explanation"]["not_evidence_yet"])
-        self.assertNotIn("review", route["route_explanation"]["not_evidence_yet"])
+        explanation = route["route_explanation"]
+        self.assertEqual(explanation["headline"], "Answer as a file or text lookup.")
+        self.assertIn("I will answer this as a file or text lookup", explanation["recommended_reply"])
+        self.assertNotIn("target is clear", explanation["recommended_reply"])
+        self.assertIn("file inspection", explanation["not_evidence_yet"])
+        self.assertNotIn("review", explanation["not_evidence_yet"])
         self.assertNotEqual(route["recommendations"][0]["skill"], route["selected_skill"])
 
     def test_chat_interact_file_lookup_fallback_uses_lookup_card(self) -> None:
@@ -4317,6 +4321,8 @@ class CliTests(unittest.TestCase):
         self.assertIn("file or text lookup", response["body"])
         self.assertEqual(response["state"]["lookup_kind"], "file_or_text")
         explanation = response["state"]["workflow_explanation"]
+        self.assertIn("I will answer this as a file or text lookup", explanation["route_recommended_reply"])
+        self.assertNotIn("target is clear", explanation["route_recommended_reply"])
         self.assertIn("file inspection", explanation["not_evidence_yet"])
         self.assertNotIn("review", explanation["not_evidence_yet"])
         self.assertNotIn("choose the right workflow", response["body"])

--- a/tests/test_wrapper_contract.py
+++ b/tests/test_wrapper_contract.py
@@ -1497,6 +1497,8 @@ class WrapperContractTests(unittest.TestCase):
                 self.assertIn("file or text lookup", response["state"]["routing_instruction"])
                 self.assertEqual(response["state"]["lookup_kind"], "file_or_text")
                 explanation = response["state"]["workflow_explanation"]
+                self.assertIn("I will answer this as a file or text lookup", explanation["route_recommended_reply"])
+                self.assertNotIn("target is clear", explanation["route_recommended_reply"])
                 self.assertIn("file inspection", explanation["claim_boundary"])
                 self.assertIn("file inspection", explanation["not_evidence_yet"])
                 self.assertNotIn("review", explanation["not_evidence_yet"])


### PR DESCRIPTION
## Feature Report

### What Changed

- Added a file-lookup-specific route explanation headline, summary, and recommended reply for `answer_file_lookup` routes.
- Locked the copy in router, CLI, and wrapper contract tests so file lookup fallback no longer sounds like an unclear workflow target.

### Why This Exists

- After Korean file lookup routing was fixed, requests such as `README 파일 찾아줘` routed correctly, but `omh chat route --summary` still said it would keep the request in the router until the target was clear.
- That wording is misleading because the target is already clear enough for the next action: answer as a file or text lookup.

### User / Operator Impact

- Hermes-facing route cards now say: `I will answer this as a file or text lookup; no file inspection or workflow execution has started.`
- Operators get a clearer boundary: OMH has routed the request, but has not inspected files, dispatched a workflow, executed code, reviewed, run CI, or merged anything.

### How It Works

- `route_explanation_payload` now passes `next_action` into the route headline builder.
- `answer_file_lookup` receives dedicated headline, summary, and recommended reply copy.
- Existing claim-boundary logic remains unchanged, so the route still reports `file inspection` and `execution` as not observed.

### Files And Contracts Touched

- `src/routing/chat.py`: route explanation copy for `answer_file_lookup`.
- `tests/test_chat_router.py`: public route payload expectations.
- `tests/test_cli.py`: CLI route/interact expectations.
- `tests/test_wrapper_contract.py`: wrapper card state expectations.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests.test_chat_router.ChatRouterTests.test_file_lookup_does_not_dispatch_to_workflow_keyword tests.test_cli.CliTests.test_chat_route_file_lookup_does_not_emit_workflow_clarification tests.test_cli.CliTests.test_chat_interact_file_lookup_fallback_uses_lookup_card tests.test_wrapper_contract.WrapperContractTests.test_file_lookup_fallback_card_uses_lookup_copy -v`
- [x] `PYTHONPATH=tests uv run python -m omh.cli chat route --source discord --summary "README 파일 찾아줘"`
- [x] `PYTHONPATH=tests uv run python -m omh.cli chat interact --source discord --summary "README 파일 찾아줘"`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — 890 tests passed
- [x] `PYTHONPATH=tests uv run python -m compileall -q src tests`
- [x] `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check`
- [x] `PYTHONPATH=tests uv run python -m omh.cli harness validate`
- [x] `PYTHONPATH=tests uv run python -m omh.cli demo grounded-score --summary` — 28/28 scenarios at 10/10
- [x] `PYTHONPATH=tests uv run python -m omh.cli release product-readiness --version 1.0.1` — ready, 100/100, 0 blocking failures, 1 warning (`local_artifact_store: not_checked`)
- [x] `git diff --check`
- [ ] `python3 -m omh.cli release checklist --json` — not run; this PR does not change release checklist contents
- [ ] `python3 -m omh.cli release hermes-smoke` — not run; no live Hermes runtime visibility claim is made
- [ ] `omh --help` — not run; no top-level CLI command shape changed
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` — not run; no setup/install surface changed
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable
- [x] Relevant dry-run or smoke command: the `chat route` and `chat interact` commands above
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; this is deterministic local copy and wrapper-contract behavior, not live Hermes chat rendering evidence

## Risk

- Low. The change only affects human-facing route copy for an existing fallback next action.
- Runtime, executor, file inspection, review, CI, merge, and delivery evidence boundaries remain unchanged.

## Compatibility / Rollout

- Existing JSON schema stays compatible; this only changes field values inside the existing `route_explanation/v1` payload.
- Wrappers that display `recommended_reply`, `headline`, or `summary` will show clearer file lookup copy automatically.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`): local deterministic contract copy only
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- None for this slice.