### PR TITLE
Cache wrapper intent classifiers

### DIFF
--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -3786,6 +3786,7 @@ def _omh_intro_route_payload(route_payload: dict[str, object]) -> dict[str, obje
     return updated
 
 
+@lru_cache(maxsize=4096)
 def _is_omh_intro_question(message: str) -> bool:
     text = message.strip().lower()
     if not text:
@@ -3848,6 +3849,7 @@ def _is_omh_intro_question(message: str) -> bool:
     return any(marker in text for marker in intro_markers)
 
 
+@lru_cache(maxsize=4096)
 def _is_omh_quickstart_question(message: str) -> bool:
     text = message.strip().lower()
     if not text:
@@ -3882,6 +3884,7 @@ def _is_omh_quickstart_question(message: str) -> bool:
     return any(marker in text for marker in quickstart_markers)
 
 
+@lru_cache(maxsize=4096)
 def _is_omh_status_question(message: str) -> bool:
     text = message.strip().lower()
     if not text:
@@ -4017,6 +4020,7 @@ def _is_skill_picker_invocation(message: str) -> bool:
     return rest in _SKILL_PICKER_HELP_TOKENS
 
 
+@lru_cache(maxsize=4096)
 def _is_command_preview_invocation(message: str) -> bool:
     token = _first_token(message).lower()
     if not token:

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -728,6 +728,27 @@ class EfficiencyContractTests(unittest.TestCase):
         self.assertEqual(cache_info.misses, 1)
         self.assertGreaterEqual(cache_info.hits, 1)
 
+    def test_wrapper_intent_classifiers_cache_repeated_messages(self) -> None:
+        classifier_cases = (
+            (contract_module._is_omh_intro_question, "What is OMH and how should I use it?"),
+            (contract_module._is_omh_quickstart_question, "OMH setup is done, what next?"),
+            (contract_module._is_omh_status_question, "show OMH status"),
+            (contract_module._is_command_preview_invocation, "./om"),
+        )
+
+        for classifier, message in classifier_cases:
+            with self.subTest(classifier=classifier.__name__):
+                classifier.cache_clear()
+
+                first = classifier(message)
+                second = classifier(message)
+                cache_info = classifier.cache_info()
+
+                self.assertTrue(first)
+                self.assertEqual(first, second)
+                self.assertEqual(cache_info.misses, 1)
+                self.assertGreaterEqual(cache_info.hits, 1)
+
     def test_chat_interaction_reuses_executor_target_hint_cache(self) -> None:
         contract_module._executor_target_from_message.cache_clear()
 


### PR DESCRIPTION
## Feature Report

### What Changed

- Added bounded caches to pure wrapper intent classifiers for OMH intro, quickstart, status, and command-preview detection.
- Added efficiency coverage proving repeated messages reuse those classifier caches.

### Why This Exists

- Profiling showed repeated Hermes UX demo and wrapper interaction rendering still spent time re-running pure string predicates after route and catalog caches landed.
- These predicates decide wrapper surface shape only from message text, so bounded caching reduces repeated work without changing routing or evidence semantics.

### User / Operator Impact

- Repeated chat rendering for common OMH status, intro, quickstart, and command-preview messages gets lighter.
- Visible chat payloads, actions, and prepared-vs-observed boundaries remain unchanged.

### How It Works

- src/wrapper/contract.py now applies lru_cache maxsize 4096 to four pure message classifiers.
- tests/test_efficiency.py clears each cache, calls the classifier twice, and asserts one miss plus hits while preserving true classifications.

### Files And Contracts Touched

- src/wrapper/contract.py
- tests/test_efficiency.py
- No public schema, CLI command, generated catalog, wrapper payload shape, setup behavior, docs, or runtime artifact shape changed.

## Validation

- PASS: PYTHONPATH=tests uv run python -m unittest tests/test_chat_router.py tests/test_efficiency.py tests/test_wrapper_contract.py -v, 186 tests.
- PASS: git diff --check HEAD~1 HEAD.
- PASS: same-session broad validation before branch split: PYTHONPATH=tests uv run python -m unittest discover -s tests -v, 954 tests; compileall; docs workflows check; harness validate; routing precision; Hermes UX quality score 100.
- Profiling evidence from the same optimization pass: cProfile 250 UX demo build avg moved about 12.764ms to 11.900ms; direct repeated interaction avg moved 0.042ms to 0.040ms; command preview cache 49637 hits and 61 misses.
- NOT RUN: Manual Hermes/TUI check; deterministic local wrapper classifier-cache optimization.

## Risk

- Risk is stale classification if these predicates ever start depending on external state. They currently depend only on static phrase lists and message text.

## Compatibility / Rollout

- Compatible with existing installs and wrappers because payload shapes and public contracts do not change.
- Existing wrappers receive the same payloads and actions.

## Release / Claims

- Release-channel impact considered: local and preview implementation optimization only.
- Runtime/native capability claims are backed by evidence or marked not observed.
- Known manual Hermes checks are listed.

## Follow-Up

- Remaining performance hot spots are payload cloning, JSON serialization, and chat response construction.
