### PR TITLE
Refactor evidence copy helpers

### DIFF
--- a/src/routing/chat.py
+++ b/src/routing/chat.py
@@ -21,6 +21,7 @@ from .recommend import recommendation_for_definition, recommend_skills
 from .route_plan import build_workflow_route_plan, compact_workflow_route_plan
 from .task_cards import classify_task, task_card_recommendation
 from ..learning_candidate import build_learning_candidate_card
+from ..surfaces.evidence_copy import not_evidence_action_suffix, not_evidence_reply_suffix
 from ..skills.catalog import SkillDefinition, primary_harness_for_skill, routable_definitions
 
 
@@ -1196,8 +1197,10 @@ def _route_recommended_reply(
     not_evidence_yet: list[str],
 ) -> str:
     if action == "dispatch":
-        not_evidence = _first_not_evidence(not_evidence_yet)
-        suffix = f" This is still not evidence of {not_evidence}." if not_evidence else " This is routing guidance, not execution evidence."
+        suffix = not_evidence_reply_suffix(
+            not_evidence_yet,
+            fallback=" This is routing guidance, not execution evidence.",
+        )
         return f"I will use `{selected}` first and start with {next_action_label}.{suffix}"
     if action == "clarify":
         return "I need one clarification before choosing a workflow; no plan or execution has started."
@@ -1227,18 +1230,13 @@ def _route_primary_action_hint(
     not_evidence_yet: list[str],
 ) -> str:
     if action == "dispatch":
-        not_evidence = _first_not_evidence(not_evidence_yet)
-        suffix = f"; do not claim {not_evidence} until observed" if not_evidence else "; keep evidence claims separate"
+        suffix = not_evidence_action_suffix(not_evidence_yet)
         return f"Route to `{selected}` and run `{next_action_label}`{suffix}."
     if action == "clarify":
         return "Ask one blocking question, then reroute with the answer."
     if next_action_label == "answer directly":
         return "Answer in the current chat without opening a workflow, picker, or handoff."
     return "Answer directly or ask for the missing target before dispatching a workflow."
-
-
-def _first_not_evidence(items: list[str]) -> str:
-    return items[0].replace("_", " ") if items else ""
 
 
 def _not_evidence_from_boundary(boundary: str) -> list[str]:

--- a/src/surfaces/evidence_copy.py
+++ b/src/surfaces/evidence_copy.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+
+def first_not_evidence_item(items: list[str]) -> str:
+    """Return the first evidence gap as readable chat copy."""
+    return items[0].replace("_", " ") if items else ""
+
+
+def not_evidence_reply_suffix(items: list[str], *, fallback: str) -> str:
+    item = first_not_evidence_item(items)
+    if item:
+        return f" This is still not evidence of {item}."
+    return fallback
+
+
+def not_evidence_action_suffix(items: list[str], *, fallback: str = "; keep evidence claims separate") -> str:
+    item = first_not_evidence_item(items)
+    if item:
+        return f"; do not claim {item} until observed"
+    return fallback

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -24,6 +24,7 @@ from ..probe import probe_capabilities
 from ..quickstart import build_quickstart_card
 from ..skills.catalog import installable_skill_definitions, primary_harness_for_skill, retained_delegation_skill_names
 from ..setup_profiles import read_setup_profile
+from ..surfaces.evidence_copy import not_evidence_action_suffix, not_evidence_reply_suffix
 from ..visual_summary import image_generation_setup_fallback
 from .hermes_runtime import (
     hermes_coding_team_body,
@@ -4579,8 +4580,7 @@ def _workflow_explanation_reason(state: dict[str, object], *, workflow: str, lab
 
 def _workflow_recommended_reply(workflow: str, label: str, next_action_label: str, not_evidence_yet: list[str]) -> str:
     name = workflow or label
-    not_evidence = _first_not_evidence_item(not_evidence_yet)
-    suffix = f" This is still not evidence of {not_evidence}." if not_evidence else " This is guidance, not execution evidence."
+    suffix = not_evidence_reply_suffix(not_evidence_yet, fallback=" This is guidance, not execution evidence.")
     return f"I will use `{name}` and start with {next_action_label}.{suffix}"
 
 
@@ -4596,13 +4596,8 @@ def _workflow_primary_action_hint(
     not_evidence_yet: list[str],
 ) -> str:
     name = workflow or label
-    not_evidence = _first_not_evidence_item(not_evidence_yet)
-    suffix = f"; do not claim {not_evidence} until observed" if not_evidence else "; keep evidence claims separate"
+    suffix = not_evidence_action_suffix(not_evidence_yet)
     return f"Route to `{name}` and run `{next_action_label}`{suffix}."
-
-
-def _first_not_evidence_item(items: list[str]) -> str:
-    return items[0].replace("_", " ") if items else ""
 
 
 def _workflow_explanation_not_evidence(state: dict[str, object], *, claim_boundary: str) -> list[str]:

--- a/tests/test_evidence_copy.py
+++ b/tests/test_evidence_copy.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import unittest
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.surfaces.evidence_copy import (  # noqa: E402
+    first_not_evidence_item,
+    not_evidence_action_suffix,
+    not_evidence_reply_suffix,
+)
+
+
+class EvidenceCopyTests(unittest.TestCase):
+    def test_first_not_evidence_item_normalizes_underscore_labels(self) -> None:
+        self.assertEqual(first_not_evidence_item(["visual_QA", "delivery"]), "visual QA")
+        self.assertEqual(first_not_evidence_item([]), "")
+
+    def test_reply_suffix_prefers_concrete_evidence_gap(self) -> None:
+        suffix = not_evidence_reply_suffix(
+            ["plan acceptance"],
+            fallback=" This is guidance, not execution evidence.",
+        )
+
+        self.assertEqual(suffix, " This is still not evidence of plan acceptance.")
+
+    def test_reply_suffix_uses_surface_specific_fallback(self) -> None:
+        suffix = not_evidence_reply_suffix([], fallback=" This is routing guidance, not execution evidence.")
+
+        self.assertEqual(suffix, " This is routing guidance, not execution evidence.")
+
+    def test_action_suffix_keeps_claim_boundary_natural(self) -> None:
+        self.assertEqual(
+            not_evidence_action_suffix(["execution"]),
+            "; do not claim execution until observed",
+        )
+        self.assertEqual(not_evidence_action_suffix([]), "; keep evidence claims separate")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- Added a shared `surfaces.evidence_copy` helper for not-yet-observed evidence copy.
- Updated router and wrapper explanation cards to use the same helper for reply suffixes and primary action hints.
- Added focused unit coverage for underscore normalization, concrete evidence-gap copy, and fallback copy.

### Why This Exists

- Recent routing work made the evidence boundary copy more natural, but the same small helper logic lived separately in `routing/chat.py` and `wrapper/contract.py`.
- Keeping the copy rule in one place reduces drift when future chat surfaces need to say what is prepared versus what is actually observed.

### User / Operator Impact

- Hermes-facing cards keep the same human wording as before, such as "not evidence of execution" instead of awkward reversed phrasing.
- Operators get a lower-risk path for future wrapper/router copy changes because the prepared-vs-observed suffix behavior is centralized and tested.

### How It Works

- `src/surfaces/evidence_copy.py` owns the first evidence-gap formatting and the two suffix builders used by visible chat cards.
- `src/routing/chat.py` uses the helper for route explanations.
- `src/wrapper/contract.py` uses the helper for workflow explanations.
- Fallback copy remains surface-specific so router guidance and wrapper guidance can keep slightly different wording.

### Files And Contracts Touched

- `src/surfaces/evidence_copy.py`: new internal helper module.
- `src/routing/chat.py`: removes duplicated route-only helper.
- `src/wrapper/contract.py`: removes duplicated wrapper-only helper.
- `tests/test_evidence_copy.py`: direct tests for shared copy behavior.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_evidence_copy.py tests/test_chat_router.py tests/test_wrapper_contract.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` (942 tests)
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli harness validate`
- [x] `uv run python -m omh.cli demo routing-precision --summary`
- [x] `uv run python -m omh.cli demo hermes-ux-quality --json` (score 100)
- [x] `git diff --check`
- [ ] `python3 -m omh.cli release checklist --json` (not run; this is an internal copy helper refactor)
- [ ] `python3 -m omh.cli release hermes-smoke` (not run; no install/runtime behavior changed)
- [ ] `omh --help` (not run; no CLI surface changed)
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` (not run; no install/runtime behavior changed)
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable
- [x] Relevant dry-run or smoke command: routing precision and Hermes UX quality demos listed above
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; deterministic local chat contracts were covered, live Hermes rendering was not changed

## Risk

- Low. The helper preserves the exact public strings locked by existing router and wrapper tests.
- Fallback copy remains call-site supplied so router and wrapper wording does not collapse into one generic phrase.

## Compatibility / Rollout

- No schema, CLI, setup, plugin, runtime, or docs contract changes.
- Existing generated skills and docs remain in sync.

## Release / Claims

- [x] Release-channel impact considered: local/internal refactor only.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] Known manual Hermes checks are listed: live Hermes rendering was not observed because this PR changes only deterministic local copy helpers.

## Follow-Up

- Use `surfaces.evidence_copy` for future workflow cards that need the same prepared-vs-observed wording.
