### PR TITLE
Reuse release evidence quality snapshot

### DIFF
--- a/src/maintenance/release.py
+++ b/src/maintenance/release.py
@@ -149,6 +149,19 @@ class ReleaseChecklistItem:
         }
 
 
+@dataclass(frozen=True)
+class ReleaseQualityEvidence:
+    skill_content: dict[str, object]
+    parity: dict[str, object]
+    grounded_score: dict[str, object]
+    chat_cards: dict[str, object]
+    route_hints: dict[str, object]
+    context_briefs: dict[str, object]
+    routing_precision: dict[str, object]
+    hermes_ux: dict[str, object]
+    checklist: dict[str, object]
+
+
 def release_readiness_checklist(
     *,
     version: str = __version__,
@@ -517,7 +530,15 @@ def product_readiness_report(
     omh_command: str = "omh",
 ) -> dict[str, object]:
     release_version = _normalize_release_version(version)
-    omh_display = _shell_word(omh_command)
+    evidence = _build_release_quality_evidence(release_version=release_version, omh_command=omh_command)
+    return _product_readiness_report_from_evidence(
+        release_version=release_version,
+        omh_command=omh_command,
+        evidence=evidence,
+    )
+
+
+def _build_release_quality_evidence(*, release_version: str, omh_command: str) -> ReleaseQualityEvidence:
     skill_content = skill_content_smoke()
     parity = build_parity_matrix()
     grounded_score = build_grounded_score_demo()
@@ -536,6 +557,35 @@ def product_readiness_report(
         routing_precision=routing_precision,
     )
     checklist = release_readiness_checklist(version=release_version, omh_command=omh_command)
+    return ReleaseQualityEvidence(
+        skill_content=skill_content,
+        parity=parity,
+        grounded_score=grounded_score,
+        chat_cards=chat_cards,
+        route_hints=route_hints,
+        context_briefs=context_briefs,
+        routing_precision=routing_precision,
+        hermes_ux=hermes_ux,
+        checklist=checklist,
+    )
+
+
+def _product_readiness_report_from_evidence(
+    *,
+    release_version: str,
+    omh_command: str,
+    evidence: ReleaseQualityEvidence,
+) -> dict[str, object]:
+    omh_display = _shell_word(omh_command)
+    skill_content = evidence.skill_content
+    parity = evidence.parity
+    grounded_score = evidence.grounded_score
+    chat_cards = evidence.chat_cards
+    route_hints = evidence.route_hints
+    context_briefs = evidence.context_briefs
+    routing_precision = evidence.routing_precision
+    hermes_ux = evidence.hermes_ux
+    checklist = evidence.checklist
 
     checklist_items = checklist.get("items", [])
     checklist_ids = {
@@ -1571,26 +1621,22 @@ def release_evidence_bundle(
 ) -> dict[str, object]:
     release_version = _normalize_release_version(version)
     resolved_paths = paths or OmhPaths(omh_home=Path("~/.omh").expanduser(), hermes_home=Path("~/.hermes").expanduser())
-    checklist = release_readiness_checklist(version=release_version, omh_command=omh_command)
-    product = product_readiness_report(version=release_version, omh_command=omh_command)
-    skill_content = skill_content_smoke()
+    quality_evidence = _build_release_quality_evidence(release_version=release_version, omh_command=omh_command)
+    checklist = quality_evidence.checklist
+    product = _product_readiness_report_from_evidence(
+        release_version=release_version,
+        omh_command=omh_command,
+        evidence=quality_evidence,
+    )
+    skill_content = quality_evidence.skill_content
     use_cases = use_case_readiness(resolved_paths)
-    grounded_score = build_grounded_score_demo()
-    chat_cards = build_chat_card_coverage_demo()
-    route_hints = build_route_hint_alignment_demo(
-        grounded_score=grounded_score,
-        chat_card_coverage=chat_cards,
-    )
-    context_briefs = build_context_brief_coverage_demo()
-    routing_precision = build_routing_precision_demo()
-    hermes_ux = build_hermes_ux_quality_demo(
-        grounded_score=grounded_score,
-        chat_card_coverage=chat_cards,
-        route_hint_alignment=route_hints,
-        context_brief_coverage=context_briefs,
-        routing_precision=routing_precision,
-    )
-    parity = build_parity_matrix()
+    grounded_score = quality_evidence.grounded_score
+    chat_cards = quality_evidence.chat_cards
+    route_hints = quality_evidence.route_hints
+    context_briefs = quality_evidence.context_briefs
+    routing_precision = quality_evidence.routing_precision
+    hermes_ux = quality_evidence.hermes_ux
+    parity = quality_evidence.parity
     local_store_status = _release_local_store_status(use_cases)
     required_status = {
         "release_checklist": "passed" if checklist.get("ok") else "failed",

--- a/tests/test_release_smoke.py
+++ b/tests/test_release_smoke.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from contextlib import ExitStack
 import json
 import sys
 import subprocess
@@ -8,6 +9,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
+import omh.maintenance.release as release_module
 from omh.paths import OmhPaths
 from omh.release import (
     hermes_release_smoke_plan,
@@ -390,6 +392,41 @@ class ReleaseSmokeTests(unittest.TestCase):
             self.assertEqual(index["schema_version"], "omh_release_evidence_index/v1")
             self.assertEqual(index["latest_version"], "1.0.1")
             self.assertEqual(index["latest_artifact_path"], str(artifact_path))
+
+    def test_release_evidence_bundle_reuses_product_readiness_quality_evidence(self) -> None:
+        counted_names = (
+            "skill_content_smoke",
+            "build_parity_matrix",
+            "build_grounded_score_demo",
+            "build_chat_card_coverage_demo",
+            "build_route_hint_alignment_demo",
+            "build_context_brief_coverage_demo",
+            "build_routing_precision_demo",
+            "build_hermes_ux_quality_demo",
+            "release_readiness_checklist",
+        )
+        counts = {name: 0 for name in counted_names}
+
+        def counted(name: str):
+            original = getattr(release_module, name)
+
+            def wrapper(*args, **kwargs):
+                counts[name] += 1
+                return original(*args, **kwargs)
+
+            return wrapper
+
+        with TemporaryDirectory() as tmp:
+            paths = OmhPaths(omh_home=Path(tmp) / ".omh", hermes_home=Path(tmp) / ".hermes")
+            with ExitStack() as stack:
+                for name in counted_names:
+                    stack.enter_context(patch.object(release_module, name, side_effect=counted(name)))
+                payload = release_evidence_bundle(version="v1.0.1", omh_command="/tmp/omh command", paths=paths)
+
+        self.assertEqual(payload["status"], "ready")
+        self.assertEqual(payload["evidence"]["product_readiness"]["status"], "ready")
+        for name in counted_names:
+            self.assertEqual(counts[name], 1, name)
 
     def test_release_readiness_checklist_rejects_empty_version(self) -> None:
         with self.assertRaises(ValueError):


### PR DESCRIPTION
## Feature Report

### What Changed

- Added a shared release quality evidence snapshot for release maintenance paths.
- Reworked product readiness and release evidence bundle generation so the expensive deterministic gates are computed once and reused.
- Added a regression test that patches the release quality gate builders and proves the release evidence bundle calls each shared quality gate only once.

### Why This Exists

- `release_evidence_bundle()` previously computed product readiness, then rebuilt the same release quality evidence again for the bundle payload.
- That duplicated work made release smoke paths more expensive without adding new evidence.
- The project goal is better OMH quality and performance without weakening prepared-vs-observed release boundaries.

### User / Operator Impact

- Operators get the same release evidence schema and summary, but the backend does less repeated work while building the bundle.
- Release checks stay deterministic and local.
- No workflow routing, Hermes setup, plugin, executor, CI, review, or merge claims change.

### How It Works

- `ReleaseQualityEvidence` collects the deterministic product-readiness gates in one internal snapshot.
- `product_readiness_report()` builds that snapshot and renders the existing report from it.
- `release_evidence_bundle()` builds the same snapshot once, renders product readiness from it, then reuses the same gate payloads for the evidence bundle.
- `use_case_readiness()` remains separate because it depends on the selected local OMH/Hermes paths and local artifact-store state.

### Files And Contracts Touched

- `src/maintenance/release.py`: internal snapshot object and shared render path for release quality evidence.
- `tests/test_release_smoke.py`: regression coverage for one-call reuse across release evidence bundle generation.
- Public JSON schema names and prepared-vs-observed boundary copy are preserved.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_release_smoke.py tests/test_cli.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli harness validate`
- [ ] `python3 -m omh.cli release checklist --json` - covered by release evidence bundle and existing release smoke tests; not run separately in this PR.
- [ ] `python3 -m omh.cli release hermes-smoke` - not run; this PR changes deterministic local bundle construction only.
- [ ] `omh --help` - not run; no root CLI help changes.
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` - not run; no live install smoke changes.
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable.
- [x] Relevant dry-run or smoke command: `PYTHONPATH=tests uv run python -m omh.cli release evidence-bundle --version 1.0.1 --json`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; this is internal release evidence computation only.

## Risk

- Low. The PR preserves release payload shapes and changes only how internal deterministic evidence is assembled.
- The main risk is accidentally sharing path-sensitive evidence, so `use_case_readiness()` intentionally stays outside the shared snapshot.

## Compatibility / Rollout

- Compatible with existing release evidence consumers.
- No new dependency, config, network call, or Hermes runtime behavior.
- Safe to roll out as a normal patch-level maintenance improvement.

## Release / Claims

- [x] Release-channel impact considered (`preview` maintenance path; no channel default change)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- Keep new release quality gates inside the shared snapshot when they feed both product readiness and release evidence bundles.
