### PR TITLE
Humanize route plan status copy

### DIFF
--- a/src/commands/chat.py
+++ b/src/commands/chat.py
@@ -255,10 +255,31 @@ _ROUTE_ACTION_LABELS = {
     "fallback": "answering without a workflow",
 }
 
+_SUMMARY_STATUS_LABELS = {
+    "prepared_not_observed": "prepared, not observed",
+    "not_observed": "not observed",
+    "observed": "observed",
+    "blocked": "blocked",
+    "completed": "completed",
+    "failed": "failed",
+    "passed": "passed",
+    "pending": "pending",
+}
+
 
 def _route_action_label_with_id(action: str) -> str:
     normalized = action.strip()
     return _action_label_with_id(normalized, _ROUTE_ACTION_LABELS.get(normalized, ""))
+
+
+def _status_label_with_id(status: str) -> str:
+    normalized = status.strip()
+    if not normalized:
+        return ""
+    label = _SUMMARY_STATUS_LABELS.get(normalized, normalized.replace("_", " "))
+    if label == normalized:
+        return normalized
+    return f"{label} (`{normalized}`)"
 
 
 def _format_summary_action(action: dict[str, object]) -> str:
@@ -403,7 +424,7 @@ def _print_chat_route_summary(payload: dict[str, object]) -> None:
             stage = _text(step.get("stage"), "stage")
             skill = _text(step.get("skill"), "workflow")
             status = _text(step.get("status"), "prepared_not_observed")
-            print(f"- {order}. {stage}: {skill} ({status})")
+            print(f"- {order}. {stage}: {skill} - {_status_label_with_id(status)}")
 
     not_evidence = [_text(item) for item in _as_list(route_explanation.get("not_evidence_yet")) if _text(item)]
     if not_evidence:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4236,7 +4236,7 @@ class CliTests(unittest.TestCase):
         self.assertIn("Top recommendations:", stdout)
         self.assertIn("- ralplan: preparing a reviewed plan (`present_plan`) (high, score 32)", stdout)
         self.assertIn("Route plan:", stdout)
-        self.assertIn("- 1. triage: feedback-triage (prepared_not_observed)", stdout)
+        self.assertIn("- 1. triage: feedback-triage - prepared, not observed (`prepared_not_observed`)", stdout)
         self.assertIn("Boundary:", stdout)
         self.assertIn("A recommendation or draft plan is not execution evidence.", stdout)
         self.assertIn("Use --json for the full machine-readable route payload.", stdout)


### PR DESCRIPTION
## Feature Report

### What Changed

- Updated `omh chat route --summary` route-plan lines to show readable status copy first.
- Preserved exact route-plan status ids in backticks, for example `prepared, not observed (`prepared_not_observed`)`.
- Added a focused CLI assertion for the new human-facing route-plan status shape.

### Why This Exists

- The top-level route and action lines were already readable, but `Route plan:` still exposed raw status strings such as `prepared_not_observed` as the only visible status.
- Hermes/chat users need to understand that a route step is merely prepared, while wrapper operators still need the exact status id for evidence contracts.

### User / Operator Impact

- A safe-feature route now reads `feedback-triage - prepared, not observed (`prepared_not_observed`)` instead of making the raw status look like an error or backend log.
- The prepared-vs-observed boundary remains explicit and easier to explain in chat.
- JSON payloads and route-plan status ids are unchanged.

### How It Works

- `src/commands/chat.py` now has a small `_status_label_with_id()` helper for summary-only status rendering.
- Known statuses get stable human labels; unknown statuses degrade to underscore-free text while still showing the original id when useful.
- The route-plan summary path uses that formatter; machine-readable route data is untouched.

### Files And Contracts Touched

- `src/commands/chat.py`: route-plan status summary formatting.
- `tests/test_cli.py`: stdout expectation for the human-readable route-plan status.
- Public JSON schemas/contracts: unchanged.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests.test_cli.CliTests.test_chat_route_summary_renders_operator_readable_route -v`
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_cli.py tests/test_chat_router.py tests/test_wrapper_contract.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check`
- [x] `PYTHONPATH=tests uv run python -m omh.cli harness validate`
- [x] `PYTHONPATH=tests uv run python -m omh.cli demo hermes-ux-quality --summary`
- [x] `PYTHONPATH=tests uv run python -m omh.cli demo route-hint-alignment --summary`
- [x] `git diff --check`
- [ ] `python3 -m omh.cli release checklist --json` not run; this PR changes chat summary copy only.
- [ ] `python3 -m omh.cli release hermes-smoke` not run; this PR does not change install/runtime packaging.
- [ ] Manual Hermes/TUI check not run; live chat rendering remains not observed.

## Risk

- Low. This changes stdout summary copy only.
- Any script scraping the old human summary should use `--json` instead; machine-readable fields are unchanged.

## Compatibility / Rollout

- No schema, command, route, status-id, or wrapper contract changes.
- Existing wrappers can keep matching JSON route-plan status ids.

## Release / Claims

- [x] Release-channel impact considered: local/preview copy improvement only.
- [x] Runtime/native capability claims are unchanged and remain observed-only.
- [x] Known manual Hermes checks are listed: live Hermes rendering was not observed.

## Follow-Up

- Continue scanning non-chat maintenance summaries for places where raw state ids should be paired with human labels.
