### PR TITLE
Cache wrapper rendering helpers

### DIFF
--- a/src/routing/chat.py
+++ b/src/routing/chat.py
@@ -483,11 +483,12 @@ def _public_chat_route_payload_cached(
 
 
 def _clone_jsonish(value: Any) -> Any:
-    if isinstance(value, dict):
+    value_type = type(value)
+    if value_type is dict:
         return {key: _clone_jsonish(item) for key, item in value.items()}
-    if isinstance(value, list):
+    if value_type is list:
         return [_clone_jsonish(item) for item in value]
-    if isinstance(value, tuple):
+    if value_type is tuple:
         return tuple(_clone_jsonish(item) for item in value)
     return value
 

--- a/src/workflows/hermes_planning.py
+++ b/src/workflows/hermes_planning.py
@@ -158,11 +158,12 @@ def _build_hermes_plan_payload_cached(
 
 
 def _clone_jsonish(value: Any) -> Any:
-    if isinstance(value, dict):
+    value_type = type(value)
+    if value_type is dict:
         return {key: _clone_jsonish(item) for key, item in value.items()}
-    if isinstance(value, list):
+    if value_type is list:
         return [_clone_jsonish(item) for item in value]
-    if isinstance(value, tuple):
+    if value_type is tuple:
         return tuple(_clone_jsonish(item) for item in value)
     return value
 

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -1551,6 +1551,7 @@ def _resolve_delegate_executor_target(executor_target: str, paths: OmhPaths | No
     }
 
 
+@lru_cache(maxsize=4096)
 def _executor_target_from_message(message: str) -> str:
     lowered = f" {message.lower()} "
     for target, hints in _MESSAGE_EXECUTOR_HINTS:
@@ -4800,9 +4801,15 @@ def _render_body_blocks(body: str, *, render_profile: str) -> list[dict[str, obj
 
 
 def _messenger_safe_body(body: str) -> tuple[str, list[str]]:
+    safe_body, transforms = _messenger_safe_body_cached(body)
+    return safe_body, list(transforms)
+
+
+@lru_cache(maxsize=4096)
+def _messenger_safe_body_cached(body: str) -> tuple[str, tuple[str, ...]]:
     lines = body.splitlines()
     if not lines:
-        return body, []
+        return body, ()
     output: list[str] = []
     transforms: list[str] = []
     index = 0
@@ -4833,7 +4840,7 @@ def _messenger_safe_body(body: str) -> tuple[str, list[str]]:
             output.append("")
         output.extend(converted)
         transforms.append("markdown_table_to_bullets")
-    return "\n".join(output), sorted(set(transforms))
+    return "\n".join(output), tuple(sorted(set(transforms)))
 
 
 def _is_code_fence_line(line: str) -> bool:
@@ -4957,32 +4964,40 @@ def _unescape_table_pipes(value: str) -> str:
 
 
 def _messenger_body_blocks(body: str) -> list[dict[str, object]]:
-    blocks: list[dict[str, object]] = []
+    return [
+        {"type": block_type, "text": text}
+        for block_type, text in _messenger_body_blocks_cached(body)
+    ]
+
+
+@lru_cache(maxsize=4096)
+def _messenger_body_blocks_cached(body: str) -> tuple[tuple[str, str], ...]:
+    blocks: list[tuple[str, str]] = []
     current: list[str] = []
     for line in body.splitlines():
         stripped = line.strip()
         if not stripped:
             if current:
-                blocks.append({"type": "paragraph", "text": " ".join(current)})
+                blocks.append(("paragraph", " ".join(current)))
                 current = []
             continue
         if stripped.startswith(("- ", "* ")):
             if current:
-                blocks.append({"type": "paragraph", "text": " ".join(current)})
+                blocks.append(("paragraph", " ".join(current)))
                 current = []
-            blocks.append({"type": "bullet", "text": stripped[2:].strip()})
+            blocks.append(("bullet", stripped[2:].strip()))
             continue
         numbered_text = _numbered_list_text(stripped)
         if numbered_text:
             if current:
-                blocks.append({"type": "paragraph", "text": " ".join(current)})
+                blocks.append(("paragraph", " ".join(current)))
                 current = []
-            blocks.append({"type": "numbered", "text": numbered_text})
+            blocks.append(("numbered", numbered_text))
             continue
         current.append(stripped)
     if current:
-        blocks.append({"type": "paragraph", "text": " ".join(current)})
-    return blocks
+        blocks.append(("paragraph", " ".join(current)))
+    return tuple(blocks)
 
 
 def _rich_markdown_body_blocks(body: str) -> list[dict[str, object]]:
@@ -5061,6 +5076,7 @@ def _numbered_list_text(stripped: str) -> str:
     return rest
 
 
+@lru_cache(maxsize=4096)
 def _short_text(value: str, *, limit: int) -> str:
     text = " ".join(value.split())
     if len(text) <= limit:

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -621,6 +621,58 @@ class EfficiencyContractTests(unittest.TestCase):
         self.assertEqual(cache_info.misses, 1)
         self.assertGreaterEqual(cache_info.hits, 1)
 
+    def test_chat_interaction_reuses_executor_target_hint_cache(self) -> None:
+        contract_module._executor_target_from_message.cache_clear()
+
+        first, first_resolution = contract_module._resolve_delegate_executor_target(
+            "choose",
+            None,
+            message="open this in Codex and prepare the coding handoff",
+        )
+        second, second_resolution = contract_module._resolve_delegate_executor_target(
+            "choose",
+            None,
+            message="open this in Codex and prepare the coding handoff",
+        )
+        cache_info = contract_module._executor_target_from_message.cache_info()
+
+        self.assertEqual(first, "codex")
+        self.assertEqual(second, "codex")
+        self.assertEqual(first_resolution["source"], "message_mention")
+        self.assertEqual(second_resolution["resolved_executor_target"], "codex")
+        self.assertEqual(cache_info.misses, 1)
+        self.assertGreaterEqual(cache_info.hits, 1)
+
+    def test_messenger_safe_body_cache_is_reused_without_transform_poisoning(self) -> None:
+        contract_module._messenger_safe_body_cached.cache_clear()
+        body = "| Field | Value |\n| --- | --- |\n| Status | Ready |"
+
+        first_body, first_transforms = contract_module._messenger_safe_body(body)
+        first_transforms.append("mutated")
+        second_body, second_transforms = contract_module._messenger_safe_body(body)
+        cache_info = contract_module._messenger_safe_body_cached.cache_info()
+
+        self.assertEqual(first_body, second_body)
+        self.assertIn("markdown_table_to_bullets", second_transforms)
+        self.assertNotIn("mutated", second_transforms)
+        self.assertEqual(cache_info.misses, 1)
+        self.assertGreaterEqual(cache_info.hits, 1)
+
+    def test_messenger_body_blocks_cache_is_reused_without_payload_poisoning(self) -> None:
+        contract_module._messenger_body_blocks_cached.cache_clear()
+        body = "Intro\n\n- first\n1. second"
+
+        first = contract_module._messenger_body_blocks(body)
+        first[0]["text"] = "mutated"
+        second = contract_module._messenger_body_blocks(body)
+        cache_info = contract_module._messenger_body_blocks_cached.cache_info()
+
+        self.assertNotEqual(second[0]["text"], "mutated")
+        self.assertEqual(second[1]["type"], "bullet")
+        self.assertEqual(second[2]["type"], "numbered")
+        self.assertEqual(cache_info.misses, 1)
+        self.assertGreaterEqual(cache_info.hits, 1)
+
     def test_hermes_plan_payload_cache_is_reused_without_payload_poisoning(self) -> None:
         hermes_planning_module._build_hermes_plan_payload_cached.cache_clear()
 


### PR DESCRIPTION
## Summary

This PR continues the OMH performance/quality pass by trimming the hot path for repeated Hermes chat-wrapper interactions. The previous cache work moved most routing cost out of repeated requests; this change focuses on the next layer: wrapper rendering helpers, executor mention detection, and safe JSON-ish payload cloning.

## Why

Hermes-facing chat surfaces repeatedly build the same wrapper cards for common messages such as risky refactors, product bug triage, safe feature requests, visual summaries, and issue-to-PR preparation. After routing and learning-candidate caches landed, profiling showed the remaining cost concentrated in safe payload cloning and deterministic rendering helpers rather than actual route selection.

The goal is not to remove clone boundaries. Public wrapper payloads remain fresh mutable dictionaries/lists so callers cannot mutate cached internals. This PR reduces repeated pure computation while preserving those safety boundaries.

## What Changed

- Cache deterministic executor mention detection in `src/wrapper/contract.py`.
- Cache messenger-safe body conversion, messenger body block parsing, and short body previews behind immutable cached internals.
- Keep public helper returns mutation-safe by reconstructing fresh `list`/`dict` values from cached tuples.
- Optimize internal JSON-ish clone helpers in `src/routing/chat.py` and `src/workflows/hermes_planning.py` with exact type checks for known generated payload types.
- Add focused efficiency tests that prove cache reuse and mutation-safety for the new helper caches.

## User/Operator Impact

Hermes wrappers and chat adapters should spend less CPU rebuilding identical route cards and messenger rendering structures for repeated prompts. This helps the chat-first OMH experience feel snappier without changing the public route, plan, status, or evidence contracts.

## Performance Evidence

Local deterministic wrapper workload: 800 calls to `build_chat_interaction_payload()` across five representative messages.

Before this PR on current main:

- elapsed: `0.042206s`
- cProfile total calls: `873,613`
- clone hot spots: route clone `0.024s`, plan clone `0.020s`

After this PR:

- elapsed: `0.030922s`
- cProfile total calls: `384,759`
- clone hot spots: route clone `0.011s`, plan clone `0.009s`
- new cache evidence:
  - executor hint: `795 hits / 5 misses`
  - safe body: `1596 hits / 4 misses`
  - body blocks: `3196 hits / 4 misses`
  - short text: `1596 hits / 4 misses`

## Boundary Notes

- No public schema changes.
- No LLM/API/network/runtime calls added.
- No change to prepared-vs-observed evidence semantics.
- Cached internals are immutable tuples or strings; public payloads still return fresh mutable objects.

## Verification

- `PYTHONPATH=tests uv run python -m unittest tests/test_efficiency.py tests/test_chat_router.py tests/test_wrapper_contract.py tests/test_cli.py -v`
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- `uv run --no-editable omh recommend "risky refactor" --limit 2 --json`
- `uv run python -m compileall -q src tests`
- `uv run python -m omh.cli docs workflows --check`
- `uv run python -m omh.cli harness validate`
- `git diff --check`

## Risks

The clone helper exact-type optimization assumes OMH-generated JSON-ish payloads use built-in `dict`, `list`, and `tuple` containers. That matches the current route/plan payload construction and is covered by existing mutation-safety tests.
