### PR TITLE
Reuse catalog question routing check

### DIFF
--- a/src/routing/chat.py
+++ b/src/routing/chat.py
@@ -167,6 +167,12 @@ class ChatRouteDecision:
         }
 
 
+@dataclass(frozen=True)
+class _CatalogFastPathResult:
+    decision: ChatRouteDecision | None
+    catalog_question: bool
+
+
 def route_chat_message(
     message: str,
     *,
@@ -191,8 +197,8 @@ def route_chat_message(
         source=source,
         min_confidence=min_confidence,
     )
-    if fast_catalog_decision is not None:
-        return fast_catalog_decision.to_dict()
+    if fast_catalog_decision.decision is not None:
+        return fast_catalog_decision.decision.to_dict()
 
     definitions = routable_definitions()
     full_recommendations = recommend_skills(routing_message, limit=len(definitions))
@@ -205,7 +211,7 @@ def route_chat_message(
     )
     if task_card and (not explicit_skill or task_card_overrides_explicit):
         full_recommendations = _prioritize_recommendation(full_recommendations, task_card_recommendation(task_card))
-    catalog_question = is_skill_catalog_question(routing_message)
+    catalog_question = fast_catalog_decision.catalog_question
     specific_catalog_match = (
         _specific_capability_catalog_match(full_recommendations)
         if catalog_question and not _is_broad_capability_catalog_question(routing_message)
@@ -357,15 +363,16 @@ def _catalog_fast_path_decision(
     routing_message: str,
     source: str,
     min_confidence: str,
-) -> ChatRouteDecision | None:
+) -> _CatalogFastPathResult:
     direct_picker = _direct_picker_alias(routing_message)
+    catalog_question = False if direct_picker else is_skill_catalog_question(routing_message)
     catalog_picker = (
         not direct_picker
-        and is_skill_catalog_question(routing_message)
+        and catalog_question
         and _generic_omh_catalog_question(routing_message)
     )
     if not direct_picker and not catalog_picker:
-        return None
+        return _CatalogFastPathResult(decision=None, catalog_question=catalog_question)
 
     matched = ("direct_picker_alias",) if direct_picker else ("catalog_question",)
     score = 12 if direct_picker else 11
@@ -376,26 +383,29 @@ def _catalog_fast_path_decision(
     )
     selected_harness = primary_harness_for_skill(_ROUTER_SKILL)
     recommendation = _router_picker_recommendation(message, matched=matched, score=score)
-    return ChatRouteDecision(
-        schema_version=1,
-        source=source,
-        action="dispatch",
-        selected_skill=_ROUTER_SKILL,
-        selected_harness=selected_harness,
-        candidate_skill=_ROUTER_SKILL,
-        candidate_harness=selected_harness,
-        confidence="high",
-        score=score,
-        threshold=min_confidence,
-        explicit=direct_picker,
-        ambiguous=False,
-        reason=reason,
-        clarification="",
-        routing_prompt=_routing_prompt("dispatch", _ROUTER_SKILL, _ROUTER_SKILL, reason, message),
-        task_card=None,
-        workflow_route_plan=None,
-        learning_candidate_card=None,
-        recommendations=(recommendation,),
+    return _CatalogFastPathResult(
+        decision=ChatRouteDecision(
+            schema_version=1,
+            source=source,
+            action="dispatch",
+            selected_skill=_ROUTER_SKILL,
+            selected_harness=selected_harness,
+            candidate_skill=_ROUTER_SKILL,
+            candidate_harness=selected_harness,
+            confidence="high",
+            score=score,
+            threshold=min_confidence,
+            explicit=direct_picker,
+            ambiguous=False,
+            reason=reason,
+            clarification="",
+            routing_prompt=_routing_prompt("dispatch", _ROUTER_SKILL, _ROUTER_SKILL, reason, message),
+            task_card=None,
+            workflow_route_plan=None,
+            learning_candidate_card=None,
+            recommendations=(recommendation,),
+        ),
+        catalog_question=catalog_question,
     )
 
 


### PR DESCRIPTION
## Feature Report

### What Changed

- Reused the catalog-question result already computed by the OMH chat router fast path.
- Added a private `_CatalogFastPathResult` wrapper so the fast path can return either a picker decision or reusable metadata for the normal route path.
- Kept the public `chat_route/v1`-style payload shape unchanged.

### Why This Exists

- The current performance pass showed `is_skill_catalog_question()` being called twice for many non-fast-path chat messages.
- That detector performs several catalog, command, file-lookup, and missed-route checks, so repeating it adds latency to every normal chat route.
- OMH chat routing is a hot path for Hermes wrappers, so small deterministic savings matter when Discord/Slack-style surfaces call it often.

### User / Operator Impact

- Users should see the same routing decisions and cards as before.
- Operators get a slightly cheaper `omh chat route` / wrapper routing path, especially for normal messages that are not direct `./omh` picker requests.
- The change does not claim execution, review, CI, merge, Hermes runtime load, or any other observed evidence.

### How It Works

- `_catalog_fast_path_decision()` now computes `catalog_question` once when the message is not a direct picker alias.
- If the message is a catalog picker fast path, it returns the same dispatch decision as before.
- If the message continues through normal routing, `route_chat_message()` reuses `fast_catalog_decision.catalog_question` instead of recomputing the detector.

### Files And Contracts Touched

- `src/routing/chat.py`
  - Private routing helper shape only.
  - No public JSON/schema contract changes.
  - No docs/generated skill changes.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_chat_router.py tests/test_catalog_questions.py tests/test_wrapper_contract.py -v` — 136 tests passing.
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — 897 tests passing.
- [x] `uv run python -m compileall -q src tests` — passing.
- [x] `uv run python -m omh.cli docs workflows --check` — passing; 48/48 tap skills checked.
- [x] `uv run python -m omh.cli harness validate` — passing; 36 harnesses and 50 skills valid.
- [x] `uv run python -m omh.cli demo grounded-score --summary` — 28/28 scenarios at 10/10.
- [x] `git diff --check` — passing.
- [x] Local route profile over 16 representative messages:
  - Before this change on current main: about `0.392ms`, `0.384ms`, `0.388ms`, `0.424ms` per payload across 320/960/1920/3840 payload runs.
  - After this change: about `0.368ms`, `0.357ms`, `0.360ms`, `0.391ms` per payload across the same run sizes.
  - `is_skill_catalog_question()` calls in the 1,920-payload profile dropped from about `3,480` to `1,800`.
- [ ] `python3 -m omh.cli release checklist --json` — not run; release surface unchanged.
- [ ] `python3 -m omh.cli release hermes-smoke` — not run; live Hermes integration unchanged.
- [ ] `omh --help` — not run; CLI help unchanged.
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` — not run; installer/setup surface unchanged.
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable; learning contracts unchanged.
- [ ] Relevant dry-run or smoke command: the local route profile above covers the changed hot path.
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; private local router helper only, no live Hermes UI behavior changed.

## Risk

- Low. The change is isolated to private router helper plumbing and existing tests cover catalog picker, specific catalog matching, normal routing, and wrapper rendering.
- The main risk is accidentally changing catalog-question semantics, mitigated by reusing the exact same boolean from the existing detector.

## Compatibility / Rollout

- Backward compatible.
- No migration needed.
- No release-channel behavior change beyond a lighter routing path once merged.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`): local/router implementation only.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed: no new runtime/native claims.
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap: live Hermes check not run because the public UI/runtime contract did not change.

## Follow-Up

- Continue profiling `recommend_skills()`, routing guard construction, and repeated normalization/tokenization if more chat-routing latency work is needed.
