### PR TITLE
Cache routing text preparation

### DIFF
--- a/src/routing/localization.py
+++ b/src/routing/localization.py
@@ -562,6 +562,11 @@ def locale_aliases() -> tuple[LocaleAlias, ...]:
 
 
 def prepare_routing_text(value: str) -> RoutingText:
+    return _prepare_routing_text_cached(value)
+
+
+@lru_cache(maxsize=8192)
+def _prepare_routing_text_cached(value: str) -> RoutingText:
     original = value.strip()
     folded = _fold_for_match(original)
     additions: list[str] = []

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -539,6 +539,19 @@ class EfficiencyContractTests(unittest.TestCase):
         self.assertEqual(cache_info.misses, 1)
         self.assertGreaterEqual(cache_info.hits, 1)
 
+    def test_prepare_routing_text_cache_reuses_locale_alias_scan(self) -> None:
+        localization_module._prepare_routing_text_cached.cache_clear()
+
+        first = localization_module.prepare_routing_text("生成一张解释 cron 功能的图片")
+        second = localization_module.prepare_routing_text("生成一张解释 cron 功能的图片")
+        cache_info = localization_module._prepare_routing_text_cached.cache_info()
+
+        self.assertIs(first, second)
+        self.assertIn("visual summary", second.scoring_text)
+        self.assertIn("zh:visual_summary", second.locale_matches)
+        self.assertEqual(cache_info.misses, 1)
+        self.assertGreaterEqual(cache_info.hits, 1)
+
     def test_routing_token_cache_reuses_terms_without_payload_poisoning(self) -> None:
         localization_module._routing_terms_cached.cache_clear()
         localization_module._routing_tokens_cached.cache_clear()


### PR DESCRIPTION
## Summary
- Cache deterministic `prepare_routing_text` locale-alias preprocessing behind an immutable `RoutingText` result.
- Add an efficiency regression test proving repeated multilingual routing text preparation reuses the cache while preserving locale match metadata.
- Keep public router behavior and prepared-vs-observed boundaries unchanged.

## Why
Repeated chat surfaces can ask the router, route plan builder, and plugin awareness hints to preprocess the same message. The locale alias table is deterministic, but previously each call still rescanned the alias table. This made common non-English prompts pay repeated normalization and phrase-scan cost even when the message was identical inside a wrapper/session path.

## What changed
- `src/routing/localization.py` now routes `prepare_routing_text()` through `_prepare_routing_text_cached()` with an LRU cache.
- `tests/test_efficiency.py` now locks that a Chinese image-summary request keeps the `zh:visual_summary` match while reusing the cached result.

## User value
Hermes-facing routing keeps the same answers, but repeated natural-language routing in Discord/Slack-style wrapper flows gets cheaper. This is especially useful for multilingual requests because the locale alias scan is now reused across repeated route/hint/recommendation calls.

## Implementation notes
- The cached object is a frozen `RoutingText`, so the cached value is not a mutable public payload.
- The change intentionally does not cache wrapper/card payloads or execution state.
- No network, LLM, platform SDK, or Hermes core behavior is added.

## Verification
- `PYTHONPATH=tests uv run python -m unittest tests/test_chat_router.py tests/test_efficiency.py tests/test_wrapper_contract.py -v && git diff --check` — 194 tests OK.
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — 962 tests OK.
- `uv run python -m compileall -q src tests` — pass.
- `uv run python -m omh.cli docs workflows --check` — pass, 48/48 tap skills checked.
- `uv run python -m omh.cli harness validate` — pass, 36 harnesses and 50 skills.
- `uv run python -m omh.cli demo hermes-ux-quality --json` — score 100, 5/5 gates passed.
- `uv run python -m omh.cli demo routing-precision --summary` — 8/8 negative controls and 13/13 interventions passed.
- Focused microprofile: 50,000 `prepare_routing_text` calls cached in `0.002348s` vs uncached `0.443879s`, about `189.08x` faster.

## Risks / follow-up
- This only proves deterministic local preprocessing. It does not prove live Hermes chat rendering, platform delivery, plugin load, source retrieval, executor dispatch, implementation, review, CI, or merge.
- Future locale alias additions should keep the cached result immutable and covered by routing tests.
