### PR TITLE
Cache learning candidate detection

### DIFF
--- a/src/workflows/learning_candidate.py
+++ b/src/workflows/learning_candidate.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+from functools import lru_cache
 import re
 from typing import Any, Iterable
 
@@ -303,12 +304,17 @@ def build_learning_candidate_scope(
 
 
 def detect_learning_signal(message: str) -> dict[str, object] | None:
+    return _copy_learning_signal(_detect_learning_signal_cached(message))
+
+
+@lru_cache(maxsize=4096)
+def _detect_learning_signal_cached(message: str) -> dict[str, object] | None:
     normalized = _fold(message)
     workflow_learning_context = "workflow learning" in normalized or "learn from this workflow" in normalized
-    if workflow_learning_context and not any(_fold(phrase) in normalized for phrase in _BRIDGE_FORCING_SIGNALS):
+    if workflow_learning_context and not any(phrase in normalized for phrase in _folded_bridge_forcing_signals()):
         return None
-    for phrase in _EXPLICIT_LEARN_SIGNALS:
-        if _fold(phrase) in normalized:
+    for phrase, folded_phrase in _folded_explicit_learn_signals():
+        if folded_phrase in normalized:
             signal_type = "skill_request" if phrase in _SKILL_FORCING_SIGNALS else "explicit_learn_request"
             if phrase in {"next time", "from now on", "다음부터", "다음부터 이렇게", "앞으로는"}:
                 signal_type = "user_correction"
@@ -320,6 +326,20 @@ def detect_learning_signal(message: str) -> dict[str, object] | None:
                 "source": "user_message",
             }
     return None
+
+
+def _copy_learning_signal(signal: dict[str, object] | None) -> dict[str, object] | None:
+    return dict(signal) if signal else None
+
+
+@lru_cache(maxsize=1)
+def _folded_bridge_forcing_signals() -> tuple[str, ...]:
+    return tuple(_fold(phrase) for phrase in _BRIDGE_FORCING_SIGNALS)
+
+
+@lru_cache(maxsize=1)
+def _folded_explicit_learn_signals() -> tuple[tuple[str, str], ...]:
+    return tuple((phrase, _fold(phrase)) for phrase in _EXPLICIT_LEARN_SIGNALS)
 
 
 def classify_learning_persistence_target(
@@ -486,6 +506,7 @@ def _contains_any(text: str, needles: Iterable[str]) -> bool:
     return any(needle and needle in text for needle in needles)
 
 
+@lru_cache(maxsize=8192)
 def _fold(text: str) -> str:
     return " ".join(text.strip().lower().split())
 

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -17,6 +17,7 @@ from omh.routing import policy as policy_module
 from omh.routing import route_plan as route_plan_module
 from omh.skills import render as render_module
 from omh.workflows import hermes_planning as hermes_planning_module
+from omh.workflows import learning_candidate as learning_candidate_module
 from omh.wrapper import contract as contract_module
 from omh.release import (
     AWARENESS_PRIMER_CONTEXT_CHAR_LIMIT,
@@ -570,6 +571,35 @@ class EfficiencyContractTests(unittest.TestCase):
         self.assertNotEqual(second["selected_skill"], "mutated")
         self.assertNotEqual(second["recommendations"][0]["skill"], "mutated")
         self.assertNotEqual(second["route_explanation"]["selected_workflow"], "mutated")
+        self.assertEqual(cache_info.misses, 1)
+        self.assertGreaterEqual(cache_info.hits, 1)
+
+    def test_learning_candidate_detection_cache_reuses_negative_messages(self) -> None:
+        learning_candidate_module._detect_learning_signal_cached.cache_clear()
+
+        first = learning_candidate_module.detect_learning_signal("risky refactor with implementation and review")
+        second = learning_candidate_module.detect_learning_signal("risky refactor with implementation and review")
+        cache_info = learning_candidate_module._detect_learning_signal_cached.cache_info()
+
+        self.assertIsNone(first)
+        self.assertIsNone(second)
+        self.assertEqual(cache_info.misses, 1)
+        self.assertGreaterEqual(cache_info.hits, 1)
+
+    def test_learning_candidate_detection_cache_is_reused_without_payload_poisoning(self) -> None:
+        learning_candidate_module._detect_learning_signal_cached.cache_clear()
+
+        first = learning_candidate_module.detect_learning_signal("learn this: always run the focused tests first")
+        self.assertIsNotNone(first)
+        assert first is not None
+        first["matched"] = "mutated"
+
+        second = learning_candidate_module.detect_learning_signal("learn this: always run the focused tests first")
+        cache_info = learning_candidate_module._detect_learning_signal_cached.cache_info()
+
+        self.assertIsNotNone(second)
+        assert second is not None
+        self.assertEqual(second["matched"], "learn this")
         self.assertEqual(cache_info.misses, 1)
         self.assertGreaterEqual(cache_info.hits, 1)
 


### PR DESCRIPTION
## Feature Report

### What Changed

- Added an LRU cache around deterministic learning-signal detection.
- Cached folded learning trigger phrase projections so repeated chat interaction rendering does not refold the same static phrase table.
- Kept full learning candidate card creation uncached because card scope depends on source metadata, selected workflow, harness, and thread context.
- Added efficiency tests for negative-message cache reuse and mutation-safe positive signal returns.

### Why This Exists

After the route/recommendation/wrapper projection cache work, the next measured wrapper hot path was `learning_candidate.detect_learning_signal()` on ordinary chat messages. Most wrapper interactions are not learning requests, but the old path still normalized the same message and learning phrase table repeatedly. This PR removes that repeated string work without changing routing outcomes.

### User / Operator Impact

- Repeated Discord/Slack-style interaction rendering is lighter, especially for normal messages that do not contain `/learn`, “remember this”, or similar learning signals.
- Learning cards still carry fresh source/thread scope, so wrapper-specific context remains correct.
- Positive learning signals still return mutable dictionaries for callers, but a caller mutation cannot poison cached signal state.

### How It Works

- `detect_learning_signal()` now clones the result of `_detect_learning_signal_cached()`.
- `_detect_learning_signal_cached()` stores only the deterministic signal decision for a raw message.
- `_folded_bridge_forcing_signals()` and `_folded_explicit_learn_signals()` cache static folded trigger tables.
- `_fold()` is cached for repeated normalization in this module.

### Files And Contracts Touched

- `src/workflows/learning_candidate.py`: deterministic learning-signal cache and folded phrase cache.
- `tests/test_efficiency.py`: cache hit and mutation-safety coverage.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_efficiency.py tests/test_chat_router.py tests/test_wrapper_contract.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_efficiency.py tests/test_chat_router.py tests/test_wrapper_contract.py tests/test_cli.py -v`
- [x] `uv run --no-editable omh recommend "risky refactor" --limit 2 --json`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli harness validate`
- [x] `git diff --check`
- [ ] Manual Hermes/TUI check: not run; this is a deterministic backend detection cache change.

Performance smoke:

- Repeated 600-call `build_chat_interaction_payload()` local workload improved from about `0.0377s` to about `0.0331s`.
- cProfile cumulative time improved from about `0.096s` to about `0.082s`.
- Cache evidence: learning signal cache `600 hits / 5 misses`; public route projection `595 hits / 5 misses`; Hermes plan payload `238 hits / 2 misses`.

## Risk

- Low behavior risk because only deterministic signal detection is cached.
- Full card projection remains dynamic, preserving thread/source scope and prepared-vs-observed learning boundaries.

## Compatibility / Rollout

- No CLI schema change.
- No generated docs or skill output change.
- No new dependency.

## Release / Claims

- [x] Release-channel impact considered: backend performance improvement only.
- [x] Runtime/native capability claims are unchanged and remain evidence-boundary safe.
- [x] Live Hermes wrapper rendering was not required for this deterministic cache change.

## Follow-Up

- Continue profiling wrapper rendering before adding more caches; avoid caching dynamic status or runtime-observed surfaces.
