### PR TITLE
Cache wrapper route projections

### DIFF
--- a/src/routing/chat.py
+++ b/src/routing/chat.py
@@ -258,6 +258,34 @@ def route_chat_message(
     return _clone_jsonish(_route_chat_message_cached(message, source, limit, min_confidence))
 
 
+def public_chat_route_payload(
+    message: str,
+    *,
+    source: str = "generic",
+    limit: int = 3,
+    min_confidence: str = "high",
+    include_message: bool = False,
+) -> dict[str, object]:
+    message = message.strip()
+    if not message:
+        raise ValueError("chat route requires a message")
+    if source not in CHAT_SOURCES:
+        raise ValueError(f"unsupported chat source: {source}")
+    if limit < 1:
+        raise ValueError("chat route --limit must be at least 1")
+    if min_confidence not in CONFIDENCE_LEVELS:
+        raise ValueError(f"unsupported chat route confidence threshold: {min_confidence}")
+    return _clone_jsonish(
+        _public_chat_route_payload_cached(
+            message,
+            source,
+            limit,
+            min_confidence,
+            include_message,
+        )
+    )
+
+
 @lru_cache(maxsize=2048)
 def _route_chat_message_cached(
     message: str,
@@ -438,6 +466,20 @@ def _route_chat_message_cached(
         recommendations=recommendations,
     )
     return decision.to_dict()
+
+
+@lru_cache(maxsize=2048)
+def _public_chat_route_payload_cached(
+    message: str,
+    source: str,
+    limit: int,
+    min_confidence: str,
+    include_message: bool,
+) -> dict[str, object]:
+    return public_route_payload(
+        _route_chat_message_cached(message, source, limit, min_confidence),
+        include_message=include_message,
+    )
 
 
 def _clone_jsonish(value: Any) -> Any:

--- a/src/workflows/hermes_planning.py
+++ b/src/workflows/hermes_planning.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from datetime import datetime, timezone
+from functools import lru_cache
 import hashlib
 import json
 import re
@@ -72,21 +73,29 @@ class HermesPlan:
     stop_condition: str
 
     def to_dict(self) -> dict[str, object]:
-        data = asdict(self)
-        for key in (
-            "clarified_assumptions",
-            "goals",
-            "non_goals",
-            "decision_drivers",
-            "options",
-            "rejection_rationale",
-            "risks",
-            "mitigations",
-            "acceptance_criteria",
-            "verification_plan",
-        ):
-            data[key] = list(data[key])
-        return data
+        return {
+            "status": self.status,
+            "task_statement": self.task_statement,
+            "recommended_workflow": self.recommended_workflow,
+            "recommended_harness": self.recommended_harness,
+            "planning_mode": self.planning_mode,
+            "clarified_assumptions": list(self.clarified_assumptions),
+            "goals": list(self.goals),
+            "non_goals": list(self.non_goals),
+            "decision_drivers": list(self.decision_drivers),
+            "options": [_clone_jsonish(option) for option in self.options],
+            "chosen_direction": self.chosen_direction,
+            "rejection_rationale": list(self.rejection_rationale),
+            "risks": list(self.risks),
+            "mitigations": list(self.mitigations),
+            "acceptance_criteria": list(self.acceptance_criteria),
+            "verification_plan": list(self.verification_plan),
+            "execution_handoff": self.execution_handoff,
+            "review_gate": dict(self.review_gate),
+            "quality_gate": _clone_jsonish(self.quality_gate),
+            "deep_interview": _clone_jsonish(self.deep_interview),
+            "stop_condition": self.stop_condition,
+        }
 
 
 def build_hermes_plan_payload(
@@ -107,10 +116,30 @@ def build_hermes_plan_payload(
     if limit < 1:
         raise ValueError("hermes plan --limit must be at least 1")
 
+    metadata_items = tuple(sorted((key, value) for key, value in (source_metadata or {}).items() if value))
+    return _clone_jsonish(
+        _build_hermes_plan_payload_cached(
+            task,
+            source,
+            limit,
+            executor_target,
+            metadata_items,
+        )
+    )
+
+
+@lru_cache(maxsize=2048)
+def _build_hermes_plan_payload_cached(
+    task: str,
+    source: str,
+    limit: int,
+    executor_target: str,
+    metadata_items: tuple[tuple[str, str], ...],
+) -> dict[str, object]:
     recommendations = _compact_recommendations(recommend_skills(task, limit=max(limit, 5))[:limit])
     top = recommendations[0] if recommendations else {"skill": "oh-my-hermes", "score": 0, "confidence": "low"}
     plan = _plan_for(task, top)
-    metadata = {key: value for key, value in (source_metadata or {}).items() if value}
+    metadata = dict(metadata_items)
     payload: dict[str, object] = {
         "schema_version": SCHEMA_VERSION,
         "source": source,
@@ -126,6 +155,16 @@ def build_hermes_plan_payload(
     if metadata:
         payload["source_metadata"] = metadata
     return payload
+
+
+def _clone_jsonish(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: _clone_jsonish(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_clone_jsonish(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_clone_jsonish(item) for item in value)
+    return value
 
 
 def build_hermes_plan_event_payload(

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -7,7 +7,7 @@ from typing import Any
 from ..context_safety import compact_progress_events
 from ..ingress import CHAT_SOURCES, compact_source_metadata, extract_message_text, extract_source_metadata
 from ..routing.catalog_questions import is_skill_catalog_question as _is_skill_catalog_question
-from ..routing.chat import public_route_payload, route_chat_message, route_explanation_payload
+from ..routing.chat import public_chat_route_payload, route_explanation_payload
 from ..routing.missed_route import is_missed_route_feedback
 from ..coding_delegation import CODING_EXECUTOR_TARGETS, build_coding_delegation_payload
 from ..capabilities.families import capability_family_cards
@@ -1354,10 +1354,15 @@ def build_chat_interaction_payload(
 
     message = extract_message_text(event_or_message)
     metadata = _source_metadata(event_or_message, source_metadata)
-    route = route_chat_message(message, source=source, limit=limit, min_confidence=min_confidence)
-    resolved_mode = _resolve_mode(mode, route, message=message)
+    route_payload = public_chat_route_payload(
+        message,
+        source=source,
+        limit=limit,
+        min_confidence=min_confidence,
+        include_message=include_message,
+    )
+    resolved_mode = _resolve_mode(mode, route_payload, message=message)
     base = _base_interaction(message, source=source, source_metadata=metadata, mode=resolved_mode, include_message=include_message)
-    route_payload = public_route_payload(route, include_message=include_message)
     if _is_generic_skill_catalog_route(message, route_payload):
         route_payload = _catalog_question_route_payload(route_payload)
     base["route"] = route_payload
@@ -1446,7 +1451,7 @@ def build_chat_interaction_payload(
         base["chat_response"] = build_chat_response_from_delegation(delegation, thread_key=str(base["thread_key"]))
         return _finish_interaction(base, target_notice)
 
-    if resolved_mode == "clarify" or route["action"] != "dispatch":
+    if resolved_mode == "clarify" or route_payload["action"] != "dispatch":
         base["chat_response"] = build_chat_response_from_route(
             route_payload,
             thread_key=str(base["thread_key"]),

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -16,6 +16,7 @@ from omh.routing import recommend as recommend_module
 from omh.routing import policy as policy_module
 from omh.routing import route_plan as route_plan_module
 from omh.skills import render as render_module
+from omh.workflows import hermes_planning as hermes_planning_module
 from omh.wrapper import contract as contract_module
 from omh.release import (
     AWARENESS_PRIMER_CONTEXT_CHAR_LIMIT,
@@ -545,6 +546,73 @@ class EfficiencyContractTests(unittest.TestCase):
         self.assertNotEqual(second["selected_skill"], "mutated")
         self.assertNotEqual(second["recommendations"][0]["skill"], "mutated")
         self.assertNotEqual(second["workflow_route_plan"]["steps"][0]["skill"], "mutated")
+        self.assertEqual(cache_info.misses, 1)
+        self.assertGreaterEqual(cache_info.hits, 1)
+
+    def test_public_chat_route_payload_cache_is_reused_without_payload_poisoning(self) -> None:
+        chat_module._route_chat_message_cached.cache_clear()
+        chat_module._public_chat_route_payload_cached.cache_clear()
+
+        first = chat_module.public_chat_route_payload(
+            "risky refactor with implementation and review",
+            source="discord",
+        )
+        first["selected_skill"] = "mutated"
+        first["recommendations"][0]["skill"] = "mutated"
+        first["route_explanation"]["selected_workflow"] = "mutated"
+
+        second = chat_module.public_chat_route_payload(
+            "risky refactor with implementation and review",
+            source="discord",
+        )
+        cache_info = chat_module._public_chat_route_payload_cached.cache_info()
+
+        self.assertNotEqual(second["selected_skill"], "mutated")
+        self.assertNotEqual(second["recommendations"][0]["skill"], "mutated")
+        self.assertNotEqual(second["route_explanation"]["selected_workflow"], "mutated")
+        self.assertEqual(cache_info.misses, 1)
+        self.assertGreaterEqual(cache_info.hits, 1)
+
+    def test_chat_interaction_uses_public_route_projection_cache(self) -> None:
+        chat_module._route_chat_message_cached.cache_clear()
+        chat_module._public_chat_route_payload_cached.cache_clear()
+
+        first = contract_module.build_chat_interaction_payload(
+            "risky refactor with implementation and review",
+            source="discord",
+        )
+        second = contract_module.build_chat_interaction_payload(
+            "risky refactor with implementation and review",
+            source="discord",
+        )
+        cache_info = chat_module._public_chat_route_payload_cached.cache_info()
+
+        self.assertEqual(first["route"]["selected_skill"], second["route"]["selected_skill"])
+        self.assertEqual(cache_info.misses, 1)
+        self.assertGreaterEqual(cache_info.hits, 1)
+
+    def test_hermes_plan_payload_cache_is_reused_without_payload_poisoning(self) -> None:
+        hermes_planning_module._build_hermes_plan_payload_cached.cache_clear()
+
+        first = hermes_planning_module.build_hermes_plan_payload(
+            "risky refactor with implementation and review",
+            source="discord",
+            executor_target="codex",
+        )
+        first["plan"]["recommended_workflow"] = "mutated"
+        first["wrapper_contract"]["coding_delegate"]["selected_executor_profile"] = "mutated"
+        first["recommendations"][0]["skill"] = "mutated"
+
+        second = hermes_planning_module.build_hermes_plan_payload(
+            "risky refactor with implementation and review",
+            source="discord",
+            executor_target="codex",
+        )
+        cache_info = hermes_planning_module._build_hermes_plan_payload_cached.cache_info()
+
+        self.assertNotEqual(second["plan"]["recommended_workflow"], "mutated")
+        self.assertNotEqual(second["wrapper_contract"]["coding_delegate"]["selected_executor_profile"], "mutated")
+        self.assertNotEqual(second["recommendations"][0]["skill"], "mutated")
         self.assertEqual(cache_info.misses, 1)
         self.assertGreaterEqual(cache_info.hits, 1)
 


### PR DESCRIPTION
## Feature Report

### What Changed

- Added a cached public chat route projection API so wrapper interaction rendering can reuse the already-deterministic route-to-public-payload conversion.
- Added a cached deterministic Hermes plan payload projection while still returning fresh mutable dictionaries to callers.
- Replaced deep dataclass `asdict()` conversion for `HermesPlan` with an explicit projection that avoids extra recursive work.
- Added mutation-safety tests for public route payload caching, wrapper interaction cache usage, and Hermes plan payload caching.

### Why This Exists

Repeated Hermes chat wrapper calls often render the same operator phrases into route cards, plan cards, and status-safe guidance. Previous PRs cached the lower routing and recommendation layers; this PR continues that performance work by reducing repeated wrapper projection work without caching dynamic runtime status surfaces.

### User / Operator Impact

- Chat-first OMH surfaces should spend less repeated compute turning the same message into wrapper-safe route and plan cards.
- Discord/Slack-style wrappers still receive fresh mutable payloads, so one caller cannot poison cached route or plan state for the next caller.
- Prepared-vs-observed boundaries stay unchanged: this only optimizes deterministic metadata projection.

### How It Works

- `public_chat_route_payload()` validates route inputs, builds a compact public route payload from the cached route decision, and returns a cloned payload.
- `build_chat_interaction_payload()` now consumes that public route projection directly instead of cloning the full raw route decision and compacting it again.
- `build_hermes_plan_payload()` normalizes source metadata into a hashable tuple, caches the deterministic plan projection, and clones results before returning them.
- `HermesPlan.to_dict()` now uses an explicit field projection instead of `dataclasses.asdict()`.

### Files And Contracts Touched

- `src/routing/chat.py`: public route projection cache.
- `src/wrapper/contract.py`: wrapper interaction rendering uses the public projection cache.
- `src/workflows/hermes_planning.py`: Hermes plan payload cache and explicit plan projection.
- `tests/test_efficiency.py`: cache hit and mutation-safety coverage.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_efficiency.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_chat_router.py tests/test_wrapper_contract.py tests/test_cli.py -v`
- [x] `uv run --no-editable omh recommend "risky refactor" --limit 2 --json`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli harness validate`
- [x] `git diff --check`
- [ ] Manual Hermes/TUI check: not run; this PR changes deterministic backend projection caching only.

Performance smoke:

- Repeated 400-call `build_chat_interaction_payload()` local workload improved from about `0.033s` before the projection cache to about `0.030s` after it.
- cProfile cumulative time improved from about `0.078s` to about `0.074s`.
- Cache evidence: public route projection `395 hits / 5 misses`; Hermes plan payload `158 hits / 2 misses`.

## Risk

- Low runtime risk because dynamic status, quickstart, target notice, and runtime-observed paths are not cached as full interaction payloads.
- Main compatibility risk is accidental mutation of cached structures; focused tests cover returned payload poisoning for route and plan projections.

## Compatibility / Rollout

- No CLI schema change.
- No new dependencies.
- No Hermes core, network, plugin load, or executor behavior change.

## Release / Claims

- [x] Release-channel impact considered: local/backend performance improvement only.
- [x] Runtime/native capability claims are unchanged and remain evidence-boundary safe.
- [x] Known manual Hermes checks are listed; live Hermes wrapper rendering was not required for this deterministic caching change.

## Follow-Up

- Continue profiling wrapper rendering only where repeated calls are proven hot; avoid caching full interaction payloads unless dynamic status surfaces are separated first.
