### PR TITLE
Fast path plain direct-answer routing

### DIFF
--- a/src/routing/chat.py
+++ b/src/routing/chat.py
@@ -442,6 +442,14 @@ def _route_chat_message_cached(
     )
     if fast_catalog_decision.decision is not None:
         return fast_catalog_decision.decision.to_dict()
+    fast_direct_answer_decision = _direct_answer_fast_path_decision(
+        message,
+        routing_message=routing_message,
+        source=source,
+        min_confidence=min_confidence,
+    )
+    if fast_direct_answer_decision is not None:
+        return fast_direct_answer_decision.to_dict()
 
     definitions = routable_definitions()
     full_recommendations = recommend_skills(routing_message, limit=len(definitions))
@@ -784,6 +792,62 @@ def _catalog_fast_path_decision(
 def _direct_picker_alias(message: str) -> bool:
     compact = message.strip().lower().strip(" \t\r\n.!?,;:")
     return compact in _DIRECT_PICKER_ALIASES
+
+
+def _direct_answer_fast_path_decision(
+    message: str,
+    *,
+    routing_message: str,
+    source: str,
+    min_confidence: str,
+) -> ChatRouteDecision | None:
+    if _has_explicit_invocation_prefix(routing_message):
+        return None
+    if not _is_fast_plain_direct_answer_question(routing_message):
+        return None
+    selected_harness = primary_harness_for_skill(_ROUTER_SKILL)
+    reason = DIRECT_ANSWER_REASON
+    return ChatRouteDecision(
+        schema_version=1,
+        source=source,
+        action="fallback",
+        selected_skill=_ROUTER_SKILL,
+        selected_harness=selected_harness,
+        candidate_skill=_ROUTER_SKILL,
+        candidate_harness=selected_harness,
+        confidence="low",
+        score=0,
+        threshold=min_confidence,
+        explicit=False,
+        ambiguous=False,
+        reason=reason,
+        clarification=_clarification("fallback", _ROUTER_SKILL, "low", min_confidence, reason),
+        routing_prompt=_routing_prompt("fallback", _ROUTER_SKILL, _ROUTER_SKILL, reason, message),
+        task_card=None,
+        workflow_route_plan=None,
+        learning_candidate_card=None,
+        recommendations=(_router_direct_answer_recommendation(message),),
+    )
+
+
+def _router_direct_answer_recommendation(query: str) -> dict[str, object]:
+    definition = _router_skill_definition()
+    return {
+        "skill": definition.name,
+        "description": definition.description,
+        "category": definition.category,
+        "phase": definition.phase,
+        "hermes_role": definition.hermes_role,
+        "handoff_policy": definition.handoff_policy,
+        "score": 0,
+        "confidence": "low",
+        "matched": ["direct_answer_fast_path"],
+        "why": DIRECT_ANSWER_REASON,
+        "next_action": "answer_directly",
+        "evidence_boundary": "No OMH workflow, picker, handoff, execution, or file inspection has started.",
+        "wrapper_guidance": "Answer in the current chat; do not open an OMH workflow, picker, or coding handoff.",
+        "suggested_prompt": query,
+    }
 
 
 def _generic_omh_catalog_question(message: str) -> bool:
@@ -1183,6 +1247,31 @@ def _is_plain_direct_answer_question(message: str, *, candidate_score: int) -> b
     if any(direct_text.startswith(starter) for starter in _DIRECT_ANSWER_STARTERS):
         return True
     return any(keyword in direct_text for keyword in _DIRECT_ANSWER_KEYWORDS) and "?" in text
+
+
+def _is_fast_plain_direct_answer_question(message: str) -> bool:
+    text = message.strip().lower()
+    if not text:
+        return False
+    direct_text = _strip_direct_answer_soft_prefix(text)
+    if _is_plain_setup_how_to_question(direct_text):
+        return True
+    if _contains_direct_answer_blocker(text) or _contains_direct_answer_blocker(direct_text):
+        return False
+    if any(direct_text.startswith(starter) for starter in _DIRECT_ANSWER_TEXT_TRANSFORM_STARTERS):
+        return True
+    if not any(
+        direct_text.startswith(starter)
+        for starter in (
+            "please explain",
+            "explain ",
+            "describe ",
+            "tell me ",
+        )
+    ):
+        return False
+    keywords = _DIRECT_ANSWER_KEYWORDS + _DIRECT_ANSWER_SETUP_KEYWORDS
+    return any(keyword in direct_text for keyword in keywords)
 
 
 def _strip_direct_answer_soft_prefix(text: str) -> str:

--- a/tests/test_chat_router.py
+++ b/tests/test_chat_router.py
@@ -230,6 +230,31 @@ class ChatRouterTests(unittest.TestCase):
         self.assertEqual(paper["action"], "dispatch")
         self.assertEqual(paper["selected_skill"], "paper-learning")
 
+    def test_plain_direct_answer_uses_fast_path_without_full_scoring(self) -> None:
+        chat_router_impl._route_chat_message_cached.cache_clear()
+        chat_router_impl._public_chat_route_payload_cached.cache_clear()
+
+        for message in ("just explain Python virtualenv", "how do I create a virtualenv in Python?"):
+            with self.subTest(message=message), mock.patch.object(
+                chat_router_impl,
+                "recommend_skills",
+                side_effect=AssertionError("plain direct answers should skip full recommendation scoring"),
+            ), mock.patch.object(
+                chat_router_impl,
+                "build_workflow_route_plan",
+                side_effect=AssertionError("plain direct answers should not build workflow route plans"),
+            ):
+                decision = route_chat_message(message, source="discord")
+
+            self.assertEqual(decision["action"], "fallback")
+            self.assertEqual(decision["selected_skill"], "oh-my-hermes")
+            self.assertEqual(decision["confidence"], "low")
+            self.assertIn("answer directly", decision["reason"])
+            self.assertEqual(decision["recommendations"][0]["matched"], ["direct_answer_fast_path"])
+            public = public_route_payload(decision)
+            self.assertEqual(public["route_explanation"]["next_action"], "answer_directly")
+            self.assertNotIn("workflow_route_plan", public)
+
     def test_below_threshold_chat_clarifies_before_dispatch(self) -> None:
         decision = route_chat_message("architecture", min_confidence="high")
 


### PR DESCRIPTION
## Summary
- Add a conservative fast path for obvious plain direct-answer requests before full workflow recommendation scoring.
- Skip `recommend_skills()` and workflow route-plan generation for safe cases such as `just explain Python virtualenv` and `how do I create a virtualenv in Python?`.
- Keep status, coding handoff, paper, OMH catalog, safe feature, and other workflow-shaped requests on the normal scored routing path.

## Why
OMH should feel chat-first. When a user asks a plain help question, Hermes should answer directly instead of spending work on workflow recommendation and route-plan construction that will be discarded anyway.

The previous routing behavior was correct after PR #410, but it still paid the full scoring cost for many direct-answer turns. This change makes the happy path lighter without broadening the direct-answer exception.

## What Users Can Do Now
- Ask plain help/setup questions and get the same direct-answer card with less router work behind it.
- Keep workflow routing for real OMH requests such as coding handoff status, safe feature planning, paper learning, and OMH workflow discovery.
- Rely on tests that fail if obvious direct-answer prompts accidentally start doing full recommendation scoring again.

## Implementation Notes
- Added `_direct_answer_fast_path_decision()` in `src/routing/chat.py` after catalog fast paths and before full recommendation scoring.
- Added `_is_fast_plain_direct_answer_question()` with deliberately narrow conditions:
  - setup how-to questions such as virtualenv/PATH/pipx,
  - paragraph/sentence transform requests,
  - explain/describe/tell-me prompts only when they contain existing direct-help keywords and no workflow blockers.
- Added a router recommendation marker, `direct_answer_fast_path`, so wrapper/public payloads remain inspectable.
- Added a regression test that patches `recommend_skills()` and `build_workflow_route_plan()` to fail if plain direct answers leave the fast path.

## Verification
- `PYTHONPATH=tests uv run python -m unittest tests/test_chat_router.py tests/test_efficiency.py tests/test_routing_precision.py tests/test_wrapper_contract.py -v`
- `PYTHONPATH=tests uv run python -m unittest discover -s tests`
- `uv run python -m compileall -q src tests`
- `uv run python -m omh.cli docs workflows --check`
- `uv run python -m omh.cli harness validate`
- `uv run python -m omh.cli demo routing-precision --summary`
- `uv run python -m omh.cli demo hermes-ux-quality --json`
- `git diff --check`

Observed key results:
- Focused router/efficiency/wrapper tests: 205 tests OK.
- Full unittest: 971 tests OK.
- Routing precision: 9/9 negative-control cases, 13/13 interventions, overroutes 0, catalog pickers 0, generic ack 0, missed interventions 0.
- Hermes UX quality: 100/100.

## Risks And Boundaries
- This is deterministic local routing and performance-path evidence only; it does not prove live Hermes rendering, platform delivery, source retrieval, executor dispatch, implementation, review, CI, merge, or plugin-load evidence.
- The fast path intentionally avoids broad `what`/status questions because those can be real OMH status or coding handoff requests.
