### PR TITLE
Cache intent and capability routing projections

### DIFF
--- a/src/capabilities/registry.py
+++ b/src/capabilities/registry.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
+from functools import lru_cache
 
 from .agents import agent_role_capabilities
 from .families import capability_family_projection
@@ -66,6 +67,11 @@ LANE_PLAYBOOK_IDS = {
 
 
 def capability_snapshot() -> dict[str, object]:
+    return deepcopy(_capability_snapshot_template())
+
+
+@lru_cache(maxsize=1)
+def _capability_snapshot_template() -> dict[str, object]:
     agent_roles = agent_role_capabilities()
     skills = skill_capabilities()
     hooks = hook_manifest()
@@ -75,7 +81,7 @@ def capability_snapshot() -> dict[str, object]:
     tools = tool_requirements_manifest()
     awareness = awareness_primer_payload()
     families = capability_family_projection()
-    snapshot = {
+    return {
         "schema_version": CAPABILITY_MANIFEST_SCHEMA_VERSION,
         "manifest_id": "omh_capabilities",
         "determinism": "static_projection_no_runtime_clock",
@@ -110,11 +116,15 @@ def capability_snapshot() -> dict[str, object]:
             "no runtime_topology schema in this PR",
         ],
     }
-    return deepcopy(snapshot)
 
 
 def capability_summary() -> dict[str, object]:
-    snapshot = capability_snapshot()
+    return deepcopy(_capability_summary_template())
+
+
+@lru_cache(maxsize=1)
+def _capability_summary_template() -> dict[str, object]:
+    snapshot = _capability_snapshot_template()
     awareness = snapshot["omh_awareness"]
     skills = {str(item.get("id")): item for item in snapshot["skills"] if isinstance(item, dict)}
     playbooks = {str(item.get("id")): item for item in snapshot["playbooks"] if isinstance(item, dict)}

--- a/src/routing/intent.py
+++ b/src/routing/intent.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass
+from functools import lru_cache
 import re
 
 from .localization import normalized_phrase, routing_tokens
@@ -517,11 +518,8 @@ def _matched_omh_system_target_cues(normalized: str) -> tuple[str, ...]:
 
 def _matched_omh_quality_cues(cues: tuple[str, ...], normalized: str, compact: str) -> tuple[str, ...]:
     matches: list[str] = []
-    for cue in cues:
-        normalized_cue = normalized_phrase(cue)
-        if not normalized_cue:
-            continue
-        if _contains_non_ascii(normalized_cue):
+    for cue, normalized_cue, contains_non_ascii in _normalized_quality_cues(cues):
+        if contains_non_ascii:
             if normalized_cue in normalized or normalized_cue.replace(" ", "") in compact:
                 matches.append(cue)
             continue
@@ -554,8 +552,7 @@ def has_missing_requirements_signal(message: str) -> bool:
 
 def _mentioned_workflows(normalized: str, tokens: set[str]) -> tuple[str, ...]:
     mentioned: list[str] = []
-    for workflow in WORKFLOW_VOCABULARY:
-        normalized_workflow = normalized_phrase(workflow)
+    for workflow, normalized_workflow in _normalized_workflow_vocabulary():
         if normalized_workflow in tokens or normalized_workflow in normalized:
             mentioned.append(workflow)
     return tuple(mentioned)
@@ -563,8 +560,7 @@ def _mentioned_workflows(normalized: str, tokens: set[str]) -> tuple[str, ...]:
 
 def _mentioned_runtime_terms(normalized: str) -> tuple[str, ...]:
     mentioned: list[str] = []
-    for term, label in RUNTIME_VOCABULARY.items():
-        normalized_term = normalized_phrase(term)
+    for _term, label, normalized_term in _normalized_runtime_vocabulary():
         if normalized_term and normalized_term in normalized and label not in mentioned:
             mentioned.append(label)
     return tuple(mentioned)
@@ -598,8 +594,7 @@ def _quoted_known_term_reference(message: str) -> bool:
     quoted_chunks = re.findall(r"[`\"']([^`\"']+)[`\"']", normalized)
     if not quoted_chunks:
         return False
-    known_terms = tuple(normalized_phrase(term) for term in (*WORKFLOW_VOCABULARY, *RUNTIME_VOCABULARY))
-    return any(any(term and term in chunk for term in known_terms) for chunk in quoted_chunks)
+    return any(any(term in chunk for term in _normalized_known_terms()) for chunk in quoted_chunks)
 
 
 def _structural_reference_context(
@@ -625,26 +620,20 @@ def _structural_negated_execution_cues(normalized: str) -> tuple[str, ...]:
 def _symbolic_negated_execution(normalized: str) -> bool:
     if "!=" not in normalized and "≠" not in normalized:
         return False
-    return any(normalized_phrase(cue) in normalized for cue in _EXECUTION_CUES)
+    return any(normalized_cue in normalized for _cue, normalized_cue in _normalized_cues(_EXECUTION_CUES))
 
 
 def _matched_cues(cues: tuple[str, ...], normalized: str, compact: str) -> tuple[str, ...]:
     matches: list[str] = []
-    for cue in cues:
-        normalized_cue = normalized_phrase(cue)
-        if not normalized_cue:
-            continue
+    for cue, normalized_cue in _normalized_cues(cues):
         if normalized_cue in normalized or normalized_cue.replace(" ", "") in compact:
             matches.append(cue)
     return tuple(matches)
 
 
 def _diagnostic_status_context(normalized: str, compact: str) -> bool:
-    for marker in _DIAGNOSTIC_STATUS_MARKERS:
-        normalized_marker = normalized_phrase(marker)
-        if normalized_marker and (
-            normalized_marker in normalized or normalized_marker.replace(" ", "") in compact
-        ):
+    for _marker, normalized_marker in _normalized_cues(_DIAGNOSTIC_STATUS_MARKERS):
+        if normalized_marker in normalized or normalized_marker.replace(" ", "") in compact:
             return True
     return False
 
@@ -663,6 +652,7 @@ def _diagnostic_omh_evaluation_context(normalized: str, compact: str) -> bool:
 
 def _without_diagnostic_status_lines(normalized: str) -> str:
     kept: list[str] = []
+    diagnostic_line_markers = _normalized_cues(_DIAGNOSTIC_STATUS_LINE_MARKERS)
     for line in normalized.splitlines() or [normalized]:
         stripped = line.strip()
         if not stripped:
@@ -673,12 +663,12 @@ def _without_diagnostic_status_lines(normalized: str) -> str:
                 continue
         if stripped.startswith(("native bridge status context", "evidence boundary", "latest runtime run")):
             continue
-        if any(normalized_phrase(marker) in stripped for marker in _DIAGNOSTIC_STATUS_LINE_MARKERS):
+        if any(normalized_marker in stripped for _marker, normalized_marker in diagnostic_line_markers):
             fragments = [fragment.strip() for fragment in re.split(r"[;|]", stripped)]
             user_fragments = [
                 fragment
                 for fragment in fragments
-                if fragment and not any(normalized_phrase(marker) in fragment for marker in _DIAGNOSTIC_STATUS_LINE_MARKERS)
+                if fragment and not any(normalized_marker in fragment for _marker, normalized_marker in diagnostic_line_markers)
             ]
             if user_fragments:
                 kept.append(" ".join(user_fragments))
@@ -703,6 +693,45 @@ def _compact_tuple(values: tuple[str, ...]) -> tuple[str, ...]:
         if value and value not in seen:
             seen.append(value)
     return tuple(seen)
+
+
+@lru_cache(maxsize=128)
+def _normalized_cues(cues: tuple[str, ...]) -> tuple[tuple[str, str], ...]:
+    return tuple((cue, normalized) for cue in cues if (normalized := normalized_phrase(cue)))
+
+
+@lru_cache(maxsize=128)
+def _normalized_quality_cues(cues: tuple[str, ...]) -> tuple[tuple[str, str, bool], ...]:
+    return tuple(
+        (cue, normalized, _contains_non_ascii(normalized))
+        for cue in cues
+        if (normalized := normalized_phrase(cue))
+    )
+
+
+@lru_cache(maxsize=1)
+def _normalized_workflow_vocabulary() -> tuple[tuple[str, str], ...]:
+    return tuple(
+        (workflow, normalized)
+        for workflow in WORKFLOW_VOCABULARY
+        if (normalized := normalized_phrase(workflow))
+    )
+
+
+@lru_cache(maxsize=1)
+def _normalized_runtime_vocabulary() -> tuple[tuple[str, str, str], ...]:
+    return tuple(
+        (term, label, normalized)
+        for term, label in RUNTIME_VOCABULARY.items()
+        if (normalized := normalized_phrase(term))
+    )
+
+
+@lru_cache(maxsize=1)
+def _normalized_known_terms() -> tuple[str, ...]:
+    workflow_terms = tuple(normalized for _workflow, normalized in _normalized_workflow_vocabulary())
+    runtime_terms = tuple(normalized for _term, _label, normalized in _normalized_runtime_vocabulary())
+    return workflow_terms + runtime_terms
 
 
 def _suppress_negated_execution_cues(

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -28,24 +28,27 @@ class CapabilityManifestTests(unittest.TestCase):
     def test_capability_snapshot_is_deterministic_and_boundary_safe(self) -> None:
         first = capability_snapshot()
         second = capability_snapshot()
+        first["summary"]["skills"] = -1
+        first["skills"].clear()
+        third = capability_snapshot()
 
-        self.assertEqual(first, second)
-        self.assertEqual(first["schema_version"], "omh_capability_manifest/v1")
-        self.assertEqual(first["determinism"], "static_projection_no_runtime_clock")
-        self.assertEqual(first["omh_awareness"]["schema_version"], "omh_awareness/v1")
-        self.assertIn("workflow-shaped requests", first["omh_awareness"]["purpose"])
-        self.assertIn("Hermes-native workflow pack", first["omh_awareness"]["product_context"])
-        self.assertIn("every OMH skill", first["omh_awareness"]["all_skill_context_rule"])
-        self.assertIn("generic tool can render or execute", first["omh_awareness"]["all_skill_context_rule"])
-        self.assertIn("Every generated workflow skill", first["omh_awareness"]["skill_coverage"])
-        self.assertIn("meeting notes -> meeting-brief", " ".join(first["omh_awareness"]["cross_lane_examples"]))
-        self.assertIn("img-summary", json.dumps(first["omh_awareness"], sort_keys=True))
-        self.assertGreaterEqual(first["summary"]["skills"], 30)
-        self.assertGreaterEqual(first["summary"]["agent_roles"], 8)
-        self.assertGreaterEqual(first["summary"]["playbooks"], 20)
-        self.assertIn("no runtime_topology schema in this PR", first["non_goals"])
-        self.assertNotIn("runtime_topology", first)
-        self.assertIn("Prepared OMH capability", first["evidence_boundaries"]["prepared_is_not"])
+        self.assertEqual(second, third)
+        self.assertEqual(third["schema_version"], "omh_capability_manifest/v1")
+        self.assertEqual(third["determinism"], "static_projection_no_runtime_clock")
+        self.assertEqual(third["omh_awareness"]["schema_version"], "omh_awareness/v1")
+        self.assertIn("workflow-shaped requests", third["omh_awareness"]["purpose"])
+        self.assertIn("Hermes-native workflow pack", third["omh_awareness"]["product_context"])
+        self.assertIn("every OMH skill", third["omh_awareness"]["all_skill_context_rule"])
+        self.assertIn("generic tool can render or execute", third["omh_awareness"]["all_skill_context_rule"])
+        self.assertIn("Every generated workflow skill", third["omh_awareness"]["skill_coverage"])
+        self.assertIn("meeting notes -> meeting-brief", " ".join(third["omh_awareness"]["cross_lane_examples"]))
+        self.assertIn("img-summary", json.dumps(third["omh_awareness"], sort_keys=True))
+        self.assertGreaterEqual(third["summary"]["skills"], 30)
+        self.assertGreaterEqual(third["summary"]["agent_roles"], 8)
+        self.assertGreaterEqual(third["summary"]["playbooks"], 20)
+        self.assertIn("no runtime_topology schema in this PR", third["non_goals"])
+        self.assertNotIn("runtime_topology", third)
+        self.assertIn("Prepared OMH capability", third["evidence_boundaries"]["prepared_is_not"])
 
     def test_awareness_lanes_cover_every_catalog_workflow_surface(self) -> None:
         awareness = capability_snapshot()["omh_awareness"]
@@ -117,6 +120,9 @@ class CapabilityManifestTests(unittest.TestCase):
         self.assertEqual(normalize_capability_section("tools"), "tool_requirements")
 
     def test_capability_summary_is_human_facing_catalog_context(self) -> None:
+        summary = capability_summary()
+        summary["capability_families"].clear()
+        summary["totals"]["skills"] = -1
         summary = capability_summary()
         families = {family["id"]: family for family in summary["capability_families"]}
         lanes = {lane["id"]: lane for lane in summary["lanes"]}


### PR DESCRIPTION
## Feature Report

### What Changed

- Cached static intent cue normalization in `src/routing/intent.py` so repeated chat routing does not re-normalize the same fixed workflow, runtime, diagnostic, and quality cue tables on every message.
- Cached internal capability snapshot and summary templates in `src/capabilities/registry.py` so workflow picker/catalog answers avoid rebuilding the full static capability projection each time.
- Kept public capability APIs mutation-safe by returning deep-copied payloads from the cached templates.
- Added regression coverage that mutates returned capability payloads and confirms later calls still return clean deterministic data.

### Why This Exists

- After the previous router phrase cache work, profiling showed the next hot spots were fixed cue normalization in intent classification and static catalog reconstruction for Hermes-facing workflow picker answers.
- These paths run during normal chat-first usage: routing a message, answering "what workflows are available?", or rendering the compact OMH picker in a wrapper.
- The change keeps OMH fast without caching raw user messages, preserving the existing privacy and prepared-vs-observed boundaries.

### User / Operator Impact

- Common chat routing stays behaviorally identical but spends less time on repeated static setup work.
- `./omh`, workflow catalog questions, and wrapper-native picker responses should feel lighter because the capability summary is now projected from cached static templates.
- Operators still get fresh copies of public JSON payloads, so code that mutates a returned manifest cannot poison later calls.

### How It Works

- `intent.py` adds small `lru_cache` helpers for static cue tuples, workflow vocabulary, runtime vocabulary, and known quoted terms.
- `registry.py` separates cached internal templates from public `capability_snapshot()` and `capability_summary()` return values; public functions still deep-copy before returning.
- `tests/test_capabilities.py` now verifies mutation isolation for both snapshot and summary payloads.

### Files And Contracts Touched

- `src/routing/intent.py`: static cue/vocabulary normalization cache.
- `src/capabilities/registry.py`: cached static capability projection templates.
- `tests/test_capabilities.py`: mutation-safety regression coverage.
- No schema, CLI command, release-channel, runtime observation, or Hermes plugin claim changes.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_capabilities.py tests/test_chat_router.py tests/test_wrapper_contract.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — 895 tests passing.
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli harness validate`
- [x] `uv run python -m omh.cli demo grounded-score --summary` — 28/28 scenarios at 10/10.
- [x] `git diff --check`
- [ ] `python3 -m omh.cli release checklist --json` — not run; no release contract or docs claim changed.
- [ ] `python3 -m omh.cli release hermes-smoke` — not run; no install/Hermes registration behavior changed.
- [ ] `omh --help` — not run; no help/CLI surface changed.
- [ ] Manual Hermes/TUI check — not run; this is a deterministic local router/catalog performance change.

Performance smoke on the same 320-sample operator mix:

- Before this branch, current `main` measured `route_elapsed=0.3840s` / `1.200ms` per sample and `wrapper_elapsed=0.4784s` / `1.495ms` per sample.
- After this branch, measured `route_elapsed=0.2885s` / `0.902ms` per sample and `wrapper_elapsed=0.3986s` / `1.246ms` per sample.

## Risk

- Low. The cache keys are static tuples and static catalog templates, not raw user text.
- The main behavioral risk is stale public payloads if a caller expected to mutate capability data globally. That is explicitly unsupported and now covered by mutation-safety tests.

## Compatibility / Rollout

- Backward compatible: schemas and public command outputs are unchanged.
- The cached templates live only in-process and are rebuilt on process restart/import reload.
- No migration or setup/update action is required.

## Release / Claims

- [x] Release-channel impact considered: no stable/preview/local channel behavior changes.
- [x] Runtime/native capability claims are unchanged and remain evidence-bound.
- [x] Known manual Hermes checks are listed: no live Hermes smoke was run because runtime integration was not touched.

## Follow-Up

- Continue profiling only if real wrapper latency still feels high; the next likely area would be `active_routing_guard_rules()` construction or recommendation scoring, but those need separate behavior-preserving review.
