### PR TITLE
Align plugin awareness with locale routing

### DIFF
--- a/src/plugin_bundle/omh/awareness.py
+++ b/src/plugin_bundle/omh/awareness.py
@@ -1909,9 +1909,11 @@ def workflow_context_card_for_workflow(workflow: str) -> dict[str, object]:
 
 def awareness_context_matches_message(message: str) -> bool:
     """Return true when a non-first-turn message should refresh OMH context."""
-    text = unicodedata.normalize("NFKC", message).casefold()
-    if not text.strip():
+    raw_text = unicodedata.normalize("NFKC", message).casefold()
+    if not raw_text.strip():
         return False
+    localized_text = unicodedata.normalize("NFKC", _localized_routing_text(message)).casefold()
+    text = f"{raw_text} {localized_text}"
     tokens = set(re.findall(r"[a-z0-9][a-z0-9_-]*", text))
     return bool(tokens & _AWARENESS_TOKEN_MARKERS) or any(
         marker in text for marker in _AWARENESS_MESSAGE_MARKERS

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -218,9 +218,13 @@ class EfficiencyContractTests(unittest.TestCase):
         self.assertTrue(awareness_context_matches_message("현재 hermes가 기억하는 맥락을 점검하고 피드백 받아줘"))
         self.assertTrue(awareness_context_matches_message("作成して、PRの要約画像"))
         self.assertTrue(awareness_context_matches_message("生成一张发布说明海报"))
+        self.assertTrue(awareness_context_matches_message("haz una imagen que explique la función cron"))
+        self.assertTrue(awareness_context_matches_message("trouve le dépôt GitHub et le PDF public"))
+        self.assertTrue(awareness_context_matches_message("erkläre dieses Paper einfach"))
         self.assertTrue(awareness_context_matches_message("make a PR summary card for reviewers"))
         self.assertTrue(awareness_context_matches_message("what is the coding handoff status?"))
         self.assertFalse(awareness_context_matches_message("prepare a sandwich"))
+        self.assertFalse(awareness_context_matches_message("gracias"))
         self.assertFalse(awareness_context_matches_message(""))
 
         doctor_hint = awareness_route_hint("update 했는데 잘 된거야?")


### PR DESCRIPTION
## Feature Report

### What Changed

- Aligned the OMH plugin awareness detector with the existing deterministic locale routing layer.
- Non-first-turn awareness refreshes now consider the locale-expanded routing text in addition to the raw user message.
- Added bounded coverage for Spanish image-summary, French source-finder, and German paper-learning operator phrases, plus a Spanish thanks negative control.

### Why This Exists

- OMH already routes common non-English operator requests through deterministic phrase packs without translation APIs.
- The plugin awareness detector was more raw-marker oriented, so a chat surface could route correctly in one layer while failing to refresh the OMH context in another.
- This keeps global chat-first behavior consistent without adding hidden language detection, platform SDKs, or network calls.

### User / Operator Impact

- Spanish requests like “haz una imagen que explique la función cron” can wake the `img-summary` context.
- French requests like “trouve le dépôt GitHub et le PDF public” can wake the `source-finder` context.
- German requests like “erkläre dieses Paper einfach” can wake the `paper-learning` context.
- Low-signal phrases such as “gracias” remain suppressed instead of over-routing.

### How It Works

- `awareness_context_matches_message()` normalizes the raw message, expands it through `_localized_routing_text()`, and evaluates awareness tokens/markers over the bounded combined string.
- The change reuses existing local phrase metadata and keeps unsupported phrasing on the normal clarify/direct-answer path.
- No raw prompt persistence, translation API, network lookup, execution claim, or platform adapter behavior is added.

### Files And Contracts Touched

- `src/plugin_bundle/omh/awareness.py`: awareness detector now shares the deterministic locale-expanded routing signal.
- `tests/test_efficiency.py`: locks the new multilingual positive cases and the negative thanks guard.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_efficiency.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_chat_router.py -v`
- [x] `git diff --check`
- [ ] `python3 -m unittest discover -s tests` (covered by CI for this narrow patch)
- [ ] `python3 -m compileall src` (covered by CI for this narrow patch)
- [ ] `python3 -m omh.cli docs workflows --check` (not touched)
- [ ] `python3 -m omh.cli harness validate` (not touched)
- [ ] `python3 -m omh.cli release checklist --json` (not release checklist work)
- [ ] `python3 -m omh.cli release hermes-smoke` (not install/release surface work)
- [ ] `omh --help` (not CLI help surface work)
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` (not install smoke work)
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable
- [x] Relevant dry-run or smoke command: targeted route/awareness unit coverage above
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: live host rendering was not run; this patch only changes deterministic local awareness matching

## Risk

- Narrow matching change, but over-routing is the main risk. The added “gracias” negative guard and existing routing tests help keep low-signal language out of OMH context refresh.
- Unsupported-language phrasing still falls back normally; this does not claim broad translation support.

## Compatibility / Rollout

- Backward compatible with existing plugin and router payload shapes.
- No schema, CLI, install, generated docs, or runtime artifact changes.
- No migration required.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`): local deterministic behavior only; normal package rollout applies.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap.

## Follow-Up

- Keep adding locale examples through the shared routing phrase layer rather than widening the awareness detector into language guessing.
