### PR TITLE
Reuse route hints in context briefs

### DIFF
--- a/src/plugin_bundle/omh/awareness.py
+++ b/src/plugin_bundle/omh/awareness.py
@@ -1930,6 +1930,11 @@ def _localized_routing_text(message: str) -> str:
 def awareness_route_hint_context(message: str, *, max_hints: int = 2) -> str:
     """Return compact hook text for message-specific workflow hints."""
     payload = awareness_route_hint(message, max_hints=max_hints)
+    return awareness_route_hint_context_from_payload(payload)
+
+
+def awareness_route_hint_context_from_payload(payload: dict[str, object]) -> str:
+    """Return compact hook text from an already-built route hint payload."""
     if payload.get("status") != "hinted":
         return ""
     adjacent_summary = ", ".join(str(item) for item in payload.get("adjacent_workflows", []))
@@ -1949,7 +1954,7 @@ def awareness_route_hint_context(message: str, *, max_hints: int = 2) -> str:
         lines.append(f"adjacent_workflows={adjacent_summary}.")
     if not_executed_summary:
         lines.append(f"not_executed={not_executed_summary}.")
-    for hint in payload["hints"]:
+    for hint in payload.get("hints", []):
         if not isinstance(hint, dict):
             continue
         adjacent = ", ".join(str(item) for item in hint.get("adjacent_workflows", []))
@@ -1973,7 +1978,7 @@ def awareness_route_hint_context(message: str, *, max_hints: int = 2) -> str:
         not_evidence = ", ".join(str(item) for item in hint.get("not_evidence_yet", [])[:4])
         if not_evidence:
             lines.append(f"  not_evidence_yet={not_evidence}.")
-    lines.append("Boundary: " + str(payload["claim_boundary"]))
+    lines.append("Boundary: " + str(payload.get("claim_boundary", "")))
     return "\n".join(lines)
 
 

--- a/src/plugin_bundle/omh/context_brief.py
+++ b/src/plugin_bundle/omh/context_brief.py
@@ -7,7 +7,7 @@ from .awareness import (
     awareness_primer_context,
     awareness_primer_payload,
     awareness_route_hint,
-    awareness_route_hint_context,
+    awareness_route_hint_context_from_payload,
 )
 
 OMH_CONTEXT_BRIEF_SCHEMA_VERSION = "omh_context_brief/v1"
@@ -74,7 +74,7 @@ def build_context_brief(
     }
     if include_prompt_context:
         prompt_context_parts = [awareness_primer_context()]
-        route_hint_context = awareness_route_hint_context(text, max_hints=limit) if text.strip() else ""
+        route_hint_context = awareness_route_hint_context_from_payload(route_hint) if text.strip() else ""
         if route_hint_context:
             prompt_context_parts.append(route_hint_context)
         payload["prompt_context"] = "\n".join(prompt_context_parts)

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -38,6 +38,7 @@ from omh.capabilities import families as families_module
 from omh.capabilities.skills import skill_capabilities
 from omh.coding import executor_readiness as executor_readiness_module
 from omh.coding import executors as executors_module
+from omh.context import build_context_brief
 from omh.plugin_bundle.omh.tools.capability_tool import standalone_skill_capability_items
 from omh.plugin_bundle.omh import awareness as awareness_module
 from omh.plugin_bundle.omh.awareness import (
@@ -277,6 +278,22 @@ class EfficiencyContractTests(unittest.TestCase):
         self.assertNotEqual(second["privacy"]["stored_fields"][0], "mutated")
         self.assertEqual(cache_info.misses, 1)
         self.assertGreaterEqual(cache_info.hits, 1)
+
+    def test_context_brief_prompt_context_reuses_route_hint_payload(self) -> None:
+        awareness_module._awareness_route_hint_cached.cache_clear()
+
+        payload = build_context_brief(
+            "Codex 작업이 어디까지 진행됐는지 알려줘",
+            source="discord",
+            include_prompt_context=True,
+        )
+        cache_info = awareness_module._awareness_route_hint_cached.cache_info()
+
+        self.assertEqual(payload["route_hint"]["primary_workflow"], "ultraprocess")
+        self.assertEqual(payload["route_hint"]["primary_next_action"], "show_coding_handoff_status")
+        self.assertIn("next_action=show_coding_handoff_status", payload["prompt_context"])
+        self.assertEqual(cache_info.misses, 1)
+        self.assertEqual(cache_info.hits, 0)
 
     def test_quality_demos_reuse_interaction_route(self) -> None:
         alignment_case = RouteHintAlignmentCase(


### PR DESCRIPTION
## Feature Report

### What Changed

- Reused the already-built `omh_route_hint/v1` payload when `omh context brief --prompt-context` renders the prompt-context text.
- Added `awareness_route_hint_context_from_payload(...)` so Hermes-facing hook text can be rendered from an existing route hint instead of recalculating the public message helper.
- Added an efficiency regression test that proves a single context-brief build creates only one route-hint cache miss and no extra same-message cache hit.

### Why This Exists

- Context brief is on the hot path for Hermes first-turn awareness, wrapper cards, and chat surfaces.
- The previous path built `route_hint` for the JSON payload, then called the message helper again to build the prompt-context text. The cache made the second route cheaper, but it still repeated public helper work and payload copying.
- This keeps the user-visible routing contract unchanged while making the internal first-turn context path lighter.

### User / Operator Impact

- Hermes still sees the same OMH route hint, next action, and prepared-vs-observed boundary copy.
- Frequent chat/context surfaces do a little less duplicated work before replying.
- Operators get a locked efficiency test for the coding-status context path, including Korean Codex progress phrasing.

### How It Works

- `awareness_route_hint_context(message, ...)` now delegates rendering to `awareness_route_hint_context_from_payload(payload)` after one route-hint build.
- `build_context_brief(..., include_prompt_context=True)` passes its existing `route_hint` payload into the new renderer.
- The renderer remains defensive for standalone plugin hosts by using optional payload fields safely.

### Files And Contracts Touched

- `src/plugin_bundle/omh/awareness.py`: adds payload-based route-hint context rendering.
- `src/plugin_bundle/omh/context_brief.py`: reuses the existing route hint when prompt context is requested.
- `tests/test_efficiency.py`: adds the cache-use regression.
- Public schemas remain unchanged: `omh_context_brief/v1` and `omh_route_hint/v1` output shapes are preserved.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_efficiency.py tests/test_context_brief_coverage.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — 987 tests OK
- [x] `uv run python -m compileall -q src tests`
- [x] `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check`
- [x] `PYTHONPATH=tests uv run python -m omh.cli harness validate`
- [x] `PYTHONPATH=tests uv run python -m omh.cli demo hermes-ux-quality --summary` — 100/100
- [x] `PYTHONPATH=tests uv run python -m omh.cli release evidence-bundle --version 1.0.1` — ready 100/100
- [x] `git diff --check`
- [x] Relevant dry-run or smoke command: `PYTHONPATH=tests uv run python -m omh.cli context brief --source discord --prompt-context --json "Codex 작업이 어디까지 진행됐는지 알려줘"`
- [x] Manual Hermes/TUI check, or explicit reason it was not run: not run; this PR changes deterministic local context assembly only, not live Hermes plugin loading or UI rendering.

## Risk

- Narrow. The output contract should stay the same because the prompt-context renderer still reads the same route-hint payload fields.
- Main risk is a standalone plugin host passing a malformed payload; the renderer now handles missing `hints` and `claim_boundary` defensively.

## Compatibility / Rollout

- Backward compatible. No CLI flags, schema versions, docs, generated skills, or runtime artifacts change.
- No migration required.

## Release / Claims

- [x] Release-channel impact considered (`preview` maintenance/performance improvement)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- Continue scanning other Hermes hot-path helpers for repeated clone/render work after this PR lands.
