### PR TITLE
Speed up router payload serialization

### DIFF
--- a/src/routing/chat.py
+++ b/src/routing/chat.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 import hashlib
 from typing import Any
 
@@ -113,9 +113,29 @@ class ChatRouteDecision:
     recommendations: tuple[dict[str, object], ...]
 
     def to_dict(self) -> dict[str, object]:
-        data = asdict(self)
-        data["recommendations"] = list(self.recommendations)
-        return data
+        return {
+            "schema_version": self.schema_version,
+            "source": self.source,
+            "action": self.action,
+            "selected_skill": self.selected_skill,
+            "selected_harness": self.selected_harness,
+            "candidate_skill": self.candidate_skill,
+            "candidate_harness": self.candidate_harness,
+            "confidence": self.confidence,
+            "score": self.score,
+            "threshold": self.threshold,
+            "explicit": self.explicit,
+            "ambiguous": self.ambiguous,
+            "reason": self.reason,
+            "clarification": self.clarification,
+            "routing_prompt": self.routing_prompt,
+            "task_card": dict(self.task_card) if self.task_card else None,
+            "workflow_route_plan": self.workflow_route_plan,
+            "learning_candidate_card": (
+                dict(self.learning_candidate_card) if self.learning_candidate_card else None
+            ),
+            "recommendations": [dict(recommendation) for recommendation in self.recommendations],
+        }
 
 
 def route_chat_message(

--- a/src/routing/missed_route.py
+++ b/src/routing/missed_route.py
@@ -97,11 +97,17 @@ MISSED_ROUTE_COMPACT_PHRASES = (
 
 
 def has_missed_omh_workflow_context(message: str) -> bool:
-    normalized = normalized_phrase(message)
-    if _contains_phrase(normalized, OMH_MISSED_WORKFLOW_PHRASES):
+    return has_normalized_missed_omh_workflow_context(normalized_phrase(message))
+
+
+def has_normalized_missed_omh_workflow_context(normalized_message: str) -> bool:
+    has_omh_context = "omh" in normalized_message or "oh-my-hermes" in normalized_message
+    if not has_omh_context:
+        return False
+    if _contains_phrase(normalized_message, OMH_MISSED_WORKFLOW_PHRASES):
         return True
-    return ("omh" in normalized or "oh-my-hermes" in normalized) and _contains_phrase(
-        normalized,
+    return _contains_phrase(
+        normalized_message,
         MISSED_WORKFLOW_ACTION_PHRASES,
     )
 

--- a/src/routing/policy.py
+++ b/src/routing/policy.py
@@ -5,7 +5,7 @@ from functools import lru_cache
 
 from .intent import classify_omh_quality_intent
 from .localization import normalized_phrase, routing_tokens
-from .missed_route import has_missed_omh_workflow_context
+from .missed_route import has_normalized_missed_omh_workflow_context
 
 
 ROUTE_ACTIONS = ("dispatch", "clarify", "fallback")
@@ -3925,7 +3925,7 @@ def _is_short_visual_summary_request(normalized_query: str) -> bool:
 
 
 def _missed_omh_workflow_context_applies(normalized_query: str) -> bool:
-    return has_missed_omh_workflow_context(normalized_query)
+    return has_normalized_missed_omh_workflow_context(normalized_query)
 
 
 def _deliverable_package_guard_applies(normalized_query: str, query_tokens: set[str]) -> bool:

--- a/src/routing/recommend.py
+++ b/src/routing/recommend.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass, replace
+from dataclasses import dataclass, replace
 from functools import lru_cache
 import re
 
@@ -492,9 +492,22 @@ class Recommendation:
     suggested_prompt: str
 
     def to_dict(self) -> dict[str, object]:
-        data = asdict(self)
-        data["matched"] = list(self.matched)
-        return data
+        return {
+            "skill": self.skill,
+            "description": self.description,
+            "category": self.category,
+            "phase": self.phase,
+            "hermes_role": self.hermes_role,
+            "handoff_policy": self.handoff_policy,
+            "score": self.score,
+            "confidence": self.confidence,
+            "matched": list(self.matched),
+            "why": self.why,
+            "next_action": self.next_action,
+            "evidence_boundary": self.evidence_boundary,
+            "wrapper_guidance": self.wrapper_guidance,
+            "suggested_prompt": self.suggested_prompt,
+        }
 
 
 def recommend_skills(query: str, *, limit: int = 5, apply_guardrails: bool = True) -> list[dict[str, object]]:


### PR DESCRIPTION
## Summary
- Replace recursive `dataclasses.asdict()` serialization in chat route and recommendation payloads with explicit dictionary builders.
- Reuse already-normalized missed-route text inside routing policy instead of normalizing again in the guard hot path.
- Add an early OMH-context check before scanning missed-workflow phrases.

## Why
This continues the OMH router performance pass. After the static routing projection caches, profiling still showed route payload construction spending time on recursive dataclass traversal and repeated normalization in missed-route guards. These are structural overheads in the wrapper path, not product behavior.

## What Users/Operators Get
- Faster Hermes-facing chat routing payload creation for repeated Discord/Slack-style wrapper calls.
- Same public fields, same route decisions, and same evidence boundaries.
- No request-text cache, no route-result cache, and no new runtime/evidence claims.

## How It Works
- `ChatRouteDecision.to_dict()` now emits the stable public payload keys directly instead of recursively walking the dataclass graph.
- `Recommendation.to_dict()` does the same for recommendation rows while preserving `matched` as a list.
- `missed_route.py` now exposes `has_normalized_missed_omh_workflow_context()` for callers that already hold normalized route text.
- `policy.py` uses that normalized helper in the guard path.

## Verification
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_chat_router.py tests/test_missed_route_detection.py tests/test_wrapper_contract.py tests/test_cli.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_missed_route_detection.py tests/test_chat_router.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli harness validate`
- [x] `uv run python -m omh.cli demo grounded-score --summary`
- [x] `git diff --check`

## Performance Evidence
Local 16-message wrapper payload workload:

- Previous main sample from the same session: `320 payloads` at about `0.590ms/payload`.
- This branch: `320 payloads` at about `0.510ms/payload`, with 60/120-round runs around `0.501-0.524ms/payload`.
- Profile calls for `960 payloads` dropped from about `9.4M` to `6.4M`.
- `dataclasses.asdict` disappeared from the top profile entries.

## Risk And Rollout
- Risk is narrow: payload keys and values are intended to stay the same, only the construction path changed.
- The new missed-route helper assumes the caller passes already-normalized text; the original public helper remains available for raw text.
- No live Hermes wrapper latency test was run in this PR.
