### PR TITLE
Fast path plain file lookup routing

### DIFF
--- a/src/routing/chat.py
+++ b/src/routing/chat.py
@@ -442,6 +442,14 @@ def _route_chat_message_cached(
     )
     if fast_catalog_decision.decision is not None:
         return fast_catalog_decision.decision.to_dict()
+    fast_file_lookup_decision = _file_lookup_fast_path_decision(
+        message,
+        routing_message=routing_message,
+        source=source,
+        min_confidence=min_confidence,
+    )
+    if fast_file_lookup_decision is not None:
+        return fast_file_lookup_decision.to_dict()
     fast_direct_answer_decision = _direct_answer_fast_path_decision(
         message,
         routing_message=routing_message,
@@ -792,6 +800,64 @@ def _catalog_fast_path_decision(
 def _direct_picker_alias(message: str) -> bool:
     compact = message.strip().lower().strip(" \t\r\n.!?,;:")
     return compact in _DIRECT_PICKER_ALIASES
+
+
+def _file_lookup_fast_path_decision(
+    message: str,
+    *,
+    routing_message: str,
+    source: str,
+    min_confidence: str,
+) -> ChatRouteDecision | None:
+    if _has_explicit_invocation_prefix(routing_message):
+        return None
+    if explicit_skill_invocation(routing_message):
+        return None
+    if not is_file_or_text_lookup_question(routing_message):
+        return None
+    selected_harness = primary_harness_for_skill(_ROUTER_SKILL)
+    reason = FILE_LOOKUP_REASON
+    return ChatRouteDecision(
+        schema_version=1,
+        source=source,
+        action="fallback",
+        selected_skill=_ROUTER_SKILL,
+        selected_harness=selected_harness,
+        candidate_skill=_ROUTER_SKILL,
+        candidate_harness=selected_harness,
+        confidence="low",
+        score=0,
+        threshold=min_confidence,
+        explicit=False,
+        ambiguous=False,
+        reason=reason,
+        clarification=_clarification("fallback", _ROUTER_SKILL, "low", min_confidence, reason),
+        routing_prompt=_routing_prompt("fallback", _ROUTER_SKILL, _ROUTER_SKILL, reason, message),
+        task_card=None,
+        workflow_route_plan=None,
+        learning_candidate_card=None,
+        recommendations=(_router_file_lookup_recommendation(message),),
+    )
+
+
+def _router_file_lookup_recommendation(query: str) -> dict[str, object]:
+    definition = _router_skill_definition()
+    return {
+        "skill": definition.name,
+        "description": definition.description,
+        "category": definition.category,
+        "phase": definition.phase,
+        "hermes_role": definition.hermes_role,
+        "handoff_policy": definition.handoff_policy,
+        "score": 0,
+        "confidence": "low",
+        "matched": ["file_lookup_fast_path"],
+        "why": FILE_LOOKUP_REASON,
+        "next_action": "answer_file_lookup",
+        "evidence_boundary": "No OMH workflow, execution, or file inspection has started.",
+        "wrapper_guidance": "Answer as a file or text lookup; ask for the missing target if needed.",
+        "suggested_prompt": query,
+    }
 
 
 def _direct_answer_fast_path_decision(

--- a/tests/test_chat_router.py
+++ b/tests/test_chat_router.py
@@ -1645,6 +1645,31 @@ selected_workflow=ultraprocess
                 self.assertIn("file inspection", explanation["not_evidence_yet"])
                 self.assertNotIn("review", explanation["not_evidence_yet"])
 
+    def test_file_lookup_uses_fast_path_without_full_scoring(self) -> None:
+        chat_router_impl._route_chat_message_cached.cache_clear()
+        chat_router_impl._public_chat_route_payload_cached.cache_clear()
+
+        for message in ("search docs/WORKFLOWS.md for loop", "README 파일 찾아줘"):
+            with self.subTest(message=message), mock.patch.object(
+                chat_router_impl,
+                "recommend_skills",
+                side_effect=AssertionError("file lookup should skip full recommendation scoring"),
+            ), mock.patch.object(
+                chat_router_impl,
+                "build_workflow_route_plan",
+                side_effect=AssertionError("file lookup should not build workflow route plans"),
+            ):
+                decision = route_chat_message(message, source="discord")
+
+            self.assertEqual(decision["action"], "fallback")
+            self.assertEqual(decision["selected_skill"], "oh-my-hermes")
+            self.assertEqual(decision["confidence"], "low")
+            self.assertIn("File or text lookup", decision["reason"])
+            self.assertEqual(decision["recommendations"][0]["matched"], ["file_lookup_fast_path"])
+            public_payload = public_route_payload(decision)
+            self.assertEqual(public_payload["route_explanation"]["next_action"], "answer_file_lookup")
+            self.assertNotIn("workflow_route_plan", public_payload)
+
     def test_korean_file_lookup_does_not_steal_readme_edit_requests(self) -> None:
         lookup = route_chat_message("README 파일 찾아줘", source="discord")
         edit = route_chat_message("README 제목 수정해줘", source="discord")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4456,7 +4456,10 @@ class CliTests(unittest.TestCase):
         self.assertNotIn("target is clear", explanation["recommended_reply"])
         self.assertIn("file inspection", explanation["not_evidence_yet"])
         self.assertNotIn("review", explanation["not_evidence_yet"])
-        self.assertNotEqual(route["recommendations"][0]["skill"], route["selected_skill"])
+        self.assertEqual(route["recommendations"][0]["skill"], route["selected_skill"])
+        self.assertEqual(route["recommendations"][0]["matched"], ["file_lookup_fast_path"])
+        self.assertEqual(route["recommendations"][0]["next_action"], "answer_file_lookup")
+        self.assertNotIn("workflow_route_plan", route)
 
     def test_chat_interact_file_lookup_fallback_uses_lookup_card(self) -> None:
         status, stdout, stderr = run_cli(["chat", "interact", "--source", "discord", "README", "파일", "찾아줘"])


### PR DESCRIPTION
## Summary

Adds a conservative chat-router fast path for obvious file and text lookup requests before OMH runs full workflow recommendation scoring or route-plan generation.

## Why

Plain requests such as `README 파일 찾아줘` or `search docs/WORKFLOWS.md for loop` should feel like normal Hermes lookup work, not like a workflow-routing problem. Previously those requests still passed through the heavier recommendation path, which was slower and made the boundary harder to reason about.

## What Changed

- Adds a `file_lookup_fast_path` decision before direct-answer fallback and full recommendation scoring.
- Returns a low-confidence `oh-my-hermes` fallback with `next_action: answer_file_lookup` and no workflow route plan.
- Preserves explicit workflow invocation precedence, so prompts like `Use OMH ultraprocess for: improve README and open PR` still dispatch to `ultraprocess` even when they mention files.
- Updates CLI/router tests to lock the new fast-path marker and public payload contract.

## User Impact

Hermes can answer obvious file/text lookup prompts more directly while OMH-shaped requests still route to the right workflow. This improves perceived responsiveness without weakening prepared-vs-observed boundaries.

## Verification

- `PYTHONPATH=tests uv run python -m unittest tests/test_chat_router.py tests/test_efficiency.py tests/test_routing_precision.py tests/test_wrapper_contract.py`
- `PYTHONPATH=tests uv run python -m unittest tests.test_cli.CliTests.test_chat_route_file_lookup_does_not_emit_workflow_clarification tests.test_chat_router.ChatRouterTests.test_file_lookup_uses_fast_path_without_full_scoring`
- `PYTHONPATH=tests uv run python -m unittest discover -s tests`
- `uv run python -m compileall -q src tests`
- `uv run python -m omh.cli docs workflows --check`
- `uv run python -m omh.cli harness validate`
- `uv run python -m omh.cli demo routing-precision --summary`
- `uv run python -m omh.cli demo hermes-ux-quality --json`
- `git diff --check`

## Risks And Boundaries

- This proves deterministic local routing behavior only.
- It does not prove live Hermes chat rendering, platform delivery, file inspection, executor dispatch, implementation, review, CI, merge, or plugin-load evidence.
- The fast path intentionally stays behind explicit workflow invocation and source acquisition guards.
