### PR TITLE
Humanize menubar next-action copy

### DIFF
--- a/src/surfaces/menubar_status.py
+++ b/src/surfaces/menubar_status.py
@@ -12,6 +12,7 @@ from ..hud import build_hud_payload
 from ..local_store import read_json_object
 from ..paths import OmhPaths
 from ..runtime.artifacts import summarize_delegated_coding_status
+from ..routing.action_copy import next_action_label
 from ..targets import read_target_registry_result
 
 
@@ -247,6 +248,7 @@ def _external_executor_row(status: dict[str, Any], executor_profile: str, coding
     evidence_state = str(prepared.get("status") or "unknown")
     execution_observed = bool(execution.get("observed", False))
     row_status = "observed" if execution_observed else "prepared" if prepared.get("available") else "not_observed"
+    evidence_next_action = str(status.get("next_action", "") or "")
     return {
         "kind": "external_coding_executor",
         "id": f"{executor_profile}:{status.get('run_id', '')}",
@@ -274,7 +276,8 @@ def _external_executor_row(status: dict[str, Any], executor_profile: str, coding
             "run_id": str(status.get("run_id", "") or ""),
             "prepared_available": bool(prepared.get("available", False)),
             "execution_observed": execution_observed,
-            "next_action": str(status.get("next_action", "") or ""),
+            "next_action": evidence_next_action,
+            "next_action_label": next_action_label(evidence_next_action),
         },
     }
 
@@ -528,7 +531,7 @@ def _coding_menu_rows(settings: dict[str, Any], current_executor_row: dict[str, 
         ]
         next_action = str(_dict(current_executor_row.get("evidence")).get("next_action", "") or "")
         if next_action:
-            rows.append(_menu_row("Next", _short_text(next_action, limit=48)))
+            rows.append(_menu_row("Next", _human_next_action(next_action)))
         return rows
     dispatch = _setting_value(settings, "send_mode", default="ask_before_dispatch")
     return [
@@ -566,8 +569,13 @@ def _evidence_next_action(current_executor_row: dict[str, Any]) -> str:
         evidence = _dict(current_executor_row.get("evidence"))
         next_action = str(evidence.get("next_action", "") or "")
         if next_action:
-            return _short_text(next_action, limit=48)
+            return _human_next_action(next_action)
     return "open Hermes or run omh doctor"
+
+
+def _human_next_action(next_action: str) -> str:
+    label = next_action_label(next_action)
+    return _short_text(label or next_action, limit=48)
 
 
 def _short_text(value: str, *, limit: int) -> str:

--- a/tests/test_menubar_status.py
+++ b/tests/test_menubar_status.py
@@ -74,6 +74,9 @@ class MenubarStatusTests(unittest.TestCase):
             self.assertNotIn("4312", json.dumps(menu_cards))
             self.assertEqual(menu_cards[1]["rows"][0]["label"], "Agent")
             self.assertEqual(menu_cards[1]["rows"][0]["value"], "Codex")
+            self.assertEqual(menu_cards[1]["rows"][3]["label"], "Next")
+            self.assertEqual(menu_cards[1]["rows"][3]["value"], "dispatching to the selected coding agent")
+            self.assertNotIn("dispatch_to_executor", json.dumps(menu_cards))
 
             hermes_agents = payload["hermes_agents"]
             self.assertEqual(len(hermes_agents), 1)
@@ -102,6 +105,11 @@ class MenubarStatusTests(unittest.TestCase):
             self.assertTrue(executors[0]["handoff"]["dispatchable"])
             self.assertEqual(executors[0]["handoff"]["dispatch_policy"], "ask_before_dispatch")
             self.assertEqual(executors[0]["evidence"]["state"], "prepared_not_observed")
+            self.assertEqual(executors[0]["evidence"]["next_action"], "dispatch_to_executor")
+            self.assertEqual(
+                executors[0]["evidence"]["next_action_label"],
+                "dispatching to the selected coding agent",
+            )
             self.assertNotIn("Codex", [agent["name"] for agent in hermes_agents])
             current = payload["current_external_coding_executor"]
             self.assertTrue(current["selected"])


### PR DESCRIPTION
## Summary

This PR makes the OMH menu bar status projection use the same human-readable next-action copy as the rest of the router and CLI surfaces. The menu cards now show phrases like `dispatching to the selected coding agent` instead of raw internal action ids such as `dispatch_to_executor`.

## Why

The menu bar is one of the most visible status surfaces for operators. It should be quick to scan and should not require users to understand internal runtime action ids. The raw id is still valuable for wrappers and deterministic integrations, so this change keeps the machine field and adds a display label rather than replacing the contract.

## What Changed

- `menubar_status/v1` external executor evidence now includes `next_action_label` next to the stable `next_action` id.
- Menu bar display cards render the shared human-readable label for Coding Agent and Evidence `Next` rows.
- Regression coverage verifies that display cards no longer expose `dispatch_to_executor` while metadata still carries it.

## User/Operator Impact

When a coding handoff is prepared, the menu bar status reads like an operator status card instead of a JSON-like runtime dump. Users still get the same evidence boundary: prepared work is not treated as execution, verification, review, CI, or merge evidence.

## Verification

Observed locally:

```sh
PYTHONPATH=tests uv run python -m unittest tests/test_menubar_status.py -v
PYTHONPATH=tests uv run python -m unittest tests/test_menubar_status.py tests/test_cli.py tests/test_router_content.py -v
uv run python -m compileall -q src tests
PYTHONPATH=tests uv run python -m omh.cli docs workflows --check
PYTHONPATH=tests uv run python -m omh.cli harness validate
git diff --check
PYTHONPATH=tests uv run python -m unittest discover -s tests -v
```

Results: all passed. Full unittest discover ran 984 tests successfully.

## Risks And Boundaries

- No live macOS menu bar process was rendered in this PR; verification covered deterministic `menubar_status/v1` payload and generated menu cards.
- No runtime evidence ladder, executor dispatch, PID observation, or schema version changed.

Signed-off-by: frirenai <frirenagent@gmail.com>