### PR TITLE
Use fast route hint payload copies

### DIFF
--- a/src/plugin_bundle/omh/awareness.py
+++ b/src/plugin_bundle/omh/awareness.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from copy import deepcopy
 from functools import lru_cache
 import hashlib
 import re
@@ -1613,7 +1612,51 @@ def awareness_context_matches_message(message: str) -> bool:
 
 def awareness_route_hint(message: str, *, max_hints: int = 2) -> dict[str, object]:
     """Return bounded message-specific workflow hints without exposing raw text."""
-    return deepcopy(_awareness_route_hint_cached(message, max(max_hints, 0)))
+    return _copy_awareness_route_hint_payload(_awareness_route_hint_cached(message, max(max_hints, 0)))
+
+
+def _copy_awareness_route_hint_payload(payload: dict[str, object]) -> dict[str, object]:
+    """Copy the bounded route-hint shape without paying for generic deepcopy."""
+    copied = dict(payload)
+    for key in ("mentioned_workflows", "mentioned_runtime_terms", "adjacent_workflows", "not_executed"):
+        values = payload.get(key, [])
+        copied[key] = list(values) if isinstance(values, list | tuple) else []
+
+    hints = payload.get("hints", [])
+    copied["hints"] = [
+        _copy_route_hint_item(hint) if isinstance(hint, dict) else hint
+        for hint in (hints if isinstance(hints, list) else [])
+    ]
+
+    privacy = payload.get("privacy")
+    if isinstance(privacy, dict):
+        copied_privacy = dict(privacy)
+        stored_fields = privacy.get("stored_fields", [])
+        copied_privacy["stored_fields"] = (
+            list(stored_fields) if isinstance(stored_fields, list | tuple) else []
+        )
+        copied["privacy"] = copied_privacy
+    return copied
+
+
+def _copy_route_hint_item(hint: dict[str, object]) -> dict[str, object]:
+    copied = dict(hint)
+    for key in ("matched_cues", "adjacent_workflows", "not_evidence_yet"):
+        values = hint.get(key, [])
+        copied[key] = list(values) if isinstance(values, list | tuple) else []
+    context_card = hint.get("workflow_context_card")
+    copied["workflow_context_card"] = (
+        _copy_workflow_context_card(context_card) if isinstance(context_card, dict) else context_card
+    )
+    return copied
+
+
+def _copy_workflow_context_card(card: dict[str, object]) -> dict[str, object]:
+    copied = dict(card)
+    for key in ("representative_workflows", "user_examples", "not_evidence_until_observed"):
+        values = card.get(key, [])
+        copied[key] = list(values) if isinstance(values, list | tuple) else []
+    return copied
 
 
 @lru_cache(maxsize=512)

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -241,6 +241,8 @@ class EfficiencyContractTests(unittest.TestCase):
         first = awareness_route_hint("show token cost latency run history for this automation loop")
         first["status"] = "mutated"
         first["hints"][0]["workflow"] = "mutated"
+        first["hints"][0]["workflow_context_card"]["representative_workflows"][0] = "mutated"
+        first["privacy"]["stored_fields"][0] = "mutated"
 
         second = awareness_route_hint("show token cost latency run history for this automation loop")
         cache_info = awareness_module._awareness_route_hint_cached.cache_info()
@@ -248,6 +250,11 @@ class EfficiencyContractTests(unittest.TestCase):
         self.assertEqual(second["status"], "hinted")
         self.assertEqual(second["primary_workflow"], "ops-observability-card")
         self.assertEqual(second["hints"][0]["workflow"], "ops-observability-card")
+        self.assertNotEqual(
+            second["hints"][0]["workflow_context_card"]["representative_workflows"][0],
+            "mutated",
+        )
+        self.assertNotEqual(second["privacy"]["stored_fields"][0], "mutated")
         self.assertEqual(cache_info.misses, 1)
         self.assertGreaterEqual(cache_info.hits, 1)
 


### PR DESCRIPTION
## Feature Report

### What Changed

- Replaced generic `deepcopy` on cached `awareness_route_hint` payloads with a route-hint-shape-specific copy path.
- Kept the public route-hint result mutation-safe by copying top-level list fields, hint item lists, privacy metadata, and nested workflow context card lists.
- Extended the efficiency regression test to mutate nested `workflow_context_card` and `privacy.stored_fields` values, proving cached payloads are not poisoned by caller mutations.

### Why This Exists

- PR #389 cached deterministic route-hint classification, but fresh profiling showed the safe `deepcopy` wrapper became the next hot path in Hermes UX quality and context-brief rendering.
- The route-hint payload shape is bounded and stable, so OMH can copy exactly the mutable parts it returns to wrappers instead of paying for a generic recursive copy every time.
- This improves chat-first responsiveness without weakening prepared-vs-observed boundaries or changing routing decisions.

### User / Operator Impact

- Hermes-facing OMH context and workflow hints should render slightly faster during repeated wrapper cards, quality demos, and context brief flows.
- Operators still get the same route hint schema, workflow choice, next action, privacy metadata, and claim boundary.
- Wrapper code can mutate returned payloads for rendering without affecting later route-hint results.

### How It Works

- `awareness_route_hint` still reads from the private LRU cache introduced by #389.
- Instead of `deepcopy`, it now calls `_copy_awareness_route_hint_payload`.
- The copy helper only duplicates the mutable structures in the known route-hint shape:
  - top-level workflow/runtime/evidence lists
  - the `hints` list and each hint dict
  - hint `matched_cues`, `adjacent_workflows`, and `not_evidence_yet`
  - nested `workflow_context_card` mutable list fields
  - `privacy.stored_fields`
- Cached payloads remain private implementation details and do not become runtime evidence.

### Files And Contracts Touched

- `src/plugin_bundle/omh/awareness.py`
  - Removes generic `deepcopy` use for route hints.
  - Adds shape-bounded route hint copy helpers.
- `tests/test_efficiency.py`
  - Strengthens mutation-safety coverage for nested route-hint payload fields.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_efficiency.py tests/test_hermes_ux_quality.py tests/test_routing_precision.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli harness validate`
- [x] `uv run python -m omh.cli demo routing-precision --summary`
- [x] `uv run python -m omh.cli demo hermes-ux-quality --json`
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_chat_router.py tests/test_efficiency.py tests/test_wrapper_contract.py -v && git diff --check`
- [x] `git diff --check`
- [ ] `python3 -m omh.cli release checklist --json` — not run; this PR does not change release metadata.
- [ ] `python3 -m omh.cli release hermes-smoke` — not run; setup/install/live Hermes surfaces are unchanged.
- [ ] `omh --help` — not run; CLI command surface is unchanged.
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` — not run; installer/setup flow is unchanged.
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable.
- [x] Relevant dry-run or smoke command: repeated route-hint and Hermes UX quality benchmark.
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; this is deterministic local payload copying only, not live Hermes rendering.

Benchmark evidence:

- After #389, repeated `awareness_route_hint` examples measured roughly `7.09-34.51us` average and Hermes UX quality warm average measured `10.12ms`.
- With this PR, repeated `awareness_route_hint` examples measured `1.7-19.15us` average and Hermes UX quality warm average measured `9.125ms`.
- The performance-goal evaluator checkpoint for `omh-router-ux-quality-perf` was recorded as passing with this evidence.

## Risk

- Low. The helper copies a fixed, local, metadata-only payload shape and is covered by mutation-poisoning tests.
- The main risk is future route-hint payloads adding new mutable nested fields. If that happens, extend `_copy_awareness_route_hint_payload` and its regression test rather than falling back to broad `deepcopy`.

## Compatibility / Rollout

- No public schema, command, setup, plugin registration, or wrapper contract changes.
- Existing callers continue to receive ordinary mutable dictionaries.
- No migration required.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`): local performance improvement only; no release metadata change.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed: no new runtime/native claim is introduced.
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap: live Hermes rendering was not exercised because this is helper copying only.

## Follow-Up

- If route-hint payload shape grows, add a matching mutation-safety assertion for the new mutable field.
