### PR TITLE
Cache intent classifier paths

### DIFF
--- a/src/routing/intent.py
+++ b/src/routing/intent.py
@@ -270,6 +270,7 @@ class OmhQualityIntent:
         )
 
 
+@lru_cache(maxsize=4096)
 def classify_workflow_intent(message: str) -> WorkflowIntent:
     """Classify whether workflow vocabulary is a reference or execution intent."""
     normalized = normalized_phrase(message)
@@ -463,6 +464,7 @@ _CUSTOMER_FEEDBACK_CUES = (
 )
 
 
+@lru_cache(maxsize=4096)
 def classify_omh_quality_intent(message: str) -> OmhQualityIntent:
     """Classify deterministic OMH self-improvement loop intent.
 
@@ -683,6 +685,7 @@ def _without_diagnostic_status_lines(normalized: str) -> str:
     return "\n".join(kept)
 
 
+@lru_cache(maxsize=4096)
 def scrub_diagnostic_status_text(message: str) -> str:
     """Remove pasted/generated OMH status fragments while preserving user text."""
     normalized = normalized_phrase(message)

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -13,6 +13,7 @@ load_local_package()
 from omh.skill_pack import builtin_definitions, builtin_skill_templates
 from omh.routing import chat as chat_module
 from omh.routing import catalog_questions as catalog_questions_module
+from omh.routing import intent as intent_module
 from omh.routing import localization as localization_module
 from omh.routing import missed_route as missed_route_module
 from omh.routing import recommend as recommend_module
@@ -550,6 +551,44 @@ class EfficiencyContractTests(unittest.TestCase):
         self.assertEqual(first_compact, second_compact)
         self.assertEqual(compact_cache.misses, 1)
         self.assertGreaterEqual(compact_cache.hits, 1)
+
+    def test_intent_classifier_cache_reuses_repeated_workflow_checks(self) -> None:
+        intent_module.classify_workflow_intent.cache_clear()
+
+        message = "OMH route: `$ultraprocess` ≠ ejecutar; Codex handoff token only."
+        first = intent_module.classify_workflow_intent(message)
+        second = intent_module.classify_workflow_intent(message)
+        cache_info = intent_module.classify_workflow_intent.cache_info()
+
+        self.assertIs(first, second)
+        self.assertEqual(first.intent_class, "meta_discussion")
+        self.assertEqual(cache_info.misses, 1)
+        self.assertGreaterEqual(cache_info.hits, 1)
+
+    def test_omh_quality_classifier_cache_reuses_repeated_quality_checks(self) -> None:
+        intent_module.classify_omh_quality_intent.cache_clear()
+
+        first = intent_module.classify_omh_quality_intent("Improve OMH routing quality and handoff reliability")
+        second = intent_module.classify_omh_quality_intent("Improve OMH routing quality and handoff reliability")
+        cache_info = intent_module.classify_omh_quality_intent.cache_info()
+
+        self.assertIs(first, second)
+        self.assertTrue(second.applies)
+        self.assertEqual(cache_info.misses, 1)
+        self.assertGreaterEqual(cache_info.hits, 1)
+
+    def test_diagnostic_status_scrub_cache_reuses_repeated_status_text(self) -> None:
+        intent_module.scrub_diagnostic_status_text.cache_clear()
+
+        status_text = "[omh] selected_workflow=ultraprocess | status=prepared\nWhy did OMH route this wrong?"
+        first = intent_module.scrub_diagnostic_status_text(status_text)
+        second = intent_module.scrub_diagnostic_status_text(status_text)
+        cache_info = intent_module.scrub_diagnostic_status_text.cache_info()
+
+        self.assertEqual(first, second)
+        self.assertIn("why did omh route this wrong", second)
+        self.assertEqual(cache_info.misses, 1)
+        self.assertGreaterEqual(cache_info.hits, 1)
 
     def test_normalized_phrase_cache_reuses_folded_text(self) -> None:
         localization_module._fold_for_match.cache_clear()


### PR DESCRIPTION
## Summary
- Adds bounded LRU caches to immutable OMH intent classification and diagnostic status scrubbing paths.
- Locks cache reuse with efficiency tests for workflow intent, OMH quality intent, and pasted-status scrubbing.
- Keeps routing semantics unchanged while reducing repeated chat/wrapper classification overhead for the same message.

## Why
Hermes chat surfaces can ask OMH to classify the same operator message across routing, cards, task abstractions, and status-aware rendering. Those calls repeatedly normalize text, build token sets, and scan cue lists even though the resulting intent objects are frozen dataclasses or strings. This PR uses those immutable boundaries as safe cache points.

## How
- `src/routing/intent.py` now applies `@lru_cache(maxsize=4096)` to:
  - `classify_workflow_intent`
  - `classify_omh_quality_intent`
  - `scrub_diagnostic_status_text`
- `tests/test_efficiency.py` verifies the caches hit on repeated inputs and that the cached payloads remain safe to reuse.

## Verification
- `PYTHONPATH=tests uv run python -m unittest tests/test_chat_router.py tests/test_efficiency.py tests/test_wrapper_contract.py -v` — 198 tests passed
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — 966 tests passed
- `uv run python -m compileall -q src tests` — passed
- `uv run python -m omh.cli docs workflows --check` — passed, 48/48 tap skills current
- `uv run python -m omh.cli harness validate` — passed, 36 harnesses and 50 skills valid
- `uv run python -m omh.cli demo hermes-ux-quality --json` — passed, score 100
- `uv run python -m omh.cli demo routing-precision --summary` — passed, 8/8 negative controls and 13/13 interventions
- `git diff --check` — passed
- Microprofile: repeated intent/scrub path warm cache improved from 0.202042s to 0.000338s for 5000 loops, about 597.24x faster

## Risks And Boundaries
- This does not change live Hermes rendering, platform delivery, executor dispatch, implementation, review, CI, or merge evidence.
- Cache is intentionally limited to immutable dataclasses and strings; mutable route payloads remain copied elsewhere.
