### PR TITLE
Guard source-layout plugin awareness imports

### DIFF
--- a/tests/test_plugin_distribution.py
+++ b/tests/test_plugin_distribution.py
@@ -4,6 +4,8 @@ import hashlib
 import importlib.resources as resources
 import importlib.util
 import json
+import os
+import subprocess
 import sys
 import tomllib
 import unittest
@@ -82,6 +84,50 @@ class PluginDistributionTests(unittest.TestCase):
             )
         for hook in PROVIDED_HOOKS:
             self.assertIn(f"  - {hook}", text)
+
+    def test_source_layout_plugin_awareness_uses_package_loopability_helpers(self) -> None:
+        script = r"""
+import json
+from omh.plugin_bundle.omh.awareness import awareness_route_hint
+
+cases = [
+    ("run a loop to improve first-run experience", "choose_permission_profile", "choosing the loop permission profile"),
+    ("Make this a 100k-star OSS", "reframe_north_star", "reframing the north-star goal"),
+    ("./loop change the button color", "route_direct_task", "routing the direct task"),
+]
+observed = []
+for message, expected_action, expected_label in cases:
+    payload = awareness_route_hint(message)
+    observed.append(
+        {
+            "message": message,
+            "workflow": payload.get("primary_workflow"),
+            "action": payload.get("primary_next_action"),
+            "label": payload.get("primary_next_action_label"),
+        }
+    )
+    assert payload.get("primary_workflow") == "loop", observed[-1]
+    assert payload.get("primary_next_action") == expected_action, observed[-1]
+    assert payload.get("primary_next_action_label") == expected_label, observed[-1]
+print(json.dumps(observed, ensure_ascii=False))
+"""
+        env = os.environ.copy()
+        env["PYTHONPATH"] = str(Path.cwd() / "src")
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            cwd=Path.cwd(),
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+        observed = json.loads(result.stdout)
+        self.assertEqual(
+            [item["action"] for item in observed],
+            ["choose_permission_profile", "reframe_north_star", "route_direct_task"],
+        )
 
     def test_probe_tool_falls_back_only_when_package_is_absent(self) -> None:
         from omh.plugin_bundle.omh.tools import probe_tool


### PR DESCRIPTION
## Summary
- Adds a source-layout subprocess smoke test for OMH plugin awareness imports.
- Verifies `PYTHONPATH=src` can import `omh.plugin_bundle.omh.awareness` without the test shim and still produce loop-specific route hints.
- Locks the exact UX regression fixed in the previous PR so future plugin awareness import changes cannot silently fall back to generic loop copy.

## Why
Most unit tests load OMH through `_local_package`, which is useful for the source checkout but can hide package-layout import problems. The previous plugin awareness fix found one of those gaps: the public router was specific, while the plugin awareness path could degrade in real package/source-layout import mode.

This PR adds a direct subprocess check that exercises the real source-layout import path instead of the local test shim.

## What Changed
- `tests/test_plugin_distribution.py`
  - Adds `test_source_layout_plugin_awareness_uses_package_loopability_helpers`.
  - Runs a subprocess with `PYTHONPATH=<repo>/src`.
  - Asserts representative loop prompts resolve to:
    - `choose_permission_profile`
    - `reframe_north_star`
    - `route_direct_task`
  - Also checks the human action labels stay aligned with router copy.

## User Value
This does not add a new user command. It hardens the route quality gate for the chat-first Hermes plugin path, which is where users feel OMH most. If plugin awareness ever loses package helper imports again, CI should catch it before users see vague `assess_loopability` copy in Hermes.

## Verification
- `PYTHONPATH=tests uv run python -m unittest tests/test_plugin_distribution.py tests/test_efficiency.py -v` -> 73 tests OK
- `PYTHONPATH=tests uv run python -m unittest tests/test_chat_router.py tests/test_wrapper_contract.py tests/test_release_smoke.py tests/test_hermes_ux_quality.py -v` -> 178 tests OK
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` -> 993 tests OK
- `PYTHONPATH=tests uv run python -m compileall -q src tests` -> OK
- `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check` -> OK, 48/48 tap skills checked
- `PYTHONPATH=tests uv run python -m omh.cli harness validate` -> OK, 36 harnesses and 50 skills
- `PYTHONPATH=tests uv run python -m omh.cli demo route-hint-alignment --summary` -> 93/93 aligned
- `PYTHONPATH=tests uv run python -m omh.cli demo hermes-ux-quality --summary` -> 100/100
- `git diff --check` -> OK

## Risks / Boundaries
- This is test coverage only. It does not prove live Hermes has reloaded the plugin, rendered the context, executed a workflow, dispatched a coding agent, reviewed code, passed CI, or merged anything.
- Existing unrelated untracked local assets were not included.
