### PR TITLE
Tighten route plan delivery signals

### DIFF
--- a/src/routing/route_plan.py
+++ b/src/routing/route_plan.py
@@ -241,6 +241,12 @@ def _build_workflow_route_plan_cached(
         score = _int_value(item.get("score", 0))
         if score < 4 and stage not in signal_stages:
             continue
+        if (
+            stage == "deliver"
+            and stage not in signal_stages
+            and _SKILL_STAGE.get(selected_skill) != "deliver"
+        ):
+            continue
         if stage == "learn" and stage not in signal_stages:
             continue
         step = _step_from_recommendation(stage, item)
@@ -463,12 +469,24 @@ def _stages_from_signals(normalized: str, tokens: set[str]) -> tuple[str, ...]:
     stages: list[str] = []
     for stage in _STAGE_ORDER:
         signal_options = _STAGE_SIGNAL_OPTIONS.get(stage, ())
-        if any(phrase in normalized for phrase, _is_token_candidate in signal_options):
+        if any(
+            _token_signal_matches(phrase, tokens)
+            for phrase, is_token_candidate in signal_options
+            if is_token_candidate
+        ):
             stages.append(stage)
             continue
-        if any(phrase in tokens for phrase, is_token_candidate in signal_options if is_token_candidate):
+        if any(phrase in normalized for phrase, is_token_candidate in signal_options if not is_token_candidate):
             stages.append(stage)
     return tuple(stages)
+
+
+def _token_signal_matches(phrase: str, tokens: set[str]) -> bool:
+    if phrase in tokens:
+        return True
+    if phrase.isascii() and len(phrase) <= 2:
+        return False
+    return any(token.startswith(phrase) for token in tokens)
 
 
 def _fallback_skill_for_stage(

--- a/tests/test_chat_router.py
+++ b/tests/test_chat_router.py
@@ -1726,6 +1726,16 @@ selected_workflow=ultraprocess
         self.assertIn("routing guidance only", route_plan["claim_boundary"])
         self.assertTrue(all(step["status"] == "prepared_not_observed" for step in route_plan["steps"]))
 
+    def test_route_plan_does_not_treat_prepare_as_pr_delivery_signal(self) -> None:
+        decision = route_chat_message("prepare source notes for a research brief", source="discord", limit=8)
+        public_payload = public_route_payload(decision)
+        route_plan = public_payload.get("workflow_route_plan")
+
+        self.assertEqual(decision["selected_skill"], "research-brief")
+        if route_plan is not None:
+            self.assertNotIn("deliver", route_plan["stages"])
+            self.assertNotIn("ultraprocess", [step["skill"] for step in route_plan["steps"]])
+
     def test_product_bug_route_plan_triages_before_coding_and_review(self) -> None:
         decision = route_chat_message(
             "결제 실패 이슈가 자주 나와. 재현 계획 세우고 codex로 고쳐서 리뷰까지 추적해줘",

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -1149,9 +1149,10 @@ class EfficiencyContractTests(unittest.TestCase):
         route_plan_module._build_workflow_route_plan_cached.cache_clear()
         route_plan_module._routable_definition_names.cache_clear()
 
-        recommendations = recommend_module.recommend_skills("risky refactor", limit=10)
+        message = "risky refactor with implementation and review"
+        recommendations = recommend_module.recommend_skills(message, limit=10)
         first = route_plan_module.build_workflow_route_plan(
-            "risky refactor",
+            message,
             recommendations,
             selected_skill="ralplan",
             action="dispatch",
@@ -1162,7 +1163,7 @@ class EfficiencyContractTests(unittest.TestCase):
         first["steps"][0]["matched"].append("mutated")
 
         second = route_plan_module.build_workflow_route_plan(
-            "risky refactor",
+            message,
             recommendations,
             selected_skill="ralplan",
             action="dispatch",


### PR DESCRIPTION
## Feature Report

### What Changed

- Tightened route-plan stage signal matching so short command-like tokens such as `pr`, `ci`, and `qa` require exact token matches.
- Preserved prefix matching for longer tokens and Korean/locale forms such as `codex로` and `고쳐서` so explicit delivery intent still produces a delivery stage.
- Prevented non-delivery workflows from adding a `deliver` step unless the message has an explicit delivery signal or the selected workflow is itself a delivery workflow.
- Added a regression test for the user-facing false-positive shape: `prepare source notes for a research brief` no longer becomes a delivery route-plan.

### Why This Exists

- The previous route-plan signal scan checked every signal as a substring before considering token boundaries.
- That meant words like `prepare` could satisfy the short `pr` delivery signal and pull `ultraprocess` into route plans that were only asking for research/source preparation.
- The router should help Hermes explain a real workflow sequence, not invent a coding/delivery stage from an incidental substring.

### User / Operator Impact

- Research or meeting preparation prompts stop showing unnecessary coding/delivery route-plan steps.
- Explicit coding requests still keep the intended staged plan, including Korean phrasing such as `codex로 고쳐서 리뷰`.
- Hermes-facing route plans remain conservative: delivery stages appear only when delivery is actually selected or signaled.

### How It Works

- `_stages_from_signals()` now checks token candidates through `_token_signal_matches()` instead of blanket substring matching.
- `_token_signal_matches()` treats short ASCII signals exactly, while allowing longer or localized tokens to match common suffix/prefix forms.
- `_build_workflow_route_plan_cached()` now skips delivery-stage recommendations for non-delivery selected workflows unless delivery is present in the route-plan signal set.

### Files And Contracts Touched

- `src/routing/route_plan.py`: route-plan stage signal matching and delivery-stage guard.
- `tests/test_chat_router.py`: public route-plan regression for `prepare` vs `pr` delivery overmatch.
- `tests/test_efficiency.py`: cache poisoning test updated to use an explicit multi-stage route-plan input.
- No CLI command, wrapper schema, runtime artifact, generated skill, or docs output changed.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_chat_router.py tests/test_efficiency.py tests/test_wrapper_contract.py -v` — 201 tests passed.
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests` — 969 tests passed.
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli harness validate`
- [ ] `python3 -m omh.cli release checklist --json` — not run; no release/package surface changed.
- [ ] `python3 -m omh.cli release hermes-smoke` — not run; no live Hermes install surface changed.
- [ ] `omh --help` — not run; no command help surface changed.
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` — not run; no install/setup surface changed.
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable.
- [x] Relevant dry-run or smoke command: `uv run python -m omh.cli demo hermes-ux-quality --json` — score 100, 5/5 gates passed.
- [x] Relevant dry-run or smoke command: `uv run python -m omh.cli demo routing-precision --summary` — 8/8 negative controls and 13/13 interventions passed.
- [x] Manual deterministic route examples:
  - `prepare source notes for a research brief` selected `research-brief` and produced no delivery route-plan stage.
  - `결제 실패 이슈가 자주 나와. 재현 계획 세우고 codex로 고쳐서 리뷰까지 추적해줘` kept `triage -> plan -> deliver -> review`.
- [x] `git diff --check`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; this is deterministic local route-plan routing logic only and does not change live rendering.

## Risk

- Risk is narrow: only route-plan stage projection changes, not selected workflow routing or recommendation ranking.
- The main behavioral change is intentional: delivery stages are no longer inferred from incidental `pr` substrings in words like `prepare`.
- Locale suffix/prefix cases remain covered by tests and example evidence.

## Compatibility / Rollout

- Backward compatible for wrappers and CLI callers.
- `workflow_route_plan/v1` shape is unchanged.
- Route plans become more conservative about delivery stages, which aligns with prepared-vs-observed boundaries.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`): local deterministic route-plan precision fix.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed: no new runtime/native claims.
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap: live Hermes/TUI not observed because the change is local deterministic route-plan projection.

## Follow-Up

- Continue collecting real chat misroute examples and add route-plan regression cases when users see confusing stage cards.
