### PR TITLE
Cache capability family projections

### DIFF
--- a/src/capabilities/families.py
+++ b/src/capabilities/families.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from copy import deepcopy
+from functools import lru_cache
 from typing import Iterable, cast
 
 from ..plugin_bundle.omh.awareness import awareness_lane_examples, awareness_primer_payload
@@ -137,12 +137,19 @@ _WORKFLOW_FAMILY_OVERRIDES = {
 
 def capability_family_projection(available_workflows: Iterable[str] | None = None) -> dict[str, object]:
     """Return the user-facing OMH capability-family projection."""
+    return _copy_capability_family_projection(
+        _capability_family_projection_cached(_available_workflows_key(available_workflows))
+    )
+
+
+@lru_cache(maxsize=128)
+def _capability_family_projection_cached(available_key: tuple[str, ...] | None) -> dict[str, object]:
     awareness = awareness_primer_payload()
     lane_by_id = {
         str(lane.get("id")): lane
         for lane in _dict_list(awareness.get("lanes", []))
     }
-    available = _available_workflows(available_workflows)
+    available = _available_workflows_from_key(available_key)
     families = [
         _family_payload(definition, lane_by_id, available)
         for definition in _FAMILY_DEFINITIONS
@@ -166,7 +173,8 @@ def capability_family_projection(available_workflows: Iterable[str] | None = Non
 
 def capability_family_cards(available_workflows: Iterable[str] | None = None) -> list[dict[str, object]]:
     """Return compact cards for picker, quickstart, and README-like surfaces."""
-    return deepcopy(_dict_list(capability_family_projection(available_workflows).get("families", [])))
+    projection = _capability_family_projection_cached(_available_workflows_key(available_workflows))
+    return _copy_family_cards(_dict_list(projection.get("families", [])))
 
 
 def family_for_workflow(workflow: str, available_workflows: Iterable[str] | None = None) -> dict[str, object]:
@@ -174,7 +182,7 @@ def family_for_workflow(workflow: str, available_workflows: Iterable[str] | None
     key = str(workflow or "").strip()
     if not key:
         return {}
-    projection = capability_family_projection(available_workflows)
+    projection = _capability_family_projection_cached(_available_workflows_key(available_workflows))
     workflow_to_family = _string_mapping(projection.get("workflow_to_family", {}))
     family_id = workflow_to_family.get(key)
     if not family_id:
@@ -183,7 +191,7 @@ def family_for_workflow(workflow: str, available_workflows: Iterable[str] | None
         return {}
     for family in _dict_list(projection.get("families", [])):
         if family.get("id") == family_id:
-            return deepcopy(family)
+            return _copy_family_payload(family)
     return {}
 
 
@@ -197,6 +205,44 @@ def _available_workflows(available_workflows: Iterable[str] | None) -> set[str]:
     if available_workflows is None:
         return set(installable_skill_names()) | CONCEPTUAL_WORKFLOW_SURFACES | {"oh-my-hermes"}
     return {str(item) for item in available_workflows if str(item)} | CONCEPTUAL_WORKFLOW_SURFACES | {"oh-my-hermes"}
+
+
+def _available_workflows_key(available_workflows: Iterable[str] | None) -> tuple[str, ...] | None:
+    if available_workflows is None:
+        return None
+    return tuple(sorted({str(item) for item in available_workflows if str(item)}))
+
+
+def _available_workflows_from_key(available_key: tuple[str, ...] | None) -> set[str]:
+    if available_key is None:
+        return _available_workflows(None)
+    return set(available_key) | CONCEPTUAL_WORKFLOW_SURFACES | {"oh-my-hermes"}
+
+
+def _copy_capability_family_projection(payload: dict[str, object]) -> dict[str, object]:
+    copied = dict(payload)
+    copied["families"] = _copy_family_cards(_dict_list(payload.get("families", [])))
+    copied["workflow_to_family"] = _string_mapping(payload.get("workflow_to_family", {}))
+    copied["family_order"] = _string_list(payload.get("family_order", []))
+    return copied
+
+
+def _copy_family_cards(families: list[dict[str, object]]) -> list[dict[str, object]]:
+    return [_copy_family_payload(family) for family in families]
+
+
+def _copy_family_payload(family: dict[str, object]) -> dict[str, object]:
+    copied = dict(family)
+    for key in (
+        "source_lanes",
+        "primary_workflows",
+        "not_evidence_until_observed",
+        "source_examples",
+        "executor_choices",
+    ):
+        if key in copied:
+            copied[key] = _string_list(copied.get(key, []))
+    return copied
 
 
 def _family_payload(

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -29,6 +29,7 @@ from omh.release import (
     STANDALONE_CAPABILITY_SKILL_ITEM_CHAR_LIMIT,
     STANDALONE_CAPABILITY_SKILL_SECTION_CHAR_LIMIT,
 )
+from omh.capabilities import families as families_module
 from omh.capabilities.skills import skill_capabilities
 from omh.plugin_bundle.omh.tools.capability_tool import standalone_skill_capability_items
 from omh.plugin_bundle.omh import awareness as awareness_module
@@ -846,6 +847,40 @@ class EfficiencyContractTests(unittest.TestCase):
         self.assertIsNot(first, second)
         self.assertNotEqual(second["workflow_groups"][0]["id"], "mutated")
         self.assertNotEqual(second["workflow_context_cards"][0]["user_examples"][0], "mutated")
+        self.assertEqual(cache_info.misses, 1)
+        self.assertGreaterEqual(cache_info.hits, 1)
+
+    def test_capability_family_projection_cache_is_reused_without_payload_poisoning(self) -> None:
+        families_module._capability_family_projection_cached.cache_clear()
+
+        first = families_module.capability_family_projection()
+        first["families"][0]["id"] = "mutated"
+        first["families"][0]["primary_workflows"][0] = "mutated"
+        workflow_key = next(iter(first["workflow_to_family"]))
+        first["workflow_to_family"][workflow_key] = "mutated"
+        first["family_order"][0] = "mutated"
+
+        second = families_module.capability_family_projection()
+        cache_info = families_module._capability_family_projection_cached.cache_info()
+
+        self.assertIsNot(first, second)
+        self.assertNotEqual(second["families"][0]["id"], "mutated")
+        self.assertNotEqual(second["families"][0]["primary_workflows"][0], "mutated")
+        self.assertNotEqual(second["workflow_to_family"][workflow_key], "mutated")
+        self.assertNotEqual(second["family_order"][0], "mutated")
+        self.assertEqual(cache_info.misses, 1)
+        self.assertGreaterEqual(cache_info.hits, 1)
+
+    def test_capability_family_cards_cache_is_reused_without_payload_poisoning(self) -> None:
+        families_module._capability_family_projection_cached.cache_clear()
+
+        first = families_module.capability_family_cards()
+        first[0]["primary_workflows"][0] = "mutated"
+        second = families_module.capability_family_cards()
+        cache_info = families_module._capability_family_projection_cached.cache_info()
+
+        self.assertIsNot(first, second)
+        self.assertNotEqual(second[0]["primary_workflows"][0], "mutated")
         self.assertEqual(cache_info.misses, 1)
         self.assertGreaterEqual(cache_info.hits, 1)
 


### PR DESCRIPTION
## Feature Report

### What Changed

- Cached the deterministic OMH capability-family projection behind `capability_family_projection()`.
- Replaced generic `deepcopy()` use for capability family cards with shape-aware copy helpers.
- Added regression tests proving cached family projections and cards are reused without caller-side mutation poisoning the cached payload.

### Why This Exists

Hermes-facing wrapper surfaces repeatedly ask for the same five user-facing OMH capability families when rendering context briefs, pickers, quickstart cards, and quality demos. Profiling showed that `capability_family_cards()` and `capability_family_projection()` were rebuilding the same static projection and deep-copying it hundreds of times in the Hermes UX quality path.

This PR keeps the public contract unchanged while removing unnecessary repeated projection work.

### User / Operator Impact

- Chat-first OMH surfaces spend less time rebuilding static capability-family cards.
- The capability family payload remains safe for wrappers to mutate locally because every public call still returns fresh list/dict containers.
- OMH routing and evidence-boundary behavior is unchanged.

### How It Works

- `src/capabilities/families.py` now stores the deterministic projection in `_capability_family_projection_cached()` keyed by the optional available-workflows set.
- Public helpers convert incoming workflow lists to stable cache keys, then return mutation-safe copies of the cached payload.
- Copy helpers preserve only the known mutable list/dict fields used by the public schema, avoiding the heavier generic `deepcopy()` path.

### Files And Contracts Touched

- `src/capabilities/families.py`: adds cached projection and mutation-safe copy helpers.
- `tests/test_efficiency.py`: adds cache reuse and payload poisoning regression coverage.
- Public schema remains `omh_capability_families/v1`.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — 949 tests passed.
- [x] `uv run python -m compileall -q src tests` — passed.
- [x] `uv run python -m omh.cli docs workflows --check` — passed, 48/48 tap skills current.
- [x] `uv run python -m omh.cli harness validate` — passed, 36 harnesses and 50 skills valid.
- [x] `uv run python -m omh.cli demo routing-precision --summary` — 8/8 negative controls and 13/13 interventions passed.
- [x] `uv run python -m omh.cli demo hermes-ux-quality --json` — score 100, all five gates passed.
- [x] Performance profile smoke — 100 Hermes UX demo runs measured at 1.49s in this branch; `capability_family_cards()` averaged 3.73us after warm cache.
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_chat_router.py tests/test_efficiency.py tests/test_wrapper_contract.py -v && git diff --check` — passed.
- [ ] Manual Hermes/TUI check — not run; this is a deterministic local projection performance change with no live Hermes rendering change.

## Risk

- Narrow risk: capability family payload copy helpers must preserve the existing public shape.
- Mitigation: existing capability tests plus new mutation-poisoning tests cover the public projection, family cards, workflow mapping, and executor choices.

## Compatibility / Rollout

- Backward compatible with existing `capability_family_projection()`, `capability_family_cards()`, and `family_for_workflow()` callers.
- No command, schema, workflow, or documentation contract change.

## Release / Claims

- [x] Release-channel impact considered: runtime behavior is internal performance only.
- [x] Runtime/native capability claims are unchanged and remain evidence-boundary safe.
- [x] No live Hermes/plugin-load claim is made from this PR.

## Follow-Up

- Continue profiling the remaining hot paths in `build_chat_interaction_payload()`, route scoring, and JSON serialization as separate narrow performance patches.
