### PR TITLE
Centralize missed route detection

### DIFF
--- a/src/routing/missed_route.py
+++ b/src/routing/missed_route.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from .localization import normalized_phrase
+
+
+OMH_MISSED_WORKFLOW_PHRASES = (
+    "did not use omh",
+    "didn't use omh",
+    "didnt use omh",
+    "omh was not used",
+    "not using omh",
+    "not use omh",
+    "without omh",
+    "missed omh",
+    "skipped omh",
+    "skipped omh for",
+    "hermes skipped omh",
+    "forgot omh",
+    "not aware of omh",
+    "did not know omh",
+    "didn't know omh",
+    "why omh was not used",
+    "why did not use omh",
+    "omh 안 쓰고",
+    "omh 안 썼",
+    "omh를 안 썼",
+    "omh를 안 써",
+    "omh 기능을 안 썼",
+    "omh 기능 안 썼",
+)
+MISSED_WORKFLOW_ACTION_PHRASES = (
+    "did not use",
+    "didn't use",
+    "didnt use",
+    "does not use",
+    "doesn't use",
+    "doesnt use",
+    "not using",
+    "not use",
+    "without",
+    "missed",
+    "skipped",
+    "forgot",
+    "not aware",
+    "did not know",
+    "didn't know",
+    "does not know",
+    "몰랐",
+    "모르",
+    "안 썼",
+    "안 써",
+    "안쓰",
+    "안 쓰",
+    "놓쳤",
+    "빠졌",
+)
+MISSED_ROUTE_FEEDBACK_PHRASES = (
+    "missed route",
+    "missed workflow",
+    "missing route",
+    "wrong route",
+    "wrong workflow",
+    "did not use omh",
+    "didn't use omh",
+    "didnt use omh",
+    "not use omh",
+    "skipped omh",
+    "omh was not used",
+    "omh was skipped",
+    "expected omh",
+    "expected workflow",
+    "why omh was not used",
+    "why did not use omh",
+)
+MISSED_ROUTE_COMPACT_PHRASES = (
+    "omh안썼",
+    "omh안썻",
+    "omh안썼어",
+    "omh안썻어",
+    "omh안쓰",
+    "omh를안썼",
+    "omh를안썻",
+    "omh를안쓰",
+    "omh기능을안썼",
+    "omh기능을안썻",
+    "omh기능안썼",
+    "omh기능안썻",
+    "omh기능안쓰",
+    "omh안씀",
+    "omh누락",
+    "워크플로누락",
+    "라우팅누락",
+    "잘못라우팅",
+)
+
+
+def has_missed_omh_workflow_context(message: str) -> bool:
+    normalized = normalized_phrase(message)
+    if _contains_phrase(normalized, OMH_MISSED_WORKFLOW_PHRASES):
+        return True
+    return ("omh" in normalized or "oh-my-hermes" in normalized) and _contains_phrase(
+        normalized,
+        MISSED_WORKFLOW_ACTION_PHRASES,
+    )
+
+
+def is_missed_route_feedback(message: str) -> bool:
+    normalized = normalized_phrase(message)
+    if not normalized:
+        return False
+    if _contains_phrase(normalized, MISSED_ROUTE_FEEDBACK_PHRASES):
+        return True
+    return _contains_compact_phrase(normalized, MISSED_ROUTE_COMPACT_PHRASES)
+
+
+def is_missed_omh_workflow_feedback(message: str) -> bool:
+    normalized = normalized_phrase(message)
+    if not normalized or "omh" not in normalized:
+        return False
+    return is_missed_route_feedback(normalized)
+
+
+def _contains_phrase(text: str, phrases: tuple[str, ...]) -> bool:
+    return any(normalized_phrase(phrase) in text for phrase in phrases)
+
+
+def _contains_compact_phrase(text: str, phrases: tuple[str, ...]) -> bool:
+    compact = text.replace(" ", "")
+    return any(normalized_phrase(phrase).replace(" ", "") in compact for phrase in phrases)

--- a/src/routing/policy.py
+++ b/src/routing/policy.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 
 from .intent import classify_omh_quality_intent
 from .localization import normalized_phrase, routing_tokens
+from .missed_route import has_missed_omh_workflow_context
 
 
 ROUTE_ACTIONS = ("dispatch", "clarify", "fallback")
@@ -717,52 +718,6 @@ _VISUAL_SUMMARY_PHRASES = (
     "發布說明圖",
     "总结海报",
     "摘要海报",
-)
-_OMH_MISSED_WORKFLOW_PHRASES = (
-    "did not use omh",
-    "didn't use omh",
-    "didnt use omh",
-    "omh was not used",
-    "not using omh",
-    "without omh",
-    "missed omh",
-    "skipped omh",
-    "skipped omh for",
-    "hermes skipped omh",
-    "forgot omh",
-    "not aware of omh",
-    "did not know omh",
-    "didn't know omh",
-    "omh 안 쓰고",
-    "omh 안 썼",
-    "omh를 안 썼",
-    "omh를 안 써",
-    "omh 기능을 안 썼",
-    "omh 기능 안 썼",
-)
-_MISSED_WORKFLOW_ACTION_PHRASES = (
-    "did not use",
-    "didn't use",
-    "didnt use",
-    "does not use",
-    "doesn't use",
-    "doesnt use",
-    "not using",
-    "missed",
-    "skipped",
-    "forgot",
-    "not aware",
-    "did not know",
-    "didn't know",
-    "does not know",
-    "몰랐",
-    "모르",
-    "안 썼",
-    "안 써",
-    "안쓰",
-    "안 쓰",
-    "놓쳤",
-    "빠졌",
 )
 _MISSED_WORKFLOW_RESEARCH_TOKENS = _normalized_token_set(
     {
@@ -3969,11 +3924,7 @@ def _is_short_visual_summary_request(normalized_query: str) -> bool:
 
 
 def _missed_omh_workflow_context_applies(normalized_query: str) -> bool:
-    if _contains_phrase(normalized_query, _OMH_MISSED_WORKFLOW_PHRASES):
-        return True
-    return ("omh" in normalized_query or "oh-my-hermes" in normalized_query) and _contains_phrase(
-        normalized_query, _MISSED_WORKFLOW_ACTION_PHRASES
-    )
+    return has_missed_omh_workflow_context(normalized_query)
 
 
 def _deliverable_package_guard_applies(normalized_query: str, query_tokens: set[str]) -> bool:

--- a/src/workflows/learning_candidate.py
+++ b/src/workflows/learning_candidate.py
@@ -4,6 +4,8 @@ import hashlib
 import re
 from typing import Any, Iterable
 
+from ..routing.missed_route import is_missed_omh_workflow_feedback
+
 
 LEARNING_CANDIDATE_CARD_SCHEMA_VERSION = "learning_candidate_card/v1"
 LEARNING_CANDIDATE_SCOPE_SCHEMA_VERSION = "learning_candidate_scope/v1"
@@ -214,7 +216,7 @@ def build_learning_candidate_card(
     thread_key: str = "",
     executor_runtime: str = "",
 ) -> dict[str, object] | None:
-    if selected_workflow == "workflow-learning" and _is_missed_omh_workflow_feedback(message):
+    if selected_workflow == "workflow-learning" and is_missed_omh_workflow_feedback(message):
         return None
 
     signal = detect_learning_signal(message)
@@ -450,40 +452,6 @@ def _candidate_summary(target: str, sanitized: str) -> str:
     if target == "session_only":
         return "Session-only learning signal; do not persist transient task, PR, run, process, branch, or channel state."
     return "Review-first learning signal; cross-channel, conflicting, or underspecified context needs memory curation review before persistence."
-
-
-def _is_missed_omh_workflow_feedback(message: str) -> bool:
-    text = _fold(message)
-    compact = text.replace(" ", "")
-    if not text or "omh" not in text:
-        return False
-    missed_route_phrases = (
-        "did not use omh",
-        "didn't use omh",
-        "didnt use omh",
-        "not use omh",
-        "skipped omh",
-        "omh was not used",
-        "omh was skipped",
-        "why omh was not used",
-        "why did not use omh",
-    )
-    if any(phrase in text for phrase in missed_route_phrases):
-        return True
-    missed_route_compact_phrases = (
-        "omh안썼",
-        "omh안썻",
-        "omh안쓰",
-        "omh를안썼",
-        "omh를안썻",
-        "omh를안쓰",
-        "omh기능을안썼",
-        "omh기능을안썻",
-        "omh기능안썼",
-        "omh기능안썻",
-        "omh누락",
-    )
-    return any(phrase in compact for phrase in missed_route_compact_phrases)
 
 
 def _strip_learning_signal(message: str) -> str:

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -7,6 +7,7 @@ from ..context_safety import compact_progress_events
 from ..ingress import CHAT_SOURCES, compact_source_metadata, extract_message_text, extract_source_metadata
 from ..routing.catalog_questions import is_skill_catalog_question as _is_skill_catalog_question
 from ..routing.chat import public_route_payload, route_chat_message, route_explanation_payload
+from ..routing.missed_route import is_missed_route_feedback
 from ..coding_delegation import CODING_EXECUTOR_TARGETS, build_coding_delegation_payload
 from ..capabilities.families import capability_family_cards
 from ..context import build_context_brief
@@ -3587,47 +3588,7 @@ def _selected_recommendation_policy(decision: dict[str, object], selected: str) 
 
 
 def _is_missed_route_feedback(message: str) -> bool:
-    text = " ".join(message.lower().split())
-    compact = text.replace(" ", "")
-    if not text:
-        return False
-    missed_route_phrases = (
-        "missed route",
-        "missed workflow",
-        "missing route",
-        "wrong route",
-        "wrong workflow",
-        "did not use omh",
-        "didn't use omh",
-        "didnt use omh",
-        "not use omh",
-        "skipped omh",
-        "omh was not used",
-        "omh was skipped",
-        "expected omh",
-        "expected workflow",
-    )
-    if any(phrase in text for phrase in missed_route_phrases):
-        return True
-    missed_route_compact_phrases = (
-        "omh안썼",
-        "omh안썻",
-        "omh안썼어",
-        "omh안썻어",
-        "omh안쓰",
-        "omh를안썼",
-        "omh를안썻",
-        "omh를안쓰",
-        "omh기능안썼",
-        "omh기능안썻",
-        "omh기능안쓰",
-        "omh안씀",
-        "omh누락",
-        "워크플로누락",
-        "라우팅누락",
-        "잘못라우팅",
-    )
-    return any(phrase in compact for phrase in missed_route_compact_phrases)
+    return is_missed_route_feedback(message)
 
 
 def _workflow_explanation_reason_for_route(

--- a/tests/test_missed_route_detection.py
+++ b/tests/test_missed_route_detection.py
@@ -1,0 +1,41 @@
+import unittest
+
+from omh.routing.missed_route import (
+    has_missed_omh_workflow_context,
+    is_missed_omh_workflow_feedback,
+    is_missed_route_feedback,
+)
+
+
+class MissedRouteDetectionTests(unittest.TestCase):
+    def test_missed_omh_context_covers_domain_recovery_phrasing(self) -> None:
+        cases = (
+            "이미지 생성 요청을 했는데 OMH를 안 썼어",
+            "회의록 요약을 부탁했는데 OMH 안 쓰고 일반 답변했어",
+            "Hermes skipped OMH for my image request",
+            "Hermes was not aware of OMH for the research request",
+        )
+
+        for message in cases:
+            with self.subTest(message=message):
+                self.assertTrue(has_missed_omh_workflow_context(message))
+
+    def test_missed_route_feedback_covers_wrapper_primary_action_phrasing(self) -> None:
+        cases = (
+            "missed route: OMH was not used",
+            "wrong workflow, expected OMH",
+            "이번 요청에서 왜 OMH를 안 썼는지 학습해줘",
+            "라우팅 누락 기록해줘",
+        )
+
+        for message in cases:
+            with self.subTest(message=message):
+                self.assertTrue(is_missed_route_feedback(message))
+
+    def test_missed_omh_workflow_feedback_requires_omh_context(self) -> None:
+        self.assertTrue(is_missed_omh_workflow_feedback("프리렌이 OMH 기능을 안 썼어"))
+        self.assertFalse(is_missed_omh_workflow_feedback("wrong workflow, expected feedback triage"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- Added one shared missed-route detector for OMH-aware routing feedback.
- Reused that detector from routing policy, workflow-learning candidate filtering, and wrapper primary-action selection.
- Added direct regressions for English and Korean phrases such as `OMH를 안 썼어`, `라우팅 누락`, and `wrong workflow, expected OMH`.

### Why This Exists

Missed-route feedback was previously recognized in three places with separate phrase lists. That made the product fragile: Hermes could route the same user correction correctly in one layer while the wrapper still chose the wrong action, or workflow-learning could create a memory-style candidate instead of the missed-route repair path.

This PR keeps the behavior chat-first and deterministic while removing that drift point.

### User / Operator Impact

- When a user says Hermes did not use OMH for an image, research, meeting, or similar request, OMH can recover to the right domain workflow consistently.
- When the user explicitly asks why OMH was not used or asks to record a missed route, the wrapper now exposes the missed-route action consistently.
- Future phrase additions have one obvious home instead of being copied through policy, wrapper, and learning code.

### How It Works

- `omh.routing.missed_route` owns the shared phrase sets and normalized matching helpers.
- `routing.policy` delegates missed-OMH context checks to `has_missed_omh_workflow_context`.
- `workflows.learning_candidate` delegates workflow-learning skip logic to `is_missed_omh_workflow_feedback`.
- `wrapper.contract` delegates the primary missed-route action decision to `is_missed_route_feedback`.
- Korean compact phrases are normalized on both sides before space removal so decomposed/normalized Hangul continues to match.

### Files And Contracts Touched

- `src/routing/missed_route.py`
- `src/routing/policy.py`
- `src/workflows/learning_candidate.py`
- `src/wrapper/contract.py`
- `tests/test_missed_route_detection.py`

No schema version, runtime artifact, docs, site, plugin bundle, or network behavior changed.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_missed_route_detection.py tests/test_chat_router.py tests/test_cli.py tests/test_wrapper_contract.py -v` — 367 tests passed.
- [x] Manual deterministic sample route check for image, research, meeting, and workflow-learning missed-route messages passed.
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — 895 tests passed.
- [x] `PYTHONPATH=tests uv run python -m compileall -q src tests`
- [x] `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check`
- [x] `PYTHONPATH=tests uv run python -m omh.cli harness validate`
- [x] `PYTHONPATH=tests uv run python -m omh.cli demo grounded-score` — 28 scenarios, all 10/10.
- [x] `git diff --check`
- [ ] `python3 -m omh.cli release checklist --json` — not run; no release checklist or channel claim changed.
- [ ] `python3 -m omh.cli release hermes-smoke` — not run; no live Hermes registration/runtime surface changed.
- [ ] `omh --help` — not run; no CLI help surface changed.
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` — not run; install path unchanged.
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: covered by `test_explicit_workflow_learning_feedback_wins_over_domain_terms`, `test_chat_interact_routes_workflow_learning_to_audit_actions`, and the new detector regressions.
- [ ] Relevant dry-run or smoke command: deterministic sample route script listed above.
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; this is deterministic local routing/wrapper contract refactor only.

## Risk

- Narrow risk: shared matching changes could over-match missed-route feedback. Existing router, wrapper, and grounded-score coverage passed, and the new detector test keeps non-OMH workflow feedback from becoming OMH-specific missed-route feedback.
- The plugin bundle awareness copy remains intentionally separate in this PR because it is a standalone install payload boundary.

## Compatibility / Rollout

- Backward compatible for existing chat route, wrapper, and workflow-learning contracts.
- No new dependency, network call, Hermes core patch, or runtime execution claim.
- Operators only see more consistent recovery behavior for missed OMH usage feedback.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`): no release-channel behavior changed.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed: no runtime/native claims added.
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap: live Hermes smoke was not run because no live Hermes surface changed.

## Follow-Up

- Add future missed-route phrases in `omh.routing.missed_route` first.
- If plugin-bundle awareness needs the same phrase expansion later, update it as a separate plugin payload change so installed bundle boundaries stay explicit.
