### PR TITLE
Report local artifact store in product readiness

### DIFF
--- a/src/commands/release.py
+++ b/src/commands/release.py
@@ -123,7 +123,11 @@ def cmd_release_skill_content_smoke(args: argparse.Namespace) -> int:
 
 def cmd_release_product_readiness(args: argparse.Namespace) -> int:
     try:
-        payload = product_readiness_report(version=args.version or __version__, omh_command=args.omh_command)
+        payload = product_readiness_report(
+            version=args.version or __version__,
+            omh_command=args.omh_command,
+            paths=_paths(args),
+        )
     except ValueError as exc:
         raise OmhError(str(exc)) from exc
     if _wants_json(args):

--- a/src/maintenance/release.py
+++ b/src/maintenance/release.py
@@ -538,13 +538,16 @@ def product_readiness_report(
     *,
     version: str = __version__,
     omh_command: str = "omh",
+    paths: OmhPaths | None = None,
 ) -> dict[str, object]:
     release_version = _normalize_release_version(version)
+    resolved_paths = paths or OmhPaths(omh_home=Path("~/.omh").expanduser(), hermes_home=Path("~/.hermes").expanduser())
     evidence = _build_release_quality_evidence(release_version=release_version, omh_command=omh_command)
     return _product_readiness_report_from_evidence(
         release_version=release_version,
         omh_command=omh_command,
         evidence=evidence,
+        paths=resolved_paths,
     )
 
 
@@ -585,6 +588,7 @@ def _product_readiness_report_from_evidence(
     release_version: str,
     omh_command: str,
     evidence: ReleaseQualityEvidence,
+    paths: OmhPaths,
 ) -> dict[str, object]:
     omh_display = _shell_word(omh_command)
     skill_content = evidence.skill_content
@@ -596,6 +600,10 @@ def _product_readiness_report_from_evidence(
     routing_precision = evidence.routing_precision
     hermes_ux = evidence.hermes_ux
     checklist = evidence.checklist
+    use_case_readiness_payload = use_case_readiness(paths)
+    use_case_readiness_failures = _blocking_gate_messages(use_case_readiness_payload)
+    use_case_readiness_warnings = _warning_gate_messages(use_case_readiness_payload)
+    local_store_status = _release_local_store_status(use_case_readiness_payload)
 
     checklist_items = checklist.get("items", [])
     checklist_ids = {
@@ -664,17 +672,18 @@ def _product_readiness_report_from_evidence(
         _product_readiness_gate(
             "use_cases",
             "G1-G10 application use cases",
-            "passed" if skill_content.get("use_case_readiness_blocking_failures") == 0 else "failed",
+            "passed" if use_case_readiness_payload.get("blocking_failures") == 0 else "failed",
             True,
             (
-                f"score {skill_content.get('use_case_readiness_score')}/100; "
-                f"blocking {skill_content.get('use_case_readiness_blocking_failures')}; "
-                f"warnings {skill_content.get('use_case_readiness_warning_count')}"
+                f"score {use_case_readiness_payload.get('score')}/100; "
+                f"blocking {use_case_readiness_payload.get('blocking_failures')}; "
+                f"warnings {use_case_readiness_payload.get('warning_count')}; "
+                f"local artifact store {local_store_status}"
             ),
             "omh cases readiness --json",
-            _string_list(skill_content.get("use_case_readiness_failures")),
-            _string_list(skill_content.get("use_case_readiness_warnings")),
-            str(skill_content.get("use_case_readiness_boundary", "")),
+            use_case_readiness_failures,
+            use_case_readiness_warnings,
+            str(use_case_readiness_payload.get("boundary", "")),
         ),
         _product_readiness_gate(
             "grounded_score",
@@ -796,7 +805,12 @@ def _product_readiness_report_from_evidence(
         ),
     ]
     blocking_failures = [gate for gate in gates if gate["blocking"] and gate["status"] != "passed"]
-    warning_count = sum(len(gate.get("warnings", [])) for gate in gates)
+    warnings = [
+        str(warning)
+        for gate in gates
+        for warning in gate.get("warnings", [])
+        if warning
+    ]
     return {
         "schema_version": PRODUCT_READINESS_SCHEMA,
         "status": "ready" if not blocking_failures else "needs_attention",
@@ -805,9 +819,11 @@ def _product_readiness_report_from_evidence(
         "observed": True,
         "version": release_version,
         "blocking_failures": len(blocking_failures),
-        "warning_count": warning_count,
+        "warning_count": len(warnings),
+        "warnings": warnings,
+        "local_artifact_store": local_store_status,
         "gates": gates,
-        "next_actions": _product_readiness_next_actions(blocking_failures, warning_count),
+        "next_actions": _product_readiness_next_actions(blocking_failures, warnings),
         "boundary": (
             "Product readiness proves deterministic local OMH package and product contracts only. "
             "It does not run the release checklist, mutate Hermes, prove live Hermes chat selection, "
@@ -1605,7 +1621,7 @@ def _string_list(value: object) -> list[str]:
     return [str(item) for item in value]
 
 
-def _product_readiness_next_actions(blocking_failures: Sequence[Mapping[str, object]], warning_count: int) -> list[str]:
+def _product_readiness_next_actions(blocking_failures: Sequence[Mapping[str, object]], warnings: Sequence[str]) -> list[str]:
     if blocking_failures:
         return [
             "Fix blocking product readiness gates, then rerun `omh release product-readiness --json`.",
@@ -1617,7 +1633,9 @@ def _product_readiness_next_actions(blocking_failures: Sequence[Mapping[str, obj
         "Run one live Hermes tap smoke from the target profile before treating Hermes runtime visibility as observed.",
         "Use `omh release product-readiness --json` when a wrapper or release note needs the full machine-readable payload.",
     ]
-    if warning_count:
+    if any(warning.startswith("local_artifact_store:") for warning in warnings):
+        actions.insert(0, "Optional: write local use-case artifacts with `omh cases artifact --all --write --json`.")
+    elif warnings:
         actions.insert(0, "Review non-blocking warnings; they should be acknowledged but do not block local product readiness.")
     return actions
 
@@ -1637,6 +1655,7 @@ def release_evidence_bundle(
         release_version=release_version,
         omh_command=omh_command,
         evidence=quality_evidence,
+        paths=resolved_paths,
     )
     skill_content = quality_evidence.skill_content
     use_cases = use_case_readiness(resolved_paths)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2012,75 +2012,86 @@ class CliTests(unittest.TestCase):
         )
 
     def test_release_product_readiness_cli_summarizes_product_story(self) -> None:
-        status, stdout, stderr = run_cli(
-            ["release", "product-readiness", "--version", "v1.0.1", "--omh-command", "/tmp/omh"],
-            output_json=False,
-        )
+        with TemporaryDirectory() as tmp:
+            base = ["--omh-home", str(Path(tmp) / ".omh"), "--hermes-home", str(Path(tmp) / ".hermes")]
+            status, stdout, stderr = run_cli(
+                base + ["release", "product-readiness", "--version", "v1.0.1", "--omh-command", "/tmp/omh"],
+                output_json=False,
+            )
 
-        self.assertEqual(status, 0, stderr)
-        self.assertEqual(stderr, "")
-        self.assertIn("OMH product readiness for 1.0.1", stdout)
-        self.assertIn("Status: ready", stdout)
-        self.assertIn("Score: 100/100", stdout)
-        self.assertIn("skill_content: passed", stdout)
-        self.assertIn("use_cases: passed", stdout)
-        self.assertIn("grounded_score: passed", stdout)
-        self.assertIn("chat_card_coverage: passed", stdout)
-        self.assertIn("route_hint_alignment: passed", stdout)
-        self.assertIn("context_brief_coverage: passed", stdout)
-        self.assertIn("routing_precision: passed", stdout)
-        self.assertIn("hermes_ux_quality: passed", stdout)
-        self.assertIn("parity_contracts: passed", stdout)
-        self.assertIn("release_checklist: passed", stdout)
-        self.assertIn("Boundary:", stdout)
-        with self.assertRaises(json.JSONDecodeError):
-            json.loads(stdout)
+            self.assertEqual(status, 0, stderr)
+            self.assertEqual(stderr, "")
+            self.assertIn("OMH product readiness for 1.0.1", stdout)
+            self.assertIn("Status: ready", stdout)
+            self.assertIn("Score: 100/100", stdout)
+            self.assertIn("Warnings: 1", stdout)
+            self.assertIn("use_cases: passed", stdout)
+            self.assertIn("local artifact store not_written", stdout)
+            self.assertIn("local_artifact_store: not_written", stdout)
+            self.assertIn("cases artifact --all --write", stdout)
+            self.assertIn("skill_content: passed", stdout)
+            self.assertIn("grounded_score: passed", stdout)
+            self.assertIn("chat_card_coverage: passed", stdout)
+            self.assertIn("route_hint_alignment: passed", stdout)
+            self.assertIn("context_brief_coverage: passed", stdout)
+            self.assertIn("routing_precision: passed", stdout)
+            self.assertIn("hermes_ux_quality: passed", stdout)
+            self.assertIn("parity_contracts: passed", stdout)
+            self.assertIn("release_checklist: passed", stdout)
+            self.assertIn("Boundary:", stdout)
+            with self.assertRaises(json.JSONDecodeError):
+                json.loads(stdout)
 
-        status, stdout, stderr = run_cli(
-            ["release", "product-readiness", "--version", "1.0.1", "--json"],
-            output_json=False,
-        )
+            status, stdout, stderr = run_cli(
+                base + ["release", "product-readiness", "--version", "1.0.1", "--json"],
+                output_json=False,
+            )
 
-        self.assertEqual(status, 0, stderr)
-        self.assertEqual(stderr, "")
-        payload = json.loads(stdout)
-        self.assertEqual(payload["schema_version"], "omh_product_readiness/v1")
-        self.assertEqual(payload["status"], "ready")
-        self.assertEqual(payload["score"], 100)
-        self.assertEqual(payload["blocking_failures"], 0)
-        gates = {gate["id"]: gate for gate in payload["gates"]}
-        self.assertEqual(
-            set(gates),
-            {
-                "skill_content",
-                "use_cases",
-                "grounded_score",
-                "chat_card_coverage",
-                "route_hint_alignment",
-                "context_brief_coverage",
-                "routing_precision",
-                "hermes_ux_quality",
-                "parity_contracts",
-                "release_checklist",
-            },
-        )
-        self.assertEqual(gates["grounded_score"]["status"], "passed")
-        self.assertIn("28/28 scenarios at 10/10", gates["grounded_score"]["summary"])
-        self.assertEqual(gates["chat_card_coverage"]["status"], "passed")
-        self.assertIn("generic ack 0", gates["chat_card_coverage"]["summary"])
-        self.assertEqual(gates["route_hint_alignment"]["status"], "passed")
-        self.assertIn("53/53 route hints aligned", gates["route_hint_alignment"]["summary"])
-        self.assertEqual(gates["context_brief_coverage"]["status"], "passed")
-        self.assertIn("8/8 context brief cases passing", gates["context_brief_coverage"]["summary"])
-        self.assertEqual(gates["routing_precision"]["status"], "passed")
-        self.assertIn("39/39 negative-control cases", gates["routing_precision"]["summary"])
-        self.assertIn("19/19 interventions", gates["routing_precision"]["summary"])
-        self.assertIn("overroutes 0", gates["routing_precision"]["summary"])
-        self.assertIn("missed interventions 0", gates["routing_precision"]["summary"])
-        self.assertEqual(gates["hermes_ux_quality"]["status"], "passed")
-        self.assertIn("5/5 UX gates passing", gates["hermes_ux_quality"]["summary"])
-        self.assertEqual(gates["parity_contracts"]["status"], "passed")
-        self.assertIn("not run the release checklist", payload["boundary"])
+            self.assertEqual(status, 0, stderr)
+            self.assertEqual(stderr, "")
+            payload = json.loads(stdout)
+            self.assertEqual(payload["schema_version"], "omh_product_readiness/v1")
+            self.assertEqual(payload["status"], "ready")
+            self.assertEqual(payload["score"], 100)
+            self.assertEqual(payload["blocking_failures"], 0)
+            self.assertEqual(payload["local_artifact_store"], "not_written")
+            self.assertIn("local_artifact_store: not_written", payload["warnings"])
+            gates = {gate["id"]: gate for gate in payload["gates"]}
+            self.assertEqual(
+                set(gates),
+                {
+                    "skill_content",
+                    "use_cases",
+                    "grounded_score",
+                    "chat_card_coverage",
+                    "route_hint_alignment",
+                    "context_brief_coverage",
+                    "routing_precision",
+                    "hermes_ux_quality",
+                    "parity_contracts",
+                    "release_checklist",
+                },
+            )
+            self.assertEqual(gates["use_cases"]["status"], "passed")
+            self.assertIn("local artifact store not_written", gates["use_cases"]["summary"])
+            self.assertEqual(gates["use_cases"]["warnings"], ["local_artifact_store: not_written"])
+            self.assertEqual(gates["grounded_score"]["status"], "passed")
+            self.assertIn("28/28 scenarios at 10/10", gates["grounded_score"]["summary"])
+            self.assertEqual(gates["chat_card_coverage"]["status"], "passed")
+            self.assertIn("generic ack 0", gates["chat_card_coverage"]["summary"])
+            self.assertEqual(gates["route_hint_alignment"]["status"], "passed")
+            self.assertIn("53/53 route hints aligned", gates["route_hint_alignment"]["summary"])
+            self.assertEqual(gates["context_brief_coverage"]["status"], "passed")
+            self.assertIn("8/8 context brief cases passing", gates["context_brief_coverage"]["summary"])
+            self.assertEqual(gates["routing_precision"]["status"], "passed")
+            self.assertIn("39/39 negative-control cases", gates["routing_precision"]["summary"])
+            self.assertIn("19/19 interventions", gates["routing_precision"]["summary"])
+            self.assertIn("overroutes 0", gates["routing_precision"]["summary"])
+            self.assertIn("missed interventions 0", gates["routing_precision"]["summary"])
+            self.assertEqual(gates["hermes_ux_quality"]["status"], "passed")
+            self.assertIn("5/5 UX gates passing", gates["hermes_ux_quality"]["summary"])
+            self.assertEqual(gates["parity_contracts"]["status"], "passed")
+            self.assertIn("not run the release checklist", payload["boundary"])
 
         status, stdout, stderr = run_cli(["release", "skill-content-smoke"], output_json=False)
 

--- a/tests/test_release_smoke.py
+++ b/tests/test_release_smoke.py
@@ -261,78 +261,85 @@ class ReleaseSmokeTests(unittest.TestCase):
         self.assertIn("does not prove the target Hermes profile", payload["proof_boundary"])
 
     def test_product_readiness_report_rolls_up_public_release_story(self) -> None:
-        payload = product_readiness_report(version="v1.0.1", omh_command="/tmp/omh command")
+        with TemporaryDirectory() as tmp:
+            paths = OmhPaths(omh_home=Path(tmp) / ".omh", hermes_home=Path(tmp) / ".hermes")
+            payload = product_readiness_report(version="v1.0.1", omh_command="/tmp/omh command", paths=paths)
 
-        self.assertEqual(payload["schema_version"], "omh_product_readiness/v1")
-        self.assertEqual(payload["status"], "ready")
-        self.assertEqual(payload["score"], 100)
-        self.assertTrue(payload["observed"])
-        self.assertEqual(payload["version"], "1.0.1")
-        self.assertEqual(payload["blocking_failures"], 0)
-        gates = {gate["id"]: gate for gate in payload["gates"]}
-        self.assertEqual(
-            set(gates),
-            {
-                "skill_content",
-                "use_cases",
-                "grounded_score",
-                "chat_card_coverage",
-                "route_hint_alignment",
-                "context_brief_coverage",
-                "routing_precision",
-                "hermes_ux_quality",
-                "parity_contracts",
-                "release_checklist",
-            },
-        )
-        self.assertEqual(gates["skill_content"]["status"], "passed")
-        self.assertEqual(gates["use_cases"]["status"], "passed")
-        self.assertEqual(gates["grounded_score"]["status"], "passed")
-        self.assertIn("28/28 scenarios at 10/10", gates["grounded_score"]["summary"])
-        self.assertIn("avg 10.0", gates["grounded_score"]["summary"])
-        self.assertEqual(gates["grounded_score"]["command"], "omh demo grounded-score --json")
-        self.assertIn("deterministic local contract-compliance", gates["grounded_score"]["proof_boundary"])
-        self.assertEqual(gates["chat_card_coverage"]["status"], "passed")
-        self.assertIn("25/25 dedicated workflow cards", gates["chat_card_coverage"]["summary"])
-        self.assertIn("generic ack 0", gates["chat_card_coverage"]["summary"])
-        self.assertEqual(gates["chat_card_coverage"]["command"], "omh demo chat-card-coverage --json")
-        self.assertIn("deterministic local wrapper-card coverage", gates["chat_card_coverage"]["proof_boundary"])
-        self.assertEqual(gates["route_hint_alignment"]["status"], "passed")
-        self.assertIn("53/53 route hints aligned", gates["route_hint_alignment"]["summary"])
-        self.assertIn("missing 0", gates["route_hint_alignment"]["summary"])
-        self.assertIn("mismatches 0", gates["route_hint_alignment"]["summary"])
-        self.assertEqual(gates["route_hint_alignment"]["command"], "omh demo route-hint-alignment --json")
-        self.assertIn("deterministic local agreement", gates["route_hint_alignment"]["proof_boundary"])
-        self.assertEqual(gates["context_brief_coverage"]["status"], "passed")
-        self.assertIn("8/8 context brief cases passing", gates["context_brief_coverage"]["summary"])
-        self.assertIn("route hints 7", gates["context_brief_coverage"]["summary"])
-        self.assertIn("catalog picker hints 1", gates["context_brief_coverage"]["summary"])
-        self.assertEqual(gates["context_brief_coverage"]["command"], "omh demo context-brief-coverage --json")
-        self.assertIn("deterministic local OMH mental-model", gates["context_brief_coverage"]["proof_boundary"])
-        self.assertEqual(gates["routing_precision"]["status"], "passed")
-        self.assertIn("39/39 negative-control cases", gates["routing_precision"]["summary"])
-        self.assertIn("19/19 interventions", gates["routing_precision"]["summary"])
-        self.assertIn("overroutes 0", gates["routing_precision"]["summary"])
-        self.assertIn("catalog pickers 0", gates["routing_precision"]["summary"])
-        self.assertIn("missed interventions 0", gates["routing_precision"]["summary"])
-        self.assertEqual(gates["routing_precision"]["command"], "omh demo routing-precision --json")
-        self.assertIn("deterministic local over-intervention", gates["routing_precision"]["proof_boundary"])
-        self.assertEqual(gates["hermes_ux_quality"]["status"], "passed")
-        self.assertIn("5/5 UX gates passing", gates["hermes_ux_quality"]["summary"])
-        self.assertIn("routing avg 10.0", gates["hermes_ux_quality"]["summary"])
-        self.assertIn("generic ack 0", gates["hermes_ux_quality"]["summary"])
-        self.assertIn("context 8/8", gates["hermes_ux_quality"]["summary"])
-        self.assertEqual(gates["hermes_ux_quality"]["command"], "omh demo hermes-ux-quality --json")
-        self.assertIn("deterministic local routing", gates["hermes_ux_quality"]["proof_boundary"])
-        self.assertEqual(gates["parity_contracts"]["status"], "passed")
-        self.assertEqual(gates["release_checklist"]["status"], "passed")
-        self.assertIn(
-            "'/tmp/omh command' release checklist --version 1.0.1 --json",
-            gates["release_checklist"]["command"],
-        )
-        self.assertIn("deterministic local OMH package", payload["boundary"])
-        self.assertIn("Attach observed evidence", " ".join(payload["next_actions"]))
-        self.assertIn("evidence-bundle", " ".join(payload["next_actions"]))
+            self.assertEqual(payload["schema_version"], "omh_product_readiness/v1")
+            self.assertEqual(payload["status"], "ready")
+            self.assertEqual(payload["score"], 100)
+            self.assertTrue(payload["observed"])
+            self.assertEqual(payload["version"], "1.0.1")
+            self.assertEqual(payload["blocking_failures"], 0)
+            self.assertEqual(payload["local_artifact_store"], "not_written")
+            self.assertIn("local_artifact_store: not_written", payload["warnings"])
+            self.assertIn("cases artifact --all --write", " ".join(payload["next_actions"]))
+            gates = {gate["id"]: gate for gate in payload["gates"]}
+            self.assertEqual(
+                set(gates),
+                {
+                    "skill_content",
+                    "use_cases",
+                    "grounded_score",
+                    "chat_card_coverage",
+                    "route_hint_alignment",
+                    "context_brief_coverage",
+                    "routing_precision",
+                    "hermes_ux_quality",
+                    "parity_contracts",
+                    "release_checklist",
+                },
+            )
+            self.assertEqual(gates["skill_content"]["status"], "passed")
+            self.assertEqual(gates["use_cases"]["status"], "passed")
+            self.assertIn("local artifact store not_written", gates["use_cases"]["summary"])
+            self.assertEqual(gates["use_cases"]["warnings"], ["local_artifact_store: not_written"])
+            self.assertEqual(gates["grounded_score"]["status"], "passed")
+            self.assertIn("28/28 scenarios at 10/10", gates["grounded_score"]["summary"])
+            self.assertIn("avg 10.0", gates["grounded_score"]["summary"])
+            self.assertEqual(gates["grounded_score"]["command"], "omh demo grounded-score --json")
+            self.assertIn("deterministic local contract-compliance", gates["grounded_score"]["proof_boundary"])
+            self.assertEqual(gates["chat_card_coverage"]["status"], "passed")
+            self.assertIn("25/25 dedicated workflow cards", gates["chat_card_coverage"]["summary"])
+            self.assertIn("generic ack 0", gates["chat_card_coverage"]["summary"])
+            self.assertEqual(gates["chat_card_coverage"]["command"], "omh demo chat-card-coverage --json")
+            self.assertIn("deterministic local wrapper-card coverage", gates["chat_card_coverage"]["proof_boundary"])
+            self.assertEqual(gates["route_hint_alignment"]["status"], "passed")
+            self.assertIn("53/53 route hints aligned", gates["route_hint_alignment"]["summary"])
+            self.assertIn("missing 0", gates["route_hint_alignment"]["summary"])
+            self.assertIn("mismatches 0", gates["route_hint_alignment"]["summary"])
+            self.assertEqual(gates["route_hint_alignment"]["command"], "omh demo route-hint-alignment --json")
+            self.assertIn("deterministic local agreement", gates["route_hint_alignment"]["proof_boundary"])
+            self.assertEqual(gates["context_brief_coverage"]["status"], "passed")
+            self.assertIn("8/8 context brief cases passing", gates["context_brief_coverage"]["summary"])
+            self.assertIn("route hints 7", gates["context_brief_coverage"]["summary"])
+            self.assertIn("catalog picker hints 1", gates["context_brief_coverage"]["summary"])
+            self.assertEqual(gates["context_brief_coverage"]["command"], "omh demo context-brief-coverage --json")
+            self.assertIn("deterministic local OMH mental-model", gates["context_brief_coverage"]["proof_boundary"])
+            self.assertEqual(gates["routing_precision"]["status"], "passed")
+            self.assertIn("39/39 negative-control cases", gates["routing_precision"]["summary"])
+            self.assertIn("19/19 interventions", gates["routing_precision"]["summary"])
+            self.assertIn("overroutes 0", gates["routing_precision"]["summary"])
+            self.assertIn("catalog pickers 0", gates["routing_precision"]["summary"])
+            self.assertIn("missed interventions 0", gates["routing_precision"]["summary"])
+            self.assertEqual(gates["routing_precision"]["command"], "omh demo routing-precision --json")
+            self.assertIn("deterministic local over-intervention", gates["routing_precision"]["proof_boundary"])
+            self.assertEqual(gates["hermes_ux_quality"]["status"], "passed")
+            self.assertIn("5/5 UX gates passing", gates["hermes_ux_quality"]["summary"])
+            self.assertIn("routing avg 10.0", gates["hermes_ux_quality"]["summary"])
+            self.assertIn("generic ack 0", gates["hermes_ux_quality"]["summary"])
+            self.assertIn("context 8/8", gates["hermes_ux_quality"]["summary"])
+            self.assertEqual(gates["hermes_ux_quality"]["command"], "omh demo hermes-ux-quality --json")
+            self.assertIn("deterministic local routing", gates["hermes_ux_quality"]["proof_boundary"])
+            self.assertEqual(gates["parity_contracts"]["status"], "passed")
+            self.assertEqual(gates["release_checklist"]["status"], "passed")
+            self.assertIn(
+                "'/tmp/omh command' release checklist --version 1.0.1 --json",
+                gates["release_checklist"]["command"],
+            )
+            self.assertIn("deterministic local OMH package", payload["boundary"])
+            self.assertIn("Attach observed evidence", " ".join(payload["next_actions"]))
+            self.assertIn("evidence-bundle", " ".join(payload["next_actions"]))
 
     def test_release_evidence_bundle_packages_and_writes_local_evidence(self) -> None:
         with TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary

This PR makes `omh release product-readiness` use the same path-aware G1-G10 use-case readiness contract as `omh cases readiness`.

Before this change, the product readiness rollup could only report the use-case local artifact store as `not_checked` because it called the use-case readiness layer without an OMH path binding. Now it passes the resolved `--omh-home` / `--hermes-home` paths, so release readiness reports concrete states such as `not_written` or `passed`.

## Why

The current quality goal is to make OMH feel clearer and more trustworthy for operators. `not_checked` was a weak release signal: it told the user that something had not been inspected, even though the underlying `omh cases readiness` command already knew how to inspect it.

After this PR, the release readiness output says exactly what is true:

- `local artifact store not_written` when optional G1-G10 artifacts have not been written locally.
- `local_artifact_store: not_written` in the warnings array.
- A direct next action: `omh cases artifact --all --write --json`.

## What Changed

- Added optional `paths` support to `product_readiness_report`.
- Passed CLI `_paths(args)` from `omh release product-readiness`.
- Rebuilt the product readiness `use_cases` gate from path-aware `use_case_readiness(paths)` instead of the package-content fallback embedded in `skill_content_smoke`.
- Added top-level `warnings` and `local_artifact_store` fields to the product readiness payload.
- Made next actions specific when the only warning is the optional local artifact store.
- Updated tests to use temporary OMH/Hermes homes so release readiness output is not dependent on the developer machine's real `~/.omh` state.

## User Impact

When a user runs:

```sh
omh release product-readiness
```

They now see a concrete release-quality state instead of a vague unchecked warning:

```text
use_cases: passed
score 100/100; blocking 0; warnings 1; local artifact store not_written
Warnings: local_artifact_store: not_written
Next: Optional: write local use-case artifacts with `omh cases artifact --all --write --json`.
```

This keeps OMH conservative while making the maintenance UX more actionable.

## Boundary

This PR does not write use-case artifacts automatically, mutate Hermes, run live Hermes profile smoke, call connectors, dispatch executors, review code, pass remote CI, merge, deliver messages, or publish a GitHub release. It only improves deterministic local release-readiness reporting.

## Verification

Observed locally:

```sh
PYTHONPATH=tests uv run python -m unittest tests/test_release_smoke.py tests/test_cli.py -v
PYTHONPATH=tests uv run python -m unittest tests/test_application_cases.py tests/test_release_smoke.py tests/test_cli.py -v
PYTHONPATH=tests uv run python -m unittest discover -s tests
uv run python -m compileall -q src tests
uv run python -m omh.cli release product-readiness --json
uv run python -m omh.cli release product-readiness
uv run python -m omh.cli release evidence-bundle --version 1.0.1 --json
git diff --check
```

Key results:

- Full unittest discovery: 976 tests passing.
- Product readiness: ready, score 100, local artifact store `not_written` observed.
- Release evidence bundle: ready, local artifact store `not_written` observed.
