### PR TITLE
Align chat help with readable output defaults

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -474,14 +474,18 @@ by default: `omh install`, `omh update`, `omh uninstall`, `omh apply`,
 `omh list`, `omh recommend`, `omh playbook ...`, `omh profile ...`,
 `omh probe`, and `omh snippet --output`. Use `--json` on those commands, or set
 `OMH_OUTPUT=json`, when a wrapper or automation needs the complete payload.
+Plain chat preview commands such as `omh chat route`, `omh chat route-hint`, and
+`omh chat interact` are also summary-first for terminal users. Use `--json` on
+those commands when an adapter needs `chat_route_hint/v1`,
+`chat_interaction/v1`, or another complete machine-readable envelope.
 Short chat requests such as `omh update`, `omh setup`, `omh doctor`, `omh
 install`, and `omh list` should stay in that maintenance lane: run the requested
 command, summarize observed output, and avoid repo changes unless the user asks
 for code work separately.
-Backend/control-plane commands such as `chat`, `coding`, `runtime`, `goal`,
-`loop`, `memory`, `state`, `harness`, `release`, and `demo` print JSON by
-design because they are wrapper contracts rather than the normal human chat
-surface.
+Ledger/control-plane commands such as `omh chat session`, `omh coding`,
+`omh runtime`, `omh goal`, `omh loop`, `omh memory`, `omh state`,
+`omh harness`, `omh release`, and `omh demo` print JSON by design because they
+are wrapper contracts rather than the normal human chat surface.
 `omh runtime status` should show the local runtime artifact directory and the
 latest install/apply/doctor state when those commands have run. `omh probe`
 reports observable Hermes capability surfaces without mutating Hermes internals.

--- a/src/commands/chat.py
+++ b/src/commands/chat.py
@@ -920,7 +920,7 @@ def _add_chat_commands(sub) -> None:
     chat = sub.add_parser("chat", help="Turn wrapper chat events into OMH routing, handoff, and status envelopes.")
     chat_sub = chat.add_subparsers(dest="chat_command", required=True)
 
-    route = chat_sub.add_parser("route")
+    route = chat_sub.add_parser("route", help="Route a plain chat message to the most relevant OMH workflow.")
     route.add_argument("message", nargs="*", help="Chat message to route before dispatching to Hermes.")
     route.add_argument(
         "--source",
@@ -1000,7 +1000,7 @@ def _add_chat_commands(sub) -> None:
     )
     route_hint.set_defaults(func=cmd_chat_route_hint)
 
-    interact = chat_sub.add_parser("interact")
+    interact = chat_sub.add_parser("interact", help="Build the wrapper/Hermes interaction card for a chat message.")
     interact.add_argument("message", nargs="*", help="Chat message to turn into a wrapper-native interaction envelope.")
     interact.add_argument(
         "--source",

--- a/src/commands/main.py
+++ b/src/commands/main.py
@@ -204,12 +204,14 @@ def build_parser() -> argparse.ArgumentParser:
             "  omh img-summary prompt-card --kind report --aspect-ratio long_scroll --section summary:Executive_summary:Weekly_metrics_changed\n"
             "  omh worktree prepare --repo . --task \"risky refactor\" --dry-run\n"
             "  omh worktree bind --path .worktrees/risky-refactor --executor codex --session <session-id>\n"
-            "  omh runtime status\n\n"
+            "  omh runtime status\n"
             "  omh runtime team-readiness\n\n"
             "Human-facing maintenance, catalog, and operator checklist commands print summaries by default;\n"
             "pass --json or set OMH_OUTPUT=json when a wrapper needs full payloads.\n"
-            "Backend/control-plane commands such as chat, coding, runtime, goal, loop,\n"
-            "learning, memory, ops, materials, state, harness, release smoke, and demo print JSON by design."
+            "Plain chat preview commands such as chat route, route-hint, and interact are summary-first;\n"
+            "pass --json for adapter envelopes.\n"
+            "Ledger/control-plane commands such as chat session, coding, runtime, goal, loop,\n"
+            "learning, memory, state, harness, release smoke, and demo print JSON by design."
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -61,12 +61,32 @@ class CliTests(unittest.TestCase):
         self.assertIn("omh ops list", help_text)
         self.assertIn("omh materials list", help_text)
         self.assertIn("Human-facing maintenance, catalog, and operator checklist commands print summaries", help_text)
-        self.assertIn("Backend/control-plane commands", help_text)
+        self.assertIn("Plain chat preview commands such as chat route, route-hint, and interact are summary-first", help_text)
+        self.assertIn("Ledger/control-plane commands", help_text)
         self.assertIn("release smoke", help_text)
-        self.assertIn("memory, ops, materials, state", help_text)
+        self.assertIn("learning, memory, state", help_text)
         self.assertIn("img-summary", help_text)
+        self.assertNotIn("commands such as chat, coding", help_text)
+        self.assertNotIn("chat, coding, runtime", help_text)
         self.assertNotIn("==SUPPRESS==", help_text)
         self.assertNotIn("visual               ==", help_text)
+
+    def test_chat_help_names_summary_first_preview_commands(self) -> None:
+        stdout_buffer = io.StringIO()
+
+        with patch("sys.stdout", stdout_buffer), self.assertRaises(SystemExit) as exit_context:
+            build_parser().parse_args(["chat", "--help"])
+
+        self.assertEqual(exit_context.exception.code, 0)
+        stdout = stdout_buffer.getvalue()
+        normalized = " ".join(stdout.split())
+        self.assertIn("route", stdout)
+        self.assertIn("Route a plain chat message to the most relevant OMH workflow.", normalized)
+        self.assertIn("route-hint", stdout)
+        self.assertIn("Print a lightweight OMH workflow hint card", normalized)
+        self.assertIn("interact", stdout)
+        self.assertIn("Build the wrapper/Hermes interaction card for a chat message.", normalized)
+        self.assertIn("session", stdout)
 
     def test_demo_help_explains_quality_lanes_and_boundary(self) -> None:
         stdout_buffer = io.StringIO()


### PR DESCRIPTION
## Summary
- Update top-level `omh --help` copy so `chat route`, `chat route-hint`, and `chat interact` are described as summary-first preview commands instead of being grouped under JSON-by-design backend commands.
- Add parent `omh chat --help` descriptions for `route` and `interact`, which previously appeared without explanatory text.
- Sync installation docs with the same human-vs-ledger output boundary.

## Why
After making `omh chat route` and `omh chat interact` readable by default, the root help still said `chat` belonged to JSON-by-design backend/control-plane commands. That was confusing for first-use operators and contradicted the actual behavior.

## What changed
- `src/commands/main.py`: split the output contract copy into summary-first chat preview commands and JSON-oriented ledger/control-plane commands.
- `src/commands/chat.py`: added help text for `route` and `interact` in `omh chat --help`.
- `docs/INSTALLATION.md`: documents summary-first chat preview commands and `--json` adapter envelopes.
- `tests/test_cli.py`: locks the corrected top-level and chat help copy.

## Verification
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- `uv run python -m compileall -q src tests`
- `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check`
- `PYTHONPATH=tests uv run python -m omh.cli demo routing-precision --summary`
- `PYTHONPATH=tests uv run python -m omh.cli demo hermes-ux-quality --summary`
- `git diff --check`
- Manual smoke:
  - `PYTHONPATH=tests uv run python -m omh.cli --help`
  - `PYTHONPATH=tests uv run python -m omh.cli chat --help`

## Risks and boundaries
- This is help/docs/test alignment only; it does not change routing decisions, adapter payload schemas, runtime evidence, or live Hermes rendering.
- Ledger/control-plane commands remain JSON-oriented where they are wrapper contracts rather than normal terminal UX.
