### PR TITLE
Make menubar status readable by default

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -224,9 +224,9 @@ context is prompt guidance only; it is not proof
 that a separate role, worker, or executor ran.
 
 `menubar_status.py` owns the platform-neutral macOS menu bar view model exposed
-by `omh menubar status`. Its `menubar_status/v1` payload is a UI projection over
-the same local HUD, target registry, and runtime evidence. It is intentionally
-not the source of truth. The payload separates `hermes_agents` from
+by `omh menubar status --json`. Its `menubar_status/v1` payload is a UI
+projection over the same local HUD, target registry, and runtime evidence. It is
+intentionally not the source of truth. The payload separates `hermes_agents` from
 `external_coding_executors` so Codex, Claude Code, OMX, OMO, OMC, or generic
 coding tools cannot be rendered as Hermes agents by accident. Compact surfaces
 receive source and model `icon_id` values plus tooltip text rather than Markdown
@@ -235,6 +235,11 @@ for the native menu bar helper, grouping the same contract into Agent Status,
 Coding Agent, and Evidence sections so compact UI surfaces do not need to render
 raw JSON-like text. The Agent Status section uses an explicit `Agent | PID |
 Status` row shape.
+
+Plain `omh menubar status` renders a short terminal summary from the same
+payload so operators see Summary, Agent Status, Coding Agent, Evidence, and
+Observation sections without reading raw JSON. Machine consumers should request
+`--json` or set `OMH_OUTPUT=json`.
 
 `current_external_coding_executor` names the selected row explicitly, preferring
 `runtime/state.json` `last_run_id` when it matches the recent executor list, so
@@ -251,11 +256,12 @@ internal-memory evidence.
 The menu bar status contract reports configured Hermes targets and prepared
 handoffs without inventing process state. PID, `running`, and `restarting`
 values are applied only from a caller-provided `menubar_process_overlay/v1`
-payload or an explicit `omh menubar status --observe-local-processes` request
-from the native macOS helper. That observation is app-local, expires after a
-short TTL, and applies restarting state only inside its restart window. OMH does
-not turn prepared handoffs into observed execution, review, CI, or merge
-evidence. Plain `omh menubar status` remains metadata-only.
+payload or an explicit `omh menubar status --observe-local-processes --json`
+request from the native macOS helper. That observation is app-local, expires
+after a short TTL, and applies restarting state only inside its restart window.
+OMH does not turn prepared handoffs into observed execution, review, CI, or merge
+evidence. Plain `omh menubar status` remains metadata-only, even though its
+default terminal output is human-readable.
 
 `cli.py` is a compatibility adapter. `commands/main.py` owns parser assembly,
 top-level error handling, and the public command handler re-export surface.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -147,28 +147,35 @@ remain distinguishable.
 If the target Hermes runtime requires a separate plugin enable command, follow
 that runtime's plugin enable/reload step.
 
-For native menu bar or status-widget integrations, use the platform-neutral
-view model:
+For a quick terminal check of the native menu bar/status-widget surface, use the
+human-readable summary:
 
 ```sh
 omh menubar status
 ```
 
-`omh menubar status` itself emits `menubar_status/v1` JSON with separate
-`hermes_agents` and `external_coding_executors` sections, friendly labels such
-as `OMH connection: Ready`, `Hermes targets: 2`, `Coding agent: Codex`, and
-`Open mode: Ask before opening Codex`, plus source/model icon IDs with tooltip
-text. It also includes `display.menu_cards`, a compact Agent Status/Coding
-Agent/Evidence card model for native menu bar surfaces. The Agent Status card is
-a small `Agent | PID | Status` list. Codex and other coding tools are external
-executors, not Hermes agents. Without an explicit process overlay or local
-process observation, the payload reports configured/prepared state only and
-shows PID as not observed.
+It prints Summary, Agent Status, Coding Agent, Evidence, and Observation
+sections instead of a raw JSON blob. For native menu bar, status-widget, wrapper,
+or automation integrations, use the platform-neutral view model:
+
+```sh
+omh menubar status --json
+```
+
+The `menubar_status/v1` JSON has separate `hermes_agents` and
+`external_coding_executors` sections, friendly labels such as `OMH connection:
+Ready`, `Hermes targets: 2`, `Coding agent: Codex`, and `Open mode: Ask before
+opening Codex`, plus source/model icon IDs with tooltip text. It also includes
+`display.menu_cards`, a compact Agent Status/Coding Agent/Evidence card model
+for native menu bar surfaces. The Agent Status card is a small `Agent | PID |
+Status` list. Codex and other coding tools are external executors, not Hermes
+agents. Without an explicit process overlay or local process observation, the
+payload reports configured/prepared state only and shows PID as not observed.
 
 On macOS, a normal user-scope `omh setup` also attempts to build and start the
 small OMH menu bar helper when `swiftc` is available. The helper lives under
 `~/.omh/menubar`, is started with a user LaunchAgent, and refreshes the same
-`omh menubar status --observe-local-processes` payload. The visible menu is
+`omh menubar status --observe-local-processes --json` payload. The visible menu is
 intentionally grouped as Agent Status, Coding Agent, and Evidence sections
 instead of a raw text list, and it shows process/PID detail only when a fresh
 overlay or explicit local observation saw that process. Use explicit commands

--- a/src/commands/main.py
+++ b/src/commands/main.py
@@ -292,7 +292,7 @@ Useful operator commands:
   omh playbook recommend "turn this issue into a PR"
   omh chat interact "turn this issue into a PR-ready plan"
   omh hud                Show the compact OMH status line
-  omh menubar status     Show the menu bar app status view model
+  omh menubar status     Show the OMH menu bar status summary
   omh mcp manifest       Print the optional stdio MCP bridge manifest
   omh release evidence-bundle --version 1.0.1 --write
                           Write local deterministic release evidence

--- a/src/commands/menubar.py
+++ b/src/commands/menubar.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import argparse
+from collections.abc import Mapping, Sequence
 
 from ..installer import OmhError
 from ..menubar_app import setup_menubar_app, start_menubar_app, stop_menubar_app, uninstall_menubar_app
 from ..menubar_status import build_menubar_status_payload, read_process_overlay_file
-from .common import _paths, _print_json
+from .common import _paths, _print_json, _wants_json
 
 
 def cmd_menubar_status(args: argparse.Namespace) -> int:
@@ -13,15 +14,17 @@ def cmd_menubar_status(args: argparse.Namespace) -> int:
         overlay = read_process_overlay_file(args.overlay) if args.overlay else None
     except ValueError as exc:
         raise OmhError(str(exc)) from exc
-    _print_json(
-        build_menubar_status_payload(
-            _paths(args),
-            limit=args.limit,
-            process_overlay=overlay,
-            observe_local_processes=bool(args.observe_local_processes),
-            now=args.now,
-        )
+    payload = build_menubar_status_payload(
+        _paths(args),
+        limit=args.limit,
+        process_overlay=overlay,
+        observe_local_processes=bool(args.observe_local_processes),
+        now=args.now,
     )
+    if _wants_json(args):
+        _print_json(payload)
+    else:
+        print(_format_menubar_status(payload))
     return 0
 
 
@@ -58,7 +61,7 @@ def _add_menubar_commands(sub) -> None:
     menubar = sub.add_parser("menubar", help="Install or inspect the OMH menu bar helper.")
     menubar_sub = menubar.add_subparsers(dest="menubar_command", required=True)
 
-    status = menubar_sub.add_parser("status", help="Print the macOS menu bar agent-status view model.")
+    status = menubar_sub.add_parser("status", help="Show the OMH menu bar status summary.")
     status.add_argument("--limit", type=int, default=3, help="Maximum recent runtime runs to inspect.")
     status.add_argument("--overlay", default=None, help="Optional menubar_process_overlay/v1 JSON from the menu bar app.")
     status.add_argument(
@@ -67,6 +70,7 @@ def _add_menubar_commands(sub) -> None:
         help="Opt in to local Hermes process observation for the native menu bar helper.",
     )
     status.add_argument("--now", default=None, help="Optional ISO timestamp for deterministic overlay TTL evaluation.")
+    status.add_argument("--json", action="store_true", help="Print the full menubar_status/v1 payload.")
     status.set_defaults(func=cmd_menubar_status)
 
     install = menubar_sub.add_parser("install", help="Install and start the native macOS OMH menu bar helper when supported.")
@@ -84,3 +88,97 @@ def _add_menubar_commands(sub) -> None:
     uninstall = menubar_sub.add_parser("uninstall", help="Stop and remove the OMH menu bar helper.")
     uninstall.add_argument("--dry-run", action="store_true")
     uninstall.set_defaults(func=cmd_menubar_uninstall)
+
+
+def _format_menubar_status(payload: Mapping[str, object]) -> str:
+    display = _as_mapping(payload.get("display"))
+    settings = _as_mapping(payload.get("settings"))
+    versions = _as_mapping(payload.get("versions"))
+    process_overlay = _as_mapping(payload.get("process_overlay"))
+
+    lines = ["OMH menu bar status", "Summary"]
+    headline = _text(display.get("headline")) or "OMH status"
+    summary = _text(display.get("summary_line"))
+    lines.append(f"  Status: {headline}")
+    if summary:
+        lines.append(f"  Activity: {summary}")
+    omh_version = _as_mapping(versions.get("omh"))
+    if omh_version:
+        lines.append(f"  OMH version: {_text(omh_version.get('value')) or 'unknown'}")
+
+    for key in ("omh_connection", "hermes_targets", "coding_handoff", "send_mode"):
+        setting = _as_mapping(settings.get(key))
+        label = _text(setting.get("label")) if setting else ""
+        if label:
+            lines.append(f"  {label}")
+
+    cards = _as_sequence(display.get("menu_cards"))
+    for card_value in cards:
+        card = _as_mapping(card_value)
+        if not card:
+            continue
+        title = _text(card.get("title")) or "Status"
+        lines.extend(["", title])
+        columns = [_text(column) for column in _as_sequence(card.get("columns"))]
+        rows = [_as_mapping(row) for row in _as_sequence(card.get("rows"))]
+        agent_rows = [row for row in rows if row.get("kind") == "agent_status"]
+        if columns and agent_rows:
+            lines.append(f"  {_pad(columns[0], 20)} {_pad(columns[1], 14)} {columns[2] if len(columns) > 2 else 'Status'}")
+            for row in agent_rows:
+                lines.append(
+                    "  "
+                    f"{_pad(_text(row.get('agent')) or 'unknown', 20)} "
+                    f"{_pad(_text(row.get('pid')) or 'not observed', 14)} "
+                    f"{_text(row.get('status')) or 'unknown'}"
+                )
+        else:
+            for row in rows:
+                label = _text(row.get("label"))
+                value = _text(row.get("value"))
+                detail = _text(row.get("detail"))
+                if not label and not value:
+                    continue
+                value = _friendly_row_value(label, value)
+                line = f"  {label}: {value}" if label and value else f"  {label or value}"
+                if detail:
+                    line = f"{line} - {detail}"
+                lines.append(line)
+        footer = _text(card.get("footer"))
+        if footer:
+            lines.append(f"  Note: {footer}")
+
+    overlay_status = _text(process_overlay.get("status"))
+    if overlay_status:
+        lines.extend(["", "Observation"])
+        lines.append(f"  Process overlay: {overlay_status.replace('_', ' ')}")
+        applied_count = _text(process_overlay.get("applied_count"))
+        if applied_count and applied_count != "0":
+            lines.append(f"  Observed rows: {applied_count}")
+        lines.append("  Boundary: configured targets are not PID evidence unless observed by the helper.")
+
+    lines.extend(["", "For machine-readable output, rerun with `--json`."])
+    return "\n".join(lines)
+
+
+def _as_mapping(value: object) -> Mapping[str, object]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _as_sequence(value: object) -> Sequence[object]:
+    return value if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)) else ()
+
+
+def _text(value: object) -> str:
+    return "" if value is None else str(value).strip()
+
+
+def _friendly_row_value(label: str, value: str) -> str:
+    if label.lower() == "boundary" and value.lower() == "unknown":
+        return "no active evidence state"
+    return value
+
+
+def _pad(value: str, width: int) -> str:
+    if len(value) > width:
+        return f"{value[: max(0, width - 3)]}..."
+    return value.ljust(width)

--- a/src/surfaces/menubar_app.py
+++ b/src/surfaces/menubar_app.py
@@ -455,7 +455,7 @@ final class OMHMenuBarDelegate: NSObject, NSApplicationDelegate {
         if !hermesHome.isEmpty {
             args.append(contentsOf: ["--hermes-home", hermesHome])
         }
-        args.append(contentsOf: ["menubar", "status", "--observe-local-processes"])
+        args.append(contentsOf: ["menubar", "status", "--observe-local-processes", "--json"])
         process.arguments = args
         let pipe = Pipe()
         process.standardOutput = pipe

--- a/tests/test_menubar_app.py
+++ b/tests/test_menubar_app.py
@@ -10,6 +10,7 @@ from _cli_harness import run_cli
 from _local_package import load_local_package
 
 load_local_package()
+import omh.menubar_app as menubar_app_module
 from omh.menubar_app import MENUBAR_APP_SCHEMA_VERSION, setup_menubar_app
 from omh.paths import resolve_paths
 
@@ -75,6 +76,12 @@ class MenubarAppTests(unittest.TestCase):
             self.assertEqual(payload["status"], "dry_run")
             self.assertEqual(payload["omh_command"], "/usr/local/bin/omh")
             self.assertFalse((root / ".omh" / "menubar").exists())
+
+    def test_native_helper_requests_json_status_payload(self) -> None:
+        self.assertIn(
+            '["menubar", "status", "--observe-local-processes", "--json"]',
+            menubar_app_module._SWIFT_SOURCE,
+        )
 
     def test_custom_path_uninstall_does_not_touch_user_launch_agent(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_menubar_status.py
+++ b/tests/test_menubar_status.py
@@ -117,6 +117,58 @@ class MenubarStatusTests(unittest.TestCase):
             self.assertEqual(current["row_id"], executors[0]["id"])
             self.assertEqual(current["run_id"], executors[0]["evidence"]["run_id"])
 
+    def test_menubar_status_defaults_to_human_readable_output(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / ".omh"
+            hermes_home = root / ".hermes"
+            self.assertEqual(run_cli(["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "setup"])[0], 0)
+            self.assertEqual(
+                run_cli(
+                    [
+                        "--omh-home",
+                        str(omh_home),
+                        "--hermes-home",
+                        str(hermes_home),
+                        "coding",
+                        "delegate",
+                        "--record",
+                        "--executor",
+                        "codex",
+                        "implement safe status feature without overclaiming",
+                    ]
+                )[0],
+                0,
+            )
+
+            status, stdout, stderr = run_cli(
+                ["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "menubar", "status"],
+                output_json=False,
+            )
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            self.assertTrue(stdout.startswith("OMH menu bar status\n"))
+            self.assertIn("Summary\n", stdout)
+            self.assertIn("Agent Status\n", stdout)
+            self.assertIn("Coding Agent\n", stdout)
+            self.assertIn("Evidence\n", stdout)
+            self.assertIn("Coding agent: Codex", stdout)
+            self.assertIn("For machine-readable output, rerun with `--json`.", stdout)
+            with self.assertRaises(json.JSONDecodeError):
+                json.loads(stdout)
+
+            status, stdout, stderr = run_cli(
+                ["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "menubar", "status", "--json"],
+                output_json=False,
+            )
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            payload = json.loads(stdout)
+            self.assertEqual(payload["schema_version"], "menubar_status/v1")
+            self.assertEqual(payload["settings"]["coding_handoff"]["label"], "Coding agent: Codex")
+
     def test_process_overlay_applies_pid_status_and_model_only_when_fresh(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## Summary
- Make `omh menubar status` print a concise human-readable status summary by default.
- Preserve the existing `menubar_status/v1` machine contract behind `omh menubar status --json` and `OMH_OUTPUT=json`.
- Update the native macOS menu bar helper to request `--json` explicitly so its JSON parsing path remains stable.

## Why
A user/operator running `omh menubar status` in a terminal should not get a large JSON blob by default. The command is often used while checking whether OMH, Hermes targets, coding-agent status, and evidence boundaries look healthy. The previous output was technically correct but hard to scan, especially when the user was trying to understand agent PID/status and coding-agent state.

## What Changed
- `cmd_menubar_status` now builds the same payload as before, then renders:
  - Summary
  - Agent Status
  - Coding Agent
  - Evidence
  - Observation
- Added `--json` to return the full `menubar_status/v1` payload.
- Kept `OMH_OUTPUT=json` support so existing test/wrapper callers remain compatible.
- Updated the native menu bar helper Swift source to call `menubar status --observe-local-processes --json`.
- Updated installation and architecture docs to explain the human default and the JSON integration mode.

## User Impact
Terminal users now see a compact status board instead of raw JSON:

```text
OMH menu bar status
Summary
  Status: OMH ready
  Activity: 1 Hermes target(s) · Generic coding agent observed
  OMH version: 1.0.1
  OMH connection: Ready
  Hermes targets: 1
  Coding agent: Generic coding agent
  Open mode: Ask before opening Generic coding agent
```

Machine consumers, wrappers, and the native menu bar app still use the same schema-versioned payload with `--json`.

## Boundary Notes
This is a rendering change, not a schema change. It does not claim process/PID evidence unless the existing overlay or explicit local observation path supplies that evidence. Prepared coding-agent state remains distinct from observed execution, verification, review, CI, and merge evidence.

## Verification
Observed locally:
- `PYTHONPATH=tests uv run python -m unittest tests/test_menubar_status.py tests/test_menubar_app.py -v` — 15 tests passed.
- `PYTHONPATH=tests uv run python -m unittest discover -s tests` — 999 tests passed.
- `uv run python -m compileall -q src tests` — passed.
- `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check` — passed, 49/49 tap skills checked.
- `PYTHONPATH=tests uv run python -m omh.cli menubar status` — printed human-readable summary.
- `PYTHONPATH=tests uv run python -m omh.cli menubar status --json` — returned valid JSON payload.
- `git diff --check` — passed.

## Not Tested
- Live macOS menu bar UI rendering after reinstall was not exercised in this PR; the helper command contract is covered by source/test and the payload contract remains unchanged.
