### PR TITLE
Cache static picker context surfaces

### DIFF
--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from copy import deepcopy
+from functools import lru_cache
 import hashlib
 from typing import Any
 
@@ -4177,6 +4179,11 @@ def _skill_picker_body(*, catalog_question: bool) -> str:
 
 
 def _skill_picker_family_body_lines() -> list[str]:
+    return list(_skill_picker_family_body_lines_cached())
+
+
+@lru_cache(maxsize=1)
+def _skill_picker_family_body_lines_cached() -> tuple[str, ...]:
     lines = []
     for family in capability_family_cards():
         workflows = _as_string_list(family.get("primary_workflows", []))[:4]
@@ -4185,7 +4192,7 @@ def _skill_picker_family_body_lines() -> list[str]:
         if executor_choices:
             workflow_text = f"{workflow_text}; executors: {', '.join(executor_choices)}"
         lines.append(f"- {family.get('label', '')}: {workflow_text}.")
-    return lines
+    return tuple(lines)
 
 
 def _skill_picker_state(message: str, *, source: str) -> dict[str, object]:
@@ -4305,6 +4312,11 @@ def _compact_picker_option(option: dict[str, object]) -> dict[str, object]:
 
 
 def _context_primer_state() -> dict[str, object]:
+    return deepcopy(_context_primer_state_cached())
+
+
+@lru_cache(maxsize=1)
+def _context_primer_state_cached() -> dict[str, object]:
     installed = {definition.name for definition in installable_skill_definitions()}
     groups = []
     for group in _CONTEXT_PRIMER_GROUPS:
@@ -4335,6 +4347,11 @@ def _context_primer_state() -> dict[str, object]:
 
 
 def _catalog_capability_summary() -> dict[str, object]:
+    return deepcopy(_catalog_capability_summary_cached())
+
+
+@lru_cache(maxsize=1)
+def _catalog_capability_summary_cached() -> dict[str, object]:
     from ..capabilities.registry import capability_summary
 
     summary = capability_summary()

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -11,6 +11,7 @@ load_local_package()
 from omh.skill_pack import builtin_definitions, builtin_skill_templates
 from omh.routing import recommend as recommend_module
 from omh.skills import render as render_module
+from omh.wrapper import contract as contract_module
 from omh.release import (
     AWARENESS_PRIMER_CONTEXT_CHAR_LIMIT,
     AWARENESS_PRIMER_MARKDOWN_CHAR_LIMIT,
@@ -426,6 +427,45 @@ class EfficiencyContractTests(unittest.TestCase):
         cache_info = recommend_module._prepared_routable_definitions.cache_info()
 
         self.assertNotEqual(second[0]["skill"], "mutated")
+        self.assertEqual(cache_info.misses, 1)
+        self.assertGreaterEqual(cache_info.hits, 1)
+
+    def test_catalog_capability_summary_cache_is_reused_without_payload_poisoning(self) -> None:
+        contract_module._catalog_capability_summary_cached.cache_clear()
+
+        first = contract_module._catalog_capability_summary()
+        first["lanes"][0]["id"] = "mutated"
+        second = contract_module._catalog_capability_summary()
+        cache_info = contract_module._catalog_capability_summary_cached.cache_info()
+
+        self.assertIsNot(first, second)
+        self.assertNotEqual(second["lanes"][0]["id"], "mutated")
+        self.assertEqual(cache_info.misses, 1)
+        self.assertGreaterEqual(cache_info.hits, 1)
+
+    def test_context_primer_cache_is_reused_without_payload_poisoning(self) -> None:
+        contract_module._context_primer_state_cached.cache_clear()
+
+        first = contract_module._context_primer_state()
+        first["workflow_groups"][0]["id"] = "mutated"
+        second = contract_module._context_primer_state()
+        cache_info = contract_module._context_primer_state_cached.cache_info()
+
+        self.assertIsNot(first, second)
+        self.assertNotEqual(second["workflow_groups"][0]["id"], "mutated")
+        self.assertEqual(cache_info.misses, 1)
+        self.assertGreaterEqual(cache_info.hits, 1)
+
+    def test_skill_picker_family_body_lines_cache_is_reused_without_list_poisoning(self) -> None:
+        contract_module._skill_picker_family_body_lines_cached.cache_clear()
+
+        first = contract_module._skill_picker_family_body_lines()
+        first[0] = "mutated"
+        second = contract_module._skill_picker_family_body_lines()
+        cache_info = contract_module._skill_picker_family_body_lines_cached.cache_info()
+
+        self.assertIsNot(first, second)
+        self.assertNotEqual(second[0], "mutated")
         self.assertEqual(cache_info.misses, 1)
         self.assertGreaterEqual(cache_info.hits, 1)
 


### PR DESCRIPTION
## Feature Report

### What Changed

- Added mutation-safe caching around the static OMH workflow picker context surfaces used by wrapper/chat responses.
- Cached the capability summary template, context primer state, and picker family body lines while still returning fresh mutable payloads to callers.
- Added efficiency regression tests that prove repeated access reuses the cache without leaking caller-side mutations into later responses.

### Why This Exists

- Repeated chat questions such as "what OMH workflows are available?" rebuild the same catalog and capability projections even though that data is static package metadata for the process.
- A representative cProfile probe showed the picker/catalog path spending measurable time in repeated static projection and deepcopy work.
- This keeps the chat-first OMH catalog/picker path lighter without changing public routing behavior or evidence boundaries.

### User / Operator Impact

- Hermes wrappers can answer workflow inventory and picker questions with less repeated compute in long-lived processes.
- Users still get the same `skill_picker` response, capability families, route explanation, and prepared-vs-observed claim boundary.
- No new command, setup step, network call, executor dispatch, or plugin/runtime claim is introduced.

### How It Works

- `_catalog_capability_summary()` now returns a deep copy of a single cached static summary template.
- `_context_primer_state()` now returns a deep copy of a single cached context-primer template.
- `_skill_picker_family_body_lines()` now returns a new list from a cached tuple of static body lines.
- Tests clear each cache, mutate the public return value, and verify later calls are cache hits without payload poisoning.

### Files And Contracts Touched

- `src/wrapper/contract.py`
  - Adds `lru_cache` and mutation-safe return wrappers for static picker/catalog/context projections.
- `tests/test_efficiency.py`
  - Adds cache reuse and mutation-safety coverage for the new cached surfaces.
- Public contracts preserved:
  - `chat_response/v1`
  - `omh_skill_picker/v1`
  - `omh_capability_summary/v1`
  - prepared-vs-observed routing boundary language.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` (`913 tests`, passing)
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli harness validate`
- [ ] `python3 -m omh.cli release checklist --json` (not release-surface work)
- [ ] `python3 -m omh.cli release hermes-smoke` (not release/Hermes install-surface work)
- [ ] `omh --help` (not command-surface work)
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` (not install-surface work)
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable; no learning contract changed.
- [x] Relevant dry-run or smoke command: `PYTHONPATH=tests uv run python -m omh.cli chat interact --source discord "what OMH workflows are available?" --json`
- [x] Additional parsed smoke: verified `kind=skill_picker`, `state.skill_picker.schema_version=omh_skill_picker/v1`, and `state.capability_summary.schema_version=omh_capability_summary/v1`.
- [x] Performance probe: representative 250-message cProfile run improved from about `0.398s` baseline to `0.352s` after caching static picker context surfaces.
- [x] `git diff --check`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; this is an internal wrapper compute optimization and the CLI JSON smoke verifies the emitted contract shape.

## Risk

- Low. The cached data is static catalog/package metadata in normal process lifetime.
- If future code mutates catalog definitions in-process, the cached templates may need an explicit cache clear. Tests expose the cache handles so this remains easy to validate.
- Full chat responses are not cached because thread/source-specific fields must remain per request.

## Compatibility / Rollout

- Backward compatible with existing wrapper payloads and tests.
- No release-channel behavior change beyond lower repeated compute for catalog/picker rendering.
- No migration, setup, generated docs, or skill regeneration required.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`): no release-channel semantic change.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed: no runtime/native capability claims added.
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap: live Hermes/TUI not run because this is not a Hermes install/runtime load change.

## Follow-Up

- Consider profiling `active_routing_guard_rules()` and localization token matching if we continue optimizing high-volume wrapper routing.
