### PR TITLE
Improve specific capability question routing

### DIFF
--- a/src/routing/chat.py
+++ b/src/routing/chat.py
@@ -42,6 +42,7 @@ _SPECIFIC_CAPABILITY_CATALOG_SKILLS = frozenset(
         "deep-interview",
         "executor-runtime-readiness",
         "feedback-triage",
+        "gateway-intent-card",
         "github-event-ops",
         "img-summary",
         "idea-to-deploy",
@@ -121,6 +122,22 @@ _GENERIC_CATALOG_LISTING_MARKERS = (
     "목록",
     "리스트",
     "할 수 있는",
+)
+_SPECIFIC_CAPABILITY_ALIAS_PHRASES = (
+    "workflow learning",
+    "workflow trace",
+    "skill patch",
+    "routing regression",
+    "route regression",
+    "research department",
+    "research ops",
+    "gateway routing",
+    "message routing",
+    "platform routing",
+    "coding agents",
+    "coding agent",
+    "executors",
+    "runtimes",
 )
 _DIRECT_ANSWER_STARTERS = (
     "what ",
@@ -565,6 +582,8 @@ def _generic_omh_catalog_question(message: str) -> bool:
         return False
     named_hits = sum(1 for skill in _SPECIFIC_CAPABILITY_CATALOG_SKILLS if skill in text)
     if named_hits:
+        return False
+    if any(phrase in text for phrase in _SPECIFIC_CAPABILITY_ALIAS_PHRASES):
         return False
     has_collection = any(marker in text for marker in _GENERIC_CATALOG_COLLECTION_MARKERS)
     has_listing_intent = any(marker in text for marker in _GENERIC_CATALOG_LISTING_MARKERS)

--- a/src/routing/policy.py
+++ b/src/routing/policy.py
@@ -2957,6 +2957,18 @@ def _feedback_before_coding_guard_applies(
 def _workflow_learning_guard_applies(normalized_query: str, query_tokens: set[str]) -> bool:
     if _contains_phrase(normalized_query, _WORKFLOW_LEARNING_PHRASES):
         return True
+    capability_terms = bool({"learning", "trace", "eval", "regression", "patch"} & query_tokens) or _contains_phrase(
+        normalized_query,
+        (
+            "workflow learning",
+            "workflow trace",
+            "skill patch",
+            "routing regression",
+            "route regression",
+        ),
+    )
+    if _omh_capability_question(normalized_query) and capability_terms:
+        return True
     learning = bool({"learn", "learning", "학습"} & query_tokens)
     workflow_or_skill = bool({"workflow", "run", "trace", "skill", "routing", "route", "워크플로우", "스킬", "라우팅"} & query_tokens)
     future_improvement = bool({"improve", "improvement", "next", "future", "regression", "개선", "회귀"} & query_tokens)
@@ -3207,7 +3219,7 @@ def _paper_learning_guard_applies(
             return False
     if _contains_phrase(normalized_query, _PAPER_LEARNING_PHRASES):
         return True
-    paper_context = bool(_PAPER_LEARNING_PAPER_TOKENS & query_tokens) or _contains_phrase(
+    paper_context = bool((_PAPER_LEARNING_PAPER_TOKENS - {"research"}) & query_tokens) or _contains_phrase(
         normalized_query,
         ("research paper", "arxiv paper", "paper pdf", "pdf paper", "논문 pdf"),
     )
@@ -3311,6 +3323,9 @@ def _explicit_material_export_requested(normalized_query: str, query_tokens: set
 def _research_department_guard_applies(normalized_query: str, query_tokens: set[str]) -> bool:
     if is_explicit_one_off_request(normalized_query, query_tokens):
         return False
+    explicit_research_ops = _contains_phrase(normalized_query, _RESEARCH_DEPARTMENT_PHRASES)
+    if _omh_capability_question(normalized_query) and explicit_research_ops:
+        return True
     research_infra_setup = _contains_phrase(normalized_query, _RESEARCH_DEPARTMENT_SETUP_PHRASES)
     if research_infra_setup:
         research_context = bool(
@@ -3374,7 +3389,6 @@ def _research_department_guard_applies(normalized_query: str, query_tokens: set[
         normalized_query,
         ("collect news synthesize", "collect, synthesize", "collect and brief", "synthesize and brief"),
     )
-    explicit_research_ops = _contains_phrase(normalized_query, _RESEARCH_DEPARTMENT_PHRASES)
     return recurring and (research or collect_synthesize_brief) and (
         support or specific_research_domain or explicit_research_ops or collect_synthesize_brief
     )
@@ -3842,6 +3856,8 @@ def _gateway_intent_guard_applies(normalized_query: str, query_tokens: set[str])
     platform = bool({"discord", "slack", "telegram", "whatsapp", "signal", "gateway", "platform"} & query_tokens)
     policy = bool(
         {
+            "route",
+            "routing",
             "thread",
             "delivery",
             "silent",
@@ -3861,6 +3877,8 @@ def _gateway_intent_guard_applies(normalized_query: str, query_tokens: set[str])
         {
             "message",
             "messages",
+            "workflow",
+            "card",
             "thread",
             "attachment",
             "file",
@@ -3874,8 +3892,24 @@ def _gateway_intent_guard_applies(normalized_query: str, query_tokens: set[str])
         & query_tokens
     ) or _contains_phrase(
         normalized_query,
-        ("file attachment", "sent an attachment", "update the thread", "thread quietly", "voice note"),
+        (
+            "file attachment",
+            "sent an attachment",
+            "update the thread",
+            "thread quietly",
+            "voice note",
+            "workflow card",
+            "gateway routing",
+            "route this telegram message",
+            "route this discord message",
+            "route this slack message",
+        ),
     )
+    if _omh_capability_question(normalized_query) and platform and (
+        {"gateway", "routing", "route"} & query_tokens
+        or _contains_phrase(normalized_query, ("gateway routing", "message routing", "platform routing"))
+    ):
+        return True
     return platform and policy and gateway_context
 
 
@@ -4088,6 +4122,20 @@ def _executor_runtime_readiness_guard_applies(normalized_query: str, query_token
         return True
     if _executor_readiness_check_requested(normalized_query, query_tokens):
         return True
+    if _contains_phrase(
+        normalized_query,
+        (
+            "what coding agents can omh use",
+            "which coding agents can omh use",
+            "what coding agent can omh use",
+            "which coding agent can omh use",
+            "what executors can omh use",
+            "which executors can omh use",
+            "what runtimes can omh use",
+            "which runtimes can omh use",
+        ),
+    ):
+        return True
     runtime_intent = bool(_EXECUTOR_RUNTIME_READINESS_TOKENS & query_tokens) or _contains_phrase(
         normalized_query,
         ("runtime", "executor", "handoff", "런타임", "실행", "위임", "넘길", "넘길지"),
@@ -4240,6 +4288,8 @@ def _voice_operator_guard_applies(normalized_query: str, query_tokens: set[str])
 def _visual_summary_guard_applies(normalized_query: str, query_tokens: set[str]) -> bool:
     if _is_short_visual_summary_request(normalized_query):
         return True
+    if _gateway_intent_guard_applies(normalized_query, query_tokens):
+        return False
     explicit_visual_phrase = _contains_phrase(normalized_query, _VISUAL_SUMMARY_PHRASES)
     if explicit_visual_phrase:
         return True

--- a/tests/test_chat_router.py
+++ b/tests/test_chat_router.py
@@ -751,6 +751,44 @@ class ChatRouterTests(unittest.TestCase):
                 self.assertEqual(decision["confidence"], "high")
                 self.assertIn("Catalog question", decision["reason"])
 
+    def test_specific_capability_questions_route_to_the_named_workflow_card(self) -> None:
+        cases = (
+            (
+                "what can OMH do for workflow learning?",
+                "workflow-learning",
+                "workflow-learning",
+            ),
+            (
+                "what can OMH do for Discord gateway routing?",
+                "gateway-intent-card",
+                "gateway-intent-card",
+            ),
+            (
+                "route this Telegram message into a workflow card",
+                "gateway-intent-card",
+                "gateway-intent-card",
+            ),
+            (
+                "what coding agents can OMH use?",
+                "executor-runtime-readiness",
+                "executor-runtime-readiness",
+            ),
+            (
+                "what can OMH do for research department?",
+                "research-department",
+                "research-department",
+            ),
+        )
+
+        for message, skill, harness in cases:
+            with self.subTest(message=message):
+                decision = route_chat_message(message, source="discord")
+
+                self.assertEqual(decision["action"], "dispatch")
+                self.assertEqual(decision["selected_skill"], skill)
+                self.assertEqual(decision["selected_harness"], harness)
+                self.assertEqual(decision["confidence"], "high")
+
     def test_paper_learning_routes_paper_explanation_without_stealing_related_lanes(self) -> None:
         explanation_cases = (
             "이 논문 PDF 아주 쉽게 설명해줘",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3247,6 +3247,30 @@ class CliTests(unittest.TestCase):
                 "prepare_source_finder_plan",
                 "guard:source_finder",
             ),
+            (
+                "what can OMH do for workflow learning?",
+                "workflow-learning",
+                "audit_learning_readiness",
+                "guard:workflow_learning",
+            ),
+            (
+                "what can OMH do for Discord gateway routing?",
+                "gateway-intent-card",
+                "prepare_gateway_intent_card",
+                "guard:gateway_intent",
+            ),
+            (
+                "what coding agents can OMH use?",
+                "executor-runtime-readiness",
+                "prepare_executor_runtime_readiness",
+                "guard:executor_runtime_readiness",
+            ),
+            (
+                "what can OMH do for research department?",
+                "research-department",
+                "prepare_research_department_plan",
+                "guard:research_department",
+            ),
         )
 
         for message, skill, next_action, guard_label in cases:
@@ -4586,6 +4610,10 @@ class CliTests(unittest.TestCase):
             ("what can OMH do for PDF papers?", "paper-learning", "paper_learning", "prepare_paper_learning"),
             ("what can OMH do for source finding?", "source-finder", "source_finder", "prepare_source_finder_plan"),
             ("what can OMH do for datasets?", "source-finder", "source_finder", "prepare_source_finder_plan"),
+            ("what can OMH do for workflow learning?", "workflow-learning", "workflow_learning", "audit_learning_readiness"),
+            ("what can OMH do for Discord gateway routing?", "gateway-intent-card", "gateway_intent", "prepare_gateway_intent_card"),
+            ("what coding agents can OMH use?", "executor-runtime-readiness", "executor_runtime_readiness", "prepare_executor_runtime_readiness"),
+            ("what can OMH do for research department?", "research-department", "research_department", "prepare_research_department_plan"),
             ("결제 실패 피드백을 모아서 회의 주제와 다음 전략을 정리해줘", "feedback-triage", "feedback_triage", "triage_feedback"),
             ("prepare weekly ops review from customer feedback and release risks", "ops-review", "ops_review", "prepare_ops_review"),
             ("we need a competitor market scan and strategy memo for next week's leadership meeting", "strategy-brief", "strategy_brief", "prepare_strategy_brief"),


### PR DESCRIPTION
## Feature Report

### What Changed

- Routed specific OMH capability questions to their matching workflow cards instead of falling back to the generic OMH picker.
- Added specific handling for workflow-learning, gateway-intent-card, executor-runtime-readiness, and research-department capability wording.
- Kept broad catalog questions such as "what OMH workflows are available?" on the compact workflow picker.
- Prevented messenger workflow-card routing language such as "route this Telegram message into a workflow card" from being stolen by img-summary.

### Why This Exists

Users often ask Hermes what OMH can do in natural language before they know the exact skill name. The previous router handled papers, source finding, and visual summaries well, but some newer capability surfaces still felt inconsistent: gateway routing could open the generic picker, research department could be confused with paper-learning, and workflow-card wording could look like an image-card request.

This PR tightens those chat-first entry points so Hermes can answer with the right workflow card without asking the user to approve shell catalog commands or manually browse skills.

### User / Operator Impact

- "what can OMH do for workflow learning?" now opens workflow-learning.
- "what can OMH do for Discord gateway routing?" now opens gateway-intent-card.
- "route this Telegram message into a workflow card" now opens gateway-intent-card instead of img-summary.
- "what coding agents can OMH use?" now opens executor-runtime-readiness.
- "what can OMH do for research department?" now opens research-department.
- Generic catalog questions still open the OMH picker.

### How It Works

- `src/routing/chat.py` now treats common capability aliases as specific workflow questions, so the generic catalog fast path does not swallow them.
- `gateway-intent-card` is included in the specific capability allowlist used by catalog-question dispatch.
- `src/routing/policy.py` adds focused guard logic for workflow-learning capability questions, research department capability questions, gateway routing/card language, and coding-agent capability questions.
- Paper-learning no longer treats the bare token `research` as enough paper context, which prevents research-department questions from being misclassified.
- Img-summary now yields to gateway intent when the message is clearly a platform/thread/message routing card rather than a visual prompt card.

### Files And Contracts Touched

- `src/routing/chat.py`
- `src/routing/policy.py`
- `tests/test_chat_router.py`
- `tests/test_cli.py`

No schema version, runtime artifact, or prepared-vs-observed contract changed. This is routing behavior only.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_chat_router.py tests/test_cli.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli harness validate`
- [ ] `python3 -m omh.cli release checklist --json` - not run; routing-only change covered by full unit/docs/harness gates.
- [ ] `python3 -m omh.cli release hermes-smoke` - not run; no install/profile changes.
- [ ] `omh --help` - not run; no CLI help changes.
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` - not run; no release install changes.
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not required; no learning schema changed.
- [x] Relevant dry-run or smoke command: route sweep for the new capability questions confirmed matching workflow cards.
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; deterministic chat routing was verified through CLI/unit tests.

## Risk

- Low. The change is limited to routing heuristics and catalog-question dispatch behavior.
- Main risk is over-routing generic words such as `routing` into workflow-learning or gateway-intent-card. Tests now cover both generic picker preservation and specific capability routing.

## Compatibility / Rollout

- Backward compatible with existing CLI, chat, wrapper, and skill catalog contracts.
- Generic catalog discovery remains unchanged for broad workflow/skill list questions.
- Runtime/native capability claims remain metadata-only routing guidance.

## Release / Claims

- [x] Release-channel impact considered (`preview` routing improvement; no package/install migration required)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- Continue route-sweep passes for newly added workflow families whenever users ask "what can OMH do for ..." in chat.
