### PR TITLE
Cache capability routing phrase patterns

### DIFF
--- a/src/routing/chat.py
+++ b/src/routing/chat.py
@@ -181,6 +181,13 @@ _DIRECT_ANSWER_BLOCKERS = (
 
 
 @dataclass(frozen=True)
+class _SpecificCapabilityPhrase:
+    skill: str
+    phrase: str
+    pattern: re.Pattern[str]
+
+
+@dataclass(frozen=True)
 class ChatRouteDecision:
     schema_version: int
     source: str
@@ -809,25 +816,31 @@ def _specific_capability_catalog_skills() -> frozenset[str]:
 
 
 @lru_cache(maxsize=1)
-def _specific_capability_phrase_map() -> tuple[tuple[str, tuple[str, ...]], ...]:
-    entries: list[tuple[str, tuple[str, ...]]] = []
+def _specific_capability_phrase_map() -> tuple[_SpecificCapabilityPhrase, ...]:
+    entries: list[_SpecificCapabilityPhrase] = []
     for skill in sorted(_specific_capability_catalog_skills()):
         variants = {
             skill,
             skill.replace("-", " "),
             skill.replace("-", "_"),
         }
-        entries.append((skill, tuple(sorted(variants))))
+        for phrase in sorted(variants):
+            entries.append(
+                _SpecificCapabilityPhrase(
+                    skill=skill,
+                    phrase=phrase,
+                    pattern=_compile_specific_capability_phrase(phrase),
+                )
+            )
     return tuple(entries)
 
 
 def _specific_capability_named_hits(message: str) -> tuple[str, ...]:
     text = message.strip().lower()
     matches: list[tuple[int, int, int, str]] = []
-    for skill, phrases in _specific_capability_phrase_map():
-        for phrase in phrases:
-            for start, end in _specific_capability_phrase_matches(text, phrase):
-                matches.append((start, end, len(phrase), skill))
+    for phrase in _specific_capability_phrase_map():
+        for start, end in _specific_capability_phrase_matches(text, phrase):
+            matches.append((start, end, len(phrase.phrase), phrase.skill))
 
     selected: list[str] = []
     selected_ranges: list[tuple[int, int]] = []
@@ -840,13 +853,19 @@ def _specific_capability_named_hits(message: str) -> tuple[str, ...]:
     return tuple(selected)
 
 
-def _specific_capability_phrase_matches(text: str, phrase: str) -> tuple[tuple[int, int], ...]:
-    if not phrase:
-        return ()
+def _compile_specific_capability_phrase(phrase: str) -> re.Pattern[str]:
     boundary = r"(?<![a-z0-9_])"
     end_boundary = r"(?![a-z0-9_])"
-    pattern = re.compile(f"{boundary}{re.escape(phrase)}{end_boundary}")
-    return tuple((match.start(), match.end()) for match in pattern.finditer(text))
+    return re.compile(f"{boundary}{re.escape(phrase)}{end_boundary}")
+
+
+def _specific_capability_phrase_matches(
+    text: str,
+    phrase: _SpecificCapabilityPhrase,
+) -> tuple[tuple[int, int], ...]:
+    if not phrase.phrase:
+        return ()
+    return tuple((match.start(), match.end()) for match in phrase.pattern.finditer(text))
 
 
 def _prioritize_recommendation(

--- a/tests/test_chat_router.py
+++ b/tests/test_chat_router.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import unittest
+from unittest import mock
 
 from _local_package import load_local_package
 
@@ -14,9 +15,10 @@ from omh.chat_router import (
     routing_record_payload,
 )
 from omh.routing.intent import classify_workflow_intent
+from omh.routing import chat as chat_router_impl
 from omh.routing.localization import normalized_phrase
 from omh.plugin_bundle.omh.awareness import awareness_route_hint
-from omh.skills.catalog import primary_harness_for_skill
+from omh.skills.catalog import primary_harness_for_skill, routable_definitions
 
 
 def sionic_omh_usage_evaluation_prompt() -> str:
@@ -820,16 +822,9 @@ class ChatRouterTests(unittest.TestCase):
                 self.assertEqual(decision["confidence"], "high")
 
     def test_exact_skill_id_capability_questions_use_catalog_metadata(self) -> None:
-        skills = (
-            "meeting-brief",
-            "ops-review",
-            "best-practice-research",
-            "ultraqa",
-            "performance-goal",
-            "autoresearch-goal",
-            "wiki",
-            "ralph",
-        )
+        excluded = {"oh-my-hermes", "ask", "cancel", "plan", "skill", "team"}
+        skills = tuple(definition.name for definition in routable_definitions() if definition.name not in excluded)
+        self.assertGreaterEqual(len(skills), 40)
 
         for skill in skills:
             for phrase in (skill, skill.replace("-", " ")):
@@ -839,7 +834,6 @@ class ChatRouterTests(unittest.TestCase):
                     self.assertEqual(decision["action"], "dispatch")
                     self.assertEqual(decision["selected_skill"], skill)
                     self.assertEqual(decision["selected_harness"], primary_harness_for_skill(skill))
-                    self.assertIn("Specific OMH capability question", decision["reason"])
 
     def test_generic_short_operator_skill_names_do_not_hijack_catalog_picker(self) -> None:
         for phrase in ("plan", "team", "ask"):
@@ -849,6 +843,29 @@ class ChatRouterTests(unittest.TestCase):
                 self.assertEqual(decision["action"], "dispatch")
                 self.assertEqual(decision["selected_skill"], "oh-my-hermes")
                 self.assertIn("Catalog question", decision["reason"])
+
+    def test_specific_capability_phrase_patterns_are_compiled_once(self) -> None:
+        chat_router_impl._specific_capability_phrase_map.cache_clear()
+        try:
+            with mock.patch.object(
+                chat_router_impl,
+                "_compile_specific_capability_phrase",
+                wraps=chat_router_impl._compile_specific_capability_phrase,
+            ) as compile_phrase:
+                self.assertEqual(
+                    chat_router_impl._specific_capability_named_hits("what can OMH do for CTO loop?"),
+                    ("cto-loop",),
+                )
+                first_call_count = compile_phrase.call_count
+                self.assertGreater(first_call_count, 40)
+
+                self.assertEqual(
+                    chat_router_impl._specific_capability_named_hits("what can OMH do for deploy and monitor?"),
+                    ("deploy-and-monitor",),
+                )
+                self.assertEqual(compile_phrase.call_count, first_call_count)
+        finally:
+            chat_router_impl._specific_capability_phrase_map.cache_clear()
 
     def test_paper_learning_routes_paper_explanation_without_stealing_related_lanes(self) -> None:
         explanation_cases = (


### PR DESCRIPTION
## Feature Report

### What Changed

- Cached specific capability phrase regex patterns when the catalog phrase map is built.
- Reused compiled patterns for capability-question matching instead of recompiling every phrase during every chat route.
- Expanded router tests so all non-generic routable workflow ids and their space-separated forms route back to their own workflow cards.
- Added a focused test that proves the capability phrase map compiles patterns once and reuses them across later named-hit checks.

### Why This Exists

- The previous catalog-driven routing change made workflow-id discovery broader, but the matcher still compiled many regex patterns on the hot routing path.
- OMH chat routing should stay responsive as the workflow catalog grows.
- This keeps the stronger exact-workflow capability matching while removing avoidable repeated setup work.

### User / Operator Impact

- Users keep the same chat-facing behavior: exact workflow questions open the named workflow card, broad catalog questions open the picker.
- Operators get a cheaper router path for capability questions, especially in wrappers that call route/preview frequently.
- New workflow ids remain covered by catalog metadata without another hard-coded allowlist.

### How It Works

- `src/routing/chat.py` introduces `_SpecificCapabilityPhrase`, which stores the skill id, phrase variant, and compiled regex pattern.
- `_specific_capability_phrase_map()` remains `lru_cache(maxsize=1)`, so regex setup is performed once per process/cache lifecycle.
- `_specific_capability_named_hits()` now scans the cached phrase objects and keeps the existing longest-overlap behavior for cases like `cto loop` versus `loop`.

### Files And Contracts Touched

- `src/routing/chat.py`
- `tests/test_chat_router.py`

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests.test_chat_router.ChatRouterTests.test_exact_skill_id_capability_questions_use_catalog_metadata tests.test_chat_router.ChatRouterTests.test_generic_short_operator_skill_names_do_not_hijack_catalog_picker tests.test_chat_router.ChatRouterTests.test_specific_capability_phrase_patterns_are_compiled_once tests.test_chat_router.ChatRouterTests.test_specific_capability_questions_route_to_the_named_workflow_card`
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_chat_router.py tests/test_cli.py tests/test_wrapper_contract.py`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli harness validate`
- [x] `git diff --check`
- [x] Relevant dry-run or smoke command: full router test sweep covers exact workflow id capability questions.
- [x] Manual Hermes/TUI check, or explicit reason it was not run: not run; this is deterministic local router matching with test coverage.

## Risk

- Low. This is a mechanical matcher optimization that preserves the existing phrase boundary regex and longest-overlap behavior.
- Main risk is cache lifecycle confusion in tests; the new test clears the phrase-map cache before and after the compile-count assertion.

## Compatibility / Rollout

- Backward compatible for existing route payloads and wrapper contracts.
- No schema, state, install, plugin, or generated docs migration is required.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`): local routing implementation only.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed: no new runtime/native claims added.
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap: live Hermes/TUI not run because local deterministic routing tests cover the changed behavior.

## Follow-Up

- If wrapper route previews become high-volume, add a lightweight timing harness around `route_chat_message` to catch future hot-path regressions.
