### PR TITLE
Make chat route output readable by default

### DIFF
--- a/docs/APPLICATION_CASES.md
+++ b/docs/APPLICATION_CASES.md
@@ -521,7 +521,7 @@ with:
 
 ```sh
 omh chat interact --source discord "<message>"
-omh chat interact --source discord --summary "<message>"
+omh chat interact --source discord --json "<message>"
 omh playbook recommend "<message>" --limit 1
 omh coding delegate --executor codex --source discord "<message>"
 omh demo grounded-score --summary
@@ -533,12 +533,12 @@ omh demo route-hint-alignment --json
 The purpose of the matrix is to keep Hermes users command-agnostic while giving
 wrapper operators a concrete contract result to render.
 
-`omh chat interact --summary` prints a compact operator-readable view of the
-same wrapper response, actions, evidence gaps, and claim boundary. The default
-`omh chat interact` output remains JSON for adapter compatibility.
-When only the lower-level router needs inspection, `omh chat route --summary`
-prints why the workflow was selected, the next action, route-plan steps, and
-the same evidence boundary while keeping default `chat route` output as JSON.
+`omh chat interact` prints a compact operator-readable view of the same wrapper
+response, actions, evidence gaps, and claim boundary. Adapters should pass
+`--json` when they need the complete machine-readable envelope. When only the
+lower-level router needs inspection, `omh chat route` prints why the workflow
+was selected, the next action, route-plan steps, and the same evidence boundary;
+use `omh chat route --json` for adapter payloads.
 
 `omh demo grounded-score --summary` prints a compact operator-readable rollup;
 `omh demo grounded-score --json` prints the full machine-readable payload.

--- a/docs/CHAT_WRAPPER_EXAMPLES.md
+++ b/docs/CHAT_WRAPPER_EXAMPLES.md
@@ -288,14 +288,14 @@ can call the transport-free backend preview:
 
 ```sh
 omh chat route-hint --source discord "make an image explaining the cron feature"
-omh chat route-hint --source discord --summary "make an image explaining the cron feature"
+omh chat route-hint --source discord --json "make an image explaining the cron feature"
 ```
 
 The preview payload also includes `generic_tool_checkpoint.routes`, so adapters
-do not need to parse prose before opening generic tool surfaces. The `--summary`
-form prints the same status, primary workflow, next action, matched cues, hint
-details, checkpoint, and evidence boundary for operator QA. Adapters should
-continue to consume the default JSON payload.
+do not need to parse prose before opening generic tool surfaces. The default
+terminal form prints status, primary workflow, next action, matched cues, hint
+details, checkpoint, and evidence boundary for operator QA. Adapters should pass
+`--json` for the complete machine-readable payload.
 
 Release QA should also run:
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -675,17 +675,16 @@ Then restart the bot process so Hermes reloads its config and skill directory.
 Minimal wrapper calls:
 
 ```sh
-omh chat interact --source discord --event-json event.json
-omh chat interact --source slack "risky refactor"
-printf '%s' "$SLACK_TEXT" | omh chat interact --source slack --stdin
-omh chat interact --source discord --summary "risky refactor"
+omh chat interact --source discord --json --event-json event.json
+omh chat interact --source slack --json "risky refactor"
+printf '%s' "$SLACK_TEXT" | omh chat interact --source slack --json --stdin
+omh chat interact --source discord "risky refactor"
 ```
 
-The default output is the machine-readable `chat_interaction/v1` JSON envelope
-that wrappers should render. Use `--summary` only when an operator wants to
-inspect the same response contract quickly in a terminal. The summary keeps the
-usual chat actions visible for operator QA; use JSON only when an adapter needs
-the complete machine-readable payload.
+The default terminal output is a compact operator summary. Wrappers and adapters
+should pass `--json` when they need the machine-readable
+`chat_interaction/v1` envelope. The summary keeps the usual chat actions visible
+for operator QA; JSON remains the complete backend contract.
 
 If the wrapper can identify the current Hermes agent target, include that as
 metadata rather than asking the user to choose a command:
@@ -766,8 +765,8 @@ verification, review, CI, or merge-readiness evidence is missing.
 Lower-level debug surfaces remain available when an adapter needs them:
 
 ```sh
-omh chat route --source discord --record "risky refactor"
-omh chat route --source discord --summary "risky refactor"
+omh chat route --source discord --record --json "risky refactor"
+omh chat route --source discord "risky refactor"
 omh hermes plan --source discord --record "risky refactor with review"
 omh hermes plan-accept .hermes/plans/<accepted-plan.md>
 omh coding delegate --executor codex --source discord --record --from-plan .hermes/plans/<accepted-plan.md>
@@ -775,9 +774,9 @@ omh coding delegate --executor claude-code --source discord --record "risky refa
 omh runtime delegation-status --run <run-id>
 ```
 
-`omh chat route --summary` is for operator inspection of the lower-level route
-decision. It does not replace the default JSON payload that adapters should
-consume.
+`omh chat route` prints an operator-readable lower-level route decision by
+default. Adapters should pass `--json` when they need the complete
+machine-readable payload.
 
 `omh hermes plan --record` writes a draft `hermes_plan/v1` Markdown artifact
 under `.hermes/plans/`. Each plan includes a deterministic `quality_gate` and

--- a/src/commands/chat.py
+++ b/src/commands/chat.py
@@ -92,8 +92,10 @@ def cmd_chat_route(args: argparse.Namespace) -> int:
         payload["runtime"] = {"run": run, "routing": routing}
     if bool(getattr(args, "summary", False)):
         _print_chat_route_summary(payload)
-    else:
+    elif _wants_json(args):
         _print_json(payload)
+    else:
+        _print_chat_route_summary(payload)
     return 0
 
 
@@ -152,8 +154,10 @@ def cmd_chat_interact(args: argparse.Namespace) -> int:
         raise OmhError(str(exc)) from exc
     if bool(getattr(args, "summary", False)):
         _print_chat_interaction_summary(payload)
-    else:
+    elif _wants_json(args):
         _print_json(payload)
+    else:
+        _print_chat_interaction_summary(payload)
     return 0
 
 
@@ -949,12 +953,12 @@ def _add_chat_commands(sub) -> None:
     route.add_argument(
         "--summary",
         action="store_true",
-        help="Print a compact human-readable route summary instead of the default JSON payload.",
+        help="Print a compact human-readable route summary. This is the default.",
     )
     route.add_argument(
         "--json",
         action="store_true",
-        help="Print the full machine-readable JSON route payload. This is the default.",
+        help="Print the full machine-readable JSON route payload.",
     )
     route.set_defaults(func=cmd_chat_route)
 
@@ -1036,12 +1040,12 @@ def _add_chat_commands(sub) -> None:
     interact.add_argument(
         "--summary",
         action="store_true",
-        help="Print a compact human-readable operator summary instead of the default JSON envelope.",
+        help="Print a compact human-readable operator summary. This is the default.",
     )
     interact.add_argument(
         "--json",
         action="store_true",
-        help="Print the full machine-readable JSON envelope. This is the default.",
+        help="Print the full machine-readable JSON envelope.",
     )
     _add_render_profile_option(interact)
     _add_target_metadata_options(interact)

--- a/src/wrapper/route_hints.py
+++ b/src/wrapper/route_hints.py
@@ -178,7 +178,7 @@ def _response_for_hint(
                 "id": "route_for_me",
                 "label": "Route for me",
                 "enabled": True,
-                "backend_command": "omh chat interact",
+                "backend_command": "omh chat interact --json",
             },
         ]
         if workflow_submit_text != "./omh":
@@ -213,7 +213,7 @@ def _response_for_hint(
                 "id": "clarify",
                 "label": "Clarify",
                 "enabled": True,
-                "backend_command": "omh chat interact --mode clarify",
+                "backend_command": "omh chat interact --mode clarify --json",
             },
         ]
         render_kind = "no_route_hint"
@@ -267,7 +267,7 @@ def _next_backend_commands(primary_hint: dict[str, object]) -> list[dict[str, ob
     commands = [
         {
             "id": "route_for_me",
-            "command": "omh chat interact --source <source> <message>",
+            "command": "omh chat interact --source <source> --json <message>",
             "purpose": "Build the full wrapper interaction envelope from the same event.",
         },
     ]
@@ -275,15 +275,15 @@ def _next_backend_commands(primary_hint: dict[str, object]) -> list[dict[str, ob
         commands.append(
             {
                 "id": "open_picker",
-                "command": "omh chat interact --source <source> ./omh",
+                "command": "omh chat interact --source <source> --json ./omh",
                 "purpose": "Open the compact OMH workflow picker.",
             }
         )
     if workflow:
         workflow_command = (
-            "omh chat interact --source <source> ./omh"
+            "omh chat interact --source <source> --json ./omh"
             if workflow == "oh-my-hermes"
-            else f"omh chat interact --source <source> ./{workflow} <message>"
+            else f"omh chat interact --source <source> --json ./{workflow} <message>"
         )
         commands.insert(
             0,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -295,7 +295,7 @@ class CliTests(unittest.TestCase):
 
     def test_chat_interact_routes_workflow_learning_to_audit_actions(self) -> None:
         status, stdout, stderr = run_cli(
-            ["chat", "interact", "--source", "discord", "learn from this workflow run"],
+            ["chat", "interact", "--source", "discord", "--json", "learn from this workflow run"],
             output_json=False,
         )
 
@@ -328,7 +328,7 @@ class CliTests(unittest.TestCase):
             "Hermes did not use OMH for my image request; record this as workflow learning",
             "이미지 생성 요청에서 OMH 안 썼어. workflow-learning으로 기록해줘",
         ):
-            status, stdout, stderr = run_cli(["chat", "interact", "--source", "discord", message], output_json=False)
+            status, stdout, stderr = run_cli(["chat", "interact", "--source", "discord", "--json", message], output_json=False)
 
             self.assertEqual(status, 0, stderr)
             self.assertEqual(stderr, "")
@@ -347,7 +347,7 @@ class CliTests(unittest.TestCase):
             root = Path(tmp)
             base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
             status, stdout, stderr = run_cli(
-                base + ["chat", "interact", "--source", "discord", "omh 상태랑 다음 액션 알려줘"],
+                base + ["chat", "interact", "--source", "discord", "--json", "omh 상태랑 다음 액션 알려줘"],
                 output_json=False,
             )
 
@@ -376,7 +376,7 @@ class CliTests(unittest.TestCase):
             root = Path(tmp)
             base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
             status, stdout, stderr = run_cli(
-                base + ["chat", "interact", "--source", "discord", "show OMH status"],
+                base + ["chat", "interact", "--source", "discord", "--json", "show OMH status"],
                 output_json=False,
             )
 
@@ -4445,6 +4445,25 @@ class CliTests(unittest.TestCase):
         self.assertEqual(route["route_explanation"]["primary_action_label"], "Open ralplan")
         self.assertIn("preparing a reviewed plan", route["route_explanation"]["recommended_reply"])
 
+    def test_chat_route_defaults_to_operator_summary_for_terminal_users(self) -> None:
+        message = "I want to safely add a feature to this repo"
+        status, stdout, stderr = run_cli(["chat", "route", "--source", "discord", message], output_json=False)
+
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        with self.assertRaises(json.JSONDecodeError):
+            json.loads(stdout)
+        self.assertIn("OMH chat route", stdout)
+        self.assertIn("Workflow: ralplan", stdout)
+        self.assertIn("Next action: preparing a reviewed plan", stdout)
+        self.assertIn("Use --json for the full machine-readable route payload.", stdout)
+
+        status, stdout, stderr = run_cli(["chat", "route", "--source", "discord", message])
+
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        self.assertEqual(json.loads(stdout)["route"]["selected_skill"], "ralplan")
+
     def test_chat_route_summary_shows_recorded_runtime_metadata_only(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -4675,7 +4694,7 @@ class CliTests(unittest.TestCase):
         self.assertEqual(payload["chat_response"]["actions"][0]["submit_text"], "./omh")
         self.assertEqual(
             payload["wrapper_contract"]["next_backend_commands"][0]["command"],
-            "omh chat interact --source <source> ./omh",
+            "omh chat interact --source <source> --json ./omh",
         )
         self.assertEqual(
             [command["id"] for command in payload["wrapper_contract"]["next_backend_commands"]],
@@ -4895,6 +4914,27 @@ class CliTests(unittest.TestCase):
         self.assertIn("Use --json for the full machine-readable payload.", stdout)
 
         status, stdout, stderr = run_cli(["chat", "interact", "--source", "discord", "--json", message], output_json=False)
+
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        payload = json.loads(stdout)
+        self.assertEqual(payload["schema_version"], "chat_interaction/v1")
+        self.assertEqual(payload["route"]["selected_skill"], "ralplan")
+
+    def test_chat_interact_defaults_to_operator_summary_for_terminal_users(self) -> None:
+        message = "I want to safely add a feature to this repo"
+        status, stdout, stderr = run_cli(["chat", "interact", "--source", "discord", message], output_json=False)
+
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        with self.assertRaises(json.JSONDecodeError):
+            json.loads(stdout)
+        self.assertIn("OMH chat interaction", stdout)
+        self.assertIn("Workflow: ralplan", stdout)
+        self.assertIn("Next action: preparing a reviewed plan", stdout)
+        self.assertIn("Use --json for the full machine-readable payload.", stdout)
+
+        status, stdout, stderr = run_cli(["chat", "interact", "--source", "discord", message])
 
         self.assertEqual(stderr, "")
         self.assertEqual(status, 0)

--- a/tests/test_wrapper_contract.py
+++ b/tests/test_wrapper_contract.py
@@ -151,7 +151,7 @@ class WrapperContractTests(unittest.TestCase):
         self.assertEqual(actions[0]["submit_text"], "./omh")
         backend_commands = payload["wrapper_contract"]["next_backend_commands"]
         self.assertEqual([command["id"] for command in backend_commands], ["open_workflow", "route_for_me"])
-        self.assertEqual(backend_commands[0]["command"], "omh chat interact --source <source> ./omh")
+        self.assertEqual(backend_commands[0]["command"], "omh chat interact --source <source> --json ./omh")
         self.assertNotIn(message, json.dumps(payload))
 
     def test_chat_interaction_renders_task_abstraction_card_without_cli_copy(self) -> None:


### PR DESCRIPTION
## Summary
- Make `omh chat route` and `omh chat interact` print compact human-readable summaries by default for terminal users.
- Preserve machine-readable `chat_route` and `chat_interaction/v1` payloads through `--json` and existing `OMH_OUTPUT=json` automation paths.
- Update route-hint wrapper backend commands and docs so adapters request JSON explicitly instead of relying on a JSON default.

## Why
Operators were still seeing large JSON payloads when they directly tried the lower-level chat route/interact commands, even after the surrounding setup, update, menubar, and route-hint surfaces were made readable by default. That made the product feel inconsistent: human CLI use looked like backend plumbing, while wrapper/backend use still needed stable JSON contracts.

## What changed
- `src/commands/chat.py`: `chat route` and `chat interact` now follow the same output policy as `route-hint`: explicit `--summary` prints summaries, explicit `--json` or `OMH_OUTPUT=json` prints JSON, and plain terminal use prints summaries.
- `src/wrapper/route_hints.py`: backend command hints now include `--json` for route-for-me, clarify, picker, and explicit workflow calls.
- `tests/test_cli.py` and `tests/test_wrapper_contract.py`: added default-summary coverage and made JSON-contract tests request `--json` explicitly.
- Docs now describe summary-first terminal output and `--json` adapter payloads.

## User impact
A user or operator can run:

```sh
omh chat route --source discord "I want to safely add a feature to this repo"
omh chat interact --source discord "I want to safely add a feature to this repo"
```

and see the workflow, next action, actions, and evidence boundary without reading raw JSON. Wrappers still have a clear machine path with `--json`.

## Verification
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- `uv run python -m compileall -q src tests`
- `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check`
- `PYTHONPATH=tests uv run python -m omh.cli demo routing-precision --summary`
- `PYTHONPATH=tests uv run python -m omh.cli demo hermes-ux-quality --summary`
- `git diff --check`
- Manual smoke:
  - `PYTHONPATH=tests uv run python -m omh.cli chat route --source discord "I want to safely add a feature to this repo"`
  - `PYTHONPATH=tests uv run python -m omh.cli chat interact --source discord "I want to safely add a feature to this repo"`
  - `PYTHONPATH=tests uv run python -m omh.cli chat route --source discord --json "I want to safely add a feature to this repo"`
  - `PYTHONPATH=tests uv run python -m omh.cli chat interact --source discord --json "I want to safely add a feature to this repo"`

## Risks and boundaries
- This does not prove live Hermes chat rendering, platform delivery, plugin load, executor dispatch, implementation, verification, review, CI, or merge.
- Wrapper/backend code that needs JSON must pass `--json`; docs and route-hint backend commands now make that explicit.
