### PR TITLE
Cache awareness route hints

### DIFF
--- a/src/plugin_bundle/omh/awareness.py
+++ b/src/plugin_bundle/omh/awareness.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from copy import deepcopy
+from functools import lru_cache
 import hashlib
 import re
 import unicodedata
@@ -1611,6 +1613,11 @@ def awareness_context_matches_message(message: str) -> bool:
 
 def awareness_route_hint(message: str, *, max_hints: int = 2) -> dict[str, object]:
     """Return bounded message-specific workflow hints without exposing raw text."""
+    return deepcopy(_awareness_route_hint_cached(message, max(max_hints, 0)))
+
+
+@lru_cache(maxsize=512)
+def _awareness_route_hint_cached(message: str, max_hints: int) -> dict[str, object]:
     normalized = unicodedata.normalize("NFKC", message).casefold()
     routing_text = _localized_routing_text(message)
     localized_normalized = unicodedata.normalize("NFKC", routing_text).casefold()
@@ -1622,7 +1629,7 @@ def awareness_route_hint(message: str, *, max_hints: int = 2) -> dict[str, objec
         else _without_diagnostic_status_lines(localized_normalized)
     )
     tokens = set(re.findall(r"[a-z0-9][a-z0-9_-]*", routing_normalized))
-    hint_limit = max(max_hints, 0)
+    hint_limit = max_hints
     intent = classify_workflow_intent(message)
     omh_quality_intent = classify_omh_quality_intent(message)
     diagnostic_learning_first = diagnostic_eval

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -31,6 +31,7 @@ from omh.release import (
 )
 from omh.capabilities.skills import skill_capabilities
 from omh.plugin_bundle.omh.tools.capability_tool import standalone_skill_capability_items
+from omh.plugin_bundle.omh import awareness as awareness_module
 from omh.plugin_bundle.omh.awareness import (
     awareness_context_matches_message,
     awareness_generic_tool_checkpoint_payload,
@@ -233,6 +234,22 @@ class EfficiencyContractTests(unittest.TestCase):
 
                 self.assertEqual(route_hint["primary_workflow"], workflow)
                 self.assertEqual(route_hint["primary_next_action"], next_action)
+
+    def test_awareness_route_hint_cache_is_reused_without_payload_poisoning(self) -> None:
+        awareness_module._awareness_route_hint_cached.cache_clear()
+
+        first = awareness_route_hint("show token cost latency run history for this automation loop")
+        first["status"] = "mutated"
+        first["hints"][0]["workflow"] = "mutated"
+
+        second = awareness_route_hint("show token cost latency run history for this automation loop")
+        cache_info = awareness_module._awareness_route_hint_cached.cache_info()
+
+        self.assertEqual(second["status"], "hinted")
+        self.assertEqual(second["primary_workflow"], "ops-observability-card")
+        self.assertEqual(second["hints"][0]["workflow"], "ops-observability-card")
+        self.assertEqual(cache_info.misses, 1)
+        self.assertGreaterEqual(cache_info.hits, 1)
 
     def test_quality_demos_reuse_interaction_route(self) -> None:
         alignment_case = RouteHintAlignmentCase(


### PR DESCRIPTION
## Feature Report

### What Changed

- Added a private LRU cache behind `awareness_route_hint` so repeated plugin/context route-hint requests reuse deterministic classification results.
- Kept the public function mutation-safe by returning a deep copy of the cached payload.
- Added a regression test proving repeated route-hint calls hit the cache without letting caller mutations poison later payloads.

### Why This Exists

- Recent Hermes UX quality profiling showed `awareness_route_hint` as the repeated hot path inside context briefs and route-hint alignment demos.
- This helper is deterministic and metadata-only for the same message and hint limit, so it is a good fit for bounded local caching.
- The performance win matters in chat-first use because Hermes can ask for workflow hints repeatedly while building cards, context briefs, and quality gates.

### User / Operator Impact

- Hermes-facing OMH context and awareness cards should feel lighter when the same message is evaluated repeatedly in a wrapper, demo, or quality gate.
- The route-hint schema, next actions, evidence boundaries, and public behavior stay the same.
- Callers still receive independent dictionaries, so wrapper code cannot accidentally mutate a shared cached object.

### How It Works

- `awareness_route_hint(message, max_hints=...)` now normalizes the hint limit, delegates to `_awareness_route_hint_cached`, and deep-copies the cached result before returning it.
- `_awareness_route_hint_cached` is capped at 512 entries and uses the same deterministic route-hint implementation as before.
- The cache remains private to the plugin awareness module; it is not a public runtime state or execution claim.

### Files And Contracts Touched

- `src/plugin_bundle/omh/awareness.py`
  - Adds `deepcopy` and `lru_cache`.
  - Adds the private cached route-hint implementation.
- `tests/test_efficiency.py`
  - Adds cache reuse and mutation-safety coverage for awareness route hints.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_efficiency.py tests/test_hermes_ux_quality.py tests/test_routing_precision.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli harness validate`
- [x] `uv run python -m omh.cli demo routing-precision --summary`
- [x] `uv run python -m omh.cli demo hermes-ux-quality --json`
- [x] `git diff --check`
- [ ] `python3 -m omh.cli release checklist --json` — not run; this is a narrow performance/cache change with no release metadata change.
- [ ] `python3 -m omh.cli release hermes-smoke` — not run; no installer or live Hermes integration changed.
- [ ] `omh --help` — not run; no CLI command surface changed.
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` — not run; no setup/install path changed.
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable.
- [x] Relevant dry-run or smoke command: benchmarked route-hint repeats and Hermes UX quality warm path locally.
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; this PR changes deterministic local helper caching only, not live Hermes rendering.

Benchmark evidence:

- Before this PR on main, repeated `awareness_route_hint` examples averaged roughly 73-126us and Hermes UX quality warm average was about 18.949ms.
- After this PR, repeated `awareness_route_hint` examples measured 7.09-34.51us average and Hermes UX quality warm average measured 10.12ms.
- Cache info after the benchmark: `CacheInfo(hits=2805, misses=45, maxsize=512, currsize=45)`.

## Risk

- Low. The cache is bounded, private, deterministic, and keyed by message plus hint limit.
- The main risk would be returning mutable cached dictionaries directly; the implementation avoids that with a deep-copy wrapper and a regression test.

## Compatibility / Rollout

- No public schema, CLI, docs, setup, plugin registration, or wrapper contract changes.
- Existing callers of `awareness_route_hint` continue to receive ordinary dictionaries.
- No migration required.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`): local performance improvement only; no channel metadata change.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed: no new runtime/native claim is introduced.
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap: live Hermes rendering was not exercised because this is helper caching only.

## Follow-Up

- If future profiling shows route-hint cache churn, tune the private LRU size with benchmark evidence rather than exposing it as user configuration.
