### PR TITLE
Humanize chat summary action lists

### DIFF
--- a/src/commands/chat.py
+++ b/src/commands/chat.py
@@ -261,6 +261,15 @@ def _route_action_label_with_id(action: str) -> str:
     return _action_label_with_id(normalized, _ROUTE_ACTION_LABELS.get(normalized, ""))
 
 
+def _format_summary_action(action: dict[str, object]) -> str:
+    action_id = _text(action.get("id"), "action")
+    label = _text(action.get("label"), action_id)
+    enabled = bool(action.get("enabled", True))
+    state_label = "enabled" if enabled else "disabled"
+    label_with_id = _action_label_with_id(action_id, label)
+    return f"- {label_with_id} - {state_label}"
+
+
 def _print_chat_interaction_summary(payload: dict[str, object]) -> None:
     response = _as_mapping(payload.get("chat_response"))
     route = _as_mapping(payload.get("route"))
@@ -302,11 +311,7 @@ def _print_chat_interaction_summary(payload: dict[str, object]) -> None:
         print("Actions:")
         action_limit = 12
         for action in actions[:action_limit]:
-            action_id = _text(action.get("id"), "action")
-            label = _text(action.get("label"), action_id)
-            enabled = bool(action.get("enabled", True))
-            state_label = "enabled" if enabled else "disabled"
-            print(f"- {action_id}: {label} ({state_label})")
+            print(_format_summary_action(action))
         if len(actions) > action_limit:
             print(f"- ... {len(actions) - action_limit} more action(s) in --json")
 
@@ -501,11 +506,7 @@ def _print_chat_route_hint_summary(payload: dict[str, object]) -> None:
         print()
         print("Actions:")
         for action in actions[:6]:
-            action_id = _text(action.get("id"), "action")
-            label = _text(action.get("label"), action_id)
-            enabled = bool(action.get("enabled", True))
-            state_label = "enabled" if enabled else "disabled"
-            print(f"- {action_id}: {label} ({state_label})")
+            print(_format_summary_action(action))
 
     checkpoint = _as_mapping(payload.get("generic_tool_checkpoint"))
     checkpoint_body = _text(checkpoint.get("body"))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4397,7 +4397,7 @@ class CliTests(unittest.TestCase):
         )
         self.assertIn("  matched: cron", stdout)
         self.assertIn("Actions:", stdout)
-        self.assertIn("- open_workflow: Open img-summary (enabled)", stdout)
+        self.assertIn("- Open img-summary (`open_workflow`) - enabled", stdout)
         self.assertIn("Checkpoint:", stdout)
         self.assertIn("Before generic tools, check OMH prep/status/learning", stdout)
         self.assertIn("Not evidence yet:", stdout)
@@ -4444,7 +4444,7 @@ class CliTests(unittest.TestCase):
         self.assertIn("Workflow: oh-my-hermes", stdout)
         self.assertIn("Next action: opening the workflow picker (`choose_skill`)", stdout)
         self.assertIn("- oh-my-hermes: opening the workflow picker (`choose_skill`) (intent_to_plan)", stdout)
-        self.assertIn("- open_workflow: Open omh (enabled)", stdout)
+        self.assertIn("- Open omh (`open_workflow`) - enabled", stdout)
 
         status, stdout, stderr = run_cli(
             ["chat", "route-hint", "--source", "discord", "--json", "open the OMH picker"],
@@ -4473,8 +4473,8 @@ class CliTests(unittest.TestCase):
         self.assertIn("Hints: 0", stdout)
         self.assertNotIn("Workflow: unknown", stdout)
         self.assertIn("[omh] no strong workflow hint yet.", stdout)
-        self.assertIn("- open_picker: Open omh (enabled)", stdout)
-        self.assertIn("- clarify: Clarify (enabled)", stdout)
+        self.assertIn("- Open omh (`open_picker`) - enabled", stdout)
+        self.assertIn("- Clarify (`clarify`) - enabled", stdout)
 
     def test_chat_route_hint_can_emit_manual_prompt_context(self) -> None:
         status, stdout, stderr = run_cli(
@@ -4625,8 +4625,8 @@ class CliTests(unittest.TestCase):
         self.assertIn("Next action: preparing a reviewed plan (`present_plan`)", stdout)
         self.assertIn("[omh] ralplan - I routed this to `ralplan`", stdout)
         self.assertIn("Actions:", stdout)
-        self.assertIn("- accept_plan: Accept plan (enabled)", stdout)
-        self.assertIn("- prepare_handoff: Prepare handoff (disabled)", stdout)
+        self.assertIn("- Accept plan (`accept_plan`) - enabled", stdout)
+        self.assertIn("- Prepare handoff (`prepare_handoff`) - disabled", stdout)
         self.assertIn("Boundary:", stdout)
         self.assertIn("A draft plan is not execution evidence.", stdout)
         self.assertIn("Use --json for the full machine-readable payload.", stdout)
@@ -4649,10 +4649,10 @@ class CliTests(unittest.TestCase):
         self.assertEqual(status, 0)
         self.assertIn("Workflow: img-summary", stdout)
         self.assertIn("Actions:", stdout)
-        self.assertIn("- show_visual_prompt_card: Show card (enabled)", stdout)
-        self.assertIn("- choose_image_generator: Choose image tool (enabled)", stdout)
-        self.assertIn("- record_visual_delivery: Record delivery (enabled)", stdout)
-        self.assertIn("- show_visual_status: Show visual status (enabled)", stdout)
+        self.assertIn("- Show card (`show_visual_prompt_card`) - enabled", stdout)
+        self.assertIn("- Choose image tool (`choose_image_generator`) - enabled", stdout)
+        self.assertIn("- Record delivery (`record_visual_delivery`) - enabled", stdout)
+        self.assertIn("- Show visual status (`show_visual_status`) - enabled", stdout)
         self.assertNotIn("more action(s) in --json", stdout)
         self.assertIn("Not evidence yet:", stdout)
         self.assertIn("- image generation", stdout)
@@ -4666,8 +4666,8 @@ class CliTests(unittest.TestCase):
         self.assertEqual(status, 0)
         self.assertIn("Workflow: img-summary", stdout)
         self.assertIn("Next action: preparing an image prompt card (`prepare_visual_prompt_card`)", stdout)
-        self.assertIn("- choose_image_generator: Choose image tool (enabled)", stdout)
-        self.assertIn("- record_visual_delivery: Record delivery (enabled)", stdout)
+        self.assertIn("- Choose image tool (`choose_image_generator`) - enabled", stdout)
+        self.assertIn("- Record delivery (`record_visual_delivery`) - enabled", stdout)
         self.assertNotIn("more action(s) in --json", stdout)
 
     def test_chat_interact_summary_renders_catalog_picker_without_shell_json(self) -> None:
@@ -4688,8 +4688,8 @@ class CliTests(unittest.TestCase):
                 self.assertIn("Workflow: oh-my-hermes", stdout)
                 self.assertIn("Next action: opening the workflow picker (`choose_skill`)", stdout)
                 self.assertIn("[omh] oh-my-hermes - Here are the OMH workflows.", stdout)
-                self.assertIn("- choose_skill: Choose workflow (enabled)", stdout)
-                self.assertIn("- search_skills: Search workflows (enabled)", stdout)
+                self.assertIn("- Choose workflow (`choose_skill`) - enabled", stdout)
+                self.assertIn("- Search workflows (`search_skills`) - enabled", stdout)
                 self.assertIn("Use --json for the full machine-readable payload.", stdout)
 
     def test_chat_interact_rejects_conflicting_output_modes(self) -> None:


### PR DESCRIPTION
## Feature Report

### What Changed

- Updated human-facing `omh chat interact --summary` and `omh chat route-hint --summary` action lists to show the readable label first and the stable action id second.
- Added one shared summary action formatter so chat interactions and route hints render actions consistently.
- Updated CLI assertions that lock the new label-first summary contract.

### Why This Exists

- Recent router UX work made top-level route and next-action lines readable, but the `Actions:` section still looked like backend output: `send_to_executor: Open in Codex`.
- In Hermes, Discord, Slack, and similar chat surfaces, the user should see the button/action meaning first, with the action id available only as supporting metadata.

### User / Operator Impact

- Coding handoff summaries now read like `Open in Codex (`send_to_executor`) - enabled` instead of leading with an internal id.
- Image, picker, and fallback route hint cards now use the same label-first action shape.
- JSON payloads and wrapper action ids remain unchanged, so adapters can keep matching stable ids.

### How It Works

- `src/commands/chat.py` now uses `_format_summary_action()` for summary-only stdout action lines.
- The formatter reuses the existing action-label helper, preserving the action id in backticks whenever the label differs from the id.
- This only changes operator/Hermes-facing text output; machine-readable contracts stay stable.

### Files And Contracts Touched

- `src/commands/chat.py`: summary stdout formatting for chat interaction and route-hint action lists.
- `tests/test_cli.py`: expected human-facing summary copy.
- Public JSON schemas/contracts: unchanged.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests.test_cli.CliTests.test_chat_route_hint_summary_renders_operator_readable_hint tests.test_cli.CliTests.test_chat_route_hint_summary_covers_loop_and_picker_language tests.test_cli.CliTests.test_chat_route_hint_summary_renders_no_hint_without_unknown_workflow tests.test_cli.CliTests.test_chat_interact_summary_renders_operator_readable_plan tests.test_cli.CliTests.test_chat_interact_summary_shows_common_visual_actions_without_json_escape_hatch tests.test_cli.CliTests.test_chat_interact_summary_renders_catalog_picker_without_shell_json -v`
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_cli.py tests/test_chat_router.py tests/test_wrapper_contract.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check`
- [x] `PYTHONPATH=tests uv run python -m omh.cli harness validate`
- [x] `PYTHONPATH=tests uv run python -m omh.cli demo hermes-ux-quality --summary`
- [x] `PYTHONPATH=tests uv run python -m omh.cli demo route-hint-alignment --summary`
- [x] `git diff --check`
- [ ] `python3 -m omh.cli release checklist --json` not run; this PR does not change release packaging.
- [ ] `python3 -m omh.cli release hermes-smoke` not run; this PR changes local summary copy only.
- [ ] Manual Hermes/TUI check not run; live chat rendering remains not observed.

## Risk

- Low. The change is stdout formatting only.
- Any external operator script scraping the old summary text instead of using `--json` would need to adjust, but the machine-readable payload remains the supported integration surface.

## Compatibility / Rollout

- No schema, command, or action-id changes.
- Existing wrappers should continue using JSON fields for automation.
- Human-readable output becomes easier to paste into chat or inspect during local QA.

## Release / Claims

- [x] Release-channel impact considered: local/preview copy improvement only.
- [x] Runtime/native capability claims remain unchanged and observed-only boundaries are preserved.
- [x] Known manual Hermes checks are listed: live Hermes rendering and platform-native button rendering were not observed.

## Follow-Up

- Continue scanning other human-facing summaries for raw backend ids that should become label-first without changing JSON contracts.
