### PR TITLE
Stream route plan recommendation signatures

### DIFF
--- a/src/routing/route_plan.py
+++ b/src/routing/route_plan.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Iterator
 from dataclasses import dataclass
 from functools import lru_cache
 
@@ -360,19 +361,17 @@ def compact_workflow_route_plan(value: object) -> dict[str, object] | None:
     }
 
 
-def _recommendation_list(recommendations: object) -> list[dict[str, object]]:
+def _iter_recommendation_dicts(recommendations: object) -> Iterator[dict[str, object]]:
     if not isinstance(recommendations, (list, tuple)):
-        return []
-    items: list[dict[str, object]] = []
+        return
     for item in recommendations:
         if isinstance(item, dict):
-            items.append(dict(item))
-    return items
+            yield item
 
 
 def _recommendation_signature(recommendations: object) -> tuple[tuple[str, int, str, tuple[str, ...]], ...]:
     signature: list[tuple[str, int, str, tuple[str, ...]]] = []
-    for item in _recommendation_list(recommendations):
+    for item in _iter_recommendation_dicts(recommendations):
         skill = str(item.get("skill", ""))
         if not skill:
             continue

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -1179,6 +1179,22 @@ class EfficiencyContractTests(unittest.TestCase):
         self.assertEqual(definition_names_cache.misses, 1)
         self.assertGreaterEqual(definition_names_cache.hits, 0)
 
+    def test_workflow_route_plan_signature_reads_recommendation_dicts(self) -> None:
+        recommendations = (
+            {"skill": "ralplan", "score": 10, "confidence": "high", "matched": ["risk", "plan"]},
+            "ignored",
+            {"skill": "", "score": 9, "confidence": "high", "matched": ["ignored"]},
+            {"skill": "code-review", "score": 7, "confidence": "medium", "matched": ("review",)},
+        )
+
+        self.assertEqual(
+            route_plan_module._recommendation_signature(recommendations),
+            (
+                ("ralplan", 10, "high", ("risk", "plan")),
+                ("code-review", 7, "medium", ()),
+            ),
+        )
+
     def test_catalog_capability_summary_cache_is_reused_without_payload_poisoning(self) -> None:
         contract_module._catalog_capability_summary_cached.cache_clear()
 


### PR DESCRIPTION
## Feature Report

### What Changed

- Replaced route-plan recommendation signature construction with a streaming read-only iterator.
- Removed the temporary copied recommendation list used only to build the cache signature.
- Added a focused efficiency contract test for recommendation signature semantics across dict, ignored, empty-skill, list-backed matched, and tuple-backed matched inputs.

### Why This Exists

- `workflow_route_plan/v1` is built during Hermes-facing chat routing, so small per-call costs show up in natural-language wrapper workloads.
- The signature builder only reads recommendation dictionaries, but it previously copied every recommendation dictionary before reading it.
- Public mutation safety is already handled at the cached payload clone/public projection boundaries; this private signature path does not need a copy.

### User / Operator Impact

- Hermes-facing route-plan guidance keeps the same shape and evidence boundaries.
- Varied chat routing avoids avoidable recommendation payload copies while preparing route-plan metadata.
- Operators still get the same deterministic route-plan, wrapper-card, routing precision, and UX quality checks.

### How It Works

- `src/routing/route_plan.py` now uses `_iter_recommendation_dicts()` to stream only dict items from list/tuple recommendations.
- `_recommendation_signature()` reads the streamed dicts directly and preserves the existing signature tuple shape.
- The new test locks the expected behavior: non-dicts are ignored, empty skills are skipped, list-backed `matched` values are included, and non-list `matched` values stay excluded as before.

### Files And Contracts Touched

- `src/routing/route_plan.py`: private helper refactor for signature construction.
- `tests/test_efficiency.py`: route-plan signature semantic coverage.
- No CLI command, wrapper schema, runtime artifact, generated skill, docs output, or public `workflow_route_plan/v1` contract changed.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_chat_router.py tests/test_efficiency.py tests/test_wrapper_contract.py -v` — 200 tests passed.
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests` — 968 tests passed.
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli harness validate`
- [ ] `python3 -m omh.cli release checklist --json` — not run; no release/package surface changed.
- [ ] `python3 -m omh.cli release hermes-smoke` — not run; no live Hermes install surface changed.
- [ ] `omh --help` — not run; no command help surface changed.
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` — not run; no install/setup surface changed.
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable.
- [x] Relevant dry-run or smoke command: `uv run python -m omh.cli demo hermes-ux-quality --json` — score 100, 5/5 gates passed.
- [x] Relevant dry-run or smoke command: `uv run python -m omh.cli demo routing-precision --summary` — 8/8 negative controls and 13/13 interventions passed.
- [x] Performance microbench: 8-run average for 20,000 route-plan signature builds per run produced the same signature; old copy path `0.092025s`, streaming path `0.077185s`.
- [x] `git diff --check`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; this is deterministic local route-plan internals only and does not change live rendering.

## Risk

- Risk is narrow: the change is private to route-plan cache signature construction.
- The main compatibility risk would be preserving non-list `matched` handling; the new test locks the existing behavior by keeping tuple-backed `matched` out of the signature.
- Mutation safety remains at public clone/projection boundaries, not inside the read-only signature builder.

## Compatibility / Rollout

- Backward compatible for users, wrappers, skills, and CLI callers.
- No schema changes and no migration needed.
- This can roll out as a local routing performance cleanup.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`): local deterministic routing performance cleanup only.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed: no new runtime/native claims.
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap: live Hermes/TUI not observed because the change is local deterministic route-plan internals.

## Follow-Up

- Continue profiling public route workloads before changing cache boundaries again.
