### PR TITLE
Reuse route hints in wrapper previews

### DIFF
--- a/src/wrapper/route_hints.py
+++ b/src/wrapper/route_hints.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from ..plugin_bundle.omh.awareness import (
     awareness_generic_tool_checkpoint_payload,
     awareness_route_hint,
-    awareness_route_hint_context,
+    awareness_route_hint_context_from_payload,
 )
 from ..routing.action_copy import next_action_label
 
@@ -58,7 +58,7 @@ def build_chat_route_hint_payload(
         "claim_boundary": str(route_hint.get("claim_boundary") or ""),
     }
     if include_prompt_context:
-        payload["prompt_context"] = awareness_route_hint_context(message, max_hints=max_hints)
+        payload["prompt_context"] = awareness_route_hint_context_from_payload(route_hint)
         payload["prompt_context_boundary"] = (
             "Prompt context is for Hermes routing guidance only; it is not workflow execution or observed evidence."
         )

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -24,6 +24,7 @@ from omh.skills import render as render_module
 from omh.workflows import hermes_planning as hermes_planning_module
 from omh.workflows import learning_candidate as learning_candidate_module
 from omh.wrapper import contract as contract_module
+from omh.wrapper.route_hints import build_chat_route_hint_payload
 from omh.paths import OmhPaths
 from omh.release import (
     AWARENESS_PRIMER_CONTEXT_CHAR_LIMIT,
@@ -283,6 +284,22 @@ class EfficiencyContractTests(unittest.TestCase):
         awareness_module._awareness_route_hint_cached.cache_clear()
 
         payload = build_context_brief(
+            "Codex 작업이 어디까지 진행됐는지 알려줘",
+            source="discord",
+            include_prompt_context=True,
+        )
+        cache_info = awareness_module._awareness_route_hint_cached.cache_info()
+
+        self.assertEqual(payload["route_hint"]["primary_workflow"], "ultraprocess")
+        self.assertEqual(payload["route_hint"]["primary_next_action"], "show_coding_handoff_status")
+        self.assertIn("next_action=show_coding_handoff_status", payload["prompt_context"])
+        self.assertEqual(cache_info.misses, 1)
+        self.assertEqual(cache_info.hits, 0)
+
+    def test_chat_route_hint_prompt_context_reuses_route_hint_payload(self) -> None:
+        awareness_module._awareness_route_hint_cached.cache_clear()
+
+        payload = build_chat_route_hint_payload(
             "Codex 작업이 어디까지 진행됐는지 알려줘",
             source="discord",
             include_prompt_context=True,


### PR DESCRIPTION
## Feature Report

### What Changed

- Reused the existing `omh_route_hint/v1` payload when wrapper route-hint previews render `prompt_context`.
- Switched `build_chat_route_hint_payload(..., include_prompt_context=True)` from the message-based context helper to the payload-based renderer added in the previous optimization.
- Added a cache-contract regression proving wrapper prompt-context previews produce one route-hint cache miss and no redundant same-message cache hit.

### Why This Exists

- Route-hint previews are part of the chat/wrapper hot path for Discord, Slack, Telegram, and Hermes-style command preview surfaces.
- The previous path built the route hint for the wrapper payload, then called the message helper again to build prompt context. That second call was cached, but still repeated cache lookup and payload copy work.
- This makes the preview path lighter without changing what Hermes or wrappers render.

### User / Operator Impact

- Users still see the same `ultraprocess` status hint for Korean Codex progress questions such as `Codex 작업이 어디까지 진행됐는지 알려줘`.
- Wrappers that request prompt context for route previews do less duplicate work before rendering the card.
- The output remains metadata-only and keeps the prepared-vs-observed boundary unchanged.

### How It Works

- `src/wrapper/route_hints.py` now imports `awareness_route_hint_context_from_payload`.
- The wrapper reuses the `route_hint` object already attached to the payload when `include_prompt_context` is enabled.
- `tests/test_efficiency.py` locks the cache behavior and confirms the selected workflow/action stay `ultraprocess -> show_coding_handoff_status`.

### Files And Contracts Touched

- `src/wrapper/route_hints.py`: route preview prompt-context rendering now reuses the existing route-hint payload.
- `tests/test_efficiency.py`: adds wrapper-preview cache reuse coverage.
- Public schemas remain unchanged: `chat_route_hint/v1`, `chat_route_hint_response/v1`, and `omh_route_hint/v1` keep the same shape.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_efficiency.py tests/test_wrapper_contract.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — 988 tests OK
- [x] `uv run python -m compileall -q src tests`
- [x] `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check`
- [x] `PYTHONPATH=tests uv run python -m omh.cli harness validate`
- [x] `PYTHONPATH=tests uv run python -m omh.cli demo hermes-ux-quality --summary` — 100/100
- [x] `PYTHONPATH=tests uv run python -m omh.cli release evidence-bundle --version 1.0.1` — ready 100/100
- [x] `git diff --check`
- [x] Relevant dry-run or smoke command: `PYTHONPATH=tests uv run python -m omh.cli chat route-hint --source discord --prompt-context --json "Codex 작업이 어디까지 진행됐는지 알려줘"`
- [x] Manual Hermes/TUI check, or explicit reason it was not run: not run; this PR changes deterministic local wrapper preview assembly only, not live Hermes plugin loading or platform UI rendering.

## Risk

- Narrow. The route hint payload is already produced before prompt context rendering, and the renderer uses the same fields as the previous message helper.
- Main risk is accidental output drift in wrapper previews; covered by wrapper contract tests and the explicit route-hint smoke.

## Compatibility / Rollout

- Backward compatible. No CLI flags, schema versions, generated docs, generated skills, or runtime records change.
- No migration required.

## Release / Claims

- [x] Release-channel impact considered (`preview` maintenance/performance improvement)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- Continue auditing live plugin hook assembly for the same payload-reuse pattern after this wrapper preview optimization lands.
