### PR TITLE
Cache task card phrase projections

### DIFF
--- a/src/routing/task_cards.py
+++ b/src/routing/task_cards.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from functools import lru_cache
 import re
 
 from .localization import normalized_phrase, routing_tokens
@@ -317,7 +318,7 @@ def _maintenance_command(normalized: str, compact: str, tokens: set[str]) -> str
 def _maintenance_surface_hit(normalized: str, compact: str, tokens: set[str]) -> bool:
     if "omh" in tokens or "oh-my-hermes" in normalized or "oh my hermes" in normalized:
         return True
-    return any(surface.replace(" ", "") in compact for surface in _MAINTENANCE_SURFACE_PHRASES)
+    return any(surface_compact in compact for _surface, _surface_normalized, surface_compact in _maintenance_surfaces())
 
 
 def _maintenance_alias_hit(
@@ -327,14 +328,8 @@ def _maintenance_alias_hit(
     compact: str,
     tokens: set[str],
 ) -> bool:
-    for alias in aliases:
-        normalized_alias = normalized_phrase(alias)
-        if not normalized_alias:
-            continue
-        compact_alias = normalized_alias.replace(" ", "")
-        for surface in _MAINTENANCE_SURFACE_PHRASES:
-            normalized_surface = normalized_phrase(surface)
-            compact_surface = normalized_surface.replace(" ", "")
+    for _alias, normalized_alias, compact_alias in _normalized_phrase_options(aliases):
+        for _surface, normalized_surface, compact_surface in _maintenance_surfaces():
             if f"{normalized_surface} {normalized_alias}" in normalized:
                 return True
             if f"{compact_surface}{compact_alias}" in compact:
@@ -349,12 +344,7 @@ def _is_near_exact_maintenance_request(normalized: str, compact: str, tokens: se
         return False
     explain_hit = _phrase_hit(_MAINTENANCE_EXPLANATION_CUES, normalized, compact)
     run_hit = _phrase_hit(_MAINTENANCE_RUN_CUES, normalized, compact)
-    exact_hit = any(
-        compact == f"{normalized_phrase(surface).replace(' ', '')}{normalized_phrase(alias).replace(' ', '')}"
-        for surface in _MAINTENANCE_SURFACE_PHRASES
-        for aliases in _MAINTENANCE_COMMAND_ALIASES.values()
-        for alias in aliases
-    )
+    exact_hit = compact in _maintenance_exact_compact_requests()
     meaningful = {token for token in tokens if token not in _MAINTENANCE_FILLER_TOKENS}
     if exact_hit:
         return True
@@ -507,13 +497,34 @@ def _is_code_cleanup_request(evaluation_region: str, tokens: set[str]) -> bool:
 
 
 def _phrase_hit(phrases: tuple[str, ...], normalized: str, compact: str) -> bool:
-    for phrase in phrases:
-        normalized_phrase_value = normalized_phrase(phrase)
-        if normalized_phrase_value and (
-            normalized_phrase_value in normalized or normalized_phrase_value.replace(" ", "") in compact
-        ):
+    for _phrase, normalized_phrase_value, compact_phrase_value in _normalized_phrase_options(phrases):
+        if normalized_phrase_value in normalized or compact_phrase_value in compact:
             return True
     return False
+
+
+@lru_cache(maxsize=128)
+def _normalized_phrase_options(phrases: tuple[str, ...]) -> tuple[tuple[str, str, str], ...]:
+    return tuple(
+        (phrase, normalized, normalized.replace(" ", ""))
+        for phrase in phrases
+        if (normalized := normalized_phrase(phrase))
+    )
+
+
+@lru_cache(maxsize=1)
+def _maintenance_surfaces() -> tuple[tuple[str, str, str], ...]:
+    return _normalized_phrase_options(_MAINTENANCE_SURFACE_PHRASES)
+
+
+@lru_cache(maxsize=1)
+def _maintenance_exact_compact_requests() -> frozenset[str]:
+    return frozenset(
+        f"{surface_compact}{alias_compact}"
+        for _surface, _normalized_surface, surface_compact in _maintenance_surfaces()
+        for aliases in _MAINTENANCE_COMMAND_ALIASES.values()
+        for _alias, _normalized_alias, alias_compact in _normalized_phrase_options(aliases)
+    )
 
 
 def _runtime_portability_card() -> dict[str, object]:


### PR DESCRIPTION
## Feature Report

### What Changed

- Cached static phrase projections used by `src/routing/task_cards.py`.
- Reused normalized/compact maintenance surface aliases instead of rebuilding them during every maintenance-command classification.
- Precomputed exact compact maintenance command forms such as `omhsetup` and `./omhdoctor`.
- Kept all caches limited to static phrase tuples and static alias tables; no raw user messages or normalized user prompts are cached.

### Why This Exists

- After the intent/capability cache work, profiling showed the task-card layer still repeatedly normalized fixed maintenance, router feedback, runtime portability, and executor-status phrase tables.
- This layer runs before lower-level workflow routing, so it affects common chat-first paths such as `./omh`, “what workflows are available?”, router feedback, and coding status questions.
- The goal is better wrapper responsiveness without changing OMH routing decisions or evidence boundaries.

### User / Operator Impact

- Chat-first task abstraction remains behaviorally unchanged but spends less time on static phrase setup.
- OMH maintenance and picker-adjacent messages should feel a little lighter in Hermes/wrapper surfaces.
- The change does not add commands, schemas, runtime claims, or setup requirements.

### How It Works

- `_phrase_hit()` now uses an `lru_cache` helper that stores static `(raw, normalized, compact)` phrase projections.
- Maintenance surface aliases and exact compact command forms are derived once from static constants.
- `classify_task()` still normalizes the current user message normally and does not cache it.

### Files And Contracts Touched

- `src/routing/task_cards.py`: static phrase projection cache for task-card and maintenance-command routing.
- No CLI, schema, docs, generated skill, plugin, runtime observation, or release-channel contracts changed.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_chat_router.py tests/test_wrapper_contract.py tests/test_cli.py -v` — 364 tests passing.
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — 895 tests passing.
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli harness validate`
- [x] `uv run python -m omh.cli demo grounded-score --summary` — 28/28 scenarios at 10/10.
- [x] `git diff --check`
- [ ] `python3 -m omh.cli release checklist --json` — not run; no release checklist or product claim changed.
- [ ] `python3 -m omh.cli release hermes-smoke` — not run; no install/Hermes registration behavior changed.
- [ ] `omh --help` — not run; no help text changed.
- [ ] Manual Hermes/TUI check — not run; this is deterministic local router hot-path optimization.

Performance smoke on the same 320-sample operator mix:

- Current `main` before this branch: `route_elapsed=0.3182s` / `0.994ms` per sample and `wrapper_elapsed=0.4547s` / `1.421ms` per sample.
- After this branch: `route_elapsed=0.2667s` / `0.833ms` per sample and `wrapper_elapsed=0.3748s` / `1.171ms` per sample.

## Risk

- Low. The caches are static phrase/table projections and do not store user text.
- The main risk would be accidental behavior drift in maintenance-command matching, covered by the existing router, wrapper, and CLI tests.

## Compatibility / Rollout

- Backward compatible. No persisted state, command, schema, or setup changes.
- The cache is in-process only and rebuilds on import/process restart.

## Release / Claims

- [x] Release-channel impact considered: no stable/preview/local channel behavior changes.
- [x] Runtime/native capability claims are unchanged and remain evidence-bound.
- [x] Known manual Hermes checks are listed: no live Hermes check was needed for this local routing optimization.

## Follow-Up

- Continue profiling only if real chat wrappers still feel slow; remaining hot spots are mostly recommendation scoring and active guard evaluation, which need more careful behavior-preserving review.
