### PR TITLE
Reuse interaction routes in quality demos

### DIFF
--- a/src/quality/grounded_score.py
+++ b/src/quality/grounded_score.py
@@ -6,7 +6,6 @@ import hashlib
 from ..catalogs.playbooks import recommend_playbooks
 from ..coding_delegation import build_coding_delegation_payload
 from ..ingress import CHAT_SOURCES
-from ..routing.chat import route_chat_message
 from ..wrapper.contract import build_chat_interaction_payload
 
 
@@ -421,8 +420,8 @@ def format_grounded_score_summary(payload: dict[str, object]) -> str:
 
 
 def _evaluate_grounded_scenario(scenario: GroundedScenario, *, source: str) -> dict[str, object]:
-    route = route_chat_message(scenario.message, source=source)
     interaction = build_chat_interaction_payload(scenario.message, source=source)
+    route = _nested(interaction, "route")
     delegation = build_coding_delegation_payload(
         scenario.message,
         source=source,

--- a/src/quality/route_hint_alignment.py
+++ b/src/quality/route_hint_alignment.py
@@ -5,7 +5,6 @@ import hashlib
 
 from ..ingress import CHAT_SOURCES
 from ..plugin_bundle.omh.awareness import awareness_route_hint
-from ..routing.chat import route_chat_message
 from ..wrapper.contract import build_chat_interaction_payload
 from .chat_card_coverage import CHAT_CARD_COVERAGE_CASES
 from .grounded_score import GROUNDED_SCENARIOS
@@ -126,8 +125,8 @@ def format_route_hint_alignment_summary(payload: dict[str, object]) -> str:
 
 
 def _evaluate_alignment_case(case: RouteHintAlignmentCase, *, source: str) -> dict[str, object]:
-    route = route_chat_message(case.message, source=source)
     interaction = build_chat_interaction_payload(case.message, source=source)
+    route = _nested(interaction, "route")
     hint = awareness_route_hint(case.message)
     hint_context_card = _nested(_first_dict(hint.get("hints")), "workflow_context_card")
     observed = {

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import unittest
+from unittest.mock import patch
 
 from _local_package import load_local_package
 
@@ -39,6 +40,10 @@ from omh.skills.catalog import (
     memory_context_policy_for_skill,
     retained_delegation_skill_names,
 )
+from omh.quality import grounded_score as grounded_score_module
+from omh.quality import route_hint_alignment as route_hint_alignment_module
+from omh.quality.grounded_score import GroundedScenario
+from omh.quality.route_hint_alignment import RouteHintAlignmentCase
 
 
 class EfficiencyContractTests(unittest.TestCase):
@@ -219,6 +224,88 @@ class EfficiencyContractTests(unittest.TestCase):
 
                 self.assertEqual(route_hint["primary_workflow"], workflow)
                 self.assertEqual(route_hint["primary_next_action"], next_action)
+
+    def test_quality_demos_reuse_interaction_route(self) -> None:
+        alignment_case = RouteHintAlignmentCase(
+            "synthetic",
+            "synthetic-route",
+            "Synthetic route reuse",
+            "synthetic message that should not hit the real router",
+            "synthetic-workflow",
+        )
+        fake_interaction = {
+            "route": {
+                "selected_skill": "synthetic-workflow",
+                "action": "dispatch",
+                "confidence": "high",
+                "score": 11,
+                "explicit": True,
+            },
+            "next_action": "synthetic_next_action",
+            "chat_response": {
+                "kind": "synthetic_card",
+                "claim_boundary": "Synthetic boundary.",
+            },
+        }
+        fake_route_hint = {
+            "status": "hinted",
+            "primary_workflow": "synthetic-workflow",
+            "primary_next_action": "synthetic_next_action",
+            "hints": [{"workflow_context_card": {"id": "intent_to_plan"}}],
+            "claim_boundary": "Synthetic hints are not workflow execution evidence.",
+        }
+
+        with (
+            patch.object(
+                route_hint_alignment_module,
+                "build_chat_interaction_payload",
+                return_value=fake_interaction,
+            ),
+            patch.object(
+                route_hint_alignment_module,
+                "awareness_route_hint",
+                return_value=fake_route_hint,
+            ),
+        ):
+            row = route_hint_alignment_module._evaluate_alignment_case(alignment_case, source="discord")
+
+        self.assertTrue(row["aligned"])
+        self.assertEqual(row["observed"]["route_workflow"], "synthetic-workflow")
+        self.assertEqual(row["observed"]["hint_workflow"], "synthetic-workflow")
+
+        grounded_scenario = GroundedScenario(
+            "synthetic-grounded",
+            "Synthetic grounded route reuse",
+            "synthetic grounded message that should not hit the real router",
+            "synthetic-workflow",
+            "synthetic_card",
+            "synthetic_next_action",
+            "fallback",
+            False,
+            invocation_mode="direct_skill",
+        )
+        fake_delegation = {
+            "delegation": {
+                "action": "fallback",
+                "recommended_workflow": "synthetic-workflow",
+            }
+        }
+        with (
+            patch.object(
+                grounded_score_module,
+                "build_chat_interaction_payload",
+                return_value=fake_interaction,
+            ),
+            patch.object(
+                grounded_score_module,
+                "build_coding_delegation_payload",
+                return_value=fake_delegation,
+            ),
+        ):
+            scenario_row = grounded_score_module._evaluate_grounded_scenario(grounded_scenario, source="discord")
+
+        self.assertEqual(scenario_row["score"], 10)
+        self.assertEqual(scenario_row["observed"]["skill"], "synthetic-workflow")
 
     def test_capability_context_is_strong_but_bounded(self) -> None:
         full_items = skill_capabilities()


### PR DESCRIPTION
## Feature Report

### What Changed

- Reused the `route` already embedded in `build_chat_interaction_payload()` for grounded-score and route-hint alignment evaluation.
- Removed redundant direct router calls from those quality demos.
- Added an efficiency regression test that uses synthetic interaction payloads to prove the evaluators consume the interaction route instead of falling back to another router pass.

### Why This Exists

- The route quality gates now run as part of product readiness and release evidence. They should stay fast because operators may run them frequently during release and wrapper QA.
- Before this change, two quality evaluators routed each message once directly and once again through the chat interaction payload. That duplicated work without adding stronger evidence.

### User / Operator Impact

- `omh demo grounded-score`, `omh demo route-hint-alignment`, and `omh release product-readiness` keep the same public output while doing less router work.
- Local timing improved in this workspace from roughly:
  - `route-hint-alignment --json`: avg 0.159s -> 0.134s
  - `product-readiness --json`: avg 0.295s -> 0.267s
- The improvement is intentionally small and low-risk, but it keeps the new release gate from making the UX feel heavier.

### How It Works

- `src/quality/grounded_score.py` now reads `interaction["route"]` after building the chat interaction payload.
- `src/quality/route_hint_alignment.py` does the same and still separately checks the plugin awareness hint.
- `tests/test_efficiency.py` adds a synthetic route-reuse contract so future changes cannot silently reintroduce an extra router dependency in those evaluators.

### Files And Contracts Touched

- `src/quality/grounded_score.py`
- `src/quality/route_hint_alignment.py`
- `tests/test_efficiency.py`

No public schema changes. Existing demo schemas and claim boundaries are unchanged.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests.test_efficiency -v`
- [x] `PYTHONPATH=tests uv run python -m unittest tests.test_cli.CliTests.test_demo_grounded_score_keeps_representative_cases_at_10 tests.test_cli.CliTests.test_demo_route_hint_alignment_keeps_router_and_awareness_hints_in_sync tests.test_release_smoke.ReleaseSmokeTests.test_product_readiness_report_rolls_up_public_release_story -v`
- [x] `PYTHONPATH=tests uv run python -m omh.cli demo route-hint-alignment --summary`
- [x] `PYTHONPATH=tests uv run python -m omh.cli demo grounded-score --summary`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli harness validate`
- [x] `git diff --check`
- [ ] Manual Hermes/TUI check was not run; this PR changes deterministic local quality demo internals only.

## Risk

- Low. The route source is the same chat interaction payload already used for the card/status assertions, and the existing public quality tests still prove 28/28 grounded-score and 53/53 route-hint alignment.

## Compatibility / Rollout

- Backward compatible. No CLI arguments, output schemas, or release checklist IDs changed.

## Release / Claims

- [x] Release-channel impact considered: this is a local quality/performance improvement for current preview/stable package behavior.
- [x] Runtime/native capability claims remain unchanged and bounded.
- [x] Known manual Hermes checks are listed as not run.

## Follow-Up

- Continue profiling release/product-readiness paths as more quality gates are added.