### PR TITLE
Speed up static wrapper payload clones

### DIFF
--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -4409,15 +4409,16 @@ def _as_dict_list(value: object) -> list[dict[str, object]]:
 
 def _clone_static_dict(value: dict[str, object]) -> dict[str, object]:
     cloned = _clone_static_payload(value)
-    return cloned if isinstance(cloned, dict) else {}
+    return cloned if type(cloned) is dict else {}
 
 
 def _clone_static_payload(value: object) -> object:
-    if isinstance(value, dict):
+    value_type = type(value)
+    if value_type is dict:
         return {key: _clone_static_payload(item) for key, item in value.items()}
-    if isinstance(value, list):
+    if value_type is list:
         return [_clone_static_payload(item) for item in value]
-    if isinstance(value, tuple):
+    if value_type is tuple:
         return tuple(_clone_static_payload(item) for item in value)
     return value
 


### PR DESCRIPTION
## Summary

This PR trims another chat-first hot path after the previous wrapper rendering cache work. It speeds up cloning for generated static wrapper payloads used by the OMH workflow picker, context primer, and capability catalog card surfaces.

## Why

A broad wrapper workload that includes `./omh`, workflow catalog questions, update/status prompts, and normal routing showed the next visible cost concentrated in `_clone_static_payload()`. That path exists for a good reason: OMH must return fresh mutable wrapper payloads so callers cannot mutate cached picker/catalog state. The clone boundary should stay, but the generated payloads are built from plain JSON-ish `dict`, `list`, and `tuple` containers, so exact type checks avoid unnecessary `isinstance()` overhead in a very tight recursive loop.

## What Changed

- Updated `_clone_static_payload()` to use exact type checks for generated `dict`, `list`, and `tuple` payload containers.
- Updated `_clone_static_dict()` to match the same exact generated-container assumption.
- Preserved all public wrapper schemas and mutation-safe clone boundaries.

## User/Operator Impact

OMH workflow picker and catalog answers should feel lighter in Hermes chat surfaces, especially when users type `./omh`, ask what workflows are available, or open picker-style fallback cards repeatedly.

## Performance Evidence

Local deterministic broad wrapper workload: 960 calls to `build_chat_interaction_payload()` across normal route, plan, visual summary, workflow catalog, `./omh`, and update prompt messages.

Before this PR on current main:

- elapsed: `0.063633s`
- cProfile total calls: `1,260,578`
- `_clone_static_payload`: `0.070s`

After this PR:

- elapsed: `0.053196s`
- cProfile total calls: `732,825`
- `_clone_static_payload`: `0.028s`

Micro-benchmark for `_skill_picker_static_state_cached()` clone:

- exact-type clone: `0.017997s`
- previous `isinstance` clone: `0.028828s`

## Boundary Notes

- No public schema changes.
- No LLM/API/network/runtime calls added.
- No change to prepared-vs-observed semantics.
- Public wrapper payloads remain fresh mutable dictionaries/lists.
- Existing mutation-safety tests cover the cached picker, context primer, and capability summary surfaces.

## Verification

- `PYTHONPATH=tests uv run python -m unittest tests/test_efficiency.py tests/test_wrapper_contract.py tests/test_chat_router.py -v`
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- `uv run --no-editable omh recommend "what OMH workflows are available?" --limit 2 --json`
- `uv run python -m compileall -q src tests`
- `uv run python -m omh.cli docs workflows --check`
- `uv run python -m omh.cli harness validate`
- `git diff --check`

## Risks

This assumes the static wrapper payload caches are generated from built-in containers. That matches current construction and is consistent with the route/plan clone optimization already merged.
