### PR TITLE
Speed up clear operator routing paths

### DIFF
--- a/src/routing/chat.py
+++ b/src/routing/chat.py
@@ -895,6 +895,14 @@ def _route_chat_message_cached(
     )
     if fast_agent_ops_status_decision is not None:
         return fast_agent_ops_status_decision.to_dict()
+    fast_operator_surface_decision = _operator_surface_fast_path_decision(
+        message,
+        routing_message=routing_message,
+        source=source,
+        min_confidence=min_confidence,
+    )
+    if fast_operator_surface_decision is not None:
+        return fast_operator_surface_decision.to_dict()
     fast_direct_answer_decision = _direct_answer_fast_path_decision(
         message,
         routing_message=routing_message,
@@ -1384,6 +1392,125 @@ def _agent_ops_status_fast_path_match(message: str) -> str | None:
     if compact in _AGENT_OPS_STATUS_FAST_PATH_COMPACT_PHRASES:
         return compact
     return None
+
+
+_OPERATOR_SURFACE_FAST_PATH_RULES: tuple[tuple[str, tuple[str, ...], str, str], ...] = (
+    (
+        "img-summary",
+        (
+            "make a thumbnail",
+            "create a thumbnail",
+            "generate a thumbnail",
+            "thumbnail card",
+            "release thumbnail",
+            "썸네일 만들어줘",
+            "썸네일 생성해줘",
+            "썸네일로 만들어줘",
+            "릴리즈 노트 썸네일",
+        ),
+        "operator_surface_fast_path:visual",
+        "Clear thumbnail or release-thumbnail request; prepare the image prompt-card workflow without scoring every workflow.",
+    ),
+    (
+        "source-finder",
+        (
+            "find arxiv link",
+            "find arxiv paper",
+            "arxiv link",
+            "arxiv 링크 찾아",
+            "arxiv 링크 찾아서",
+        ),
+        "operator_surface_fast_path:source",
+        "Clear source-acquisition request; scope source candidates before explanation or downstream work.",
+    ),
+    (
+        "automation-blueprint",
+        (
+            "automate this",
+            "automate workflow",
+            "자동화해줘",
+            "자동화 해줘",
+            "자동화하는 흐름",
+        ),
+        "operator_surface_fast_path:automation",
+        "Clear automation request; prepare the scheduled-ops blueprint without scoring every workflow.",
+    ),
+)
+
+
+def _operator_surface_fast_path_decision(
+    message: str,
+    *,
+    routing_message: str,
+    source: str,
+    min_confidence: str,
+) -> ChatRouteDecision | None:
+    if _has_explicit_invocation_prefix(routing_message):
+        return None
+    if explicit_skill_invocation(routing_message):
+        return None
+    match = _operator_surface_fast_path_match(routing_message)
+    if match is None:
+        return None
+    selected_skill, phrase, marker, reason = match
+    selected_harness = primary_harness_for_skill(selected_skill)
+    definition = _skill_definition_by_name(selected_skill)
+    recommendation = recommendation_for_definition(
+        definition,
+        message,
+        matched=(marker, f"phrase:{phrase}"),
+        score=13,
+        why=reason,
+    )
+    return ChatRouteDecision(
+        schema_version=1,
+        source=source,
+        action="dispatch",
+        selected_skill=selected_skill,
+        selected_harness=selected_harness,
+        candidate_skill=selected_skill,
+        candidate_harness=selected_harness,
+        confidence="high",
+        score=13,
+        threshold=min_confidence,
+        explicit=False,
+        ambiguous=False,
+        reason=reason,
+        clarification="",
+        routing_prompt=_routing_prompt("dispatch", selected_skill, selected_skill, reason, message),
+        task_card=None,
+        workflow_route_plan=None,
+        learning_candidate_card=None,
+        recommendations=(recommendation,),
+    )
+
+
+def _operator_surface_fast_path_match(message: str) -> tuple[str, str, str, str] | None:
+    text = _fast_path_text(message)
+    compact = _fast_path_compact(text)
+    for skill, phrase, normalized_phrase, normalized_compact, marker, reason in _operator_surface_fast_path_patterns():
+        if normalized_phrase in text or (normalized_compact and normalized_compact in compact):
+            return skill, phrase, marker, reason
+    return None
+
+
+@lru_cache(maxsize=1)
+def _operator_surface_fast_path_patterns() -> tuple[tuple[str, str, str, str, str, str], ...]:
+    patterns: list[tuple[str, str, str, str, str, str]] = []
+    for skill, phrases, marker, reason in _OPERATOR_SURFACE_FAST_PATH_RULES:
+        for phrase in phrases:
+            normalized_phrase = _fast_path_text(phrase)
+            if normalized_phrase:
+                patterns.append((skill, phrase, normalized_phrase, _fast_path_compact(normalized_phrase), marker, reason))
+    return tuple(patterns)
+
+
+def _fast_path_text(value: str) -> str:
+    return re.sub(r"\s+", " ", unicodedata.normalize("NFC", value).strip().lower().strip(" \t\r\n.!?,;:~…？"))
+
+
+def _fast_path_compact(value: str) -> str:
+    return re.sub(r"[\s\?\!\.,;:~…？]+", "", value)
 
 
 def _direct_answer_fast_path_decision(

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -918,6 +918,24 @@ class EfficiencyContractTests(unittest.TestCase):
         self.assertEqual(cache_info.misses, 1)
         self.assertGreaterEqual(cache_info.hits, 1)
 
+    def test_operator_surface_fast_paths_skip_full_recommendation_scan(self) -> None:
+        chat_module._route_chat_message_cached.cache_clear()
+        cases = (
+            ("릴리즈 노트 썸네일로 만들어줘", "img-summary"),
+            ("arxiv 링크 찾아서 쉽게 설명해줘", "source-finder"),
+            ("오늘 아침 경쟁사 뉴스 요약 자동화해줘", "automation-blueprint"),
+        )
+
+        with patch.object(chat_module, "recommend_skills", side_effect=AssertionError("fast path should skip scoring")):
+            for message, expected_skill in cases:
+                with self.subTest(message=message):
+                    decision = chat_module.route_chat_message(message, source="discord")
+
+                    self.assertEqual(decision["selected_skill"], expected_skill)
+                    self.assertEqual(decision["action"], "dispatch")
+                    self.assertEqual(decision["confidence"], "high")
+                    self.assertIn("operator_surface_fast_path", decision["recommendations"][0]["matched"][0])
+
     def test_public_chat_route_payload_cache_is_reused_without_payload_poisoning(self) -> None:
         chat_module._route_chat_message_cached.cache_clear()
         chat_module._public_chat_route_payload_cached.cache_clear()


### PR DESCRIPTION
## Feature Report

### What Changed

- Added a deterministic operator fast path for clear chat requests that should immediately route to `img-summary`, `source-finder`, or `automation-blueprint`.
- Added an efficiency regression test that proves these fast-path requests do not call the full workflow recommendation scan.

### Why This Exists

- Short Hermes chat requests like "릴리즈 노트 썸네일로 만들어줘", "arxiv 링크 찾아서 쉽게 설명해줘", and "오늘 아침 경쟁사 뉴스 요약 자동화해줘" should feel immediate.
- Before this change, these clear operator-surface requests could still pay the broader catalog scoring cost. The most visible local case was thumbnail routing at about 7.35 ms on a cold first hit.

### User / Operator Impact

- Hermes wrappers can route common thumbnail, source-acquisition, and automation-intent prompts faster while preserving deterministic behavior.
- The selected workflow is still explicit and conservative: `img-summary`, `source-finder`, or `automation-blueprint`.
- This does not claim image generation, source retrieval, scheduler creation, platform delivery, execution, review, CI, or merge evidence.

### How It Works

- `src/routing/chat.py` now checks a narrow cached phrase table after the existing agent-ops status fast path and before the direct-answer/full recommendation paths.
- Explicit skill invocations still take precedence; the fast path only applies to non-explicit natural-language operator requests.
- Fast-path recommendations carry `operator_surface_fast_path:*` matched markers so wrappers and tests can identify why the route was selected.

### Files And Contracts Touched

- `src/routing/chat.py`: operator-surface fast-path decision, cached normalized patterns, and compact matching helpers.
- `tests/test_efficiency.py`: regression coverage that patches `recommend_skills` to fail if the fast path accidentally falls back to full scoring.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` (`Ran 1008 tests in 21.065s OK`)
- [x] `uv run python -m compileall -q src tests`
- [x] `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check` (`ok`, tap skills checked `49/49`)
- [x] `PYTHONPATH=tests uv run python -m omh.cli harness validate` (`ok`, `36` harnesses, `50` skills)
- [ ] `python3 -m omh.cli release checklist --json` (not run; no release checklist or packaging surface changed)
- [ ] `python3 -m omh.cli release hermes-smoke` (not run; no install/live Hermes surface changed)
- [ ] `omh --help` (not run; no CLI help surface changed)
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` (not run; no install path changed)
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable
- [x] Relevant dry-run or smoke command: `PYTHONPATH=tests uv run python -m omh.cli demo hermes-ux-quality --summary` (`Status: passed (100/100)`, route hint `129/129`, routing precision `39/39` negative controls and `52/52` interventions)
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; this is deterministic backend routing only.

Additional timing evidence from local route calls:

- Baseline before this fast path: thumbnail first hit about `7.352ms`; source first hit about `0.970ms`; status fast path about `0.187ms`.
- After cached fast-path patterns: thumbnail first hit about `0.372ms`; source first hit about `0.079ms`; automation first hit about `0.107ms`.

## Risk

- Main risk is over-routing short prompts. Mitigation: the phrase list is intentionally narrow, explicit invocations still win, and the full routing precision gate stayed green.

## Compatibility / Rollout

- Backward compatible. The returned chat route payload shape is unchanged.
- Existing explicit skill and direct-answer routing behavior remains intact.

## Release / Claims

- [x] Release-channel impact considered (`local` routing optimization only)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- Add more operator fast paths only after routing precision examples prove they do not over-route ordinary direct-answer questions.
