### PR TITLE
Cache specific capability route checks

### DIFF
--- a/src/routing/chat.py
+++ b/src/routing/chat.py
@@ -1020,6 +1020,7 @@ def _is_eligible_specific_capability_recommendation(recommendation: dict[str, ob
     return bool(next_action and next_action != "clarify_or_route")
 
 
+@lru_cache(maxsize=2048)
 def _is_broad_capability_catalog_question(message: str) -> bool:
     text = message.strip().lower()
     if any(phrase in text for phrase in _BROAD_CAPABILITY_CATALOG_PHRASES):
@@ -1061,6 +1062,7 @@ def _specific_capability_phrase_map() -> tuple[_SpecificCapabilityPhrase, ...]:
     return tuple(entries)
 
 
+@lru_cache(maxsize=2048)
 def _specific_capability_named_hits(message: str) -> tuple[str, ...]:
     text = message.strip().lower()
     matches: list[tuple[int, int, int, str]] = []
@@ -1079,6 +1081,7 @@ def _specific_capability_named_hits(message: str) -> tuple[str, ...]:
     return tuple(selected)
 
 
+@lru_cache(maxsize=2048)
 def _specific_capability_exact_id_hit(message: str) -> str | None:
     text = message.strip().lower()
     hits: list[str] = []

--- a/tests/test_chat_router.py
+++ b/tests/test_chat_router.py
@@ -948,6 +948,7 @@ class ChatRouterTests(unittest.TestCase):
 
     def test_specific_capability_phrase_patterns_are_compiled_once(self) -> None:
         chat_router_impl._specific_capability_phrase_map.cache_clear()
+        chat_router_impl._specific_capability_named_hits.cache_clear()
         try:
             with mock.patch.object(
                 chat_router_impl,
@@ -968,6 +969,7 @@ class ChatRouterTests(unittest.TestCase):
                 self.assertEqual(compile_phrase.call_count, first_call_count)
         finally:
             chat_router_impl._specific_capability_phrase_map.cache_clear()
+            chat_router_impl._specific_capability_named_hits.cache_clear()
 
     def test_paper_learning_routes_paper_explanation_without_stealing_related_lanes(self) -> None:
         explanation_cases = (

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -630,6 +630,34 @@ class EfficiencyContractTests(unittest.TestCase):
         self.assertEqual(search_cache.misses, 1)
         self.assertGreater(token_cache.misses, 0)
 
+    def test_specific_capability_hits_cache_repeated_catalog_checks(self) -> None:
+        chat_module._specific_capability_named_hits.cache_clear()
+        chat_module._specific_capability_exact_id_hit.cache_clear()
+        chat_module._is_broad_capability_catalog_question.cache_clear()
+
+        first_hits = chat_module._specific_capability_named_hits("what can OMH do for paper-learning?")
+        second_hits = chat_module._specific_capability_named_hits("what can OMH do for paper-learning?")
+        first_exact = chat_module._specific_capability_exact_id_hit("what can OMH do for paper-learning?")
+        second_exact = chat_module._specific_capability_exact_id_hit("what can OMH do for paper-learning?")
+        first_broad = chat_module._is_broad_capability_catalog_question("paper-learning / web-research")
+        second_broad = chat_module._is_broad_capability_catalog_question("paper-learning / web-research")
+        hits_cache = chat_module._specific_capability_named_hits.cache_info()
+        exact_cache = chat_module._specific_capability_exact_id_hit.cache_info()
+        broad_cache = chat_module._is_broad_capability_catalog_question.cache_info()
+
+        self.assertEqual(first_hits, second_hits)
+        self.assertIn("paper-learning", second_hits)
+        self.assertEqual(first_exact, "paper-learning")
+        self.assertEqual(first_exact, second_exact)
+        self.assertTrue(first_broad)
+        self.assertEqual(first_broad, second_broad)
+        self.assertEqual(hits_cache.misses, 2)
+        self.assertGreaterEqual(hits_cache.hits, 1)
+        self.assertEqual(exact_cache.misses, 1)
+        self.assertGreaterEqual(exact_cache.hits, 1)
+        self.assertEqual(broad_cache.misses, 1)
+        self.assertGreaterEqual(broad_cache.hits, 1)
+
     def test_file_lookup_question_cache_reuses_repeated_lookup_checks(self) -> None:
         catalog_questions_module.is_file_or_text_lookup_question.cache_clear()
         catalog_questions_module._catalog_search_texts.cache_clear()


### PR DESCRIPTION
## Feature Report

### What Changed

- Added lightweight LRU caches around the specific-capability catalog detectors in `src/routing/chat.py`.
- Added an efficiency contract proving repeated capability questions reuse cached detector results.
- Updated the phrase-pattern compilation test to clear the new detector cache so the test continues to assert the intended compile-once behavior.

### Why This Exists

OMH chat routing now handles many natural questions such as "what can OMH do for paper-learning?", "tell me about img-summary", or direct workflow picker prompts. These routes are already deterministic and correct, but repeated wrapper/card/demo evaluations could still rescan the specific-capability phrase catalog. This PR trims that hot path without changing route scores, next actions, workflow copy, runtime observations, or evidence boundaries.

### User / Operator Impact

- Hermes-facing catalog and workflow questions stay responsive when the same request is rendered across route cards, status cards, demos, and wrapper hints.
- Users still see the same workflow-specific OMH cards and route decisions.
- Operators get a bounded cache test that protects this optimization from regressing into repeated catalog scans.

### How It Works

- `_is_broad_capability_catalog_question`, `_specific_capability_named_hits`, and `_specific_capability_exact_id_hit` now cache by normalized message input.
- The cached functions are pure detectors only; they do not carry source metadata, wrapper runtime observations, user-visible payloads, or mutable artifacts.
- The new efficiency test clears caches, exercises repeated exact and broad capability questions, and asserts cache hit/miss behavior.

### Files And Contracts Touched

- `src/routing/chat.py`: pure detector caching for repeated capability route checks.
- `tests/test_efficiency.py`: regression coverage for repeated specific capability detector caches.
- `tests/test_chat_router.py`: test isolation for the new cache around phrase-pattern compilation.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_chat_router.py tests/test_efficiency.py tests/test_wrapper_contract.py -v && git diff --check` — 192 tests OK.
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — 960 tests OK.
- [x] `uv run python -m compileall -q src tests`.
- [x] `uv run python -m omh.cli docs workflows --check`.
- [x] `uv run python -m omh.cli harness validate`.
- [x] `uv run python -m omh.cli demo hermes-ux-quality --json` — score 100, 5/5 gates passed.
- [x] `uv run python -m omh.cli demo routing-precision --summary` — 8/8 negative controls, 13/13 interventions.
- [x] Focused microprofile: 12,000 repeated capability detector calls took 0.002625s cached vs 0.306753s through `.__wrapped__`, about 116.85x faster for the optimized detector path.
- [ ] `python3 -m omh.cli release checklist --json` — not run; this is not a release packaging change.
- [ ] `python3 -m omh.cli release hermes-smoke` — not run; this is a local deterministic routing optimization.
- [ ] `omh --help` — not run; CLI surface unchanged.
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` — not run; install/setup surface unchanged.
- [ ] Manual Hermes/TUI check — not run; live Hermes rendering is not claimed by this PR.

## Risk

Low. The cache wraps pure string detectors only. It does not cache mutable wrapper payloads, source metadata, runtime observations, or evidence state. The main risk is stale detector state if the in-process catalog changes dynamically, but OMH catalog metadata is static for the process in normal CLI/wrapper execution.

## Compatibility / Rollout

Backward compatible. No command, schema, docs, workflow, or runtime artifact format changes.

## Release / Claims

- [x] Release-channel impact considered: local/preview runtime behavior only, no packaging change.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] Known manual Hermes checks are listed: live Hermes/TUI rendering was not run and is not claimed.

## Follow-Up

- Continue profiling higher-level demo builders separately before touching broader payload caching; this PR intentionally stays at the narrow detector layer.
