### PR TITLE
Cache OMH status probe responses

### DIFF
--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from functools import lru_cache
 import hashlib
+from pathlib import Path
 from typing import Any
 
 from ..context_safety import compact_progress_events
@@ -3177,7 +3178,7 @@ def build_chat_response_from_status(status_payload: dict[str, Any], *, thread_ke
 
 
 def build_chat_response_from_omh_status_roadmap(paths: OmhPaths, *, thread_key: str = "") -> dict[str, object]:
-    probe = probe_capabilities(paths, include_roadmap=True)
+    probe = _omh_status_probe(paths)
     roadmap = _nested(probe, "capability_gap_roadmap")
     summary = _nested(roadmap, "summary")
     next_actions = _roadmap_next_actions(roadmap, limit=3)
@@ -3228,6 +3229,143 @@ def build_chat_response_from_omh_status_roadmap(paths: OmhPaths, *, thread_key: 
             ],
         },
     )
+
+
+def _omh_status_probe(paths: OmhPaths) -> dict[str, object]:
+    return _clone_static_dict(
+        _omh_status_probe_cached(
+            str(paths.omh_home),
+            str(paths.hermes_home),
+            _omh_status_probe_fingerprint(paths),
+        )
+    )
+
+
+@lru_cache(maxsize=64)
+def _omh_status_probe_cached(
+    omh_home: str,
+    hermes_home: str,
+    _fingerprint: tuple[tuple[str, int, int, int], ...],
+) -> dict[str, object]:
+    return _omh_status_probe_projection(
+        probe_capabilities(OmhPaths(omh_home=Path(omh_home), hermes_home=Path(hermes_home)), include_roadmap=True)
+    )
+
+
+def _omh_status_probe_projection(probe: dict[str, object]) -> dict[str, object]:
+    roadmap = probe.get("capability_gap_roadmap")
+    return {
+        "claim_boundary": probe.get("claim_boundary"),
+        "plugin_distribution_ready": bool(probe.get("plugin_distribution_ready")),
+        "plugin_runtime_active": bool(probe.get("plugin_runtime_active")),
+        "native_integration_claim_ready": bool(probe.get("native_integration_claim_ready")),
+        "team_worker_readiness_ready": bool(probe.get("team_worker_readiness_ready")),
+        "mcp_host_session_observed": bool(probe.get("mcp_host_session_observed")),
+        "capability_gap_roadmap": roadmap if isinstance(roadmap, dict) else {},
+    }
+
+
+def _omh_status_probe_fingerprint(paths: OmhPaths) -> tuple[tuple[str, int, int, int], ...]:
+    watched = (
+        paths.hermes_config_path,
+        paths.skills_dir / "oh-my-hermes" / "SKILL.md",
+        paths.runtime_state_path,
+        paths.runtime_runs_dir,
+        paths.runtime_wrapper_sessions_dir,
+        paths.runtime_mcp_host_sessions_path,
+        paths.runtime_plugin_host_observations_path,
+        paths.runtime_worktrees_path,
+        paths.executor_readiness_path,
+        paths.target_registry_path,
+        paths.hermes_home / "hooks.yaml",
+        paths.hermes_home / "hooks.json",
+        paths.hermes_home / ".mcp.json",
+        paths.hermes_home / "mcp.json",
+        paths.hermes_plugins_dir,
+        paths.hermes_plugin_dir,
+        paths.hermes_plugin_dir / ".omh-plugin-manifest.json",
+        paths.hermes_plugin_dir / "plugin.yaml",
+        paths.hermes_plugin_dir / "__init__.py",
+        paths.hermes_home / "apps",
+    )
+    run_child_fingerprint = _child_dir_fingerprints(paths.runtime_runs_dir)
+    session_child_fingerprint = _child_dir_fingerprints(paths.runtime_wrapper_sessions_dir)
+    runtime_files = (
+        _glob_fingerprints(
+            paths.runtime_runs_dir,
+            "*/run.json",
+            child_dir_fingerprints=run_child_fingerprint,
+        )
+        + _glob_fingerprints(
+            paths.runtime_runs_dir,
+            "*/wrapper.json",
+            child_dir_fingerprints=run_child_fingerprint,
+        )
+        + _glob_fingerprints(
+            paths.runtime_runs_dir,
+            "*/runtime_observations.jsonl",
+            child_dir_fingerprints=run_child_fingerprint,
+        )
+        + _glob_fingerprints(
+            paths.runtime_wrapper_sessions_dir,
+            "*/session.json",
+            child_dir_fingerprints=session_child_fingerprint,
+        )
+        + _glob_fingerprints(
+            paths.runtime_wrapper_sessions_dir,
+            "*/runtime_observations.jsonl",
+            child_dir_fingerprints=session_child_fingerprint,
+        )
+    )
+    return tuple(_path_fingerprint(path) for path in watched) + runtime_files
+
+
+def _glob_fingerprints(
+    root: Path,
+    pattern: str,
+    *,
+    child_dir_fingerprints: tuple[tuple[str, int, int, int], ...] | None = None,
+    limit: int = 256,
+) -> tuple[tuple[str, int, int, int], ...]:
+    paths = _glob_fingerprint_paths_cached(
+        str(root),
+        pattern,
+        limit,
+        _path_fingerprint(root),
+        child_dir_fingerprints if child_dir_fingerprints is not None else _child_dir_fingerprints(root, limit=limit),
+    )
+    return tuple(_path_fingerprint(Path(path)) for path in paths)
+
+
+@lru_cache(maxsize=128)
+def _glob_fingerprint_paths_cached(
+    root: str,
+    pattern: str,
+    limit: int,
+    _root_fingerprint: tuple[str, int, int, int],
+    _child_dir_fingerprints: tuple[tuple[str, int, int, int], ...],
+) -> tuple[str, ...]:
+    try:
+        paths = sorted(Path(root).glob(pattern))
+    except OSError:
+        return ()
+    return tuple(str(path) for path in paths[:limit])
+
+
+def _child_dir_fingerprints(root: Path, *, limit: int = 256) -> tuple[tuple[str, int, int, int], ...]:
+    try:
+        children = sorted(path for path in root.iterdir() if path.is_dir())
+    except OSError:
+        return ()
+    return tuple(_path_fingerprint(path) for path in children[:limit])
+
+
+def _path_fingerprint(path: Path) -> tuple[str, int, int, int]:
+    try:
+        stat = path.stat()
+    except OSError:
+        return (str(path), 0, 0, 0)
+    return (str(path), int(stat.st_mtime_ns), int(stat.st_size), int(stat.st_mode))
 
 
 def build_chat_response_from_omh_quickstart(

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
 import unittest
 from unittest.mock import patch
 
@@ -20,6 +22,7 @@ from omh.skills import render as render_module
 from omh.workflows import hermes_planning as hermes_planning_module
 from omh.workflows import learning_candidate as learning_candidate_module
 from omh.wrapper import contract as contract_module
+from omh.paths import OmhPaths
 from omh.release import (
     AWARENESS_PRIMER_CONTEXT_CHAR_LIMIT,
     AWARENESS_PRIMER_MARKDOWN_CHAR_LIMIT,
@@ -748,6 +751,49 @@ class EfficiencyContractTests(unittest.TestCase):
                 self.assertEqual(first, second)
                 self.assertEqual(cache_info.misses, 1)
                 self.assertGreaterEqual(cache_info.hits, 1)
+
+    def test_omh_status_probe_cache_reuses_probe_without_payload_poisoning(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = OmhPaths(omh_home=Path(tmp) / ".omh", hermes_home=Path(tmp) / ".hermes")
+            contract_module._omh_status_probe_cached.cache_clear()
+
+            first = contract_module.build_chat_response_from_omh_status_roadmap(paths)
+            first["state"]["probe_summary"]["plugin_distribution_ready"] = "mutated"
+            second = contract_module.build_chat_response_from_omh_status_roadmap(paths)
+            cache_info = contract_module._omh_status_probe_cached.cache_info()
+
+            self.assertFalse(second["state"]["probe_summary"]["plugin_distribution_ready"])
+            self.assertEqual(cache_info.misses, 1)
+            self.assertGreaterEqual(cache_info.hits, 1)
+
+            paths.hermes_home.mkdir(parents=True, exist_ok=True)
+            paths.hermes_config_path.write_text("skills:\n  external_dirs: []\n", encoding="utf-8")
+            contract_module.build_chat_response_from_omh_status_roadmap(paths)
+            refreshed_cache_info = contract_module._omh_status_probe_cached.cache_info()
+
+            self.assertEqual(refreshed_cache_info.misses, 2)
+
+            session_dir = paths.runtime_wrapper_sessions_dir / "session-1"
+            session_dir.mkdir(parents=True, exist_ok=True)
+            session_path = session_dir / "session.json"
+            session_path.write_text('{"session_id":"session-1"}\n', encoding="utf-8")
+            before = contract_module._omh_status_probe_fingerprint(paths)
+            session_path.write_text('{"session_id":"session-1","status":"updated"}\n', encoding="utf-8")
+            after = contract_module._omh_status_probe_fingerprint(paths)
+
+            self.assertNotEqual(before, after)
+
+            run_dir = paths.runtime_runs_dir / "run-1"
+            run_dir.mkdir(parents=True, exist_ok=True)
+            contract_module._glob_fingerprint_paths_cached.cache_clear()
+            self.assertEqual(contract_module._glob_fingerprints(paths.runtime_runs_dir, "*/wrapper.json"), ())
+            wrapper_path = run_dir / "wrapper.json"
+            wrapper_path.write_text('{"schema_version":"wrapper_observation/v1"}\n', encoding="utf-8")
+
+            self.assertIn(
+                contract_module._path_fingerprint(wrapper_path),
+                contract_module._glob_fingerprints(paths.runtime_runs_dir, "*/wrapper.json"),
+            )
 
     def test_chat_interaction_reuses_executor_target_hint_cache(self) -> None:
         contract_module._executor_target_from_message.cache_clear()


### PR DESCRIPTION
## Summary
- Cache the OMH status roadmap probe behind a fingerprinted LRU key so repeated Hermes status questions do not re-run plugin/import/register and capability-roadmap probes every time.
- Keep the cache clone-safe by returning a compact status projection and deep-copying the response payload before wrapper rendering can mutate it.
- Add shallow runtime artifact freshness checks for run, wrapper, session, and runtime observation files so status changes invalidate the cached roadmap instead of going stale.

## Why
Profiling repeated chat interactions showed OMH status questions spending most time rebuilding the full capability probe. That made normal wrapper usage feel heavier than needed when a user repeatedly asks what OMH is doing or what the next action is.

## User Impact
Hermes can answer repeated OMH status or next-action questions faster while preserving the prepared-vs-observed boundary. Local setup, plugin, wrapper, and runtime changes still refresh the cached roadmap through watched file fingerprints.

## Implementation Notes
- src/wrapper/contract.py now routes status-roadmap rendering through a fingerprinted _omh_status_probe cache.
- The cache key watches Hermes config, managed skills, runtime state, plugin files, MCP/plugin observation files, target registry, and shallow runtime run/session artifacts.
- tests/test_efficiency.py locks cache reuse, mutation safety, config invalidation, runtime session file invalidation, and wrapper artifact discovery.

## Verification
- PYTHONPATH=tests uv run python -m unittest tests/test_chat_router.py tests/test_efficiency.py tests/test_wrapper_contract.py -v && git diff --check: PASS, 187 tests.
- uv run python -m compileall -q src tests: PASS.
- uv run python -m omh.cli docs workflows --check: PASS.
- PYTHONPATH=tests uv run python -m unittest discover -s tests -v: PASS, 955 tests.
- uv run python -m omh.cli harness validate: PASS.
- Mixed interaction profile over 2000 calls improved from about 1.1651ms average to 0.2712ms average; status_probe_cache reported hits=249 misses=1.

## Risk
The cache intentionally keeps a bounded shallow view of runtime artifacts. It invalidates for normal setup, plugin, wrapper, run, session, and runtime-observation changes, but live Hermes/TUI rendering was not manually exercised in this PR.