### PR TITLE
Fast path exact capability routing

### DIFF
--- a/src/quality/routing_precision.py
+++ b/src/quality/routing_precision.py
@@ -134,7 +134,7 @@ ROUTING_INTERVENTION_CASES: tuple[RoutingInterventionCase, ...] = (
     RoutingInterventionCase(
         "exact-ops-review-capability",
         "Exact operations workflow questions open ops review",
-        "what can OMH do for ops review?",
+        "what can OMH do for ops-review?",
         "dispatch",
         "ops-review",
         "prepare_ops_review",

--- a/src/routing/chat.py
+++ b/src/routing/chat.py
@@ -17,7 +17,7 @@ from .policy import (
     is_ambiguous_scores,
     meets_confidence_threshold,
 )
-from .recommend import recommend_skills
+from .recommend import recommendation_for_definition, recommend_skills
 from .route_plan import build_workflow_route_plan, compact_workflow_route_plan
 from .task_cards import classify_task, task_card_recommendation
 from ..learning_candidate import build_learning_candidate_card
@@ -510,6 +510,54 @@ def _catalog_fast_path_decision(
 ) -> _CatalogFastPathResult:
     direct_picker = _direct_picker_alias(routing_message)
     catalog_question = False if direct_picker else is_skill_catalog_question(routing_message)
+    exact_skill = (
+        _specific_capability_exact_id_hit(routing_message)
+        if catalog_question and not _is_broad_capability_catalog_question(routing_message)
+        else None
+    )
+    if exact_skill is not None:
+        definition = _skill_definition_by_name(exact_skill)
+        recommendation = recommendation_for_definition(
+            definition,
+            message,
+            matched=("catalog_question", f"name:{exact_skill}"),
+            score=12,
+            why=f"Matched exact OMH capability `{exact_skill}` from catalog metadata.",
+        )
+        reason = (
+            f"Specific OMH capability question matched `{exact_skill}`; "
+            "show that workflow card instead of the generic workflow picker."
+        )
+        selected_harness = primary_harness_for_skill(exact_skill)
+        return _CatalogFastPathResult(
+            decision=ChatRouteDecision(
+                schema_version=1,
+                source=source,
+                action="dispatch",
+                selected_skill=exact_skill,
+                selected_harness=selected_harness,
+                candidate_skill=exact_skill,
+                candidate_harness=selected_harness,
+                confidence="high",
+                score=12,
+                threshold=min_confidence,
+                explicit=False,
+                ambiguous=False,
+                reason=reason,
+                clarification="",
+                routing_prompt=_routing_prompt("dispatch", exact_skill, exact_skill, reason, message),
+                task_card=None,
+                workflow_route_plan=build_workflow_route_plan(
+                    message,
+                    [recommendation],
+                    selected_skill=exact_skill,
+                    action="dispatch",
+                ),
+                learning_candidate_card=None,
+                recommendations=(recommendation,),
+            ),
+            catalog_question=catalog_question,
+        )
     catalog_picker = (
         not direct_picker
         and catalog_question
@@ -600,10 +648,15 @@ def _router_picker_recommendation(query: str, *, matched: tuple[str, ...], score
 
 @lru_cache(maxsize=1)
 def _router_skill_definition() -> SkillDefinition:
+    return _skill_definition_by_name(_ROUTER_SKILL)
+
+
+@lru_cache(maxsize=128)
+def _skill_definition_by_name(name: str) -> SkillDefinition:
     for definition in routable_definitions():
-        if definition.name == _ROUTER_SKILL:
+        if definition.name == name:
             return definition
-    raise RuntimeError("oh-my-hermes router skill definition is missing")
+    raise RuntimeError(f"{name} skill definition is missing")
 
 
 def _task_card_overrides_explicit_invocation(
@@ -851,6 +904,21 @@ def _specific_capability_named_hits(message: str) -> tuple[str, ...]:
             selected.append(skill)
         selected_ranges.append((start, end))
     return tuple(selected)
+
+
+def _specific_capability_exact_id_hit(message: str) -> str | None:
+    text = message.strip().lower()
+    hits: list[str] = []
+    for phrase in _specific_capability_phrase_map():
+        if "-" not in phrase.phrase and "_" not in phrase.phrase:
+            continue
+        if phrase.phrase not in (phrase.skill, phrase.skill.replace("-", "_")):
+            continue
+        if not _specific_capability_phrase_matches(text, phrase):
+            continue
+        if phrase.skill not in hits:
+            hits.append(phrase.skill)
+    return hits[0] if len(hits) == 1 else None
 
 
 def _compile_specific_capability_phrase(phrase: str) -> re.Pattern[str]:

--- a/src/routing/recommend.py
+++ b/src/routing/recommend.py
@@ -518,6 +518,34 @@ def recommend_skills(query: str, *, limit: int = 5, apply_guardrails: bool = Tru
     return [recommendation.to_dict() for recommendation in _recommend_skills_cached(query, limit, apply_guardrails)]
 
 
+def recommendation_for_definition(
+    definition: SkillDefinition,
+    query: str,
+    *,
+    matched: tuple[str, ...],
+    score: int,
+    why: str | None = None,
+) -> dict[str, object]:
+    policy = _policy_for(definition)
+    matched_tuple = tuple(sorted(matched))
+    return Recommendation(
+        skill=definition.name,
+        description=definition.description,
+        category=definition.category,
+        phase=definition.phase,
+        hermes_role=definition.hermes_role,
+        handoff_policy=definition.handoff_policy,
+        score=score,
+        confidence=_confidence(score),
+        matched=matched_tuple,
+        why=why or _why(matched_tuple),
+        next_action=policy.next_action,
+        evidence_boundary=policy.evidence_boundary,
+        wrapper_guidance=policy.wrapper_guidance,
+        suggested_prompt=_suggested_prompt(definition.name, query),
+    ).to_dict()
+
+
 @lru_cache(maxsize=2048)
 def _recommend_skills_cached(query: str, limit: int, apply_guardrails: bool) -> tuple[Recommendation, ...]:
     routing_text = prepare_routing_text(_strip_path_like_fragments(query))

--- a/tests/test_chat_router.py
+++ b/tests/test_chat_router.py
@@ -835,6 +835,28 @@ class ChatRouterTests(unittest.TestCase):
                     self.assertEqual(decision["selected_skill"], skill)
                     self.assertEqual(decision["selected_harness"], primary_harness_for_skill(skill))
 
+    def test_exact_skill_id_capability_questions_use_fast_path_without_full_scoring(self) -> None:
+        chat_router_impl._route_chat_message_cached.cache_clear()
+        chat_router_impl._public_chat_route_payload_cached.cache_clear()
+
+        with mock.patch.object(
+            chat_router_impl,
+            "recommend_skills",
+            side_effect=AssertionError("exact workflow-id capability questions should use the catalog fast path"),
+        ):
+            decision = route_chat_message("what can OMH do for paper-learning?", source="discord")
+
+        self.assertEqual(decision["action"], "dispatch")
+        self.assertEqual(decision["selected_skill"], "paper-learning")
+        self.assertEqual(decision["selected_harness"], "paper-learning")
+        self.assertEqual(decision["confidence"], "high")
+        self.assertEqual(decision["recommendations"][0]["next_action"], "prepare_paper_learning")
+        self.assertEqual(
+            decision["recommendations"][0]["matched"],
+            ["catalog_question", "name:paper-learning"],
+        )
+        self.assertIn("exact OMH capability", decision["recommendations"][0]["why"])
+
     def test_generic_short_operator_skill_names_do_not_hijack_catalog_picker(self) -> None:
         for phrase in ("plan", "team", "ask"):
             with self.subTest(phrase=phrase):


### PR DESCRIPTION
## Feature Report

### What Changed

- Added a catalog-backed fast path for exact OMH workflow-id capability questions such as `what can OMH do for paper-learning?`.
- Reused catalog metadata to build the recommendation card without running the full `recommend_skills` scoring path.
- Updated the routing precision fixture to exercise exact workflow-id coverage for `ops-review`.
- Added a regression test proving exact workflow-id capability questions avoid full scoring.

### Why This Exists

- Hermes users often ask what a specific OMH workflow does from chat surfaces.
- Exact workflow-id questions should feel instant and deterministic because the catalog already has the answer.
- Natural-language aliases still need the normal scoring and guardrail path because phrases such as `CTO loop` can otherwise be misread as the shorter `loop` workflow.

### User / Operator Impact

- Asking Hermes about a known OMH workflow id now opens the relevant workflow card more directly.
- The router remains conservative for natural language phrasing and broad catalog questions.
- This improves perceived responsiveness without claiming execution, review, CI, or wrapper delivery happened.

### How It Works

- `src/routing/chat.py` detects exact hyphenated or underscored workflow ids only for specific catalog questions.
- `src/routing/recommend.py` exposes `recommendation_for_definition(...)`, which converts a catalog `SkillDefinition` into the same recommendation dictionary shape used by normal routing.
- The exact-id fast path still includes `workflow_route_plan/v1` advisory metadata and keeps the existing prepared-vs-observed boundary.
- Natural aliases and broad picker requests continue through the full recommendation path.

### Files And Contracts Touched

- `src/routing/chat.py`: exact workflow-id fast path and reusable skill definition lookup.
- `src/routing/recommend.py`: metadata-only recommendation builder for known catalog definitions.
- `src/quality/routing_precision.py`: exact `ops-review` routing precision fixture.
- `tests/test_chat_router.py`: regression coverage for no full scoring on exact workflow-id questions.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests.test_chat_router tests.test_routing_precision tests.test_efficiency -v`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli harness validate`
- [ ] `python3 -m omh.cli release checklist --json` (not run; release packaging is not changed)
- [ ] `python3 -m omh.cli release hermes-smoke` (not run; live Hermes smoke is not changed)
- [ ] `omh --help` (not run; CLI help surface is not changed)
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` (not run; install path is not changed)
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable
- [x] Relevant dry-run or smoke command: `uv run python -m omh.cli demo routing-precision --summary`; `uv run python -m omh.cli demo hermes-ux-quality --json`; `uv run python -m omh.cli chat route "what can OMH do for paper-learning?" --json`; `uv run python -m omh.cli chat route "what can OMH do for CTO loop?" --json`; `git diff --check`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; this PR changes deterministic router logic only, and live wrapper rendering remains outside this repository.

## Risk

- Narrow routing risk: exact-id matching must not hijack natural-language aliases.
- Mitigated by limiting the fast path to workflow ids containing `-` or `_`, and by validating `CTO loop` still routes to `cto-loop` through normal scoring.

## Compatibility / Rollout

- Backward compatible recommendation dictionary shape.
- No new dependencies.
- No schema version bump required; `workflow_route_plan/v1` remains advisory metadata.

## Release / Claims

- [x] Release-channel impact considered (`preview`; router behavior improvement only)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- Consider a broader benchmark for exact workflow-id catalog questions if chat catalog traffic grows enough to warrant more instrumentation.
