### PR TITLE
Cache playbook scoring profiles

### DIFF
--- a/src/catalogs/playbooks.py
+++ b/src/catalogs/playbooks.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from functools import lru_cache
 
 from ..routing.localization import normalized_phrase, prepare_routing_text, routing_terms, routing_tokens
 
@@ -93,6 +94,20 @@ class Playbook:
             }
         )
         return payload
+
+
+@dataclass(frozen=True)
+class _ScoringTerm:
+    label: str
+    tokens: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class _PlaybookScoringProfile:
+    playbook: Playbook
+    keyword_terms: tuple[_ScoringTerm, ...]
+    intent_tokens: frozenset[str]
+    intent_tag_terms: tuple[_ScoringTerm, ...]
 
 
 _COMMON_NOT_EVIDENCE = (
@@ -2350,9 +2365,11 @@ def recommend_playbooks(query: str, *, limit: int = 3) -> dict[str, object]:
     if not task:
         raise ValueError("playbook recommend requires a task description")
     routing_text = prepare_routing_text(task)
+    query_tokens = _tokens(routing_text.scoring_text)
+    query_terms = _terms(routing_text.scoring_text)
     scored = [
-        _score_playbook(playbook, routing_text.scoring_text, routing_text.locale_matches)
-        for playbook in _all_playbooks()
+        _score_playbook(profile, query_tokens, query_terms, routing_text.locale_matches)
+        for profile in _playbook_scoring_profiles()
     ]
     scored.sort(key=lambda item: (-int(item["score"]), str(item["id"])))
     matches = [item for item in scored if int(item["score"]) > 0] or [_fallback_playbook(task)]
@@ -2370,28 +2387,29 @@ def _playbook_by_id(playbook_id: str) -> Playbook:
     raise KeyError(playbook_id)
 
 
-def _score_playbook(playbook: Playbook, query: str, locale_matches: tuple[str, ...] = ()) -> dict[str, object]:
-    query_tokens = _tokens(query)
-    query_terms = _terms(query)
+def _score_playbook(
+    profile: _PlaybookScoringProfile,
+    query_tokens: set[str],
+    query_terms: set[str],
+    locale_matches: tuple[str, ...] = (),
+) -> dict[str, object]:
+    playbook = profile.playbook
     score = 0
     matched: set[str] = set()
 
-    for keyword in playbook.keywords:
-        normalized_keyword = keyword.lower()
-        if _matches_term(normalized_keyword, query_terms):
+    for keyword in profile.keyword_terms:
+        if _matches_term_tokens(keyword.tokens, query_terms):
             score += 5
-            matched.add(f"keyword:{normalized_keyword}")
+            matched.add(f"keyword:{keyword.label}")
 
-    intent_tokens = _tokens(" ".join((playbook.id, *playbook.intent_tags)))
-    for token in sorted(query_tokens & intent_tokens):
+    for token in sorted(query_tokens & profile.intent_tokens):
         score += 2
         matched.add(f"intent:{token}")
 
-    for intent_tag in playbook.intent_tags:
-        normalized_intent = intent_tag.lower()
-        if _matches_term(normalized_intent, query_terms):
+    for intent_tag in profile.intent_tag_terms:
+        if _matches_term_tokens(intent_tag.tokens, query_terms):
             score += 3
-            matched.add(f"intent-tag:{normalized_intent}")
+            matched.add(f"intent-tag:{intent_tag.label}")
 
     if "coding" in query_tokens or "code" in query_tokens or "implement" in query_tokens:
         if playbook.delegated_to_executor:
@@ -2438,18 +2456,52 @@ def _recommendation_payload(playbook: Playbook, *, score: int, matched: tuple[st
 
 
 def _tokens(value: str) -> set[str]:
-    return routing_tokens(value, stopwords=_STOPWORDS)
+    return set(_tokens_cached(value))
 
 
 def _terms(value: str) -> set[str]:
-    return routing_terms(value)
+    return set(_terms_cached(value))
 
 
 def _matches_term(term: str, query_terms: set[str]) -> bool:
-    term_tokens = tuple(_terms(normalized_phrase(term)))
-    if not term_tokens:
-        return False
-    return all(token in query_terms for token in term_tokens)
+    return _matches_term_tokens(_normalized_term_tokens(term), query_terms)
+
+
+def _matches_term_tokens(term_tokens: tuple[str, ...], query_terms: set[str]) -> bool:
+    return bool(term_tokens) and query_terms.issuperset(term_tokens)
+
+
+@lru_cache(maxsize=1)
+def _playbook_scoring_profiles() -> tuple[_PlaybookScoringProfile, ...]:
+    return tuple(_build_scoring_profile(playbook) for playbook in _all_playbooks())
+
+
+def _build_scoring_profile(playbook: Playbook) -> _PlaybookScoringProfile:
+    return _PlaybookScoringProfile(
+        playbook=playbook,
+        keyword_terms=tuple(_scoring_term(keyword.lower()) for keyword in playbook.keywords),
+        intent_tokens=_tokens_cached(" ".join((playbook.id, *playbook.intent_tags))),
+        intent_tag_terms=tuple(_scoring_term(intent_tag.lower()) for intent_tag in playbook.intent_tags),
+    )
+
+
+def _scoring_term(label: str) -> _ScoringTerm:
+    return _ScoringTerm(label=label, tokens=_normalized_term_tokens(label))
+
+
+@lru_cache(maxsize=512)
+def _tokens_cached(value: str) -> frozenset[str]:
+    return frozenset(routing_tokens(value, stopwords=_STOPWORDS))
+
+
+@lru_cache(maxsize=1024)
+def _terms_cached(value: str) -> frozenset[str]:
+    return frozenset(routing_terms(value))
+
+
+@lru_cache(maxsize=1024)
+def _normalized_term_tokens(term: str) -> tuple[str, ...]:
+    return tuple(_terms_cached(normalized_phrase(term)))
 
 
 def _confidence(score: int) -> str:

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -15,6 +15,7 @@ from omh.routing import localization as localization_module
 from omh.routing import recommend as recommend_module
 from omh.routing import policy as policy_module
 from omh.routing import route_plan as route_plan_module
+from omh.catalogs import playbooks as playbooks_module
 from omh.skills import render as render_module
 from omh.workflows import hermes_planning as hermes_planning_module
 from omh.workflows import learning_candidate as learning_candidate_module
@@ -503,6 +504,50 @@ class EfficiencyContractTests(unittest.TestCase):
         self.assertNotIn("mutated", second_tokens)
         self.assertEqual(tokens_cache.misses, 1)
         self.assertGreaterEqual(tokens_cache.hits, 1)
+
+    def test_playbook_token_cache_reuses_static_terms_without_payload_poisoning(self) -> None:
+        playbooks_module._playbook_scoring_profiles.cache_clear()
+        playbooks_module._tokens_cached.cache_clear()
+        playbooks_module._terms_cached.cache_clear()
+        playbooks_module._normalized_term_tokens.cache_clear()
+
+        first_terms = playbooks_module._terms("Risky refactor with code-review")
+        first_terms.add("mutated")
+        second_terms = playbooks_module._terms("Risky refactor with code-review")
+
+        self.assertIn("risky", second_terms)
+        self.assertIn("code-review", second_terms)
+        self.assertNotIn("mutated", second_terms)
+        terms_cache = playbooks_module._terms_cached.cache_info()
+        self.assertEqual(terms_cache.misses, 1)
+        self.assertGreaterEqual(terms_cache.hits, 1)
+
+        first_tokens = playbooks_module._tokens("Risky refactor with code-review")
+        first_tokens.add("mutated")
+        second_tokens = playbooks_module._tokens("Risky refactor with code-review")
+        tokens_cache = playbooks_module._tokens_cached.cache_info()
+
+        self.assertIn("risky", second_tokens)
+        self.assertIn("code-review", second_tokens)
+        self.assertNotIn("mutated", second_tokens)
+        self.assertEqual(tokens_cache.misses, 1)
+        self.assertGreaterEqual(tokens_cache.hits, 1)
+
+    def test_playbook_recommendation_reuses_cached_term_tokens(self) -> None:
+        playbooks_module._playbook_scoring_profiles.cache_clear()
+        playbooks_module._tokens_cached.cache_clear()
+        playbooks_module._terms_cached.cache_clear()
+        playbooks_module._normalized_term_tokens.cache_clear()
+
+        first = playbooks_module.recommend_playbooks("risky refactor", limit=2)
+        second = playbooks_module.recommend_playbooks("risky refactor", limit=2)
+        profile_cache = playbooks_module._playbook_scoring_profiles.cache_info()
+        term_cache = playbooks_module._normalized_term_tokens.cache_info()
+
+        self.assertEqual(first, second)
+        self.assertEqual(profile_cache.misses, 1)
+        self.assertGreaterEqual(profile_cache.hits, 1)
+        self.assertGreater(term_cache.misses, 0)
 
     def test_phrase_match_cache_reuses_repeated_recommendation_pairs(self) -> None:
         recommend_module._phrase_match.cache_clear()


### PR DESCRIPTION
## Feature Report

### What Changed

- Adds private immutable scoring profiles for playbook recommendation metadata.
- Caches static playbook keyword tokens, intent tokens, and normalized term-token tuples so repeated routing QA and recommendation calls do not re-tokenize the same catalog text.
- Keeps query scoring dynamic and keeps returned `_tokens()` / `_terms()` sets mutation-safe by copying cached `frozenset` data for callers.
- Adds efficiency tests proving the playbook scoring profile cache is reused and cache payloads cannot be poisoned by caller mutation.

### Why This Exists

OMH's chat-first quality gates run many representative routing and wrapper-card examples. The `hermes_ux_quality` demo repeatedly calls playbook recommendation while checking grounded routing behavior, route hints, and intervention boundaries. Profiling showed repeated static playbook term processing as a hot path.

The user-facing goal is simple: quality checks and routing demos should stay cheap enough to run often, so OMH can keep raising routing coverage without making verification feel heavy.

### User / Operator Impact

- Repeated deterministic routing QA runs are faster.
- `omh demo hermes-ux-quality --json` remains responsive even as representative workflow coverage grows.
- Playbook recommendation behavior and public schemas stay unchanged.
- Operators still get the same recommendation payloads, evidence boundaries, and wrapper UX results.

### How It Works

- `src/catalogs/playbooks.py` now builds a cached `_PlaybookScoringProfile` per playbook.
- Each profile contains static keyword term tokens, intent tokens, and intent-tag term tokens.
- `recommend_playbooks()` computes query tokens/terms once, then scores against cached profile metadata.
- Private token/term cache helpers return immutable cached data internally and fresh mutable sets to existing callers.
- `tests/test_efficiency.py` locks cache reuse and mutation safety for the new playbook caches.

### Files And Contracts Touched

- `src/catalogs/playbooks.py`: private scoring profile cache and token/term cache helpers.
- `tests/test_efficiency.py`: cache reuse and payload-poisoning tests.

No public schema, CLI argument, wrapper contract, runtime artifact, or generated skill content changed.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — 946 tests passing.
- [x] `uv run python -m compileall -q src tests` — passing.
- [x] `uv run python -m omh.cli docs workflows --check` — ok, 48/48 tap skills checked.
- [x] `uv run python -m omh.cli harness validate` — ok, 36 harnesses and 50 skills validated.
- [ ] `python3 -m omh.cli release checklist --json` — not run; this is a private performance-path PR, not a release checklist change.
- [ ] `python3 -m omh.cli release hermes-smoke` — not run; live Hermes release smoke is outside this deterministic scoring-cache PR.
- [ ] `omh --help` — not run; help output was not changed.
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` — not run; install smoke is outside this PR.
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable.
- [x] Relevant dry-run or smoke command: `uv run python -m omh.cli demo routing-precision --summary` — 8/8 negative controls, 13/13 interventions, 0 overroutes, 0 missed interventions.
- [x] Relevant dry-run or smoke command: `uv run python -m omh.cli demo hermes-ux-quality --json` — status passed, score 100/100, 5/5 gates passing.
- [x] Performance smoke: in-process `build_hermes_ux_quality_demo(source="discord")` warm average improved from about 26.0ms before to about 18.9ms after in this workspace.
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; this PR changes private deterministic scoring caches only.
- [x] `git diff --check` — passing.

## Risk

- Low-to-moderate cache risk: stale static scoring metadata would be bad if playbooks were mutated dynamically after import.
- Mitigation: playbook catalogs are static module data in this repo; the cache is private and can be cleared in tests.
- Mitigation: returned token/term sets remain fresh copies, so callers cannot mutate cached data.

## Compatibility / Rollout

- Backward compatible.
- No dependency changes.
- No network calls, Hermes core patching, platform SDKs, executor dispatch, or runtime behavior changes.
- Cache is bounded and private.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`): local performance improvement only.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap.

## Follow-Up

- Continue profiling `awareness_route_hint` and context brief generation if future workflow coverage grows enough to make those paths hot.
