### PR TITLE
Humanize recommendation summaries

### DIFF
--- a/src/commands/common.py
+++ b/src/commands/common.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from ..ingress import extract_message_text, extract_source_metadata
 from ..installer import OmhError
 from ..paths import resolve_paths
-from ..routing.action_copy import next_action_label_with_id
+from ..routing.action_copy import next_action_label, next_action_label_with_id
 from ..setup_profiles import read_setup_profile
 from ..targets import TARGET_METADATA_KEYS
 
@@ -29,6 +29,14 @@ def _wants_json(args: argparse.Namespace) -> bool:
 
 def _action_label_with_id(action: str, label: str = "") -> str:
     return next_action_label_with_id(action, label)
+
+
+def _action_label(action: str, label: str = "") -> str:
+    normalized = action.strip()
+    if not normalized:
+        return ""
+    resolved_label = label.strip() or next_action_label(normalized)
+    return resolved_label or normalized
 
 
 def _explicit_source_metadata(args: argparse.Namespace) -> dict[str, str]:

--- a/src/commands/playbook.py
+++ b/src/commands/playbook.py
@@ -4,7 +4,7 @@ import argparse
 
 from ..installer import OmhError
 from ..playbooks import inspect_playbook, list_playbooks, recommend_playbooks
-from .common import _action_label_with_id, _print_json, _wants_json
+from .common import _action_label, _print_json, _wants_json
 
 
 def cmd_playbook_list(args: argparse.Namespace) -> int:
@@ -120,7 +120,7 @@ def _print_playbook_recommend_summary(payload: dict[str, object]) -> None:
         print(f"   {title}")
         next_action = str(recommendation.get("next_action", "")).strip()
         if next_action:
-            print(f"   Next action: {_action_label_with_id(next_action)}")
+            print(f"   Next action: {_action_label(next_action)}")
         boundary = _short_summary(str(recommendation.get("evidence_boundary", "")), limit=120)
         if boundary:
             print(f"   Boundary: {boundary}")

--- a/src/commands/setup.py
+++ b/src/commands/setup.py
@@ -51,7 +51,7 @@ from ..team_profiles import (
     list_team_profile_packs,
     operating_model_ids,
 )
-from .common import _action_label_with_id, _paths, _print_json, _wants_json
+from .common import _action_label, _action_label_with_id, _paths, _print_json, _wants_json
 from .language import LANGUAGE_CODES, language_from_env, language_options, normalize_language, tr
 
 INSTALLER_COMMAND = "curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes/main/install.sh | sh"
@@ -1979,7 +1979,7 @@ def _print_recommend_summary(payload: dict[str, object]) -> None:
             print(f"   {description}")
         next_action = str(recommendation.get("next_action", "")).strip()
         if next_action:
-            print(f"   Next action: {_action_label_with_id(next_action)}")
+            print(f"   Next action: {_action_label(next_action)}")
         why = _short_summary(str(recommendation.get("why", "")), limit=120)
         if why:
             print(f"   Why: {why}")

--- a/src/commands/use_cases.py
+++ b/src/commands/use_cases.py
@@ -18,7 +18,7 @@ from ..use_cases import (
     write_all_use_case_artifacts,
     write_use_case_artifact,
 )
-from .common import _action_label_with_id, _paths, _print_json, _wants_json
+from .common import _action_label, _action_label_with_id, _paths, _print_json, _wants_json
 
 
 def cmd_cases_list(args: argparse.Namespace) -> int:
@@ -421,7 +421,7 @@ def _print_cases_recommend_summary(payload: dict[str, object]) -> None:
         )
         next_action = str(case.get("next_action", "")).strip()
         if next_action:
-            print(f"   Next action: {_action_label_with_id(next_action)}")
+            print(f"   Next action: {_action_label(next_action)}")
         print(f"   Boundary: {case.get('evidence_boundary')}")
     print("Boundary")
     print("  A use-case recommendation is routing guidance, not accepted work or observed evidence.")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1003,29 +1003,34 @@ class CliTests(unittest.TestCase):
         cases = (
             (
                 ["recommend", "I", "want", "to", "safely", "add", "a", "feature", "to", "this", "repo"],
-                "Next action: preparing a reviewed plan (`present_plan`)",
+                "Next action: preparing a reviewed plan",
+                "(`present_plan`)",
             ),
             (
                 ["recommend", "make", "an", "image", "explaining", "the", "cron", "feature"],
-                "Next action: preparing an image prompt card (`prepare_visual_prompt_card`)",
+                "Next action: preparing an image prompt card",
+                "(`prepare_visual_prompt_card`)",
             ),
             (
                 ["playbook", "recommend", "turn", "this", "issue", "into", "a", "PR"],
-                "Next action: scope event (`scope_event`)",
+                "Next action: scope event",
+                "(`scope_event`)",
             ),
             (
                 ["cases", "recommend", "daily", "competitor", "digest"],
-                "Next action: preparing a scheduled-ops blueprint (`prepare_scheduled_ops_blueprint`)",
+                "Next action: preparing a scheduled-ops blueprint",
+                "(`prepare_scheduled_ops_blueprint`)",
             ),
         )
 
-        for args, expected in cases:
+        for args, expected, forbidden in cases:
             with self.subTest(args=args):
                 status, stdout, stderr = run_cli(args, output_json=False)
 
                 self.assertEqual(stderr, "")
                 self.assertEqual(status, 0)
                 self.assertIn(expected, stdout)
+                self.assertNotIn(forbidden, stdout)
 
     def test_playbook_recommendation_summary_uses_human_action_labels(self) -> None:
         status, stdout, stderr = run_cli(
@@ -1035,9 +1040,42 @@ class CliTests(unittest.TestCase):
 
         self.assertEqual(stderr, "")
         self.assertEqual(status, 0)
-        self.assertIn("Next action: scope event (`scope_event`)", stdout)
-        self.assertIn("Next action: recommending the playbook (`recommend`)", stdout)
+        self.assertIn("Next action: scope event", stdout)
+        self.assertIn("Next action: recommending the playbook", stdout)
+        self.assertNotIn("(`scope_event`)", stdout)
+        self.assertNotIn("(`recommend`)", stdout)
         self.assertNotIn("Next action: recommend\n", stdout)
+
+        status, stdout, stderr = run_cli(
+            ["playbook", "recommend", "turn", "this", "issue", "into", "a", "PR", "--json"],
+            output_json=False,
+        )
+
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        payload = json.loads(stdout)
+        self.assertEqual(payload["recommendations"][0]["next_action"], "scope_event")
+
+    def test_recommendation_json_preserves_machine_action_ids(self) -> None:
+        cases = (
+            (
+                ["recommend", "I", "want", "to", "safely", "add", "a", "feature", "to", "this", "repo", "--json"],
+                "present_plan",
+            ),
+            (
+                ["cases", "recommend", "daily", "competitor", "digest", "--json"],
+                "prepare_scheduled_ops_blueprint",
+            ),
+        )
+
+        for args, expected_next_action in cases:
+            with self.subTest(args=args):
+                status, stdout, stderr = run_cli(args, output_json=False)
+
+                self.assertEqual(stderr, "")
+                self.assertEqual(status, 0)
+                payload = json.loads(stdout)
+                self.assertEqual(payload["recommendations"][0]["next_action"], expected_next_action)
 
     def test_recommendation_reasons_avoid_internal_metadata_copy(self) -> None:
         status, stdout, stderr = run_cli(["recommend", "risky", "refactor"], output_json=False)


### PR DESCRIPTION
## Summary

This PR finishes the human-facing cleanup for recommendation surfaces. `omh recommend`, `omh playbook recommend`, and `omh cases recommend` now show plain next-action copy instead of exposing backend action ids like `present_plan`, `scope_event`, or `prepare_scheduled_ops_blueprint` in normal terminal output.

Machine-readable JSON is intentionally unchanged, so wrappers and tests can still depend on stable `next_action` ids.

## Why

After the chat summary cleanup, manual smoke testing still showed raw internal ids in recommendation summaries. That made the CLI feel like a backend diagnostic surface instead of a user/operator surface. Recommendation summaries should explain the next step in natural language, while `--json` keeps the exact ids for automation.

## What changed

- Added a shared label-only `_action_label(...)` helper next to the existing id-preserving helper.
- Updated the human summary renderers for:
  - `omh recommend`
  - `omh playbook recommend`
  - `omh cases recommend`
- Added CLI coverage that asserts human output hides raw ids while JSON still preserves them.

## User impact

Users now see output such as:

- `Next action: preparing a reviewed plan`
- `Next action: scope event`
- `Next action: preparing a scheduled-ops blueprint`

Wrappers still receive stable payloads such as `present_plan`, `scope_event`, and `prepare_scheduled_ops_blueprint` through `--json`.

## Verification

- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- `uv run python -m compileall -q src tests`
- `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check`
- `PYTHONPATH=tests uv run python -m omh.cli harness validate`
- `git diff --check`

## Risks / notes

- Live Hermes messenger rendering was not exercised in this PR.
- The change is scoped to human summary output; JSON payloads remain the automation contract.
