### PR TITLE
Add root OMH version output

### DIFF
--- a/src/commands/main.py
+++ b/src/commands/main.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import sys
 
+from ..version import __version__
 from ..installer import OmhError
 from .capabilities import (
     _add_capabilities_commands,
@@ -270,6 +271,7 @@ Start:
   omh doctor             Check local OMH health and registration
   omh quickstart         Show what to do next in Hermes
   omh update             Refresh managed skills and update metadata
+  omh --version          Print the installed command version
 
 First five minutes:
   1. Run `omh setup` and accept the recommended choices.
@@ -315,8 +317,12 @@ Run `omh --help` for the full command list."""
 
 
 def main(argv: list[str] | None = None) -> int:
+    raw_argv = list(sys.argv[1:] if argv is None else argv)
+    if raw_argv in (["--version"], ["-V"]):
+        print(f"omh {__version__}")
+        return 0
     parser = build_parser()
-    args = parser.parse_args(argv)
+    args = parser.parse_args(raw_argv)
     if not getattr(args, "command", None):
         _print_welcome()
         return 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -34,6 +34,14 @@ class CliTests(unittest.TestCase):
         self.assertIn("If `omh` is not found", stdout)
         self.assertIn("If this screen appears after `omh uninstall`", stdout)
         self.assertIn("omh --help", stdout)
+        self.assertIn("omh --version", stdout)
+
+    def test_root_version_flag_prints_installed_command_version(self) -> None:
+        status, stdout, stderr = run_cli(["--version"], output_json=False)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertRegex(stdout.strip(), r"^omh \d+\.\d+\.\d+$")
 
     def test_root_help_explains_command_lanes(self) -> None:
         help_text = build_parser().format_help()


### PR DESCRIPTION
## Summary

Add a root-level `omh --version` / `omh -V` fast path so users can immediately see which OMH command package is installed after curl install, update, or troubleshooting.

## Why

A real install audit showed that `command -v omh` succeeded, but `omh --version` failed with `unrecognized arguments`. That made the install/update story harder to trust from a normal terminal: users could run `omh doctor`, but they could not quickly answer "which command did I actually install?"

The tricky part is that several subcommands already use `--version`, especially release commands such as `omh release checklist --version 1.0.1`. This PR keeps those subcommand contracts intact by handling only the exact root invocations `omh --version` and `omh -V` before argparse parses subcommands.

## What Changed

- Adds root command version output:
  - `omh --version`
  - `omh -V`
- Adds the version shortcut to the no-argument welcome screen.
- Adds a focused CLI harness test proving the root version command exits cleanly and prints `omh <semver>`.
- Avoids argparse's built-in version action because it raises `SystemExit` in the harness and collides with existing subcommand `--version` options.

## User Impact

After install or update, users can now run:

```sh
omh --version
```

and get a clear terminal answer like:

```text
omh 1.0.1
```

without touching Hermes registration, managed skills, plugin state, or runtime artifacts.

## Verification

Observed locally:

```sh
PYTHONPATH=tests uv run python -m unittest tests/test_cli.py -v
PYTHONPATH=tests uv run python -m unittest discover -s tests -v
uv run python -m compileall -q src tests
PYTHONPATH=tests uv run python -m omh.cli docs workflows --check
PYTHONPATH=tests uv run python -m omh.cli harness validate
PYTHONPATH=tests uv run python -m omh.cli demo route-hint-alignment --summary
PYTHONPATH=tests uv run python -m omh.cli demo routing-precision --summary
PYTHONPATH=tests uv run python -m omh.cli demo hermes-ux-quality --summary
git diff --check
```

Key results:

- `tests/test_cli.py`: 244 tests passing.
- Full unittest discover: 994 tests passing.
- Route hint alignment: 93/93 aligned.
- Routing precision: 39/39 negative controls passing, 0 overroutes, 0 missed interventions.
- Hermes UX quality: passed, 100/100.

## Boundary

This is a terminal command UX improvement only. It does not claim live Hermes chat rendering, plugin loading, platform delivery, executor dispatch, implementation, review, CI, merge, or release publication.
