### PR TITLE
Humanize playbook recommendation actions

### DIFF
--- a/src/routing/action_copy.py
+++ b/src/routing/action_copy.py
@@ -57,6 +57,7 @@ NEXT_ACTION_LABELS: dict[str, str] = {
     "record_missed_route": "recording a missed-route improvement candidate",
     "record_verification_evidence": "recording verification evidence",
     "refresh_agent_ops_status": "refreshing agent operations status",
+    "recommend": "recommending the playbook",
     "run_cto_loop": "preparing the CTO loop",
     "run_hermes_research": "starting source-backed Hermes research",
     "run_local_operator_check": "running the local operator check",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1027,6 +1027,18 @@ class CliTests(unittest.TestCase):
                 self.assertEqual(status, 0)
                 self.assertIn(expected, stdout)
 
+    def test_playbook_recommendation_summary_uses_human_action_labels(self) -> None:
+        status, stdout, stderr = run_cli(
+            ["playbook", "recommend", "turn", "this", "issue", "into", "a", "PR"],
+            output_json=False,
+        )
+
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        self.assertIn("Next action: scope event (`scope_event`)", stdout)
+        self.assertIn("Next action: recommending the playbook (`recommend`)", stdout)
+        self.assertNotIn("Next action: recommend\n", stdout)
+
     def test_recommendation_reasons_avoid_internal_metadata_copy(self) -> None:
         status, stdout, stderr = run_cli(["recommend", "risky", "refactor"], output_json=False)
 


### PR DESCRIPTION
## Summary

This PR cleans up one remaining raw action label in the human-readable `omh playbook recommend` output. Playbook recommendations can still expose the stable action id for wrappers, but the visible summary now says `recommending the playbook (`recommend`)` instead of showing `Next action: recommend` as bare machine vocabulary.

## Why

OMH has been tightening terminal and chat copy so Hermes-facing users see understandable workflow actions rather than internal ids. The normal `omh recommend` output already used shared action labels, but playbook recommendations could still leak the raw `recommend` action when a playbook did not provide a more specific next action. That made the output feel unfinished and inconsistent with the rest of the routing UX.

## What Changed

- Added a shared label for the `recommend` next-action id in `src/routing/action_copy.py`.
- Added CLI regression coverage for `omh playbook recommend "turn this issue into a PR"` so the summary keeps the human label and still preserves the action id in parentheses.
- Left recommendation ranking, schemas, JSON payloads, and playbook semantics unchanged.

## User/Operator Impact

Operators reading playbook recommendations now get a clear action phrase while wrapper authors can still key off the stable id. The output is friendlier without weakening deterministic contracts.

## Verification

Observed locally:

```sh
PYTHONPATH=tests uv run python -m unittest tests.test_cli.CliTests.test_playbook_recommendation_summary_uses_human_action_labels tests.test_cli.CliTests.test_recommendation_summaries_use_human_action_labels -v
PYTHONPATH=tests uv run python -m unittest tests/test_cli.py tests/test_router_content.py -v
uv run python -m compileall -q src tests
PYTHONPATH=tests uv run python -m omh.cli docs workflows --check
PYTHONPATH=tests uv run python -m omh.cli harness validate
git diff --check
PYTHONPATH=tests uv run python -m unittest discover -s tests -v
```

Results: all passed. Full unittest discover ran 984 tests successfully.

## Risks And Boundaries

- No live Hermes chat rendering was run; this is deterministic CLI copy and test coverage only.
- No schema, ranking, install, or runtime evidence behavior changed.

Signed-off-by: frirenai <frirenagent@gmail.com>