### PR TITLE
Use direct recommendation phrase matching

### DIFF
--- a/src/routing/recommend.py
+++ b/src/routing/recommend.py
@@ -797,7 +797,6 @@ def _command_trigger_match(query: str, value: str) -> bool:
     return bool(_COMMAND_TRIGGER_PATTERNS[value].search(query))
 
 
-@lru_cache(maxsize=16384)
 def _phrase_match(query: str, value: str) -> bool:
     return bool(query and value and (query in value or value in query))
 

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -704,18 +704,17 @@ class EfficiencyContractTests(unittest.TestCase):
         self.assertEqual(profile_cache.misses, 1)
         self.assertGreater(term_cache.misses, 0)
 
-    def test_phrase_match_cache_reuses_repeated_recommendation_pairs(self) -> None:
-        recommend_module._phrase_match.cache_clear()
+    def test_direct_phrase_match_preserves_recommendation_scoring(self) -> None:
         recommend_module._recommend_skills_cached.cache_clear()
 
         first = recommend_module.recommend_skills("risky refactor", limit=2)
         recommend_module._recommend_skills_cached.cache_clear()
         second = recommend_module.recommend_skills("risky refactor", limit=2)
-        cache_info = recommend_module._phrase_match.cache_info()
 
         self.assertEqual(first, second)
-        self.assertGreater(cache_info.misses, 0)
-        self.assertGreater(cache_info.hits, 0)
+        self.assertTrue(recommend_module._phrase_match("risky refactor", "risky refactor planning"))
+        self.assertTrue(recommend_module._phrase_match("risky refactor planning", "risky refactor"))
+        self.assertFalse(recommend_module._phrase_match("payment failures", "risky refactor"))
 
     def test_catalog_question_caches_repeated_search_and_token_checks(self) -> None:
         catalog_questions_module.is_skill_catalog_question.cache_clear()


### PR DESCRIPTION
## Feature Report

### What Changed

- Removed the low-level LRU cache from recommendation phrase matching.
- Replaced the cache-hit efficiency assertion with a contract test that proves recommendation scoring stays stable after forced recomputation.
- Kept the higher-level recommendation ranking cache intact, so repeated full recommendation requests are still cached at the public boundary.

### Why This Exists

- Recent performance work already caches complete recommendation rankings independently of `--limit`.
- The remaining `_phrase_match` cache sat inside the per-definition scoring hot path and mostly saw unique chat-style query/value pairs.
- For those varied wrapper messages, the LRU bookkeeping cost is higher than the direct substring comparison it wraps.

### User / Operator Impact

- Hermes-facing chat routing keeps the same recommendation behavior and evidence boundaries.
- Varied natural-language routing workloads avoid unnecessary cache overhead.
- Operators still get deterministic routing, UX quality, and precision gate coverage before this change is claimed as safe.

### How It Works

- `recommend_skills()` still delegates to `_recommend_skills_cached()` and slices the cached full ranking by requested limit.
- `_phrase_match()` is now a direct boolean helper for the tiny substring check used during score calculation.
- The updated efficiency test clears the higher-level recommendation cache, recomputes the same query, and verifies the recommendation output and phrase semantics remain unchanged.

### Files And Contracts Touched

- `src/routing/recommend.py`: removes the low-level `_phrase_match` LRU wrapper.
- `tests/test_efficiency.py`: replaces the cache-specific assertion with scoring and phrase-match semantic coverage.
- No CLI schema, wrapper contract, runtime artifact, docs, generated skill, or public command output changed.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_chat_router.py tests/test_efficiency.py tests/test_wrapper_contract.py -v` — 199 tests passed.
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests` — 967 tests passed.
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli harness validate`
- [ ] `python3 -m omh.cli release checklist --json` — not run; no release/package surface changed.
- [ ] `python3 -m omh.cli release hermes-smoke` — not run; no live Hermes install surface changed.
- [ ] `omh --help` — not run; no command help surface changed.
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` — not run; no install/setup surface changed.
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable.
- [x] Relevant dry-run or smoke command: `uv run python -m omh.cli demo hermes-ux-quality --json` — score 100, 5/5 gates passed.
- [x] Relevant dry-run or smoke command: `uv run python -m omh.cli demo routing-precision --summary` — 8/8 negative controls and 13/13 interventions passed.
- [x] Performance microbench: 30,000 unique chat-style phrase pairs produced the same result with direct matching and local LRU wrapping; direct `0.002382s`, local LRU `0.005702s`.
- [x] `git diff --check`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; this is deterministic local routing internals only and does not change live rendering.

## Risk

- Risk is narrow: this removes an implementation cache around a pure substring helper.
- Repeated full recommendation calls still use the public ranking cache, so the removed cache only affects low-level per-definition checks.
- The main risk would be an untested dependency on `_phrase_match.cache_info()` or `.cache_clear()`, which was checked and removed from tests.

## Compatibility / Rollout

- Backward compatible for users, wrappers, and CLI callers.
- No schema or output contract changes.
- No migration needed.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`): local/runtime performance cleanup only.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed: no new runtime/native claims.
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap: live Hermes/TUI not observed because the change is local deterministic routing internals.

## Follow-Up

- Continue profiling chat router workloads at the public route boundary before adding any further caches.
