### PR TITLE
Humanize recommendation reasons

### DIFF
--- a/src/routing/recommend.py
+++ b/src/routing/recommend.py
@@ -508,7 +508,7 @@ class Recommendation:
             "score": self.score,
             "confidence": self.confidence,
             "matched": list(self.matched),
-            "why": self.why,
+            "why": _humanize_recommendation_reason(self.why),
             "next_action": self.next_action,
             "evidence_boundary": self.evidence_boundary,
             "wrapper_guidance": self.wrapper_guidance,
@@ -818,7 +818,51 @@ def _why(matched: tuple[str, ...]) -> str:
     if not matched:
         return _FALLBACK_WHY
     sources = sorted({item.split(":", 1)[0] for item in matched})
-    return f"Matched {'/'.join(sources)} metadata for this task."
+    labels = [_match_source_label(source) for source in sources]
+    return f"Matched {_human_join(labels)} for this task."
+
+
+def _humanize_recommendation_reason(reason: str) -> str:
+    text = reason.strip()
+    guard_prefix = "Matched guard/trigger metadata; "
+    if text.startswith(guard_prefix):
+        return _capitalize_sentence(text[len(guard_prefix) :])
+    if text == "Matched trigger metadata for this task.":
+        return "Matched workflow trigger language for this task."
+    if text == "Matched metadata metadata for this task.":
+        return "Matched catalog keywords for this task."
+    return text
+
+
+def _capitalize_sentence(value: str) -> str:
+    text = value.strip()
+    if not text:
+        return text
+    return text[:1].upper() + text[1:]
+
+
+def _match_source_label(source: str) -> str:
+    return {
+        "category": "workflow category",
+        "description": "catalog description",
+        "locale": "deterministic multilingual hint",
+        "metadata": "catalog keywords",
+        "name": "workflow name",
+        "phase": "workflow phase",
+        "trigger": "workflow trigger language",
+        "use_when": "catalog use-when guidance",
+    }.get(source, source.replace("_", " "))
+
+
+def _human_join(items: list[str]) -> str:
+    unique_items = list(dict.fromkeys(item for item in items if item))
+    if not unique_items:
+        return "catalog signals"
+    if len(unique_items) == 1:
+        return unique_items[0]
+    if len(unique_items) == 2:
+        return f"{unique_items[0]} and {unique_items[1]}"
+    return f"{', '.join(unique_items[:-1])}, and {unique_items[-1]}"
 
 
 def _suggested_prompt(skill: str, query: str) -> str:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1027,6 +1027,28 @@ class CliTests(unittest.TestCase):
                 self.assertEqual(status, 0)
                 self.assertIn(expected, stdout)
 
+    def test_recommendation_reasons_avoid_internal_metadata_copy(self) -> None:
+        status, stdout, stderr = run_cli(["recommend", "risky", "refactor"], output_json=False)
+
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        self.assertIn("Why: Risky code-change requests should get a reviewed plan before cleanup.", stdout)
+        self.assertIn("Why: Matched workflow trigger language for this task.", stdout)
+        self.assertIn("Why: Matched catalog keywords for this task.", stdout)
+        self.assertNotIn("metadata metadata", stdout)
+        self.assertNotIn("Matched guard/trigger metadata", stdout)
+
+        status, stdout, stderr = run_cli(["recommend", "risky", "refactor", "--json"], output_json=False)
+
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        payload = json.loads(stdout)
+        reasons = [str(item.get("why", "")) for item in payload["recommendations"]]
+        self.assertIn("Risky code-change requests should get a reviewed plan before cleanup.", reasons)
+        self.assertIn("Matched catalog keywords for this task.", reasons)
+        self.assertFalse(any("metadata metadata" in reason for reason in reasons))
+        self.assertFalse(any("Matched guard/trigger metadata" in reason for reason in reasons))
+
     def test_cases_catalog_exposes_g1_to_g10_and_recommends_real_situations(self) -> None:
         status, stdout, stderr = run_cli(["cases", "list", "--json"], output_json=False)
 


### PR DESCRIPTION
## Feature Report

### What Changed

- Humanized OMH recommendation `why` text at the public payload boundary.
- Converted internal match-source prefixes into readable labels such as workflow trigger language, catalog keywords, catalog description, workflow category, and deterministic multilingual hint.
- Removed user-facing leakage of phrases like internal guard metadata wording and duplicated metadata phrasing from `omh recommend` summaries and JSON.

### Why This Exists

- `omh recommend "risky refactor"` was technically correct, but some lower-ranked explanations read like internal routing diagnostics.
- Recommendation copy is a high-touch surface: it explains why Hermes should choose a workflow. If the reason looks machine-generated, users trust the routing less even when the route is correct.

### User / Operator Impact

- Users now see reasons like `Risky code-change requests should get a reviewed plan before cleanup.` and `Matched catalog keywords for this task.`
- Raw scoring, ranking, selected workflows, next action ids, wrapper policy, and evidence boundaries remain unchanged.
- JSON consumers keep the same schema shape while getting cleaner user-facing reason text.

### How It Works

- `Recommendation.to_dict()` now passes final reason text through a small humanization helper before exposing it.
- The existing `_why()` source-prefix summary now maps prefixes to readable source labels instead of joining raw prefixes and appending metadata.
- Guardrail policy strings remain stable internally; the public recommendation payload strips the diagnostic prefix when rendering final copy.

### Files And Contracts Touched

- `src/routing/recommend.py`: recommendation reason humanization at payload boundary.
- `tests/test_cli.py`: CLI and JSON regression coverage for recommendation reasons.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests.test_cli.CliTests.test_recommendation_reasons_avoid_internal_metadata_copy tests.test_cli.CliTests.test_recommendation_summaries_use_human_action_labels tests.test_cli.CliTests.test_recommend_risky_refactor_includes_cleanup_workflow -v`
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_cli.py tests/test_chat_router.py tests/test_router_content.py tests/test_wrapper_contract.py -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check`
- [x] `PYTHONPATH=tests uv run python -m omh.cli harness validate`
- [x] `PYTHONPATH=tests uv run python -m omh.cli demo hermes-ux-quality --summary`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `git diff --check`
- [ ] Manual Hermes/TUI check — not run; recommendation output is deterministic local routing guidance only.

## Risk

- Low. This changes public reason text only and does not change scoring, ranking, selected workflows, next actions, or schemas.
- Existing wrapper consumers that display `why` get cleaner text; consumers that parse exact reason prose should not rely on prose equality.

## Compatibility / Rollout

- Compatible schema shape.
- Existing action ids and matched source arrays remain available for machine traceability.
- Recommended update path is normal OMH update/install refresh.

## Release / Claims

- [x] Release-channel impact considered: recommendation copy only.
- [x] Runtime/native capability claims are unchanged.
- [x] Prepared-vs-observed evidence boundaries remain unchanged.

## Follow-Up

- Continue scanning high-touch human summaries for diagnostic wording that should remain machine-readable only.
