### PR TITLE
Tighten route evidence labels

### DIFF
--- a/src/routing/chat.py
+++ b/src/routing/chat.py
@@ -1178,25 +1178,47 @@ def _not_evidence_from_boundary(boundary: str) -> list[str]:
         return items
     items: list[str] = []
     for marker, label in (
-        ("plan acceptance", "plan acceptance"),
-        ("dispatch", "executor/runtime dispatch"),
-        ("execution", "execution"),
-        ("implementation", "implementation"),
-        ("image", "image generation"),
-        ("file", "file generation/export"),
+        ("full pdf extraction", "full PDF extraction"),
+        ("figure ocr", "figure OCR"),
+        ("external citation checking", "external citation checking"),
+        ("citation checking", "external citation checking"),
+        ("math validation", "math validation"),
+        ("code reproduction", "code reproduction"),
+        ("paper claims", "paper claim verification"),
+        ("generated image", "image generation"),
+        ("image generation", "image generation"),
+        ("visual qa", "visual QA"),
+        ("file export", "file export"),
+        ("file generation", "file generation/export"),
+        ("file extraction", "file extraction"),
+        ("web search", "web search"),
+        ("source retrieval", "source retrieval"),
+        ("sources were fetched", "source retrieval"),
+        ("repository clone", "repository clone"),
         ("download", "download"),
-        ("search", "source retrieval"),
-        ("api", "API access"),
-        ("credential", "credential validation"),
-        ("connector", "connector invocation"),
-        ("delivery", "delivery"),
-        ("attachment", "attachment"),
-        ("review", "review"),
-        ("verification", "verification"),
-        ("ci", "CI"),
-        ("merge", "merge"),
+        ("file hash verification", "file hash verification"),
+        ("license verification", "license verification"),
+        ("source correctness verification", "source correctness verification"),
     ):
         if marker in text and label not in items:
+            items.append(label)
+    peer_review_free_text = text.replace("peer review", "")
+    for pattern, label in (
+        (r"\bplan acceptance\b", "plan acceptance"),
+        (r"\bdispatch(?:ed)?\b", "executor/runtime dispatch"),
+        (r"\bexecution\b", "execution"),
+        (r"\bimplementation\b", "implementation"),
+        (r"\bapi\b", "API access"),
+        (r"\bcredential\b", "credential validation"),
+        (r"\bconnector\b", "connector invocation"),
+        (r"\bdelivery\b", "delivery"),
+        (r"\battachment\b", "attachment"),
+        (r"\breview\b", "review"),
+        (r"\bverification\b", "verification"),
+        (r"\bci\b", "CI"),
+        (r"\bmerge(?:-readiness)?\b", "merge"),
+    ):
+        if re.search(pattern, peer_review_free_text) and label not in items:
             items.append(label)
     if items:
         return items

--- a/tests/test_chat_router.py
+++ b/tests/test_chat_router.py
@@ -860,7 +860,13 @@ class ChatRouterTests(unittest.TestCase):
             ["catalog_question", "name:paper-learning"],
         )
         self.assertIn("exact OMH capability", decision["recommendations"][0]["why"])
-        self.assertNotIn("workflow_route_plan", public_route_payload(decision))
+        public = public_route_payload(decision)
+        self.assertNotIn("workflow_route_plan", public)
+        explanation = public["route_explanation"]
+        self.assertIn("full PDF extraction", explanation["not_evidence_yet"])
+        self.assertIn("external citation checking", explanation["not_evidence_yet"])
+        self.assertNotIn("review", explanation["not_evidence_yet"])
+        self.assertNotIn("CI", explanation["not_evidence_yet"])
 
     def test_generic_short_operator_skill_names_do_not_hijack_catalog_picker(self) -> None:
         for phrase in ("plan", "team", "ask"):


### PR DESCRIPTION
## Feature Report

### What Changed

- Tightened `route_explanation/v1` missing-evidence label extraction so domain terms do not accidentally become coding gates.
- Added concrete paper/source/image evidence labels before generic execution/review/CI markers.
- Prevented `citation` from matching `CI` and `peer review` from matching coding `review`.
- Extended the exact `paper-learning` capability-card regression test to prove it shows paper evidence gaps instead of review/CI gaps.

### Why This Exists

- Hermes-facing route cards should explain what is still not observed in the terms of the selected workflow.
- Before this change, an exact `paper-learning` capability question could say `review` and `CI` were missing because `citation` contains `ci` and `peer review` contains `review`.
- That makes a non-coding explanation card feel like a coding handoff or PR gate, which is confusing for users.

### User / Operator Impact

- Asking what `paper-learning` does now shows paper-specific gaps such as full PDF extraction, figure OCR, citation checking, math validation, and code reproduction.
- Source and image workflows keep visible domain-specific gaps such as web search, repository clone, file extraction, visual QA, and image generation.
- Coding workflows still keep review, CI, merge, dispatch, and implementation boundaries where those words are actually present as standalone evidence gates.

### How It Works

- `src/routing/chat.py` now extracts specific evidence labels first from known phrases, then applies regex word-boundary matching for generic labels.
- The generic scan removes `peer review` before testing for standalone `review`.
- `CI` is now matched with `\bci\b`, so words such as `citation` no longer create a CI gap.
- `tests/test_chat_router.py` locks the exact paper-learning route explanation behavior.

### Files And Contracts Touched

- `src/routing/chat.py`: safer `_not_evidence_from_boundary(...)` extraction.
- `tests/test_chat_router.py`: exact `paper-learning` route explanation regression coverage.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests.test_chat_router.ChatRouterTests.test_exact_skill_id_capability_questions_use_fast_path_without_full_scoring tests.test_wrapper_contract.WrapperContractTests.test_paper_learning_interaction_uses_learning_evidence_not_coding_gates tests.test_wrapper_contract.WrapperContractTests.test_source_finder_interaction_uses_acquisition_evidence_not_coding_gates tests.test_wrapper_contract.WrapperContractTests.test_visual_summary_interaction_exposes_prompt_card_actions tests.test_wrapper_contract.WrapperContractTests.test_route_mode_exposes_visible_omh_usage_trace_for_web_research -v`
- [x] `PYTHONPATH=tests uv run python -m unittest tests.test_chat_router tests.test_wrapper_contract tests.test_cli tests.test_efficiency -v`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli harness validate`
- [ ] `python3 -m omh.cli release checklist --json` (not run; release packaging is not changed)
- [ ] `python3 -m omh.cli release hermes-smoke` (not run; live Hermes smoke is not changed)
- [ ] `omh --help` (not run; CLI help surface is not changed)
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` (not run; install path is not changed)
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable
- [x] Relevant dry-run or smoke command: `uv run python -m omh.cli demo routing-precision --summary`; `uv run python -m omh.cli demo hermes-ux-quality --json`; `uv run python -m omh.cli chat route "what can OMH do for paper-learning?" --json`; `git diff --check`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; this is deterministic route-card projection logic only.

## Risk

- Narrow risk: evidence label wording changes in route explanation cards.
- Mitigation: existing wrapper, CLI, routing, and UX quality suites were run, including paper/source/image/coding boundary tests.

## Compatibility / Rollout

- No schema change; `route_explanation/v1` keeps the same fields.
- Existing wrappers receive clearer values in `not_evidence_yet` without needing rendering changes.
- No dependency changes.

## Release / Claims

- [x] Release-channel impact considered (`preview`; route-card copy precision improvement only)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- If more domain-specific workflows need custom wording, add phrase-level evidence labels before generic markers rather than expanding substring matching.
