### PR TITLE
Humanize HUD evidence state copy

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -406,7 +406,9 @@ omh doctor</code>
               Discord, Slack, hosted chat, and Hermes-native plugin surfaces
               can consume local envelopes instead of guessing what a workflow
               means. The UI can show actions, disabled gates, and evidence
-              labels from the same state.
+              labels from the same state. Adapter metadata can still carry
+              <code>harness_progress/v1</code> when a wrapper needs the raw
+              contract.
             </p>
           </div>
           <div class="wrapper-card" role="region" aria-label="Wrapper response example">
@@ -416,9 +418,9 @@ omh doctor</code>
             </div>
             <div class="route-lens">
               <span>playbook: request-to-handoff</span>
-              <span>next: present_plan</span>
-              <span>state: prepared_not_observed</span>
-              <span>progress: harness_progress/v1</span>
+              <span>next: show safe plan</span>
+              <span>state: prepared, not run</span>
+              <span>progress: tracked</span>
             </div>
             <h3>Present the safe plan first.</h3>
             <p>

--- a/src/plugin_bundle/omh/runtime_reader.py
+++ b/src/plugin_bundle/omh/runtime_reader.py
@@ -601,7 +601,7 @@ def _hud_segments(payload: dict[str, Any], *, preset: str) -> list[str]:
     focused.append(_coding_agent_segment(runtime, executor))
     evidence_state = str(runtime.get("evidence_state", "unknown") or "unknown")
     if preset == "full" and evidence_state not in {"idle", "unknown"}:
-        focused.append(f"evidence:{evidence_state}")
+        focused.append(f"evidence:{_evidence_display_status(evidence_state)}")
     return focused
 
 
@@ -612,6 +612,19 @@ def _plugin_display_status(plugin: dict[str, Any]) -> str:
         "stale": "update-needed",
     }
     return labels.get(status, status)
+
+
+def _evidence_display_status(state: str) -> str:
+    labels = {
+        "prepared_not_observed": "prepared",
+        "dispatch_observed": "dispatched",
+        "execution_observed": "executed",
+        "verification_observed": "verified",
+        "review_observed": "reviewed",
+        "ci_observed": "ci-pass",
+        "merge_observed": "merged",
+    }
+    return labels.get(state, state.replace("_", "-"))
 
 
 def _coding_agent_segment(runtime: dict[str, Any], executor: dict[str, Any]) -> str:
@@ -643,6 +656,8 @@ def _activity_label(runtime: dict[str, Any]) -> str:
 
 def _coding_agent_state(runtime: dict[str, Any]) -> str:
     if not str(runtime.get("latest_run_id", "")):
+        return "idle"
+    if not str(runtime.get("executor_target", "")).strip():
         return "idle"
     return str(runtime.get("phase", "unknown") or "unknown")
 

--- a/tests/test_hud.py
+++ b/tests/test_hud.py
@@ -89,8 +89,55 @@ class HudCliTests(unittest.TestCase):
             self.assertNotIn("skills:", payload["display"]["line"])
             self.assertNotIn("executor:", payload["display"]["line"])
             self.assertNotIn("handoff:", payload["display"]["line"])
-            self.assertIn("evidence:prepared_not_observed", payload["display"]["line"])
+            self.assertIn("evidence:prepared", payload["display"]["line"])
+            self.assertNotIn("evidence:prepared_not_observed", payload["display"]["line"])
             self.assertIn("Prepared handoffs are not execution", payload["evidence_boundary"])
+
+    def test_hud_does_not_treat_non_coding_runtime_as_busy_coding_agent(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / ".omh"
+            hermes_home = root / ".hermes"
+            run_dir = omh_home / "runtime" / "runs" / "20260630T000000Z-loop"
+            run_dir.mkdir(parents=True)
+            (run_dir / "run.json").write_text(
+                json.dumps(
+                    {
+                        "run_id": "20260630T000000Z-loop",
+                        "skill": "loop",
+                        "phase": "runtime",
+                        "observation_status": "unknown",
+                    }
+                ),
+                encoding="utf-8",
+            )
+            (run_dir / "delegation.json").write_text(
+                json.dumps({"observed": True, "result": "completed"}),
+                encoding="utf-8",
+            )
+
+            status, stdout, stderr = run_cli(
+                [
+                    "--omh-home",
+                    str(omh_home),
+                    "--hermes-home",
+                    str(hermes_home),
+                    "hud",
+                    "--json",
+                    "--preset",
+                    "full",
+                ],
+                output_json=False,
+            )
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            payload = json.loads(stdout)
+            self.assertEqual(payload["runtime"]["workflow"], "loop")
+            self.assertEqual(payload["runtime"]["evidence_state"], "execution_observed")
+            self.assertIn("coding-agent:idle(ask)", payload["display"]["line"])
+            self.assertIn("evidence:executed", payload["display"]["line"])
+            self.assertNotIn("coding-agent:runtime(ask)", payload["display"]["line"])
 
     def test_hud_marks_older_plugin_bundle_as_stale(self) -> None:
         with TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Feature Report

### What Changed

- `omh hud --preset full` now renders human-readable evidence labels in the compact display line.
  - `prepared_not_observed` displays as `evidence:prepared`.
  - `execution_observed` displays as `evidence:executed`.
  - Other observed ladder states display as `dispatched`, `verified`, `reviewed`, `ci-pass`, or `merged`.
- Non-coding runtime runs no longer make the HUD show confusing coding-agent states such as `coding-agent:runtime(ask)`.
- The homepage wrapper example now uses readable pills: `next: show safe plan`, `state: prepared, not run`, and `progress: tracked`, while keeping `harness_progress/v1` in adapter-facing explanatory copy.

### Why This Exists

- The HUD and homepage are high-visibility surfaces. Raw schema states such as `prepared_not_observed` and phase names such as `runtime` are correct for JSON payloads, but awkward for operators reading the status line.
- OMH should preserve machine-readable contracts without making humans decode internal state names.

### User / Operator Impact

- Hermes/menu/plugin HUD surfaces stay compact and easier to scan.
- A non-coding loop or workflow run no longer looks like a busy coding-agent session.
- Developers and wrappers still get the original `runtime.evidence_state` field in `omh_hud/v1`; only display copy changed.

### How It Works

- `src/plugin_bundle/omh/runtime_reader.py`
  - Adds display-only evidence state label mapping.
  - Keeps raw `runtime.evidence_state` unchanged in the payload.
  - Treats latest runs without an `executor_target` as `coding-agent:idle(...)` for the coding-agent segment.
- `tests/test_hud.py`
  - Locks the humanized evidence display line.
  - Adds a regression test for non-coding runtime runs so `coding-agent:runtime(ask)` does not return.
- `site/index.html`
  - Humanizes the visible wrapper response example while retaining raw contract metadata in adapter-facing prose.

### Files And Contracts Touched

- `src/plugin_bundle/omh/runtime_reader.py`
- `tests/test_hud.py`
- `site/index.html`
- Contract boundary:
  - `omh_hud/v1` JSON fields remain stable.
  - This PR changes display copy only; it does not change runtime evidence semantics or observed state calculation.

## Validation

- [x] `PYTHONPATH=tests uv run python -m omh.cli hud --preset full`
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_hud.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_hud.py tests/test_plugin_distribution.py tests/test_router_content.py -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check`
- [x] `PYTHONPATH=tests uv run python -m omh.cli harness validate`
- [x] `git diff --check`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [ ] Browser visual screenshot of the GitHub Pages site: not captured; content tests cover the changed copy.

## Risk

- Low. The raw payload state is preserved and tests lock both the payload and display line behavior.
- The only behavioral change is how compact text is rendered for humans.

## Compatibility / Rollout

- Existing wrappers reading `runtime.evidence_state` continue to receive the same raw values.
- Wrappers that display `payload.display.line` get clearer text automatically after update/setup refresh.

## Release / Claims

- [x] Release-channel impact considered: this is user-facing display polish for the plugin/HUD/site surface.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] No live Hermes runtime execution, CI, review, or merge evidence is claimed by this change.

## Follow-Up

- Continue scanning high-visibility terminal and wrapper display surfaces for raw schema/action names that should stay in JSON but not in human copy.
