### PR TITLE
Guard risky refactor cleanup recommendations

### DIFF
--- a/src/routing/recommend.py
+++ b/src/routing/recommend.py
@@ -79,6 +79,17 @@ _COMMAND_TRIGGER_PATTERNS = {
     phrase: re.compile(rf"(?<![\w./-]){re.escape(phrase)}(?![\w./-])")
     for phrase in _COMMAND_TRIGGER_PHRASES
 }
+_RISKY_REFACTOR_GUARD_ID = "risky_refactor_before_cleanup"
+_RISKY_REFACTOR_FOLLOWUP_ONLY_SKILLS = frozenset({"ai-slop-cleaner"})
+_RISKY_REFACTOR_FOLLOWUP_SCORE_CAP = 7
+_RISKY_REFACTOR_FOLLOWUP_MATCHED = "guard:risky_refactor_followup_after_plan"
+_RISKY_REFACTOR_FOLLOWUP_WHY = (
+    "Follow-up only: use cleanup after a reviewed plan locks scope, risks, and verification."
+)
+_RISKY_REFACTOR_FOLLOWUP_GUIDANCE_PREFIX = (
+    "Treat this as a follow-up only after an accepted reviewed plan; do not present cleanup "
+    "as the first action for risk-marked refactoring language. "
+)
 
 
 @dataclass(frozen=True)
@@ -574,6 +585,7 @@ def _recommend_skills_cached(query: str, apply_guardrails: bool) -> tuple[Recomm
             matches,
             guards=guards,
         )
+        matches = _apply_guardrail_followup_boundaries(matches, guards)
         visual_guard_active = any(guard.id == "img_summary_before_materials_or_delivery" for guard in guards)
         if explicit_skill != "img-summary" and not visual_guard_active:
             matches = [recommendation for recommendation in matches if recommendation.skill != "img-summary"]
@@ -781,6 +793,32 @@ def _apply_guard_rules_to_recommendation(
                 why=guard.why,
             )
     return updated
+
+
+def _apply_guardrail_followup_boundaries(
+    recommendations: list[Recommendation],
+    guards: tuple[RoutingGuardRule, ...],
+) -> list[Recommendation]:
+    guard_ids = {guard.id for guard in guards}
+    if _RISKY_REFACTOR_GUARD_ID not in guard_ids:
+        return recommendations
+
+    return [_risky_refactor_followup_boundary(recommendation) for recommendation in recommendations]
+
+
+def _risky_refactor_followup_boundary(recommendation: Recommendation) -> Recommendation:
+    if recommendation.skill not in _RISKY_REFACTOR_FOLLOWUP_ONLY_SKILLS:
+        return recommendation
+
+    score = min(recommendation.score, _RISKY_REFACTOR_FOLLOWUP_SCORE_CAP)
+    return replace(
+        recommendation,
+        score=score,
+        confidence=_confidence(score),
+        matched=tuple(sorted({*recommendation.matched, _RISKY_REFACTOR_FOLLOWUP_MATCHED})),
+        why=_RISKY_REFACTOR_FOLLOWUP_WHY,
+        wrapper_guidance=_RISKY_REFACTOR_FOLLOWUP_GUIDANCE_PREFIX + recommendation.wrapper_guidance,
+    )
 
 
 def _tokens(value: str) -> set[str]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3290,6 +3290,28 @@ class CliTests(unittest.TestCase):
         cleanup = next(recommendation for recommendation in recommendations if recommendation["skill"] == "ai-slop-cleaner")
         self.assertEqual(cleanup["hermes_role"], "handoff-guide")
         self.assertIn("selected coding runtime", cleanup["handoff_policy"])
+        self.assertEqual(cleanup["confidence"], "medium")
+        self.assertLess(cleanup["score"], 8)
+        self.assertIn("guard:risky_refactor_followup_after_plan", cleanup["matched"])
+        self.assertIn("Follow-up only", cleanup["why"])
+        self.assertIn("after an accepted reviewed plan", cleanup["wrapper_guidance"])
+
+    def test_recommend_concrete_cleanup_refactor_still_uses_cleanup_workflow(self) -> None:
+        status, stdout, stderr = run_cli(
+            [
+                "recommend",
+                "remove duplicated router branches and lock behavior with regression tests before refactoring",
+                "--limit",
+                "3",
+            ]
+        )
+
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        recommendations = json.loads(stdout)["recommendations"]
+        self.assertEqual(recommendations[0]["skill"], "ai-slop-cleaner")
+        self.assertEqual(recommendations[0]["confidence"], "high")
+        self.assertNotIn("guard:risky_refactor_followup_after_plan", recommendations[0]["matched"])
 
     def test_recommend_implementation_plan_includes_planning_workflow(self) -> None:
         status, stdout, stderr = run_cli(["recommend", "implementation", "plan", "with", "review"])


### PR DESCRIPTION
## Summary

This PR tightens the `omh recommend` experience for risk-marked refactor requests.

When a user says something like `risky refactor`, OMH already routes the first workflow to `ralplan`, but the recommendation list still showed `ai-slop-cleaner` as another high-confidence candidate. That made the UX read like cleanup could be started immediately, even though the safer product contract is plan/review first and cleanup only after scope and verification are accepted.

## What changed

- Adds a recommendation post-guard boundary for `risky_refactor_before_cleanup`.
- Keeps `ralplan` as the high-confidence first workflow.
- Keeps `ai-slop-cleaner` visible as a useful follow-up, but caps it below high confidence and labels it as follow-up-only after an accepted reviewed plan.
- Preserves normal high-confidence cleanup recommendations for concrete behavior-locking cleanup prompts.
- Extends CLI tests for both paths.

## User impact

A Hermes/chat user asking about a risky refactor now sees the safer sequence:

1. prepare a reviewed plan first
2. accept the plan/scope and verification strategy
3. then use cleanup/coding handoff as a follow-up

This reduces accidental over-routing into a coding handoff while keeping the cleanup workflow discoverable.

## Verification

Observed locally:

- `PYTHONPATH=tests uv run python -m unittest tests.test_cli.CliTests.test_recommend_risky_refactor_includes_cleanup_workflow tests.test_cli.CliTests.test_recommend_concrete_cleanup_refactor_still_uses_cleanup_workflow tests.test_cli.CliTests.test_recommend_dangerous_refactor_routes_to_reviewed_plan_first tests.test_cli.CliTests.test_chat_route_dispatches_plain_chat_message tests.test_cli.CliTests.test_chat_route_summary_renders_operator_readable_route -v`
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` - 1006 tests passing
- `uv run python -m compileall -q src tests`
- `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check`
- `PYTHONPATH=tests uv run python -m omh.cli harness validate`
- `PYTHONPATH=tests uv run python -m omh.cli demo routing-precision --summary`
- `PYTHONPATH=tests uv run python -m omh.cli demo hermes-ux-quality --summary`
- `git diff --check`

Manual smoke:

- `omh recommend "risky refactor" --json` now returns `ralplan high` first and `ai-slop-cleaner medium` as follow-up-only.
- Concrete cleanup prompt still returns `ai-slop-cleaner high`.

## Risks / rollout notes

- No schema or command changes.
- No LLM, API, network, Hermes core, or platform transport changes.
- Live Hermes rendering and platform delivery are not proven by this PR; this only proves deterministic local routing/recommendation contracts.
