### PR TITLE
Tighten direct answer and PR status routing

### DIFF
--- a/src/routing/chat.py
+++ b/src/routing/chat.py
@@ -280,6 +280,10 @@ _AGENT_OPS_STATUS_FAST_PATH_EXACT_PHRASES = (
     "what is going on rn",
     "what are you working on",
     "what was i working on",
+    "what is the current pr status",
+    "what is current pr status",
+    "current pr status",
+    "pr status update",
     "show session status",
     "show me the session status",
     "where are we",
@@ -321,6 +325,10 @@ _AGENT_OPS_STATUS_FAST_PATH_COMPACT_PHRASES = (
     "현재작업뭐야",
     "현재세션상태",
     "세션상태보여줘",
+    "pr상태알려줘",
+    "현재pr상태",
+    "pr진행상황",
+    "pr어디까지됐어",
     "내가뭘하고있었는지알려줘",
     "뭘하고있었는지알려줘",
     "현재진행상황",
@@ -2091,6 +2099,8 @@ def _is_direct_answer_concept_question(text: str, direct_text: str) -> bool:
     stripped = direct_text.strip(" \t\r\n.!?¿¡。！？")
     if any(stripped.startswith(marker) for marker in _DIRECT_ANSWER_MULTILINGUAL_CONTEXT_QUESTIONS):
         return False
+    if _is_what_means_concept_question(direct_text):
+        return True
     has_concept_keyword = _contains_concept_keyword(direct_text)
     if any(direct_text.startswith(starter) for starter in _DIRECT_ANSWER_CONCEPT_STARTERS):
         return has_concept_keyword or _is_short_generic_concept_question(direct_text)
@@ -2110,6 +2120,20 @@ def _is_direct_answer_concept_question(text: str, direct_text: str) -> bool:
         return has_concept_keyword or _is_short_generic_korean_concept_question(direct_text)
     if any(marker in direct_text for marker in _DIRECT_ANSWER_MULTILINGUAL_EXPLAIN_MARKERS):
         return _is_short_generic_multilingual_concept_question(direct_text)
+    return False
+
+
+def _is_what_means_concept_question(text: str) -> bool:
+    stripped = text.strip(" \t\r\n.!?¿¡。！？")
+    if not stripped.startswith("what "):
+        return False
+    for suffix in (" means", " mean"):
+        if stripped.endswith(suffix):
+            subject = stripped[len("what ") : -len(suffix)].strip(" \t\r\n.!?¿¡。！？")
+            if not subject:
+                return False
+            words = _word_tokens(subject)
+            return 1 <= len(words) <= _DIRECT_ANSWER_GENERIC_CONCEPT_MAX_WORDS
     return False
 
 

--- a/tests/test_chat_router.py
+++ b/tests/test_chat_router.py
@@ -378,6 +378,7 @@ class ChatRouterTests(unittest.TestCase):
 
         for message in (
             "just explain Python virtualenv",
+            "what Python list comprehension means?",
             "how do I create a virtualenv in Python?",
             "what is a loop in Python?",
             "strategy pattern 설명해줘",
@@ -448,6 +449,8 @@ class ChatRouterTests(unittest.TestCase):
             "what are you doing now",
             "show session status",
             "what is going on rn",
+            "what is the current PR status?",
+            "PR 상태 알려줘",
             "status update please",
             "今何してる？",
             "现在在做什么？",


### PR DESCRIPTION
## Feature Report

### What Changed

- Added a narrow direct-answer fast path for `what <short concept> means/mean` questions.
- Added PR-status phrases to the existing agent-ops status fast path in English and Korean.
- Extended chat-router regression coverage so these turns skip full recommendation scoring and keep workflow blockers intact.

### Why This Exists

- Some ordinary explanation questions were eventually answered directly, but only after the full workflow recommendation scan. The clearest local example was `what Python list comprehension means?`.
- Some status turns such as `what is the current PR status?` were correctly prevented from becoming direct answers, but still fell into the slower clarify/scoring path instead of opening the status workflow.
- These are common chat shapes; they should feel immediate without weakening OMH's workflow boundaries.

### User / Operator Impact

- A plain concept question like `what Python list comprehension means?` now stays in direct chat response through the fast path.
- `what is the current PR status?` and `PR 상태 알려줘` now route directly to `agent-ops-review`, which is the workflow that can show prepared/observed status boundaries.
- Workflow, coding, PR, repo, file, image, paper, and OMH-specific blockers remain guarded from the direct-answer path.

### How It Works

- `src/routing/chat.py` adds `_is_what_means_concept_question()` under the existing direct-answer concept classifier.
- The new grammar only accepts `what ... means/mean` when the subject is short and the existing hard blockers have already been checked.
- The agent-ops fast-path phrase tables now include PR-status forms, so clear progress/status questions avoid the full scorer.

### Files And Contracts Touched

- `src/routing/chat.py`: direct-answer concept grammar and agent-ops status fast-path phrases.
- `tests/test_chat_router.py`: regression cases for fast direct answer and PR status routing.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` (`Ran 1008 tests in 21.138s OK`)
- [x] `uv run python -m compileall -q src tests`
- [x] `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check` (`ok`, tap skills checked `49/49`)
- [x] `PYTHONPATH=tests uv run python -m omh.cli harness validate` (`ok`, `36` harnesses, `50` skills)
- [ ] `python3 -m omh.cli release checklist --json` (not run; no release checklist or packaging surface changed)
- [ ] `python3 -m omh.cli release hermes-smoke` (not run; no install/live Hermes surface changed)
- [ ] `omh --help` (not run; no CLI help surface changed)
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` (not run; no install path changed)
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable
- [x] Relevant dry-run or smoke command: `PYTHONPATH=tests uv run python -m omh.cli demo routing-precision --summary` (`39/39` negative controls, `52/52` interventions, `0` overroutes, `0` missed interventions)
- [x] Relevant dry-run or smoke command: `PYTHONPATH=tests uv run python -m omh.cli demo hermes-ux-quality --summary` (`Status: passed (100/100)`)
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; this is deterministic backend routing only.

Local timing evidence from route calls with a cleared route cache:

- `what Python list comprehension means?`: `0.254ms`, `fallback`, `direct_answer_fast_path`.
- `what is the current PR status?`: `0.047ms`, `dispatch`, `agent-ops-review`, `agent_ops_status_fast_path`.
- `PR 상태 알려줘`: `0.047ms`, `dispatch`, `agent-ops-review`, `agent_ops_status_fast_path`.

## Risk

- Main risk is over-routing broader `what` questions. Mitigation: the new direct-answer grammar is limited to short `what ... means/mean` forms and still runs after the existing concept hard blockers.
- Main risk for PR status phrases is conflating runtime evidence with prose. Mitigation: the route opens `agent-ops-review` only; it does not claim PR, CI, review, merge, or executor evidence.

## Compatibility / Rollout

- Backward compatible. The route payload schema is unchanged.
- Existing explicit skill invocations, file lookup routing, and workflow dispatch remain intact.

## Release / Claims

- [x] Release-channel impact considered (`local` routing optimization only)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- Continue adding fast paths only for narrow, measured chat forms that stay green under routing precision and Hermes UX quality gates.
