### PR TITLE
Optimize router guard reuse

### DIFF
--- a/src/routing/policy.py
+++ b/src/routing/policy.py
@@ -2462,7 +2462,11 @@ def active_routing_guard_rules(
     direct_coding_task_applies = _direct_coding_task_guard_applies(normalized_query, query_tokens)
     if direct_coding_task_applies:
         rules.append(DIRECT_CODING_TASK_GUARD)
-    if _feedback_before_coding_guard_applies(normalized_query, query_tokens):
+    if _feedback_before_coding_guard_applies(
+        normalized_query,
+        query_tokens,
+        direct_coding_task_applies=direct_coding_task_applies,
+    ):
         rules.append(FEEDBACK_BEFORE_CODING_GUARD)
     if _product_shaping_guard_applies(normalized_query, query_tokens):
         rules.append(PRODUCT_SHAPING_GUARD)
@@ -2615,29 +2619,6 @@ def _direct_coding_task_guard_applies(normalized_query: str, query_tokens: set[s
         ),
     ):
         return False
-    if _visual_summary_guard_applies(normalized_query, query_tokens):
-        return False
-    if _materials_package_guard_applies(normalized_query, query_tokens):
-        return False
-    if _source_finder_guard_applies(normalized_query, query_tokens):
-        return False
-    if _paper_learning_guard_applies(normalized_query, query_tokens):
-        return False
-    if _github_event_ops_guard_applies(normalized_query, query_tokens):
-        return False
-    if _coding_progress_status_guard_applies(normalized_query, query_tokens):
-        return False
-    if _release_claim_review_guard_applies(normalized_query, query_tokens):
-        return False
-    if _doctor_health_guard_applies(normalized_query, query_tokens):
-        return False
-    if _safe_feature_plan_guard_applies(normalized_query, query_tokens):
-        return False
-    if _risky_refactor_guard_applies(normalized_query, query_tokens):
-        return False
-    if _cleanup_refactor_guard_applies(normalized_query, query_tokens):
-        return False
-
     action = bool(
         {
             "add",
@@ -2735,17 +2716,49 @@ def _direct_coding_task_guard_applies(normalized_query: str, query_tokens: set[s
             "맞는지 검토",
         ),
     )
-    return not review_only
+    if review_only:
+        return False
+
+    if _visual_summary_guard_applies(normalized_query, query_tokens):
+        return False
+    if _materials_package_guard_applies(normalized_query, query_tokens):
+        return False
+    if _source_finder_guard_applies(normalized_query, query_tokens):
+        return False
+    if _paper_learning_guard_applies(normalized_query, query_tokens):
+        return False
+    if _github_event_ops_guard_applies(normalized_query, query_tokens):
+        return False
+    if _coding_progress_status_guard_applies(normalized_query, query_tokens):
+        return False
+    if _release_claim_review_guard_applies(normalized_query, query_tokens):
+        return False
+    if _doctor_health_guard_applies(normalized_query, query_tokens):
+        return False
+    if _safe_feature_plan_guard_applies(normalized_query, query_tokens):
+        return False
+    if _risky_refactor_guard_applies(normalized_query, query_tokens):
+        return False
+    if _cleanup_refactor_guard_applies(normalized_query, query_tokens):
+        return False
+    return True
 
 
-def _feedback_before_coding_guard_applies(normalized_query: str, query_tokens: set[str]) -> bool:
+def _feedback_before_coding_guard_applies(
+    normalized_query: str,
+    query_tokens: set[str],
+    *,
+    direct_coding_task_applies: bool | None = None,
+) -> bool:
     if _gateway_intent_guard_applies(normalized_query, query_tokens):
         return False
     if _github_event_ops_guard_applies(normalized_query, query_tokens):
         return False
     if _doctor_health_guard_applies(normalized_query, query_tokens):
         return False
-    if _direct_coding_task_guard_applies(normalized_query, query_tokens):
+    if direct_coding_task_applies is None:
+        direct_coding_task_applies = _direct_coding_task_guard_applies(normalized_query, query_tokens)
+    if direct_coding_task_applies:
         return False
     planning_before_coding = _contains_phrase(
         normalized_query,


### PR DESCRIPTION
## Summary

- Reduces OMH chat-router guard overhead by reordering the direct-coding guard so cheap action/surface checks run before expensive exclusion guards.
- Reuses the already-computed direct-coding decision when evaluating feedback-before-coding routing in the same request.
- Keeps routing behavior, prepared-vs-observed boundaries, and public payload contracts unchanged.

## Why

Router profiling after the previous catalog fast path showed `active_routing_guard_rules` still consuming a noticeable share of route time. The remaining hot path was not a new feature gap; it was repeated guard work on messages that were not direct coding tasks. The router should stay deterministic and conservative, but it should avoid doing expensive exclusion checks until a message is actually a plausible coding request.

## What changed

- Moved `direct_coding_task` action and concrete-surface checks ahead of visual/material/source/paper/github/status/doctor exclusion guards.
- Converted the final review-only check into an explicit early false return before exclusion checks.
- Let `_feedback_before_coding_guard_applies` accept the already-computed direct-coding result so `active_routing_guard_rules` does not repeat that guard for the same request.

## User/operator impact

- Natural-language chat routing is slightly faster for common non-coding and mixed workflow prompts.
- Existing route decisions remain the same; this PR is a performance cleanup, not a routing policy change.
- The change does not store raw prompts, call networks, modify Hermes core behavior, or claim executor/runtime evidence.

## Verification

- `PYTHONPATH=tests uv run python -m unittest tests/test_chat_router.py tests/test_cli.py tests/test_wrapper_contract.py tests/test_capabilities.py -v` — 375 tests passed.
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — 897 tests passed.
- `uv run python -m compileall -q src tests` — passed.
- `uv run python -m omh.cli docs workflows --check` — passed.
- `uv run python -m omh.cli harness validate` — passed.
- `uv run python -m omh.cli demo grounded-score --summary` — 28/28 scenarios at 10/10.
- `git diff --check` — passed.

## Performance evidence

- Before this PR on current main: 320 payloads at 0.460ms each, 960 at 0.451ms, 1920 at 0.464ms.
- After this PR: 320 payloads at 0.407ms each, 960 at 0.401ms, 1920 at 0.404ms.
- `active_routing_guard_rules` profile time dropped from about 0.281s to 0.186s on the same 960-payload profile loop.

## Risks and rollout notes

- Risk is narrow because only private guard evaluation order and reuse changed.
- The key semantic risk was accidentally changing routing precedence for visual/material/source/paper/status/doctor requests; targeted router and wrapper tests passed against those surfaces.
- Live Hermes chat runtime was not exercised in this PR; the deterministic local contract suite is the evidence boundary.
