### PR TITLE
Split command trigger recommendation scoring

### DIFF
--- a/src/routing/recommend.py
+++ b/src/routing/recommend.py
@@ -70,6 +70,10 @@ _GUARDRAIL_CANDIDATE_INJECTION_IDS = frozenset(
     }
 )
 _COMMAND_TRIGGER_PHRASES = frozenset(("/", "./", "/o", "./o", "/om", "./om", "/omh", "./omh", "/skills", "./skills"))
+_COMMAND_TRIGGER_PATTERNS = {
+    phrase: re.compile(rf"(?<![\w./-]){re.escape(phrase)}(?![\w./-])")
+    for phrase in _COMMAND_TRIGGER_PHRASES
+}
 
 
 @dataclass(frozen=True)
@@ -83,6 +87,8 @@ class RecommendationPolicy:
 class _PreparedDefinition:
     definition: SkillDefinition
     trigger_phrases: tuple[str, ...]
+    command_trigger_phrases: tuple[str, ...]
+    plain_trigger_phrases: tuple[str, ...]
     trigger_tokens: frozenset[str]
     name_phrase: str
     description_phrase: str
@@ -534,9 +540,12 @@ def _prepared_routable_definitions() -> tuple[_PreparedDefinition, ...]:
 
 
 def _prepare_definition(definition: SkillDefinition) -> _PreparedDefinition:
+    trigger_phrases = tuple(normalized_phrase(trigger) for trigger in definition.triggers)
     return _PreparedDefinition(
         definition=definition,
-        trigger_phrases=tuple(normalized_phrase(trigger) for trigger in definition.triggers),
+        trigger_phrases=trigger_phrases,
+        command_trigger_phrases=tuple(trigger for trigger in trigger_phrases if trigger in _COMMAND_TRIGGER_PHRASES),
+        plain_trigger_phrases=tuple(trigger for trigger in trigger_phrases if trigger and trigger not in _COMMAND_TRIGGER_PHRASES),
         trigger_tokens=frozenset(_tokens(" ".join(definition.triggers))),
         name_phrase=normalized_phrase(definition.name),
         description_phrase=normalized_phrase(definition.description),
@@ -558,8 +567,13 @@ def _score_definition(
     score = 0
     matched: set[str] = set()
 
-    for trigger_phrase in prepared.trigger_phrases:
-        if _trigger_phrase_match(normalized_query, trigger_phrase):
+    for trigger_phrase in prepared.plain_trigger_phrases:
+        if _phrase_match(normalized_query, trigger_phrase):
+            score += 6
+            matched.add(f"trigger:{trigger_phrase}")
+
+    for trigger_phrase in prepared.command_trigger_phrases:
+        if _command_trigger_match(normalized_query, trigger_phrase):
             score += 6
             matched.add(f"trigger:{trigger_phrase}")
 
@@ -726,11 +740,8 @@ def _strip_path_like_fragments(value: str) -> str:
     return " ".join(neutralized)
 
 
-def _trigger_phrase_match(query: str, value: str) -> bool:
-    if value in _COMMAND_TRIGGER_PHRASES:
-        escaped = re.escape(value)
-        return bool(re.search(rf"(?<![\w./-]){escaped}(?![\w./-])", query))
-    return _phrase_match(query, value)
+def _command_trigger_match(query: str, value: str) -> bool:
+    return bool(_COMMAND_TRIGGER_PATTERNS[value].search(query))
 
 
 def _phrase_match(query: str, value: str) -> bool:


### PR DESCRIPTION
## Feature Report

### What Changed

- Split prepared recommendation triggers into plain trigger phrases and command-style trigger phrases.
- Precompiled slash-command trigger regexes such as `/omh`, `./omh`, `/skills`, and `./skills` so recommendation scoring does not rebuild regexes in the hot path.
- Removed the old per-trigger branch from normal phrase scoring while preserving the path-fragment guard for command-like OMH invocations.

### Why This Exists

- The router and wrapper paths call `recommend_skills` frequently when Hermes chat asks OMH to choose or explain workflows.
- After the previous static cue and task-card caches, profiling showed recommendation scoring still spent measurable time checking every trigger through the same helper even though only a small fixed subset needs command-boundary regex behavior.
- This PR keeps OMH's chat-first routing responsive without caching raw user messages or changing the prepared-vs-observed contract.

### User / Operator Impact

- Hermes-facing routing stays behaviorally the same: ordinary workflow triggers still match as before, and slash-style commands still avoid matching path-like fragments accidentally.
- Chat wrappers and CLI operators get a slightly lighter `recommend` path, which benefits repeated route/status/picker rendering.
- No new command, schema, setup, plugin, runtime, or messenger contract is introduced.

### How It Works

- `_prepare_definition()` now computes normalized triggers once, then stores `plain_trigger_phrases` and `command_trigger_phrases` on the prepared catalog definition.
- `_score_definition()` runs plain triggers through `_phrase_match()` directly and only applies `_command_trigger_match()` to command triggers.
- `_COMMAND_TRIGGER_PATTERNS` holds precompiled regexes for the fixed command trigger set.
- The change remains metadata-only and does not retain user prompt text.

### Files And Contracts Touched

- `src/routing/recommend.py`
- Public route payloads, scores, schema versions, CLI output, runtime artifacts, and generated docs are unchanged.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_chat_router.py tests/test_wrapper_contract.py tests/test_cli.py -v` — 364 tests passed.
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — 895 tests passed.
- [x] `uv run python -m compileall -q src tests` — passed.
- [x] `uv run python -m omh.cli docs workflows --check` — passed; 48/48 tap skills checked.
- [x] `uv run python -m omh.cli harness validate` — passed; 36 harnesses and 50 skills valid.
- [x] `uv run python -m omh.cli demo grounded-score --summary` — 28/28 scenarios at 10/10.
- [x] `git diff --check` — passed.
- [x] Relevant dry-run or smoke command: warmed local route benchmark over 320 representative chat samples.
- [ ] `python3 -m omh.cli release checklist --json` — not run; no release checklist or release claim changed.
- [ ] `python3 -m omh.cli release hermes-smoke` — not run; no live Hermes registration behavior changed.
- [ ] `omh --help` — not run; no CLI help changed.
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` — not run; install path unchanged.
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; this is a deterministic recommendation scoring refactor, not a live Hermes/TUI integration change.

Benchmark evidence on this branch:

- Previous current-main baseline after PR #333: route `0.833ms/sample`, wrapper `1.171ms/sample`.
- Warmed branch benchmark: route `0.780ms/sample`, wrapper `1.130ms/sample`.

## Risk

- Low. The diff is narrow and keeps the same scoring weights and command-boundary regex semantics.
- The main risk is accidentally changing command trigger matching; existing CLI coverage includes path-like fragment regression tests and full router/wrapper suites.

## Compatibility / Rollout

- Fully backward compatible.
- No migration required.
- No release-channel behavior changes.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`): no release channel impact.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed: no runtime/native capability claim added.
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap: live Hermes check not run because runtime behavior is unchanged.

## Follow-Up

- Continue measuring the remaining route hot spots before changing public router behavior.
