### PR TITLE
Cache static guard phrase matching

### DIFF
--- a/src/routing/intent.py
+++ b/src/routing/intent.py
@@ -533,12 +533,18 @@ def _contains_non_ascii(value: str) -> bool:
 
 
 def _contains_bounded_english_cue(normalized: str, normalized_cue: str) -> bool:
+    pattern = _bounded_english_cue_pattern(normalized_cue)
+    return pattern is not None and pattern.search(normalized) is not None
+
+
+@lru_cache(maxsize=512)
+def _bounded_english_cue_pattern(normalized_cue: str) -> re.Pattern[str] | None:
     parts = re.findall(r"[a-z0-9]+", normalized_cue)
     if not parts:
-        return False
+        return None
     separator = r"[\s_-]+"
     pattern = r"(?<![a-z0-9])" + separator.join(re.escape(part) for part in parts) + r"(?![a-z0-9])"
-    return re.search(pattern, normalized) is not None
+    return re.compile(pattern)
 
 
 def is_workflow_meta_or_feedback(message: str) -> bool:

--- a/src/routing/policy.py
+++ b/src/routing/policy.py
@@ -3994,7 +3994,10 @@ def _explicit_delivery_or_implementation_requested(normalized_query: str, query_
 
 
 def _contains_phrase(normalized_query: str, phrases: tuple[str, ...] | frozenset[str]) -> bool:
-    return any(phrase in normalized_query for phrase in _normalized_phrase_options(phrases))
+    for phrase in _normalized_phrase_options(phrases):
+        if phrase in normalized_query:
+            return True
+    return False
 
 
 @lru_cache(maxsize=512)


### PR DESCRIPTION
## Feature Report

### What Changed

- Replaced the hot `policy._contains_phrase()` generator/`any()` path with an explicit early-return loop.
- Added a static compiled-regex cache for bounded English cue matching in OMH quality-intent classification.
- Kept all caches on static phrase/cue metadata only; no raw or normalized user request text is cached.

### Why This Exists

- After the previous routing performance PRs, profiling showed `active_routing_guard_rules()` and OMH quality-intent cue checks were still meaningful cost centers in repeated Hermes chat routing.
- The largest avoidable costs were generator allocation in phrase checks and repeated construction of the same bounded English cue regexes.
- This improves the chat-first wrapper path while preserving OMH's prepared-vs-observed and no-raw-prompt-cache boundaries.

### User / Operator Impact

- Hermes chat wrappers should feel slightly snappier when repeatedly rendering route, status, picker, or handoff cards.
- Routing behavior, recommendation scores, wrapper payloads, CLI output, schemas, generated docs, and runtime artifacts stay unchanged.
- No user-visible command or setup behavior changes.

### How It Works

- `src/routing/policy.py` now scans normalized static phrase options with a direct `for` loop and returns on the first match.
- `src/routing/intent.py` now compiles bounded English cue patterns once per static normalized cue with an LRU cache.
- The regex cache stores only cue-derived patterns such as static workflow quality terms, never user messages.

### Files And Contracts Touched

- `src/routing/policy.py`
- `src/routing/intent.py`
- Public route contracts are unchanged.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_chat_router.py tests/test_wrapper_contract.py tests/test_cli.py -v` — 364 tests passed.
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — 895 tests passed.
- [x] `uv run python -m compileall -q src tests` — passed.
- [x] `uv run python -m omh.cli docs workflows --check` — passed; 48/48 tap skills checked.
- [x] `uv run python -m omh.cli harness validate` — passed; 36 harnesses and 50 skills valid.
- [x] `uv run python -m omh.cli demo grounded-score --summary` — 28/28 scenarios at 10/10.
- [x] `git diff --check` — passed.
- [x] Relevant dry-run or smoke command: warmed local route benchmark over 320 representative chat samples.
- [ ] `python3 -m omh.cli release checklist --json` — not run; release checklist behavior unchanged.
- [ ] `python3 -m omh.cli release hermes-smoke` — not run; live Hermes registration behavior unchanged.
- [ ] `omh --help` — not run; CLI help unchanged.
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` — not run; install path unchanged.
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; this is deterministic routing internals only.

Benchmark evidence on this branch:

- Current-main baseline after PR #334 measured in this run: route `0.881ms/sample`, wrapper `1.445ms/sample` before edits.
- Warmed branch benchmark after edits: route `0.757ms/sample`, wrapper `1.034ms/sample`.
- cProfile guard evidence: `active_routing_guard_rules` cumulative time dropped from about `0.440s` on pre-PR profile to `0.218s` on this branch profile over the same representative sample shape.

## Risk

- Low. Matching conditions are intentionally equivalent: phrase options and bounded cue regex boundaries remain the same.
- The primary risk is subtle route drift from refactoring the matching helper; existing route, wrapper, CLI, and grounded-score suites passed.

## Compatibility / Rollout

- Fully backward compatible.
- No migration required.
- No release-channel or install-channel behavior changes.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`): no release channel impact.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed: no runtime/native capability claim added.
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap: live Hermes check not run because runtime behavior is unchanged.

## Follow-Up

- Continue profiling route-plan and response-rendering costs before changing public routing behavior.
