### PR TITLE
Align loop public route actions

### DIFF
--- a/src/routing/chat.py
+++ b/src/routing/chat.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from ..goal_loop import explicit_loop_invocation_signal
 from ..ingress import CHAT_SOURCES, extract_message_text
+from ..loopability import assess_loopability
 from .catalog_questions import is_file_or_text_lookup_question, is_skill_catalog_question
 from .action_copy import next_action_label as _route_next_action_label
 from .intent import scrub_diagnostic_status_text
@@ -729,9 +730,10 @@ class ChatRouteDecision:
     workflow_route_plan: dict[str, object] | None
     learning_candidate_card: dict[str, object] | None
     recommendations: tuple[dict[str, object], ...]
+    route_next_action: str = ""
 
     def to_dict(self) -> dict[str, object]:
-        return {
+        payload = {
             "schema_version": self.schema_version,
             "source": self.source,
             "action": self.action,
@@ -754,6 +756,9 @@ class ChatRouteDecision:
             ),
             "recommendations": [dict(recommendation) for recommendation in self.recommendations],
         }
+        if self.route_next_action:
+            payload["route_next_action"] = self.route_next_action
+        return payload
 
 
 @dataclass(frozen=True)
@@ -998,6 +1003,11 @@ def _route_chat_message_cached(
         action=action,
     )
     clarification = _clarification(action, candidate_skill, candidate_confidence, min_confidence, reason)
+    route_next_action = _route_specific_next_action(
+        routing_message,
+        selected_skill=selected_skill,
+        explicit_loop=explicit_loop_signal or explicit_loop_invocation_signal(routing_message),
+    )
     decision = ChatRouteDecision(
         schema_version=1,
         source=source,
@@ -1018,6 +1028,7 @@ def _route_chat_message_cached(
         workflow_route_plan=workflow_route_plan,
         learning_candidate_card=learning_candidate_card,
         recommendations=recommendations,
+        route_next_action=route_next_action,
     )
     return decision.to_dict()
 
@@ -1543,6 +1554,30 @@ def _explicit_loop_signal(message: str, recommendations: list[dict[str, object]]
     return explicit_loop_invocation_signal(message)
 
 
+def _route_specific_next_action(message: str, *, selected_skill: str, explicit_loop: bool) -> str:
+    if selected_skill != "loop":
+        return ""
+    return _loop_route_next_action(message, explicit_loop=explicit_loop)
+
+
+def _loop_route_next_action(message: str, *, explicit_loop: bool) -> str:
+    try:
+        assessment = assess_loopability(message, expose_goal=False)
+    except ValueError:
+        return "ask_goal_boundary" if explicit_loop else ""
+    loopability = str(assessment.get("loopability", ""))
+    recommended_next_action = str(assessment.get("recommended_next_action", "")).strip()
+    if explicit_loop:
+        if loopability == "needs_clarification":
+            return recommended_next_action or "ask_goal_boundary"
+        if loopability == "direct_task":
+            return "route_direct_task"
+        if loopability == "external_wait_only":
+            return "record_external_wait"
+        return "start_loop_cycle"
+    return recommended_next_action
+
+
 def routing_record_payload(
     decision: dict[str, object],
     message: str,
@@ -2013,6 +2048,9 @@ def _selected_recommendation(route: dict[str, object]) -> dict[str, object]:
 
 
 def _route_next_action(route: dict[str, object], recommendation: dict[str, object]) -> str:
+    route_next_action = str(route.get("route_next_action", "")).strip()
+    if route_next_action:
+        return route_next_action
     action = str(route.get("action", "fallback"))
     if action == "dispatch":
         if str(route.get("selected_skill", "")) == "ultraprocess" and _route_is_coding_status_request(route):

--- a/tests/test_chat_router.py
+++ b/tests/test_chat_router.py
@@ -2175,16 +2175,46 @@ selected_workflow=ultraprocess
         self.assertIn("why / next / not-yet-evidence", explanation["rendering_hint"])
         self.assertNotIn(message, json.dumps(explanation, ensure_ascii=False))
 
-    def test_loop_route_explanation_uses_human_action_copy(self) -> None:
-        decision = route_chat_message("run a loop to improve first-run experience", source="discord")
-        public = public_route_payload(decision)
-        explanation = public["route_explanation"]
+    def test_loop_route_explanation_uses_loopability_specific_action_copy(self) -> None:
+        cases = (
+            (
+                "run a loop to improve first-run experience",
+                "choose_permission_profile",
+                "choosing the loop permission profile",
+            ),
+            (
+                "Make this a 100k-star OSS",
+                "reframe_north_star",
+                "reframing the north-star goal",
+            ),
+            (
+                "./loop make this project a 10k star OSS",
+                "start_loop_cycle",
+                "starting the loopability-gated cycle",
+            ),
+            (
+                "./loop change the button color",
+                "route_direct_task",
+                "routing the direct task",
+            ),
+            (
+                "./loop",
+                "ask_goal_boundary",
+                "asking for the loop boundary",
+            ),
+        )
 
-        self.assertEqual(decision["selected_skill"], "loop")
-        self.assertEqual(explanation["next_action"], "assess_loopability")
-        self.assertEqual(explanation["next_action_label"], "checking whether the goal is loopable")
-        self.assertIn("start by checking whether the goal is loopable", explanation["recommended_reply"])
-        self.assertNotIn("start by assess loopability", explanation["recommended_reply"])
+        for message, next_action, next_action_label in cases:
+            with self.subTest(message=message):
+                decision = route_chat_message(message, source="discord")
+                public = public_route_payload(decision)
+                explanation = public["route_explanation"]
+
+                self.assertEqual(decision["selected_skill"], "loop")
+                self.assertEqual(explanation["next_action"], next_action)
+                self.assertEqual(explanation["next_action_label"], next_action_label)
+                self.assertIn(next_action_label, explanation["recommended_reply"])
+                self.assertNotIn("start by assess loopability", explanation["recommended_reply"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Feature Report

### What Changed

- Added advisory `route_next_action` metadata to chat route decisions when the selected workflow is `loop`.
- Made public `route_explanation` prefer that metadata before falling back to the recommendation card default.
- Expanded chat router tests so loop public route explanations now cover loopable projects, north-star ambitions, explicit loop starts, direct tasks, and bare `./loop` clarification.

### Why This Exists

- PR #454 aligned `route-hint` and `chat interact`, but `chat route` still showed the generic `assess_loopability` action for loop-shaped requests.
- Some Hermes wrappers can call `chat route` directly, so the public route explanation needs to say the same user-facing next action as the hint and interaction layers.

### User / Operator Impact

- A wrapper asking OMH how to route `Make this a 100k-star OSS` now gets `reframe_north_star` instead of a generic loopability check.
- A wrapper asking about `./loop change the button color` now gets `route_direct_task` instead of suggesting a persistent loop.
- A wrapper asking for `run a loop to improve first-run experience` now gets `choose_permission_profile`, matching the route-hint and interact surfaces.

### How It Works

- `src/routing/chat.py` calls the existing deterministic `assess_loopability` classifier only when the selected skill is `loop`.
- The classifier result is stored as metadata-only `route_next_action` on the route decision.
- `route_explanation_payload` uses that metadata to render the human next-action label and recommended reply, while still omitting raw prompt text by default.

### Files And Contracts Touched

- `src/routing/chat.py`: route decision metadata and route explanation next-action override.
- `tests/test_chat_router.py`: loop public route explanation regression coverage.
- Contract impact: `route_next_action` remains advisory routing metadata. It is not execution, verification, review, CI, merge, market-response, or live Hermes rendering evidence.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_chat_router.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_cli.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_wrapper_contract.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_hermes_ux_quality.py tests/test_release_smoke.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `PYTHONPATH=tests uv run python -m compileall -q src tests`
- [x] `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check`
- [x] `PYTHONPATH=tests uv run python -m omh.cli harness validate`
- [x] `PYTHONPATH=tests uv run python -m omh.cli demo hermes-ux-quality --summary` — 100/100
- [x] `PYTHONPATH=tests uv run python -m omh.cli demo route-hint-alignment --summary` — 93/93 aligned
- [x] `PYTHONPATH=tests uv run python -m omh.cli demo routing-precision --summary` — overroutes 0
- [x] `git diff --check`
- [x] Relevant dry-run or smoke command: `PYTHONPATH=tests uv run python -m omh.cli chat route --source discord "Make this a 100k-star OSS"` showed `loop reframe_north_star`; `./loop change the button color` showed `loop route_direct_task`.
- [x] Manual Hermes/TUI check, or explicit reason it was not run: not run; this PR changes deterministic local route payloads only and does not claim live Hermes rendering.

## Risk

- Low. The new override only applies when the selected workflow is `loop` and uses the existing deterministic loopability classifier.
- Existing non-loop routing continues to use recommendation policy next actions.

## Compatibility / Rollout

- Backward compatible. Existing route payload fields remain intact, and `route_next_action` is omitted unless a workflow-specific override exists.
- No release-channel, install, setup, plugin, or generated-doc behavior changes.

## Release / Claims

- [x] Release-channel impact considered (`preview` behavior only through normal source/package update flow; no installer changes)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- None required for this slice. Future workflow-specific public route overrides should follow the same metadata-only pattern and add route/hint/interact alignment tests.
