### PR TITLE
Promote coding progress guidance into OMH skills

### DIFF
--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -169,6 +169,8 @@ When wrapper metadata reports `omh_target_topology/v1`, skills bind workflow sta
   - The goal_completion_gate/v1 result passes from required evidence, not from a summary-only message.
   - All explicitly linked coding milestones have matching observed runtime evidence or are still named as gaps.
   - The final user-facing status says complete, blocked, or continue with the exact remaining checkpoint.
+  - Long-running or background executor milestones report observed handles, current state, changed-file summaries, missing checks, and prepared-vs-observed boundaries while work is running.
+  - Branch, PR, CI, review, and merge claims are verified against local HEAD, remote branch SHA, PR head SHA, and merge commit before saying a fix landed.
 - Recovery notes:
   - If the goal ledger is stale or missing, inspect .omh/goals and ask which checkpoint to resume before continuing.
   - If a blocker checkpoint exists, keep the goal open and record the blocker plus the smallest unblock action.

--- a/skills/oh-my-hermes/SKILL.md
+++ b/skills/oh-my-hermes/SKILL.md
@@ -112,6 +112,7 @@ Load these only when exact detail matters:
 - `references/workflow-registry.md` for full workflow triggers and role registry.
 - `references/harness-registry.md` for representative harnesses and priority.
 - `references/wrapper-routing.md` for backend/plugin/chat/coding delegation contracts.
+- `references/coding-handoff-progress-reporting.md` for active progress cadence, background executor watchdogs, PR head/merge verification, and memory/context collision pitfalls.
 - `references/evidence-boundaries.md` for prepared-vs-observed, target topology, memory, and compatibility rules.
 
 ## Recovery
@@ -119,6 +120,7 @@ Load these only when exact detail matters:
 - If exact route detail matters, load `references/workflow-registry.md` or the specific workflow skill before answering.
 - If harness behavior matters, load `references/harness-registry.md`.
 - If wrapper/backend behavior matters, load `references/wrapper-routing.md`.
+- If delegated coding work is running or being reported, load `references/coding-handoff-progress-reporting.md`.
 - If maintenance command behavior matters, load `references/operator-maintenance.md`.
 - If evidence or target topology is disputed, load `references/evidence-boundaries.md`.
 - If the right skill was not loaded, call `skills_list` or `skill_view`.

--- a/skills/oh-my-hermes/references/coding-handoff-progress-reporting.md
+++ b/skills/oh-my-hermes/references/coding-handoff-progress-reporting.md
@@ -1,0 +1,39 @@
+# OMH Coding Handoff Progress Reporting
+
+Use this reference when coding work is delegated, attached to an executor
+session, or running in the background.
+
+## Active Narration
+
+Hermes must remain an active status narrator after it prepares or observes a
+coding handoff. Immediately report the observed executor handle when available:
+process/session id, PID, branch or PR target, and the prepared-vs-observed
+boundary. Do not silently wait for a final result after saying an executor is
+running.
+
+## Progress Cadence
+
+For long-running executor work, use an event-triggered status loop or bounded
+watchdog when the wrapper exposes one, and remove it when work completes. Each
+update should separate:
+
+- prepared handoff
+- dispatch or attached session
+- running process
+- changed files or affected area
+- tests/checks started, passed, failed, or still missing
+- commit, push, PR, CI, review, and merge evidence
+
+## Completion Verification
+
+After completion, verify the executor self-report against local git status/log,
+remote branch SHA, PR metadata, and required checks before claiming anything
+landed. If a PR was already merged before follow-up commits landed, open or
+prepare a follow-up PR instead of implying the merged PR contains the new fix.
+
+## Boundary
+
+Progress narration is not execution proof by itself. Only observed runtime
+events, git state, PR metadata, checks, review records, and merge records can
+satisfy their matching evidence states. Revert or follow-up commits still need
+the repository's DCO and commit trailers when required.

--- a/skills/ultragoal/SKILL.md
+++ b/skills/ultragoal/SKILL.md
@@ -44,6 +44,8 @@ Bad example:
 - The goal_completion_gate/v1 result passes from required evidence, not from a summary-only message.
 - All explicitly linked coding milestones have matching observed runtime evidence or are still named as gaps.
 - The final user-facing status says complete, blocked, or continue with the exact remaining checkpoint.
+- Long-running or background executor milestones report observed handles, current state, changed-file summaries, missing checks, and prepared-vs-observed boundaries while work is running.
+- Branch, PR, CI, review, and merge claims are verified against local HEAD, remote branch SHA, PR head SHA, and merge commit before saying a fix landed.
 
 ## Recovery Notes
 

--- a/src/skills/catalog.py
+++ b/src/skills/catalog.py
@@ -863,6 +863,8 @@ _DEFINITIONS = [
             "The goal_completion_gate/v1 result passes from required evidence, not from a summary-only message.",
             "All explicitly linked coding milestones have matching observed runtime evidence or are still named as gaps.",
             "The final user-facing status says complete, blocked, or continue with the exact remaining checkpoint.",
+            "Long-running or background executor milestones report observed handles, current state, changed-file summaries, missing checks, and prepared-vs-observed boundaries while work is running.",
+            "Branch, PR, CI, review, and merge claims are verified against local HEAD, remote branch SHA, PR head SHA, and merge commit before saying a fix landed.",
         ),
         recovery_notes=(
             "If the goal ledger is stale or missing, inspect .omh/goals and ask which checkpoint to resume before continuing.",

--- a/src/skills/render.py
+++ b/src/skills/render.py
@@ -290,6 +290,11 @@ def _router_reference_templates_cached() -> tuple[SkillReferenceTemplate, ...]:
         ),
         SkillReferenceTemplate(
             "oh-my-hermes",
+            "references/coding-handoff-progress-reporting.md",
+            _router_coding_handoff_progress_reference(),
+        ),
+        SkillReferenceTemplate(
+            "oh-my-hermes",
             "references/operator-maintenance.md",
             _router_operator_maintenance_reference(),
         ),
@@ -438,6 +443,49 @@ Maintenance commands should prefer compact human summaries for chat/operator flo
 """.rstrip() + "\n"
 
 
+def _router_coding_handoff_progress_reference() -> str:
+    return """# OMH Coding Handoff Progress Reporting
+
+Use this reference when coding work is delegated, attached to an executor
+session, or running in the background.
+
+## Active Narration
+
+Hermes must remain an active status narrator after it prepares or observes a
+coding handoff. Immediately report the observed executor handle when available:
+process/session id, PID, branch or PR target, and the prepared-vs-observed
+boundary. Do not silently wait for a final result after saying an executor is
+running.
+
+## Progress Cadence
+
+For long-running executor work, use an event-triggered status loop or bounded
+watchdog when the wrapper exposes one, and remove it when work completes. Each
+update should separate:
+
+- prepared handoff
+- dispatch or attached session
+- running process
+- changed files or affected area
+- tests/checks started, passed, failed, or still missing
+- commit, push, PR, CI, review, and merge evidence
+
+## Completion Verification
+
+After completion, verify the executor self-report against local git status/log,
+remote branch SHA, PR metadata, and required checks before claiming anything
+landed. If a PR was already merged before follow-up commits landed, open or
+prepare a follow-up PR instead of implying the merged PR contains the new fix.
+
+## Boundary
+
+Progress narration is not execution proof by itself. Only observed runtime
+events, git state, PR metadata, checks, review records, and merge records can
+satisfy their matching evidence states. Revert or follow-up commits still need
+the repository's DCO and commit trailers when required.
+""".rstrip() + "\n"
+
+
 def _router_evidence_boundaries_reference() -> str:
     return f"""# OMH Evidence Boundaries
 
@@ -551,6 +599,7 @@ Load these only when exact detail matters:
 - `references/workflow-registry.md` for full workflow triggers and role registry.
 - `references/harness-registry.md` for representative harnesses and priority.
 - `references/wrapper-routing.md` for backend/plugin/chat/coding delegation contracts.
+- `references/coding-handoff-progress-reporting.md` for active progress cadence, background executor watchdogs, PR head/merge verification, and memory/context collision pitfalls.
 - `references/evidence-boundaries.md` for prepared-vs-observed, target topology, memory, and compatibility rules.
 
 ## Recovery
@@ -558,6 +607,7 @@ Load these only when exact detail matters:
 - If exact route detail matters, load `references/workflow-registry.md` or the specific workflow skill before answering.
 - If harness behavior matters, load `references/harness-registry.md`.
 - If wrapper/backend behavior matters, load `references/wrapper-routing.md`.
+- If delegated coding work is running or being reported, load `references/coding-handoff-progress-reporting.md`.
 - If maintenance command behavior matters, load `references/operator-maintenance.md`.
 - If evidence or target topology is disputed, load `references/evidence-boundaries.md`.
 - If the right skill was not loaded, call `skills_list` or `skill_view`.

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -89,6 +89,7 @@ class RouterContentTests(unittest.TestCase):
         }
         workflow_registry = references["oh-my-hermes/references/workflow-registry.md"]
         wrapper_routing = references["oh-my-hermes/references/wrapper-routing.md"]
+        progress_reporting = references["oh-my-hermes/references/coding-handoff-progress-reporting.md"]
         maintenance = references["oh-my-hermes/references/operator-maintenance.md"]
         evidence = references["oh-my-hermes/references/evidence-boundaries.md"]
 
@@ -113,6 +114,11 @@ class RouterContentTests(unittest.TestCase):
         self.assertIn("omh chat native-command --source discord", router.content)
         self.assertIn("omh_command_fallback_card/v1", router.content)
         self.assertIn("`./omh`, `/omh`, `./skills`, or `/skills`", router.content)
+        self.assertIn("coding-handoff-progress-reporting.md", router.content)
+        self.assertIn("Active Narration", progress_reporting)
+        self.assertIn("observed executor handle", progress_reporting)
+        self.assertIn("PR metadata", progress_reporting)
+        self.assertIn("merge records", progress_reporting)
         self.assertIn("Keep real skill names unchanged", router.content)
         self.assertIn("chat_response.state.skill_picker.options", router.content)
         self.assertIn("Do not make the user approve `omh list`", router.content)
@@ -820,6 +826,8 @@ class RouterContentTests(unittest.TestCase):
         self.assertIn("Cross-skill context", skills["ultragoal"].content)
         self.assertIn("Every generated workflow skill", skills["ultragoal"].content)
         self.assertIn("Prepared OMH routing", skills["ultragoal"].content)
+        self.assertIn("Long-running or background executor milestones report observed handles", skills["ultragoal"].content)
+        self.assertIn("PR head SHA", skills["ultragoal"].content)
         self.assertIn("omh_target_topology/v1", skills["ultragoal"].content)
         self.assertIn("active_agent_count", skills["ultragoal"].content)
         self.assertIn("omh runtime record --skill ultragoal --harness goal-execution --status started", skills["ultragoal"].content)


### PR DESCRIPTION
## Feature Report

### What Changed

- Added a generated `coding-handoff-progress-reporting.md` reference to the OMH router skill.
- Updated the router skill to load that reference whenever delegated coding work is running or being reported.
- Strengthened `ultragoal` completion checks so long-running executor work must report observed handles, current state, changed files, missing checks, and prepared-vs-observed boundaries.
- Regenerated `skills/` and `docs/WORKFLOWS.md` from the source catalog/rendering definitions.
- Added router content tests that lock the new reference and ultragoal progress guidance.

### Why This Exists

- A real `omh update` refreshed the command package successfully but stopped during workflow refresh because two managed local skill files had useful progress-reporting changes that were not yet source-controlled.
- Force-overwriting those files would have made the update succeed but would have discarded the behavior the user actually wanted: Hermes should not say a coding agent is running and then go silent or overclaim completion.
- This PR makes that local operational rule part of the canonical generated OMH workflow pack.

### User / Operator Impact

- When Hermes delegates coding to Codex, Claude Code, Hermes runtime, or another selected executor, OMH guidance now tells Hermes to actively narrate observed session/process/branch/PR handles when available.
- Status updates should separate prepared handoff, dispatch/attached session, running process, changed files, checks, PR/CI/review/merge evidence, and missing verification.
- After this lands, a workflow refresh can preserve the progress-reporting behavior instead of treating it as unmanaged local drift.

### How It Works

- `src/skills/render.py` now emits a router reference for coding handoff progress reporting.
- The main `oh-my-hermes` skill lists the new reference in progressive disclosure and recovery guidance.
- `src/skills/catalog.py` adds ultragoal final-checklist entries for observed executor milestones and branch/PR/CI/merge verification.
- Generated skill/docs surfaces are updated from those source definitions.
- `tests/test_router_content.py` asserts the router exposes the reference and ultragoal includes the new verification language.

### Files And Contracts Touched

- `src/skills/render.py`
- `src/skills/catalog.py`
- `skills/oh-my-hermes/SKILL.md`
- `skills/oh-my-hermes/references/coding-handoff-progress-reporting.md`
- `skills/ultragoal/SKILL.md`
- `docs/WORKFLOWS.md`
- `tests/test_router_content.py`

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_router_content.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check`
- [x] `PYTHONPATH=tests uv run python -m omh.cli harness validate`
- [ ] `python3 -m omh.cli release checklist --json`
- [ ] `python3 -m omh.cli release hermes-smoke`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable; this is generated skill guidance, not a workflow-learning queue change.
- [x] Relevant dry-run or smoke command: `PYTHONPATH=tests uv run python -m omh.cli demo route-hint-alignment --summary`; `PYTHONPATH=tests uv run python -m omh.cli demo routing-precision --summary`; `PYTHONPATH=tests uv run python -m omh.cli demo hermes-ux-quality --summary`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run in this PR; deterministic skill/router contracts were verified locally, live Hermes rendering remains observed-only.

## Risk

- Risk is narrow. The PR changes generated guidance and tests, not executor dispatch, runtime recording, or Hermes core behavior.
- The main risk is wording drift: too much status narration could sound like execution evidence. The reference explicitly says narration is not proof by itself.

## Compatibility / Rollout

- Existing commands remain compatible.
- `omh update` may still need `--force` on machines where older managed files already diverged, but after this lands the canonical generated content includes the progress guidance instead of losing it.

## Release / Claims

- [x] Release-channel impact considered (`preview` workflow-pack refresh behavior; no stable release cut here)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- After merge, refresh the installed local workflow pack and verify the previous `omh update` drift blocker is resolved without discarding the progress-reporting guidance.
