### PR TITLE
Cache repeated recommendation results

### DIFF
--- a/src/routing/recommend.py
+++ b/src/routing/recommend.py
@@ -515,6 +515,11 @@ def recommend_skills(query: str, *, limit: int = 5, apply_guardrails: bool = Tru
     if limit < 1:
         raise ValueError("recommend --limit must be at least 1")
 
+    return [recommendation.to_dict() for recommendation in _recommend_skills_cached(query, limit, apply_guardrails)]
+
+
+@lru_cache(maxsize=2048)
+def _recommend_skills_cached(query: str, limit: int, apply_guardrails: bool) -> tuple[Recommendation, ...]:
     routing_text = prepare_routing_text(_strip_path_like_fragments(query))
     normalized_query = normalized_phrase(routing_text.scoring_text)
     query_tokens = _tokens(normalized_query)
@@ -541,12 +546,12 @@ def recommend_skills(query: str, *, limit: int = 5, apply_guardrails: bool = Tru
             matches = [recommendation for recommendation in matches if recommendation.skill != "img-summary"]
             if not matches:
                 matches = _fallback_recommendations(definitions, query)
-                return [recommendation.to_dict() for recommendation in matches[:limit]]
+                return tuple(matches[:limit])
     if not matches:
         matches = _fallback_recommendations(definitions, query)
-        return [recommendation.to_dict() for recommendation in matches[:limit]]
+        return tuple(matches[:limit])
     matches.sort(key=lambda recommendation: (-recommendation.score, recommendation.skill))
-    return [recommendation.to_dict() for recommendation in matches[:limit]]
+    return tuple(matches[:limit])
 
 
 @lru_cache(maxsize=1)

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -423,9 +423,11 @@ class EfficiencyContractTests(unittest.TestCase):
 
     def test_recommendation_metadata_cache_is_reused_without_payload_poisoning(self) -> None:
         recommend_module._prepared_routable_definitions.cache_clear()
+        recommend_module._recommend_skills_cached.cache_clear()
 
         first = recommend_module.recommend_skills("risky refactor", limit=2)
         first[0]["skill"] = "mutated"
+        recommend_module._recommend_skills_cached.cache_clear()
         second = recommend_module.recommend_skills("risky refactor", limit=2)
         cache_info = recommend_module._prepared_routable_definitions.cache_info()
 
@@ -433,10 +435,26 @@ class EfficiencyContractTests(unittest.TestCase):
         self.assertEqual(cache_info.misses, 1)
         self.assertGreaterEqual(cache_info.hits, 1)
 
-    def test_routing_guard_cache_is_reused_for_repeated_recommendations(self) -> None:
-        policy_module._active_routing_guard_rules_cached.cache_clear()
+    def test_recommendation_result_cache_is_reused_without_payload_poisoning(self) -> None:
+        recommend_module._recommend_skills_cached.cache_clear()
 
         first = recommend_module.recommend_skills("risky refactor", limit=2)
+        first[0]["skill"] = "mutated"
+        first[0]["matched"].append("mutated")
+        second = recommend_module.recommend_skills("risky refactor", limit=2)
+        cache_info = recommend_module._recommend_skills_cached.cache_info()
+
+        self.assertNotEqual(second[0]["skill"], "mutated")
+        self.assertNotIn("mutated", second[0]["matched"])
+        self.assertEqual(cache_info.misses, 1)
+        self.assertGreaterEqual(cache_info.hits, 1)
+
+    def test_routing_guard_cache_is_reused_for_repeated_recommendations(self) -> None:
+        policy_module._active_routing_guard_rules_cached.cache_clear()
+        recommend_module._recommend_skills_cached.cache_clear()
+
+        first = recommend_module.recommend_skills("risky refactor", limit=2)
+        recommend_module._recommend_skills_cached.cache_clear()
         second = recommend_module.recommend_skills("risky refactor", limit=2)
         cache_info = policy_module._active_routing_guard_rules_cached.cache_info()
 
@@ -484,8 +502,10 @@ class EfficiencyContractTests(unittest.TestCase):
 
     def test_phrase_match_cache_reuses_repeated_recommendation_pairs(self) -> None:
         recommend_module._phrase_match.cache_clear()
+        recommend_module._recommend_skills_cached.cache_clear()
 
         first = recommend_module.recommend_skills("risky refactor", limit=2)
+        recommend_module._recommend_skills_cached.cache_clear()
         second = recommend_module.recommend_skills("risky refactor", limit=2)
         cache_info = recommend_module._phrase_match.cache_info()
 


### PR DESCRIPTION
## Summary
- Cache completed recommendation selections as immutable `Recommendation` tuples.
- Keep `recommend_skills()` returning fresh dictionaries and fresh `matched` lists so caller mutation cannot poison cached results.
- Add efficiency coverage for recommendation result cache reuse and update lower-level cache tests to bypass the new top-level cache when they are specifically proving sub-cache behavior.

## Why
The wrapper chat route still calls recommendation scoring during repeated natural-language interactions. After earlier tokenization and catalog cache work, the next safe hot path was repeated scoring for identical messages. Caching the completed recommendation tuple lets repeated wrapper renders reuse the same deterministic route result while preserving the existing public payload shape.

## How
- `recommend_skills()` now validates `limit`, delegates to `_recommend_skills_cached()`, and materializes fresh dicts via `Recommendation.to_dict()`.
- `_recommend_skills_cached()` contains the existing scoring, guardrail, fallback, sort, and limit logic and returns immutable recommendation tuples.
- Efficiency tests mutate returned dictionaries and `matched` lists to prove the cached tuple is not exposed directly.

## User Impact
Repeated chat-first routing for common Hermes prompts does less catalog scoring work. The observable routing output and evidence boundaries stay unchanged.

## Verification
- `PYTHONPATH=tests uv run python -m unittest tests/test_efficiency.py tests/test_chat_router.py tests/test_wrapper_contract.py tests/test_routing_precision.py -v`
  - `Ran 159 tests in 0.332s OK`
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
  - `Ran 920 tests in 21.056s OK`
- `uv run python -m compileall -q src tests`
  - passed
- `uv run python -m omh.cli docs workflows --check`
  - passed; `tap_skills.checked=48`, `ok=true`
- `uv run python -m omh.cli harness validate`
  - passed; `harnesses=36`, `skills=50`, `ok=true`
- `git diff --check`
  - passed
- `PYTHONPATH=tests uv run python -m omh.cli recommend ...` smoke commands
  - `risky refactor`, `implementation plan with review --limit 2`, and `what OMH workflows are available? --limit 2` returned expected recommendation output
- Representative cProfile for 250 wrapper routing payloads:
  - previous main: about `1.04M` calls in `0.174s`
  - this branch: about `0.90M` calls in `0.129s`

## Risks / Notes
- This is intentionally an internal cache-path change; it does not add a new public schema or workflow.
- Source-checkout `uv run omh ...` still fails in this local venv with `No module named omh`; repo-local validation uses `PYTHONPATH=tests uv run python -m omh.cli ...`, and installed user command behavior is outside this PR.
- Live Hermes rendering, platform autocomplete, connector execution, executor dispatch, review, CI, merge, and plugin load were not exercised by this local verification.
