### PR TITLE
Humanize Hermes release smoke output

### DIFF
--- a/src/commands/release.py
+++ b/src/commands/release.py
@@ -51,7 +51,10 @@ def cmd_release_hermes_smoke(args: argparse.Namespace) -> int:
             timeout_seconds=args.timeout,
             include_command_smoke=args.include_command_smoke,
         )
-        _print_json(payload)
+        if _wants_json(args):
+            _print_json(payload)
+        else:
+            _print_hermes_smoke_summary(payload)
         return 0 if payload["ok"] else 1
     installed_command_smoke = (
         run_installed_command_smoke(
@@ -72,7 +75,10 @@ def cmd_release_hermes_smoke(args: argparse.Namespace) -> int:
         hermes_home=args.hermes_home,
         installed_command_smoke=installed_command_smoke,
     )
-    _print_json(payload)
+    if _wants_json(args):
+        _print_json(payload)
+    else:
+        _print_hermes_smoke_summary(payload)
     return 0 if payload["ok"] else 1
 
 
@@ -192,6 +198,7 @@ def _add_release_commands(sub) -> None:
         help="Also execute installed `omh --help` and installed setup-path plan rendering without mutating Hermes.",
     )
     smoke.add_argument("--timeout", type=int, default=30, help="Per-command timeout in seconds for --live or --include-command-smoke.")
+    smoke.add_argument("--json", action="store_true", help="Print the machine-readable Hermes smoke payload.")
     smoke.set_defaults(func=cmd_release_hermes_smoke)
 
     install_smoke = release_sub.add_parser(
@@ -285,6 +292,128 @@ def _print_release_checklist_summary(payload: dict[str, object]) -> None:
     print("")
     print(f"Next: {payload['recommended_next_action']}")
     print("For machine-readable output, rerun with `--json`.")
+
+
+def _print_hermes_smoke_summary(payload: dict[str, object]) -> None:
+    mode = str(payload.get("mode", "plan"))
+    observed = "yes" if payload.get("observed") else "no"
+    print("OMH Hermes release smoke")
+    print(f"Mode: {mode}; observed evidence: {observed}")
+    print(f"Status: {'ok' if payload.get('ok') else 'failed'}")
+    print(f"Install path: {payload.get('install_path')}")
+    print(f"Skill: {payload.get('skill')}")
+    if payload.get("tap"):
+        print(f"Tap: {payload.get('tap')}")
+    target = payload.get("target_binding", {})
+    if isinstance(target, dict):
+        print(f"OMH home: {target.get('omh_home')}")
+        print(f"Hermes home: {target.get('hermes_home')}")
+    print("")
+    _print_hermes_smoke_steps(payload)
+    _print_installed_command_smoke_section(payload.get("installed_command_smoke"))
+    _print_first_use_status_smoke_section(payload.get("first_use_status_smoke"))
+    print("Next")
+    print(f"  - {_hermes_smoke_summary_next(payload)}")
+    print("")
+    print(f"Boundary: {payload.get('proof_boundary')}")
+    print("For machine-readable output, rerun with `--json`.")
+
+
+def _print_hermes_smoke_steps(payload: dict[str, object]) -> None:
+    results = payload.get("results")
+    if isinstance(results, list) and results:
+        print("Observed steps")
+        for result in results:
+            if not isinstance(result, dict):
+                continue
+            status = "ok" if result.get("ok") else "failed"
+            print(f"  - {result.get('name')} [{result.get('phase')}; {status}; rc={result.get('returncode')}]")
+            command = result.get("command", [])
+            if isinstance(command, list):
+                print(f"    {_join_command(command)}")
+            stdout = str(result.get("stdout_excerpt", "") or "").strip()
+            stderr = str(result.get("stderr_excerpt", "") or "").strip()
+            if stdout:
+                print(f"    stdout: {_one_line(stdout)}")
+            if stderr:
+                print(f"    stderr: {_one_line(stderr)}")
+            boundary = str(result.get("proof_boundary", "") or "")
+            if boundary:
+                print(f"    Boundary: {boundary}")
+        print("")
+        return
+    print("Planned steps")
+    for step in payload.get("steps", []):
+        if not isinstance(step, dict):
+            continue
+        marker = "profile-mutating" if step.get("mutates_profile") else "local"
+        required = "required" if step.get("required", True) else "optional"
+        print(f"  - {step.get('name')} [{step.get('phase')}; {marker}; {required}]")
+        command = step.get("command", [])
+        if isinstance(command, list):
+            print(f"    {_join_command(command)}")
+        boundary = str(step.get("proof_boundary", "") or "")
+        if boundary:
+            print(f"    Boundary: {boundary}")
+    print("")
+
+
+def _print_installed_command_smoke_section(payload: object) -> None:
+    if not isinstance(payload, dict):
+        return
+    print("Installed command")
+    print(f"  Status: {'ok' if payload.get('ok') else 'failed'}")
+    print(f"  Mode: {payload.get('mode')}; observed: {'yes' if payload.get('observed') else 'no'}")
+    print(f"  Command: {payload.get('command_under_test')}")
+    failed_step = str(payload.get("failed_step", "") or "")
+    if failed_step:
+        print(f"  Failed step: {failed_step}")
+    path_check = payload.get("path_check")
+    if isinstance(path_check, dict):
+        resolved = path_check.get("resolved_path") or "not observed"
+        print(f"  PATH: {'ok' if path_check.get('ok') else 'not ready'} ({resolved})")
+    next_action = str(payload.get("recommended_next_action", "") or "")
+    if next_action:
+        print(f"  Next: {next_action}")
+    print("")
+
+
+def _print_first_use_status_smoke_section(payload: object) -> None:
+    if not isinstance(payload, dict):
+        return
+    print("First-use status")
+    print(f"  Mode: {payload.get('mode')}; observed: {'yes' if payload.get('observed') else 'no'}")
+    print(f"  Status: {'ok' if payload.get('ok') else 'failed'}")
+    example = str(payload.get("example_message", "") or "")
+    if example:
+        print(f"  Example: {example}")
+    boundary = str(payload.get("proof_boundary", "") or "")
+    if boundary:
+        print(f"  Boundary: {boundary}")
+    print("")
+
+
+def _hermes_smoke_summary_next(payload: dict[str, object]) -> str:
+    next_action = str(payload.get("recommended_next_action", "") or "")
+    if next_action:
+        return next_action
+    command = payload.get("live_command")
+    if isinstance(command, list) and command:
+        return f"Run `{_join_command(command)}` against the target Hermes profile when you are ready to observe it."
+    command_smoke = payload.get("installed_command_smoke")
+    if isinstance(command_smoke, dict):
+        nested = str(command_smoke.get("recommended_next_action", "") or "")
+        if nested:
+            return nested
+    return "Run the planned smoke steps, then record the observed evidence before treating Hermes visibility as ready."
+
+
+def _join_command(command: list[object]) -> str:
+    return " ".join(str(part) for part in command)
+
+
+def _one_line(value: str) -> str:
+    return " ".join(value.split())
 
 
 def _print_install_smoke_summary(payload: dict[str, object]) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1954,7 +1954,7 @@ class CliTests(unittest.TestCase):
         payload = json.loads(result.stdout)
         self.assertEqual(payload["query"], "risky refactor")
 
-    def test_release_hermes_smoke_cli_defaults_to_plan_mode(self) -> None:
+    def test_release_hermes_smoke_defaults_to_human_plan_with_json_escape_hatch(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)
             omh_home = root / ".omh"
@@ -1971,7 +1971,41 @@ class CliTests(unittest.TestCase):
                     "setup",
                     "--omh-command",
                     "omh-dev",
-                ]
+                ],
+                output_json=False,
+            )
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            self.assertIn("OMH Hermes release smoke", stdout)
+            self.assertIn("Mode: plan; observed evidence: no", stdout)
+            self.assertIn("Status: ok", stdout)
+            self.assertIn("Install path: setup", stdout)
+            self.assertIn("Planned steps", stdout)
+            self.assertIn("omh-dev --omh-home", stdout)
+            self.assertIn("hermes skills list --enabled-only", stdout)
+            self.assertIn("Installed command", stdout)
+            self.assertIn("First-use status", stdout)
+            self.assertIn("Boundary:", stdout)
+            self.assertIn("For machine-readable output", stdout)
+            with self.assertRaises(json.JSONDecodeError):
+                json.loads(stdout)
+
+            status, stdout, stderr = run_cli(
+                [
+                    "--omh-home",
+                    str(omh_home),
+                    "--hermes-home",
+                    str(hermes_home),
+                    "release",
+                    "hermes-smoke",
+                    "--install-path",
+                    "setup",
+                    "--omh-command",
+                    "omh-dev",
+                    "--json",
+                ],
+                output_json=False,
             )
 
         self.assertEqual(stderr, "")
@@ -2353,6 +2387,7 @@ class CliTests(unittest.TestCase):
                     "--omh-command",
                     str(fake_omh),
                     "--include-command-smoke",
+                    "--json",
                 ]
             )
 
@@ -2390,6 +2425,7 @@ class CliTests(unittest.TestCase):
                     "--omh-command",
                     missing_command,
                     "--include-command-smoke",
+                    "--json",
                 ]
             )
 


### PR DESCRIPTION
## Feature Report

### What Changed

- `omh release hermes-smoke` now defaults to a human-readable terminal summary instead of printing the full JSON payload.
- Added an explicit `--json` escape hatch for the same machine-readable `hermes_release_smoke/v1` payload automation already consumes.
- The summary shows mode, observed evidence state, status, install path, skill/tap, target homes, planned or observed smoke steps, installed command smoke, first-use status, next action, and the proof boundary.

### Why This Exists

- Release/install smoke output was one of the remaining operator-facing commands that still dumped a large JSON blob by default.
- That made the release check feel inconsistent with `release checklist`, `release install-smoke`, and product-readiness summaries, and it was hard to read during real setup/update verification.
- The command should be pleasant for humans first while preserving deterministic JSON for wrappers and CI.

### User / Operator Impact

- Operators can run `omh release hermes-smoke` and immediately understand what would happen, what has or has not been observed, and what to do next.
- Automation can keep using `omh release hermes-smoke --json` without schema or semantic changes.
- Failed installed-command smoke still returns a non-zero exit code and remains inspectable through JSON.

### How It Works

- `src/commands/release.py` now routes `release hermes-smoke` through `_print_hermes_smoke_summary()` unless `_wants_json(args)` is true.
- The new summary helpers render planned steps or observed command results and reuse the existing payload fields rather than inventing new state.
- `tests/test_cli.py` now locks the human default output, the `--json` payload escape hatch, and the installed-command-smoke JSON behavior.

### Files And Contracts Touched

- `src/commands/release.py`
  - Adds `--json` to `release hermes-smoke`.
  - Adds human summary rendering for plan/live mode.
- `tests/test_cli.py`
  - Updates release smoke tests to distinguish terminal output from machine-readable output.
- Contract boundary:
  - `hermes_release_smoke/v1` remains unchanged behind `--json`.
  - This PR changes rendering only; it does not run or alter live Hermes profile mutation behavior.

## Validation

- [x] `PYTHONPATH=tests uv run python -m omh.cli release hermes-smoke | sed -n '1,220p'`
- [x] `PYTHONPATH=tests uv run python -m omh.cli release hermes-smoke --json | python3 -m json.tool >/dev/null`
- [x] `PYTHONPATH=tests uv run python -m unittest tests.test_cli.CliTests.test_release_hermes_smoke_defaults_to_human_plan_with_json_escape_hatch tests.test_cli.CliTests.test_release_hermes_smoke_cli_can_observe_installed_command_without_live_profile_mutation tests.test_cli.CliTests.test_release_hermes_smoke_cli_fails_when_installed_command_is_not_on_path -v`
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_cli.py tests/test_release_smoke.py -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check`
- [x] `PYTHONPATH=tests uv run python -m omh.cli harness validate`
- [x] `git diff --check`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [ ] Manual Hermes/TUI check: not run; this PR changes local release smoke rendering and does not mutate a live Hermes profile.

## Risk

- Low. The JSON payload contract stays available and tested through `--json` and `OMH_OUTPUT=json` behavior.
- Main risk is terminal wording drift, now covered by focused CLI assertions.

## Compatibility / Rollout

- Compatible with existing automation that requests JSON explicitly or uses `OMH_OUTPUT=json`.
- Human operators get improved default output with no migration step.

## Release / Claims

- [x] Release-channel impact considered: rendering-only CLI polish, suitable for preview/stable once merged.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] Known manual Hermes checks are listed: live `omh release hermes-smoke --live` was not run.

## Follow-Up

- Continue scanning remaining operator-facing commands for raw JSON or internal action copy that should be hidden behind `--json`.
