### PR TITLE
Improve chat routing for missed OMH feedback

### DIFF
--- a/src/routing/policy.py
+++ b/src/routing/policy.py
@@ -722,14 +722,23 @@ _OMH_MISSED_WORKFLOW_PHRASES = (
     "did not use omh",
     "didn't use omh",
     "didnt use omh",
+    "omh was not used",
     "not using omh",
     "without omh",
     "missed omh",
     "skipped omh",
+    "skipped omh for",
+    "hermes skipped omh",
     "forgot omh",
     "not aware of omh",
     "did not know omh",
     "didn't know omh",
+    "omh 안 쓰고",
+    "omh 안 썼",
+    "omh를 안 썼",
+    "omh를 안 써",
+    "omh 기능을 안 썼",
+    "omh 기능 안 썼",
 )
 _MISSED_WORKFLOW_ACTION_PHRASES = (
     "did not use",
@@ -1024,6 +1033,8 @@ _WORKFLOW_LEARNING_PHRASES = (
     "routing went wrong",
     "routing failed",
     "hermes should learn",
+    "why omh was not used",
+    "why did not use omh",
     "이번 실행 학습",
     "이번 워크플로우 학습",
     "다음에 스킬 개선",
@@ -1031,6 +1042,12 @@ _WORKFLOW_LEARNING_PHRASES = (
     "회귀 케이스",
     "omh 안 썼어",
     "omh 안 썼",
+    "omh 기능을 안 썼",
+    "omh 기능 안 썼",
+    "왜 omh를 안 썼",
+    "왜 omh 안 썼",
+    "omh 안 썼는지 학습",
+    "omh를 안 썼는지 학습",
     "워크플로 누락",
     "라우팅 누락",
 )
@@ -1370,6 +1387,13 @@ _MATERIALS_PACKAGE_PHRASES = (
     "package it as a pdf",
     "ppt로 만들",
     "pdf로 만들",
+    "ppt 만들어",
+    "ppt 만들어줘",
+    "피피티 만들",
+    "피피티 만들어",
+    "피피티 만들어줘",
+    "슬라이드 만들",
+    "슬라이드 만들어",
 )
 _MATERIALS_PACKAGE_FORMAT_TOKENS = _normalized_token_set(
     {
@@ -1385,6 +1409,9 @@ _MATERIALS_PACKAGE_FORMAT_TOKENS = _normalized_token_set(
         "hwp",
         "document",
         "피디에프",
+        "피피티",
+        "슬라이드",
+        "덱",
         "엑셀",
         "문서",
         "자료",
@@ -3047,11 +3074,28 @@ def _paper_learning_guard_applies(normalized_query: str, query_tokens: set[str])
             "이해하고 싶",
         ),
     )
+    supplied_pdf_context = (
+        bool({"pdf", "피디에프"} & query_tokens)
+        and not bool({"ppt", "pptx", "deck", "slides", "피피티", "슬라이드", "덱"} & query_tokens)
+        and not _contains_phrase(
+            normalized_query,
+            (
+                "pdf deck",
+                "pdf slide",
+                "pdf slide deck",
+                "pdf report",
+                "pdf를 ppt",
+                "pdf를 ppt로",
+                "pdf to ppt",
+                "pdf into ppt",
+            ),
+        )
+    )
     search_only = bool({"find", "search", "latest", "current", "fresh"} & query_tokens) or _contains_phrase(
         normalized_query,
         ("find papers", "search papers", "latest papers", "current papers", "논문 찾아", "최신 논문"),
     )
-    return paper_context and explanation_context and not search_only
+    return (paper_context or supplied_pdf_context) and explanation_context and not search_only
 
 
 def _paper_validation_or_citation_requested(normalized_query: str, query_tokens: set[str]) -> bool:
@@ -3450,6 +3494,25 @@ def _materials_package_guard_applies(normalized_query: str, query_tokens: set[st
         normalized_query,
         ("make", "turn into", "prepare", "export", "만들", "정리", "준비", "공유"),
     )
+    non_pdf_output_formats = {
+        "ppt",
+        "pptx",
+        "spreadsheet",
+        "excel",
+        "xlsx",
+        "deck",
+        "slides",
+        "docx",
+        "hwp",
+        "document",
+        "피피티",
+        "슬라이드",
+        "덱",
+        "엑셀",
+        "문서",
+    }
+    if action and _MATERIALS_PACKAGE_FORMAT_TOKENS & query_tokens & non_pdf_output_formats:
+        return True
     return format_hits >= 2 and action
 
 

--- a/src/workflows/learning_candidate.py
+++ b/src/workflows/learning_candidate.py
@@ -214,6 +214,9 @@ def build_learning_candidate_card(
     thread_key: str = "",
     executor_runtime: str = "",
 ) -> dict[str, object] | None:
+    if selected_workflow == "workflow-learning" and _is_missed_omh_workflow_feedback(message):
+        return None
+
     signal = detect_learning_signal(message)
     if signal is None:
         return None
@@ -447,6 +450,40 @@ def _candidate_summary(target: str, sanitized: str) -> str:
     if target == "session_only":
         return "Session-only learning signal; do not persist transient task, PR, run, process, branch, or channel state."
     return "Review-first learning signal; cross-channel, conflicting, or underspecified context needs memory curation review before persistence."
+
+
+def _is_missed_omh_workflow_feedback(message: str) -> bool:
+    text = _fold(message)
+    compact = text.replace(" ", "")
+    if not text or "omh" not in text:
+        return False
+    missed_route_phrases = (
+        "did not use omh",
+        "didn't use omh",
+        "didnt use omh",
+        "not use omh",
+        "skipped omh",
+        "omh was not used",
+        "omh was skipped",
+        "why omh was not used",
+        "why did not use omh",
+    )
+    if any(phrase in text for phrase in missed_route_phrases):
+        return True
+    missed_route_compact_phrases = (
+        "omh안썼",
+        "omh안썻",
+        "omh안쓰",
+        "omh를안썼",
+        "omh를안썻",
+        "omh를안쓰",
+        "omh기능을안썼",
+        "omh기능을안썻",
+        "omh기능안썼",
+        "omh기능안썻",
+        "omh누락",
+    )
+    return any(phrase in compact for phrase in missed_route_compact_phrases)
 
 
 def _strip_learning_signal(message: str) -> str:

--- a/tests/test_chat_router.py
+++ b/tests/test_chat_router.py
@@ -617,7 +617,9 @@ class ChatRouterTests(unittest.TestCase):
     def test_paper_learning_routes_paper_explanation_without_stealing_related_lanes(self) -> None:
         explanation_cases = (
             "이 논문 PDF 아주 쉽게 설명해줘",
+            "이 PDF 쉽게 설명해줘",
             "Explain this arXiv paper at expert level without dropping details",
+            "explain this PDF at an easy level",
             "./paper-explainer explain the attached paper at moderate difficulty",
             "Can OMH help me summarize a paper PDF?",
             "Can OMH help with paper summaries?",
@@ -645,6 +647,10 @@ class ChatRouterTests(unittest.TestCase):
         file_export = route_chat_message("PDF를 PPT로 바꿔줘", source="discord")
         self.assertEqual(file_export["selected_skill"], "materials-package")
         self.assertEqual(file_export["selected_harness"], "materials-package")
+
+        short_ppt_export = route_chat_message("PPT 만들어줘", source="discord")
+        self.assertEqual(short_ppt_export["selected_skill"], "materials-package")
+        self.assertEqual(short_ppt_export["selected_harness"], "materials-package")
 
         mixed_export_cases = (
             "explain this paper and make a PPT",
@@ -708,6 +714,8 @@ class ChatRouterTests(unittest.TestCase):
     def test_explicit_workflow_learning_feedback_wins_over_domain_terms(self) -> None:
         cases = (
             "Hermes did not use OMH for my image request; record this as workflow learning",
+            "프리렌이 OMH 기능을 안 썼어",
+            "이번 요청에서 왜 OMH를 안 썼는지 학습해줘",
             "이미지 생성 요청에서 OMH 안 썼어. workflow-learning으로 기록해줘",
             "OMH 안 썼어",
             "missed route: Hermes skipped OMH for my image request",
@@ -723,6 +731,23 @@ class ChatRouterTests(unittest.TestCase):
                 self.assertEqual(decision["selected_harness"], "workflow-learning")
                 self.assertEqual(decision["confidence"], "high")
                 self.assertIn("guard:workflow_learning", decision["recommendations"][0]["matched"])
+
+    def test_missed_omh_feedback_recovers_to_domain_workflow_when_not_learning_request(self) -> None:
+        cases = (
+            ("Hermes가 OMH 안 쓰고 그냥 이미지 만들었어", "img-summary", "img-summary"),
+            ("이미지 생성 요청을 했는데 OMH를 안 썼어", "img-summary", "img-summary"),
+            ("리서치 요청했는데 OMH를 안 썼어", "web-research", "research"),
+            ("회의록 요약을 부탁했는데 OMH 안 쓰고 일반 답변했어", "operating-rhythm", "operating-rhythm"),
+        )
+
+        for message, skill, harness in cases:
+            with self.subTest(message=message):
+                decision = route_chat_message(message, source="discord")
+
+                self.assertEqual(decision["action"], "dispatch")
+                self.assertEqual(decision["selected_skill"], skill)
+                self.assertEqual(decision["selected_harness"], harness)
+                self.assertEqual(decision["confidence"], "high")
 
     def test_runtime_portability_task_card_sits_above_workflow_route(self) -> None:
         message = (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -284,6 +284,7 @@ class CliTests(unittest.TestCase):
         for message in (
             "missed route: OMH was not used",
             "OMH 안 썼어",
+            "이번 요청에서 왜 OMH를 안 썼는지 학습해줘",
             "missed route: Hermes skipped OMH for my image request",
             "Hermes did not use OMH for my image request; record this as workflow learning",
             "이미지 생성 요청에서 OMH 안 썼어. workflow-learning으로 기록해줘",
@@ -4485,6 +4486,7 @@ class CliTests(unittest.TestCase):
             ("지금은 Hermes가 답할 차례인지, coding handoff를 준비할 차례인지, review gate를 열 차례인지 정리해줘", "plan", "plan", "present_plan"),
             ("고객사 프로젝트별 요구사항 정리, 조사, 구현 handoff, QA, 리뷰, 릴리즈 보고 운영 템플릿이 필요해", "plan", "plan", "present_plan"),
             ("논문 PDF 이해하고 싶어", "paper-learning", "paper_learning", "prepare_paper_learning"),
+            ("이 PDF 쉽게 설명해줘", "paper-learning", "paper_learning", "prepare_paper_learning"),
             ("결제 실패 피드백을 모아서 회의 주제와 다음 전략을 정리해줘", "feedback-triage", "feedback_triage", "triage_feedback"),
             ("prepare weekly ops review from customer feedback and release risks", "ops-review", "ops_review", "prepare_ops_review"),
             ("we need a competitor market scan and strategy memo for next week's leadership meeting", "strategy-brief", "strategy_brief", "prepare_strategy_brief"),
@@ -4498,6 +4500,7 @@ class CliTests(unittest.TestCase):
             ("리서치 요청했는데 OMH를 안 썼어", "web-research", "web_research", "run_hermes_research"),
             ("회의록 요약을 부탁했는데 OMH 안 쓰고 일반 답변했어", "operating-rhythm", "operating_rhythm", "prepare_operating_record"),
             ("Hermes가 기억하고 있는 프로젝트 맥락이 오래된 것 같아 정리해줘", "memory-curation-review", "memory_curation", "prepare_memory_curation_review"),
+            ("PPT 만들어줘", "materials-package", "materials_package", "prepare_material_package"),
             ("첨부한 엑셀을 월간 보고서 PDF랑 PPT로 만들 수 있게 정리해줘", "materials-package", "materials_package", "prepare_material_package"),
             ("Codex 작업이 어디까지 진행됐는지 알려줘", "ultraprocess", "handoff", "send_to_executor"),
             ("今何してる？", "agent-ops-review", "agent_ops_review", "show_agent_ops_review"),


### PR DESCRIPTION
## Feature Report

### What Changed

This PR tightens OMH's chat-first routing for short, real operator messages that came up during manual Hermes/Discord use:

- Missed OMH feedback now separates domain recovery from workflow learning.
- Generic feedback such as "프리렌이 OMH 기능을 안 썼어" routes to `workflow-learning`.
- Domain-specific missed feedback still recovers to the intended workflow, such as `img-summary`, `web-research`, or `operating-rhythm`.
- Supplied PDF explanation requests such as "이 PDF 쉽게 설명해줘" route to `paper-learning`.
- Short presentation requests such as "PPT 만들어줘" route to `materials-package`.

### Why This Exists

The current router was mostly correct for explicit workflow names, but it still had rough edges for how users actually talk to Hermes in chat. In particular, a message asking OMH to learn why it was not used could be interpreted as memory curation because the learning-candidate card treated broad "learn this" language as a durable memory review.

That is the wrong user experience: missed OMH usage is workflow/process feedback, not a user preference to save in memory.

### User / Operator Impact

After this change, Hermes can respond more naturally when an operator says things like:

- "이미지 생성 요청을 했는데 OMH를 안 썼어" -> recover with `img-summary` when the intended domain is obvious.
- "이번 요청에서 왜 OMH를 안 썼는지 학습해줘" -> prepare `workflow-learning` missed-route feedback.
- "이 PDF 쉽게 설명해줘" -> prepare `paper-learning` instead of a file export package.
- "PPT 만들어줘" -> prepare `materials-package` without requiring a longer export phrase.

The result is less "why did it choose that?" friction in chat surfaces while keeping all actions prepared-only until a wrapper records observed evidence.

### How It Works

- `src/routing/policy.py` expands missed-OMH, workflow-learning, paper-learning, and material-package phrase guards.
- `src/workflows/learning_candidate.py` skips memory-candidate card creation when the selected workflow is `workflow-learning` and the message is missed-OMH workflow feedback.
- Router tests lock the distinction between domain recovery and explicit workflow-learning feedback.
- CLI tests lock the grounded operator examples and the new missed-route learning phrase.

### Files And Contracts Touched

- `src/routing/policy.py`
- `src/workflows/learning_candidate.py`
- `tests/test_chat_router.py`
- `tests/test_cli.py`

No schema, network, Hermes core, Discord/Slack/Telegram transport, or executor runtime behavior changed.

## Validation

Observed locally:

```sh
PYTHONPATH=tests uv run python -m unittest tests/test_chat_router.py tests/test_cli.py tests/test_wrapper_contract.py tests/test_workflow_learning.py -v
PYTHONPATH=tests uv run python -m unittest discover -s tests -v
PYTHONPATH=tests uv run python -m compileall -q src tests
PYTHONPATH=tests uv run python -m omh.cli docs workflows --check
PYTHONPATH=tests uv run python -m omh.cli harness validate
PYTHONPATH=tests uv run python -m omh.cli demo grounded-score
git diff --check
```

Results:

- Targeted router/CLI/wrapper/workflow-learning tests: 384 tests OK.
- Full unittest suite: 892 tests OK.
- Compile check: OK.
- Docs workflow sync check: OK, 48/48 tap skills current.
- Harness validation: OK, 36 harnesses and 50 skills valid.
- Grounded-score demo: 28 scenarios, all 10/10.
- Diff whitespace check: OK.

## Risk

Low. This is a phrase-guard and classification fix with regression coverage. The main risk is future phrase drift between missed-route detection in routing and wrapper rendering. The new tests cover the currently observed Korean and English cases.

## Compatibility / Rollout

Backward compatible. Existing memory learning behavior remains intact for durable preferences such as "다음부터 짧게 한국어로 답해줘". Domain-specific missed OMH feedback still routes to the domain workflow unless the user explicitly asks for workflow learning.

## Release / Claims

This PR improves deterministic local routing and wrapper contracts. It does not claim live Hermes chat execution, image generation, PDF extraction, file export, memory mutation, executor dispatch, review, CI, or merge evidence.

## Follow-Up

A later pass can centralize missed-route phrase detection between routing, learning-candidate, and wrapper rendering to reduce duplicate phrase lists.
