### PR TITLE
Optimize pre-LLM route hint reuse

### DIFF
--- a/src/plugin_bundle/omh/context_brief.py
+++ b/src/plugin_bundle/omh/context_brief.py
@@ -19,12 +19,18 @@ def build_context_brief(
     source: str = "generic",
     max_hints: int = 2,
     include_prompt_context: bool = False,
+    route_hint_payload: dict[str, object] | None = None,
 ) -> dict[str, object]:
     """Build bounded Hermes-facing OMH operating context."""
     text = str(message or "")
     limit = bounded_context_hint_limit(max_hints, default=2)
     primer = awareness_primer_payload()
-    route_hint = awareness_route_hint(text, max_hints=limit) if text.strip() else awareness_route_hint("", max_hints=0)
+    if route_hint_payload is not None:
+        route_hint = route_hint_payload
+    elif text.strip():
+        route_hint = awareness_route_hint(text, max_hints=limit)
+    else:
+        route_hint = awareness_route_hint("", max_hints=0)
     payload: dict[str, object] = {
         "schema_version": OMH_CONTEXT_BRIEF_SCHEMA_VERSION,
         "source": source,

--- a/src/plugin_bundle/omh/hooks/llm_hooks.py
+++ b/src/plugin_bundle/omh/hooks/llm_hooks.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
-from ..awareness import awareness_context_matches_message, awareness_primer_context, awareness_route_hint_context
+from ..awareness import (
+    awareness_context_matches_message,
+    awareness_primer_context,
+    awareness_route_hint,
+    awareness_route_hint_context_from_payload,
+)
 from ..context_brief import build_context_brief
 from ..host_observation import observe_plugin_hook_call
 from ..omh_roles import extract_role_marker, role_context_payload
@@ -25,15 +30,24 @@ def pre_llm_call(**kwargs) -> dict[str, object] | None:
     payload: dict[str, object] = {}
     user_message = str(kwargs.get("user_message", "") or "")
     is_first_turn = bool(kwargs.get("is_first_turn", False))
-    route_hint_context = awareness_route_hint_context(user_message)
-    should_include_awareness = is_first_turn or bool(route_hint_context) or awareness_context_matches_message(user_message)
-    if kwargs.get("include_omh_awareness", True) is not False and should_include_awareness:
+    include_awareness = kwargs.get("include_omh_awareness", True) is not False
+    route_hint_context = ""
+    route_hint_payload: dict[str, object] | None = None
+    if include_awareness:
+        route_hint_payload = awareness_route_hint(user_message)
+        route_hint_context = awareness_route_hint_context_from_payload(route_hint_payload)
+    should_include_awareness = (
+        include_awareness
+        and (is_first_turn or bool(route_hint_context) or awareness_context_matches_message(user_message))
+    )
+    if should_include_awareness:
         context_parts.append(awareness_primer_context())
         payload["omh_context_brief"] = build_context_brief(
             user_message,
             source=str(kwargs.get("source") or kwargs.get("host") or "pre_llm_call"),
             max_hints=2,
             include_prompt_context=False,
+            route_hint_payload=route_hint_payload,
         )
         if route_hint_context:
             context_parts.append(route_hint_context)

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -40,6 +40,7 @@ from omh.capabilities.skills import skill_capabilities
 from omh.coding import executor_readiness as executor_readiness_module
 from omh.coding import executors as executors_module
 from omh.context import build_context_brief
+from omh.plugin_bundle.omh.hooks.llm_hooks import pre_llm_call
 from omh.plugin_bundle.omh.tools.capability_tool import standalone_skill_capability_items
 from omh.plugin_bundle.omh import awareness as awareness_module
 from omh.plugin_bundle.omh.awareness import (
@@ -310,6 +311,46 @@ class EfficiencyContractTests(unittest.TestCase):
         self.assertEqual(payload["route_hint"]["primary_next_action"], "show_coding_handoff_status")
         self.assertIn("next_action=show_coding_handoff_status", payload["prompt_context"])
         self.assertEqual(cache_info.misses, 1)
+        self.assertEqual(cache_info.hits, 0)
+
+    def test_pre_llm_call_reuses_route_hint_payload_for_context_brief(self) -> None:
+        awareness_module._awareness_route_hint_cached.cache_clear()
+
+        with TemporaryDirectory() as temp_dir:
+            payload = pre_llm_call(
+                omh_home=temp_dir,
+                hermes_home=temp_dir,
+                user_message="Codex 작업이 어디까지 진행됐는지 알려줘",
+                is_first_turn=False,
+            )
+        cache_info = awareness_module._awareness_route_hint_cached.cache_info()
+
+        self.assertIsNotNone(payload)
+        assert payload is not None
+        self.assertEqual(payload["omh_context_brief"]["route_hint"]["primary_workflow"], "ultraprocess")
+        self.assertEqual(
+            payload["omh_context_brief"]["route_hint"]["primary_next_action"],
+            "show_coding_handoff_status",
+        )
+        self.assertIn("next_action=show_coding_handoff_status", payload["context"])
+        self.assertEqual(cache_info.misses, 1)
+        self.assertEqual(cache_info.hits, 0)
+
+    def test_pre_llm_call_suppressed_awareness_skips_route_hint_cache(self) -> None:
+        awareness_module._awareness_route_hint_cached.cache_clear()
+
+        with TemporaryDirectory() as temp_dir:
+            payload = pre_llm_call(
+                omh_home=temp_dir,
+                hermes_home=temp_dir,
+                user_message="make an image explaining the cron feature",
+                is_first_turn=False,
+                include_omh_awareness=False,
+            )
+        cache_info = awareness_module._awareness_route_hint_cached.cache_info()
+
+        self.assertIsNone(payload)
+        self.assertEqual(cache_info.misses, 0)
         self.assertEqual(cache_info.hits, 0)
 
     def test_quality_demos_reuse_interaction_route(self) -> None:


### PR DESCRIPTION
## Feature Report

### What Changed

- Optimized the OMH plugin `pre_llm_call` path so it builds the awareness route hint payload once and reuses that payload for the Hermes-facing context brief.
- Added an optional `route_hint_payload` parameter to the plugin context brief builder for callers that already have deterministic route metadata.
- Added efficiency tests proving the hot hook path performs one route-hint cache miss, and zero cache work when OMH awareness is explicitly suppressed.

### Why This Exists

- The live pre-LLM hook had started sharing richer route hints with Hermes, but it rebuilt the same route metadata once for awareness text and again for the context brief.
- The user-facing goal is a snappier Hermes chat experience where OMH context injection stays helpful without doing avoidable duplicate routing work.

### User / Operator Impact

- Hermes receives the same OMH workflow context, next action, and evidence-boundary guidance as before.
- Plugin hook calls avoid unnecessary route-hint cache work on normal awareness injection.
- Operators that suppress OMH awareness get a cleaner no-op path: no route hint payload, no context brief, and no cache miss.

### How It Works

- `pre_llm_call` now computes `awareness_route_hint(user_message)` only when awareness injection is enabled.
- The hook converts that already-built payload into user-facing hint text with `awareness_route_hint_context_from_payload`.
- The same payload is passed into `build_context_brief(..., route_hint_payload=...)`, so the brief does not call back into route-hint generation for the same message.
- `build_context_brief` keeps backward compatibility by computing the route hint itself when no payload is provided.

### Files And Contracts Touched

- `src/plugin_bundle/omh/hooks/llm_hooks.py`: route-hint reuse and suppressed-awareness fast path.
- `src/plugin_bundle/omh/context_brief.py`: optional payload injection while preserving existing default behavior.
- `tests/test_efficiency.py`: regression coverage for route-hint reuse and suppressed-awareness no-op behavior.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — 990 tests passed.
- [x] `uv run python -m compileall -q src tests`
- [x] `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check`
- [x] `PYTHONPATH=tests uv run python -m omh.cli harness validate`
- [ ] `python3 -m omh.cli release checklist --json` — not run; this PR does not alter release checklist claims.
- [ ] `python3 -m omh.cli release hermes-smoke` — not run; live Hermes rendering is outside this local deterministic hook change.
- [ ] `omh --help` — not run; no CLI command surface changed.
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` — not run; no setup/install path changed.
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable.
- [x] Relevant dry-run or smoke command: `PYTHONPATH=tests uv run python -m omh.cli demo hermes-ux-quality --summary` — 100/100, 5/5 gates.
- [x] Relevant dry-run or smoke command: `PYTHONPATH=tests uv run python -m omh.cli release evidence-bundle --version 1.0.1` — ready, product/use-case readiness 100/100.
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; this PR changes deterministic local plugin payload construction, not live host UI rendering.

## Risk

- Low. The new parameter is optional, existing callers keep the previous behavior, and tests lock both reuse and disabled-awareness behavior.
- The main compatibility risk is any caller passing a malformed route hint payload, but the parameter is internal to the plugin path in this PR.

## Compatibility / Rollout

- Backward compatible with existing plugin context brief callers.
- No schema, CLI, setup, docs generation, or Hermes core behavior changes.
- Safe to roll out through the normal preview/stable package path after CI passes.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`): local code change only; eligible for next package release.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap.

## Follow-Up

- Continue using the efficiency suite for future live-hook changes so route hints, context briefs, and wrapper previews do not drift back into duplicate work.
