### PR TITLE
Cache static routing phrase normalization

### DIFF
--- a/src/routing/localization.py
+++ b/src/routing/localization.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from functools import lru_cache
 import re
 import unicodedata
 
@@ -555,12 +556,20 @@ def prepare_routing_text(value: str) -> RoutingText:
     folded = _fold_for_match(original)
     additions: list[str] = []
     matches: list[str] = []
-    for alias in _ALIASES:
-        if any(_fold_for_match(phrase) in folded for phrase in alias.phrases):
+    for alias, folded_phrases in _folded_alias_phrases():
+        if any(phrase in folded for phrase in folded_phrases):
             additions.append(alias.canonical)
             matches.append(f"{alias.locale}:{alias.label}")
     scoring_text = " ".join((original, *additions)).strip()
     return RoutingText(original=original, scoring_text=scoring_text, locale_matches=tuple(sorted(set(matches))))
+
+
+@lru_cache(maxsize=1)
+def _folded_alias_phrases() -> tuple[tuple[LocaleAlias, tuple[str, ...]], ...]:
+    folded_aliases: list[tuple[LocaleAlias, tuple[str, ...]]] = []
+    for alias in _ALIASES:
+        folded_aliases.append((alias, tuple(_fold_for_match(phrase) for phrase in alias.phrases)))
+    return tuple(folded_aliases)
 
 
 def routing_tokens(value: str, *, stopwords: set[str] | None = None) -> set[str]:

--- a/src/routing/missed_route.py
+++ b/src/routing/missed_route.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from functools import lru_cache
+
 from .localization import normalized_phrase
 
 
@@ -121,9 +123,24 @@ def is_missed_omh_workflow_feedback(message: str) -> bool:
 
 
 def _contains_phrase(text: str, phrases: tuple[str, ...]) -> bool:
-    return any(normalized_phrase(phrase) in text for phrase in phrases)
+    return any(phrase in text for phrase in _normalized_phrases(phrases))
 
 
 def _contains_compact_phrase(text: str, phrases: tuple[str, ...]) -> bool:
     compact = text.replace(" ", "")
-    return any(normalized_phrase(phrase).replace(" ", "") in compact for phrase in phrases)
+    return any(phrase in compact for phrase in _normalized_compact_phrases(phrases))
+
+
+@lru_cache(maxsize=16)
+def _normalized_phrases(phrases: tuple[str, ...]) -> tuple[str, ...]:
+    normalized_phrases: list[str] = []
+    for phrase in phrases:
+        normalized = normalized_phrase(phrase)
+        if normalized:
+            normalized_phrases.append(normalized)
+    return tuple(normalized_phrases)
+
+
+@lru_cache(maxsize=16)
+def _normalized_compact_phrases(phrases: tuple[str, ...]) -> tuple[str, ...]:
+    return tuple(phrase.replace(" ", "") for phrase in _normalized_phrases(phrases))

--- a/src/routing/policy.py
+++ b/src/routing/policy.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from functools import lru_cache
 
 from .intent import classify_omh_quality_intent
 from .localization import normalized_phrase, routing_tokens
@@ -3993,4 +3994,14 @@ def _explicit_delivery_or_implementation_requested(normalized_query: str, query_
 
 
 def _contains_phrase(normalized_query: str, phrases: tuple[str, ...] | frozenset[str]) -> bool:
-    return any(normalized_phrase(phrase) in normalized_query for phrase in phrases)
+    return any(phrase in normalized_query for phrase in _normalized_phrase_options(phrases))
+
+
+@lru_cache(maxsize=512)
+def _normalized_phrase_options(phrases: tuple[str, ...] | frozenset[str]) -> tuple[str, ...]:
+    normalized_phrases: list[str] = []
+    for phrase in phrases:
+        normalized = normalized_phrase(phrase)
+        if normalized:
+            normalized_phrases.append(normalized)
+    return tuple(normalized_phrases)


### PR DESCRIPTION
## Feature Report

### What Changed

- Cached normalized routing guard phrase options in `src/routing/policy.py`.
- Cached normalized missed-route phrase options and compact Korean variants in `src/routing/missed_route.py`.
- Cached folded multilingual locale alias phrases in `src/routing/localization.py`.

### Why This Exists

Profiling representative chat and wrapper interactions showed route latency was dominated by repeatedly normalizing the same static phrase constants. The router was doing the right work, but doing the same Unicode/case folding for fixed guard strings again and again on every chat request.

This PR keeps routing decisions unchanged while reducing that repeated work.

### User / Operator Impact

- Hermes chat surfaces get faster OMH route and wrapper payload generation.
- Multilingual routing and missed-route recovery keep the same behavior, but with less repeated normalization overhead.
- Raw user messages are not cached globally; only static code-owned phrase lists are cached.

### How It Works

- `policy._contains_phrase` now reads from a bounded cache keyed by static tuple/frozenset phrase collections.
- `missed_route` caches its fixed phrase lists and compact Korean variants separately.
- `localization.prepare_routing_text` pre-folds locale alias phrases once per process.
- The public `normalized_phrase()` function remains uncached so arbitrary user messages are not retained in a global normalization cache.

### Files And Contracts Touched

- `src/routing/policy.py`
- `src/routing/missed_route.py`
- `src/routing/localization.py`

No CLI schema, runtime artifact, workflow catalog, docs/site content, plugin bundle, or network/runtime behavior changed.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_chat_router.py tests/test_cli.py tests/test_wrapper_contract.py tests/test_missed_route_detection.py -v` — 367 tests passed.
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — 895 tests passed.
- [x] `PYTHONPATH=tests uv run python -m compileall -q src tests`
- [x] `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check`
- [x] `PYTHONPATH=tests uv run python -m omh.cli harness validate`
- [x] `PYTHONPATH=tests uv run python -m omh.cli demo grounded-score --summary` — 28/28 scenarios at 10/10.
- [x] `git diff --check`
- [x] Representative route/wrapper benchmark script:
  - Before this branch: route 320 samples in 1.8849s (5.890ms each), wrapper 320 samples in 2.7066s (8.458ms each).
  - After this branch: route 320 samples in 0.3587s (1.121ms each), wrapper 320 samples in 0.4842s (1.513ms each).
- [ ] `python3 -m omh.cli release checklist --json` — not run; no release checklist or release-channel claim changed.
- [ ] `python3 -m omh.cli release hermes-smoke` — not run; no live Hermes setup/runtime surface changed.
- [ ] `omh --help` — not run; no CLI help surface changed.
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` — not run; install flow unchanged.
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable; no learning contract changed.
- [ ] Relevant dry-run or smoke command: deterministic benchmark and grounded-score commands listed above.
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; this is deterministic local router/wrapper hot-path optimization only.

## Risk

- Narrow risk: stale cache if static phrase lists were mutated in place at runtime. OMH treats these phrase collections as constants, and no runtime mutation path exists.
- Privacy risk was avoided by not caching arbitrary normalized user messages.

## Compatibility / Rollout

- Backward compatible; routing output remains covered by existing route, wrapper, CLI, and grounded-score tests.
- No dependency, network call, Hermes core patch, or runtime execution claim.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`): no channel semantics changed.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed: no runtime/native claims added.
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap: live Hermes smoke was not run because no live Hermes surface changed.

## Follow-Up

- If future routing hot spots remain, prefer static-data caches or precomputed catalog projections over global raw-message caches.
