### PR TITLE
Cache metadata-safe chat interaction payloads

### DIFF
--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -1355,6 +1355,96 @@ def build_chat_interaction_payload(
         raise ValueError("chat interact --limit must be at least 1")
 
     message = extract_message_text(event_or_message)
+    if _can_use_chat_interaction_cache(
+        event_or_message,
+        include_message=include_message,
+        source_metadata=source_metadata,
+        target_notice=target_notice,
+        paths=paths,
+    ):
+        return _copy_chat_interaction_payload(
+            _build_chat_interaction_payload_cached(
+                message,
+                source,
+                mode,
+                limit,
+                min_confidence,
+                executor_target,
+            )
+        )
+
+    return _build_chat_interaction_payload_uncached(
+        event_or_message,
+        source=source,
+        mode=mode,
+        limit=limit,
+        min_confidence=min_confidence,
+        include_message=include_message,
+        executor_target=executor_target,
+        source_metadata=source_metadata,
+        target_notice=target_notice,
+        paths=paths,
+    )
+
+
+def _can_use_chat_interaction_cache(
+    event_or_message: dict[str, Any] | str,
+    *,
+    include_message: bool,
+    source_metadata: dict[str, str] | None,
+    target_notice: dict[str, object] | None,
+    paths: OmhPaths | None,
+) -> bool:
+    return (
+        isinstance(event_or_message, str)
+        and not include_message
+        and source_metadata is None
+        and target_notice is None
+        and paths is None
+    )
+
+
+def _copy_chat_interaction_payload(payload: dict[str, object]) -> dict[str, object]:
+    return _clone_static_dict(payload)
+
+
+@lru_cache(maxsize=2048)
+def _build_chat_interaction_payload_cached(
+    message: str,
+    source: str,
+    mode: str,
+    limit: int,
+    min_confidence: str,
+    executor_target: str,
+) -> dict[str, object]:
+    return _build_chat_interaction_payload_uncached(
+        message,
+        source=source,
+        mode=mode,
+        limit=limit,
+        min_confidence=min_confidence,
+        include_message=False,
+        executor_target=executor_target,
+        source_metadata=None,
+        target_notice=None,
+        paths=None,
+    )
+
+
+def _build_chat_interaction_payload_uncached(
+    event_or_message: dict[str, Any] | str,
+    *,
+    source: str,
+    mode: str,
+    limit: int,
+    min_confidence: str,
+    include_message: bool,
+    executor_target: str,
+    source_metadata: dict[str, str] | None,
+    target_notice: dict[str, object] | None,
+    paths: OmhPaths | None,
+) -> dict[str, object]:
+    message = extract_message_text(event_or_message)
     metadata = _source_metadata(event_or_message, source_metadata)
     route_payload = public_chat_route_payload(
         message,

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -734,20 +734,60 @@ class EfficiencyContractTests(unittest.TestCase):
     def test_chat_interaction_uses_public_route_projection_cache(self) -> None:
         chat_module._route_chat_message_cached.cache_clear()
         chat_module._public_chat_route_payload_cached.cache_clear()
+        contract_module._build_chat_interaction_payload_cached.cache_clear()
 
         first = contract_module.build_chat_interaction_payload(
             "risky refactor with implementation and review",
             source="discord",
+            source_metadata={"source_event_id": "evt-1"},
         )
         second = contract_module.build_chat_interaction_payload(
             "risky refactor with implementation and review",
             source="discord",
+            source_metadata={"source_event_id": "evt-1"},
         )
         cache_info = chat_module._public_chat_route_payload_cached.cache_info()
 
         self.assertEqual(first["route"]["selected_skill"], second["route"]["selected_skill"])
         self.assertEqual(cache_info.misses, 1)
         self.assertGreaterEqual(cache_info.hits, 1)
+
+    def test_chat_interaction_cache_is_reused_without_payload_poisoning(self) -> None:
+        contract_module._build_chat_interaction_payload_cached.cache_clear()
+
+        first = contract_module.build_chat_interaction_payload(
+            "risky refactor with implementation and review",
+            source="discord",
+        )
+        first["route"]["selected_skill"] = "mutated"
+        first["chat_response"]["state"]["workflow_explanation"]["why_this_workflow"] = "mutated"
+        first["chat_response"]["actions"][0]["label"] = "mutated"
+
+        second = contract_module.build_chat_interaction_payload(
+            "risky refactor with implementation and review",
+            source="discord",
+        )
+        cache_info = contract_module._build_chat_interaction_payload_cached.cache_info()
+
+        self.assertNotEqual(second["route"]["selected_skill"], "mutated")
+        self.assertNotEqual(second["chat_response"]["state"]["workflow_explanation"]["why_this_workflow"], "mutated")
+        self.assertNotEqual(second["chat_response"]["actions"][0]["label"], "mutated")
+        self.assertEqual(cache_info.misses, 1)
+        self.assertGreaterEqual(cache_info.hits, 1)
+
+    def test_chat_interaction_cache_skips_event_metadata_calls(self) -> None:
+        contract_module._build_chat_interaction_payload_cached.cache_clear()
+
+        payload = contract_module.build_chat_interaction_payload(
+            "risky refactor with implementation and review",
+            source="discord",
+            source_metadata={"source_event_id": "evt-123", "channel_ref": "chan-1"},
+        )
+        cache_info = contract_module._build_chat_interaction_payload_cached.cache_info()
+
+        self.assertIn("evt-123", payload["thread_key"])
+        self.assertEqual(cache_info.misses, 0)
+        self.assertEqual(cache_info.hits, 0)
 
     def test_wrapper_intent_classifiers_cache_repeated_messages(self) -> None:
         classifier_cases = (


### PR DESCRIPTION
## Feature Report

### What Changed

- Added an interaction-level cache for metadata-safe `build_chat_interaction_payload()` calls.
- The cache applies only to plain string requests with metadata-only output: no event metadata, no target notice, no raw-message stdout, and no setup-profile `paths` object.
- Added regression coverage proving cached interaction payloads cannot be mutated by callers and that event metadata calls bypass the cache.

### Why This Exists

- The Hermes UX quality demos repeatedly build the same wrapper interaction payloads while checking routing quality, card coverage, context, and precision.
- After the previous route-copy improvement, profiling showed `build_chat_interaction_payload()` remained the largest hot path.
- This change improves perceived local demo/router responsiveness without weakening thread scoping, executor default resolution, or prepared-vs-observed boundaries.

### User / Operator Impact

- Repeated OMH route-quality and wrapper demos are faster.
- Common chat-first routing checks remain deterministic and metadata-only.
- Real platform events still keep their own source metadata and thread keys instead of being served from a plain-string cache.

### How It Works

- `build_chat_interaction_payload()` now delegates cache-eligible calls to `_build_chat_interaction_payload_cached()`.
- `_can_use_chat_interaction_cache()` restricts caching to plain string input, `include_message=False`, no explicit source metadata, no target notice, and no paths-dependent setup profile.
- Cached payloads are copied before returning so callers cannot mutate the cached object.
- Existing uncached behavior remains the path for event-shaped wrapper calls and runtime/profile-dependent calls.

### Files And Contracts Touched

- `src/wrapper/contract.py`: metadata-safe interaction payload cache and uncached helper split.
- `tests/test_efficiency.py`: cache reuse, payload poisoning, and event metadata bypass tests.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_chat_router.py tests/test_efficiency.py tests/test_wrapper_contract.py -v && git diff --check`
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_context_brief_coverage.py tests/test_routing_precision.py tests/test_hermes_ux_quality.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli harness validate`
- [x] `uv run python -m omh.cli demo hermes-ux-quality --json`
- [x] `uv run python -m omh.cli demo routing-precision --summary`
- [x] Profile smoke: 100 `build_hermes_ux_quality_demo(source="discord")` runs improved from this turn's local baseline of about `12.893ms` per run to `10.052ms` per run.
- [ ] `python3 -m omh.cli release checklist --json` not run; this PR is not a release packaging change.
- [ ] `python3 -m omh.cli release hermes-smoke` not run; this PR does not change install or live Hermes runtime integration.
- [ ] `omh --help` not run; command surface is unchanged.
- [ ] Manual Hermes/TUI check not run; this PR changes deterministic local wrapper payload caching only.

## Risk

- Low to moderate. The cached function is high-traffic, but the cache gate is intentionally narrow and event/profile-sensitive calls bypass it.
- Mutation risk is covered by tests that alter returned route, workflow explanation, and action labels before calling again.

## Compatibility / Rollout

- No schema, command, docs, or generated skill changes.
- Existing wrapper response shape is preserved.
- Release channel impact: local performance improvement only.

## Release / Claims

- [x] Release-channel impact considered (`local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Known manual Hermes checks are listed; live Hermes rendering was not observed and is not claimed

## Follow-Up

- The next remaining hot spot is cached-payload copying itself; a future pass can replace generic recursive copying with shape-aware interaction copies if the extra complexity is worth it.
