### PR TITLE
Cache route plan and catalog projections

### DIFF
--- a/src/routing/route_plan.py
+++ b/src/routing/route_plan.py
@@ -156,6 +156,14 @@ _STAGE_SIGNAL_PHRASES = {
         "검증",
     ),
 }
+_STAGE_SIGNAL_OPTIONS = {
+    stage: tuple(
+        (normalized, " " not in phrase)
+        for phrase in phrases
+        if (normalized := normalized_phrase(phrase))
+    )
+    for stage, phrases in _STAGE_SIGNAL_PHRASES.items()
+}
 
 
 @dataclass(frozen=True)
@@ -365,11 +373,11 @@ def _risk_or_review_signal(normalized: str) -> bool:
 def _stages_from_signals(normalized: str, tokens: set[str]) -> tuple[str, ...]:
     stages: list[str] = []
     for stage in _STAGE_ORDER:
-        phrases = _STAGE_SIGNAL_PHRASES.get(stage, ())
-        if any(normalized_phrase(phrase) in normalized for phrase in phrases):
+        signal_options = _STAGE_SIGNAL_OPTIONS.get(stage, ())
+        if any(phrase in normalized for phrase, _is_token_candidate in signal_options):
             stages.append(stage)
             continue
-        if any(normalized_phrase(phrase) in tokens for phrase in phrases if " " not in phrase):
+        if any(phrase in tokens for phrase, is_token_candidate in signal_options if is_token_candidate):
             stages.append(stage)
     return tuple(stages)
 

--- a/src/skills/catalog.py
+++ b/src/skills/catalog.py
@@ -4789,11 +4789,16 @@ def _default_surface_exposure(name: str) -> SurfaceExposure:
 
 
 def _projected_definitions(projection: str) -> list[SkillDefinition]:
-    return [
+    return list(_projected_definitions_cached(projection))
+
+
+@lru_cache(maxsize=8)
+def _projected_definitions_cached(projection: str) -> tuple[SkillDefinition, ...]:
+    return tuple(
         definition
         for definition in _builtin_definitions_cached()
         if projection in surface_exposure_for_skill(definition.name).projections
-    ]
+    )
 
 
 @lru_cache(maxsize=1)


### PR DESCRIPTION
## Summary
- Cache static stage-signal normalization used by `workflow_route_plan/v1` so wrapper route planning no longer normalizes the same phrases on every request.
- Cache catalog projection membership for repeated capability and wrapper lookups while preserving the public list-returning helper shape.
- Keep all route plans advisory: this does not cache user messages, dispatch state, execution results, review, CI, or merge evidence.

## Why
The current performance pass is reducing latency in OMH's chat-first wrapper path. After earlier fast-path PRs, route-plan generation and repeated catalog projection scans were still visible in local profile output. These are static metadata problems, so they can be cached safely without changing user-facing routing semantics or evidence boundaries.

## What Users/Operators Get
- Faster deterministic chat routing and wrapper status preparation for repeated Hermes requests.
- No change to CLI output, schemas, generated workflows, or runtime artifact meaning.
- The `workflow_route_plan/v1` payload remains prepared/advisory metadata only.

## How It Works
- `src/routing/route_plan.py` builds `_STAGE_SIGNAL_OPTIONS` once from `_STAGE_SIGNAL_PHRASES`, preserving the original token-candidate behavior for single-token phrases.
- `src/skills/catalog.py` adds an internal LRU cache for `_projected_definitions_cached(projection)` and keeps `_projected_definitions()` returning a fresh list for caller safety.

## Verification
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_chat_router.py tests/test_wrapper_contract.py tests/test_cli.py tests/test_capabilities.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli harness validate`
- [x] `uv run python -m omh.cli demo grounded-score --summary`
- [x] `git diff --check`

## Performance Evidence
Local 320-sample benchmark on the same routing workload:

- Baseline after PR #335: route `0.738ms/sample`, wrapper `1.228ms/sample`.
- This branch: route `0.563ms/sample`, wrapper `0.868ms/sample`.
- Profile signal: `build_workflow_route_plan` cumulative time dropped from about `0.111s` to `0.053s`; catalog projection scanning disappeared from the top profile entries.

## Risk And Rollout
- Risk is narrow because the caches are static metadata caches, not request/result caches.
- No live Hermes wrapper latency test was run in this PR.
- If future catalog projection metadata becomes dynamic, this cache needs explicit invalidation or removal.
