### PR TITLE
Fast path OMH help and status routing

### DIFF
--- a/src/routing/chat.py
+++ b/src/routing/chat.py
@@ -14,6 +14,7 @@ from .catalog_questions import is_file_or_text_lookup_question, is_skill_catalog
 from .action_copy import next_action_label as _route_next_action_label
 from .intent import scrub_diagnostic_status_text
 from .missed_route import is_missed_route_feedback
+from .omh_help import is_omh_intro_question, is_omh_quickstart_question, is_omh_status_question
 from .policy import (
     CONFIDENCE_LEVELS,
     ROUTE_ACTIONS,
@@ -965,6 +966,14 @@ def _route_chat_message_cached(
     min_confidence: str,
 ) -> dict[str, object]:
     routing_message = scrub_diagnostic_status_text(message)
+    fast_omh_help_decision = _omh_help_fast_path_decision(
+        message,
+        routing_message=routing_message,
+        source=source,
+        min_confidence=min_confidence,
+    )
+    if fast_omh_help_decision is not None:
+        return fast_omh_help_decision.to_dict()
     fast_catalog_decision = _catalog_fast_path_decision(
         message,
         routing_message=routing_message,
@@ -1256,6 +1265,139 @@ def _copy_workflow_route_plan(value: dict[str, object]) -> dict[str, object]:
     stages = value.get("stages")
     copied["stages"] = list(stages) if isinstance(stages, list) else []
     return copied
+
+
+def _omh_help_fast_path_decision(
+    message: str,
+    *,
+    routing_message: str,
+    source: str,
+    min_confidence: str,
+) -> ChatRouteDecision | None:
+    if _has_explicit_invocation_prefix(routing_message):
+        return None
+    if explicit_skill_invocation(routing_message):
+        return None
+    if is_omh_quickstart_question(routing_message):
+        return _router_help_decision(
+            message,
+            source=source,
+            min_confidence=min_confidence,
+            matched=("omh_quickstart_question",),
+            next_action="show_quickstart",
+            reason="OMH first-use or post-setup question; show the quickstart card instead of drafting a plan.",
+            evidence_boundary=(
+                "Quickstart output is local setup and wrapper guidance only; it is not host plugin load, "
+                "executor work, review, CI, or merge evidence."
+            ),
+            wrapper_guidance="Render the OMH quickstart card with the smallest useful next action.",
+            score=12,
+        )
+    if is_omh_status_question(routing_message):
+        return _router_help_decision(
+            message,
+            source=source,
+            min_confidence=min_confidence,
+            matched=("omh_status_question",),
+            next_action="show_status",
+            reason="OMH status or next-action question; show probe-backed status instead of drafting a plan.",
+            evidence_boundary=(
+                "Status and roadmap output is local probe evidence only; it is not host plugin load, executor work, "
+                "review, CI, or merge evidence."
+            ),
+            wrapper_guidance="Render the OMH status card and only claim observed local probe results.",
+            score=12,
+        )
+    if is_omh_intro_question(routing_message):
+        return _router_help_decision(
+            message,
+            source=source,
+            min_confidence=min_confidence,
+            matched=("omh_intro_question",),
+            next_action="show_context_brief",
+            reason="OMH intro or usage question; show the compact Hermes-facing mental model before the full picker.",
+            evidence_boundary=(
+                "Context brief output is routing/help context only; it is not workflow execution, delivery, "
+                "verification, review, CI, or merge evidence."
+            ),
+            wrapper_guidance="Render the OMH context brief first, then offer the workflow picker or quickstart card.",
+            score=12,
+        )
+    return None
+
+
+def _router_help_decision(
+    message: str,
+    *,
+    source: str,
+    min_confidence: str,
+    matched: tuple[str, ...],
+    next_action: str,
+    reason: str,
+    evidence_boundary: str,
+    wrapper_guidance: str,
+    score: int,
+) -> ChatRouteDecision:
+    selected_harness = primary_harness_for_skill(_ROUTER_SKILL)
+    recommendation = _router_help_recommendation(
+        message,
+        matched=matched,
+        next_action=next_action,
+        reason=reason,
+        evidence_boundary=evidence_boundary,
+        wrapper_guidance=wrapper_guidance,
+        score=score,
+    )
+    return ChatRouteDecision(
+        schema_version=1,
+        source=source,
+        action="dispatch",
+        selected_skill=_ROUTER_SKILL,
+        selected_harness=selected_harness,
+        candidate_skill=_ROUTER_SKILL,
+        candidate_harness=selected_harness,
+        confidence="high",
+        score=score,
+        threshold=min_confidence,
+        explicit=False,
+        ambiguous=False,
+        reason=reason,
+        clarification="",
+        routing_prompt=_routing_prompt("dispatch", _ROUTER_SKILL, _ROUTER_SKILL, reason, message),
+        task_card=None,
+        workflow_route_plan=None,
+        learning_candidate_card=None,
+        recommendations=(recommendation,),
+    )
+
+
+def _router_help_recommendation(
+    query: str,
+    *,
+    matched: tuple[str, ...],
+    next_action: str,
+    reason: str,
+    evidence_boundary: str,
+    wrapper_guidance: str,
+    score: int,
+) -> dict[str, object]:
+    definition = _router_skill_definition()
+    return {
+        "skill": definition.name,
+        "description": definition.description,
+        "category": definition.category,
+        "phase": definition.phase,
+        "hermes_role": definition.hermes_role,
+        "handoff_policy": definition.handoff_policy,
+        "score": score,
+        "confidence": "high",
+        "matched": list(matched),
+        "why": reason,
+        "next_action": next_action,
+        "evidence_boundary": evidence_boundary,
+        "wrapper_guidance": wrapper_guidance,
+        "suggested_prompt": query,
+    }
 
 
 def _has_explicit_invocation_prefix(message: str) -> bool:

--- a/src/routing/omh_help.py
+++ b/src/routing/omh_help.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+from functools import lru_cache
+
+
+_OMH_MARKERS = ("omh", "oh-my-hermes", "oh my hermes", "오마이헤르메스")
+
+
+@lru_cache(maxsize=4096)
+def is_omh_intro_question(message: str) -> bool:
+    text = message.strip().lower()
+    if not text:
+        return False
+    if not any(marker in text for marker in _OMH_MARKERS):
+        return False
+    if any(
+        marker in text
+        for marker in (
+            "status",
+            "doctor",
+            "health",
+            "install",
+            "setup",
+            "next",
+            "상태",
+            "설치",
+            "셋업",
+            "세팅",
+            "다음",
+        )
+    ):
+        return False
+    catalog_only_markers = (
+        "available",
+        "workflow",
+        "workflows",
+        "skill",
+        "skills",
+        "workflows available",
+        "skills available",
+        "commands available",
+        "deep-interview",
+        "ralplan",
+        "ultragoal",
+        "loop",
+        "ultraprocess",
+        "list",
+        "menu",
+        "picker",
+        "명령어",
+        "스킬",
+        "워크플로",
+        "워크플로우",
+        "有哪些",
+        "可用",
+        "使える",
+    )
+    if any(marker in text for marker in catalog_only_markers):
+        return False
+    intro_markers = (
+        "what is",
+        "what are you",
+        "how do i use",
+        "how should i use",
+        "how to use",
+        "how does",
+        "explain",
+        "overview",
+        "getting started",
+        "mental model",
+        "뭐야",
+        "무엇이야",
+        "어떻게 써",
+        "어떻게 사용",
+        "사용법",
+        "소개",
+        "설명",
+        "何ですか",
+        "使い方",
+        "是什么",
+        "怎么用",
+    )
+    return any(marker in text for marker in intro_markers)
+
+
+@lru_cache(maxsize=4096)
+def is_omh_quickstart_question(message: str) -> bool:
+    text = message.strip().lower()
+    if not text:
+        return False
+    if not any(marker in text for marker in _OMH_MARKERS):
+        return False
+    troubleshooting_markers = (
+        "does not show",
+        "doesn't show",
+        "cannot see",
+        "can't see",
+        "not found",
+        "stale",
+        "failed",
+        "fails",
+        "error",
+        "안 보여",
+        "안보여",
+        "못 봐",
+        "못봐",
+        "안됨",
+        "안 돼",
+        "실패",
+        "오류",
+        "에러",
+    )
+    if any(marker in text for marker in troubleshooting_markers):
+        return False
+    quickstart_markers = (
+        "quickstart",
+        "getting started",
+        "first use",
+        "what next",
+        "what should i do next",
+        "what do i do next",
+        "next action",
+        "after setup",
+        "after install",
+        "installed correctly",
+        "setup next",
+        "next step",
+        "처음",
+        "퀵스타트",
+        "다음 액션",
+        "다음 단계",
+        "이제 뭐",
+        "설치됐",
+        "설치 되었",
+        "설치 완료",
+    )
+    return any(marker in text for marker in quickstart_markers)
+
+
+@lru_cache(maxsize=4096)
+def is_omh_status_question(message: str) -> bool:
+    text = message.strip().lower()
+    if not text:
+        return False
+    if not any(marker in text for marker in _OMH_MARKERS):
+        return False
+    catalog_markers = (
+        "what can",
+        "what does",
+        "available",
+        "workflows",
+        "skills",
+        "commands",
+        "뭐 할",
+        "뭘 도와",
+        "명령어",
+        "스킬",
+        "워크플로",
+    )
+    status_markers = (
+        "status",
+        "health",
+        "상태",
+        "정상",
+        "확인",
+        "헬스",
+        "진단",
+    )
+    if any(marker in text for marker in catalog_markers) and not any(marker in text for marker in status_markers):
+        return False
+    return any(marker in text for marker in status_markers)

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -10,6 +10,11 @@ from ..ingress import CHAT_SOURCES, compact_source_metadata, extract_message_tex
 from ..routing.catalog_questions import is_skill_catalog_question as _is_skill_catalog_question
 from ..routing.chat import public_chat_route_payload, route_explanation_payload
 from ..routing.missed_route import is_missed_route_feedback
+from ..routing.omh_help import (
+    is_omh_intro_question as _is_omh_intro_question,
+    is_omh_quickstart_question as _is_omh_quickstart_question,
+    is_omh_status_question as _is_omh_status_question,
+)
 from ..coding_delegation import CODING_EXECUTOR_TARGETS, build_coding_delegation_payload
 from ..capabilities.families import capability_family_cards
 from ..context import build_context_brief
@@ -4520,157 +4525,6 @@ def _omh_intro_route_payload(route_payload: dict[str, object]) -> dict[str, obje
     )
     updated["route_explanation"] = route_explanation_payload(updated)
     return updated
-
-
-@lru_cache(maxsize=4096)
-def _is_omh_intro_question(message: str) -> bool:
-    text = message.strip().lower()
-    if not text:
-        return False
-    omh_markers = ("omh", "oh-my-hermes", "oh my hermes", "오마이헤르메스")
-    if not any(marker in text for marker in omh_markers):
-        return False
-    if any(marker in text for marker in ("status", "doctor", "health", "install", "setup", "next", "상태", "설치", "셋업", "세팅", "다음")):
-        return False
-    catalog_only_markers = (
-        "available",
-        "workflow",
-        "workflows",
-        "skill",
-        "skills",
-        "workflows available",
-        "skills available",
-        "commands available",
-        "deep-interview",
-        "ralplan",
-        "ultragoal",
-        "loop",
-        "ultraprocess",
-        "list",
-        "menu",
-        "picker",
-        "명령어",
-        "스킬",
-        "워크플로",
-        "워크플로우",
-        "有哪些",
-        "可用",
-        "使える",
-    )
-    if any(marker in text for marker in catalog_only_markers):
-        return False
-    intro_markers = (
-        "what is",
-        "what are you",
-        "how do i use",
-        "how should i use",
-        "how to use",
-        "how does",
-        "explain",
-        "overview",
-        "getting started",
-        "mental model",
-        "뭐야",
-        "무엇이야",
-        "어떻게 써",
-        "어떻게 사용",
-        "사용법",
-        "소개",
-        "설명",
-        "何ですか",
-        "使い方",
-        "是什么",
-        "怎么用",
-    )
-    return any(marker in text for marker in intro_markers)
-
-
-@lru_cache(maxsize=4096)
-def _is_omh_quickstart_question(message: str) -> bool:
-    text = message.strip().lower()
-    if not text:
-        return False
-    omh_markers = ("omh", "oh-my-hermes", "oh my hermes", "오마이헤르메스")
-    if not any(marker in text for marker in omh_markers):
-        return False
-    quickstart_markers = (
-        "quickstart",
-        "getting started",
-        "first use",
-        "what next",
-        "what should i do next",
-        "what do i do next",
-        "next action",
-        "after setup",
-        "after install",
-        "installed correctly",
-        "setup next",
-        "next step",
-        "처음",
-        "퀵스타트",
-        "다음 액션",
-        "다음 단계",
-        "이제 뭐",
-        "설치됐",
-        "설치 되었",
-        "설치 완료",
-        "셋업",
-        "세팅",
-    )
-    return any(marker in text for marker in quickstart_markers)
-
-
-@lru_cache(maxsize=4096)
-def _is_omh_status_question(message: str) -> bool:
-    text = message.strip().lower()
-    if not text:
-        return False
-    omh_markers = ("omh", "oh-my-hermes", "oh my hermes", "오마이헤르메스")
-    if not any(marker in text for marker in omh_markers):
-        return False
-    catalog_markers = (
-        "what can",
-        "what does",
-        "available",
-        "workflows",
-        "skills",
-        "commands",
-        "뭐 할",
-        "뭘 도와",
-        "명령어",
-        "스킬",
-        "워크플로",
-    )
-    if any(marker in text for marker in catalog_markers) and not any(
-        marker in text
-        for marker in ("status", "health", "doctor", "setup", "install", "installed", "next", "상태", "다음", "설치", "셋업", "세팅", "정상", "진단")
-    ):
-        return False
-    status_markers = (
-        "status",
-        "health",
-        "doctor",
-        "diagnose",
-        "installed",
-        "installation",
-        "setup",
-        "set up",
-        "next action",
-        "what next",
-        "what should i do next",
-        "what do i do next",
-        "상태",
-        "다음",
-        "액션",
-        "설치",
-        "셋업",
-        "세팅",
-        "정상",
-        "확인",
-        "헬스",
-        "진단",
-    )
-    return any(marker in text for marker in status_markers)
 
 
 def _roadmap_next_actions(roadmap: dict[str, Any], *, limit: int) -> list[dict[str, object]]:

--- a/tests/test_chat_router.py
+++ b/tests/test_chat_router.py
@@ -478,6 +478,56 @@ class ChatRouterTests(unittest.TestCase):
             self.assertEqual(public["route_explanation"]["next_action"], "prepare_agent_ops_review")
             self.assertNotIn("workflow_route_plan", public)
 
+    def test_omh_help_questions_use_fast_path_without_full_scoring(self) -> None:
+        chat_router_impl._route_chat_message_cached.cache_clear()
+        chat_router_impl._public_chat_route_payload_cached.cache_clear()
+
+        cases = (
+            ("what is OMH?", "omh_intro_question", "show_context_brief"),
+            ("what is oh-my-hermes?", "omh_intro_question", "show_context_brief"),
+            ("how do I use OMH?", "omh_intro_question", "show_context_brief"),
+            ("how do I use OMH with Discord/Slack/Telegram?", "omh_intro_question", "show_context_brief"),
+            ("OMH 뭐야?", "omh_intro_question", "show_context_brief"),
+            ("OMH 어떻게 써?", "omh_intro_question", "show_context_brief"),
+            ("OMH 디스코드에서 어떻게 써?", "omh_intro_question", "show_context_brief"),
+            ("what is OMH status?", "omh_status_question", "show_status"),
+            ("show OMH status", "omh_status_question", "show_status"),
+            ("OMH 상태 보여줘", "omh_status_question", "show_status"),
+            ("what should I do next with OMH setup?", "omh_quickstart_question", "show_quickstart"),
+            ("OMH 설치됐는데 이제 뭐해?", "omh_quickstart_question", "show_quickstart"),
+        )
+
+        for message, matched, next_action in cases:
+            with self.subTest(message=message), mock.patch.object(
+                chat_router_impl,
+                "recommend_skills",
+                side_effect=AssertionError("OMH help questions should skip full recommendation scoring"),
+            ), mock.patch.object(
+                chat_router_impl,
+                "build_workflow_route_plan",
+                side_effect=AssertionError("OMH help questions should not build workflow route plans"),
+            ):
+                decision = route_chat_message(message, source="discord")
+
+            self.assertEqual(decision["action"], "dispatch")
+            self.assertEqual(decision["selected_skill"], "oh-my-hermes")
+            self.assertEqual(decision["candidate_skill"], "oh-my-hermes")
+            self.assertEqual(decision["confidence"], "high")
+            self.assertEqual(decision["recommendations"][0]["matched"], [matched])
+            self.assertEqual(decision["recommendations"][0]["next_action"], next_action)
+            public = public_route_payload(decision)
+            self.assertEqual(public["route_explanation"]["next_action"], next_action)
+            self.assertNotIn("workflow_route_plan", public)
+
+    def test_omh_help_fast_path_preserves_catalog_picker_questions(self) -> None:
+        decision = route_chat_message("what does OMH do?", source="discord")
+        public = public_route_payload(decision)
+
+        self.assertEqual(decision["action"], "dispatch")
+        self.assertEqual(decision["selected_skill"], "oh-my-hermes")
+        self.assertEqual(decision["recommendations"][0]["matched"], ["catalog_question"])
+        self.assertEqual(public["route_explanation"]["next_action"], "choose_skill")
+
     def test_plain_text_transform_keeps_workflow_blockers(self) -> None:
         cases = (
             ("회의록 요약 이미지로 만들어줘", "img-summary", "prepare_visual_prompt_card"),


### PR DESCRIPTION
## Feature Report

### What Changed

- Added a shared deterministic OMH help detector for intro, first-use quickstart, and status questions.
- Routed common chat prompts such as `what is OMH?`, `how do I use OMH?`, `OMH 상태 보여줘`, and `OMH 설치됐는데 이제 뭐해?` before full workflow recommendation scoring.
- Updated the wrapper contract to reuse the same detector instead of carrying a duplicate local copy.
- Added router regression tests proving these help/status prompts do not call full recommendation scoring or workflow route-plan generation.

### Why This Exists

- Hermes users often ask simple OMH context questions in chat before they know workflow names.
- Those prompts should feel instant and helpful, not like a heavy workflow-planning request.
- The previous correction lived mostly in wrapper rendering, so the lower-level router still performed more work and could drift from the wrapper behavior.

### User / Operator Impact

- Asking `what is OMH?` now opens the compact OMH mental-model/context brief directly.
- Asking `how do I use OMH?` or messenger-specific usage questions goes to the same context brief without shell approval or full scoring.
- Asking `show OMH status` or `OMH 상태 보여줘` goes to the local status card directly.
- Asking first-use questions after setup goes to quickstart.
- Troubleshooting phrases such as `Hermes skills list does not show OMH after setup` still route to setup/doctor handling instead of being swallowed by quickstart.

### How It Works

- `src/routing/omh_help.py` owns cached intro/quickstart/status phrase detection.
- `src/routing/chat.py` checks those detectors early in `_route_chat_message_cached` and returns an `oh-my-hermes` recommendation with the correct `next_action` and evidence boundary.
- `src/wrapper/contract.py` imports the shared detectors so route and wrapper cards stay aligned.
- Tests patch `recommend_skills` and `build_workflow_route_plan` to fail if OMH help/status prompts fall through to full scoring.

### Files And Contracts Touched

- `src/routing/omh_help.py`: new shared cached detector module.
- `src/routing/chat.py`: fast path decisions for `show_context_brief`, `show_quickstart`, and `show_status`.
- `src/wrapper/contract.py`: removed duplicate detector implementations and reused the routing helper.
- `tests/test_chat_router.py`: no-full-scoring regression tests and catalog preservation coverage.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check`
- [x] `PYTHONPATH=tests uv run python -m omh.cli harness validate`
- [ ] `python3 -m omh.cli release checklist --json` (not run; this PR changes routing fast paths, not release packaging)
- [ ] `python3 -m omh.cli release hermes-smoke` (not run; no live Hermes install/rendering change)
- [ ] `omh --help` (not run; CLI help unchanged)
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` (not run; setup/install flow unchanged)
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable
- [x] Relevant dry-run or smoke command: `PYTHONPATH=tests uv run python -m omh.cli demo routing-precision --summary`; `PYTHONPATH=tests uv run python -m omh.cli demo hermes-ux-quality --summary`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; deterministic local routing and wrapper contract tests covered this change, live chat rendering remains not observed

## Risk

- Low-to-moderate routing risk: early fast paths can steal phrases if too broad.
- Mitigation: status detection was narrowed to real status/health language, and tests cover setup troubleshooting, missed-route feedback, exact capability questions, and catalog picker preservation.

## Compatibility / Rollout

- Backward compatible JSON shape: same `oh-my-hermes` router workflow, same `route_explanation/v1`, and existing wrapper actions.
- No new dependencies, network calls, Hermes core patches, or executor behavior changes.
- Existing catalog picker questions such as `what does OMH do?` still open the picker.

## Release / Claims

- [x] Release-channel impact considered (`preview` routing polish; stable unaffected until release/update)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- Consider adding localized intro/status phrases beyond the current shared detector if real chat transcripts reveal gaps.
