### PR TITLE
Humanize recommendation next-action copy

### DIFF
--- a/src/commands/common.py
+++ b/src/commands/common.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from ..ingress import extract_message_text, extract_source_metadata
 from ..installer import OmhError
 from ..paths import resolve_paths
+from ..routing.action_copy import next_action_label
 from ..setup_profiles import read_setup_profile
 from ..targets import TARGET_METADATA_KEYS
 
@@ -24,6 +25,16 @@ def _print_json(data: object) -> None:
 def _wants_json(args: argparse.Namespace) -> bool:
     output = os.environ.get("OMH_OUTPUT", "").strip().lower()
     return bool(getattr(args, "json", False)) or output == "json"
+
+
+def _action_label_with_id(action: str, label: str = "") -> str:
+    normalized = action.strip()
+    if not normalized:
+        return ""
+    resolved_label = label.strip() or next_action_label(normalized)
+    if not resolved_label or resolved_label == normalized:
+        return normalized
+    return f"{resolved_label} (`{normalized}`)"
 
 
 def _explicit_source_metadata(args: argparse.Namespace) -> dict[str, str]:

--- a/src/commands/playbook.py
+++ b/src/commands/playbook.py
@@ -4,7 +4,7 @@ import argparse
 
 from ..installer import OmhError
 from ..playbooks import inspect_playbook, list_playbooks, recommend_playbooks
-from .common import _print_json, _wants_json
+from .common import _action_label_with_id, _print_json, _wants_json
 
 
 def cmd_playbook_list(args: argparse.Namespace) -> int:
@@ -120,7 +120,7 @@ def _print_playbook_recommend_summary(payload: dict[str, object]) -> None:
         print(f"   {title}")
         next_action = str(recommendation.get("next_action", "")).strip()
         if next_action:
-            print(f"   Next action: {next_action}")
+            print(f"   Next action: {_action_label_with_id(next_action)}")
         boundary = _short_summary(str(recommendation.get("evidence_boundary", "")), limit=120)
         if boundary:
             print(f"   Boundary: {boundary}")

--- a/src/commands/setup.py
+++ b/src/commands/setup.py
@@ -51,7 +51,7 @@ from ..team_profiles import (
     list_team_profile_packs,
     operating_model_ids,
 )
-from .common import _paths, _print_json, _wants_json
+from .common import _action_label_with_id, _paths, _print_json, _wants_json
 from .language import LANGUAGE_CODES, language_from_env, language_options, normalize_language, tr
 
 INSTALLER_COMMAND = "curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes/main/install.sh | sh"
@@ -1979,7 +1979,7 @@ def _print_recommend_summary(payload: dict[str, object]) -> None:
             print(f"   {description}")
         next_action = str(recommendation.get("next_action", "")).strip()
         if next_action:
-            print(f"   Next action: {next_action}")
+            print(f"   Next action: {_action_label_with_id(next_action)}")
         why = _short_summary(str(recommendation.get("why", "")), limit=120)
         if why:
             print(f"   Why: {why}")

--- a/src/commands/use_cases.py
+++ b/src/commands/use_cases.py
@@ -18,7 +18,7 @@ from ..use_cases import (
     write_all_use_case_artifacts,
     write_use_case_artifact,
 )
-from .common import _paths, _print_json, _wants_json
+from .common import _action_label_with_id, _paths, _print_json, _wants_json
 
 
 def cmd_cases_list(args: argparse.Namespace) -> int:
@@ -419,7 +419,9 @@ def _print_cases_recommend_summary(payload: dict[str, object]) -> None:
             f"   Surface: {case.get('primary_skill')} | exposure: {case.get('exposure')} "
             f"| playbook: {case.get('playbook')}"
         )
-        print(f"   Next action: {case.get('next_action')}")
+        next_action = str(case.get("next_action", "")).strip()
+        if next_action:
+            print(f"   Next action: {_action_label_with_id(next_action)}")
         print(f"   Boundary: {case.get('evidence_boundary')}")
     print("Boundary")
     print("  A use-case recommendation is routing guidance, not accepted work or observed evidence.")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -973,6 +973,34 @@ class CliTests(unittest.TestCase):
                 self.assertEqual(status, 0)
                 self.assertIn(json_key, json.loads(stdout))
 
+    def test_recommendation_summaries_use_human_action_labels(self) -> None:
+        cases = (
+            (
+                ["recommend", "I", "want", "to", "safely", "add", "a", "feature", "to", "this", "repo"],
+                "Next action: preparing a reviewed plan (`present_plan`)",
+            ),
+            (
+                ["recommend", "make", "an", "image", "explaining", "the", "cron", "feature"],
+                "Next action: preparing an image prompt card (`prepare_visual_prompt_card`)",
+            ),
+            (
+                ["playbook", "recommend", "turn", "this", "issue", "into", "a", "PR"],
+                "Next action: scope event (`scope_event`)",
+            ),
+            (
+                ["cases", "recommend", "daily", "competitor", "digest"],
+                "Next action: preparing a scheduled-ops blueprint (`prepare_scheduled_ops_blueprint`)",
+            ),
+        )
+
+        for args, expected in cases:
+            with self.subTest(args=args):
+                status, stdout, stderr = run_cli(args, output_json=False)
+
+                self.assertEqual(stderr, "")
+                self.assertEqual(status, 0)
+                self.assertIn(expected, stdout)
+
     def test_cases_catalog_exposes_g1_to_g10_and_recommends_real_situations(self) -> None:
         status, stdout, stderr = run_cli(["cases", "list", "--json"], output_json=False)
 


### PR DESCRIPTION
## Feature Report

### What Changed

- Human-facing recommendation summaries now show readable next-action copy before the stable action id.
- Applied the same formatting to `omh recommend`, `omh playbook recommend`, and `omh cases recommend`.
- Added CLI coverage for representative recommendation surfaces so raw-only action ids do not regress back into normal output.

### Why This Exists

- Operators should not see only internal ids such as `present_plan` or `prepare_visual_prompt_card` when they ask OMH what to do next.
- Wrappers and maintainers still need stable action ids for debugging, routing traces, and machine-readable correlation.
- The change keeps both needs: readable text first, stable id in parentheses.

### User / Operator Impact

- Before: `Next action: present_plan`.
- After: `Next action: preparing a reviewed plan (`present_plan`)`.
- Users get a clearer terminal/setup/recommendation experience without losing the exact routing action for support or wrapper debugging.

### How It Works

- Adds a shared command helper that resolves action ids through the existing routing action-copy catalog.
- Recommendation summary printers call that helper instead of printing raw action ids directly.
- Unknown or already-readable actions remain unchanged, keeping compatibility for future actions without a catalog label.

### Files And Contracts Touched

- `src/commands/common.py`: shared `_action_label_with_id` helper.
- `src/commands/setup.py`: `omh recommend` summary next-action output.
- `src/commands/playbook.py`: playbook recommendation summary next-action output.
- `src/commands/use_cases.py`: use-case recommendation summary next-action output.
- `tests/test_cli.py`: regression coverage for recommend/playbook/cases summaries.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests.test_cli.CliTests.test_recommendation_summaries_use_human_action_labels tests.test_cli.CliTests.test_operator_catalog_commands_default_to_human_summary_with_json_escape_hatch -v`
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_cli.py tests/test_chat_router.py tests/test_wrapper_contract.py -v`
- [x] `PYTHONPATH=tests uv run python -m omh.cli demo hermes-ux-quality --summary`
- [x] `PYTHONPATH=tests uv run python -m omh.cli demo route-hint-alignment --summary`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check`
- [x] `PYTHONPATH=tests uv run python -m omh.cli harness validate`
- [x] `git diff --check`
- [ ] `python3 -m omh.cli release checklist --json` - not run; change is narrow CLI copy only.
- [ ] `python3 -m omh.cli release hermes-smoke` - not run; no install/runtime surface changed.
- [ ] `omh --help` - not run; no command parser/help surface changed.
- [ ] Manual Hermes/TUI check - not run; this PR changes deterministic CLI summary rendering only.

## Risk

- Low. The machine-readable JSON payloads and action ids are unchanged.
- The helper intentionally preserves unknown actions as-is so new action ids do not fail rendering.

## Compatibility / Rollout

- Backward compatible for automation consuming JSON.
- Human stdout changes only by adding readable labels before existing action ids.
- No release-channel, setup, plugin, or runtime migration behavior changes.

## Release / Claims

- [x] Release-channel impact considered: local/preview copy improvement only.
- [x] Runtime/native capability claims are not changed.
- [x] Live Hermes/plugin execution is not claimed or required for this PR.

## Follow-Up

- Continue using the shared helper for any new human-facing recommendation summaries.
