### PR TITLE
Cache playbook recommendation results

### DIFF
--- a/src/catalogs/playbooks.py
+++ b/src/catalogs/playbooks.py
@@ -2364,6 +2364,11 @@ def recommend_playbooks(query: str, *, limit: int = 3) -> dict[str, object]:
     task = query.strip()
     if not task:
         raise ValueError("playbook recommend requires a task description")
+    return _copy_playbook_recommendation_payload(_recommend_playbooks_cached(task, limit))
+
+
+@lru_cache(maxsize=512)
+def _recommend_playbooks_cached(task: str, limit: int) -> dict[str, object]:
     routing_text = prepare_routing_text(task)
     query_tokens = _tokens(routing_text.scoring_text)
     query_terms = _terms(routing_text.scoring_text)
@@ -2378,6 +2383,31 @@ def recommend_playbooks(query: str, *, limit: int = 3) -> dict[str, object]:
         "query": task,
         "recommendations": matches[:limit],
     }
+
+
+def _copy_playbook_recommendation_payload(payload: dict[str, object]) -> dict[str, object]:
+    copied = dict(payload)
+    recommendations = payload.get("recommendations", [])
+    copied["recommendations"] = [
+        _copy_playbook_recommendation(item) if isinstance(item, dict) else item
+        for item in (recommendations if isinstance(recommendations, list) else [])
+    ]
+    return copied
+
+
+def _copy_playbook_recommendation(recommendation: dict[str, object]) -> dict[str, object]:
+    copied = dict(recommendation)
+    for key in (
+        "matched",
+        "pipeline",
+        "wrapper_actions",
+        "retained_by_hermes",
+        "delegated_to_executor",
+        "not_evidence_until_observed",
+    ):
+        values = recommendation.get(key, [])
+        copied[key] = list(values) if isinstance(values, list | tuple) else []
+    return copied
 
 
 def _playbook_by_id(playbook_id: str) -> Playbook:

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -557,20 +557,28 @@ class EfficiencyContractTests(unittest.TestCase):
         self.assertEqual(tokens_cache.misses, 1)
         self.assertGreaterEqual(tokens_cache.hits, 1)
 
-    def test_playbook_recommendation_reuses_cached_term_tokens(self) -> None:
+    def test_playbook_recommendation_cache_is_reused_without_payload_poisoning(self) -> None:
+        playbooks_module._recommend_playbooks_cached.cache_clear()
         playbooks_module._playbook_scoring_profiles.cache_clear()
         playbooks_module._tokens_cached.cache_clear()
         playbooks_module._terms_cached.cache_clear()
         playbooks_module._normalized_term_tokens.cache_clear()
 
         first = playbooks_module.recommend_playbooks("risky refactor", limit=2)
+        first["recommendations"][0]["id"] = "mutated"
+        first["recommendations"][0]["matched"].append("mutated")
+        first["recommendations"][0]["pipeline"][0] = "mutated"
         second = playbooks_module.recommend_playbooks("risky refactor", limit=2)
+        result_cache = playbooks_module._recommend_playbooks_cached.cache_info()
         profile_cache = playbooks_module._playbook_scoring_profiles.cache_info()
         term_cache = playbooks_module._normalized_term_tokens.cache_info()
 
-        self.assertEqual(first, second)
+        self.assertNotEqual(second["recommendations"][0]["id"], "mutated")
+        self.assertNotIn("mutated", second["recommendations"][0]["matched"])
+        self.assertNotEqual(second["recommendations"][0]["pipeline"][0], "mutated")
+        self.assertEqual(result_cache.misses, 1)
+        self.assertGreaterEqual(result_cache.hits, 1)
         self.assertEqual(profile_cache.misses, 1)
-        self.assertGreaterEqual(profile_cache.hits, 1)
         self.assertGreater(term_cache.misses, 0)
 
     def test_phrase_match_cache_reuses_repeated_recommendation_pairs(self) -> None:


### PR DESCRIPTION
## Feature Report

### What Changed

- Added a bounded private cache for `recommend_playbooks(query, limit=...)` results.
- Preserved the public mutable payload contract by returning mutation-safe copies of cached recommendation payloads.
- Strengthened the efficiency test so it mutates returned recommendation ids, matched cues, and pipeline fields, then proves later calls are not poisoned.

### Why This Exists

- After the route-hint cache improvements, profiling showed repeated `recommend_playbooks` scoring as the next meaningful hot path in Hermes UX quality runs.
- The same wrapper/card quality scenarios call playbook recommendation repeatedly with the same prompt and limit.
- Recommendation scoring is deterministic for a given stripped query and limit, so caching the result avoids rescoring every playbook while keeping the output contract unchanged.

### User / Operator Impact

- Hermes-facing cards and quality gates that include playbook context do less repeated local scoring work.
- The recommendation schema, selected playbooks, scores, suggested prompts, and evidence boundaries stay the same.
- Wrappers can still mutate returned dict/list payloads for rendering without corrupting cached results.

### How It Works

- `recommend_playbooks` still validates `limit` and non-empty task text before using the cache.
- `_recommend_playbooks_cached(task, limit)` performs the existing routing text preparation, tokenization, scoring, sorting, and fallback logic once per key.
- `_copy_playbook_recommendation_payload` and `_copy_playbook_recommendation` return fresh mutable dictionaries/lists for callers while keeping cached payloads private.

### Files And Contracts Touched

- `src/catalogs/playbooks.py`
  - Adds `_recommend_playbooks_cached` with a 512-entry LRU cache.
  - Adds shape-bounded copy helpers for recommendation payloads.
- `tests/test_efficiency.py`
  - Updates the playbook recommendation efficiency test to cover result-cache reuse and payload mutation safety.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_efficiency.py tests/test_hermes_ux_quality.py tests/test_routing_precision.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli harness validate`
- [x] `uv run python -m omh.cli demo routing-precision --summary`
- [x] `uv run python -m omh.cli demo hermes-ux-quality --json`
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_chat_router.py tests/test_efficiency.py tests/test_wrapper_contract.py -v && git diff --check`
- [ ] `python3 -m omh.cli release checklist --json` — not run; no release metadata changed.
- [ ] `python3 -m omh.cli release hermes-smoke` — not run; setup/install/live Hermes integration is unchanged.
- [ ] `omh --help` — not run; CLI surface is unchanged.
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` — not run; installer/setup flow is unchanged.
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable.
- [x] Relevant dry-run or smoke command: repeated playbook recommendation and Hermes UX quality benchmark.
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; deterministic local recommendation caching only.

Benchmark evidence:

- Before this PR, `recommend_playbooks` and `_score_playbook` appeared near the top of the Hermes UX quality profile.
- After this PR, `recommend_playbooks` dropped out of the top hot path during the same 80-run profile.
- `hermes_ux_quality` warm average measured `6.709ms`.
- Repeated `recommend_playbooks` examples measured `1.75-2.36us` after the first miss.
- The performance-goal evaluator checkpoint for `omh-router-ux-quality-perf` was recorded as passing with this evidence.

## Risk

- Low. The cache is bounded, keyed by stripped query plus limit, and only caches deterministic local metadata.
- The main risk is future recommendation payload fields adding mutable nested data; the copy helper and test should be extended when that happens.

## Compatibility / Rollout

- No public schema, CLI, docs, setup, plugin registration, or wrapper contract changes.
- Existing callers continue to receive ordinary mutable dictionaries.
- No migration required.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`): local performance improvement only.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed: no new runtime/native claim is introduced.
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap: live Hermes rendering was not exercised because this is local recommendation caching only.

## Follow-Up

- If playbook recommendation payloads gain nested mutable structures, add mutation-safety assertions for those fields before widening the cache.
