### PR TITLE
Default route hints to readable output

### DIFF
--- a/src/commands/chat.py
+++ b/src/commands/chat.py
@@ -40,7 +40,15 @@ from ..wrapper.sessions import (
     select_wrapper_session_executor,
     show_wrapper_session,
 )
-from .common import _chat_input_and_metadata, _chat_message, _explicit_source_metadata, _paths, _print_json, _resolved_executor
+from .common import (
+    _chat_input_and_metadata,
+    _chat_message,
+    _explicit_source_metadata,
+    _paths,
+    _print_json,
+    _resolved_executor,
+    _wants_json,
+)
 from .runtime import _validate_runtime_names
 
 
@@ -106,8 +114,10 @@ def cmd_chat_route_hint(args: argparse.Namespace) -> int:
         raise OmhError(str(exc)) from exc
     if bool(getattr(args, "summary", False)):
         _print_chat_route_hint_summary(payload)
-    else:
+    elif _wants_json(args):
         _print_json(payload)
+    else:
+        _print_chat_route_hint_summary(payload)
     return 0
 
 
@@ -977,12 +987,12 @@ def _add_chat_commands(sub) -> None:
     route_hint.add_argument(
         "--summary",
         action="store_true",
-        help="Print a compact human-readable route-hint summary instead of the default JSON payload.",
+        help="Print a compact human-readable route-hint summary. This is the default.",
     )
     route_hint.add_argument(
         "--json",
         action="store_true",
-        help="Print the full machine-readable JSON route-hint payload. This is the default.",
+        help="Print the full machine-readable JSON route-hint payload.",
     )
     route_hint.set_defaults(func=cmd_chat_route_hint)
 

--- a/src/commands/menubar.py
+++ b/src/commands/menubar.py
@@ -38,22 +38,22 @@ def cmd_menubar_install(args: argparse.Namespace) -> int:
         )
     except RuntimeError as exc:
         raise OmhError(str(exc)) from exc
-    _print_json(payload)
+    _print_menubar_app_payload(args, payload)
     return 0
 
 
 def cmd_menubar_start(args: argparse.Namespace) -> int:
-    _print_json(start_menubar_app(_paths(args)))
+    _print_menubar_app_payload(args, start_menubar_app(_paths(args)))
     return 0
 
 
 def cmd_menubar_stop(args: argparse.Namespace) -> int:
-    _print_json(stop_menubar_app(_paths(args)))
+    _print_menubar_app_payload(args, stop_menubar_app(_paths(args)))
     return 0
 
 
 def cmd_menubar_uninstall(args: argparse.Namespace) -> int:
-    _print_json(uninstall_menubar_app(_paths(args), dry_run=bool(args.dry_run)))
+    _print_menubar_app_payload(args, uninstall_menubar_app(_paths(args), dry_run=bool(args.dry_run)))
     return 0
 
 
@@ -77,16 +77,20 @@ def _add_menubar_commands(sub) -> None:
     install.add_argument("--dry-run", action="store_true")
     install.add_argument("--force", action="store_true")
     install.add_argument("--no-start", action="store_true", help="Install the helper without starting the LaunchAgent.")
+    install.add_argument("--json", action="store_true", help="Print the full menubar_app/v1 payload.")
     install.set_defaults(func=cmd_menubar_install)
 
     start = menubar_sub.add_parser("start", help="Start the installed OMH menu bar helper.")
+    start.add_argument("--json", action="store_true", help="Print the full menubar_app/v1 payload.")
     start.set_defaults(func=cmd_menubar_start)
 
     stop = menubar_sub.add_parser("stop", help="Stop the OMH menu bar helper LaunchAgent.")
+    stop.add_argument("--json", action="store_true", help="Print the full menubar_app/v1 payload.")
     stop.set_defaults(func=cmd_menubar_stop)
 
     uninstall = menubar_sub.add_parser("uninstall", help="Stop and remove the OMH menu bar helper.")
     uninstall.add_argument("--dry-run", action="store_true")
+    uninstall.add_argument("--json", action="store_true", help="Print the full menubar_app/v1 payload.")
     uninstall.set_defaults(func=cmd_menubar_uninstall)
 
 
@@ -160,6 +164,52 @@ def _format_menubar_status(payload: Mapping[str, object]) -> str:
     return "\n".join(lines)
 
 
+def _print_menubar_app_payload(args: argparse.Namespace, payload: Mapping[str, object]) -> None:
+    if _wants_json(args):
+        _print_json(payload)
+    else:
+        print(_format_menubar_app_payload(payload))
+
+
+def _format_menubar_app_payload(payload: Mapping[str, object]) -> str:
+    operation = _text(payload.get("operation")) or "menubar"
+    status = _text(payload.get("status")) or "unknown"
+    message = _text(payload.get("message"))
+    lines = [f"OMH menu bar {operation}", "Summary", f"  Status: {status.replace('_', ' ')}"]
+    if message:
+        lines.append(f"  Message: {_single_line(message)}")
+
+    if _truthy(payload.get("started")):
+        lines.append("  Result: helper started")
+    if _truthy(payload.get("stopped")):
+        lines.append("  Result: helper stopped")
+
+    removed = [_text(item) for item in _as_sequence(payload.get("removed")) if _text(item)]
+    would_remove = [_text(item) for item in _as_sequence(payload.get("would_remove")) if _text(item)]
+    if removed:
+        lines.append(f"  Removed: {len(removed)} path(s)")
+    if would_remove:
+        lines.append(f"  Would remove: {len(would_remove)} path(s)")
+
+    launch_agent = _text(payload.get("launch_agent"))
+    if launch_agent:
+        lines.append(f"  LaunchAgent: {launch_agent}")
+
+    if status in {"missing", "failed", "installed_start_failed"}:
+        lines.extend(["", "Next"])
+        if status == "missing":
+            lines.append("  Run `omh menubar install` to install the helper.")
+        elif operation == "start":
+            lines.append("  Run `omh doctor`, then `omh menubar install --force` if the helper needs repair.")
+        elif operation == "stop":
+            lines.append("  The helper may already be stopped. Run `omh menubar status` to inspect the current view.")
+        else:
+            lines.append("  Run `omh doctor` for the local health report.")
+
+    lines.extend(["", "For machine-readable output, rerun with `--json`."])
+    return "\n".join(lines)
+
+
 def _as_mapping(value: object) -> Mapping[str, object]:
     return value if isinstance(value, Mapping) else {}
 
@@ -170,6 +220,14 @@ def _as_sequence(value: object) -> Sequence[object]:
 
 def _text(value: object) -> str:
     return "" if value is None else str(value).strip()
+
+
+def _single_line(value: str) -> str:
+    return " ".join(value.split())
+
+
+def _truthy(value: object) -> bool:
+    return bool(value) and str(value).lower() not in {"false", "0", "none", "null"}
 
 
 def _friendly_row_value(label: str, value: str) -> str:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4615,6 +4615,26 @@ class CliTests(unittest.TestCase):
             "preparing an image prompt card",
         )
 
+    def test_chat_route_hint_defaults_to_operator_summary_for_terminal_users(self) -> None:
+        message = "what OMH workflows are available?"
+        status, stdout, stderr = run_cli(["chat", "route-hint", "--source", "discord", message], output_json=False)
+
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        self.assertIn("OMH route hint", stdout)
+        self.assertIn("Workflow: oh-my-hermes", stdout)
+        self.assertIn("Next action: opening the workflow picker", stdout)
+        with self.assertRaises(json.JSONDecodeError):
+            json.loads(stdout)
+
+        status, stdout, stderr = run_cli(["chat", "route-hint", "--source", "discord", message])
+
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        payload = json.loads(stdout)
+        self.assertEqual(payload["schema_version"], "chat_route_hint/v1")
+        self.assertEqual(payload["route_hint"]["primary_workflow"], "oh-my-hermes")
+
     def test_chat_route_hint_summary_covers_loop_and_picker_language(self) -> None:
         status, stdout, stderr = run_cli(
             ["chat", "route-hint", "--source", "discord", "--summary", "run a loop to improve first-run experience"],

--- a/tests/test_menubar_app.py
+++ b/tests/test_menubar_app.py
@@ -83,6 +83,58 @@ class MenubarAppTests(unittest.TestCase):
             menubar_app_module._SWIFT_SOURCE,
         )
 
+    def test_menubar_start_defaults_to_human_readable_output(self) -> None:
+        payload = {
+            "schema_version": MENUBAR_APP_SCHEMA_VERSION,
+            "operation": "start",
+            "platform": "Darwin",
+            "label": "com.rlaope.omh.menubar",
+            "launch_agent": "/tmp/com.rlaope.omh.menubar.plist",
+            "started": True,
+            "status": "running",
+            "message": "OMH menu bar helper started.",
+        }
+        with patch("omh.commands.menubar.start_menubar_app", return_value=payload):
+            status, stdout, stderr = run_cli(["menubar", "start"], output_json=False)
+
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        self.assertIn("OMH menu bar start", stdout)
+        self.assertIn("Status: running", stdout)
+        self.assertIn("Result: helper started", stdout)
+        with self.assertRaises(json.JSONDecodeError):
+            json.loads(stdout)
+
+        with patch("omh.commands.menubar.start_menubar_app", return_value=payload):
+            status, stdout, stderr = run_cli(["menubar", "start", "--json"], output_json=False)
+
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        self.assertEqual(json.loads(stdout)["schema_version"], MENUBAR_APP_SCHEMA_VERSION)
+
+    def test_menubar_stop_failure_is_readable_without_json(self) -> None:
+        payload = {
+            "schema_version": MENUBAR_APP_SCHEMA_VERSION,
+            "operation": "stop",
+            "platform": "Darwin",
+            "label": "com.rlaope.omh.menubar",
+            "launch_agent": "/tmp/com.rlaope.omh.menubar.plist",
+            "stopped": False,
+            "status": "failed",
+            "message": "Boot-out failed: 5: Input/output error\nTry re-running the command as root for richer errors.",
+        }
+        with patch("omh.commands.menubar.stop_menubar_app", return_value=payload):
+            status, stdout, stderr = run_cli(["menubar", "stop"], output_json=False)
+
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        self.assertIn("OMH menu bar stop", stdout)
+        self.assertIn("Status: failed", stdout)
+        self.assertIn("Boot-out failed: 5: Input/output error", stdout)
+        self.assertIn("Run `omh menubar status`", stdout)
+        with self.assertRaises(json.JSONDecodeError):
+            json.loads(stdout)
+
     def test_custom_path_uninstall_does_not_touch_user_launch_agent(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## Summary
- Make `omh chat route-hint ...` render the existing human summary by default for terminal users.
- Keep the full `chat_route_hint/v1` payload available through `--json` and `OMH_OUTPUT=json`.
- Make `omh menubar install/start/stop/uninstall` render short human summaries by default while keeping `menubar_app/v1` JSON available through `--json`.

## Why
Direct OMH support commands are part of the first-use and debugging experience. A user asking what OMH workflows exist, or trying to restart the menu bar helper, should see a readable answer first instead of a large JSON object. Wrappers and automation still need the schema-versioned payloads, so this change preserves the machine contract with explicit JSON mode.

## What Changed
- `cmd_chat_route_hint` now defaults to `_print_chat_route_hint_summary` unless `--json` or `OMH_OUTPUT=json` is used.
- `--summary` remains supported and still conflicts with explicit `--json`.
- `menubar install/start/stop/uninstall` now share a small renderer that shows status, message, result, launch agent, and next step on failure.
- Added `--json` flags to the menu bar action commands.
- Added tests for default route-hint summary, JSON escape hatch, readable menu bar start output, and readable menu bar stop failure output.

## User Impact
Users now get output like:

```text
OMH route hint
Source: discord
Status: hinted
Workflow: oh-my-hermes
Next action: opening the workflow picker
```

instead of raw JSON when they run `omh chat route-hint` directly. If a menu bar helper action fails, the user sees the status and next step without reading a JSON object.

## Boundary Notes
This is a presentation change. It does not change routing schemas, wrapper contracts, route decisions, evidence boundaries, executor dispatch, plugin behavior, or runtime observation semantics.

## Verification
Observed locally:
- `PYTHONPATH=tests uv run python -m unittest tests/test_cli.py tests/test_menubar_app.py -v` — 252 tests passed.
- `PYTHONPATH=tests uv run python -m unittest discover -s tests` — 1002 tests passed.
- `uv run python -m compileall -q src tests` — passed.
- `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check` — passed, 49/49 tap skills checked.
- `PYTHONPATH=tests uv run python -m omh.cli demo routing-precision --summary` — 39/39 negative controls, 19/19 interventions, 0 overroutes, 0 missed interventions.
- `PYTHONPATH=tests uv run python -m omh.cli demo hermes-ux-quality --summary` — 100/100.
- `PYTHONPATH=tests uv run python -m omh.cli chat route-hint --source discord "what OMH workflows are available?"` — printed human-readable summary.
- `PYTHONPATH=tests uv run python -m omh.cli chat route-hint --source discord --json "what OMH workflows are available?"` — returned `chat_route_hint/v1` JSON.
- `git diff --check` — passed.

## Not Tested
- Live menu bar stop/start failure behavior across every possible macOS LaunchAgent state was not exhaustively tested; action rendering is covered with mocked payloads and the existing app helper contract remains unchanged.
