### PR TITLE
Add source checkout command smoke

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,10 +232,15 @@ in [Release](docs/RELEASE.md). For a quick local sanity check from a source
 checkout:
 
 ```sh
-python3 -m unittest discover -s tests
-python3 -m compileall src
-python3 -m omh.cli docs workflows --check
+PYTHONPATH=tests uv run python -m unittest discover -s tests -v
+uv run python -m compileall -q src tests
+uv run python -m omh.cli docs workflows --check
+uv run --no-editable omh recommend "risky refactor" --limit 1 --json
 ```
+
+The final command intentionally uses `uv run --no-editable` so the source
+checkout proves the packaged `omh` console script can import and run. Normal
+users should use the installed `omh` command printed by the curl installer.
 
 OMH 1.0.1 is a quality-gated stable baseline. Richer profile activation probes
 and more artifact-backed wrapper examples are tracked in the roadmap and

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -353,6 +353,18 @@ python3 -m omh.cli --omh-home /tmp/omh-smoke runtime validate --run "$run_id"
 python3 -m omh.cli --omh-home /tmp/omh-smoke runtime export --redacted
 ```
 
+Source-checkout console smoke:
+
+```sh
+uv run --no-editable omh recommend "risky refactor" --limit 1 --json
+```
+
+Use `uv run python -m omh.cli ...` for fast module-level development checks.
+Use `uv run --no-editable omh ...` when the release question is whether the
+packaged `omh` console script imports and runs from a source checkout. This
+check is local command importability only; it is not Hermes chat visibility,
+plugin load, executor dispatch, review, CI, merge, or delivery evidence.
+
 ## Release Notes Must Include
 
 - Release version and channel.
@@ -360,6 +372,7 @@ python3 -m omh.cli --omh-home /tmp/omh-smoke runtime export --redacted
 - Update path tested.
 - Workflow docs generation status.
 - Harness catalog validation status.
+- Source-checkout console script smoke status.
 - Runtime validation status.
 - Workflow learning review queue status when workflow-learning contracts changed.
 - Capability probe status.

--- a/src/maintenance/release.py
+++ b/src/maintenance/release.py
@@ -213,6 +213,16 @@ def release_readiness_checklist(
             "Harness validation proves local schemas and metadata, not runtime execution.",
         ),
         ReleaseChecklistItem(
+            "source_checkout_command_smoke",
+            "Check source-checkout console command importability",
+            'uv run --no-editable omh recommend "risky refactor" --limit 1 --json',
+            "local-quality",
+            True,
+            False,
+            "The source checkout can build/install the package non-editably and run the `omh` console script.",
+            "This proves console-script importability for the local checkout only; it does not prove Hermes chat visibility, plugin load, executor work, review, CI, merge, or delivery.",
+        ),
+        ReleaseChecklistItem(
             "use_case_demo_cards",
             "Check G1-G10 use-case demo cards",
             "uv run python -m omh.cli cases demo --all --json",

--- a/tests/test_release_smoke.py
+++ b/tests/test_release_smoke.py
@@ -70,6 +70,13 @@ class ReleaseSmokeTests(unittest.TestCase):
         self.assertIn("wheel_setup_dry_run", items)
         self.assertIn("setup --dry-run --channel stable --version 1.0.0", items["wheel_setup_dry_run"]["command"])
         self.assertIn("release install-smoke --live", items["installer_smoke"]["command"])
+        self.assertEqual(
+            items["source_checkout_command_smoke"]["command"],
+            'uv run --no-editable omh recommend "risky refactor" --limit 1 --json',
+        )
+        self.assertIn("console script", items["source_checkout_command_smoke"]["evidence_required"])
+        self.assertIn("console-script importability", items["source_checkout_command_smoke"]["proof_boundary"])
+        self.assertIn("does not prove Hermes chat visibility", items["source_checkout_command_smoke"]["proof_boundary"])
         self.assertEqual(items["use_case_demo_cards"]["command"], "uv run python -m omh.cli cases demo --all --json")
         self.assertIn("G1-G10", items["use_case_demo_cards"]["evidence_required"])
         self.assertIn("wrapper-renderable projections", items["use_case_demo_cards"]["proof_boundary"])


### PR DESCRIPTION
## Summary
- Add a release-readiness checklist item for source-checkout `omh` console-script importability.
- Document `uv run --no-editable omh recommend \"risky refactor\" --limit 1 --json` as the packaged command smoke for source checkouts.
- Update the README development sanity check and release docs so local module checks and packaged command checks are not conflated.

## Why
A real source-checkout smoke showed `uv run omh ...` can fail locally when an editable install's `.pth` file is skipped by Python, even though the package can build and run as a normal console command. The release gate now proves the safer claim directly: the source checkout can install the package non-editably and run the `omh` console script.

## What Changes For Operators
- Release reviewers get an explicit `source_checkout_command_smoke` gate.
- Developers still use `uv run python -m omh.cli ...` for fast module-level checks.
- Packaged command importability is checked with `uv run --no-editable omh ...`.
- The docs avoid treating a local editable-install quirk as Hermes chat visibility, plugin load, executor dispatch, review, CI, merge, or delivery evidence.

## Implementation Notes
- `src/maintenance/release.py` adds the new checklist item and proof boundary.
- `tests/test_release_smoke.py` locks the command and boundary language.
- `README.md` and `docs/RELEASE.md` explain when to use module checks versus packaged command smoke.

## Verification
- `PYTHONPATH=tests uv run python -m unittest tests/test_release_smoke.py tests/test_cli.py -v` — 260 tests passed.
- `uv run --no-editable omh recommend \"risky refactor\" --limit 1 --json` — passed and returned a `ralplan` recommendation.
- `uv run omh recommend \"risky refactor\" --limit 1 --json` — passed after the local venv package was refreshed.
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — 920 tests passed.
- `uv run python -m compileall -q src tests` — passed.
- `uv run python -m omh.cli docs workflows --check` — passed, 48/48 tap skills checked.
- `uv run python -m omh.cli harness validate` — passed, 36 harnesses and 50 skills valid.
- `git diff --check` — passed.

## Risks And Boundaries
- This does not claim live Hermes chat visibility, Hermes plugin load, platform autocomplete, connector execution, executor dispatch, code review, CI, merge, or delivery evidence.
- `uv run --no-editable` may rebuild the local venv package during the smoke; that is expected for this release-gate purpose and does not modify repository files.
- Unrelated untracked `assets/agent-era-dev-checklist.*` files were left untouched.