### PR TITLE
Route catalog previews to the OMH picker

### DIFF
--- a/src/wrapper/route_hints.py
+++ b/src/wrapper/route_hints.py
@@ -5,6 +5,7 @@ from ..plugin_bundle.omh.awareness import (
     awareness_route_hint,
     awareness_route_hint_context_from_payload,
 )
+from ..routing.catalog_questions import is_skill_catalog_question
 from ..routing.action_copy import next_action_label
 
 CHAT_ROUTE_HINT_SCHEMA_VERSION = "chat_route_hint/v1"
@@ -21,6 +22,7 @@ def build_chat_route_hint_payload(
 ) -> dict[str, object]:
     """Return a wrapper-facing route hint without storing or echoing raw prompt text."""
     route_hint = awareness_route_hint(message, max_hints=max_hints)
+    route_hint = _route_hint_with_catalog_picker(route_hint, message)
     generic_tool_checkpoint = _generic_tool_checkpoint()
     hints = [hint for hint in route_hint.get("hints", []) if isinstance(hint, dict)]
     primary_hint = hints[0] if hints else {}
@@ -69,6 +71,50 @@ def _generic_tool_checkpoint() -> dict[str, object]:
     return awareness_generic_tool_checkpoint_payload()
 
 
+def _route_hint_with_catalog_picker(route_hint: dict[str, object], message: str) -> dict[str, object]:
+    hints = [hint for hint in route_hint.get("hints", []) if isinstance(hint, dict)]
+    if hints or not is_skill_catalog_question(message):
+        return route_hint
+    hint = {
+        "id": "catalog_question_picker",
+        "workflow": "oh-my-hermes",
+        "lane": "intent_to_plan",
+        "next_action": "choose_skill",
+        "next_action_label": next_action_label("choose_skill"),
+        "reason": "The user is asking which OMH workflows are available; show the workflow picker without shell approval.",
+        "fallback_action": "show_workflow_picker_or_capability_summary",
+        "fallback_action_label": next_action_label("show_workflow_picker"),
+        "matched_cues": ["catalog_question"],
+        "adjacent_workflows": ["deep-interview", "ralplan", "loop", "ultraprocess"],
+        "workflow_context_card": {
+            "id": "intent_to_plan",
+            "label": "Intent to plan",
+            "first_response_shape": "Open the OMH workflow picker, then let the user pick a lane or route the original request.",
+            "not_evidence_until_observed": [
+                "workflow selection",
+                "plan acceptance",
+                "executor dispatch",
+                "verification",
+            ],
+        },
+        "not_evidence_yet": ["workflow selection", "plan acceptance", "executor dispatch", "verification"],
+    }
+    updated = dict(route_hint)
+    updated.update(
+        {
+            "status": "hinted",
+            "selected_workflow": "oh-my-hermes",
+            "primary_workflow": "oh-my-hermes",
+            "primary_next_action": "choose_skill",
+            "primary_next_action_label": next_action_label("choose_skill"),
+            "adjacent_workflows": list(hint["adjacent_workflows"]),
+            "hints": [hint],
+            "catalog_question": True,
+        }
+    )
+    return updated
+
+
 def _checkpoint_body_text(generic_tool_checkpoint: dict[str, object]) -> str:
     body = str(generic_tool_checkpoint.get("body") or "").strip()
     if not body:
@@ -102,12 +148,21 @@ def _response_for_hint(
         workflow_submit_text = "./omh" if workflow == "oh-my-hermes" and next_action == "choose_skill" else f"./{workflow}"
         workflow_action_label = "Open omh" if workflow_submit_text == "./omh" else f"Open {workflow}"
         lane = str(primary_hint.get("lane") or "")
-        headline = f"[omh] {workflow} looks relevant."
-        body = (
-            f"I can open `{workflow}` first because this request matches the {lane.replace('_', ' ')} lane. "
-            f"Next action: {_action_label_with_id(next_action, next_action_label_text)}. "
-            "This is only a route hint until a workflow is selected and observed."
-        )
+        if workflow == "oh-my-hermes" and next_action == "choose_skill":
+            headline = "[omh] workflow picker is ready."
+            body = (
+                "This looks like an OMH catalog question, so I can open the workflow picker instead of asking "
+                "for shell approval. "
+                f"Next action: {_action_label_with_id(next_action, next_action_label_text)}. "
+                "This is only a route hint until a workflow is selected and observed."
+            )
+        else:
+            headline = f"[omh] {workflow} looks relevant."
+            body = (
+                f"I can open `{workflow}` first because this request matches the {lane.replace('_', ' ')} lane. "
+                f"Next action: {_action_label_with_id(next_action, next_action_label_text)}. "
+                "This is only a route hint until a workflow is selected and observed."
+            )
         if checkpoint_body:
             body = f"{body} {checkpoint_body}"
         actions = [
@@ -125,13 +180,16 @@ def _response_for_hint(
                 "enabled": True,
                 "backend_command": "omh chat interact",
             },
-            {
-                "id": "open_picker",
-                "label": "Open omh",
-                "enabled": True,
-                "submit_text": "./omh",
-            },
         ]
+        if workflow_submit_text != "./omh":
+            actions.append(
+                {
+                    "id": "open_picker",
+                    "label": "Open omh",
+                    "enabled": True,
+                    "submit_text": "./omh",
+                }
+            )
         render_kind = "workflow_route_hint"
     else:
         workflow = ""
@@ -194,6 +252,7 @@ def _response_for_hint(
                 "adjacent_workflows": list(route_hint.get("adjacent_workflows", [])),
                 "not_executed": list(route_hint.get("not_executed", [])),
                 "hints": hints,
+                "catalog_question": bool(route_hint.get("catalog_question", False)),
             },
         },
         "claim_boundary": (
@@ -211,12 +270,15 @@ def _next_backend_commands(primary_hint: dict[str, object]) -> list[dict[str, ob
             "command": "omh chat interact --source <source> <message>",
             "purpose": "Build the full wrapper interaction envelope from the same event.",
         },
-        {
-            "id": "open_picker",
-            "command": "omh chat interact --source <source> ./omh",
-            "purpose": "Open the compact OMH workflow picker.",
-        },
     ]
+    if workflow != "oh-my-hermes":
+        commands.append(
+            {
+                "id": "open_picker",
+                "command": "omh chat interact --source <source> ./omh",
+                "purpose": "Open the compact OMH workflow picker.",
+            }
+        )
     if workflow:
         workflow_command = (
             "omh chat interact --source <source> ./omh"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4649,6 +4649,46 @@ class CliTests(unittest.TestCase):
             payload["wrapper_contract"]["next_backend_commands"][0]["command"],
             "omh chat interact --source <source> ./omh",
         )
+        self.assertEqual(
+            [command["id"] for command in payload["wrapper_contract"]["next_backend_commands"]],
+            ["open_workflow", "route_for_me"],
+        )
+
+        status, stdout, stderr = run_cli(
+            ["chat", "route-hint", "--source", "discord", "--summary", "what OMH workflows are available?"],
+            output_json=False,
+        )
+
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        self.assertIn("Status: hinted", stdout)
+        self.assertIn("Workflow: oh-my-hermes", stdout)
+        self.assertIn("Next action: opening the workflow picker", stdout)
+        self.assertIn("[omh] workflow picker is ready.", stdout)
+        self.assertIn("instead of asking for shell approval", stdout)
+        self.assertIn("matched: catalog_question", stdout)
+        self.assertIn("- Open omh - enabled", stdout)
+        self.assertEqual(stdout.count("- Open omh - enabled"), 1)
+
+        status, stdout, stderr = run_cli(
+            ["chat", "route-hint", "--source", "discord", "--json", "what OMH workflows are available?"],
+            output_json=False,
+        )
+
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        payload = json.loads(stdout)
+        self.assertTrue(payload["route_hint"]["catalog_question"])
+        self.assertEqual(payload["route_hint"]["primary_workflow"], "oh-my-hermes")
+        self.assertEqual(payload["route_hint"]["primary_next_action"], "choose_skill")
+        self.assertEqual(
+            [action["id"] for action in payload["chat_response"]["actions"]],
+            ["open_workflow", "route_for_me"],
+        )
+        self.assertEqual(
+            [command["id"] for command in payload["wrapper_contract"]["next_backend_commands"]],
+            ["open_workflow", "route_for_me"],
+        )
 
     def test_chat_route_hint_summary_renders_no_hint_without_unknown_workflow(self) -> None:
         status, stdout, stderr = run_cli(["chat", "route-hint", "--source", "slack", "--summary", "zzzzzz"], output_json=False)

--- a/tests/test_wrapper_contract.py
+++ b/tests/test_wrapper_contract.py
@@ -133,6 +133,27 @@ class WrapperContractTests(unittest.TestCase):
         self.assertIn("clarify", actions)
         self.assertNotIn("zzzzzz", json.dumps(payload))
 
+    def test_route_hint_payload_opens_picker_for_catalog_questions(self) -> None:
+        message = "what OMH workflows are available?"
+
+        payload = build_chat_route_hint_payload(message, source="discord")
+
+        self.assertEqual(payload["route_hint"]["status"], "hinted")
+        self.assertTrue(payload["route_hint"]["catalog_question"])
+        self.assertEqual(payload["route_hint"]["primary_workflow"], "oh-my-hermes")
+        self.assertEqual(payload["route_hint"]["primary_next_action"], "choose_skill")
+        self.assertEqual(payload["chat_response"]["kind"], "workflow_route_hint")
+        self.assertEqual(payload["chat_response"]["headline"], "[omh] workflow picker is ready.")
+        self.assertTrue(payload["chat_response"]["state"]["route_hint"]["catalog_question"])
+        self.assertIn("instead of asking for shell approval", payload["chat_response"]["body"])
+        actions = payload["chat_response"]["actions"]
+        self.assertEqual([action["id"] for action in actions], ["open_workflow", "route_for_me"])
+        self.assertEqual(actions[0]["submit_text"], "./omh")
+        backend_commands = payload["wrapper_contract"]["next_backend_commands"]
+        self.assertEqual([command["id"] for command in backend_commands], ["open_workflow", "route_for_me"])
+        self.assertEqual(backend_commands[0]["command"], "omh chat interact --source <source> ./omh")
+        self.assertNotIn(message, json.dumps(payload))
+
     def test_chat_interaction_renders_task_abstraction_card_without_cli_copy(self) -> None:
         message = (
             "Reproduce this Hermes and Friren setup on another MacBook, backup the state to private GitHub, "


### PR DESCRIPTION
## Feature Report

### What Changed

- Made `chat route-hint` previews recognize natural OMH catalog questions such as “what OMH workflows are available?”.
- Added a synthetic metadata-only picker hint for catalog questions when normal workflow hints do not match.
- Cleaned up the picker preview so wrapper cards do not render duplicate `Open omh` actions or duplicate backend commands.

### Why This Exists

- `chat interact` already routed catalog questions to the OMH workflow picker, but the lighter `chat route-hint` preview still returned `no_hint`.
- Some Discord/Slack/Telegram wrappers can use the lightweight preview contract before opening a full interaction. For those surfaces, users asking “what workflows are available?” should see the picker directly, not a vague clarify fallback.

### User / Operator Impact

- Hermes/wrappers can answer catalog questions without asking the user to approve `omh list` or another shell command.
- The user sees a compact picker-ready card: workflow `oh-my-hermes`, next action “opening the workflow picker”, matched cue `catalog_question`.
- The card remains advisory metadata only; it does not claim workflow selection, execution, dispatch, review, CI, or verification.

### How It Works

- `build_chat_route_hint_payload` still asks awareness routing for normal workflow hints first.
- If there are no normal hints and `is_skill_catalog_question(message)` matches, it adds an `oh-my-hermes / choose_skill` route hint with picker-specific copy and evidence boundaries.
- Picker preview actions and backend commands now omit the secondary `open_picker` entry when the primary action already opens `./omh`.

### Files And Contracts Touched

- `src/wrapper/route_hints.py`: catalog-question route-hint projection and duplicate picker action cleanup.
- `tests/test_wrapper_contract.py`: wrapper contract coverage for catalog-question preview behavior.
- `tests/test_cli.py`: CLI summary/json coverage for route-hint catalog questions and duplicate action prevention.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_wrapper_contract.py tests/test_cli.py -v` — 323 tests passed.
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — 991 tests passed.
- [x] `uv run python -m compileall -q src tests`
- [x] `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check`
- [x] `PYTHONPATH=tests uv run python -m omh.cli harness validate`
- [ ] `python3 -m omh.cli release checklist --json` — not run; release checklist contents did not change.
- [ ] `python3 -m omh.cli release hermes-smoke` — not run; live Hermes rendering is outside this local route-hint contract change.
- [ ] `omh --help` — not run; no top-level CLI help changed.
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` — not run; install/setup path did not change.
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable.
- [x] Relevant dry-run or smoke command: `PYTHONPATH=tests uv run python -m omh.cli chat route-hint "what OMH workflows are available?" --source discord --summary` — now renders `Status: hinted`, `Workflow: oh-my-hermes`, and one `Open omh` action.
- [x] Relevant dry-run or smoke command: `PYTHONPATH=tests uv run python -m omh.cli demo hermes-ux-quality --summary` — 100/100, 5/5 gates.
- [x] Relevant dry-run or smoke command: `PYTHONPATH=tests uv run python -m omh.cli release evidence-bundle --version 1.0.1` — ready, product/use-case readiness 100/100.
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; this PR changes deterministic local wrapper preview payloads, not live host rendering.

## Risk

- Low. The new catalog picker hint is only added when normal route hints are empty and the existing catalog detector classifies the message as an OMH skill/workflow catalog question.
- Existing no-hint behavior remains for unrelated text such as `zzzzzz`.

## Compatibility / Rollout

- Backward compatible schema shape: the payload is still `chat_route_hint/v1` and `omh_route_hint/v1`.
- Adds `catalog_question: true` as metadata for picker previews.
- No Hermes core patch, network call, transport bot, or executor dispatch behavior changed.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`): eligible for next package release.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap.

## Follow-Up

- Keep `chat route-hint`, `chat interact`, and `context brief` catalog behavior aligned when adding new catalog-question languages or surfaces.
