### PR TITLE
Polish route evidence reply copy

### DIFF
--- a/src/routing/chat.py
+++ b/src/routing/chat.py
@@ -1197,7 +1197,7 @@ def _route_recommended_reply(
 ) -> str:
     if action == "dispatch":
         not_evidence = _first_not_evidence(not_evidence_yet)
-        suffix = f" This is still not {not_evidence} evidence." if not_evidence else " This is routing guidance, not execution evidence."
+        suffix = f" This is still not evidence of {not_evidence}." if not_evidence else " This is routing guidance, not execution evidence."
         return f"I will use `{selected}` first and start with {next_action_label}.{suffix}"
     if action == "clarify":
         return "I need one clarification before choosing a workflow; no plan or execution has started."

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -4580,7 +4580,7 @@ def _workflow_explanation_reason(state: dict[str, object], *, workflow: str, lab
 def _workflow_recommended_reply(workflow: str, label: str, next_action_label: str, not_evidence_yet: list[str]) -> str:
     name = workflow or label
     not_evidence = _first_not_evidence_item(not_evidence_yet)
-    suffix = f" This is still not {not_evidence} evidence." if not_evidence else " This is guidance, not execution evidence."
+    suffix = f" This is still not evidence of {not_evidence}." if not_evidence else " This is guidance, not execution evidence."
     return f"I will use `{name}` and start with {next_action_label}.{suffix}"
 
 

--- a/tests/test_chat_router.py
+++ b/tests/test_chat_router.py
@@ -917,6 +917,8 @@ class ChatRouterTests(unittest.TestCase):
                 for label in expected_labels:
                     self.assertIn(label, not_evidence_yet)
                 self.assertNotIn("completion claim without observed evidence", not_evidence_yet)
+                self.assertIn(f"not evidence of {expected_labels[0]}", public["route_explanation"]["recommended_reply"])
+                self.assertNotIn(f"not {expected_labels[0]} evidence", public["route_explanation"]["recommended_reply"])
 
     def test_generic_short_operator_skill_names_do_not_hijack_catalog_picker(self) -> None:
         for phrase in ("plan", "team", "ask"):
@@ -1833,6 +1835,8 @@ selected_workflow=ultraprocess
         self.assertIn("connector invocation", explanation["not_evidence_yet"])
         self.assertIn("toolbelt-readiness", explanation["recommended_reply"])
         self.assertIn("prepare toolbelt readiness", explanation["recommended_reply"])
+        self.assertIn("not evidence of execution", explanation["recommended_reply"])
+        self.assertNotIn("not execution evidence", explanation["recommended_reply"])
         self.assertEqual(explanation["primary_action_label"], "Open toolbelt-readiness")
         self.assertIn("do not claim", explanation["primary_action_hint"])
         self.assertIn("execution", explanation["primary_action_hint"])

--- a/tests/test_wrapper_contract.py
+++ b/tests/test_wrapper_contract.py
@@ -940,6 +940,8 @@ class WrapperContractTests(unittest.TestCase):
         self.assertIn("verification", explanation["not_evidence_yet"])
         self.assertIn("feedback-triage", explanation["recommended_reply"])
         self.assertIn("triage feedback", explanation["recommended_reply"])
+        self.assertIn("not evidence of completed feedback triage", explanation["recommended_reply"])
+        self.assertNotIn("not completed feedback triage evidence", explanation["recommended_reply"])
         self.assertEqual(explanation["primary_action_label"], "Open feedback-triage")
         self.assertIn("do not claim completed feedback triage", explanation["primary_action_hint"])
 
@@ -957,7 +959,9 @@ class WrapperContractTests(unittest.TestCase):
         self.assertEqual(explanation["next_action"], "accept_or_revise_plan")
         self.assertEqual(explanation["route_next_action"], "present_plan")
         self.assertIn("accept or revise plan", explanation["recommended_reply"])
+        self.assertIn("not evidence of plan acceptance", explanation["recommended_reply"])
         self.assertIn("present plan", explanation["route_recommended_reply"])
+        self.assertIn("not evidence of execution", explanation["route_recommended_reply"])
         self.assertIn("do not claim plan acceptance", explanation["primary_action_hint"])
         self.assertIn("do not claim execution", explanation["route_primary_action_hint"])
 


### PR DESCRIPTION
## Feature Report

### What Changed

- Updated route and wrapper recommended-reply copy from `not <thing> evidence` to `not evidence of <thing>`.
- Added regression checks for exact capability cards, toolbelt readiness, feedback triage, and accepted-plan wrapper explanations.

### Why This Exists

The route evidence labels are now concrete, but some labels read awkwardly in the old sentence shape. For example, `This is still not billing truth evidence` is technically understandable but feels machine-written in Hermes chat. The new wording keeps the same boundary while making the first reply easier to read: `This is still not evidence of billing truth.`

### User / Operator Impact

- Hermes chat responses sound more natural when explaining what OMH has not observed yet.
- Wrapper cards keep the same evidence discipline but avoid clunky phrasing for labels such as `billing truth`, `target acceptance`, `completed feedback triage`, and `plan acceptance`.
- No CLI commands, action IDs, schemas, or routing decisions change.

### How It Works

- `src/routing/chat.py` changes the route-level `recommended_reply` suffix only.
- `src/wrapper/contract.py` applies the same wording to wrapper workflow explanations.
- Tests assert the new wording and reject the old awkward phrase for representative route and wrapper surfaces.

### Files And Contracts Touched

- `src/routing/chat.py`: route explanation recommended reply copy.
- `src/wrapper/contract.py`: wrapper workflow explanation recommended reply copy.
- `tests/test_chat_router.py`: route copy regressions.
- `tests/test_wrapper_contract.py`: wrapper copy regressions.
- Public contract: no schema changes; only human-facing string copy changes.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests.test_chat_router.ChatRouterTests.test_exact_capability_cards_use_concrete_not_evidence_labels tests.test_chat_router.ChatRouterTests.test_public_route_payload_includes_human_route_explanation tests.test_wrapper_contract.WrapperContractTests.test_feedback_triage_interaction_shows_investigation_before_coding tests.test_wrapper_contract.WrapperContractTests.test_plan_interaction_keeps_route_specific_reason_in_workflow_explanation -v`
- [x] `PYTHONPATH=tests uv run python -m unittest tests.test_chat_router tests.test_wrapper_contract tests.test_cli -v`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli harness validate`
- [x] `uv run python -m omh.cli demo routing-precision --summary`
- [x] `uv run python -m omh.cli demo hermes-ux-quality --json`
- [x] `git diff --check`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; this is deterministic local chat-copy projection only.

## Risk

- Low. This is a narrow copy change with no schema or state changes.
- Main risk is downstream tests expecting exact old prose; updated local coverage locks the new phrasing.

## Compatibility / Rollout

- Backward compatible for wrappers that treat `recommended_reply` as display text.
- Machine-readable action IDs and evidence arrays are unchanged.

## Release / Claims

- [x] Release-channel impact considered: human-facing copy polish only.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] Known manual Hermes checks are listed: live Hermes rendering was not observed in this PR.

## Follow-Up

- None required for this slice.
