### PR TITLE
Cache missed route feedback checks

### DIFF
--- a/src/routing/missed_route.py
+++ b/src/routing/missed_route.py
@@ -128,10 +128,12 @@ def is_missed_omh_workflow_feedback(message: str) -> bool:
     return is_missed_route_feedback(normalized)
 
 
+@lru_cache(maxsize=4096)
 def _contains_phrase(text: str, phrases: tuple[str, ...]) -> bool:
     return any(phrase in text for phrase in _normalized_phrases(phrases))
 
 
+@lru_cache(maxsize=4096)
 def _contains_compact_phrase(text: str, phrases: tuple[str, ...]) -> bool:
     compact = text.replace(" ", "")
     return any(phrase in compact for phrase in _normalized_compact_phrases(phrases))

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -14,6 +14,7 @@ from omh.skill_pack import builtin_definitions, builtin_skill_templates
 from omh.routing import chat as chat_module
 from omh.routing import catalog_questions as catalog_questions_module
 from omh.routing import localization as localization_module
+from omh.routing import missed_route as missed_route_module
 from omh.routing import recommend as recommend_module
 from omh.routing import policy as policy_module
 from omh.routing import route_plan as route_plan_module
@@ -526,6 +527,29 @@ class EfficiencyContractTests(unittest.TestCase):
         self.assertEqual(first, second)
         self.assertEqual(cache_info.misses, 1)
         self.assertGreaterEqual(cache_info.hits, 1)
+
+    def test_missed_route_phrase_cache_reuses_feedback_checks(self) -> None:
+        missed_route_module._contains_phrase.cache_clear()
+        missed_route_module._contains_compact_phrase.cache_clear()
+
+        first = missed_route_module.is_missed_route_feedback("missed route: OMH was not used")
+        second = missed_route_module.is_missed_route_feedback("missed route: OMH was not used")
+        phrase_cache = missed_route_module._contains_phrase.cache_info()
+
+        self.assertTrue(first)
+        self.assertEqual(first, second)
+        self.assertEqual(phrase_cache.misses, 1)
+        self.assertGreaterEqual(phrase_cache.hits, 1)
+
+        missed_route_module._contains_compact_phrase.cache_clear()
+        first_compact = missed_route_module.is_missed_route_feedback("라우팅 누락 기록해줘")
+        second_compact = missed_route_module.is_missed_route_feedback("라우팅 누락 기록해줘")
+        compact_cache = missed_route_module._contains_compact_phrase.cache_info()
+
+        self.assertTrue(first_compact)
+        self.assertEqual(first_compact, second_compact)
+        self.assertEqual(compact_cache.misses, 1)
+        self.assertGreaterEqual(compact_cache.hits, 1)
 
     def test_normalized_phrase_cache_reuses_folded_text(self) -> None:
         localization_module._fold_for_match.cache_clear()


### PR DESCRIPTION
## Summary
- Cache missed-route phrase and compact-phrase checks used by OMH workflow-learning/router feedback paths.
- Add an efficiency regression test for both normal phrase matching and compact Korean feedback such as routing omission reports.
- Preserve existing missed-route routing semantics and prepared-vs-observed boundaries.

## Why
Operators often report usability misses in chat with messages like "OMH did not use the workflow" or "라우팅 누락". That signal flows through route hints, chat responses, and workflow-learning cards. The phrase lists are deterministic and immutable, but the detector previously rescanned them each time the same message was evaluated.

## What changed
- `src/routing/missed_route.py` now caches `_contains_phrase()` and `_contains_compact_phrase()` results with bounded LRU caches.
- `tests/test_efficiency.py` now proves repeated English missed-route feedback and compact Korean missed-route feedback reuse those caches.

## User value
Hermes can keep recognizing "OMH missed this" feedback while spending less repeated work on the same message inside wrapper/router/learning flows. This strengthens the feedback loop that turns real user complaints into reviewable OMH learning artifacts.

## Boundary
This is deterministic local signal detection only. It does not record a learning artifact by itself, mutate skills, prove live Hermes rendering, or claim source retrieval, executor dispatch, implementation, review, CI, merge, or delivery.

## Verification
- `PYTHONPATH=tests uv run python -m unittest tests/test_missed_route_detection.py tests/test_chat_router.py tests/test_efficiency.py tests/test_wrapper_contract.py -v && git diff --check` — 198 tests OK.
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — 963 tests OK.
- `uv run python -m compileall -q src tests` — pass.
- `uv run python -m omh.cli docs workflows --check` — pass, 48/48 tap skills checked.
- `uv run python -m omh.cli harness validate` — pass, 36 harnesses and 50 skills.
- `uv run python -m omh.cli demo hermes-ux-quality --json` — score 100, 5/5 gates passed.
- `uv run python -m omh.cli demo routing-precision --summary` — 8/8 negative controls and 13/13 interventions passed.
- Focused microprofile: 50,000 `is_missed_route_feedback` calls cached in `0.008505s` vs uncached `0.061176s`, about `7.19x` faster.

## Risks / follow-up
- Cache keys are message text plus immutable phrase tuple, so this should stay bounded and deterministic.
- If future missed-route detection starts reading dynamic configuration, that dynamic input must become part of the cache key or bypass this cache.
