### PR TITLE
Humanize use-case route copy

### DIFF
--- a/examples/use-cases/g1-g10-demo-cards.json
+++ b/examples/use-cases/g1-g10-demo-cards.json
@@ -6,7 +6,7 @@
         {
           "id": "prepare_scheduled_ops_blueprint",
           "kind": "hermes_prompt",
-          "label": "Prepare scheduled ops blueprint",
+          "label": "Prepare a scheduled-ops blueprint",
           "style": "primary",
           "value": "Use OMH automation-blueprint for: Every morning, research competitor updates and send a digest only if something changed."
         },
@@ -60,6 +60,7 @@
           "\uc790\ub3d9\ud654"
         ],
         "next_action": "prepare_scheduled_ops_blueprint",
+        "next_action_label": "preparing a scheduled-ops blueprint",
         "playbook": "scheduled-ops-blueprint",
         "preferred_usage": "Use as an installed Hermes workflow skill when the user asks for recurring automation or scheduled ops planning.",
         "primary_skill": "automation-blueprint",
@@ -83,13 +84,13 @@
       "chat_surface": {
         "body_lines": [
           "Turn a plain recurring request into a Hermes cron/automation blueprint with delivery target and confirmation card.",
-          "Route: automation-blueprint -> prepare_scheduled_ops_blueprint.",
+          "Route: automation-blueprint -> preparing a scheduled-ops blueprint (`prepare_scheduled_ops_blueprint`).",
           "Hermes can shape recurring work without pretending cron, source retrieval, or delivery already happened."
         ],
         "direct_skill_invocation": "$automation-blueprint Every morning, research competitor updates and send a digest only if something changed.",
         "headline": "[omh] Natural-language scheduled automation",
         "source": "hermes_agent_chat",
-        "status_line": "prepared_not_observed | automation-blueprint | prepare_scheduled_ops_blueprint",
+        "status_line": "prepared_not_observed | automation-blueprint | preparing a scheduled-ops blueprint (`prepare_scheduled_ops_blueprint`)",
         "suggested_user_prompt": "Use OMH automation-blueprint for: Every morning, research competitor updates and send a digest only if something changed."
       },
       "evidence": {
@@ -122,6 +123,7 @@
         "harness": "scheduled-ops-blueprint",
         "install_visibility": true,
         "next_action": "prepare_scheduled_ops_blueprint",
+        "next_action_label": "preparing a scheduled-ops blueprint",
         "playbook": "scheduled-ops-blueprint",
         "primary_skill": "automation-blueprint"
       },
@@ -163,7 +165,7 @@
         {
           "id": "prepare_github_event_ops_card",
           "kind": "hermes_prompt",
-          "label": "Prepare github event ops card",
+          "label": "Prepare a GitHub event operations card",
           "style": "primary",
           "value": "Use OMH github-event-ops for: PR opened with failing CI; decide whether to review, label, or prepare a fix handoff."
         },
@@ -216,6 +218,7 @@
           "ci"
         ],
         "next_action": "prepare_github_event_ops_card",
+        "next_action_label": "preparing a GitHub event operations card",
         "playbook": "github-event-ops",
         "preferred_usage": "Prefer natural-language Hermes routing into the GitHub event ops playbook/harness instead of showing this as a primary skill picker item.",
         "primary_skill": "github-event-ops",
@@ -238,13 +241,13 @@
       "chat_surface": {
         "body_lines": [
           "Route PR opened, CI failed, issue opened, and review events into review, triage, labeling, or fix-handoff cards.",
-          "Route: github-event-ops -> prepare_github_event_ops_card.",
+          "Route: github-event-ops -> preparing a GitHub event operations card (`prepare_github_event_ops_card`).",
           "Maintainers can paste or receive GitHub events and get a safe next action without claiming a bot mutated GitHub."
         ],
         "direct_skill_invocation": "$github-event-ops PR opened with failing CI; decide whether to review, label, or prepare a fix handoff.",
         "headline": "[omh] GitHub PR/Issue event operations",
         "source": "hermes_agent_chat",
-        "status_line": "prepared_not_observed | github-event-ops | prepare_github_event_ops_card",
+        "status_line": "prepared_not_observed | github-event-ops | preparing a GitHub event operations card (`prepare_github_event_ops_card`)",
         "suggested_user_prompt": "Use OMH github-event-ops for: PR opened with failing CI; decide whether to review, label, or prepare a fix handoff."
       },
       "evidence": {
@@ -277,6 +280,7 @@
         "harness": "github-event-ops",
         "install_visibility": false,
         "next_action": "prepare_github_event_ops_card",
+        "next_action_label": "preparing a GitHub event operations card",
         "playbook": "github-event-ops",
         "primary_skill": "github-event-ops"
       },
@@ -318,7 +322,7 @@
         {
           "id": "prepare_agent_board_card",
           "kind": "hermes_prompt",
-          "label": "Prepare agent board card",
+          "label": "Prepare an agent board card",
           "style": "primary",
           "value": "Use OMH agent-board for: Coordinate CTO, PM, QA, and release agents on this launch checklist."
         },
@@ -370,6 +374,7 @@
           "\uc5ec\ub7ec \uc5d0\uc774\uc804\ud2b8"
         ],
         "next_action": "prepare_agent_board_card",
+        "next_action_label": "preparing an agent board card",
         "playbook": "agent-board",
         "preferred_usage": "Use as Hermes agent/context guidance for board-shaped collaboration; keep direct invocation compatibility only for existing references.",
         "primary_skill": "agent-board",
@@ -392,13 +397,13 @@
       "chat_surface": {
         "body_lines": [
           "Let multiple Hermes profiles or agents collaborate through task, handoff, heartbeat, blocker, and completion states.",
-          "Route: agent-board -> prepare_agent_board_card.",
+          "Route: agent-board -> preparing an agent board card (`prepare_agent_board_card`).",
           "Teams see who owns each lane and which states are only prepared versus observed."
         ],
         "direct_skill_invocation": "$agent-board Coordinate CTO, PM, QA, and release agents on this launch checklist.",
         "headline": "[omh] Multi-agent Kanban board",
         "source": "hermes_agent_chat",
-        "status_line": "prepared_not_observed | agent-board | prepare_agent_board_card",
+        "status_line": "prepared_not_observed | agent-board | preparing an agent board card (`prepare_agent_board_card`)",
         "suggested_user_prompt": "Use OMH agent-board for: Coordinate CTO, PM, QA, and release agents on this launch checklist."
       },
       "evidence": {
@@ -431,6 +436,7 @@
         "harness": "agent-board",
         "install_visibility": false,
         "next_action": "prepare_agent_board_card",
+        "next_action_label": "preparing an agent board card",
         "playbook": "agent-board",
         "primary_skill": "agent-board"
       },
@@ -472,7 +478,7 @@
         {
           "id": "prepare_memory_curation_review",
           "kind": "hermes_prompt",
-          "label": "Prepare memory curation review",
+          "label": "Prepare a memory curation review",
           "style": "primary",
           "value": "Use OMH memory-curation-review for: Inspect stale project memories and ask me what to keep."
         },
@@ -525,6 +531,7 @@
           "\uc911\ubcf5"
         ],
         "next_action": "prepare_memory_curation_review",
+        "next_action_label": "preparing a memory curation review",
         "playbook": "memory-curation-review",
         "preferred_usage": "Use as an installed Hermes workflow skill when the user asks to review stale, duplicate, or conflicting memory and skill context.",
         "primary_skill": "memory-curation-review",
@@ -548,13 +555,13 @@
       "chat_surface": {
         "body_lines": [
           "Review stale memories, conflicting facts, and duplicate skills with approve/reject/update actions.",
-          "Route: memory-curation-review -> prepare_memory_curation_review.",
+          "Route: memory-curation-review -> preparing a memory curation review (`prepare_memory_curation_review`).",
           "Users can clean memory and skill drift without a silent destructive edit."
         ],
         "direct_skill_invocation": "$memory-curation-review Inspect stale project memories and ask me what to keep.",
         "headline": "[omh] Memory and skill curation review",
         "source": "hermes_agent_chat",
-        "status_line": "prepared_not_observed | memory-curation-review | prepare_memory_curation_review",
+        "status_line": "prepared_not_observed | memory-curation-review | preparing a memory curation review (`prepare_memory_curation_review`)",
         "suggested_user_prompt": "Use OMH memory-curation-review for: Inspect stale project memories and ask me what to keep."
       },
       "evidence": {
@@ -587,6 +594,7 @@
         "harness": "memory-curation-review",
         "install_visibility": true,
         "next_action": "prepare_memory_curation_review",
+        "next_action_label": "preparing a memory curation review",
         "playbook": "memory-curation-review",
         "primary_skill": "memory-curation-review"
       },
@@ -628,7 +636,7 @@
         {
           "id": "prepare_gateway_intent_card",
           "kind": "hermes_prompt",
-          "label": "Prepare gateway intent card",
+          "label": "Prepare a gateway intent card",
           "style": "primary",
           "value": "Use OMH gateway-intent-card for: Route this Discord thread update silently unless action is needed."
         },
@@ -682,6 +690,7 @@
           "\uc2ac\ub799"
         ],
         "next_action": "prepare_gateway_intent_card",
+        "next_action_label": "preparing a gateway intent card",
         "playbook": "gateway-intent-card",
         "preferred_usage": "Prefer wrapper or Hermes natural-language routing into gateway intent policy instead of exposing this as a primary user skill.",
         "primary_skill": "gateway-intent-card",
@@ -704,13 +713,13 @@
       "chat_surface": {
         "body_lines": [
           "Normalize Discord, Slack, Telegram, and other gateway sessions into origin/thread/delivery/silent/attachment/status-update policy.",
-          "Route: gateway-intent-card -> prepare_gateway_intent_card.",
+          "Route: gateway-intent-card -> preparing a gateway intent card (`prepare_gateway_intent_card`).",
           "Gateway builders get a platform-neutral card Hermes can use without hardcoding a bot SDK into OMH."
         ],
         "direct_skill_invocation": "$gateway-intent-card Route this Discord thread update silently unless action is needed.",
         "headline": "[omh] Gateway-native intent card",
         "source": "hermes_agent_chat",
-        "status_line": "prepared_not_observed | gateway-intent-card | prepare_gateway_intent_card",
+        "status_line": "prepared_not_observed | gateway-intent-card | preparing a gateway intent card (`prepare_gateway_intent_card`)",
         "suggested_user_prompt": "Use OMH gateway-intent-card for: Route this Discord thread update silently unless action is needed."
       },
       "evidence": {
@@ -743,6 +752,7 @@
         "harness": "gateway-intent-card",
         "install_visibility": false,
         "next_action": "prepare_gateway_intent_card",
+        "next_action_label": "preparing a gateway intent card",
         "playbook": "gateway-intent-card",
         "primary_skill": "gateway-intent-card"
       },
@@ -784,7 +794,7 @@
         {
           "id": "prepare_executor_runtime_readiness",
           "kind": "hermes_prompt",
-          "label": "Prepare executor runtime readiness",
+          "label": "Check coding-agent readiness",
           "style": "primary",
           "value": "Use OMH executor-runtime-readiness for: Can this task run in Codex, Claude Code, or Hermes coding?"
         },
@@ -838,6 +848,7 @@
           "\ud074\ub85c\ub4dc"
         ],
         "next_action": "prepare_executor_runtime_readiness",
+        "next_action_label": "checking coding-agent readiness",
         "playbook": "executor-runtime-readiness",
         "preferred_usage": "Use as a readiness harness/status surface when Hermes needs to compare executor/runtime options before handoff.",
         "primary_skill": "executor-runtime-readiness",
@@ -860,13 +871,13 @@
       "chat_surface": {
         "body_lines": [
           "Show whether Codex, Claude Code, Hermes coding, or an oh-my runtime has the tools, credentials, and handoff mode needed.",
-          "Route: executor-runtime-readiness -> prepare_executor_runtime_readiness.",
+          "Route: executor-runtime-readiness -> checking coding-agent readiness (`prepare_executor_runtime_readiness`).",
           "Users can choose Codex, Claude Code, Hermes, or plugin runtimes without guessing hidden capabilities."
         ],
         "direct_skill_invocation": "$executor-runtime-readiness Can this task run in Codex, Claude Code, or Hermes coding?",
         "headline": "[omh] Executor runtime readiness",
         "source": "hermes_agent_chat",
-        "status_line": "prepared_not_observed | executor-runtime-readiness | prepare_executor_runtime_readiness",
+        "status_line": "prepared_not_observed | executor-runtime-readiness | checking coding-agent readiness (`prepare_executor_runtime_readiness`)",
         "suggested_user_prompt": "Use OMH executor-runtime-readiness for: Can this task run in Codex, Claude Code, or Hermes coding?"
       },
       "evidence": {
@@ -899,6 +910,7 @@
         "harness": "executor-runtime-readiness",
         "install_visibility": false,
         "next_action": "prepare_executor_runtime_readiness",
+        "next_action_label": "checking coding-agent readiness",
         "playbook": "executor-runtime-readiness",
         "primary_skill": "executor-runtime-readiness"
       },
@@ -940,7 +952,7 @@
         {
           "id": "prepare_deliverable_package",
           "kind": "hermes_prompt",
-          "label": "Prepare deliverable package",
+          "label": "Prepare a deliverable package",
           "style": "primary",
           "value": "Use OMH deliverable-package for: Turn this research into PPT and PDF with attachment status."
         },
@@ -995,6 +1007,7 @@
           "\ud30c\uc77c"
         ],
         "next_action": "prepare_deliverable_package",
+        "next_action_label": "preparing a deliverable package",
         "playbook": "deliverable-package",
         "preferred_usage": "Use as an installed Hermes workflow skill when the user asks for file deliverable packaging and attachment lifecycle status.",
         "primary_skill": "deliverable-package",
@@ -1018,13 +1031,13 @@
       "chat_surface": {
         "body_lines": [
           "Track PPT, PDF, XLSX, DOCX, HWP, Markdown, and attachments through prepared/generated/QA/attached states.",
-          "Route: deliverable-package -> prepare_deliverable_package.",
+          "Route: deliverable-package -> preparing a deliverable package (`prepare_deliverable_package`).",
           "Users can ask for files in chat and see exactly whether they are planned, generated, QAed, approved, or attached."
         ],
         "direct_skill_invocation": "$deliverable-package Turn this research into PPT and PDF with attachment status.",
         "headline": "[omh] Deliverable file package",
         "source": "hermes_agent_chat",
-        "status_line": "prepared_not_observed | deliverable-package | prepare_deliverable_package",
+        "status_line": "prepared_not_observed | deliverable-package | preparing a deliverable package (`prepare_deliverable_package`)",
         "suggested_user_prompt": "Use OMH deliverable-package for: Turn this research into PPT and PDF with attachment status."
       },
       "evidence": {
@@ -1057,6 +1070,7 @@
         "harness": "deliverable-package",
         "install_visibility": true,
         "next_action": "prepare_deliverable_package",
+        "next_action_label": "preparing a deliverable package",
         "playbook": "deliverable-package",
         "primary_skill": "deliverable-package"
       },
@@ -1098,7 +1112,7 @@
         {
           "id": "prepare_voice_operator_card",
           "kind": "hermes_prompt",
-          "label": "Prepare voice operator card",
+          "label": "Prepare a voice-operator card",
           "style": "primary",
           "value": "Use OMH voice-operator for: 'release before lunch, check risky parts' from mobile."
         },
@@ -1150,6 +1164,7 @@
           "\uc811\uadfc\uc131"
         ],
         "next_action": "prepare_voice_operator_card",
+        "next_action_label": "preparing a voice-operator card",
         "playbook": "voice-operator",
         "preferred_usage": "Use as Hermes voice/mobile context guidance that normalizes short commands before choosing a concrete workflow.",
         "primary_skill": "voice-operator",
@@ -1171,13 +1186,13 @@
       "chat_surface": {
         "body_lines": [
           "Convert terse voice/mobile commands into clarify, plan, status, handoff, or confirmation actions.",
-          "Route: voice-operator -> prepare_voice_operator_card.",
+          "Route: voice-operator -> preparing a voice-operator card (`prepare_voice_operator_card`).",
           "Voice and mobile users get concise, safe routing instead of long CLI-like responses."
         ],
         "direct_skill_invocation": "$voice-operator 'release before lunch, check risky parts' from mobile.",
         "headline": "[omh] Voice and mobile operator",
         "source": "hermes_agent_chat",
-        "status_line": "prepared_not_observed | voice-operator | prepare_voice_operator_card",
+        "status_line": "prepared_not_observed | voice-operator | preparing a voice-operator card (`prepare_voice_operator_card`)",
         "suggested_user_prompt": "Use OMH voice-operator for: 'release before lunch, check risky parts' from mobile."
       },
       "evidence": {
@@ -1210,6 +1225,7 @@
         "harness": "voice-operator",
         "install_visibility": false,
         "next_action": "prepare_voice_operator_card",
+        "next_action_label": "preparing a voice-operator card",
         "playbook": "voice-operator",
         "primary_skill": "voice-operator"
       },
@@ -1251,7 +1267,7 @@
         {
           "id": "prepare_toolbelt_readiness",
           "kind": "hermes_prompt",
-          "label": "Prepare toolbelt readiness",
+          "label": "Check toolbelt readiness",
           "style": "primary",
           "value": "Use OMH toolbelt-readiness for: What MCP or CLI tools do I need for weekly Linear and GitHub triage?"
         },
@@ -1304,6 +1320,7 @@
           "\uc678\ubd80 \ub3c4\uad6c"
         ],
         "next_action": "prepare_toolbelt_readiness",
+        "next_action_label": "checking toolbelt readiness",
         "playbook": "toolbelt-readiness",
         "preferred_usage": "Use as a readiness harness when Hermes needs to show missing MCP, CLI, API, credential, or connector requirements.",
         "primary_skill": "toolbelt-readiness",
@@ -1326,13 +1343,13 @@
       "chat_surface": {
         "body_lines": [
           "Check which MCP servers, CLIs, APIs, credentials, and connectors a workflow needs before claiming it can run.",
-          "Route: toolbelt-readiness -> prepare_toolbelt_readiness.",
+          "Route: toolbelt-readiness -> checking toolbelt readiness (`prepare_toolbelt_readiness`).",
           "Users see missing MCP/CLI/API pieces before an automation or handoff overclaims readiness."
         ],
         "direct_skill_invocation": "$toolbelt-readiness What MCP or CLI tools do I need for weekly Linear and GitHub triage?",
         "headline": "[omh] MCP and external toolbelt readiness",
         "source": "hermes_agent_chat",
-        "status_line": "prepared_not_observed | toolbelt-readiness | prepare_toolbelt_readiness",
+        "status_line": "prepared_not_observed | toolbelt-readiness | checking toolbelt readiness (`prepare_toolbelt_readiness`)",
         "suggested_user_prompt": "Use OMH toolbelt-readiness for: What MCP or CLI tools do I need for weekly Linear and GitHub triage?"
       },
       "evidence": {
@@ -1365,6 +1382,7 @@
         "harness": "toolbelt-readiness",
         "install_visibility": false,
         "next_action": "prepare_toolbelt_readiness",
+        "next_action_label": "checking toolbelt readiness",
         "playbook": "toolbelt-readiness",
         "primary_skill": "toolbelt-readiness"
       },
@@ -1406,7 +1424,7 @@
         {
           "id": "prepare_ops_observability_card",
           "kind": "hermes_prompt",
-          "label": "Prepare ops observability card",
+          "label": "Prepare an ops observability card",
           "style": "primary",
           "value": "Use OMH ops-observability-card for: Show token, cost, latency, and last run status for this loop."
         },
@@ -1459,6 +1477,7 @@
           "\uad00\uce21\uc131"
         ],
         "next_action": "prepare_ops_observability_card",
+        "next_action_label": "preparing an ops observability card",
         "playbook": "ops-observability-card",
         "preferred_usage": "Use as a telemetry/status harness for token, cost, latency, run history, and failure-mode boundaries.",
         "primary_skill": "ops-observability-card",
@@ -1481,13 +1500,13 @@
       "chat_surface": {
         "body_lines": [
           "Keep automation and loop work from failing silently by showing token/cost/latency/run-history/failure-mode telemetry boundaries.",
-          "Route: ops-observability-card -> prepare_ops_observability_card.",
+          "Route: ops-observability-card -> preparing an ops observability card (`prepare_ops_observability_card`).",
           "Operators can see health/cost signals without confusing estimates with provider truth or completion evidence."
         ],
         "direct_skill_invocation": "$ops-observability-card Show token, cost, latency, and last run status for this loop.",
         "headline": "[omh] Ops observability and cost card",
         "source": "hermes_agent_chat",
-        "status_line": "prepared_not_observed | ops-observability-card | prepare_ops_observability_card",
+        "status_line": "prepared_not_observed | ops-observability-card | preparing an ops observability card (`prepare_ops_observability_card`)",
         "suggested_user_prompt": "Use OMH ops-observability-card for: Show token, cost, latency, and last run status for this loop."
       },
       "evidence": {
@@ -1520,6 +1539,7 @@
         "harness": "ops-observability-card",
         "install_visibility": false,
         "next_action": "prepare_ops_observability_card",
+        "next_action_label": "preparing an ops observability card",
         "playbook": "ops-observability-card",
         "primary_skill": "ops-observability-card"
       },

--- a/src/commands/use_cases.py
+++ b/src/commands/use_cases.py
@@ -177,7 +177,7 @@ def _print_case_summary(case: dict[str, object]) -> None:
     print(f"  Compatibility alias: {case.get('compatibility_alias')}")
     print(f"  Playbook: {case.get('playbook')}")
     print(f"  Harness: {case.get('harness')}")
-    print(f"  Next action: {case.get('next_action')}")
+    print(f"  Next action: {_action_label_with_id(str(case.get('next_action', '')))}")
     print("Use it")
     print(f"  Hermes chat: {case.get('hermes_chat_prompt')}")
     print(f"  Compatibility alias: {case.get('direct_skill_invocation')}")
@@ -206,7 +206,7 @@ def _print_case_demo_summary(card: dict[str, object]) -> None:
     print(f"OMH use-case demo card: {card.get('goal')} - {card.get('title')}")
     print("Route")
     print(
-        f"  {route.get('primary_skill')} -> {route.get('next_action')} "
+        f"  {_route_summary(route)} "
         f"({route.get('exposure')}; playbook {route.get('playbook')}; harness {route.get('harness')})"
     )
     print("Hermes card")
@@ -237,7 +237,7 @@ def _print_cases_demo_collection_summary(payload: dict[str, object]) -> None:
         route = card.get("route", {})
         if not isinstance(route, dict):
             route = {}
-        print(f"  - {card.get('goal')}: {card.get('title')} ({route.get('primary_skill')} -> {route.get('next_action')})")
+        print(f"  - {card.get('goal')}: {card.get('title')} ({_route_summary(route)})")
     print("Boundary")
     print(f"  {payload.get('boundary')}")
     print("Next")
@@ -288,7 +288,7 @@ def _print_cases_artifact_summary(payload: dict[str, object]) -> None:
             route = artifact.get("route", {})
             if not isinstance(route, dict):
                 route = {}
-            print(f"  - {artifact.get('goal')}: {artifact.get('title')} ({route.get('primary_skill')} -> {route.get('next_action')})")
+            print(f"  - {artifact.get('goal')}: {artifact.get('title')} ({_route_summary(route)})")
         print("Boundary")
         print(f"  {payload.get('boundary')}")
         print("Next")
@@ -303,7 +303,7 @@ def _print_cases_artifact_summary(payload: dict[str, object]) -> None:
         evidence = {}
     print(f"OMH use-case artifact: {payload.get('goal')} - {payload.get('title')}")
     print("Route")
-    print(f"  {route.get('primary_skill')} -> {route.get('next_action')}")
+    print(f"  {_route_summary(route)}")
     print("Artifact")
     print(f"  ID: {payload.get('artifact_id')}")
     print(f"  Status: {payload.get('observation_status')}")
@@ -447,6 +447,16 @@ def _print_cases_validate_summary(payload: dict[str, object]) -> None:
     print("Boundary")
     print("  Validation proves catalog registration only, not external runtime execution.")
     print("  For machine-readable output, rerun with `--json`.")
+
+
+def _route_summary(route: dict[str, object]) -> str:
+    primary_skill = str(route.get("primary_skill", "")).strip()
+    next_action = str(route.get("next_action", "")).strip()
+    if not primary_skill and not next_action:
+        return ""
+    if not next_action:
+        return primary_skill
+    return f"{primary_skill} -> {_action_label_with_id(next_action, str(route.get('next_action_label', '')))}"
 
 
 def _add_cases_commands(sub) -> None:

--- a/src/workflows/use_cases.py
+++ b/src/workflows/use_cases.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from ..local_store import atomic_write_json, ensure_dir, read_json_object, read_json_object_result, utc_now
 from ..paths import OmhPaths
+from ..routing.action_copy import next_action_label
 
 
 USE_CASE_CATALOG_SCHEMA_VERSION = "omh_use_case_catalog/v1"
@@ -968,6 +969,7 @@ def _public_case(case: UseCase) -> dict[str, Any]:
 
     payload = asdict(case)
     payload.update(skill_exposure_payload(case.primary_skill))
+    payload["next_action_label"] = _action_label(case.next_action)
     payload["proof_surfaces"] = list(case.proof_surfaces)
     payload["keywords"] = list(case.keywords)
     return payload
@@ -988,6 +990,7 @@ def _demo_card(case: UseCase) -> dict[str, Any]:
             "install_visibility": exposure["install_visibility"],
             "compatibility_alias": exposure["compatibility_alias"],
             "next_action": case.next_action,
+            "next_action_label": _action_label(case.next_action),
         },
         "chat_surface": {
             "source": "hermes_agent_chat",
@@ -996,10 +999,10 @@ def _demo_card(case: UseCase) -> dict[str, Any]:
             "headline": f"[omh] {case.title}",
             "body_lines": [
                 case.hermes_use_case,
-                f"Route: {case.primary_skill} -> {case.next_action}.",
+                f"Route: {case.primary_skill} -> {_action_label_with_id(case.next_action)}.",
                 case.user_value,
             ],
-            "status_line": f"prepared_not_observed | {case.primary_skill} | {case.next_action}",
+            "status_line": f"prepared_not_observed | {case.primary_skill} | {_action_label_with_id(case.next_action)}",
         },
         "wrapper_card": {
             "component": "omh_use_case_card",
@@ -1029,7 +1032,7 @@ def _demo_card(case: UseCase) -> dict[str, Any]:
         "actions": [
             {
                 "id": case.next_action,
-                "label": _action_label(case.next_action),
+                "label": _action_button_label(case.next_action),
                 "kind": "hermes_prompt",
                 "style": "primary",
                 "value": case.hermes_chat_prompt,
@@ -1083,7 +1086,36 @@ def _demo_card(case: UseCase) -> dict[str, Any]:
 
 
 def _action_label(action: str) -> str:
-    return action.replace("_", " ").capitalize()
+    return next_action_label(action)
+
+
+def _action_label_with_id(action: str) -> str:
+    normalized = action.strip()
+    if not normalized:
+        return ""
+    label = _action_label(normalized)
+    if not label or label == normalized:
+        return normalized
+    return f"{label} (`{normalized}`)"
+
+
+def _action_button_label(action: str) -> str:
+    label = _action_label(action)
+    replacements = (
+        ("preparing ", "Prepare "),
+        ("checking ", "Check "),
+        ("showing ", "Show "),
+        ("opening ", "Open "),
+        ("scoping ", "Scope "),
+        ("reviewing ", "Review "),
+        ("classifying ", "Classify "),
+        ("gathering ", "Gather "),
+        ("starting ", "Start "),
+    )
+    for prefix, replacement in replacements:
+        if label.startswith(prefix):
+            return replacement + label[len(prefix) :]
+    return label[:1].upper() + label[1:]
 
 
 def _artifact_operator_steps(case: UseCase) -> list[dict[str, str]]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1068,15 +1068,31 @@ class CliTests(unittest.TestCase):
         self.assertEqual(demo["goal"], "G1")
         self.assertEqual(demo["route"]["primary_skill"], "automation-blueprint")
         self.assertEqual(demo["route"]["next_action"], "prepare_scheduled_ops_blueprint")
+        self.assertEqual(demo["route"]["next_action_label"], "preparing a scheduled-ops blueprint")
         self.assertEqual(demo["wrapper_card"]["component"], "omh_use_case_card")
         self.assertEqual(demo["wrapper_card"]["status"], "prepared_not_observed")
         self.assertIn("prepared_not_observed", demo["chat_surface"]["status_line"])
+        self.assertIn(
+            "Route: automation-blueprint -> preparing a scheduled-ops blueprint (`prepare_scheduled_ops_blueprint`).",
+            demo["chat_surface"]["body_lines"],
+        )
         self.assertEqual(demo["actions"][0]["id"], "prepare_scheduled_ops_blueprint")
+        self.assertEqual(demo["actions"][0]["label"], "Prepare a scheduled-ops blueprint")
         self.assertEqual(demo["actions"][0]["kind"], "hermes_prompt")
         self.assertIn("omh playbook inspect scheduled-ops-blueprint", demo["operator_commands"][1])
         self.assertIn("connector_invocation", demo["evidence"]["not_evidence_until_observed"])
         self.assertIn("executor_dispatch", demo["evidence"]["not_evidence_until_observed"])
         self.assertIn("not host cron creation", demo["evidence"]["claim_boundary"])
+
+        status, stdout, stderr = run_cli(["cases", "demo", "G1"], output_json=False)
+
+        self.assertEqual(status, 0, stderr)
+        self.assertEqual(stderr, "")
+        self.assertIn(
+            "automation-blueprint -> preparing a scheduled-ops blueprint (`prepare_scheduled_ops_blueprint`)",
+            stdout,
+        )
+        self.assertNotIn("automation-blueprint -> prepare_scheduled_ops_blueprint (", stdout)
 
         status, stdout, stderr = run_cli(["cases", "demo", "--all", "--json"], output_json=False)
 


### PR DESCRIPTION
## Feature Report

### What Changed

- G1-G10 use-case cards now include `next_action_label` alongside the stable `next_action` id.
- Human terminal summaries for `omh cases inspect`, `omh cases demo`, and `omh cases artifact` now show readable route text such as `preparing a scheduled-ops blueprint (`prepare_scheduled_ops_blueprint`)`.
- The generated `examples/use-cases/g1-g10-demo-cards.json` fixture was refreshed to match the new wrapper-renderable copy.
- Added regression coverage for both JSON card labels and stdout route summaries.

### Why This Exists

- Recent recommendation output was improved so operators do not see only raw internal action ids.
- The same rough edge still existed in the use-case demo/artifact surfaces, where routes displayed as `automation-blueprint -> prepare_scheduled_ops_blueprint`.
- Use cases are one of the clearest product-story surfaces, so they should explain what Hermes will do next in readable language while keeping ids available for wrappers.

### User / Operator Impact

- Operators reading `omh cases demo --all` can understand each route without decoding snake_case action ids.
- Wrapper authors still receive stable `next_action` ids, plus a ready-to-render `next_action_label`.
- Demo cards and prepared artifacts feel closer to the chat-first OMH experience instead of a raw backend dump.

### How It Works

- `src/workflows/use_cases.py` now resolves action labels through the shared routing action-copy catalog.
- Use-case public payloads and demo-card route objects include `next_action_label` without changing existing `next_action` ids.
- Chat-surface body/status lines and CLI route summaries use readable action text with the stable id in parentheses.
- Primary action button labels stay imperative, for example `Prepare a scheduled-ops blueprint`.

### Files And Contracts Touched

- `src/workflows/use_cases.py`: adds label projection to use-case catalog/demo artifacts.
- `src/commands/use_cases.py`: humanizes route summaries in terminal output.
- `examples/use-cases/g1-g10-demo-cards.json`: regenerated canonical demo-card fixture.
- `tests/test_cli.py`: locks JSON and stdout copy behavior.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests.test_cli.CliTests.test_cases_catalog_exposes_g1_to_g10_and_recommends_real_situations tests.test_cli.CliTests.test_recommendation_summaries_use_human_action_labels -v`
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_application_cases.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_cli.py tests/test_application_cases.py tests/test_chat_router.py tests/test_wrapper_contract.py -v`
- [x] `PYTHONPATH=tests uv run python -m omh.cli demo hermes-ux-quality --summary`
- [x] `PYTHONPATH=tests uv run python -m omh.cli demo route-hint-alignment --summary`
- [x] `PYTHONPATH=tests uv run python -m omh.cli cases readiness --json`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check`
- [x] `PYTHONPATH=tests uv run python -m omh.cli harness validate`
- [x] `git diff --check`
- [ ] `python3 -m omh.cli release checklist --json` - not run; change is narrow use-case rendering/copy only.
- [ ] `python3 -m omh.cli release hermes-smoke` - not run; no install/runtime behavior changed.
- [ ] `omh --help` - not run; no parser/help surface changed.
- [ ] Manual Hermes/TUI check - not run; deterministic CLI and wrapper fixture contracts were tested.

## Risk

- Low. Existing stable ids remain unchanged; this only adds labels and changes human-readable stdout/card copy.
- Generated fixture churn is expected because the canonical card body/status/labels changed.

## Compatibility / Rollout

- Backward compatible for consumers of `next_action`.
- New `next_action_label` is additive.
- Human stdout changes are intentional and improve readability.

## Release / Claims

- [x] Release-channel impact considered: local/preview copy improvement only.
- [x] Runtime/native capability claims are not changed.
- [x] Live Hermes/plugin execution is not claimed by this PR.

## Follow-Up

- Continue using the shared action-copy catalog anywhere OMH renders next-action ids to users.
