### PR TITLE
Open workflow picker for generic catalog questions

### DIFF
--- a/src/routing/chat.py
+++ b/src/routing/chat.py
@@ -162,6 +162,9 @@ _GENERIC_CATALOG_COLLECTION_MARKERS = (
     "워크플로",
     "워크플로우",
 )
+_GENERIC_PICKER_COLLECTION_MARKERS = tuple(
+    marker for marker in _GENERIC_CATALOG_COLLECTION_MARKERS if marker != "기능"
+)
 _GENERIC_CATALOG_LISTING_MARKERS = (
     "available",
     "installed",
@@ -179,6 +182,21 @@ _GENERIC_CATALOG_LISTING_MARKERS = (
     "목록",
     "리스트",
     "할 수 있는",
+)
+_GENERIC_OMH_CAPABILITY_LISTING_MARKERS = (
+    "what can omh do",
+    "what can oh-my-hermes do",
+    "what does omh do",
+    "what does oh-my-hermes do",
+    "how can omh help",
+    "how can oh-my-hermes help",
+    "omh 뭐 할 수",
+    "omh 무엇을 할 수",
+    "omh가 뭐 해",
+    "omh가 무엇을 해",
+    "omh는 뭐 해",
+    "omh는 무엇을 해",
+    "omh 기능 뭐",
 )
 _SPECIFIC_CAPABILITY_ALIAS_PHRASES = (
     "workflow learning",
@@ -1711,8 +1729,9 @@ def _generic_omh_catalog_question(message: str) -> bool:
     text = message.strip().lower()
     if _is_broad_capability_catalog_question(text):
         return True
-    if not any(marker in text for marker in ("omh", "oh-my-hermes", "oh my hermes")):
-        return False
+    has_omh_context = any(marker in text for marker in ("omh", "oh-my-hermes", "oh my hermes"))
+    if not has_omh_context:
+        return _generic_catalog_listing_question(text)
     if any(marker in text for marker in ("picker", "menu", "workflow picker", "skill picker")):
         return True
     named_hits = len(_specific_capability_named_hits(text))
@@ -1720,9 +1739,29 @@ def _generic_omh_catalog_question(message: str) -> bool:
         return False
     if any(phrase in text for phrase in _SPECIFIC_CAPABILITY_ALIAS_PHRASES):
         return False
-    has_collection = any(marker in text for marker in _GENERIC_CATALOG_COLLECTION_MARKERS)
+    if _is_specific_capability_question_shape(text):
+        return False
+    if any(marker in text for marker in _GENERIC_OMH_CAPABILITY_LISTING_MARKERS):
+        return True
+    return _generic_catalog_listing_question(text)
+
+
+def _generic_catalog_listing_question(text: str) -> bool:
+    has_collection = any(marker in text for marker in _GENERIC_PICKER_COLLECTION_MARKERS)
     has_listing_intent = any(marker in text for marker in _GENERIC_CATALOG_LISTING_MARKERS)
     return has_collection and has_listing_intent
+
+
+def _is_specific_capability_question_shape(text: str) -> bool:
+    return any(
+        marker in text
+        for marker in (
+            "what can omh do for ",
+            "what can oh-my-hermes do for ",
+            "can omh help with ",
+            "can oh-my-hermes help with ",
+        )
+    )
 
 
 def _router_picker_recommendation(query: str, *, matched: tuple[str, ...], score: int) -> dict[str, object]:

--- a/tests/test_chat_router.py
+++ b/tests/test_chat_router.py
@@ -1221,6 +1221,37 @@ class ChatRouterTests(unittest.TestCase):
         self.assertNotIn("review", explanation["not_evidence_yet"])
         self.assertNotIn("CI", explanation["not_evidence_yet"])
 
+    def test_generic_catalog_questions_use_picker_fast_path_without_full_scoring(self) -> None:
+        chat_router_impl._route_chat_message_cached.cache_clear()
+        chat_router_impl._public_chat_route_payload_cached.cache_clear()
+
+        for message in (
+            "what workflows are available?",
+            "what skills are available?",
+            "show workflows",
+            "omh 뭐 할 수 있어?",
+        ):
+            with self.subTest(message=message), mock.patch.object(
+                chat_router_impl,
+                "recommend_skills",
+                side_effect=AssertionError("generic catalog questions should use the picker fast path"),
+            ), mock.patch.object(
+                chat_router_impl,
+                "build_workflow_route_plan",
+                side_effect=AssertionError("generic catalog picker should not build a route plan"),
+            ):
+                decision = route_chat_message(message, source="discord")
+
+            self.assertEqual(decision["action"], "dispatch")
+            self.assertEqual(decision["selected_skill"], "oh-my-hermes")
+            self.assertEqual(decision["selected_harness"], primary_harness_for_skill("oh-my-hermes"))
+            self.assertEqual(decision["confidence"], "high")
+            self.assertEqual(decision["recommendations"][0]["next_action"], "choose_skill")
+            self.assertEqual(decision["recommendations"][0]["matched"], ["catalog_question"])
+            public = public_route_payload(decision)
+            self.assertNotIn("workflow_route_plan", public)
+            self.assertEqual(public["route_explanation"]["next_action"], "choose_skill")
+
     def test_exact_capability_cards_use_concrete_not_evidence_labels(self) -> None:
         cases = {
             "meeting-brief": (

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -947,6 +947,30 @@ class EfficiencyContractTests(unittest.TestCase):
                         )
                     )
 
+    def test_generic_catalog_fast_paths_skip_full_recommendation_scan(self) -> None:
+        chat_module._route_chat_message_cached.cache_clear()
+        cases = (
+            "what workflows are available?",
+            "what skills are available?",
+            "show workflows",
+            "omh 뭐 할 수 있어?",
+        )
+
+        with patch.object(
+            chat_module,
+            "recommend_skills",
+            side_effect=AssertionError("catalog fast path should skip scoring"),
+        ):
+            for message in cases:
+                with self.subTest(message=message):
+                    decision = chat_module.route_chat_message(message, source="discord")
+
+                    self.assertEqual(decision["selected_skill"], "oh-my-hermes")
+                    self.assertEqual(decision["action"], "dispatch")
+                    self.assertEqual(decision["confidence"], "high")
+                    self.assertEqual(decision["recommendations"][0]["matched"], ["catalog_question"])
+                    self.assertEqual(decision["recommendations"][0]["next_action"], "choose_skill")
+
     def test_public_chat_route_payload_cache_is_reused_without_payload_poisoning(self) -> None:
         chat_module._route_chat_message_cached.cache_clear()
         chat_module._public_chat_route_payload_cached.cache_clear()


### PR DESCRIPTION
## Summary
- Route generic workflow inventory questions such as "what workflows are available?", "what skills are available?", "show workflows", and "omh 뭐 할 수 있어?" directly to the OMH workflow picker.
- Keep specific capability questions such as papers, source finding, workflow learning, and image generation on their dedicated workflow cards.
- Add chat-router and efficiency regression tests that block full recommendation scoring for generic catalog questions.

## Why
When a user asks Hermes what OMH workflows or skills are available, the chat surface should render the picker directly instead of falling through to low-confidence workflow scoring or requiring shell approval. This supports the chat-first product direction while keeping specific workflow discovery precise.

## What Changes For Users
- "what workflows are available?" now opens the OMH picker path immediately.
- "omh 뭐 할 수 있어?" now opens the same picker without running `omh list` through a terminal.
- "what can OMH do for papers?", "what can OMH do for source finding?", and "이미지 생성 기능 뭐 있어?" still show paper/source/image workflow-specific guidance instead of a generic catalog card.

## Implementation Notes
- `src/routing/chat.py` separates generic picker inventory phrases from broad "feature" phrases so domain-specific capability questions do not get swallowed.
- `tests/test_chat_router.py` adds a no-full-scoring picker fast-path regression.
- `tests/test_efficiency.py` adds a matching efficiency contract.

## Verification
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` passed: 1010 tests.
- `uv run python -m compileall -q src tests` passed.
- `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check` passed: 49/49 workflows checked.
- `PYTHONPATH=tests uv run python -m omh.cli harness validate` passed: 36 harnesses, 50 skills, no errors or warnings.
- `PYTHONPATH=tests uv run python -m omh.cli demo routing-precision --summary` passed: 41/41 negative controls, 52/52 interventions.
- `PYTHONPATH=tests uv run python -m omh.cli demo hermes-ux-quality --summary` passed: 100/100, routing average 10.0.
- `git diff --check` passed.

## Risks And Boundaries
- Live Hermes chat rendering and messenger-native autocomplete were not exercised.
- This only prepares deterministic routing/picker metadata; it does not prove platform rendering, plugin load, execution, source retrieval, image generation, review, CI, or delivery evidence.