### PR TITLE
Humanize context route hints

### DIFF
--- a/src/commands/common.py
+++ b/src/commands/common.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from ..ingress import extract_message_text, extract_source_metadata
 from ..installer import OmhError
 from ..paths import resolve_paths
-from ..routing.action_copy import next_action_label
+from ..routing.action_copy import next_action_label_with_id
 from ..setup_profiles import read_setup_profile
 from ..targets import TARGET_METADATA_KEYS
 
@@ -28,13 +28,7 @@ def _wants_json(args: argparse.Namespace) -> bool:
 
 
 def _action_label_with_id(action: str, label: str = "") -> str:
-    normalized = action.strip()
-    if not normalized:
-        return ""
-    resolved_label = label.strip() or next_action_label(normalized)
-    if not resolved_label or resolved_label == normalized:
-        return normalized
-    return f"{resolved_label} (`{normalized}`)"
+    return next_action_label_with_id(action, label)
 
 
 def _explicit_source_metadata(args: argparse.Namespace) -> dict[str, str]:

--- a/src/commands/context.py
+++ b/src/commands/context.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import argparse
 
 from ..context import build_context_brief
-from .common import _print_json, _wants_json
+from .common import _action_label_with_id, _print_json, _wants_json
 
 
 def cmd_context_brief(args: argparse.Namespace) -> int:
@@ -30,15 +30,17 @@ def _print_context_brief_summary(payload: dict[str, object]) -> None:
     if isinstance(route_hint, dict):
         primary = str(route_hint.get("primary_workflow") or "")
         action = str(route_hint.get("primary_next_action") or "")
+        action_label = str(route_hint.get("primary_next_action_label") or "")
         if primary:
-            print(f"  Route hint: {primary} -> {action}")
+            print(f"  Route hint: {primary} -> {_action_label_with_id(action, action_label)}")
         else:
             print("  Route hint: no strong message-specific hint")
     catalog_question = payload.get("catalog_question")
     if isinstance(catalog_question, dict) and catalog_question.get("status") == "matched":
         print(
             "  Catalog question: "
-            f"{catalog_question.get('next_action')} via {catalog_question.get('recommended_tool')}"
+            f"{_action_label_with_id(str(catalog_question.get('next_action', '')))} "
+            f"via {catalog_question.get('recommended_tool')}"
         )
     print("Workflow lanes")
     lanes = payload.get("lanes", [])

--- a/src/quality/context_brief_coverage.py
+++ b/src/quality/context_brief_coverage.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from ..context import build_context_brief
 from ..ingress import CHAT_SOURCES
+from ..routing.action_copy import next_action_label_with_id
 
 
 CONTEXT_BRIEF_COVERAGE_SCHEMA_VERSION = "context_brief_coverage/v1"
@@ -145,7 +146,10 @@ def format_context_brief_coverage_summary(payload: dict[str, object]) -> str:
         status = "ok" if row.get("passed") else "needs attention"
         workflow = observed.get("primary_workflow") or "catalog"
         action = observed.get("primary_next_action") or observed.get("catalog_next_action") or "unknown"
-        lines.append(f"- {row.get('title', 'Untitled context')}: {status}; {workflow} -> {action}")
+        lines.append(
+            f"- {row.get('title', 'Untitled context')}: "
+            f"{status}; {workflow} -> {next_action_label_with_id(str(action))}"
+        )
     failed = [row for row in rows if not row.get("passed")]
     if failed:
         lines.extend(["", "Failures:"])

--- a/src/routing/action_copy.py
+++ b/src/routing/action_copy.py
@@ -59,6 +59,7 @@ NEXT_ACTION_LABELS: dict[str, str] = {
     "show_agent_ops_review": "showing agent-ops status",
     "show_coding_handoff_status": "showing coding-agent progress",
     "show_workflow_guidance": "showing workflow guidance",
+    "show_workflow_picker": "opening the workflow picker",
     "start_loop_cycle": "starting the loopability-gated cycle",
     "start_ultraprocess": "preparing the one-cycle delivery process",
     "triage_feedback": "triaging the feedback signal",
@@ -70,3 +71,13 @@ def next_action_label(next_action: str) -> str:
     if not normalized:
         return ""
     return NEXT_ACTION_LABELS.get(normalized, normalized.replace("_", " "))
+
+
+def next_action_label_with_id(next_action: str, label: str = "") -> str:
+    normalized = next_action.strip()
+    if not normalized:
+        return ""
+    resolved_label = label.strip() or next_action_label(normalized)
+    if not resolved_label or resolved_label == normalized:
+        return normalized
+    return f"{resolved_label} (`{normalized}`)"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -69,7 +69,10 @@ class CliTests(unittest.TestCase):
         self.assertEqual(status, 0, stderr)
         self.assertEqual(stderr, "")
         self.assertIn("OMH context brief", stdout)
-        self.assertIn("Route hint: img-summary -> prepare_visual_prompt_card", stdout)
+        self.assertIn(
+            "Route hint: img-summary -> preparing an image prompt card (`prepare_visual_prompt_card`)",
+            stdout,
+        )
         self.assertIn("Workflow lanes", stdout)
         self.assertIn("Generic tool checkpoint", stdout)
         self.assertIn("Do not skip OMH merely because a generic tool", stdout)
@@ -81,7 +84,10 @@ class CliTests(unittest.TestCase):
 
         self.assertEqual(status, 0, stderr)
         self.assertEqual(stderr, "")
-        self.assertIn("Catalog question: show_workflow_picker via omh_capabilities", stdout)
+        self.assertIn(
+            "Catalog question: opening the workflow picker (`show_workflow_picker`) via omh_capabilities",
+            stdout,
+        )
 
         status, stdout, stderr = run_cli(
             [

--- a/tests/test_context_brief_coverage.py
+++ b/tests/test_context_brief_coverage.py
@@ -41,6 +41,16 @@ class ContextBriefCoverageTests(unittest.TestCase):
         self.assertIn("OMH context brief coverage", stdout)
         self.assertIn("8/8 context brief cases passing", stdout)
         self.assertIn("catalog picker hints: 1", stdout)
+        self.assertIn(
+            "Visual summary before generic image tools: ok; "
+            "img-summary -> preparing an image prompt card (`prepare_visual_prompt_card`)",
+            stdout,
+        )
+        self.assertIn(
+            "Catalog picker without shell approval: ok; "
+            "catalog -> opening the workflow picker (`show_workflow_picker`)",
+            stdout,
+        )
 
         status, stdout, stderr = run_cli(["demo", "context-brief-coverage", "--json"], output_json=False)
 


### PR DESCRIPTION
## Summary
- Render `omh context brief` route hints with human-readable next-action copy while keeping the stable action id in parentheses.
- Add `show_workflow_picker` to the shared action-copy catalog so catalog questions read as "opening the workflow picker" instead of a raw internal id.
- Reuse the same action-copy helper in the context-brief coverage demo so quality summaries stay readable too.

## Why
Hermes-facing context should feel like operational guidance, not backend JSON leaking through the chat surface. Before this change, context brief summaries could show lines such as `img-summary -> prepare_visual_prompt_card` or `show_workflow_picker via omh_capabilities`. That was accurate for machines but awkward for users and Hermes wrapper narration.

## What Changes For Users
- Image requests now summarize as `img-summary -> preparing an image prompt card (`prepare_visual_prompt_card`)`.
- Workflow catalog questions now summarize as `opening the workflow picker (`show_workflow_picker`)`.
- Context-brief coverage output now uses the same readable wording across all rollup rows.

## Implementation Notes
- Added `next_action_label_with_id` to `src/routing/action_copy.py` as the shared formatter.
- Kept `src/commands/common.py` as the command-level compatibility helper while delegating to the shared routing formatter.
- Updated `src/commands/context.py` and `src/quality/context_brief_coverage.py` to use the shared human label formatting.
- JSON payload fields such as `primary_next_action` remain unchanged for wrapper compatibility.

## Verification
- `PYTHONPATH=tests uv run python -m unittest tests.test_cli.CliTests.test_context_brief_exposes_omh_mental_model_and_route_hint tests.test_context_brief_coverage.ContextBriefCoverageTests.test_context_brief_coverage_cli_outputs_summary_and_json tests.test_router_content.RouterContentTests.test_route_next_action_labels_cover_recommendation_policies -v`
- `PYTHONPATH=tests uv run python -m unittest tests/test_cli.py tests/test_context_brief_coverage.py tests/test_hook_manifest.py tests/test_plugin_distribution.py tests/test_plugin_capabilities.py -v`
- `PYTHONPATH=tests uv run python -m omh.cli demo context-brief-coverage --summary`
- `PYTHONPATH=tests uv run python -m omh.cli demo hermes-ux-quality --summary`
- `uv run python -m compileall -q src tests`
- `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check`
- `PYTHONPATH=tests uv run python -m omh.cli harness validate`
- `git diff --check`
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`

## Risks And Boundaries
- This is deterministic local CLI/demo copy only.
- It does not prove live Hermes chat rendering, platform delivery, plugin load, workflow execution, verification, review, CI, or merge.
- Wrapper-visible JSON action ids are intentionally preserved.
