### PR TITLE
Reuse recommendation rankings across limits

### DIFF
--- a/src/routing/recommend.py
+++ b/src/routing/recommend.py
@@ -515,7 +515,7 @@ def recommend_skills(query: str, *, limit: int = 5, apply_guardrails: bool = Tru
     if limit < 1:
         raise ValueError("recommend --limit must be at least 1")
 
-    return [recommendation.to_dict() for recommendation in _recommend_skills_cached(query, limit, apply_guardrails)]
+    return [recommendation.to_dict() for recommendation in _recommend_skills_cached(query, apply_guardrails)[:limit]]
 
 
 def recommendation_for_definition(
@@ -547,7 +547,7 @@ def recommendation_for_definition(
 
 
 @lru_cache(maxsize=2048)
-def _recommend_skills_cached(query: str, limit: int, apply_guardrails: bool) -> tuple[Recommendation, ...]:
+def _recommend_skills_cached(query: str, apply_guardrails: bool) -> tuple[Recommendation, ...]:
     routing_text = prepare_routing_text(_strip_path_like_fragments(query))
     normalized_query = normalized_phrase(routing_text.scoring_text)
     query_tokens = _tokens(normalized_query)
@@ -574,12 +574,12 @@ def _recommend_skills_cached(query: str, limit: int, apply_guardrails: bool) -> 
             matches = [recommendation for recommendation in matches if recommendation.skill != "img-summary"]
             if not matches:
                 matches = _fallback_recommendations(definitions, query)
-                return tuple(matches[:limit])
+                return tuple(matches)
     if not matches:
         matches = _fallback_recommendations(definitions, query)
-        return tuple(matches[:limit])
+        return tuple(matches)
     matches.sort(key=lambda recommendation: (-recommendation.score, recommendation.skill))
-    return tuple(matches[:limit])
+    return tuple(matches)
 
 
 @lru_cache(maxsize=1)

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -498,6 +498,17 @@ class EfficiencyContractTests(unittest.TestCase):
         self.assertEqual(cache_info.misses, 1)
         self.assertGreaterEqual(cache_info.hits, 1)
 
+    def test_recommendation_ranking_cache_is_reused_across_limits(self) -> None:
+        recommend_module._recommend_skills_cached.cache_clear()
+
+        first = recommend_module.recommend_skills("risky refactor", limit=2)
+        second = recommend_module.recommend_skills("risky refactor", limit=8)
+        cache_info = recommend_module._recommend_skills_cached.cache_info()
+
+        self.assertEqual([item["skill"] for item in first], [item["skill"] for item in second[:2]])
+        self.assertEqual(cache_info.misses, 1)
+        self.assertGreaterEqual(cache_info.hits, 1)
+
     def test_routing_guard_cache_is_reused_for_repeated_recommendations(self) -> None:
         policy_module._active_routing_guard_rules_cached.cache_clear()
         recommend_module._recommend_skills_cached.cache_clear()


### PR DESCRIPTION
## Summary
- Changes recommendation caching to store the full sorted ranking once per query/guardrail mode.
- Slices the cached ranking at the public `recommend_skills(..., limit=...)` boundary.
- Adds an efficiency regression test proving the same query reuses the cached ranking across different limits.

## Why
Hermes chat routing often needs multiple views of the same recommendation set: a compact card can ask for a short list while planning or route explanations can ask for a larger list. The previous cache key included `limit`, so the same message could rescore the catalog when only presentation size changed.

## How
- `src/routing/recommend.py` removes `limit` from `_recommend_skills_cached`.
- The cache now returns a complete immutable tuple of `Recommendation` objects.
- `recommend_skills()` performs the limit slice while still returning fresh dict projections to callers.

## Verification
- `PYTHONPATH=tests uv run python -m unittest tests/test_chat_router.py tests/test_efficiency.py tests/test_wrapper_contract.py -v` — 199 tests passed
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — 967 tests passed
- `uv run python -m compileall -q src tests` — passed
- `uv run python -m omh.cli docs workflows --check` — passed, 48/48 tap skills current
- `uv run python -m omh.cli harness validate` — passed, 36 harnesses and 50 skills valid
- `uv run python -m omh.cli demo hermes-ux-quality --json` — passed, score 100
- `uv run python -m omh.cli demo routing-precision --summary` — passed, 8/8 negative controls and 13/13 interventions
- `git diff --check` — passed
- Microprofile: repeated `limit=2` + `limit=8` recommendation pair improved from 0.100473s to 0.002181s for 1000 loops, about 46.07x faster

## Risks And Boundaries
- This does not change recommendation scoring, ordering, routing semantics, live Hermes rendering, executor dispatch, review, CI, or merge evidence.
- Mutable public dict payloads are still regenerated per call; the cache stores immutable `Recommendation` tuples only.
