### PR TITLE
Cache repeated routing guard decisions

### DIFF
--- a/src/routing/policy.py
+++ b/src/routing/policy.py
@@ -2574,6 +2574,14 @@ def active_routing_guard_rules(
 ) -> tuple[RoutingGuardRule, ...]:
     if explicit_skill:
         return ()
+    return _active_routing_guard_rules_cached(normalized_query, frozenset(query_tokens))
+
+
+@lru_cache(maxsize=512)
+def _active_routing_guard_rules_cached(
+    normalized_query: str,
+    query_tokens: frozenset[str],
+) -> tuple[RoutingGuardRule, ...]:
     rules: list[RoutingGuardRule] = []
     if _risky_refactor_guard_applies(normalized_query, query_tokens):
         rules.append(RISKY_REFACTOR_GUARD)

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -10,6 +10,7 @@ from _local_package import load_local_package
 load_local_package()
 from omh.skill_pack import builtin_definitions, builtin_skill_templates
 from omh.routing import recommend as recommend_module
+from omh.routing import policy as policy_module
 from omh.skills import render as render_module
 from omh.wrapper import contract as contract_module
 from omh.release import (
@@ -427,6 +428,17 @@ class EfficiencyContractTests(unittest.TestCase):
         cache_info = recommend_module._prepared_routable_definitions.cache_info()
 
         self.assertNotEqual(second[0]["skill"], "mutated")
+        self.assertEqual(cache_info.misses, 1)
+        self.assertGreaterEqual(cache_info.hits, 1)
+
+    def test_routing_guard_cache_is_reused_for_repeated_recommendations(self) -> None:
+        policy_module._active_routing_guard_rules_cached.cache_clear()
+
+        first = recommend_module.recommend_skills("risky refactor", limit=2)
+        second = recommend_module.recommend_skills("risky refactor", limit=2)
+        cache_info = policy_module._active_routing_guard_rules_cached.cache_info()
+
+        self.assertEqual(first, second)
         self.assertEqual(cache_info.misses, 1)
         self.assertGreaterEqual(cache_info.hits, 1)
 


### PR DESCRIPTION
## Feature Report

### What Changed

- Added a bounded cache for `active_routing_guard_rules()` decisions keyed by normalized query text and routing tokens.
- Kept explicit skill invocations outside the cache path so direct `./skill`, `$skill`, and explicit skill routing still bypass guardrails exactly as before.
- Added an efficiency regression test proving repeated `recommend_skills()` calls reuse the guard cache while preserving identical recommendation output.

### Why This Exists

- Representative wrapper routing profiles still showed repeated guard evaluation as a meaningful hot path after static picker context caching.
- Long-lived Hermes/wrapper processes often see repeated inventory, preview, status, and route-check messages; rerunning every guard predicate for identical normalized input wastes compute.
- This moves one more stable decision surface out of the per-request hot loop without caching full recommendation payloads.

### User / Operator Impact

- Repeated chat routing is lighter for common repeated messages and preview flows.
- Router output, skill picker behavior, route explanations, and evidence-boundary copy remain unchanged.
- No new setup step, command, network call, executor dispatch, or runtime claim is introduced.

### How It Works

- `active_routing_guard_rules()` still returns an empty tuple immediately for explicit skill invocations.
- Non-explicit requests now call `_active_routing_guard_rules_cached(normalized_query, frozenset(query_tokens))` with `maxsize=512`.
- The cached function returns immutable tuples of existing `RoutingGuardRule` objects, so callers cannot mutate cached lists.
- Full recommendations remain uncached because scoring output and payload shape should stay straightforward and per request.

### Files And Contracts Touched

- `src/routing/policy.py`
  - Adds the bounded guard-rule cache behind the existing public helper.
- `tests/test_efficiency.py`
  - Adds cache reuse coverage through the real `recommend_skills()` path.
- Public contracts preserved:
  - recommendation JSON shape
  - chat wrapper route payload shape
  - explicit skill invocation semantics
  - prepared-vs-observed evidence boundaries.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_efficiency.py tests/test_router_content.py tests/test_chat_router.py tests/test_wrapper_contract.py -v` (`189 tests`, passing)
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` (`914 tests`, passing)
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli harness validate`
- [ ] `python3 -m omh.cli release checklist --json` (not release-surface work)
- [ ] `python3 -m omh.cli release hermes-smoke` (not release/Hermes install-surface work)
- [ ] `omh --help` (not command-surface work)
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` (not install-surface work)
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable; no learning contract changed.
- [x] Relevant dry-run or smoke command: representative cProfile wrapper routing probe over 250 messages.
- [x] Performance probe: representative 250-message cProfile run improved from about `0.352s` after PR #358 to `0.322s` with routing guard caching.
- [x] `git diff --check`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; this is an internal deterministic routing hot-path optimization and targeted/full tests cover route behavior.

## Risk

- Low. The cache key is normalized text plus tokens and the returned rule tuple is immutable.
- If future routing policy becomes dependent on dynamic process state, those dynamic inputs must be added to the cache key or the cache should be cleared.
- The cache is bounded to avoid unbounded growth in long-lived wrapper processes.

## Compatibility / Rollout

- Backward compatible with existing router, wrapper, and CLI behavior.
- No generated docs, skill templates, setup output, or runtime artifact migration required.
- Can roll out on stable/preview as a transparent performance improvement.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`): transparent performance improvement only.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed: no runtime/native capability claims added.
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap: live Hermes/TUI not run because this is not a Hermes install/runtime load change.

## Follow-Up

- Continue profiling localization tokenization and catalog-question detection if high-volume wrapper routing remains a priority.
