### PR TITLE
Align plugin awareness loop hints

### DIFF
--- a/src/plugin_bundle/omh/awareness.py
+++ b/src/plugin_bundle/omh/awareness.py
@@ -352,10 +352,20 @@ except ImportError:  # pragma: no cover - exercised by standalone plugin hosts.
             routing_context=routing_context,
         )
 
+try:  # File-loaded plugin bundles should still use package classifiers when OMH is installed.
+    from omh.routing.intent import META_OR_FEEDBACK_INTENTS, classify_omh_quality_intent, classify_workflow_intent
+except ImportError:  # pragma: no cover - standalone plugin hosts keep the fallback above.
+    pass
+
 try:  # Keep route hints aligned with router locale phrase packs when available.
     from ...routing.localization import prepare_routing_text as _prepare_routing_text
 except ImportError:  # pragma: no cover - exercised by standalone plugin hosts.
     _prepare_routing_text = None
+
+try:  # File-loaded plugin bundles can still reuse OMH locale phrase packs.
+    from omh.routing.localization import prepare_routing_text as _prepare_routing_text
+except ImportError:  # pragma: no cover - standalone plugin hosts keep the fallback above.
+    pass
 
 try:  # Prefer the package copy table, but keep copied plugin bundles standalone.
     from ...routing.action_copy import next_action_label as _next_action_label
@@ -364,10 +374,18 @@ except ImportError:  # pragma: no cover - exercised by standalone plugin hosts.
     def _next_action_label(action: str) -> str:
         return action.strip().replace("_", " ")
 
+try:  # File-loaded plugin bundles should keep the nicer action copy when OMH is installed.
+    from omh.routing.action_copy import next_action_label as _next_action_label
+except ImportError:  # pragma: no cover - standalone plugin hosts keep the fallback above.
+    pass
+
 try:  # Keep loop route hints aligned with the deterministic loopability assessor.
-    from ...loopability import assess_loopability as _assess_loopability
+    from omh.loopability import assess_loopability as _assess_loopability
 except ImportError:  # pragma: no cover - exercised by standalone plugin hosts.
-    _assess_loopability = None
+    try:
+        from ...loopability import assess_loopability as _assess_loopability
+    except ImportError:
+        _assess_loopability = None
 
 OMH_AWARENESS_SCHEMA_VERSION = "omh_awareness/v1"
 OMH_ROUTE_HINT_SCHEMA_VERSION = "omh_route_hint/v1"

--- a/tests/test_plugin_distribution.py
+++ b/tests/test_plugin_distribution.py
@@ -613,6 +613,20 @@ class PluginDistributionTests(unittest.TestCase):
                 json.dumps(mid_session_visual_context["omh_context_brief"], sort_keys=True),
             )
 
+            loop_route_context = ctx.hooks["pre_llm_call"](
+                omh_home=str(root / ".empty-omh"),
+                user_message="Make this a 100k-star OSS",
+                is_first_turn=False,
+            )
+            self.assertIsNotNone(loop_route_context)
+            loop_route_hint = loop_route_context["omh_context_brief"]["route_hint"]
+            self.assertEqual(loop_route_hint["primary_workflow"], "loop")
+            self.assertEqual(loop_route_hint["primary_next_action"], "reframe_north_star")
+            self.assertIn("selected=loop", loop_route_context["context"])
+            self.assertIn("next_action=reframe_north_star", loop_route_context["context"])
+            self.assertNotIn("next_action=assess_loopability", loop_route_context["context"])
+            self.assertNotIn("Make this a 100k-star OSS", loop_route_context["context"])
+
             mid_session_generic_context = ctx.hooks["pre_llm_call"](
                 omh_home=str(root / ".empty-omh"),
                 user_message="tell me a short joke",


### PR DESCRIPTION
## Summary
- Aligns file-loaded OMH plugin awareness with installed package helpers for workflow intent, locale phrase packs, action-copy labels, and loopability assessment.
- Fixes a real UX gap where the Hermes plugin awareness route could keep saying `assess_loopability` for loop prompts even after the public chat router had more specific actions such as `reframe_north_star`, `route_direct_task`, or `choose_permission_profile`.
- Adds plugin distribution coverage so an installed plugin `pre_llm_call` context proves loop route hints stay specific and do not echo the raw user message.

## Why
Hermes users mostly feel OMH through chat/plugin context, not direct backend CLI calls. The public router was already specific, but the plugin bundle could be loaded from `~/.hermes/plugins/omhm` as a standalone file package. In that path, relative imports could fall back to degraded helper logic even when the full OMH command package was installed.

## What Changed
- `src/plugin_bundle/omh/awareness.py`
  - Reuses installed `omh.routing.intent`, `omh.routing.localization`, and `omh.routing.action_copy` helpers when available.
  - Imports `omh.loopability.assess_loopability` first, with the existing relative/standalone fallback preserved.
  - Keeps standalone plugin fallback behavior intact when the full package is absent.
- `tests/test_plugin_distribution.py`
  - Adds an installed-plugin `pre_llm_call` regression case for `Make this a 100k-star OSS`.
  - Verifies the plugin context reports `loop` with `reframe_north_star`, avoids generic `assess_loopability`, and does not leak the raw user prompt.

## User Value
When Hermes sees a loop-style request through the OMH plugin, it now gives the same specific next action users see through `omh chat route`: reframe an oversized north-star goal, start a loopable cycle, route direct tasks away from loop overhead, or ask for the missing loop boundary. That makes the chat-first experience less vague.

## Verification
- `PYTHONPATH=tests uv run python -m unittest tests/test_plugin_distribution.py -v` -> 10 tests OK
- `PYTHONPATH=tests uv run python -m unittest tests/test_efficiency.py -v` -> 62 tests OK
- `PYTHONPATH=tests uv run python -m unittest tests/test_chat_router.py tests/test_wrapper_contract.py tests/test_release_smoke.py tests/test_hermes_ux_quality.py -v` -> 178 tests OK
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` -> 992 tests OK
- `PYTHONPATH=tests uv run python -m compileall -q src tests` -> OK
- `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check` -> OK, 48/48 tap skills checked
- `PYTHONPATH=tests uv run python -m omh.cli harness validate` -> OK, 36 harnesses and 50 skills
- `PYTHONPATH=tests uv run python -m omh.cli demo route-hint-alignment --summary` -> 93/93 aligned
- `PYTHONPATH=tests uv run python -m omh.cli demo hermes-ux-quality --summary` -> 100/100
- `PYTHONPATH=src uv run python - <<'PY' ... awareness_route_hint(...) ... PY` -> plugin bundle direct import reports loop-specific next actions
- `git diff --check` -> OK

## Risks / Boundaries
- This is deterministic local plugin-awareness alignment only. It does not prove live Hermes has reloaded the plugin, rendered the context, executed a workflow, dispatched a coding agent, reviewed code, passed CI, or merged anything.
- Standalone hosts without the full OMH package still use the existing fallback logic.
