### PR TITLE
Cache repeated recommendation phrase matches

### DIFF
--- a/src/routing/recommend.py
+++ b/src/routing/recommend.py
@@ -764,6 +764,7 @@ def _command_trigger_match(query: str, value: str) -> bool:
     return bool(_COMMAND_TRIGGER_PATTERNS[value].search(query))
 
 
+@lru_cache(maxsize=16384)
 def _phrase_match(query: str, value: str) -> bool:
     return bool(query and value and (query in value or value in query))
 

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -455,6 +455,17 @@ class EfficiencyContractTests(unittest.TestCase):
         self.assertEqual(cache_info.misses, 1)
         self.assertGreaterEqual(cache_info.hits, 1)
 
+    def test_phrase_match_cache_reuses_repeated_recommendation_pairs(self) -> None:
+        recommend_module._phrase_match.cache_clear()
+
+        first = recommend_module.recommend_skills("risky refactor", limit=2)
+        second = recommend_module.recommend_skills("risky refactor", limit=2)
+        cache_info = recommend_module._phrase_match.cache_info()
+
+        self.assertEqual(first, second)
+        self.assertGreater(cache_info.misses, 0)
+        self.assertGreater(cache_info.hits, 0)
+
     def test_catalog_capability_summary_cache_is_reused_without_payload_poisoning(self) -> None:
         contract_module._catalog_capability_summary_cached.cache_clear()
 


### PR DESCRIPTION
## Summary
- Cache repeated recommendation phrase matching in the router scoring hot path with a bounded pure query/value cache.
- Add an efficiency regression test that proves repeated recommendation calls reuse phrase-pair decisions without changing recommendation output.

## Why
Representative wrapper routing profiles still spent noticeable time redoing identical catalog/query substring checks across repeated route previews and workflow-picker questions. This keeps the existing recommendation semantics while shaving another small chunk from the long-lived Hermes wrapper path.

## How
- Adds `@lru_cache(maxsize=16384)` to `_phrase_match(query, value)` in `src/routing/recommend.py`.
- Keeps full recommendation payloads uncached so per-request prompt copy and prepared-vs-observed boundaries stay easy to reason about.
- Clears and inspects the cache in `tests/test_efficiency.py` to lock repeat-call reuse.

## User Impact
Repeated natural-language routing, catalog preview, and workflow-picker interactions do less duplicate local scoring work. The visible workflow choice and scoring behavior remain unchanged.

## Verification
- `PYTHONPATH=tests uv run python -m unittest tests/test_efficiency.py tests/test_chat_router.py tests/test_wrapper_contract.py -v` -> 153 tests passed
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` -> 916 tests passed
- `uv run python -m compileall -q src tests` -> passed
- `uv run python -m omh.cli docs workflows --check` -> passed, 48/48 tap skills checked
- `uv run python -m omh.cli harness validate` -> passed, 36 harnesses and 50 skills validated
- `git diff --check` -> passed
- Representative cProfile chat-routing probe -> 0.306s before this slice, 0.273s after this slice

## Risks And Boundaries
- The cache is bounded and stores only pure string-pair boolean decisions.
- No schema, CLI, docs, Hermes registration, executor dispatch, connector, plugin-load, review, CI, or merge evidence behavior changes.
