### PR TITLE
Speed up specific capability catalog questions

### DIFF
--- a/src/routing/chat.py
+++ b/src/routing/chat.py
@@ -213,6 +213,60 @@ _SPECIFIC_CAPABILITY_ALIAS_PHRASES = (
     "executors",
     "runtimes",
 )
+_SPECIFIC_CAPABILITY_FAST_ALIASES: tuple[tuple[str, tuple[str, ...]], ...] = (
+    (
+        "paper-learning",
+        (
+            "papers",
+            "paper pdf",
+            "paper pdfs",
+            "pdf papers",
+            "paper explanation",
+            "paper learning",
+        ),
+    ),
+    (
+        "source-finder",
+        (
+            "source finding",
+            "source acquisition",
+            "source candidates",
+            "datasets",
+            "dataset search",
+            "github repos",
+            "github repositories",
+            "github oss repos",
+            "public presentations",
+        ),
+    ),
+    (
+        "workflow-learning",
+        (
+            "workflow learning",
+            "learning trace",
+            "skill patch",
+            "routing regression",
+        ),
+    ),
+    (
+        "gateway-intent-card",
+        (
+            "discord gateway routing",
+            "gateway routing",
+            "message routing",
+            "platform routing",
+        ),
+    ),
+    (
+        "executor-runtime-readiness",
+        (
+            "coding agents",
+            "coding agent",
+            "executors",
+            "runtimes",
+        ),
+    ),
+)
 _DIRECT_ANSWER_STARTERS = (
     "what ",
     "what's ",
@@ -1224,41 +1278,26 @@ def _catalog_fast_path_decision(
         else None
     )
     if exact_skill is not None:
-        definition = _skill_definition_by_name(exact_skill)
-        recommendation = recommendation_for_definition(
-            definition,
-            message,
+        return _specific_capability_fast_path_result(
+            skill=exact_skill,
+            message=message,
+            source=source,
+            min_confidence=min_confidence,
             matched=("catalog_question", f"name:{exact_skill}"),
             score=12,
             why=f"Matched exact OMH capability `{exact_skill}` from catalog metadata.",
+            catalog_question=catalog_question,
         )
-        reason = (
-            f"Specific OMH capability question matched `{exact_skill}`; "
-            "show that workflow card instead of the generic workflow picker."
-        )
-        selected_harness = primary_harness_for_skill(exact_skill)
-        return _CatalogFastPathResult(
-            decision=ChatRouteDecision(
-                schema_version=1,
-                source=source,
-                action="dispatch",
-                selected_skill=exact_skill,
-                selected_harness=selected_harness,
-                candidate_skill=exact_skill,
-                candidate_harness=selected_harness,
-                confidence="high",
-                score=12,
-                threshold=min_confidence,
-                explicit=False,
-                ambiguous=False,
-                reason=reason,
-                clarification="",
-                routing_prompt=_routing_prompt("dispatch", exact_skill, exact_skill, reason, message),
-                task_card=None,
-                workflow_route_plan=None,
-                learning_candidate_card=None,
-                recommendations=(recommendation,),
-            ),
+    alias_skill, alias_label = _specific_capability_alias_hit(routing_message)
+    if catalog_question and alias_skill and not _is_broad_capability_catalog_question(routing_message):
+        return _specific_capability_fast_path_result(
+            skill=alias_skill,
+            message=message,
+            source=source,
+            min_confidence=min_confidence,
+            matched=("catalog_question", f"alias:{alias_label}"),
+            score=11,
+            why=f"Matched OMH capability alias `{alias_label}` from catalog metadata.",
             catalog_question=catalog_question,
         )
     catalog_picker = (
@@ -1307,6 +1346,56 @@ def _catalog_fast_path_decision(
 def _direct_picker_alias(message: str) -> bool:
     compact = message.strip().lower().strip(" \t\r\n.!?,;:")
     return compact in _DIRECT_PICKER_ALIASES
+
+
+def _specific_capability_fast_path_result(
+    *,
+    skill: str,
+    message: str,
+    source: str,
+    min_confidence: str,
+    matched: tuple[str, ...],
+    score: int,
+    why: str,
+    catalog_question: bool,
+) -> _CatalogFastPathResult:
+    definition = _skill_definition_by_name(skill)
+    recommendation = recommendation_for_definition(
+        definition,
+        message,
+        matched=matched,
+        score=score,
+        why=why,
+    )
+    reason = (
+        f"Specific OMH capability question matched `{skill}`; "
+        "show that workflow card instead of the generic workflow picker."
+    )
+    selected_harness = primary_harness_for_skill(skill)
+    return _CatalogFastPathResult(
+        decision=ChatRouteDecision(
+            schema_version=1,
+            source=source,
+            action="dispatch",
+            selected_skill=skill,
+            selected_harness=selected_harness,
+            candidate_skill=skill,
+            candidate_harness=selected_harness,
+            confidence="high",
+            score=score,
+            threshold=min_confidence,
+            explicit=False,
+            ambiguous=False,
+            reason=reason,
+            clarification="",
+            routing_prompt=_routing_prompt("dispatch", skill, skill, reason, message),
+            task_card=None,
+            workflow_route_plan=None,
+            learning_candidate_card=None,
+            recommendations=(recommendation,),
+        ),
+        catalog_question=catalog_question,
+    )
 
 
 def _file_lookup_fast_path_decision(
@@ -2078,6 +2167,48 @@ def _specific_capability_named_hits(message: str) -> tuple[str, ...]:
             selected.append(skill)
         selected_ranges.append((start, end))
     return tuple(selected)
+
+
+@lru_cache(maxsize=2048)
+def _specific_capability_alias_hit(message: str) -> tuple[str, str]:
+    text = message.strip().lower()
+    if not _is_specific_capability_question_shape(text):
+        return ("", "")
+    named_hits = _specific_capability_named_hits(text)
+    if len(named_hits) == 1:
+        return (named_hits[0], named_hits[0])
+
+    hits: list[tuple[int, int, int, str, str]] = []
+    for phrase in _specific_capability_alias_phrase_map():
+        for start, end in _specific_capability_phrase_matches(text, phrase):
+            hits.append((start, end, len(phrase.phrase), phrase.skill, phrase.phrase))
+    if not hits:
+        return ("", "")
+
+    ordered = sorted(hits, key=lambda item: (-(item[2]), item[0], item[3]))
+    first_skill = ordered[0][3]
+    first_alias = ordered[0][4]
+    if any(
+        skill != first_skill and start == ordered[0][0] and end == ordered[0][1]
+        for start, end, _size, skill, _alias in ordered[1:]
+    ):
+        return ("", "")
+    return (first_skill, first_alias)
+
+
+@lru_cache(maxsize=1)
+def _specific_capability_alias_phrase_map() -> tuple[_SpecificCapabilityPhrase, ...]:
+    entries: list[_SpecificCapabilityPhrase] = []
+    for skill, aliases in _SPECIFIC_CAPABILITY_FAST_ALIASES:
+        for alias in aliases:
+            entries.append(
+                _SpecificCapabilityPhrase(
+                    skill=skill,
+                    phrase=alias,
+                    pattern=_compile_specific_capability_phrase(alias),
+                )
+            )
+    return tuple(entries)
 
 
 @lru_cache(maxsize=2048)

--- a/tests/test_chat_router.py
+++ b/tests/test_chat_router.py
@@ -1221,6 +1221,46 @@ class ChatRouterTests(unittest.TestCase):
         self.assertNotIn("review", explanation["not_evidence_yet"])
         self.assertNotIn("CI", explanation["not_evidence_yet"])
 
+    def test_specific_capability_alias_questions_use_fast_path_without_full_scoring(self) -> None:
+        chat_router_impl._route_chat_message_cached.cache_clear()
+        chat_router_impl._public_chat_route_payload_cached.cache_clear()
+        cases = (
+            ("what can OMH do for papers?", "paper-learning", "prepare_paper_learning"),
+            ("what can OMH do for PDF papers?", "paper-learning", "prepare_paper_learning"),
+            ("what can OMH do for source finding?", "source-finder", "prepare_source_finder_plan"),
+            ("what can OMH do for datasets?", "source-finder", "prepare_source_finder_plan"),
+            ("what can OMH do for GitHub repos?", "source-finder", "prepare_source_finder_plan"),
+            ("what can OMH do for workflow learning?", "workflow-learning", "audit_learning_readiness"),
+            ("what can OMH do for Discord gateway routing?", "gateway-intent-card", "prepare_gateway_intent_card"),
+            ("what can OMH do for coding agents?", "executor-runtime-readiness", "prepare_executor_runtime_readiness"),
+            ("what can OMH do for deploy and monitor?", "deploy-and-monitor", "prepare_deploy_monitor_plan"),
+            ("what can OMH do for CTO loop?", "cto-loop", "run_cto_loop"),
+        )
+
+        with mock.patch.object(
+            chat_router_impl,
+            "recommend_skills",
+            side_effect=AssertionError("specific capability aliases should use the catalog fast path"),
+        ), mock.patch.object(
+            chat_router_impl,
+            "build_workflow_route_plan",
+            side_effect=AssertionError("specific capability aliases should render a card, not a route plan"),
+        ):
+            for message, expected_skill, expected_action in cases:
+                with self.subTest(message=message):
+                    decision = route_chat_message(message, source="discord")
+
+                self.assertEqual(decision["action"], "dispatch")
+                self.assertEqual(decision["selected_skill"], expected_skill)
+                self.assertEqual(decision["confidence"], "high")
+                self.assertEqual(decision["recommendations"][0]["next_action"], expected_action)
+                self.assertIn("catalog_question", decision["recommendations"][0]["matched"])
+                self.assertTrue(
+                    any(str(item).startswith(("alias:", "name:")) for item in decision["recommendations"][0]["matched"])
+                )
+                public = public_route_payload(decision)
+                self.assertNotIn("workflow_route_plan", public)
+
     def test_generic_catalog_questions_use_picker_fast_path_without_full_scoring(self) -> None:
         chat_router_impl._route_chat_message_cached.cache_clear()
         chat_router_impl._public_chat_route_payload_cached.cache_clear()

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -971,6 +971,36 @@ class EfficiencyContractTests(unittest.TestCase):
                     self.assertEqual(decision["recommendations"][0]["matched"], ["catalog_question"])
                     self.assertEqual(decision["recommendations"][0]["next_action"], "choose_skill")
 
+    def test_specific_capability_catalog_fast_paths_skip_full_recommendation_scan(self) -> None:
+        chat_module._route_chat_message_cached.cache_clear()
+        cases = (
+            ("what can OMH do for papers?", "paper-learning"),
+            ("what can OMH do for source finding?", "source-finder"),
+            ("what can OMH do for workflow learning?", "workflow-learning"),
+            ("what can OMH do for Discord gateway routing?", "gateway-intent-card"),
+            ("what can OMH do for coding agents?", "executor-runtime-readiness"),
+        )
+
+        with patch.object(
+            chat_module,
+            "recommend_skills",
+            side_effect=AssertionError("specific catalog fast path should skip scoring"),
+        ):
+            for message, expected_skill in cases:
+                with self.subTest(message=message):
+                    decision = chat_module.route_chat_message(message, source="discord")
+
+                    self.assertEqual(decision["selected_skill"], expected_skill)
+                    self.assertEqual(decision["action"], "dispatch")
+                    self.assertEqual(decision["confidence"], "high")
+                    self.assertIn("catalog_question", decision["recommendations"][0]["matched"])
+                    self.assertTrue(
+                        any(
+                            str(item).startswith(("alias:", "name:"))
+                            for item in decision["recommendations"][0]["matched"]
+                        )
+                    )
+
     def test_public_chat_route_payload_cache_is_reused_without_payload_poisoning(self) -> None:
         chat_module._route_chat_message_cached.cache_clear()
         chat_module._public_chat_route_payload_cached.cache_clear()


### PR DESCRIPTION
## Feature Report

### What Changed

- Added curated catalog fast paths for specific OMH capability questions such as papers, PDF papers, source finding, datasets, GitHub repos, workflow learning, Discord gateway routing, and coding agents.
- Reused the exact-skill catalog fast path through a shared helper so exact names like `deploy-and-monitor` and `cto-loop` still render their dedicated workflow cards.
- Added regression and efficiency tests that fail if those specific questions fall back to full recommendation scoring or multi-workflow route-plan construction.

### Why This Exists

- Chat users often ask capability-shaped questions like "what can OMH do for papers?" instead of typing a workflow name.
- Those questions should feel instant and concrete: Hermes should show the relevant workflow card, not scan the full catalog or open the generic picker.
- Broad questions such as planning/research/coding should still use the picker or normal routing, so the fast path has to stay curated and phrase-bounded.

### User / Operator Impact

- Users get a direct paper-learning, source-finder, workflow-learning, gateway-intent-card, or executor-runtime-readiness card for common capability questions.
- Wrapper operators avoid shell approval, full scoring overhead, and generic picker detours for these common catalog lookups.
- Existing picker behavior remains available for generic inventory questions and broad capability discovery.

### How It Works

- `src/routing/chat.py` now keeps a small `_SPECIFIC_CAPABILITY_FAST_ALIASES` table for catalog-only capability language.
- `_specific_capability_alias_hit()` first confirms the prompt shape is a specific capability question, then matches phrase-bounded aliases using the existing compiled phrase machinery.
- `_specific_capability_fast_path_result()` builds the same high-confidence dispatch card used by exact skill-id questions, with `workflow_route_plan` intentionally absent.
- Ambiguous equal-span alias collisions return no hit, preserving the slower but safer normal router path.

### Files And Contracts Touched

- `src/routing/chat.py`: specific capability alias table, alias fast-path detection, shared catalog dispatch-card helper.
- `tests/test_chat_router.py`: no-full-scoring regression coverage for alias and exact-name capability questions.
- `tests/test_efficiency.py`: efficiency contract proving representative capability questions skip the full recommendation scan.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check`
- [x] `PYTHONPATH=tests uv run python -m omh.cli harness validate`
- [ ] `python3 -m omh.cli release checklist --json` - not run; release packaging was not changed.
- [ ] `python3 -m omh.cli release hermes-smoke` - not run; Hermes install/runtime surface was not changed.
- [ ] `omh --help` - not run; CLI command surface was not changed.
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` - not run; setup/install surface was not changed.
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable; learning trace persistence was not changed.
- [x] Relevant dry-run or smoke command: `PYTHONPATH=tests uv run python -m omh.cli demo routing-precision --summary`
- [x] Relevant dry-run or smoke command: `PYTHONPATH=tests uv run python -m omh.cli demo hermes-ux-quality --summary`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; this PR changes deterministic local router fast paths only, not live Hermes rendering.

## Risk

- Risk is narrow: overly broad aliases could steal generic catalog questions. The implementation gates aliases behind the specific capability question shape and keeps broad catalog wording on the existing picker path.
- Curated alias tables require maintenance as new workflows become common capability questions.

## Compatibility / Rollout

- Backward compatible with existing route payloads.
- Fast-path decisions still return normal `ChatRouteDecision` and recommendation payloads.
- No network calls, hidden execution, setup mutation, or Hermes core behavior changes.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`): local deterministic routing behavior only; no installer or release-channel change.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed: this PR claims only local routing/card behavior.
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap: live Hermes rendering was not exercised because runtime integration did not change.

## Follow-Up

- Add more aliases only when they correspond to a clear workflow surface and have no-full-scoring tests plus negative controls.