### PR TITLE
Hide legacy visual alias from help

### DIFF
--- a/src/commands/visual.py
+++ b/src/commands/visual.py
@@ -158,14 +158,17 @@ def _add_visual_commands(sub) -> None:
         sub,
         "visual",
         help=argparse.SUPPRESS,
+        hidden=True,
     )
 
 
-def _add_visual_parser(sub, name: str, *, help: str) -> None:
+def _add_visual_parser(sub, name: str, *, help: str, hidden: bool = False) -> None:
     visual = sub.add_parser(
         name,
         help=help,
     )
+    if hidden:
+        sub._choices_actions = [action for action in sub._choices_actions if action.dest != name]
     visual_sub = visual.add_subparsers(dest=f"{name.replace('-', '_')}_command", required=True)
 
     prompt_card = visual_sub.add_parser(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -56,6 +56,9 @@ class CliTests(unittest.TestCase):
         self.assertIn("Backend/control-plane commands", help_text)
         self.assertIn("release smoke", help_text)
         self.assertIn("memory, ops, materials, state", help_text)
+        self.assertIn("img-summary", help_text)
+        self.assertNotIn("==SUPPRESS==", help_text)
+        self.assertNotIn("visual               ==", help_text)
 
     def test_context_brief_exposes_omh_mental_model_and_route_hint(self) -> None:
         status, stdout, stderr = run_cli(


### PR DESCRIPTION
## Summary
- Hide the legacy `visual` compatibility alias from the top-level `omh --help` command list.
- Keep the alias executable so existing `omh visual ...` callers still work.
- Add a regression assertion that root help never prints argparse's `==SUPPRESS==` marker.

## Why
`omh --help` is one of the first surfaces a user sees after install. It was exposing the internal compatibility alias as `visual ==SUPPRESS==`, which made the CLI feel unfinished even though the preferred public command is `img-summary`.

## How
- `src/commands/visual.py` now removes hidden compatibility aliases from argparse's displayed subcommand choices after registering the parser.
- `tests/test_cli.py` locks the public help output so `img-summary` remains visible and suppressed aliases do not leak.

## User-facing effect
Users now see a cleaner top-level command list with `img-summary` as the visual summary entry. Existing automation or local muscle memory using `omh visual ...` continues to work.

## Verification
- `PYTHONPATH=tests uv run python -m unittest tests/test_cli.py -v`
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- `uv run python -m compileall -q src tests`
- `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check`
- `PYTHONPATH=tests uv run python -m omh.cli harness validate`
- `PYTHONPATH=tests uv run python -m omh.cli --help`
- `PYTHONPATH=tests uv run python -m omh.cli visual prompt-card --kind meeting --section summary:Title:Body --json`
- `PYTHONPATH=tests uv run python -m omh.cli img-summary prompt-card --kind meeting --section summary:Title:Body --json`
- `git diff --check`

## Risks / notes
- This uses argparse's existing subparser choices list to keep a compatibility command registered but out of the human-facing help table.
- No runtime, router, schema, or generated skill behavior changes.
