### PR TITLE
Humanize demo quality summaries

### DIFF
--- a/examples/use-cases/g1-g10-demo-cards.json
+++ b/examples/use-cases/g1-g10-demo-cards.json
@@ -84,13 +84,13 @@
       "chat_surface": {
         "body_lines": [
           "Turn a plain recurring request into a Hermes cron/automation blueprint with delivery target and confirmation card.",
-          "Route: automation-blueprint -> preparing a scheduled-ops blueprint (`prepare_scheduled_ops_blueprint`).",
+          "Route: automation-blueprint -> preparing a scheduled-ops blueprint.",
           "Hermes can shape recurring work without pretending cron, source retrieval, or delivery already happened."
         ],
         "direct_skill_invocation": "$automation-blueprint Every morning, research competitor updates and send a digest only if something changed.",
         "headline": "[omh] Natural-language scheduled automation",
         "source": "hermes_agent_chat",
-        "status_line": "prepared_not_observed | automation-blueprint | preparing a scheduled-ops blueprint (`prepare_scheduled_ops_blueprint`)",
+        "status_line": "prepared_not_observed | automation-blueprint | preparing a scheduled-ops blueprint",
         "suggested_user_prompt": "Use OMH automation-blueprint for: Every morning, research competitor updates and send a digest only if something changed."
       },
       "evidence": {
@@ -241,13 +241,13 @@
       "chat_surface": {
         "body_lines": [
           "Route PR opened, CI failed, issue opened, and review events into review, triage, labeling, or fix-handoff cards.",
-          "Route: github-event-ops -> preparing a GitHub event operations card (`prepare_github_event_ops_card`).",
+          "Route: github-event-ops -> preparing a GitHub event operations card.",
           "Maintainers can paste or receive GitHub events and get a safe next action without claiming a bot mutated GitHub."
         ],
         "direct_skill_invocation": "$github-event-ops PR opened with failing CI; decide whether to review, label, or prepare a fix handoff.",
         "headline": "[omh] GitHub PR/Issue event operations",
         "source": "hermes_agent_chat",
-        "status_line": "prepared_not_observed | github-event-ops | preparing a GitHub event operations card (`prepare_github_event_ops_card`)",
+        "status_line": "prepared_not_observed | github-event-ops | preparing a GitHub event operations card",
         "suggested_user_prompt": "Use OMH github-event-ops for: PR opened with failing CI; decide whether to review, label, or prepare a fix handoff."
       },
       "evidence": {
@@ -397,13 +397,13 @@
       "chat_surface": {
         "body_lines": [
           "Let multiple Hermes profiles or agents collaborate through task, handoff, heartbeat, blocker, and completion states.",
-          "Route: agent-board -> preparing an agent board card (`prepare_agent_board_card`).",
+          "Route: agent-board -> preparing an agent board card.",
           "Teams see who owns each lane and which states are only prepared versus observed."
         ],
         "direct_skill_invocation": "$agent-board Coordinate CTO, PM, QA, and release agents on this launch checklist.",
         "headline": "[omh] Multi-agent Kanban board",
         "source": "hermes_agent_chat",
-        "status_line": "prepared_not_observed | agent-board | preparing an agent board card (`prepare_agent_board_card`)",
+        "status_line": "prepared_not_observed | agent-board | preparing an agent board card",
         "suggested_user_prompt": "Use OMH agent-board for: Coordinate CTO, PM, QA, and release agents on this launch checklist."
       },
       "evidence": {
@@ -555,13 +555,13 @@
       "chat_surface": {
         "body_lines": [
           "Review stale memories, conflicting facts, and duplicate skills with approve/reject/update actions.",
-          "Route: memory-curation-review -> preparing a memory curation review (`prepare_memory_curation_review`).",
+          "Route: memory-curation-review -> preparing a memory curation review.",
           "Users can clean memory and skill drift without a silent destructive edit."
         ],
         "direct_skill_invocation": "$memory-curation-review Inspect stale project memories and ask me what to keep.",
         "headline": "[omh] Memory and skill curation review",
         "source": "hermes_agent_chat",
-        "status_line": "prepared_not_observed | memory-curation-review | preparing a memory curation review (`prepare_memory_curation_review`)",
+        "status_line": "prepared_not_observed | memory-curation-review | preparing a memory curation review",
         "suggested_user_prompt": "Use OMH memory-curation-review for: Inspect stale project memories and ask me what to keep."
       },
       "evidence": {
@@ -713,13 +713,13 @@
       "chat_surface": {
         "body_lines": [
           "Normalize Discord, Slack, Telegram, and other gateway sessions into origin/thread/delivery/silent/attachment/status-update policy.",
-          "Route: gateway-intent-card -> preparing a gateway intent card (`prepare_gateway_intent_card`).",
+          "Route: gateway-intent-card -> preparing a gateway intent card.",
           "Gateway builders get a platform-neutral card Hermes can use without hardcoding a bot SDK into OMH."
         ],
         "direct_skill_invocation": "$gateway-intent-card Route this Discord thread update silently unless action is needed.",
         "headline": "[omh] Gateway-native intent card",
         "source": "hermes_agent_chat",
-        "status_line": "prepared_not_observed | gateway-intent-card | preparing a gateway intent card (`prepare_gateway_intent_card`)",
+        "status_line": "prepared_not_observed | gateway-intent-card | preparing a gateway intent card",
         "suggested_user_prompt": "Use OMH gateway-intent-card for: Route this Discord thread update silently unless action is needed."
       },
       "evidence": {
@@ -871,13 +871,13 @@
       "chat_surface": {
         "body_lines": [
           "Show whether Codex, Claude Code, Hermes coding, or an oh-my runtime has the tools, credentials, and handoff mode needed.",
-          "Route: executor-runtime-readiness -> checking coding-agent readiness (`prepare_executor_runtime_readiness`).",
+          "Route: executor-runtime-readiness -> checking coding-agent readiness.",
           "Users can choose Codex, Claude Code, Hermes, or plugin runtimes without guessing hidden capabilities."
         ],
         "direct_skill_invocation": "$executor-runtime-readiness Can this task run in Codex, Claude Code, or Hermes coding?",
         "headline": "[omh] Executor runtime readiness",
         "source": "hermes_agent_chat",
-        "status_line": "prepared_not_observed | executor-runtime-readiness | checking coding-agent readiness (`prepare_executor_runtime_readiness`)",
+        "status_line": "prepared_not_observed | executor-runtime-readiness | checking coding-agent readiness",
         "suggested_user_prompt": "Use OMH executor-runtime-readiness for: Can this task run in Codex, Claude Code, or Hermes coding?"
       },
       "evidence": {
@@ -1031,13 +1031,13 @@
       "chat_surface": {
         "body_lines": [
           "Track PPT, PDF, XLSX, DOCX, HWP, Markdown, and attachments through prepared/generated/QA/attached states.",
-          "Route: deliverable-package -> preparing a deliverable package (`prepare_deliverable_package`).",
+          "Route: deliverable-package -> preparing a deliverable package.",
           "Users can ask for files in chat and see exactly whether they are planned, generated, QAed, approved, or attached."
         ],
         "direct_skill_invocation": "$deliverable-package Turn this research into PPT and PDF with attachment status.",
         "headline": "[omh] Deliverable file package",
         "source": "hermes_agent_chat",
-        "status_line": "prepared_not_observed | deliverable-package | preparing a deliverable package (`prepare_deliverable_package`)",
+        "status_line": "prepared_not_observed | deliverable-package | preparing a deliverable package",
         "suggested_user_prompt": "Use OMH deliverable-package for: Turn this research into PPT and PDF with attachment status."
       },
       "evidence": {
@@ -1186,13 +1186,13 @@
       "chat_surface": {
         "body_lines": [
           "Convert terse voice/mobile commands into clarify, plan, status, handoff, or confirmation actions.",
-          "Route: voice-operator -> preparing a voice-operator card (`prepare_voice_operator_card`).",
+          "Route: voice-operator -> preparing a voice-operator card.",
           "Voice and mobile users get concise, safe routing instead of long CLI-like responses."
         ],
         "direct_skill_invocation": "$voice-operator 'release before lunch, check risky parts' from mobile.",
         "headline": "[omh] Voice and mobile operator",
         "source": "hermes_agent_chat",
-        "status_line": "prepared_not_observed | voice-operator | preparing a voice-operator card (`prepare_voice_operator_card`)",
+        "status_line": "prepared_not_observed | voice-operator | preparing a voice-operator card",
         "suggested_user_prompt": "Use OMH voice-operator for: 'release before lunch, check risky parts' from mobile."
       },
       "evidence": {
@@ -1343,13 +1343,13 @@
       "chat_surface": {
         "body_lines": [
           "Check which MCP servers, CLIs, APIs, credentials, and connectors a workflow needs before claiming it can run.",
-          "Route: toolbelt-readiness -> checking toolbelt readiness (`prepare_toolbelt_readiness`).",
+          "Route: toolbelt-readiness -> checking toolbelt readiness.",
           "Users see missing MCP/CLI/API pieces before an automation or handoff overclaims readiness."
         ],
         "direct_skill_invocation": "$toolbelt-readiness What MCP or CLI tools do I need for weekly Linear and GitHub triage?",
         "headline": "[omh] MCP and external toolbelt readiness",
         "source": "hermes_agent_chat",
-        "status_line": "prepared_not_observed | toolbelt-readiness | checking toolbelt readiness (`prepare_toolbelt_readiness`)",
+        "status_line": "prepared_not_observed | toolbelt-readiness | checking toolbelt readiness",
         "suggested_user_prompt": "Use OMH toolbelt-readiness for: What MCP or CLI tools do I need for weekly Linear and GitHub triage?"
       },
       "evidence": {
@@ -1500,13 +1500,13 @@
       "chat_surface": {
         "body_lines": [
           "Keep automation and loop work from failing silently by showing token/cost/latency/run-history/failure-mode telemetry boundaries.",
-          "Route: ops-observability-card -> preparing an ops observability card (`prepare_ops_observability_card`).",
+          "Route: ops-observability-card -> preparing an ops observability card.",
           "Operators can see health/cost signals without confusing estimates with provider truth or completion evidence."
         ],
         "direct_skill_invocation": "$ops-observability-card Show token, cost, latency, and last run status for this loop.",
         "headline": "[omh] Ops observability and cost card",
         "source": "hermes_agent_chat",
-        "status_line": "prepared_not_observed | ops-observability-card | preparing an ops observability card (`prepare_ops_observability_card`)",
+        "status_line": "prepared_not_observed | ops-observability-card | preparing an ops observability card",
         "suggested_user_prompt": "Use OMH ops-observability-card for: Show token, cost, latency, and last run status for this loop."
       },
       "evidence": {

--- a/src/commands/context.py
+++ b/src/commands/context.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import argparse
 
 from ..context import build_context_brief
-from .common import _action_label_with_id, _print_json, _wants_json
+from .common import _action_label, _print_json, _wants_json
 
 
 def cmd_context_brief(args: argparse.Namespace) -> int:
@@ -32,14 +32,14 @@ def _print_context_brief_summary(payload: dict[str, object]) -> None:
         action = str(route_hint.get("primary_next_action") or "")
         action_label = str(route_hint.get("primary_next_action_label") or "")
         if primary:
-            print(f"  Route hint: {primary} -> {_action_label_with_id(action, action_label)}")
+            print(f"  Route hint: {primary} -> {_action_label(action, action_label)}")
         else:
             print("  Route hint: no strong message-specific hint")
     catalog_question = payload.get("catalog_question")
     if isinstance(catalog_question, dict) and catalog_question.get("status") == "matched":
         print(
             "  Catalog question: "
-            f"{_action_label_with_id(str(catalog_question.get('next_action', '')))} "
+            f"{_action_label(str(catalog_question.get('next_action', '')))} "
             f"via {catalog_question.get('recommended_tool')}"
         )
     print("Workflow lanes")

--- a/src/commands/setup.py
+++ b/src/commands/setup.py
@@ -51,7 +51,7 @@ from ..team_profiles import (
     list_team_profile_packs,
     operating_model_ids,
 )
-from .common import _action_label, _action_label_with_id, _paths, _print_json, _wants_json
+from .common import _action_label, _paths, _print_json, _wants_json
 from .language import LANGUAGE_CODES, language_from_env, language_options, normalize_language, tr
 
 INSTALLER_COMMAND = "curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes/main/install.sh | sh"

--- a/src/commands/use_cases.py
+++ b/src/commands/use_cases.py
@@ -18,7 +18,7 @@ from ..use_cases import (
     write_all_use_case_artifacts,
     write_use_case_artifact,
 )
-from .common import _action_label, _action_label_with_id, _paths, _print_json, _wants_json
+from .common import _action_label, _paths, _print_json, _wants_json
 
 
 def cmd_cases_list(args: argparse.Namespace) -> int:
@@ -177,7 +177,7 @@ def _print_case_summary(case: dict[str, object]) -> None:
     print(f"  Compatibility alias: {case.get('compatibility_alias')}")
     print(f"  Playbook: {case.get('playbook')}")
     print(f"  Harness: {case.get('harness')}")
-    print(f"  Next action: {_action_label_with_id(str(case.get('next_action', '')))}")
+    print(f"  Next action: {_action_label(str(case.get('next_action', '')))}")
     print("Use it")
     print(f"  Hermes chat: {case.get('hermes_chat_prompt')}")
     print(f"  Compatibility alias: {case.get('direct_skill_invocation')}")
@@ -456,7 +456,7 @@ def _route_summary(route: dict[str, object]) -> str:
         return ""
     if not next_action:
         return primary_skill
-    return f"{primary_skill} -> {_action_label_with_id(next_action, str(route.get('next_action_label', '')))}"
+    return f"{primary_skill} -> {_action_label(next_action, str(route.get('next_action_label', '')))}"
 
 
 def _add_cases_commands(sub) -> None:

--- a/src/quality/chat_card_coverage.py
+++ b/src/quality/chat_card_coverage.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 import hashlib
 
 from ..ingress import CHAT_SOURCES
-from ..routing.action_copy import next_action_label_with_id
+from ..routing.action_copy import next_action_label
 from ..wrapper.contract import build_chat_interaction_payload
 
 
@@ -280,7 +280,7 @@ def format_chat_card_coverage_summary(payload: dict[str, object]) -> str:
     for row in rows:
         observed = _nested(row, "observed")
         status = "ok" if row.get("passed") else "needs attention"
-        next_action = next_action_label_with_id(str(observed.get("next_action", "unknown")))
+        next_action = next_action_label(str(observed.get("next_action", "unknown")))
         lines.append(
             f"- {row.get('title', 'Untitled card')}: {status}; "
             f"{observed.get('workflow', 'unknown')} -> {next_action}; card={observed.get('kind', 'unknown')}"

--- a/src/quality/context_brief_coverage.py
+++ b/src/quality/context_brief_coverage.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from ..context import build_context_brief
 from ..ingress import CHAT_SOURCES
-from ..routing.action_copy import next_action_label_with_id
+from ..routing.action_copy import next_action_label
 
 
 CONTEXT_BRIEF_COVERAGE_SCHEMA_VERSION = "context_brief_coverage/v1"
@@ -148,7 +148,7 @@ def format_context_brief_coverage_summary(payload: dict[str, object]) -> str:
         action = observed.get("primary_next_action") or observed.get("catalog_next_action") or "unknown"
         lines.append(
             f"- {row.get('title', 'Untitled context')}: "
-            f"{status}; {workflow} -> {next_action_label_with_id(str(action))}"
+            f"{status}; {workflow} -> {next_action_label(str(action))}"
         )
     failed = [row for row in rows if not row.get("passed")]
     if failed:

--- a/src/quality/grounded_score.py
+++ b/src/quality/grounded_score.py
@@ -6,7 +6,7 @@ import hashlib
 from ..catalogs.playbooks import recommend_playbooks
 from ..coding_delegation import build_coding_delegation_payload
 from ..ingress import CHAT_SOURCES
-from ..routing.action_copy import next_action_label_with_id
+from ..routing.action_copy import next_action_label
 from ..wrapper.contract import build_chat_interaction_payload
 
 
@@ -604,7 +604,7 @@ def format_grounded_score_summary(payload: dict[str, object]) -> str:
     for scenario in scenario_rows:
         observed = _nested(scenario, "observed")
         skill = observed.get("skill", "unknown")
-        next_action = next_action_label_with_id(str(observed.get("next_action", "unknown")))
+        next_action = next_action_label(str(observed.get("next_action", "unknown")))
         handoff = observed.get("handoff_status", "unknown")
         score = scenario.get("score", 0)
         status = "ok" if int(score) == 10 else "needs attention"

--- a/src/quality/route_hint_alignment.py
+++ b/src/quality/route_hint_alignment.py
@@ -6,7 +6,7 @@ from typing import Mapping
 
 from ..ingress import CHAT_SOURCES
 from ..plugin_bundle.omh.awareness import awareness_route_hint
-from ..routing.action_copy import next_action_label_with_id
+from ..routing.action_copy import next_action_label
 from ..wrapper.contract import build_chat_interaction_payload
 from .chat_card_coverage import CHAT_CARD_COVERAGE_CASES
 from .grounded_score import GROUNDED_SCENARIOS
@@ -125,7 +125,7 @@ def format_route_hint_alignment_summary(payload: dict[str, object]) -> str:
             f"- {row.get('title', 'Untitled route')}: {status}; "
             f"route={observed.get('route_workflow', 'unknown')} "
             f"hint={observed.get('hint_workflow', 'unknown')} "
-            f"next={next_action_label_with_id(str(observed.get('hint_next_action', 'unknown')))}"
+            f"next={next_action_label(str(observed.get('hint_next_action', 'unknown')))}"
         )
     failed = [row for row in rows if not row.get("aligned")]
     if failed:

--- a/src/quality/routing_precision.py
+++ b/src/quality/routing_precision.py
@@ -5,7 +5,7 @@ import hashlib
 from typing import Mapping, Sequence
 
 from ..ingress import CHAT_SOURCES
-from ..routing.action_copy import next_action_label_with_id
+from ..routing.action_copy import next_action_label
 from ..wrapper.contract import build_chat_interaction_payload
 
 
@@ -586,7 +586,7 @@ def format_routing_precision_summary(payload: Mapping[str, object]) -> str:
     for row in rows:
         observed = _nested(row, "observed")
         status = "ok" if row.get("passed") else "needs attention"
-        next_action = next_action_label_with_id(str(observed.get("next_action", "unknown")))
+        next_action = next_action_label(str(observed.get("next_action", "unknown")))
         lines.append(
             f"- {row.get('title', 'Untitled precision case')}: {status}; "
             f"route={observed.get('route_action', 'unknown')} -> {next_action}"
@@ -596,7 +596,7 @@ def format_routing_precision_summary(payload: Mapping[str, object]) -> str:
         for row in intervention_rows:
             observed = _nested(row, "observed")
             status = "ok" if row.get("passed") else "needs attention"
-            next_action = next_action_label_with_id(str(observed.get("next_action", "unknown")))
+            next_action = next_action_label(str(observed.get("next_action", "unknown")))
             lines.append(
                 f"- {row.get('title', 'Untitled intervention case')}: {status}; "
                 f"{observed.get('route_workflow', 'unknown')} -> {next_action}"

--- a/src/workflows/use_cases.py
+++ b/src/workflows/use_cases.py
@@ -999,10 +999,10 @@ def _demo_card(case: UseCase) -> dict[str, Any]:
             "headline": f"[omh] {case.title}",
             "body_lines": [
                 case.hermes_use_case,
-                f"Route: {case.primary_skill} -> {_action_label_with_id(case.next_action)}.",
+                f"Route: {case.primary_skill} -> {_action_label(case.next_action)}.",
                 case.user_value,
             ],
-            "status_line": f"prepared_not_observed | {case.primary_skill} | {_action_label_with_id(case.next_action)}",
+            "status_line": f"prepared_not_observed | {case.primary_skill} | {_action_label(case.next_action)}",
         },
         "wrapper_card": {
             "component": "omh_use_case_card",
@@ -1087,16 +1087,6 @@ def _demo_card(case: UseCase) -> dict[str, Any]:
 
 def _action_label(action: str) -> str:
     return next_action_label(action)
-
-
-def _action_label_with_id(action: str) -> str:
-    normalized = action.strip()
-    if not normalized:
-        return ""
-    label = _action_label(normalized)
-    if not label or label == normalized:
-        return normalized
-    return f"{label} (`{normalized}`)"
 
 
 def _action_button_label(action: str) -> str:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -90,9 +90,10 @@ class CliTests(unittest.TestCase):
         self.assertEqual(stderr, "")
         self.assertIn("OMH context brief", stdout)
         self.assertIn(
-            "Route hint: img-summary -> preparing an image prompt card (`prepare_visual_prompt_card`)",
+            "Route hint: img-summary -> preparing an image prompt card",
             stdout,
         )
+        self.assertNotIn("(`prepare_visual_prompt_card`)", stdout)
         self.assertIn("Workflow lanes", stdout)
         self.assertIn("Generic tool checkpoint", stdout)
         self.assertIn("Do not skip OMH merely because a generic tool", stdout)
@@ -105,9 +106,10 @@ class CliTests(unittest.TestCase):
         self.assertEqual(status, 0, stderr)
         self.assertEqual(stderr, "")
         self.assertIn(
-            "Catalog question: opening the workflow picker (`show_workflow_picker`) via omh_capabilities",
+            "Catalog question: opening the workflow picker via omh_capabilities",
             stdout,
         )
+        self.assertNotIn("(`show_workflow_picker`)", stdout)
 
         status, stdout, stderr = run_cli(
             [
@@ -1171,9 +1173,10 @@ class CliTests(unittest.TestCase):
         self.assertEqual(demo["wrapper_card"]["status"], "prepared_not_observed")
         self.assertIn("prepared_not_observed", demo["chat_surface"]["status_line"])
         self.assertIn(
-            "Route: automation-blueprint -> preparing a scheduled-ops blueprint (`prepare_scheduled_ops_blueprint`).",
+            "Route: automation-blueprint -> preparing a scheduled-ops blueprint.",
             demo["chat_surface"]["body_lines"],
         )
+        self.assertNotIn("(`prepare_scheduled_ops_blueprint`)", json.dumps(demo["chat_surface"]))
         self.assertEqual(demo["actions"][0]["id"], "prepare_scheduled_ops_blueprint")
         self.assertEqual(demo["actions"][0]["label"], "Prepare a scheduled-ops blueprint")
         self.assertEqual(demo["actions"][0]["kind"], "hermes_prompt")
@@ -1187,9 +1190,10 @@ class CliTests(unittest.TestCase):
         self.assertEqual(status, 0, stderr)
         self.assertEqual(stderr, "")
         self.assertIn(
-            "automation-blueprint -> preparing a scheduled-ops blueprint (`prepare_scheduled_ops_blueprint`)",
+            "automation-blueprint -> preparing a scheduled-ops blueprint",
             stdout,
         )
+        self.assertNotIn("(`prepare_scheduled_ops_blueprint`)", stdout)
         self.assertNotIn("automation-blueprint -> prepare_scheduled_ops_blueprint (", stdout)
 
         status, stdout, stderr = run_cli(["cases", "demo", "--all", "--json"], output_json=False)
@@ -6039,9 +6043,10 @@ class CliTests(unittest.TestCase):
         self.assertIn("Result: 47/47 scenarios at 10/10 (all passing)", stdout)
         self.assertIn(
             "Startup SaaS product triage: 10/10 ok; "
-            "feedback-triage -> triaging the feedback signal (`triage_feedback`); handoff_absent",
+            "feedback-triage -> triaging the feedback signal; handoff_absent",
             stdout,
         )
+        self.assertNotIn("(`triage_feedback`)", stdout)
         self.assertIn("Boundary: This is deterministic local contract-compliance evaluation", stdout)
         self.assertIn("Use --json for the full machine-readable payload.", stdout)
 
@@ -6081,10 +6086,11 @@ class CliTests(unittest.TestCase):
         self.assertIn("Generic ack responses: 0", stdout)
         self.assertIn(
             "Scheduled ops blueprint: ok; "
-            "automation-blueprint -> preparing a scheduled-ops blueprint (`prepare_scheduled_ops_blueprint`); "
+            "automation-blueprint -> preparing a scheduled-ops blueprint; "
             "card=automation_blueprint",
             stdout,
         )
+        self.assertNotIn("(`prepare_scheduled_ops_blueprint`)", stdout)
         self.assertIn("Boundary: This is deterministic local wrapper-card coverage", stdout)
         self.assertIn("Use --json for the full machine-readable payload.", stdout)
 
@@ -6142,9 +6148,10 @@ class CliTests(unittest.TestCase):
         self.assertIn("Hints present: 72/72; missing hints: 0; mismatches: 0", stdout)
         self.assertIn(
             "AI agent product QA: ok; "
-            "route=ultraqa hint=ultraqa next=opening the selected workflow (`dispatch_to_workflow`)",
+            "route=ultraqa hint=ultraqa next=opening the selected workflow",
             stdout,
         )
+        self.assertNotIn("(`dispatch_to_workflow`)", stdout)
         self.assertIn("Boundary: Route hint alignment proves deterministic local agreement", stdout)
         self.assertIn("Use --json for the full machine-readable payload.", stdout)
 

--- a/tests/test_context_brief_coverage.py
+++ b/tests/test_context_brief_coverage.py
@@ -43,14 +43,16 @@ class ContextBriefCoverageTests(unittest.TestCase):
         self.assertIn("catalog picker hints: 1", stdout)
         self.assertIn(
             "Visual summary before generic image tools: ok; "
-            "img-summary -> preparing an image prompt card (`prepare_visual_prompt_card`)",
+            "img-summary -> preparing an image prompt card",
             stdout,
         )
         self.assertIn(
             "Catalog picker without shell approval: ok; "
-            "catalog -> opening the workflow picker (`show_workflow_picker`)",
+            "catalog -> opening the workflow picker",
             stdout,
         )
+        self.assertNotIn("(`prepare_visual_prompt_card`)", stdout)
+        self.assertNotIn("(`show_workflow_picker`)", stdout)
 
         status, stdout, stderr = run_cli(["demo", "context-brief-coverage", "--json"], output_json=False)
 

--- a/tests/test_routing_precision.py
+++ b/tests/test_routing_precision.py
@@ -132,14 +132,16 @@ class RoutingPrecisionTests(unittest.TestCase):
         self.assertIn("missed interventions: 0", stdout)
         self.assertIn(
             "Repo file lookup stays direct: ok; "
-            "route=fallback -> answering as a file or text lookup (`answer_file_lookup`)",
+            "route=fallback -> answering as a file or text lookup",
             stdout,
         )
         self.assertIn(
             "Korean short status slang opens agent ops review: ok; "
-            "agent-ops-review -> refreshing agent operations status (`refresh_agent_ops_status`)",
+            "agent-ops-review -> refreshing agent operations status",
             stdout,
         )
+        self.assertNotIn("(`answer_file_lookup`)", stdout)
+        self.assertNotIn("(`refresh_agent_ops_status`)", stdout)
 
         status, stdout, stderr = run_cli(["demo", "routing-precision", "--json"], output_json=False)
 


### PR DESCRIPTION
## Summary

This PR continues the human-facing cleanup from recommendation and chat summaries. It removes raw backend action ids from terminal summaries for:

- `omh context brief` route hints and catalog-picker hints
- `omh cases inspect` / `omh cases demo` / `omh cases demo --all`
- `omh demo grounded-score --summary`
- `omh demo chat-card-coverage --summary`
- `omh demo route-hint-alignment --summary`
- `omh demo context-brief-coverage --summary` and routing precision summary output

The machine-readable JSON contracts still keep the stable action ids such as `prepare_scheduled_ops_blueprint`, `dispatch_to_workflow`, and `show_workflow_picker`.

## Why

Normal OMH users and Hermes operators should not see backend ids in summary output. Those ids are useful for wrappers and tests, but they make the terminal and demo reports feel like internal diagnostics instead of operator-readable guidance.

## What changed

- Switched affected summary formatters from id-bearing action copy to label-only action copy.
- Updated G1-G10 use-case demo card generation so chat-facing body/status lines use readable action labels.
- Regenerated `examples/use-cases/g1-g10-demo-cards.json` from the deterministic demo command.
- Updated tests to assert raw ids are absent from human summaries while JSON still preserves ids.

## User impact

Before:

- `automation-blueprint -> preparing a scheduled-ops blueprint (\`prepare_scheduled_ops_blueprint\`)`

After:

- `automation-blueprint -> preparing a scheduled-ops blueprint`

For automation, `--json` still exposes `next_action: prepare_scheduled_ops_blueprint`.

## Verification

- `PYTHONPATH=tests uv run python -m unittest discover -s tests`
- `uv run python -m compileall -q src tests`
- `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check`
- `PYTHONPATH=tests uv run python -m omh.cli harness validate`
- `git diff --check`
- Smoke checked `omh context brief`, `omh cases inspect`, `omh cases demo`, and multiple `omh demo ... --summary` outputs for label-only action copy.

## Risks / notes

- Live Hermes messenger rendering was not exercised.
- This PR intentionally keeps raw action ids in JSON payloads, fixture action ids, and wrapper contracts.
