### PR TITLE
Cache workflow route plan builds

### DIFF
--- a/src/routing/route_plan.py
+++ b/src/routing/route_plan.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from functools import lru_cache
 
 from ..skills.catalog import routable_definitions
 from .localization import normalized_phrase, prepare_routing_text, routing_tokens
@@ -199,16 +200,36 @@ def build_workflow_route_plan(
 ) -> dict[str, object] | None:
     if action == "fallback":
         return None
-    recommendation_list = _recommendation_list(recommendations)
-    if not recommendation_list:
+    recommendation_signature = _recommendation_signature(recommendations)
+    if not recommendation_signature:
         return None
+    return _clone_workflow_route_plan(
+        _build_workflow_route_plan_cached(
+            message,
+            recommendation_signature,
+            selected_skill,
+            action,
+        )
+    )
+
+
+@lru_cache(maxsize=2048)
+def _build_workflow_route_plan_cached(
+    message: str,
+    recommendation_signature: tuple[tuple[str, int, str, tuple[str, ...]], ...],
+    selected_skill: str,
+    action: str,
+) -> dict[str, object] | None:
+    if action == "fallback":
+        return None
+    recommendation_list = _recommendation_list_from_signature(recommendation_signature)
 
     routing_text = prepare_routing_text(message)
     normalized = normalized_phrase(routing_text.scoring_text)
     tokens = routing_tokens(normalized, stopwords=_STOPWORDS)
     signal_stages = set(_stages_from_signals(normalized, tokens))
     by_skill = {item["skill"]: item for item in recommendation_list if item.get("skill")}
-    definition_names = {definition.name for definition in routable_definitions()}
+    definition_names = _routable_definition_names()
     steps_by_stage: dict[str, _RouteStep] = {}
 
     for item in recommendation_list:
@@ -265,6 +286,38 @@ def build_workflow_route_plan(
     }
 
 
+def _clone_workflow_route_plan(value: dict[str, object] | None) -> dict[str, object] | None:
+    if value is None:
+        return None
+    cloned: dict[str, object] = {
+        "schema_version": str(value.get("schema_version", SCHEMA_VERSION)),
+        "mode": str(value.get("mode", "multi_workflow")),
+        "primary_skill": str(value.get("primary_skill", "")),
+        "stages": list(value.get("stages", [])) if isinstance(value.get("stages"), list) else [],
+        "steps": [],
+        "next_action": str(value.get("next_action", "")),
+        "claim_boundary": CLAIM_BOUNDARY,
+    }
+    steps = value.get("steps", [])
+    if isinstance(steps, list):
+        cloned["steps"] = [
+            {
+                "order": int(step.get("order", index + 1)),
+                "stage": str(step.get("stage", "")),
+                "skill": str(step.get("skill", "")),
+                "score": _int_value(step.get("score", 0)),
+                "confidence": str(step.get("confidence", "low")),
+                "matched": list(step.get("matched", [])) if isinstance(step.get("matched"), list) else [],
+                "reason": str(step.get("reason", "")),
+                "evidence_boundary": str(step.get("evidence_boundary", "")),
+                "status": "prepared_not_observed",
+            }
+            for index, step in enumerate(steps)
+            if isinstance(step, dict)
+        ]
+    return cloned
+
+
 def _ordered_stages(steps_by_stage: dict[str, _RouteStep], *, selected_skill: str) -> list[str]:
     stages = [stage for stage in _STAGE_ORDER if stage in steps_by_stage]
     if selected_skill == "workflow-learning" and "learn" in stages:
@@ -315,6 +368,43 @@ def _recommendation_list(recommendations: object) -> list[dict[str, object]]:
         if isinstance(item, dict):
             items.append(dict(item))
     return items
+
+
+def _recommendation_signature(recommendations: object) -> tuple[tuple[str, int, str, tuple[str, ...]], ...]:
+    signature: list[tuple[str, int, str, tuple[str, ...]]] = []
+    for item in _recommendation_list(recommendations):
+        skill = str(item.get("skill", ""))
+        if not skill:
+            continue
+        matched = item.get("matched", [])
+        signature.append(
+            (
+                skill,
+                _int_value(item.get("score", 0)),
+                str(item.get("confidence", "low")),
+                tuple(str(value) for value in matched) if isinstance(matched, list) else (),
+            )
+        )
+    return tuple(signature)
+
+
+def _recommendation_list_from_signature(
+    signature: tuple[tuple[str, int, str, tuple[str, ...]], ...],
+) -> list[dict[str, object]]:
+    return [
+        {
+            "skill": skill,
+            "score": score,
+            "confidence": confidence,
+            "matched": list(matched),
+        }
+        for skill, score, confidence, matched in signature
+    ]
+
+
+@lru_cache(maxsize=1)
+def _routable_definition_names() -> frozenset[str]:
+    return frozenset(definition.name for definition in routable_definitions())
 
 
 def _step_from_recommendation(stage: str, item: dict[str, object]) -> _RouteStep:

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -13,6 +13,7 @@ from omh.routing import catalog_questions as catalog_questions_module
 from omh.routing import localization as localization_module
 from omh.routing import recommend as recommend_module
 from omh.routing import policy as policy_module
+from omh.routing import route_plan as route_plan_module
 from omh.skills import render as render_module
 from omh.wrapper import contract as contract_module
 from omh.release import (
@@ -528,6 +529,40 @@ class EfficiencyContractTests(unittest.TestCase):
         self.assertGreaterEqual(search_cache.hits, 1)
         self.assertGreater(token_cache.misses, 0)
         self.assertGreater(token_cache.hits, 0)
+
+    def test_workflow_route_plan_cache_is_reused_without_payload_poisoning(self) -> None:
+        route_plan_module._build_workflow_route_plan_cached.cache_clear()
+        route_plan_module._routable_definition_names.cache_clear()
+
+        recommendations = recommend_module.recommend_skills("risky refactor", limit=10)
+        first = route_plan_module.build_workflow_route_plan(
+            "risky refactor",
+            recommendations,
+            selected_skill="ralplan",
+            action="dispatch",
+        )
+        self.assertIsNotNone(first)
+        assert first is not None
+        first["steps"][0]["skill"] = "mutated"
+        first["steps"][0]["matched"].append("mutated")
+
+        second = route_plan_module.build_workflow_route_plan(
+            "risky refactor",
+            recommendations,
+            selected_skill="ralplan",
+            action="dispatch",
+        )
+        cache_info = route_plan_module._build_workflow_route_plan_cached.cache_info()
+        definition_names_cache = route_plan_module._routable_definition_names.cache_info()
+
+        self.assertIsNotNone(second)
+        assert second is not None
+        self.assertNotEqual(second["steps"][0]["skill"], "mutated")
+        self.assertNotIn("mutated", second["steps"][0]["matched"])
+        self.assertEqual(cache_info.misses, 1)
+        self.assertGreaterEqual(cache_info.hits, 1)
+        self.assertEqual(definition_names_cache.misses, 1)
+        self.assertGreaterEqual(definition_names_cache.hits, 0)
 
     def test_catalog_capability_summary_cache_is_reused_without_payload_poisoning(self) -> None:
         contract_module._catalog_capability_summary_cached.cache_clear()


### PR DESCRIPTION
## Summary
- Cache deterministic `workflow_route_plan/v1` construction for repeated chat/router requests.
- Key the cache by message, selected skill, action, and a compact recommendation signature.
- Return fresh dictionaries/lists to callers so wrapper-side mutation cannot poison later route decisions.

## Why
Recent routing performance work cached recommendation metadata and recommendation results. The next repeated work in chat-first wrapper paths was route-plan construction: after recommendations are already stable, `build_workflow_route_plan()` still normalized text, tokenized, scanned signal stages, and rebuilt the advisory plan on every repeated render/status path. This PR removes that duplicate work without changing routing semantics.

## What Changes For Users And Operators
- Repeated wrapper/chat calls for the same routed message can reuse the same deterministic route-plan computation.
- `workflow_route_plan/v1` remains advisory routing metadata only: it still does not prove research, plan acceptance, executor dispatch, implementation, review, CI, PR, merge, or delivery evidence.
- Returned payloads remain safe for wrapper rendering code to copy or mutate locally because each public call receives fresh nested dict/list objects.

## Implementation Notes
- `src/routing/route_plan.py` adds `_build_workflow_route_plan_cached()` and `_routable_definition_names()` caches.
- Recommendation inputs are reduced to a compact immutable signature containing only the fields route-plan construction reads: skill, score, confidence, and matched labels.
- `_clone_workflow_route_plan()` rebuilds caller-visible payloads from the cached value to preserve mutation safety.
- `tests/test_efficiency.py` adds a regression test that mutates the first returned plan and confirms the second call is cache-backed but clean.

## Verification
- `PYTHONPATH=tests uv run python -m unittest tests/test_efficiency.py -v` — 24 tests passed.
- `PYTHONPATH=tests uv run python -m unittest tests/test_chat_router.py tests/test_cli.py -v` — 292 tests passed.
- `uv run --no-editable omh recommend \"risky refactor\" --limit 2 --json` — passed and returned `ralplan` plus `ai-slop-cleaner` with a `plan -> deliver` route plan.
- `PYTHONPATH=src uv run python ... route_chat_message cache smoke` — repeated 5 calls produced `{'hits': 4, 'misses': 1, 'maxsize': 2048, 'currsize': 1}`.
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — 921 tests passed.
- `uv run python -m compileall -q src tests` — passed.
- `uv run python -m omh.cli docs workflows --check` — passed, 48/48 tap skills checked.
- `uv run python -m omh.cli harness validate` — passed, 36 harnesses and 50 skills valid.
- `git diff --check` — passed.

## Risks And Boundaries
- This is an in-process cache only; it does not persist route decisions or create runtime evidence.
- This does not claim live Hermes chat visibility, plugin load, platform autocomplete, connector execution, executor dispatch, review, CI, merge, or delivery evidence.
- Unrelated untracked `assets/agent-era-dev-checklist.*` files were left untouched.