### PR TITLE
Skip zero-score recommendation objects

### DIFF
--- a/src/routing/recommend.py
+++ b/src/routing/recommend.py
@@ -521,13 +521,14 @@ def recommend_skills(query: str, *, limit: int = 5, apply_guardrails: bool = Tru
     prepared_definitions = _prepared_routable_definitions()
     definitions = [prepared.definition for prepared in prepared_definitions]
     explicit_skill = explicit_skill_invocation(query, {definition.name for definition in definitions})
-    scored = [
-        _score_definition(prepared, normalized_query, query_tokens, query, routing_text.locale_matches)
-        for prepared in prepared_definitions
-    ]
+    scored = []
+    for prepared in prepared_definitions:
+        recommendation = _score_definition(prepared, normalized_query, query_tokens, query, routing_text.locale_matches)
+        if recommendation is not None:
+            scored.append(recommendation)
     if explicit_skill != "automation-blueprint" and is_explicit_one_off_request(normalized_query, query_tokens):
         scored = [recommendation for recommendation in scored if recommendation.skill != "automation-blueprint"]
-    matches = [recommendation for recommendation in scored if recommendation.score > 0]
+    matches = scored
     if apply_guardrails:
         guards = active_routing_guard_rules(normalized_query, query_tokens, explicit_skill=explicit_skill)
         matches = _ensure_guardrail_candidates(matches, definitions, guards, query)
@@ -577,7 +578,7 @@ def _score_definition(
     query_tokens: set[str],
     original_query: str,
     locale_matches: tuple[str, ...],
-) -> Recommendation:
+) -> Recommendation | None:
     definition = prepared.definition
     policy = prepared.policy
     score = 0
@@ -617,6 +618,9 @@ def _score_definition(
     for token in query_tokens & prepared.metadata_tokens:
         score += 1
         matched.add(f"metadata:{token}")
+
+    if score <= 0:
+        return None
 
     if score > 0:
         matched.update(f"locale:{match}" for match in locale_matches)


### PR DESCRIPTION
## Summary

- Skips constructing full `Recommendation` objects for zero-score catalog definitions during `omh` chat recommendation.
- Keeps guardrail candidate injection, fallback behavior, route payloads, and prepared-vs-observed boundaries unchanged.
- Leaves the rejected trigger-token gate out because targeted tests and profiling showed it was not safe or faster.

## Why

After PR #340, profiling showed the next hot path was recommendation scoring. The router was still building a complete `Recommendation` object, policy fields, matched tuple, why text, and suggested prompt for every routable skill even when that skill scored zero and would immediately be filtered out. Normal chat requests usually match only a small subset of the catalog, so zero-score object construction is unnecessary work.

## What changed

- `recommend_skills` now collects only non-null recommendations from `_score_definition`.
- `_score_definition` returns `None` when the definition score remains zero.
- Existing fallback recommendations and guardrail-injected candidates still construct zero-score records deliberately where those records are user-visible.

## User/operator impact

- Natural-language OMH routing gets a small latency reduction without changing routing decisions.
- Wrapper output remains metadata-only and does not add raw prompt storage, network calls, Hermes core patches, or executor evidence claims.
- The deterministic route coverage and grounded-score gates still pass at the same expected values.

## Verification

- `PYTHONPATH=tests uv run python -m unittest tests/test_chat_router.py tests/test_cli.py tests/test_wrapper_contract.py tests/test_capabilities.py -v` — 375 tests passed.
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — 897 tests passed.
- `uv run python -m compileall -q src tests` — passed.
- `uv run python -m omh.cli docs workflows --check` — passed.
- `uv run python -m omh.cli harness validate` — passed.
- `uv run python -m omh.cli demo grounded-score --summary` — 28/28 scenarios at 10/10.
- `git diff --check` — passed.

## Performance evidence

- Current main after PR #340, same sample set: roughly 0.40ms per payload.
- This branch, same sample set after targeted/full gates: 320 payloads at 0.377ms each, 960 at 0.367ms, 1920 at 0.369ms.
- `_score_definition` still runs for the full catalog, but it no longer builds user-facing recommendation records for zero-score definitions.

## Rejected approach

- I tested trigger-token gating before substring matching. It regressed Korean/materials and route-priority cases such as suffixed `PDF를`/`PPT로` prompts, and the safer substring fallback made the benchmark slower. That experimental path was removed from this PR.

## Risks and rollout notes

- Risk is narrow because the public recommendation set already filtered out zero-score results before guardrail/fallback logic.
- The main risk is a caller depending on internal zero-score objects from `_score_definition`; no external API exposes that private helper.
- Live Hermes chat runtime was not exercised; deterministic local router, wrapper, docs, harness, and grounded-score evidence are the boundary.
