### PR TITLE
Cache recommendation policies in prepared definitions

### DIFF
--- a/src/routing/recommend.py
+++ b/src/routing/recommend.py
@@ -86,6 +86,7 @@ class RecommendationPolicy:
 @dataclass(frozen=True)
 class _PreparedDefinition:
     definition: SkillDefinition
+    policy: RecommendationPolicy
     trigger_phrases: tuple[str, ...]
     command_trigger_phrases: tuple[str, ...]
     plain_trigger_phrases: tuple[str, ...]
@@ -556,6 +557,7 @@ def _prepare_definition(definition: SkillDefinition) -> _PreparedDefinition:
     trigger_phrases = tuple(normalized_phrase(trigger) for trigger in definition.triggers)
     return _PreparedDefinition(
         definition=definition,
+        policy=_policy_for(definition),
         trigger_phrases=trigger_phrases,
         command_trigger_phrases=tuple(trigger for trigger in trigger_phrases if trigger in _COMMAND_TRIGGER_PHRASES),
         plain_trigger_phrases=tuple(trigger for trigger in trigger_phrases if trigger and trigger not in _COMMAND_TRIGGER_PHRASES),
@@ -577,6 +579,7 @@ def _score_definition(
     locale_matches: tuple[str, ...],
 ) -> Recommendation:
     definition = prepared.definition
+    policy = prepared.policy
     score = 0
     matched: set[str] = set()
 
@@ -607,11 +610,11 @@ def _score_definition(
             score += 2
             matched.add(f"{field_name}:{normalized_value}")
 
-    for token in sorted(query_tokens & prepared.trigger_tokens):
+    for token in query_tokens & prepared.trigger_tokens:
         score += 3
         matched.add(f"trigger:{token}")
 
-    for token in sorted(query_tokens & prepared.metadata_tokens):
+    for token in query_tokens & prepared.metadata_tokens:
         score += 1
         matched.add(f"metadata:{token}")
 
@@ -630,9 +633,9 @@ def _score_definition(
         confidence=_confidence(score),
         matched=matched_tuple,
         why=_why(matched_tuple),
-        next_action=_next_action(definition),
-        evidence_boundary=_evidence_boundary(definition),
-        wrapper_guidance=_wrapper_guidance(definition),
+        next_action=policy.next_action,
+        evidence_boundary=policy.evidence_boundary,
+        wrapper_guidance=policy.wrapper_guidance,
         suggested_prompt=_suggested_prompt(definition.name, original_query),
     )
 


### PR DESCRIPTION
## Summary
- Cache static recommendation policy metadata on prepared skill definitions so the chat/recommend scoring hot path does not recompute next action, evidence boundary, and wrapper guidance for every scored catalog entry.
- Avoid sorting trigger and metadata token intersections inside the scoring loop; the final matched tuple is still sorted, preserving deterministic public output.
- Keep the cache limited to catalog-derived static metadata. No user prompt text, message payloads, runtime evidence, or wrapper events are cached.

## Why
Router latency is now one of the main user-perceived OMH quality surfaces because Hermes wrappers can call recommend/chat routing often. PR #337 removed payload serialization overhead, but profiling still showed repeated policy lookup work during recommendation scoring. This PR trims that inner loop without changing routing semantics or prepared-vs-observed boundaries.

## How
- `src/routing/recommend.py` extends `_PreparedDefinition` with a `RecommendationPolicy`.
- `_prepare_definition()` computes the policy once when catalog definitions are prepared.
- `_score_definition()` reuses the prepared policy and keeps deterministic output by sorting only the final matched tuple.

## Verification
- `PYTHONPATH=tests uv run python -m unittest tests/test_chat_router.py tests/test_cli.py tests/test_wrapper_contract.py tests/test_capabilities.py -v` -> 373 tests passed.
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` -> 895 tests passed.
- `uv run python -m compileall -q src tests` -> passed.
- `uv run python -m omh.cli docs workflows --check` -> passed, 48/48 tap skills current.
- `uv run python -m omh.cli harness validate` -> passed, 36 harnesses and 50 skills valid.
- `uv run python -m omh.cli demo grounded-score --summary` -> 28/28 scenarios at 10/10.
- `git diff --check` -> passed.
- Local benchmark/profile: 320 payloads 0.502ms each, 960 payloads 0.495ms each, 1920 payloads 0.503ms each; `_policy_for` no longer appears in the top profile entries for the route hot path.

## Risk
Low. The change is narrow and output ordering remains deterministic through the existing final `matched` tuple sort. Live Hermes wrapper latency was not measured in this PR.
