### PR TITLE
Cache executor readiness contracts

### DIFF
--- a/src/coding/executor_readiness.py
+++ b/src/coding/executor_readiness.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import shutil
 import subprocess
+from functools import lru_cache
 from typing import Any
 
 from ..executors import EXECUTOR_PROFILES, executor_label
@@ -23,6 +24,11 @@ _COMMANDS: dict[str, tuple[str, tuple[str, ...]]] = {
 
 def executor_readiness_contract(profile: str | None) -> dict[str, object]:
     normalized = _normalize_profile(profile)
+    return _copy_executor_readiness_payload(_executor_readiness_contract_cached(normalized))
+
+
+@lru_cache(maxsize=16)
+def _executor_readiness_contract_cached(normalized: str) -> dict[str, object]:
     if normalized == "choose":
         return {
             "schema_version": EXECUTOR_READINESS_SCHEMA_VERSION,
@@ -78,6 +84,32 @@ def executor_readiness_contract(profile: str | None) -> dict[str, object]:
         ],
         "claim_boundary": "Readiness is not dispatch, execution, verification, review, CI, or merge evidence; it only checks whether the selected executor path appears available.",
     }
+
+
+def _copy_executor_readiness_payload(payload: dict[str, object]) -> dict[str, object]:
+    copied = dict(payload)
+    probe = copied.get("probe")
+    if isinstance(probe, dict):
+        copied_probe = dict(probe)
+        copied_probe["args"] = _copy_list(probe.get("args", []))
+        copied_probe["captures"] = _copy_list(probe.get("captures", []))
+        copied["probe"] = copied_probe
+    fallback_policy = copied.get("fallback_policy")
+    if isinstance(fallback_policy, dict):
+        copied_policy = dict(fallback_policy)
+        if "suggested_actions" in copied_policy:
+            copied_policy["suggested_actions"] = _copy_list(copied_policy.get("suggested_actions", []))
+        copied["fallback_policy"] = copied_policy
+    if "not_evidence" in copied:
+        copied["not_evidence"] = _copy_list(copied.get("not_evidence", []))
+    profiles = copied.get("profiles")
+    if isinstance(profiles, list):
+        copied["profiles"] = [
+            _copy_executor_readiness_payload(profile)
+            for profile in profiles
+            if isinstance(profile, dict)
+        ]
+    return copied
 
 
 def executor_readiness_for_selection(
@@ -219,6 +251,12 @@ def _normalize_profile(profile: str | None) -> str:
     if value not in EXECUTOR_READINESS_PROFILES:
         raise ValueError(f"unsupported executor readiness profile: {value}")
     return value
+
+
+def _copy_list(value: object) -> list[object]:
+    if not isinstance(value, list):
+        return []
+    return list(value)
 
 
 def _read_state(paths: OmhPaths) -> tuple[dict[str, Any], str]:

--- a/src/coding/executors.py
+++ b/src/coding/executors.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from functools import lru_cache
 
 
 EXECUTOR_HANDOFF_SCHEMA_VERSION = "coding_executor_handoff/v1"
@@ -336,8 +337,12 @@ def public_executor_options() -> list[dict[str, object]]:
 
 
 def executor_label(profile: str | None) -> str:
-    labels = {str(option["profile"]): str(option["label"]) for option in public_executor_options()}
-    return labels.get(profile or "", "Unselected executor")
+    return _executor_label_map().get(profile or "", "Unselected executor")
+
+
+@lru_cache(maxsize=1)
+def _executor_label_map() -> dict[str, str]:
+    return {str(option["profile"]): str(option["label"]) for option in public_executor_options()}
 
 
 def prompt_invocation_for_profile(profile: str) -> dict[str, str]:

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -31,6 +31,8 @@ from omh.release import (
 )
 from omh.capabilities import families as families_module
 from omh.capabilities.skills import skill_capabilities
+from omh.coding import executor_readiness as executor_readiness_module
+from omh.coding import executors as executors_module
 from omh.plugin_bundle.omh.tools.capability_tool import standalone_skill_capability_items
 from omh.plugin_bundle.omh import awareness as awareness_module
 from omh.plugin_bundle.omh.awareness import (
@@ -729,6 +731,55 @@ class EfficiencyContractTests(unittest.TestCase):
         self.assertEqual(first_resolution["source"], "message_mention")
         self.assertEqual(second_resolution["resolved_executor_target"], "codex")
         self.assertEqual(cache_info.misses, 1)
+        self.assertGreaterEqual(cache_info.hits, 1)
+
+    def test_executor_label_map_cache_is_reused(self) -> None:
+        executors_module._executor_label_map.cache_clear()
+
+        first = executors_module.executor_label("codex")
+        second = executors_module.executor_label("codex")
+        cache_info = executors_module._executor_label_map.cache_info()
+
+        self.assertEqual(first, "Codex")
+        self.assertEqual(first, second)
+        self.assertEqual(cache_info.misses, 1)
+        self.assertGreaterEqual(cache_info.hits, 1)
+
+    def test_executor_readiness_contract_cache_is_reused_without_payload_poisoning(self) -> None:
+        executor_readiness_module._executor_readiness_contract_cached.cache_clear()
+
+        first = executor_readiness_module.executor_readiness_contract("codex")
+        first["probe"]["args"][0] = "mutated"
+        first["probe"]["captures"][0] = "mutated"
+        first["fallback_policy"]["suggested_actions"][0] = "mutated"
+        first["not_evidence"][0] = "mutated"
+
+        second = executor_readiness_module.executor_readiness_contract("codex")
+        cache_info = executor_readiness_module._executor_readiness_contract_cached.cache_info()
+
+        self.assertIsNot(first, second)
+        self.assertEqual(second["probe"]["args"], ["--version"])
+        self.assertEqual(second["probe"]["captures"][0], "available")
+        self.assertEqual(second["fallback_policy"]["suggested_actions"][0], "choose_executor")
+        self.assertEqual(second["not_evidence"][0], "executor dispatch")
+        self.assertEqual(cache_info.misses, 1)
+        self.assertGreaterEqual(cache_info.hits, 1)
+
+    def test_executor_readiness_selection_cache_is_reused_without_profile_poisoning(self) -> None:
+        executor_readiness_module._executor_readiness_contract_cached.cache_clear()
+
+        first = executor_readiness_module.executor_readiness_for_selection(None, choice_required=True)
+        first["profiles"][0]["profile"] = "mutated"
+        first["profiles"][0]["probe"]["command"] = "mutated"
+
+        second = executor_readiness_module.executor_readiness_for_selection(None, choice_required=True)
+        cache_info = executor_readiness_module._executor_readiness_contract_cached.cache_info()
+
+        self.assertIsNot(first, second)
+        self.assertEqual(second["status"], "choice_required")
+        self.assertEqual(second["profiles"][0]["profile"], "codex")
+        self.assertEqual(second["profiles"][0]["probe"]["command"], "codex")
+        self.assertGreaterEqual(cache_info.misses, 1)
         self.assertGreaterEqual(cache_info.hits, 1)
 
     def test_messenger_safe_body_cache_is_reused_without_transform_poisoning(self) -> None:


### PR DESCRIPTION
## Feature Report

### What Changed

- Cached the static executor readiness contract builder so repeated Codex, Claude Code, Hermes, and runtime profile readiness payloads reuse the same internal shape.
- Cached the public executor label map used by coding-agent status and handoff cards.
- Added mutation-safety tests so wrapper payload callers cannot poison the cached readiness payload.

### Why This Exists

- The Hermes UX demo repeatedly builds coding delegation and chat interaction payloads while rendering wrapper-safe cards.
- Profiling showed static executor readiness and label generation were being rebuilt thousands of times across the hot path.
- The change keeps the existing executor-neutral evidence boundary while reducing repeated local object construction.

### User / Operator Impact

- Hermes chat surfaces that show coding-agent readiness, fallback, or handoff status can prepare those cards with less repeated work.
- Operators still see the same prepared-vs-observed states; this does not claim dispatch, execution, review, CI, or merge evidence.
- The default executor choices and setup/runtime behavior are unchanged.

### How It Works

- `executor_readiness_contract()` now normalizes the profile, retrieves a cached static payload, and returns a shallow/deep-enough copy for mutable nested fields.
- `executor_label()` now uses a cached map derived from `public_executor_options()` instead of rebuilding labels on each lookup.
- Efficiency tests clear and inspect the caches, then mutate returned payloads to confirm later calls remain clean.

### Files And Contracts Touched

- `src/coding/executor_readiness.py`: cached readiness contract construction plus mutation-safe payload copy helper.
- `src/coding/executors.py`: cached executor label map.
- `tests/test_efficiency.py`: cache reuse and cache-poisoning regression coverage.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` passed, 952 tests.
- [x] `uv run python -m compileall -q src tests` passed.
- [x] `uv run python -m omh.cli docs workflows --check` passed, 48/48 tap skills.
- [x] `uv run python -m omh.cli harness validate` passed, 36 harnesses and 50 skills.
- [ ] `python3 -m omh.cli release checklist --json` not run; release packaging was not touched.
- [ ] `python3 -m omh.cli release hermes-smoke` not run; live Hermes install behavior was not touched.
- [ ] `omh --help` not run; CLI command surface was not changed.
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` not run; setup/install behavior was not changed.
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable.
- [x] Relevant dry-run or smoke command: `uv run python -m omh.cli demo routing-precision --summary` passed, 8/8 negative controls and 13/13 interventions; `uv run python -m omh.cli demo hermes-ux-quality --json` passed with score 100.
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; this is a deterministic local payload-cache optimization.
- [x] Performance evaluator: `PYTHONPATH=tests uv run python -m unittest tests/test_chat_router.py tests/test_efficiency.py tests/test_wrapper_contract.py -v && git diff --check` passed, 184 tests plus diff check.
- [x] Profiling evidence: warm Hermes UX demo average was about 5.67ms; readiness cache reported 41592 hits / 8 misses; label cache reported 2006 hits / 1 miss.

## Risk

- The main risk is accidental shared mutable payload state from caching nested dict/list structures.
- The new tests mutate returned readiness payloads and selection payloads to lock the cache-safety boundary.

## Compatibility / Rollout

- No schema, command, docs, setup, or runtime-state migration is required.
- Existing wrappers should receive the same payload shapes as before.
- The change is local and reversible if later profiling shows a different hot path dominates.

## Release / Claims

- [x] Release-channel impact considered: local/preview implementation optimization only.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] Known manual Hermes checks are listed: live Hermes/TUI rendering was not observed in this PR.

## Follow-Up

- Continue measuring whole-demo latency rather than only micro-cache timings so future optimizations target visible chat latency.