### PR TITLE
Cache chat catalog classifiers

### DIFF
--- a/src/routing/catalog_questions.py
+++ b/src/routing/catalog_questions.py
@@ -462,6 +462,7 @@ _OPERATOR_ACTION_QUESTION_MARKERS = (
 )
 
 
+@lru_cache(maxsize=4096)
 def is_skill_catalog_question(message: str) -> bool:
     lowered = message.strip().lower()
     if not lowered:
@@ -496,6 +497,7 @@ def is_skill_catalog_question(message: str) -> bool:
     return has_context and len(words) <= 4 and _contains_catalog_token(search_texts, _PLURAL_CATALOG_WORDS)
 
 
+@lru_cache(maxsize=4096)
 def is_file_or_text_lookup_question(message: str) -> bool:
     lowered = message.strip().lower()
     if not lowered:

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -598,20 +598,37 @@ class EfficiencyContractTests(unittest.TestCase):
         self.assertGreater(cache_info.hits, 0)
 
     def test_catalog_question_caches_repeated_search_and_token_checks(self) -> None:
+        catalog_questions_module.is_skill_catalog_question.cache_clear()
         catalog_questions_module._catalog_search_texts.cache_clear()
         catalog_questions_module._contains_catalog_token.cache_clear()
 
         first = catalog_questions_module.is_skill_catalog_question("what OMH workflows are available?")
         second = catalog_questions_module.is_skill_catalog_question("what OMH workflows are available?")
+        question_cache = catalog_questions_module.is_skill_catalog_question.cache_info()
         search_cache = catalog_questions_module._catalog_search_texts.cache_info()
         token_cache = catalog_questions_module._contains_catalog_token.cache_info()
 
         self.assertTrue(first)
         self.assertEqual(first, second)
+        self.assertEqual(question_cache.misses, 1)
+        self.assertGreaterEqual(question_cache.hits, 1)
         self.assertEqual(search_cache.misses, 1)
-        self.assertGreaterEqual(search_cache.hits, 1)
         self.assertGreater(token_cache.misses, 0)
-        self.assertGreater(token_cache.hits, 0)
+
+    def test_file_lookup_question_cache_reuses_repeated_lookup_checks(self) -> None:
+        catalog_questions_module.is_file_or_text_lookup_question.cache_clear()
+        catalog_questions_module._catalog_search_texts.cache_clear()
+
+        first = catalog_questions_module.is_file_or_text_lookup_question("find the README file")
+        second = catalog_questions_module.is_file_or_text_lookup_question("find the README file")
+        lookup_cache = catalog_questions_module.is_file_or_text_lookup_question.cache_info()
+        search_cache = catalog_questions_module._catalog_search_texts.cache_info()
+
+        self.assertTrue(first)
+        self.assertEqual(first, second)
+        self.assertEqual(lookup_cache.misses, 1)
+        self.assertGreaterEqual(lookup_cache.hits, 1)
+        self.assertEqual(search_cache.misses, 1)
 
     def test_chat_route_decision_cache_is_reused_without_payload_poisoning(self) -> None:
         chat_module._route_chat_message_cached.cache_clear()


### PR DESCRIPTION
## Feature Report

### What Changed

- Added bounded `lru_cache` wrappers to the top-level catalog question and file/text lookup classifiers.
- Updated efficiency tests so repeated classifier calls prove top-level cache reuse instead of only inner helper reuse.

### Why This Exists

- Hermes chat interaction rendering repeatedly asks whether a message is a catalog/menu question or a file lookup request.
- The lower-level normalization/token helpers were already cached, but the public classifier still reran several marker checks for repeated messages.
- Profiling the Hermes UX demo showed classifier work still inside the route/interaction hot path after earlier payload caches landed.

### User / Operator Impact

- Repeated Discord/Slack/Hermes wrapper interactions can classify common OMH catalog and lookup prompts with less repeated CPU work.
- The visible routing behavior is unchanged: catalog questions still open the OMH picker, file lookup questions still stay out of workflow dispatch, and evidence boundaries stay the same.
- This helps the chat-first surface feel lighter without adding commands or changing setup.

### How It Works

- `is_skill_catalog_question(message)` and `is_file_or_text_lookup_question(message)` are pure boolean decisions over the supplied message string, so they can be cached safely by message text.
- The cache is bounded at 4096 entries, matching other router hot-path caches in this area.
- Tests clear the caches and assert one miss plus later hits for repeated catalog and lookup prompts.

### Files And Contracts Touched

- `src/routing/catalog_questions.py`: top-level classifier cache decorators.
- `tests/test_efficiency.py`: cache reuse coverage for catalog and file lookup classification.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` passed, 953 tests.
- [x] `uv run python -m compileall -q src tests` passed.
- [x] `uv run python -m omh.cli docs workflows --check` passed, 48/48 tap skills.
- [x] `uv run python -m omh.cli harness validate` passed, 36 harnesses and 50 skills.
- [ ] `python3 -m omh.cli release checklist --json` not run; release packaging was not touched.
- [ ] `python3 -m omh.cli release hermes-smoke` not run; live Hermes install behavior was not touched.
- [ ] `omh --help` not run; CLI command surface was not changed.
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` not run; setup/install behavior was not changed.
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable.
- [x] Relevant dry-run or smoke command: `uv run python -m omh.cli demo routing-precision --summary` passed, 8/8 negative controls and 13/13 interventions; `uv run python -m omh.cli demo hermes-ux-quality --json` passed with score 100.
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; this is a deterministic local classifier-cache optimization.
- [x] Performance evaluator: `PYTHONPATH=tests uv run python -m unittest tests/test_chat_router.py tests/test_efficiency.py tests/test_wrapper_contract.py -v && git diff --check` passed, 185 tests plus diff check.
- [x] Profiling evidence: 250 Hermes UX demo builds under cProfile moved from about 13.315ms/build to about 12.673ms/build; `is_skill_catalog_question` reported 56472 hits / 64 misses.

## Risk

- The main risk is stale classification if the function depended on external mutable state.
- It does not: both classifiers derive their answer from static phrase tables and the message string.

## Compatibility / Rollout

- No public schema, command, setup, docs, or runtime artifact shape changed.
- Existing wrappers receive the same route payloads and chat cards.
- Cache size is bounded and local to the process.

## Release / Claims

- [x] Release-channel impact considered: local/preview implementation optimization only.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] Known manual Hermes checks are listed: live Hermes/TUI rendering was not observed in this PR.

## Follow-Up

- Continue profiling `build_chat_interaction_payload`; current remaining hot spots are payload cloning/JSON serialization and chat response construction.