### PR TITLE
Reuse quality snapshots in release gates

### DIFF
--- a/src/maintenance/release.py
+++ b/src/maintenance/release.py
@@ -489,7 +489,10 @@ def product_readiness_report(
     parity = build_parity_matrix()
     grounded_score = build_grounded_score_demo()
     chat_cards = build_chat_card_coverage_demo()
-    route_hints = build_route_hint_alignment_demo()
+    route_hints = build_route_hint_alignment_demo(
+        grounded_score=grounded_score,
+        chat_card_coverage=chat_cards,
+    )
     checklist = release_readiness_checklist(version=release_version, omh_command=omh_command)
 
     checklist_items = checklist.get("items", [])
@@ -1439,7 +1442,10 @@ def release_evidence_bundle(
     use_cases = use_case_readiness(resolved_paths)
     grounded_score = build_grounded_score_demo()
     chat_cards = build_chat_card_coverage_demo()
-    route_hints = build_route_hint_alignment_demo()
+    route_hints = build_route_hint_alignment_demo(
+        grounded_score=grounded_score,
+        chat_card_coverage=chat_cards,
+    )
     parity = build_parity_matrix()
     local_store_status = _release_local_store_status(use_cases)
     required_status = {

--- a/src/quality/route_hint_alignment.py
+++ b/src/quality/route_hint_alignment.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import hashlib
+from typing import Mapping
 
 from ..ingress import CHAT_SOURCES
 from ..plugin_bundle.omh.awareness import awareness_route_hint
@@ -47,10 +48,26 @@ def route_hint_alignment_cases() -> tuple[RouteHintAlignmentCase, ...]:
     )
 
 
-def build_route_hint_alignment_demo(*, source: str = "discord") -> dict[str, object]:
+def build_route_hint_alignment_demo(
+    *,
+    source: str = "discord",
+    grounded_score: Mapping[str, object] | None = None,
+    chat_card_coverage: Mapping[str, object] | None = None,
+) -> dict[str, object]:
     if source not in CHAT_SOURCES:
         raise ValueError(f"unsupported demo source: {source}")
-    rows = [_evaluate_alignment_case(case, source=source) for case in route_hint_alignment_cases()]
+    precomputed_routes = _precomputed_route_observations(
+        grounded_score=grounded_score,
+        chat_card_coverage=chat_card_coverage,
+    )
+    rows = [
+        _evaluate_alignment_case(
+            case,
+            source=source,
+            route_observation=precomputed_routes.get((case.corpus, case.id)),
+        )
+        for case in route_hint_alignment_cases()
+    ]
     aligned_count = sum(1 for row in rows if bool(row["aligned"]))
     hinted_count = sum(1 for row in rows if _nested(row, "observed").get("hint_status") == "hinted")
     return {
@@ -124,16 +141,27 @@ def format_route_hint_alignment_summary(payload: dict[str, object]) -> str:
     return "\n".join(lines)
 
 
-def _evaluate_alignment_case(case: RouteHintAlignmentCase, *, source: str) -> dict[str, object]:
-    interaction = build_chat_interaction_payload(case.message, source=source)
-    route = _nested(interaction, "route")
+def _evaluate_alignment_case(
+    case: RouteHintAlignmentCase,
+    *,
+    source: str,
+    route_observation: Mapping[str, object] | None = None,
+) -> dict[str, object]:
+    if route_observation is None:
+        interaction = build_chat_interaction_payload(case.message, source=source)
+        route_observation = {
+            "route_workflow": _nested(interaction, "route").get("selected_skill"),
+            "route_action": _nested(interaction, "route").get("action"),
+            "route_next_action": interaction.get("next_action"),
+            "route_confidence": _nested(interaction, "route").get("confidence"),
+        }
     hint = awareness_route_hint(case.message)
     hint_context_card = _nested(_first_dict(hint.get("hints")), "workflow_context_card")
     observed = {
-        "route_workflow": route.get("selected_skill"),
-        "route_action": route.get("action"),
-        "route_next_action": interaction.get("next_action"),
-        "route_confidence": route.get("confidence"),
+        "route_workflow": route_observation.get("route_workflow"),
+        "route_action": route_observation.get("route_action"),
+        "route_next_action": route_observation.get("route_next_action"),
+        "route_confidence": route_observation.get("route_confidence"),
         "hint_status": hint.get("status"),
         "hint_workflow": hint.get("primary_workflow"),
         "hint_next_action": hint.get("primary_next_action"),
@@ -163,6 +191,39 @@ def _evaluate_alignment_case(case: RouteHintAlignmentCase, *, source: str) -> di
         "observed": observed,
         "issues": issues,
     }
+
+
+def _precomputed_route_observations(
+    *,
+    grounded_score: Mapping[str, object] | None,
+    chat_card_coverage: Mapping[str, object] | None,
+) -> dict[tuple[str, str], dict[str, object]]:
+    observations: dict[tuple[str, str], dict[str, object]] = {}
+    if grounded_score is not None:
+        for row in _dict_rows(grounded_score.get("scenarios", [])):
+            observed = _nested(row, "observed")
+            route_workflow = observed.get("skill")
+            if not route_workflow:
+                continue
+            observations[("grounded_score", str(row.get("id", "")))] = {
+                "route_workflow": route_workflow,
+                "route_action": observed.get("route_action"),
+                "route_next_action": observed.get("next_action"),
+                "route_confidence": observed.get("route_confidence") or "precomputed",
+            }
+    if chat_card_coverage is not None:
+        for row in _dict_rows(chat_card_coverage.get("cases", [])):
+            observed = _nested(row, "observed")
+            route_workflow = observed.get("workflow")
+            if not route_workflow:
+                continue
+            observations[("chat_card_coverage", str(row.get("id", "")))] = {
+                "route_workflow": route_workflow,
+                "route_action": observed.get("route_action"),
+                "route_next_action": observed.get("next_action"),
+                "route_confidence": observed.get("confidence") or "precomputed",
+            }
+    return observations
 
 
 def _first_dict(value: object) -> dict[str, object]:

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -307,6 +307,53 @@ class EfficiencyContractTests(unittest.TestCase):
         self.assertEqual(scenario_row["score"], 10)
         self.assertEqual(scenario_row["observed"]["skill"], "synthetic-workflow")
 
+    def test_route_hint_alignment_reuses_precomputed_quality_routes(self) -> None:
+        alignment_case = RouteHintAlignmentCase(
+            "grounded_score",
+            "synthetic-grounded",
+            "Synthetic precomputed route reuse",
+            "synthetic message with precomputed route",
+            "synthetic-workflow",
+        )
+        grounded_payload = {
+            "scenarios": [
+                {
+                    "id": "synthetic-grounded",
+                    "observed": {
+                        "skill": "synthetic-workflow",
+                        "route_action": "dispatch",
+                        "next_action": "synthetic_next_action",
+                    },
+                }
+            ]
+        }
+        fake_route_hint = {
+            "status": "hinted",
+            "primary_workflow": "synthetic-workflow",
+            "primary_next_action": "synthetic_next_action",
+            "hints": [{"workflow_context_card": {"id": "intent_to_plan"}}],
+            "claim_boundary": "Synthetic hints are not workflow execution evidence.",
+        }
+
+        with (
+            patch.object(route_hint_alignment_module, "route_hint_alignment_cases", return_value=(alignment_case,)),
+            patch.object(
+                route_hint_alignment_module,
+                "build_chat_interaction_payload",
+                side_effect=AssertionError("precomputed routes should avoid rebuilding interaction payloads"),
+            ),
+            patch.object(route_hint_alignment_module, "awareness_route_hint", return_value=fake_route_hint),
+        ):
+            payload = route_hint_alignment_module.build_route_hint_alignment_demo(
+                source="discord",
+                grounded_score=grounded_payload,
+            )
+
+        self.assertTrue(payload["summary"]["all_aligned"])
+        self.assertEqual(payload["summary"]["aligned_count"], 1)
+        self.assertEqual(payload["cases"][0]["observed"]["route_workflow"], "synthetic-workflow")
+        self.assertEqual(payload["cases"][0]["observed"]["route_confidence"], "precomputed")
+
     def test_capability_context_is_strong_but_bounded(self) -> None:
         full_items = skill_capabilities()
         standalone_items = standalone_skill_capability_items()


### PR DESCRIPTION
## Feature Report

### What Changed

- Release/product readiness checks now pass already-computed grounded-score and chat-card route observations into route-hint alignment.
- Route-hint alignment remains usable as a standalone demo, but release gates no longer rebuild the same chat interaction route payloads when prior quality snapshots already contain the route facts.
- Added an efficiency regression test that proves precomputed route observations skip interaction payload rebuilding.

### Why This Exists

- Recent route-quality work brought OMH quality scoring to 10/10 and aligned 53/53 route hints, but release readiness still repeated some routing work across adjacent gates.
- The user-facing goal is faster quality/release feedback without weakening the prepared-vs-observed boundary or changing public JSON claims.

### User / Operator Impact

- `omh release product-readiness --version 1.0.1 --json` stays at `ready` / score `100`, with grounded score 28/28 at 10/10 and route hints 53/53 aligned.
- Local timing improved further in this branch: product readiness averaged about 0.237s in the current run, compared with roughly 0.267s after the previous reuse PR and roughly 0.295s before route reuse work.
- Operators get the same evidence, but the release gate spends less time recomputing facts it already has.

### How It Works

- `build_route_hint_alignment_demo()` now accepts optional `grounded_score` and `chat_card_coverage` snapshots.
- It indexes only bounded route observation fields from those snapshots: workflow, route action, next action, and confidence.
- `product_readiness_report()` and `release_evidence_bundle()` pass their existing snapshots into route-hint alignment.
- If snapshots are absent, route-hint alignment uses the old standalone path and builds chat interaction payloads itself.

### Files And Contracts Touched

- `src/quality/route_hint_alignment.py`: optional precomputed route observation reuse.
- `src/maintenance/release.py`: release/product readiness passes precomputed quality snapshots.
- `tests/test_efficiency.py`: regression coverage for the reuse path.
- Public schema names and evidence boundaries are unchanged.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests` - 903 tests passed.
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli harness validate`
- [x] `git diff --check`
- [x] `PYTHONPATH=tests uv run python -m omh.cli release product-readiness --version 1.0.1 --json` - ready, score 100; grounded_score 28/28 at 10/10; chat_card_coverage 25/25; route_hint_alignment 53/53.
- [x] `PYTHONPATH=tests uv run python -m omh.cli release evidence-bundle --version 1.0.1 --json` - ready; route_hint_alignment 53/53, all aligned.
- [x] Timing smoke: product-readiness min 0.212s / avg 0.237s / max 0.265s; evidence-bundle min 0.327s / avg 0.331s / max 0.337s.
- [ ] `python3 -m omh.cli release checklist --json` - not required; this PR only changes already-covered product readiness and evidence bundle paths.
- [ ] `python3 -m omh.cli release hermes-smoke` - not required; no live Hermes registration or TUI behavior changed.
- [ ] `omh --help` - not required; no CLI help or command shape changed.
- [ ] Manual Hermes/TUI check: not run; this is a deterministic local release-gate performance change.

## Risk

- Low. The reuse path copies a small bounded set of already-observed route fields; when no snapshot exists, standalone behavior is preserved.
- The main risk is future quality payload schema drift, covered by the focused regression test and existing release smoke tests.

## Compatibility / Rollout

- Backward compatible. Callers that do not pass precomputed snapshots see the previous route-hint alignment behavior.
- No new dependencies, no network calls, no Hermes core behavior changes.

## Release / Claims

- [x] Release-channel impact considered: local/package quality gate performance only.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] Known manual Hermes checks are listed: live Hermes checks were not run because no live Hermes behavior changed.

## Follow-Up

- Continue watching release-gate latency as more quality demos are added so the quality pipeline does not drift back into duplicate route work.