### PR TITLE
Cache repeated routing tokenization

### DIFF
--- a/src/routing/localization.py
+++ b/src/routing/localization.py
@@ -583,16 +583,26 @@ def _folded_alias_phrases() -> tuple[tuple[LocaleAlias, tuple[str, ...]], ...]:
 
 
 def routing_tokens(value: str, *, stopwords: set[str] | None = None) -> set[str]:
-    stopwords = _STOPWORDS if stopwords is None else stopwords
+    stopword_key = frozenset(_STOPWORDS if stopwords is None else stopwords)
+    return set(_routing_tokens_cached(value, stopword_key))
+
+
+@lru_cache(maxsize=8192)
+def _routing_tokens_cached(value: str, stopwords: frozenset[str]) -> frozenset[str]:
     tokens: set[str] = set()
     for raw_token in routing_terms(value):
         for token in (raw_token, *raw_token.split("-")):
             if len(token) >= 3 and token not in stopwords:
                 tokens.add(token)
-    return tokens
+    return frozenset(tokens)
 
 
 def routing_terms(value: str) -> set[str]:
+    return set(_routing_terms_cached(value))
+
+
+@lru_cache(maxsize=8192)
+def _routing_terms_cached(value: str) -> frozenset[str]:
     folded = _fold_for_match(value)
     terms: set[str] = set()
     for raw_token in _TOKEN_RE.findall(folded):
@@ -600,7 +610,7 @@ def routing_terms(value: str) -> set[str]:
         if token:
             terms.add(token)
             terms.update(part for part in token.split("-") if part)
-    return terms
+    return frozenset(terms)
 
 
 def normalized_phrase(value: str) -> str:

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -456,6 +456,32 @@ class EfficiencyContractTests(unittest.TestCase):
         self.assertEqual(cache_info.misses, 1)
         self.assertGreaterEqual(cache_info.hits, 1)
 
+    def test_routing_token_cache_reuses_terms_without_payload_poisoning(self) -> None:
+        localization_module._routing_terms_cached.cache_clear()
+        localization_module._routing_tokens_cached.cache_clear()
+
+        first_terms = localization_module.routing_terms("Risky refactor with code-review")
+        first_terms.add("mutated")
+        second_terms = localization_module.routing_terms("Risky refactor with code-review")
+
+        self.assertIn("risky", second_terms)
+        self.assertIn("code-review", second_terms)
+        self.assertNotIn("mutated", second_terms)
+        terms_cache = localization_module._routing_terms_cached.cache_info()
+        self.assertEqual(terms_cache.misses, 1)
+        self.assertGreaterEqual(terms_cache.hits, 1)
+
+        first_tokens = localization_module.routing_tokens("Risky refactor with code-review", stopwords=set())
+        first_tokens.add("mutated")
+        second_tokens = localization_module.routing_tokens("Risky refactor with code-review", stopwords=set())
+        tokens_cache = localization_module._routing_tokens_cached.cache_info()
+
+        self.assertIn("risky", second_tokens)
+        self.assertIn("code-review", second_tokens)
+        self.assertNotIn("mutated", second_tokens)
+        self.assertEqual(tokens_cache.misses, 1)
+        self.assertGreaterEqual(tokens_cache.hits, 1)
+
     def test_phrase_match_cache_reuses_repeated_recommendation_pairs(self) -> None:
         recommend_module._phrase_match.cache_clear()
 


### PR DESCRIPTION
## Summary
- Cache repeated routing term and routing token derivation behind immutable frozenset cache entries.
- Keep the public `routing_terms` / `routing_tokens` APIs returning fresh mutable `set` values so callers cannot poison cached state.
- Add an efficiency regression test that proves repeated calls reuse the cache while mutated caller payloads do not leak into later calls.

## Why
Repeated chat routing touches the same normalized text through recommendation, intent detection, task cards, and route-plan projection. The previous optimization passes removed larger hot spots, and tokenization remained a safe, deterministic place to trim more repeated work without changing routing behavior or public contracts.

## How
- `routing_terms()` now delegates to `_routing_terms_cached()` and returns a fresh set.
- `routing_tokens()` now keys by a frozen stopword set and delegates to `_routing_tokens_cached()`.
- Cached entries are immutable `frozenset` values; public helpers clone them before returning.

## User Impact
Repeated natural-language routing does less normalization/tokenization work, so chat-first OMH surfaces should feel slightly lighter under repeated wrapper interactions. Output semantics stay the same.

## Verification
- `PYTHONPATH=tests uv run python -m unittest tests/test_efficiency.py tests/test_chat_router.py tests/test_wrapper_contract.py tests/test_routing_precision.py -v`
  - `Ran 158 tests in 0.361s OK`
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
  - `Ran 919 tests in 21.667s OK`
- `uv run python -m compileall -q src tests`
  - passed
- `uv run python -m omh.cli docs workflows --check`
  - passed; `tap_skills.checked=48`, `ok=true`
- `uv run python -m omh.cli harness validate`
  - passed; `harnesses=36`, `skills=50`, `ok=true`
- `git diff --check`
  - passed
- Representative cProfile for 250 wrapper routing payloads:
  - latest main before this PR: about `1.12M` calls in `0.193s`
  - this branch: about `1.04M` calls in `0.182s`

## Risks / Notes
- This is a narrow cache-path change and does not change routing classifications intentionally.
- Live Hermes rendering, platform autocomplete, connector execution, executor dispatch, review, CI, merge, and plugin load were not exercised by this local verification.
