### PR TITLE
Cache routing phrase guard checks

### DIFF
--- a/src/routing/policy.py
+++ b/src/routing/policy.py
@@ -4417,6 +4417,7 @@ def _explicit_delivery_or_implementation_requested(normalized_query: str, query_
     )
 
 
+@lru_cache(maxsize=16384)
 def _contains_phrase(normalized_query: str, phrases: tuple[str, ...] | frozenset[str]) -> bool:
     for phrase in _normalized_phrase_options(phrases):
         if phrase in normalized_query:

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -509,6 +509,24 @@ class EfficiencyContractTests(unittest.TestCase):
         self.assertEqual(cache_info.misses, 1)
         self.assertGreaterEqual(cache_info.hits, 1)
 
+    def test_routing_phrase_presence_cache_reuses_guard_checks(self) -> None:
+        policy_module._contains_phrase.cache_clear()
+
+        first = policy_module._contains_phrase(
+            "this refactor feels risky",
+            policy_module._RISKY_REFACTOR_RISK_PHRASES,
+        )
+        second = policy_module._contains_phrase(
+            "this refactor feels risky",
+            policy_module._RISKY_REFACTOR_RISK_PHRASES,
+        )
+        cache_info = policy_module._contains_phrase.cache_info()
+
+        self.assertTrue(first)
+        self.assertEqual(first, second)
+        self.assertEqual(cache_info.misses, 1)
+        self.assertGreaterEqual(cache_info.hits, 1)
+
     def test_normalized_phrase_cache_reuses_folded_text(self) -> None:
         localization_module._fold_for_match.cache_clear()
 


### PR DESCRIPTION
## Feature Report

### What Changed

- Added an LRU cache to the pure `_contains_phrase` helper used by routing policy guard evaluation.
- Added an efficiency test proving repeated guard phrase checks reuse the cache.

### Why This Exists

OMH routing uses many guard rules to keep natural-language requests on the right workflow: risky refactors go to planning, product feedback goes to triage, image-card requests go to `img-summary`, and ordinary direct questions stay out of workflow dispatch. The guard path repeatedly checks normalized queries against stable phrase sets. This PR trims that repeated phrase-presence work without changing any route scores, workflow choices, wrapper payloads, or evidence claims.

### User / Operator Impact

- Repeated route/card/demo evaluation has a lighter guard-check path.
- Hermes-facing route decisions and response cards remain unchanged.
- The optimization avoids mutable payload caching and stays limited to immutable boolean phrase checks.

### How It Works

- `_contains_phrase(normalized_query, phrases)` now uses `@lru_cache(maxsize=16384)`.
- The helper returns a boolean only, so no mutation-safe copy path is needed.
- The new test clears the cache, runs a real risky-refactor guard phrase twice, and asserts one miss plus at least one hit.

### Files And Contracts Touched

- `src/routing/policy.py`: cache pure phrase-presence checks.
- `tests/test_efficiency.py`: cache reuse coverage for guard phrase checks.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_chat_router.py tests/test_efficiency.py tests/test_wrapper_contract.py -v && git diff --check` — 193 tests OK.
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — 961 tests OK.
- [x] `uv run python -m compileall -q src tests`.
- [x] `uv run python -m omh.cli docs workflows --check`.
- [x] `uv run python -m omh.cli harness validate`.
- [x] `uv run python -m omh.cli demo hermes-ux-quality --json` — score 100, 5/5 gates passed.
- [x] `uv run python -m omh.cli demo routing-precision --summary` — 8/8 negative controls, 13/13 interventions, overroutes 0, missed interventions 0.
- [x] Focused microprofile: 50,000 `_contains_phrase` calls took 0.002229s cached vs 0.004658s through `.__wrapped__`, about 2.09x faster for the optimized helper path.
- [ ] `python3 -m omh.cli release checklist --json` — not run; this is not a release packaging change.
- [ ] `python3 -m omh.cli release hermes-smoke` — not run; this is a local deterministic routing optimization.
- [ ] `omh --help` — not run; CLI surface unchanged.
- [ ] Manual Hermes/TUI check — not run; live Hermes rendering is not claimed by this PR.

## Risk

Low. The cache key is the normalized query plus an immutable tuple/frozenset phrase collection, and the return value is a boolean. No wrapper payload, runtime observation, source metadata, or user-visible mutable artifact is cached.

A larger route-hint payload cache was tested and rejected because it was slower: payload copy cost exceeded reconstruction after lower-level awareness caching. This PR keeps only the measured positive change.

## Compatibility / Rollout

Backward compatible. No command, schema, workflow, docs, packaging, or runtime artifact changes.

## Release / Claims

- [x] Release-channel impact considered: local/preview runtime behavior only, no packaging change.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] Known manual Hermes checks are listed: live Hermes/TUI rendering was not run and is not claimed.

## Follow-Up

- Continue profiling before adding broader caches. In particular, avoid payload-level cache changes unless a microprofile proves copy cost is lower than rebuild cost.
