### PR TITLE
Keep capability questions card only

### DIFF
--- a/src/routing/chat.py
+++ b/src/routing/chat.py
@@ -547,12 +547,7 @@ def _catalog_fast_path_decision(
                 clarification="",
                 routing_prompt=_routing_prompt("dispatch", exact_skill, exact_skill, reason, message),
                 task_card=None,
-                workflow_route_plan=build_workflow_route_plan(
-                    message,
-                    [recommendation],
-                    selected_skill=exact_skill,
-                    action="dispatch",
-                ),
+                workflow_route_plan=None,
                 learning_candidate_card=None,
                 recommendations=(recommendation,),
             ),

--- a/tests/test_chat_router.py
+++ b/tests/test_chat_router.py
@@ -843,6 +843,10 @@ class ChatRouterTests(unittest.TestCase):
             chat_router_impl,
             "recommend_skills",
             side_effect=AssertionError("exact workflow-id capability questions should use the catalog fast path"),
+        ), mock.patch.object(
+            chat_router_impl,
+            "build_workflow_route_plan",
+            side_effect=AssertionError("exact workflow-id capability questions should render a card, not a route plan"),
         ):
             decision = route_chat_message("what can OMH do for paper-learning?", source="discord")
 
@@ -856,6 +860,7 @@ class ChatRouterTests(unittest.TestCase):
             ["catalog_question", "name:paper-learning"],
         )
         self.assertIn("exact OMH capability", decision["recommendations"][0]["why"])
+        self.assertNotIn("workflow_route_plan", public_route_payload(decision))
 
     def test_generic_short_operator_skill_names_do_not_hijack_catalog_picker(self) -> None:
         for phrase in ("plan", "team", "ask"):


### PR DESCRIPTION
## Feature Report

### What Changed

- Exact workflow-id capability questions now return the workflow card without also building `workflow_route_plan/v1`.
- The exact-id fast-path regression test now proves it does not call `recommend_skills` or `build_workflow_route_plan`.
- Public route payloads for questions like `what can OMH do for paper-learning?` stay compact and card-shaped.

### Why This Exists

- A question about what a specific OMH workflow can do is a capability explanation, not a multi-step plan.
- Returning a route plan for this case adds avoidable work and can make wrappers treat a simple card like a prepared workflow sequence.
- This keeps the user-facing response faster, smaller, and clearer while preserving natural-language routing for real workflow requests.

### User / Operator Impact

- Hermes can answer exact workflow questions with a compact workflow card.
- Wrapper surfaces do not need to render a route-plan section when the user only asked what a workflow does.
- The existing evidence boundary remains conservative: explaining a capability is not plan acceptance, dispatch, execution, verification, review, CI, or merge evidence.

### How It Works

- `src/routing/chat.py` keeps exact workflow-id catalog questions on the catalog metadata fast path but sets `workflow_route_plan=None`.
- `tests/test_chat_router.py` patches both `recommend_skills` and `build_workflow_route_plan` to make accidental regressions fail loudly.
- Full workflow requests still build route plans through the normal routing path.

### Files And Contracts Touched

- `src/routing/chat.py`: exact capability-card route no longer builds `workflow_route_plan/v1`.
- `tests/test_chat_router.py`: regression test locks fast-path and card-only behavior.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests.test_chat_router tests.test_routing_precision tests.test_efficiency -v`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli harness validate`
- [ ] `python3 -m omh.cli release checklist --json` (not run; release packaging is not changed)
- [ ] `python3 -m omh.cli release hermes-smoke` (not run; live Hermes smoke is not changed)
- [ ] `omh --help` (not run; CLI help surface is not changed)
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` (not run; install path is not changed)
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable
- [x] Relevant dry-run or smoke command: `uv run python -m omh.cli demo routing-precision --summary`; `uv run python -m omh.cli demo hermes-ux-quality --json`; `uv run python -m omh.cli chat route "what can OMH do for paper-learning?" --json`; `git diff --check`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; this is deterministic router contract behavior only.

## Risk

- Narrow risk: some wrapper code might have tolerated route plans on exact capability cards.
- Mitigation: public payload remains valid and compact; route plans still exist for real multi-step workflow requests.

## Compatibility / Rollout

- Backward compatible for route decisions and recommendations.
- No schema or dependency change.
- Wrapper rendering should treat missing `workflow_route_plan` as the existing compact-card case.

## Release / Claims

- [x] Release-channel impact considered (`preview`; router card-shape improvement only)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- If wrappers need a richer capability-card schema later, add it separately instead of reusing route-plan metadata.
