### PR TITLE
Cache repeated chat route decisions

### DIFF
--- a/src/routing/chat.py
+++ b/src/routing/chat.py
@@ -255,6 +255,16 @@ def route_chat_message(
     if min_confidence not in CONFIDENCE_LEVELS:
         raise ValueError(f"unsupported chat route confidence threshold: {min_confidence}")
 
+    return _clone_jsonish(_route_chat_message_cached(message, source, limit, min_confidence))
+
+
+@lru_cache(maxsize=2048)
+def _route_chat_message_cached(
+    message: str,
+    source: str,
+    limit: int,
+    min_confidence: str,
+) -> dict[str, object]:
     routing_message = scrub_diagnostic_status_text(message)
     fast_catalog_decision = _catalog_fast_path_decision(
         message,
@@ -428,6 +438,16 @@ def route_chat_message(
         recommendations=recommendations,
     )
     return decision.to_dict()
+
+
+def _clone_jsonish(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: _clone_jsonish(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_clone_jsonish(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_clone_jsonish(item) for item in value)
+    return value
 
 
 def _has_explicit_invocation_prefix(message: str) -> bool:

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -9,6 +9,7 @@ from _local_package import load_local_package
 
 load_local_package()
 from omh.skill_pack import builtin_definitions, builtin_skill_templates
+from omh.routing import chat as chat_module
 from omh.routing import catalog_questions as catalog_questions_module
 from omh.routing import localization as localization_module
 from omh.routing import recommend as recommend_module
@@ -529,6 +530,23 @@ class EfficiencyContractTests(unittest.TestCase):
         self.assertGreaterEqual(search_cache.hits, 1)
         self.assertGreater(token_cache.misses, 0)
         self.assertGreater(token_cache.hits, 0)
+
+    def test_chat_route_decision_cache_is_reused_without_payload_poisoning(self) -> None:
+        chat_module._route_chat_message_cached.cache_clear()
+
+        first = chat_module.route_chat_message("risky refactor with implementation and review", source="discord")
+        first["selected_skill"] = "mutated"
+        first["recommendations"][0]["skill"] = "mutated"
+        first["workflow_route_plan"]["steps"][0]["skill"] = "mutated"
+
+        second = chat_module.route_chat_message("risky refactor with implementation and review", source="discord")
+        cache_info = chat_module._route_chat_message_cached.cache_info()
+
+        self.assertNotEqual(second["selected_skill"], "mutated")
+        self.assertNotEqual(second["recommendations"][0]["skill"], "mutated")
+        self.assertNotEqual(second["workflow_route_plan"]["steps"][0]["skill"], "mutated")
+        self.assertEqual(cache_info.misses, 1)
+        self.assertGreaterEqual(cache_info.hits, 1)
 
     def test_workflow_route_plan_cache_is_reused_without_payload_poisoning(self) -> None:
         route_plan_module._build_workflow_route_plan_cached.cache_clear()


### PR DESCRIPTION
## Summary
- Cache deterministic `route_chat_message()` decisions for repeated wrapper/chat calls.
- Return fresh JSON-like dict/list payloads so wrappers can mutate render state without poisoning later route decisions.
- Add efficiency coverage for cache reuse and nested payload mutation safety.

## Why
After caching recommendation results and workflow route-plan construction, repeated chat-first wrapper paths still recomputed the top-level route decision for the same message. In practice, a wrapper can ask for the same route multiple times while rendering a card, status, quick action, or native-command fallback. Caching the whole deterministic route decision removes that repeated routing work while preserving the public response shape.

## What Changes For Users And Operators
- Repeated natural-language routing for the same message/source/limit/confidence path is faster in long-lived Hermes/wrapper processes.
- Routing semantics are unchanged: explicit skill invocations, catalog picker paths, task cards, workflow learning cards, and `workflow_route_plan/v1` boundaries still behave the same.
- Cached route decisions remain advisory only. They do not prove execution, review, CI, merge-readiness, delivery, or Hermes plugin-load evidence.

## Implementation Notes
- `src/routing/chat.py` wraps the existing routing body in `_route_chat_message_cached()` with a 2048-entry LRU cache.
- Public `route_chat_message()` still validates inputs and returns a fresh payload via `_clone_jsonish()`.
- `_clone_jsonish()` intentionally handles only dict/list/tuple JSON-like structures; this avoids the `copy.deepcopy` overhead that showed up during profiling while keeping mutation safety.
- `tests/test_efficiency.py` mutates `selected_skill`, `recommendations`, and `workflow_route_plan.steps` from one call and verifies the next cached call stays clean.

## Verification
- `PYTHONPATH=tests uv run python -m unittest tests/test_efficiency.py -v` — 25 tests passed.
- `PYTHONPATH=tests uv run python -m unittest tests/test_chat_router.py tests/test_cli.py -v` — 292 tests passed.
- `PYTHONPATH=src uv run python ... route_chat_message profile smoke` — repeated 400 calls over 5 messages showed cache `hits=395, misses=5`; profile time moved from about `0.080s` before this PR to about `0.045s` after the JSON-like clone optimization.
- `uv run --no-editable omh recommend \"risky refactor\" --limit 2 --json` — passed and returned `ralplan` plus `ai-slop-cleaner` with a `plan -> deliver` route plan.
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — 922 tests passed.
- `uv run python -m compileall -q src tests` — passed.
- `uv run python -m omh.cli docs workflows --check` — passed, 48/48 tap skills checked.
- `uv run python -m omh.cli harness validate` — passed, 36 harnesses and 50 skills valid.
- `git diff --check` — passed.

## Risks And Boundaries
- The cache is in-process only and stores route decisions for repeated messages during the process lifetime.
- This does not persist user requests, alter local runtime artifacts, or create observed evidence.
- This does not claim live Hermes chat visibility, plugin load, platform autocomplete, connector execution, executor dispatch, review, CI, merge, or delivery evidence.
- Unrelated untracked `assets/agent-era-dev-checklist.*` files were left untouched.