### PR TITLE
Explain demo quality lanes in help

### DIFF
--- a/src/commands/demo.py
+++ b/src/commands/demo.py
@@ -18,6 +18,26 @@ from ..installer import OmhError
 from .common import _print_json
 
 
+DEMO_EPILOG = """Demo lanes:
+  orchestration           Shows recommend -> chat -> plan -> handoff -> status for one request.
+  grounded-score          Scores representative real-world prompts against dedicated OMH routes.
+  chat-card-coverage      Verifies wrapper cards are specific, not generic acknowledgements.
+  route-hint-alignment    Checks plugin/router route hints agree before Hermes speaks.
+  context-brief-coverage  Checks compact OMH context briefs keep the right workflow visible.
+  routing-precision       Guards against over-routing simple requests and missing OMH interventions.
+  hermes-ux-quality       Runs the combined user-feel gate across routing, cards, hints, and context.
+
+Recommended operator checks:
+  omh demo hermes-ux-quality --summary
+  omh demo routing-precision --summary
+  omh demo orchestration "I want to safely add a feature to this repo"
+
+Boundary:
+  Demo commands are deterministic local contract artifacts. They do not call Hermes,
+  dispatch a coding agent, deliver a chat message, or observe platform runtime evidence.
+"""
+
+
 def cmd_demo_orchestration(args: argparse.Namespace) -> int:
     message = " ".join(args.message).strip() or DEFAULT_ORCHESTRATION_MESSAGE
     try:
@@ -107,10 +127,23 @@ def cmd_demo_hermes_ux_quality(args: argparse.Namespace) -> int:
 
 
 def _add_demo_commands(sub) -> None:
-    demo = sub.add_parser("demo", help="Print deterministic demo artifacts for OMH orchestration examples.")
-    demo_sub = demo.add_subparsers(dest="demo_command", required=True)
+    demo = sub.add_parser(
+        "demo",
+        help="Print deterministic demo artifacts for OMH orchestration examples.",
+        description=(
+            "Run local OMH demo artifacts that show how Hermes should route, explain, "
+            "and status workflow requests before any live platform or executor evidence exists."
+        ),
+        epilog=DEMO_EPILOG,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    demo_sub = demo.add_subparsers(dest="demo_command", required=True, metavar="<demo>")
 
-    orchestration = demo_sub.add_parser("orchestration")
+    orchestration = demo_sub.add_parser(
+        "orchestration",
+        help="Show the recommend -> chat -> plan -> handoff -> status flow for one request.",
+        description="Build a fixture-backed end-to-end orchestration artifact for one natural-language request.",
+    )
     orchestration.add_argument(
         "message",
         nargs="*",
@@ -126,42 +159,66 @@ def _add_demo_commands(sub) -> None:
     )
     orchestration.set_defaults(func=cmd_demo_orchestration)
 
-    grounded_score = demo_sub.add_parser("grounded-score")
+    grounded_score = demo_sub.add_parser(
+        "grounded-score",
+        help="Score representative prompts against dedicated OMH workflow routes.",
+        description="Evaluate whether real-world operator prompts land on the intended OMH workflow instead of generic chat.",
+    )
     grounded_score.add_argument("--source", choices=CHAT_SOURCES, default="discord")
     output = grounded_score.add_mutually_exclusive_group()
     output.add_argument("--json", action="store_true", help="Print the full machine-readable JSON payload. This is the default.")
     output.add_argument("--summary", action="store_true", help="Print a compact human-readable score summary.")
     grounded_score.set_defaults(func=cmd_demo_grounded_score)
 
-    card_coverage = demo_sub.add_parser("chat-card-coverage")
+    card_coverage = demo_sub.add_parser(
+        "chat-card-coverage",
+        help="Verify routed prompts produce specific wrapper cards.",
+        description="Check that wrapper-facing chat cards stay workflow-specific and avoid generic acknowledgement responses.",
+    )
     card_coverage.add_argument("--source", choices=CHAT_SOURCES, default="discord")
     card_output = card_coverage.add_mutually_exclusive_group()
     card_output.add_argument("--json", action="store_true", help="Print the full machine-readable JSON payload. This is the default.")
     card_output.add_argument("--summary", action="store_true", help="Print a compact human-readable card coverage summary.")
     card_coverage.set_defaults(func=cmd_demo_chat_card_coverage)
 
-    route_hint_alignment = demo_sub.add_parser("route-hint-alignment")
+    route_hint_alignment = demo_sub.add_parser(
+        "route-hint-alignment",
+        help="Check router and plugin awareness route hints agree.",
+        description="Compare router decisions with plugin-awareness hints so Hermes receives the same workflow guidance.",
+    )
     route_hint_alignment.add_argument("--source", choices=CHAT_SOURCES, default="discord")
     alignment_output = route_hint_alignment.add_mutually_exclusive_group()
     alignment_output.add_argument("--json", action="store_true", help="Print the full machine-readable JSON payload. This is the default.")
     alignment_output.add_argument("--summary", action="store_true", help="Print a compact human-readable alignment summary.")
     route_hint_alignment.set_defaults(func=cmd_demo_route_hint_alignment)
 
-    context_brief_coverage = demo_sub.add_parser("context-brief-coverage")
+    context_brief_coverage = demo_sub.add_parser(
+        "context-brief-coverage",
+        help="Check compact OMH context briefs keep the right workflow visible.",
+        description="Verify context briefs expose the workflow, next action, and boundary that wrappers or plugins should show.",
+    )
     context_brief_coverage.add_argument("--source", choices=CHAT_SOURCES, default="discord")
     context_output = context_brief_coverage.add_mutually_exclusive_group()
     context_output.add_argument("--json", action="store_true", help="Print the full machine-readable JSON payload. This is the default.")
     context_output.add_argument("--summary", action="store_true", help="Print a compact human-readable context brief coverage summary.")
     context_brief_coverage.set_defaults(func=cmd_demo_context_brief_coverage)
 
-    routing_precision = demo_sub.add_parser("routing-precision")
+    routing_precision = demo_sub.add_parser(
+        "routing-precision",
+        help="Guard against over-routing simple prompts and missing OMH interventions.",
+        description="Evaluate negative controls and intervention prompts so OMH routes only when it adds workflow value.",
+    )
     routing_precision.add_argument("--source", choices=CHAT_SOURCES, default="discord")
     precision_output = routing_precision.add_mutually_exclusive_group()
     precision_output.add_argument("--json", action="store_true", help="Print the full machine-readable JSON payload. This is the default.")
     precision_output.add_argument("--summary", action="store_true", help="Print a compact human-readable routing precision summary.")
     routing_precision.set_defaults(func=cmd_demo_routing_precision)
 
-    hermes_ux_quality = demo_sub.add_parser("hermes-ux-quality")
+    hermes_ux_quality = demo_sub.add_parser(
+        "hermes-ux-quality",
+        help="Run the combined user-feel quality gate.",
+        description="Aggregate the major deterministic demos into one pass/fail Hermes UX quality report.",
+    )
     hermes_ux_quality.add_argument("--source", choices=CHAT_SOURCES, default="discord")
     ux_output = hermes_ux_quality.add_mutually_exclusive_group()
     ux_output.add_argument("--json", action="store_true", help="Print the full machine-readable JSON payload. This is the default.")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -60,6 +60,26 @@ class CliTests(unittest.TestCase):
         self.assertNotIn("==SUPPRESS==", help_text)
         self.assertNotIn("visual               ==", help_text)
 
+    def test_demo_help_explains_quality_lanes_and_boundary(self) -> None:
+        stdout_buffer = io.StringIO()
+
+        with patch("sys.stdout", stdout_buffer), self.assertRaises(SystemExit) as exit_context:
+            build_parser().parse_args(["demo", "--help"])
+
+        self.assertEqual(exit_context.exception.code, 0)
+        stdout = stdout_buffer.getvalue()
+        self.assertIn("Run local OMH demo artifacts", stdout)
+        self.assertIn("Demo lanes:", stdout)
+        self.assertIn("orchestration           Shows recommend -> chat -> plan -> handoff -> status", stdout)
+        self.assertIn("grounded-score          Scores representative real-world prompts", stdout)
+        self.assertIn("routing-precision       Guards against over-routing simple requests", stdout)
+        self.assertIn("hermes-ux-quality       Runs the combined user-feel gate", stdout)
+        self.assertIn("Recommended operator checks:", stdout)
+        self.assertIn("omh demo hermes-ux-quality --summary", stdout)
+        self.assertIn("Boundary:", stdout)
+        self.assertIn("They do not call Hermes", stdout)
+        self.assertIn("dispatch a coding agent", stdout)
+
     def test_context_brief_exposes_omh_mental_model_and_route_hint(self) -> None:
         status, stdout, stderr = run_cli(
             ["context", "brief", "--source", "discord", "make an image card for this PR"],


### PR DESCRIPTION
## Feature Report

### What Changed

- Expanded `omh demo --help` so it explains every deterministic demo lane in plain language.
- Added recommended operator checks for the most useful quality gates: `hermes-ux-quality`, `routing-precision`, and the orchestration demo.
- Added a clear boundary note that demos do not call Hermes, dispatch coding agents, deliver messages, or observe runtime evidence.
- Added purpose-oriented help and descriptions to each `omh demo <lane>` subcommand.

### Why This Exists

- The quality demo commands had become important proof surfaces, but the top-level help only showed a raw argparse command list.
- A user or operator trying to understand OMH quality checks should not need to read source code or docs before knowing which demo proves routing, card coverage, route hints, context briefs, precision, or combined UX quality.

### User / Operator Impact

- `omh demo --help` now reads like an operator map: what each lane checks, which commands to run first, and what claims are not being made.
- This improves first-use discoverability and keeps the prepared-vs-observed boundary visible directly in the terminal.
- Existing JSON payloads and summary outputs remain stable.

### How It Works

- `src/commands/demo.py` now gives the demo parser a description, raw-description epilog, explicit `<demo>` metavar, and help/description text for each subcommand.
- `tests/test_cli.py` captures argparse help output and asserts that quality lanes, recommended checks, and boundary copy remain visible.

### Files And Contracts Touched

- `src/commands/demo.py`: human-readable demo command help and subcommand descriptions.
- `tests/test_cli.py`: regression coverage for the `omh demo --help` operator contract.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests.test_cli.CliTests.test_demo_help_explains_quality_lanes_and_boundary tests.test_cli.CliTests.test_root_help_explains_command_lanes -v`
- [x] `PYTHONPATH=tests uv run python -m omh.cli demo routing-precision --help`
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_cli.py tests/test_routing_precision.py tests/test_hermes_ux_quality.py -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check`
- [x] `PYTHONPATH=tests uv run python -m omh.cli harness validate`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `git diff --check`
- [ ] `python3 -m omh.cli release checklist --json` — not run; no release packaging, docs generation, or runtime claim changed.
- [ ] `python3 -m omh.cli release hermes-smoke` — not run; no install or live Hermes visibility path changed.
- [ ] Manual Hermes/TUI check — not run; this is local CLI help text only.

## Risk

- Low. This is argparse help text and one regression test.
- The main maintenance risk is forgetting to add a new demo lane to the help epilog; the new test makes the current high-value lanes visible.

## Compatibility / Rollout

- Compatible. No command names, arguments, payload schemas, summaries, or routing behavior changed.
- Operators get better help output immediately after updating the command package/workflows.

## Release / Claims

- [x] Release-channel impact considered: CLI help copy only.
- [x] Runtime/native capability claims are unchanged and explicitly bounded in help text.
- [x] Known manual Hermes checks are listed as not run because no live Hermes behavior changed.

## Follow-Up

- Keep the demo lane help in sync whenever a new deterministic quality artifact is added.
