### PR TITLE
Humanize chat route summaries

### DIFF
--- a/src/commands/chat.py
+++ b/src/commands/chat.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -239,14 +240,11 @@ def _text(value: object, default: str = "") -> str:
     return text or default
 
 
-def _action_label_with_id(action: str, label: str = "") -> str:
-    normalized = action.strip()
-    if not normalized:
-        return ""
-    resolved_label = label.strip() or next_action_label(normalized)
-    if not resolved_label or resolved_label == normalized:
-        return normalized
-    return f"{resolved_label} (`{normalized}`)"
+_INLINE_INTERNAL_ID_RE = re.compile(r"\s\(`[-A-Za-z0-9_:]+`\)")
+
+
+def _summary_text(value: object, default: str = "") -> str:
+    return _INLINE_INTERNAL_ID_RE.sub("", _text(value, default))
 
 
 def _action_label_without_id(action: str, label: str = "") -> str:
@@ -275,29 +273,24 @@ _SUMMARY_STATUS_LABELS = {
 }
 
 
-def _route_action_label_with_id(action: str) -> str:
+def _route_action_label_without_id(action: str) -> str:
     normalized = action.strip()
-    return _action_label_with_id(normalized, _ROUTE_ACTION_LABELS.get(normalized, ""))
+    return _action_label_without_id(normalized, _ROUTE_ACTION_LABELS.get(normalized, ""))
 
 
-def _status_label_with_id(status: str) -> str:
+def _status_label_without_id(status: str) -> str:
     normalized = status.strip()
     if not normalized:
         return ""
-    label = _SUMMARY_STATUS_LABELS.get(normalized, normalized.replace("_", " "))
-    if label == normalized:
-        return normalized
-    return f"{label} (`{normalized}`)"
+    return _SUMMARY_STATUS_LABELS.get(normalized, normalized.replace("_", " ")) or normalized
 
 
-def _format_summary_action(action: dict[str, object], *, include_id: bool = True) -> str:
+def _format_summary_action(action: dict[str, object]) -> str:
     action_id = _text(action.get("id"), "action")
     label = _text(action.get("label"), action_id)
     enabled = bool(action.get("enabled", True))
     state_label = "enabled" if enabled else "disabled"
-    label_with_id = (
-        _action_label_with_id(action_id, label) if include_id else _action_label_without_id(action_id, label)
-    )
+    label_with_id = _action_label_without_id(action_id, label)
     return f"- {label_with_id} - {state_label}"
 
 
@@ -327,8 +320,8 @@ def _print_chat_interaction_summary(payload: dict[str, object]) -> None:
     print(f"Workflow: {selected_workflow}")
     print(f"Next action: {_action_label_without_id(next_action, next_action_label_text)}")
 
-    headline = _text(response.get("headline") or response.get("plain_headline"))
-    body = _text(response.get("body") or response.get("plain_body"))
+    headline = _summary_text(response.get("headline") or response.get("plain_headline"))
+    body = _summary_text(response.get("body") or response.get("plain_body"))
     if headline or body:
         print()
         if headline:
@@ -342,7 +335,7 @@ def _print_chat_interaction_summary(payload: dict[str, object]) -> None:
         print("Actions:")
         action_limit = 12
         for action in actions[:action_limit]:
-            print(_format_summary_action(action, include_id=False))
+            print(_format_summary_action(action))
         if len(actions) > action_limit:
             print(f"- ... {len(actions) - action_limit} more action(s) in --json")
 
@@ -390,23 +383,23 @@ def _print_chat_route_summary(payload: dict[str, object]) -> None:
     print(f"Source: {source}")
     print(f"Workflow: {selected_workflow}")
     print(f"Harness: {selected_harness}")
-    print(f"Action: {_route_action_label_with_id(action)}")
-    print(f"Next action: {_action_label_with_id(next_action, next_action_label_text)}")
+    print(f"Action: {_route_action_label_without_id(action)}")
+    print(f"Next action: {_action_label_without_id(next_action, next_action_label_text)}")
     print(f"Confidence: {confidence} (score {score})")
 
-    why = _text(route_explanation.get("why_this_workflow") or route.get("reason"))
+    why = _summary_text(route_explanation.get("why_this_workflow") or route.get("reason"))
     if why:
         print()
         print("Why:")
         print(f"  {why}")
 
-    recommended_reply = _text(route_explanation.get("recommended_reply"))
+    recommended_reply = _summary_text(route_explanation.get("recommended_reply"))
     if recommended_reply:
         print()
         print("Reply:")
         print(f"  {recommended_reply}")
 
-    primary_action_hint = _text(route_explanation.get("primary_action_hint"))
+    primary_action_hint = _summary_text(route_explanation.get("primary_action_hint"))
     if primary_action_hint:
         print()
         print("Action hint:")
@@ -422,7 +415,7 @@ def _print_chat_route_summary(payload: dict[str, object]) -> None:
             item_next_label = _text(item.get("next_action_label"), next_action_label(item_next))
             item_confidence = _text(item.get("confidence"), "unknown")
             item_score = _text(item.get("score"), "0")
-            print(f"- {skill}: {_action_label_with_id(item_next, item_next_label)} ({item_confidence}, score {item_score})")
+            print(f"- {skill}: {_action_label_without_id(item_next, item_next_label)} ({item_confidence}, score {item_score})")
 
     route_plan = _as_mapping(route.get("workflow_route_plan"))
     steps = [item for item in _as_list(route_plan.get("steps")) if isinstance(item, dict)]
@@ -434,7 +427,7 @@ def _print_chat_route_summary(payload: dict[str, object]) -> None:
             stage = _text(step.get("stage"), "stage")
             skill = _text(step.get("skill"), "workflow")
             status = _text(step.get("status"), "prepared_not_observed")
-            print(f"- {order}. {stage}: {skill} - {_status_label_with_id(status)}")
+            print(f"- {order}. {stage}: {skill} - {_status_label_without_id(status)}")
 
     not_evidence = [_text(item) for item in _as_list(route_explanation.get("not_evidence_yet")) if _text(item)]
     if not_evidence:
@@ -495,7 +488,7 @@ def _print_chat_route_hint_summary(payload: dict[str, object]) -> None:
     print(f"Source: {source}")
     print(f"Status: {status}")
     print(f"Workflow: {selected_workflow}")
-    print(f"Next action: {_action_label_with_id(next_action, next_action_label_text)}")
+    print(f"Next action: {_action_label_without_id(next_action, next_action_label_text)}")
     print(f"Hints: {hint_count}")
 
     matched_cues = _text_items(_as_list(primary_hint.get("matched_cues")))
@@ -507,8 +500,8 @@ def _print_chat_route_hint_summary(payload: dict[str, object]) -> None:
     if adjacent_workflows:
         print(f"Adjacent workflows: {_join_text_items(adjacent_workflows)}")
 
-    headline = _text(response.get("headline"))
-    body = _text(response.get("body"))
+    headline = _summary_text(response.get("headline"))
+    body = _summary_text(response.get("body"))
     if headline or body:
         print()
         if headline:
@@ -524,8 +517,8 @@ def _print_chat_route_hint_summary(payload: dict[str, object]) -> None:
             lane = _text(hint.get("lane"), "unknown")
             action = _text(hint.get("next_action"), "unknown")
             action_label = _text(hint.get("next_action_label"), next_action_label(action))
-            reason = _text(hint.get("reason"))
-            print(f"- {workflow}: {_action_label_with_id(action, action_label)} ({lane})")
+            reason = _summary_text(hint.get("reason"))
+            print(f"- {workflow}: {_action_label_without_id(action, action_label)} ({lane})")
             hint_cues = _text_items(_as_list(hint.get("matched_cues")))
             if hint_cues:
                 print(f"  matched: {_join_text_items(hint_cues)}")
@@ -536,11 +529,18 @@ def _print_chat_route_hint_summary(payload: dict[str, object]) -> None:
     if actions:
         print()
         print("Actions:")
-        for action in actions[:6]:
-            print(_format_summary_action(action))
+        printed_rows: set[str] = set()
+        for action in actions:
+            row = _format_summary_action(action)
+            if row in printed_rows:
+                continue
+            printed_rows.add(row)
+            print(row)
+            if len(printed_rows) >= 6:
+                break
 
     checkpoint = _as_mapping(payload.get("generic_tool_checkpoint"))
-    checkpoint_body = _text(checkpoint.get("body"))
+    checkpoint_body = _summary_text(checkpoint.get("body"))
     if checkpoint_body:
         print()
         print("Checkpoint:")
@@ -566,7 +566,7 @@ def _print_chat_route_hint_summary(payload: dict[str, object]) -> None:
         print()
         print("Prompt context: included")
 
-    boundary = _text(payload.get("claim_boundary") or response.get("claim_boundary") or route_hint.get("claim_boundary"))
+    boundary = _summary_text(payload.get("claim_boundary") or response.get("claim_boundary") or route_hint.get("claim_boundary"))
     if boundary:
         print()
         print("Boundary:")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4364,8 +4364,10 @@ class CliTests(unittest.TestCase):
         self.assertIn("Source: discord", stdout)
         self.assertIn("Workflow: ralplan", stdout)
         self.assertIn("Harness: planning", stdout)
-        self.assertIn("Action: routing to a workflow (`dispatch`)", stdout)
-        self.assertIn("Next action: preparing a reviewed plan (`present_plan`)", stdout)
+        self.assertIn("Action: routing to a workflow", stdout)
+        self.assertIn("Next action: preparing a reviewed plan", stdout)
+        self.assertNotIn("(`dispatch`)", stdout)
+        self.assertNotIn("(`present_plan`)", stdout)
         self.assertIn("Confidence: high (score 32)", stdout)
         self.assertIn("Why:", stdout)
         self.assertIn("Matched safe feature-change language", stdout)
@@ -4374,9 +4376,10 @@ class CliTests(unittest.TestCase):
         self.assertIn("Action hint:", stdout)
         self.assertIn("Route to `ralplan` and start by preparing a reviewed plan", stdout)
         self.assertIn("Top recommendations:", stdout)
-        self.assertIn("- ralplan: preparing a reviewed plan (`present_plan`) (high, score 32)", stdout)
+        self.assertIn("- ralplan: preparing a reviewed plan (high, score 32)", stdout)
         self.assertIn("Route plan:", stdout)
-        self.assertIn("- 1. triage: feedback-triage - prepared, not observed (`prepared_not_observed`)", stdout)
+        self.assertIn("- 1. triage: feedback-triage - prepared, not observed", stdout)
+        self.assertNotIn("(`prepared_not_observed`)", stdout)
         self.assertIn("Boundary:", stdout)
         self.assertIn("A recommendation or draft plan is not execution evidence.", stdout)
         self.assertIn("Use --json for the full machine-readable route payload.", stdout)
@@ -4404,7 +4407,8 @@ class CliTests(unittest.TestCase):
             self.assertEqual(stderr, "")
             self.assertEqual(status, 0)
             self.assertIn("Workflow: feedback-triage", stdout)
-            self.assertIn("Next action: triaging the feedback signal (`triage_feedback`)", stdout)
+            self.assertIn("Next action: triaging the feedback signal", stdout)
+            self.assertNotIn("(`triage_feedback`)", stdout)
             self.assertIn("Runtime record:", stdout)
             self.assertIn("run_id: ", stdout)
             self.assertIn("status: recorded metadata only", stdout)
@@ -4522,22 +4526,23 @@ class CliTests(unittest.TestCase):
         self.assertIn("Source: discord", stdout)
         self.assertIn("Status: hinted", stdout)
         self.assertIn("Workflow: img-summary", stdout)
-        self.assertIn("Next action: preparing an image prompt card (`prepare_visual_prompt_card`)", stdout)
+        self.assertIn("Next action: preparing an image prompt card", stdout)
+        self.assertNotIn("(`prepare_visual_prompt_card`)", stdout)
         self.assertIn("Hints: 2", stdout)
         self.assertIn("Matched cues: image", stdout)
         self.assertIn("Adjacent workflows: materials-package, report-package, research-department", stdout)
         self.assertIn("[omh] img-summary looks relevant.", stdout)
         self.assertIn("Hint details:", stdout)
-        self.assertIn("- img-summary: preparing an image prompt card (`prepare_visual_prompt_card`) (materials_and_visuals)", stdout)
+        self.assertIn("- img-summary: preparing an image prompt card (materials_and_visuals)", stdout)
         self.assertIn("  matched: image", stdout)
         self.assertIn(
-            "- automation-blueprint: preparing a scheduled-ops blueprint (`prepare_scheduled_ops_blueprint`) "
-            "(automation_and_status)",
+            "- automation-blueprint: preparing a scheduled-ops blueprint (automation_and_status)",
             stdout,
         )
         self.assertIn("  matched: cron", stdout)
         self.assertIn("Actions:", stdout)
-        self.assertIn("- Open img-summary (`open_workflow`) - enabled", stdout)
+        self.assertIn("- Open img-summary - enabled", stdout)
+        self.assertNotIn("(`open_workflow`)", stdout)
         self.assertIn("Checkpoint:", stdout)
         self.assertIn("Before generic tools, check OMH prep/status/learning", stdout)
         self.assertIn("Not evidence yet:", stdout)
@@ -4570,8 +4575,9 @@ class CliTests(unittest.TestCase):
         self.assertEqual(status, 0)
         self.assertIn("Status: hinted", stdout)
         self.assertIn("Workflow: loop", stdout)
-        self.assertIn("Next action: checking whether the goal is loopable (`assess_loopability`)", stdout)
-        self.assertIn("- loop: checking whether the goal is loopable (`assess_loopability`) (intent_to_plan)", stdout)
+        self.assertIn("Next action: checking whether the goal is loopable", stdout)
+        self.assertIn("- loop: checking whether the goal is loopable (intent_to_plan)", stdout)
+        self.assertNotIn("(`assess_loopability`)", stdout)
 
         status, stdout, stderr = run_cli(
             ["chat", "route-hint", "--source", "discord", "--summary", "open the OMH picker"],
@@ -4582,9 +4588,11 @@ class CliTests(unittest.TestCase):
         self.assertEqual(status, 0)
         self.assertIn("Status: hinted", stdout)
         self.assertIn("Workflow: oh-my-hermes", stdout)
-        self.assertIn("Next action: opening the workflow picker (`choose_skill`)", stdout)
-        self.assertIn("- oh-my-hermes: opening the workflow picker (`choose_skill`) (intent_to_plan)", stdout)
-        self.assertIn("- Open omh (`open_workflow`) - enabled", stdout)
+        self.assertIn("Next action: opening the workflow picker", stdout)
+        self.assertIn("- oh-my-hermes: opening the workflow picker (intent_to_plan)", stdout)
+        self.assertIn("- Open omh - enabled", stdout)
+        self.assertEqual(stdout.count("- Open omh - enabled"), 1)
+        self.assertNotIn("(`choose_skill`)", stdout)
 
         status, stdout, stderr = run_cli(
             ["chat", "route-hint", "--source", "discord", "--json", "open the OMH picker"],
@@ -4609,12 +4617,13 @@ class CliTests(unittest.TestCase):
         self.assertIn("Source: slack", stdout)
         self.assertIn("Status: no_hint", stdout)
         self.assertIn("Workflow: none", stdout)
-        self.assertIn("Next action: opening the picker or asking one clarification (`open_picker_or_clarify`)", stdout)
+        self.assertIn("Next action: opening the picker or asking one clarification", stdout)
+        self.assertNotIn("(`open_picker_or_clarify`)", stdout)
         self.assertIn("Hints: 0", stdout)
         self.assertNotIn("Workflow: unknown", stdout)
         self.assertIn("[omh] no strong workflow hint yet.", stdout)
-        self.assertIn("- Open omh (`open_picker`) - enabled", stdout)
-        self.assertIn("- Clarify (`clarify`) - enabled", stdout)
+        self.assertIn("- Open omh - enabled", stdout)
+        self.assertIn("- Clarify - enabled", stdout)
 
     def test_chat_route_hint_can_emit_manual_prompt_context(self) -> None:
         status, stdout, stderr = run_cli(
@@ -4638,9 +4647,10 @@ class CliTests(unittest.TestCase):
         self.assertEqual(status, 0)
         self.assertIn("Workflow: workflow-learning", stdout)
         self.assertIn(
-            "Next action: recording a missed-route improvement candidate (`record_missed_route`)",
+            "Next action: recording a missed-route improvement candidate",
             stdout,
         )
+        self.assertNotIn("(`record_missed_route`)", stdout)
         self.assertIn("Prompt context: included", stdout)
 
     def test_chat_route_hint_rejects_conflicting_output_modes(self) -> None:


### PR DESCRIPTION
## Feature Report

### What Changed

- Updated `omh chat route --summary` and `omh chat route-hint --summary` to show human labels without raw action/status ids.
- Sanitized inline route-hint body copy so phrases like `Next action: ... (`action_id`)` render as plain text in summaries.
- Deduplicated repeated action rows in route-hint summaries, so picker cards do not show `Open omh` twice.
- Kept JSON payloads unchanged for wrappers, tests, and automation consumers that need exact ids.

### Why This Exists

- The router already scores well, but the operator-facing summary still leaked backend ids like `dispatch`, `present_plan`, `prepare_visual_prompt_card`, and `prepared_not_observed`.
- Hermes/chat users should see the workflow, next action, and evidence boundary in plain language, while machines keep the stable ids in `--json`.

### User / Operator Impact

- `chat route --summary` now reads like `Action: routing to a workflow` and `Next action: preparing a reviewed plan`.
- `chat route-hint --summary` now reads like `Open img-summary - enabled` instead of exposing `open_workflow`.
- Picker route hints no longer duplicate identical `Open omh` rows.

### How It Works

- `src/commands/chat.py` now uses label-only helpers for route, route-hint, status, and action summary rendering.
- A small summary sanitizer removes inline backticked internal ids from human body text only.
- `tests/test_cli.py` locks the new summary output and confirms the human surface does not leak those ids.

### Files And Contracts Touched

- `src/commands/chat.py`: human summary rendering for route and route-hint commands.
- `tests/test_cli.py`: CLI regression coverage for label-only route summaries and deduped route-hint actions.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check`
- [x] `PYTHONPATH=tests uv run python -m omh.cli harness validate`
- [ ] `python3 -m omh.cli release checklist --json`
- [ ] `python3 -m omh.cli release hermes-smoke`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable.
- [x] Relevant dry-run or smoke command: `PYTHONPATH=tests uv run python -m omh.cli chat route --source discord --summary "I want to safely add a feature to this repo"`; `PYTHONPATH=tests uv run python -m omh.cli chat route-hint --source discord --summary "make an image explaining the cron feature"`; `PYTHONPATH=tests uv run python -m omh.cli chat route-hint --source discord --summary "open the OMH picker"`
- [x] Manual Hermes/TUI check, or explicit reason it was not run: live Hermes messenger rendering was not exercised; this is a deterministic CLI summary renderer change.

## Risk

- Narrow risk: anyone scraping human summaries for ids should switch to `--json`, which remains the stable machine surface.
- JSON contracts and wrapper payloads are unchanged.

## Compatibility / Rollout

- Backward-compatible for JSON consumers.
- Human-output-only UX improvement for route and route-hint summaries.

## Release / Claims

- [x] Release-channel impact considered (`preview` copy/UX improvement; no packaging change).
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap.

## Follow-Up

- Continue moving low-level ids out of human summaries in other command families as real usage reveals noisy spots.