### PR TITLE
Cache awareness context matching

### DIFF
--- a/src/plugin_bundle/omh/awareness.py
+++ b/src/plugin_bundle/omh/awareness.py
@@ -1909,6 +1909,11 @@ def workflow_context_card_for_workflow(workflow: str) -> dict[str, object]:
 
 def awareness_context_matches_message(message: str) -> bool:
     """Return true when a non-first-turn message should refresh OMH context."""
+    return _awareness_context_matches_message_cached(message)
+
+
+@lru_cache(maxsize=512)
+def _awareness_context_matches_message_cached(message: str) -> bool:
     raw_text = unicodedata.normalize("NFKC", message).casefold()
     if not raw_text.strip():
         return False

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -262,6 +262,17 @@ class EfficiencyContractTests(unittest.TestCase):
                 self.assertEqual(route_hint["primary_workflow"], workflow)
                 self.assertEqual(route_hint["primary_next_action"], next_action)
 
+    def test_mid_session_awareness_detector_cache_reuses_locale_scan(self) -> None:
+        awareness_module._awareness_context_matches_message_cached.cache_clear()
+
+        message = "trouve le dépôt GitHub et le PDF public"
+        self.assertTrue(awareness_context_matches_message(message))
+        self.assertTrue(awareness_context_matches_message(message))
+        cache_info = awareness_module._awareness_context_matches_message_cached.cache_info()
+
+        self.assertEqual(cache_info.misses, 1)
+        self.assertGreaterEqual(cache_info.hits, 1)
+
     def test_awareness_route_hint_cache_is_reused_without_payload_poisoning(self) -> None:
         awareness_module._awareness_route_hint_cached.cache_clear()
 


### PR DESCRIPTION
## Feature Report

### What Changed

- Added a bounded `lru_cache` around the plugin mid-session awareness matcher.
- Added an efficiency test proving repeated non-English awareness checks reuse the cached result after the first locale-expanded scan.

### Why This Exists

- The previous PR aligned awareness matching with locale-expanded routing text, which improved multilingual chat behavior.
- That matcher can run on every non-first-turn plugin hook, so repeated status/image/source requests should avoid repeating the same normalization, tokenization, and locale phrase scan work.
- This keeps the chat-first experience responsive while preserving the same deterministic local behavior.

### User / Operator Impact

- Repeated Hermes chat turns that ask about the same OMH-shaped request can reuse awareness matching work.
- Non-English operator requests still wake the right OMH context, and low-signal messages still stay out of workflow routing.
- No new CLI surface, schema, network call, platform SDK, or hidden execution behavior is introduced.

### How It Works

- `awareness_context_matches_message()` remains the public function.
- The actual matching now delegates to `_awareness_context_matches_message_cached()` with `maxsize=512`, matching the bounded-cache style used by route hints and related routing helpers.
- Cache contents are process-local only; no raw prompt persistence or runtime artifact changes are added.

### Files And Contracts Touched

- `src/plugin_bundle/omh/awareness.py`: adds the cached helper for mid-session awareness matching.
- `tests/test_efficiency.py`: asserts repeated matching produces one miss and at least one hit.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_efficiency.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_chat_router.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_hook_manifest.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `PYTHONPATH=tests uv run python -m omh.cli demo route-hint-alignment --summary`
- [x] `PYTHONPATH=tests uv run python -m omh.cli demo routing-precision --summary`
- [x] `PYTHONPATH=tests uv run python -m omh.cli demo hermes-ux-quality --summary`
- [x] `git diff --check`
- [ ] `python3 -m omh.cli docs workflows --check` (not touched)
- [ ] `python3 -m omh.cli harness validate` (not touched)
- [ ] `python3 -m omh.cli release checklist --json` (not release checklist work)
- [ ] `python3 -m omh.cli release hermes-smoke` (not install/release surface work)
- [ ] `omh --help` (not CLI help surface work)
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` (not install smoke work)
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable
- [x] Relevant dry-run or smoke command: cache smoke showed `CacheInfo(hits=1, misses=1, maxsize=512, currsize=1)`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: live host latency measurement was not run; deterministic local tests cover the changed path

## Risk

- Low risk: the cached value is a boolean derived only from the message string and bounded local phrase metadata.
- The main risk is stale matching logic if future global state is added to the matcher; the directive is to keep this helper pure or include any future state in the cache key.

## Compatibility / Rollout

- Backward compatible with existing plugin, hook, wrapper, and router payloads.
- No docs regeneration or migration required.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`): normal package rollout applies.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap.

## Follow-Up

- Continue measuring hook hot paths when routing phrase packs grow.
