### PR TITLE
Cache static wrapper picker payloads

### DIFF
--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from copy import deepcopy
 from functools import lru_cache
 import hashlib
 from typing import Any
@@ -4196,6 +4195,14 @@ def _skill_picker_family_body_lines_cached() -> tuple[str, ...]:
 
 
 def _skill_picker_state(message: str, *, source: str) -> dict[str, object]:
+    state = _clone_static_dict(_skill_picker_static_state_cached())
+    state["trigger"] = _first_token(message)
+    state["source"] = source
+    return state
+
+
+@lru_cache(maxsize=1)
+def _skill_picker_static_state_cached() -> dict[str, object]:
     installed = {definition.name: definition for definition in installable_skill_definitions()}
     options = []
     for skill_id, label, description, direct_invocation in _SKILL_PICKER_ENTRIES:
@@ -4226,8 +4233,8 @@ def _skill_picker_state(message: str, *, source: str) -> dict[str, object]:
     family_cards = _skill_picker_family_cards(options)
     return {
         "schema_version": SKILL_PICKER_SCHEMA_VERSION,
-        "trigger": _first_token(message),
-        "source": source,
+        "trigger": "",
+        "source": "",
         "selection_mode": "single_select",
         "options": options,
         "featured_options": featured_options,
@@ -4312,7 +4319,7 @@ def _compact_picker_option(option: dict[str, object]) -> dict[str, object]:
 
 
 def _context_primer_state() -> dict[str, object]:
-    return deepcopy(_context_primer_state_cached())
+    return _clone_static_dict(_context_primer_state_cached())
 
 
 @lru_cache(maxsize=1)
@@ -4347,7 +4354,7 @@ def _context_primer_state_cached() -> dict[str, object]:
 
 
 def _catalog_capability_summary() -> dict[str, object]:
-    return deepcopy(_catalog_capability_summary_cached())
+    return _clone_static_dict(_catalog_capability_summary_cached())
 
 
 @lru_cache(maxsize=1)
@@ -4392,6 +4399,21 @@ def _as_dict_list(value: object) -> list[dict[str, object]]:
     if not isinstance(value, list):
         return []
     return [item for item in value if isinstance(item, dict)]
+
+
+def _clone_static_dict(value: dict[str, object]) -> dict[str, object]:
+    cloned = _clone_static_payload(value)
+    return cloned if isinstance(cloned, dict) else {}
+
+
+def _clone_static_payload(value: object) -> object:
+    if isinstance(value, dict):
+        return {key: _clone_static_payload(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_clone_static_payload(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_clone_static_payload(item) for item in value)
+    return value
 
 
 def _as_string_list(value: object) -> list[str]:

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -471,11 +471,13 @@ class EfficiencyContractTests(unittest.TestCase):
 
         first = contract_module._catalog_capability_summary()
         first["lanes"][0]["id"] = "mutated"
+        first["workflow_context_cards"][0]["user_examples"][0] = "mutated"
         second = contract_module._catalog_capability_summary()
         cache_info = contract_module._catalog_capability_summary_cached.cache_info()
 
         self.assertIsNot(first, second)
         self.assertNotEqual(second["lanes"][0]["id"], "mutated")
+        self.assertNotEqual(second["workflow_context_cards"][0]["user_examples"][0], "mutated")
         self.assertEqual(cache_info.misses, 1)
         self.assertGreaterEqual(cache_info.hits, 1)
 
@@ -484,11 +486,30 @@ class EfficiencyContractTests(unittest.TestCase):
 
         first = contract_module._context_primer_state()
         first["workflow_groups"][0]["id"] = "mutated"
+        first["workflow_context_cards"][0]["user_examples"][0] = "mutated"
         second = contract_module._context_primer_state()
         cache_info = contract_module._context_primer_state_cached.cache_info()
 
         self.assertIsNot(first, second)
         self.assertNotEqual(second["workflow_groups"][0]["id"], "mutated")
+        self.assertNotEqual(second["workflow_context_cards"][0]["user_examples"][0], "mutated")
+        self.assertEqual(cache_info.misses, 1)
+        self.assertGreaterEqual(cache_info.hits, 1)
+
+    def test_skill_picker_static_state_cache_preserves_dynamic_fields_without_payload_poisoning(self) -> None:
+        contract_module._skill_picker_static_state_cached.cache_clear()
+
+        first = contract_module._skill_picker_state("./omh", source="discord")
+        first["options"][0]["id"] = "mutated"
+        second = contract_module._skill_picker_state("/omh", source="slack")
+        cache_info = contract_module._skill_picker_static_state_cached.cache_info()
+
+        self.assertIsNot(first, second)
+        self.assertEqual(first["trigger"], "./omh")
+        self.assertEqual(first["source"], "discord")
+        self.assertEqual(second["trigger"], "/omh")
+        self.assertEqual(second["source"], "slack")
+        self.assertNotEqual(second["options"][0]["id"], "mutated")
         self.assertEqual(cache_info.misses, 1)
         self.assertGreaterEqual(cache_info.hits, 1)
 


### PR DESCRIPTION
## Summary
- Cache the static OMH workflow picker template used by `./omh`, `/omh`, and workflow catalog questions.
- Replace generic `deepcopy` for static wrapper capability payloads with a focused dict/list/tuple clone that keeps response mutation isolation with less overhead.
- Extend efficiency tests so nested wrapper payload mutations cannot poison later cached responses.

## Why
The representative chat-routing profile after the previous routing caches still showed wrapper picker and catalog responses spending time rebuilding static picker state and running generic `deepcopy` over JSON-like payloads. These surfaces are directly user-visible when someone asks what OMH can do or opens the workflow picker, so trimming repeated local work improves chat-first responsiveness without changing routing behavior.

## How
- Adds `_skill_picker_static_state_cached()` for the source-independent picker template.
- Keeps per-message `trigger` and per-wrapper `source` dynamic by applying them after cloning the static template.
- Adds `_clone_static_payload()` for the static JSON-like wrapper payloads instead of exposing cached dictionaries directly.
- Keeps capability summary and context primer mutation-safe for wrapper consumers.

## User Impact
Repeated OMH workflow-picker and catalog-help interactions do less local recomputation. The visible picker options, groups, capability summary, and evidence boundaries stay the same.

## Verification
- `PYTHONPATH=tests uv run python -m unittest tests/test_efficiency.py tests/test_wrapper_contract.py tests/test_chat_router.py -v` -> 154 tests passed
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` -> 917 tests passed
- `uv run python -m compileall -q src tests` -> passed
- `uv run python -m omh.cli docs workflows --check` -> passed, 48/48 tap skills checked
- `uv run python -m omh.cli harness validate` -> passed, 36 harnesses and 50 skills validated
- `git diff --check` -> passed
- Representative cProfile chat-routing probe -> `0.268s` on current main before this PR, `0.246s` after this PR

## Risks And Boundaries
- Cached templates are still cloned before returning, so wrappers can mutate response payloads without corrupting later responses.
- This does not change schemas, CLI behavior, generated skills, Hermes registration, executor dispatch, connector behavior, plugin-load evidence, review, CI, or merge boundaries.
