### PR TITLE
Polish Korean source and coding routing

### DIFF
--- a/src/routing/chat.py
+++ b/src/routing/chat.py
@@ -1409,6 +1409,8 @@ def _file_lookup_fast_path_decision(
         return None
     if explicit_skill_invocation(routing_message):
         return None
+    if _operator_surface_fast_path_match(routing_message) is not None:
+        return None
     if not is_file_or_text_lookup_question(routing_message):
         return None
     selected_harness = primary_harness_for_skill(_ROUTER_SKILL)
@@ -1573,9 +1575,27 @@ _OPERATOR_SURFACE_FAST_PATH_RULES: tuple[tuple[str, tuple[str, ...], str, str], 
             "논문 pdf 링크 찾아",
             "arxiv 링크 찾아",
             "arxiv 링크 찾아서",
+            "깃허브 repo 소스 찾아",
+            "깃허브 리포 소스 찾아",
+            "깃허브 저장소 찾아",
+            "github repo 소스 찾아",
+            "github repository 소스 찾아",
         ),
         "operator_surface_fast_path:source",
         "Clear source-acquisition request; scope source candidates before explanation or downstream work.",
+    ),
+    (
+        "ultraprocess",
+        (
+            "codex issue pr",
+            "codex로 이 이슈 pr",
+            "codex로 이슈 pr",
+            "코덱스로 이 이슈 pr",
+            "코덱스로 이슈 pr",
+            "코덱스로 이 이슈 pr 만들어",
+        ),
+        "operator_surface_fast_path:delivery",
+        "Clear executor-backed issue-to-PR request; prepare the one-cycle delivery path.",
     ),
     (
         "automation-blueprint",
@@ -1678,9 +1698,11 @@ def _operator_surface_fast_path_patterns() -> tuple[tuple[str, str, str, str, st
 
 
 def _operator_surface_extra_markers(skill: str, phrase: str) -> tuple[str, ...]:
+    normalized = _fast_path_text(phrase)
+    if skill == "ultraprocess" and any(marker in normalized for marker in ("codex", "코덱스")):
+        return ("guard:coding_handoff_status",)
     if skill != "ralplan":
         return ()
-    normalized = _fast_path_text(phrase)
     if any(marker in normalized for marker in ("safe", "safely", "안전")):
         markers = ["guard:safe_feature_change"]
         if "안전" in normalized:
@@ -1701,6 +1723,8 @@ def _operator_surface_phrase_marker(marker: str, phrase: str) -> str:
         return "phrase:visual_request"
     if marker == "operator_surface_fast_path:source":
         return "phrase:source_request"
+    if marker == "operator_surface_fast_path:delivery":
+        return "phrase:delivery_request"
     if marker == "operator_surface_fast_path:automation":
         return "phrase:automation_request"
     return "phrase:operator_surface"

--- a/tests/test_chat_router.py
+++ b/tests/test_chat_router.py
@@ -1450,6 +1450,8 @@ class ChatRouterTests(unittest.TestCase):
             "논문 데이터셋 찾아서 후보로 정리해줘",
             "공개 프레젠테이션 자료를 찾아서 요약해줘",
             "github oss repo 찾아서 비교해줘",
+            "깃허브 repo 소스 찾아줘",
+            "github repo 소스 찾아줘",
             "이 주제 관련 소스 후보 찾아줘",
         )
         for message in acquisition_cases:
@@ -2086,6 +2088,7 @@ selected_workflow=ultraprocess
             "codex로 이 기능 구현 맡겨줘",
             "이 이슈를 Codex로 구현하게 맡기고 진행상태 추적해줘",
             "코덱스로 이 이슈 PR 만들 수 있게 작업 시작해줘",
+            "코덱스로 이 이슈 PR 만들어줘",
             "$ultraprocess로 이 repo 변경을 PR-ready까지 준비해줘",
             "Can OMH do one full research plan implementation review cycle?",
         )

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -926,9 +926,11 @@ class EfficiencyContractTests(unittest.TestCase):
             ("위험한 리팩터링 같아", "ralplan"),
             ("릴리즈 노트 썸네일로 만들어줘", "img-summary"),
             ("github oss repo 찾아서 비교해줘", "source-finder"),
+            ("깃허브 repo 소스 찾아줘", "source-finder"),
             ("자료 출처 찾아줘 데이터셋이랑 깃허브까지", "source-finder"),
             ("find papers datasets github repos and public presentations about agent memory", "source-finder"),
             ("arxiv 링크 찾아서 쉽게 설명해줘", "source-finder"),
+            ("코덱스로 이 이슈 PR 만들어줘", "ultraprocess"),
             ("오늘 아침 경쟁사 뉴스 요약 자동화해줘", "automation-blueprint"),
         )
 


### PR DESCRIPTION
## Feature Report

### What Changed

- Added Korean/English operator fast-path phrases for source-acquisition prompts such as `깃허브 repo 소스 찾아줘` and `github repo 소스 찾아줘`.
- Added an executor-backed issue-to-PR fast path for short Codex prompts such as `코덱스로 이 이슈 PR 만들어줘`.
- Adjusted file lookup fast path so it defers when a concrete operator workflow fast path is available, preserving direct file lookup for real file/text reads.
- Marked the Codex issue-to-PR fast path with `guard:coding_handoff_status` so wrapper UI keeps the existing `show_coding_handoff_status` action instead of jumping to `send_to_executor`.

### Why This Exists

- Profiling showed two real chat-shaped misses after the previous fast-path work:
  - `깃허브 repo 소스 찾아줘` was treated as a file lookup instead of source acquisition.
  - `코덱스로 이 이슈 PR 만들어줘` clarified instead of opening the one-cycle delivery/coding handoff flow.
- These are common Korean operator phrasings, so they should feel natural without requiring users to know exact skill names.

### User / Operator Impact

- Users can ask Hermes to find GitHub/source candidates in Korean and get `source-finder` instead of a file lookup fallback.
- Users can ask Hermes to let Codex turn an issue into a PR and get the `ultraprocess` coding handoff/status UX.
- Existing README/file lookup questions still stay direct and do not open OMH workflows.

### How It Works

- `src/routing/chat.py` extends `_OPERATOR_SURFACE_FAST_PATH_RULES` with narrow source-acquisition and Codex issue-to-PR phrases.
- `_file_lookup_fast_path_decision()` now checks for an operator fast-path match before returning a direct lookup fallback.
- `_operator_surface_extra_markers()` adds `guard:coding_handoff_status` for Codex-backed ultraprocess fast paths, preserving the public wrapper action contract.

### Files And Contracts Touched

- `src/routing/chat.py`: operator fast-path phrases, file lookup deferral, coding handoff status marker.
- `tests/test_chat_router.py`: routing regressions for Korean source acquisition and short Codex issue-to-PR phrasing.
- `tests/test_efficiency.py`: no-full-scoring fast-path regression coverage for the same chat-shaped prompts.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check`
- [x] `PYTHONPATH=tests uv run python -m omh.cli harness validate`
- [ ] `python3 -m omh.cli release checklist --json` - not run; release packaging was not changed.
- [ ] `python3 -m omh.cli release hermes-smoke` - not run; Hermes install/runtime surface was not changed.
- [ ] `omh --help` - not run; CLI command surface was not changed.
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` - not run; setup/install surface was not changed.
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable; learning trace persistence was not changed.
- [x] Relevant dry-run or smoke command: `PYTHONPATH=tests uv run python -m omh.cli demo routing-precision --summary`
- [x] Relevant dry-run or smoke command: `PYTHONPATH=tests uv run python -m omh.cli demo hermes-ux-quality --summary`
- [x] Targeted route profile confirmed full recommendation scans stay at 0 for the new source/coding fast-path prompts.
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; this PR changes deterministic local router fast paths only, not live Hermes rendering.

## Risk

- Risk is narrow but real: source-looking words can be confused with file lookup. The new phrases are concrete and the full routing precision gate still reports zero overroutes.
- Additional operator phrases should be added only with negative controls and no-full-scoring tests.

## Compatibility / Rollout

- Backward compatible with existing route payloads.
- Preserves prepared-vs-observed boundaries; this is routing/card guidance only.
- No network calls, hidden execution, setup mutation, or Hermes core behavior changes.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`): local deterministic routing behavior only; no installer or release-channel change.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed: this PR claims only local routing/card behavior.
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap: live Hermes rendering was not exercised because runtime integration did not change.

## Follow-Up

- Keep measuring real chat transcripts for short Korean operator phrasings that still fall into clarify or direct lookup.