### PR TITLE
Cache repeated routing text normalization

### DIFF
--- a/src/routing/localization.py
+++ b/src/routing/localization.py
@@ -607,6 +607,7 @@ def normalized_phrase(value: str) -> str:
     return _fold_for_match(value)
 
 
+@lru_cache(maxsize=8192)
 def _fold_for_match(value: str) -> str:
     normalized = unicodedata.normalize("NFKC", value).casefold()
     decomposed = unicodedata.normalize("NFKD", normalized)

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -9,6 +9,7 @@ from _local_package import load_local_package
 
 load_local_package()
 from omh.skill_pack import builtin_definitions, builtin_skill_templates
+from omh.routing import localization as localization_module
 from omh.routing import recommend as recommend_module
 from omh.routing import policy as policy_module
 from omh.skills import render as render_module
@@ -438,6 +439,18 @@ class EfficiencyContractTests(unittest.TestCase):
         second = recommend_module.recommend_skills("risky refactor", limit=2)
         cache_info = policy_module._active_routing_guard_rules_cached.cache_info()
 
+        self.assertEqual(first, second)
+        self.assertEqual(cache_info.misses, 1)
+        self.assertGreaterEqual(cache_info.hits, 1)
+
+    def test_normalized_phrase_cache_reuses_folded_text(self) -> None:
+        localization_module._fold_for_match.cache_clear()
+
+        first = localization_module.normalized_phrase("Café risky refactor")
+        second = localization_module.normalized_phrase("Café risky refactor")
+        cache_info = localization_module._fold_for_match.cache_info()
+
+        self.assertEqual(first, "cafe risky refactor")
         self.assertEqual(first, second)
         self.assertEqual(cache_info.misses, 1)
         self.assertGreaterEqual(cache_info.hits, 1)


### PR DESCRIPTION
## Feature Report

### What Changed

- Added a bounded cache to the pure routing text folding helper used by `normalized_phrase()`, `routing_terms()`, and multilingual alias matching.
- Added an efficiency regression test proving repeated normalized text calls reuse the fold cache and preserve accent-stripping behavior.

### Why This Exists

- Representative wrapper routing profiles still showed `_fold_for_match()` as a repeated hot path after prior picker and guard caching.
- Hermes/wrapper processes often route repeated previews, status messages, catalog questions, and similar operator phrases, so identical string normalization should not redo Unicode normalization every time.
- This keeps deterministic multilingual routing lighter without changing route scoring or public payloads.

### User / Operator Impact

- Repeated natural-language routing is slightly faster and does less repeated compute.
- Existing English/Korean/Japanese/Chinese/Spanish/French/German phrase-pack behavior is preserved.
- No new command, setup flow, generated skill output, network call, executor dispatch, or runtime claim is introduced.

### How It Works

- `_fold_for_match()` now uses `@lru_cache(maxsize=8192)`.
- The cache is below the existing public helper surface, so callers keep using `normalized_phrase()`, `routing_terms()`, and `routing_tokens()` exactly as before.
- `routing_tokens()` itself is not cached because callers pass different stopword sets; caching the pure string fold gives the safe shared benefit without broadening cache keys.

### Files And Contracts Touched

- `src/routing/localization.py`
  - Adds bounded caching to pure string folding.
- `tests/test_efficiency.py`
  - Adds cache reuse coverage for normalization and verifies `Café` still folds to `cafe`.
- Public contracts preserved:
  - router recommendations
  - chat wrapper payloads
  - multilingual phrase-pack behavior
  - prepared-vs-observed evidence boundaries.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_efficiency.py tests/test_chat_router.py tests/test_wrapper_contract.py -v` (`152 tests`, passing)
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` (`915 tests`, passing)
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli harness validate`
- [ ] `python3 -m omh.cli release checklist --json` (not release-surface work)
- [ ] `python3 -m omh.cli release hermes-smoke` (not release/Hermes install-surface work)
- [ ] `omh --help` (not command-surface work)
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` (not install-surface work)
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable; no learning contract changed.
- [x] Relevant dry-run or smoke command: representative cProfile wrapper routing probe over 250 messages.
- [x] Performance probe: representative 250-message cProfile run improved from about `0.319s` on current main to `0.306s` with normalization caching.
- [x] `git diff --check`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; this is an internal deterministic routing hot-path optimization and targeted/full tests cover route behavior.

## Risk

- Low. `_fold_for_match()` is a pure string normalization helper and the cache is bounded.
- If future normalization behavior depends on runtime locale or mutable settings, those inputs must become part of the cache key or the cache should be cleared.
- Cache memory is bounded by `maxsize=8192` to avoid unbounded growth in long-lived wrapper processes.

## Compatibility / Rollout

- Backward compatible with existing router, wrapper, CLI, and generated docs behavior.
- No migration, setup, generated output, or runtime artifact changes required.
- Can roll out as a transparent performance improvement.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`): transparent performance improvement only.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed: no runtime/native capability claims added.
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap: live Hermes/TUI not run because this is not a Hermes install/runtime load change.

## Follow-Up

- Continue profiling catalog-question detection and scoring if high-volume wrapper routing needs further latency reduction.
