### PR TITLE
Cache repeated catalog question checks

### DIFF
--- a/src/routing/catalog_questions.py
+++ b/src/routing/catalog_questions.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from functools import lru_cache
 import unicodedata
 
 
@@ -484,6 +485,7 @@ def is_file_or_text_lookup_question(message: str) -> bool:
     return _is_file_or_text_search_question(_catalog_search_texts(lowered))
 
 
+@lru_cache(maxsize=4096)
 def _catalog_search_texts(lowered: str) -> tuple[str, ...]:
     folded = "".join(
         character for character in unicodedata.normalize("NFKD", lowered) if not unicodedata.combining(character)
@@ -560,5 +562,6 @@ def _is_operator_action_question(search_texts: tuple[str, ...]) -> bool:
     )
 
 
+@lru_cache(maxsize=16384)
 def _contains_catalog_token(search_texts: tuple[str, ...], tokens: tuple[str, ...]) -> bool:
     return any(token in text for text in search_texts for token in tokens)

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -9,6 +9,7 @@ from _local_package import load_local_package
 
 load_local_package()
 from omh.skill_pack import builtin_definitions, builtin_skill_templates
+from omh.routing import catalog_questions as catalog_questions_module
 from omh.routing import localization as localization_module
 from omh.routing import recommend as recommend_module
 from omh.routing import policy as policy_module
@@ -465,6 +466,22 @@ class EfficiencyContractTests(unittest.TestCase):
         self.assertEqual(first, second)
         self.assertGreater(cache_info.misses, 0)
         self.assertGreater(cache_info.hits, 0)
+
+    def test_catalog_question_caches_repeated_search_and_token_checks(self) -> None:
+        catalog_questions_module._catalog_search_texts.cache_clear()
+        catalog_questions_module._contains_catalog_token.cache_clear()
+
+        first = catalog_questions_module.is_skill_catalog_question("what OMH workflows are available?")
+        second = catalog_questions_module.is_skill_catalog_question("what OMH workflows are available?")
+        search_cache = catalog_questions_module._catalog_search_texts.cache_info()
+        token_cache = catalog_questions_module._contains_catalog_token.cache_info()
+
+        self.assertTrue(first)
+        self.assertEqual(first, second)
+        self.assertEqual(search_cache.misses, 1)
+        self.assertGreaterEqual(search_cache.hits, 1)
+        self.assertGreater(token_cache.misses, 0)
+        self.assertGreater(token_cache.hits, 0)
 
     def test_catalog_capability_summary_cache_is_reused_without_payload_poisoning(self) -> None:
         contract_module._catalog_capability_summary_cached.cache_clear()


### PR DESCRIPTION
## Summary
- Cache normalized search-text generation for workflow catalog questions.
- Cache repeated catalog token-presence checks over static marker tuples.
- Add an efficiency regression test proving repeated `what OMH workflows are available?` checks reuse both caches.

## Why
After the previous wrapper/picker optimizations, the representative chat-routing profile still spent time repeatedly scanning the same catalog marker sets to decide whether a message is a workflow catalog question. That path is user-visible when Hermes answers “what OMH workflows are available?” or opens the picker without shell approval.

## How
- Adds bounded `lru_cache` to `_catalog_search_texts(lowered)`.
- Adds bounded `lru_cache` to `_contains_catalog_token(search_texts, tokens)`.
- Keeps caching at pure helper boundaries instead of caching the whole catalog-question decision, so existing branching semantics remain explicit.

## User Impact
Repeated catalog/help/picker routing does less local string scanning. The visible routing decision, picker response, and workflow inventory behavior stay unchanged.

## Verification
- `PYTHONPATH=tests uv run python -m unittest tests/test_efficiency.py tests/test_catalog_questions.py tests/test_wrapper_contract.py tests/test_chat_router.py -v` -> 159 tests passed
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` -> 918 tests passed
- `uv run python -m compileall -q src tests` -> passed
- `uv run python -m omh.cli docs workflows --check` -> passed, 48/48 tap skills checked
- `uv run python -m omh.cli harness validate` -> passed, 36 harnesses and 50 skills validated
- `git diff --check` -> passed
- Representative cProfile chat-routing probe -> `0.232s` on current main before this PR, `0.201s` after this PR

## Risks And Boundaries
- The caches are bounded and keyed only by normalized strings plus static marker tuples.
- This does not change schemas, CLI behavior, generated skills, Hermes registration, executor dispatch, connector behavior, plugin-load evidence, review, CI, or merge boundaries.
