### PR TITLE
Fast path explicit OMH workflow invocations

### DIFF
--- a/src/routing/chat.py
+++ b/src/routing/chat.py
@@ -982,6 +982,14 @@ def _route_chat_message_cached(
     )
     if fast_maintenance_task_decision is not None:
         return fast_maintenance_task_decision.to_dict()
+    fast_explicit_skill_decision = _explicit_skill_fast_path_decision(
+        message,
+        routing_message=routing_message,
+        source=source,
+        min_confidence=min_confidence,
+    )
+    if fast_explicit_skill_decision is not None:
+        return fast_explicit_skill_decision.to_dict()
     fast_catalog_decision = _catalog_fast_path_decision(
         message,
         routing_message=routing_message,
@@ -1466,6 +1474,66 @@ def _task_card_fast_path_recommendation(task_card: dict[str, object], query: str
         **recommendation,
         "suggested_prompt": query,
     }
+
+
+def _explicit_skill_fast_path_decision(
+    message: str,
+    *,
+    routing_message: str,
+    source: str,
+    min_confidence: str,
+) -> ChatRouteDecision | None:
+    definitions = routable_definitions()
+    selected_skill = explicit_skill_invocation(routing_message, definitions)
+    if not selected_skill or selected_skill == _ROUTER_SKILL:
+        return None
+    if not _has_explicit_invocation_prefix(routing_message) and is_missed_route_feedback(routing_message):
+        return None
+    task_card = classify_task(routing_message)
+    if _task_card_overrides_explicit_invocation(
+        task_card,
+        explicit_prefix=_has_explicit_invocation_prefix(routing_message),
+    ):
+        return None
+
+    definition = _skill_definition_by_name(selected_skill)
+    selected_harness = primary_harness_for_skill(selected_skill)
+    reason = "Explicit workflow invocation wins over heuristic routing."
+    recommendation = recommendation_for_definition(
+        definition,
+        message,
+        matched=("explicit_invocation", f"name:{selected_skill}"),
+        score=12,
+        why=reason,
+    )
+    explicit_loop = selected_skill == "loop" and explicit_loop_invocation_signal(routing_message)
+    route_next_action = _route_specific_next_action(
+        routing_message,
+        selected_skill=selected_skill,
+        explicit_loop=explicit_loop,
+    )
+    return ChatRouteDecision(
+        schema_version=1,
+        source=source,
+        action="dispatch",
+        selected_skill=selected_skill,
+        selected_harness=selected_harness,
+        candidate_skill=selected_skill,
+        candidate_harness=selected_harness,
+        confidence="high",
+        score=12,
+        threshold=min_confidence,
+        explicit=True,
+        ambiguous=False,
+        reason=reason,
+        clarification="",
+        routing_prompt=_routing_prompt("dispatch", selected_skill, selected_skill, reason, message),
+        task_card=None,
+        workflow_route_plan=None,
+        learning_candidate_card=None,
+        recommendations=(recommendation,),
+        route_next_action=route_next_action,
+    )
 
 
 def _has_explicit_invocation_prefix(message: str) -> bool:

--- a/tests/test_chat_router.py
+++ b/tests/test_chat_router.py
@@ -565,6 +565,43 @@ class ChatRouterTests(unittest.TestCase):
         self.assertTrue(decision["explicit"])
         self.assertEqual(decision["confidence"], "high")
 
+    def test_explicit_skill_invocations_use_fast_path_without_full_scoring(self) -> None:
+        chat_router_impl._route_chat_message_cached.cache_clear()
+        chat_router_impl._public_chat_route_payload_cached.cache_clear()
+
+        cases = (
+            ("$ralplan risky refactor", "ralplan"),
+            ("./loop improve first-run experience", "loop"),
+            ("Use OMH web-research for: research loop engineering", "web-research"),
+            ("Use OMH paper-learning for: explain this PDF at beginner level", "paper-learning"),
+            ("deep-interview onboarding feels vague", "deep-interview"),
+            ("paper-learning: explain this arxiv paper", "paper-learning"),
+            ("/paper-learning explain this paper", "paper-learning"),
+            ("@paper-learning explain this paper", "paper-learning"),
+            ("$ultraprocess make setup easier", "ultraprocess"),
+        )
+
+        for message, selected_skill in cases:
+            with self.subTest(message=message), mock.patch.object(
+                chat_router_impl,
+                "recommend_skills",
+                side_effect=AssertionError("explicit skill invocations should skip full recommendation scoring"),
+            ), mock.patch.object(
+                chat_router_impl,
+                "build_workflow_route_plan",
+                side_effect=AssertionError("explicit skill invocations should not build workflow route plans"),
+            ):
+                decision = route_chat_message(message, source="discord")
+
+            self.assertEqual(decision["action"], "dispatch")
+            self.assertEqual(decision["selected_skill"], selected_skill)
+            self.assertEqual(decision["selected_harness"], primary_harness_for_skill(selected_skill))
+            self.assertTrue(decision["explicit"])
+            self.assertEqual(decision["recommendations"][0]["matched"], ["explicit_invocation", f"name:{selected_skill}"])
+            self.assertIsNone(decision["workflow_route_plan"])
+            public = public_route_payload(decision)
+            self.assertNotIn("workflow_route_plan", public)
+
     def test_direct_picker_alias_uses_fast_catalog_route(self) -> None:
         for message in ("./omh", "/omh", "./skills", "/skills"):
             with self.subTest(message=message):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5082,6 +5082,7 @@ class CliTests(unittest.TestCase):
             ("what coding agents can OMH use?", "executor-runtime-readiness", "executor_runtime_readiness", "prepare_executor_runtime_readiness"),
             ("what can OMH do for research department?", "research-department", "research_department", "prepare_research_department_plan"),
             ("what can OMH do for research brief?", "research-brief", "web_research", "run_hermes_research"),
+            ("Use OMH web-research for: research loop engineering", "web-research", "web_research", "run_hermes_research"),
             ("what can OMH do for GitHub event ops?", "github-event-ops", "github_event_ops", "prepare_github_event_ops_card"),
             ("what can OMH do for coding agents?", "executor-runtime-readiness", "executor_runtime_readiness", "prepare_executor_runtime_readiness"),
             ("what can OMH do for reliability review?", "reliability-review", "reliability_review", "prepare_reliability_review"),


### PR DESCRIPTION
## Feature Report

### What Changed

- Added a deterministic fast path for explicit OMH workflow invocations such as `$ralplan ...`, `./loop ...`, `/paper-learning ...`, `@paper-learning ...`, `deep-interview ...`, and `Use OMH web-research for: ...`.
- Directly selected workflows now dispatch without calling the full recommendation scorer or building `workflow_route_plan/v1`.
- Fixed a direct-selection UX issue where `Use OMH web-research for: ...` could fall into the generic `oh-my-hermes` picker instead of the selected `web-research` workflow.

### Why This Exists

- When a user explicitly picks a workflow in Hermes chat, routing should feel immediate and should not ask the entire catalog to vote again.
- Full scoring is still useful for natural-language routing, but it is wasted work for direct invocations and can let catalog-help logic steal the route from the selected skill.
- This is part of making OMH feel natural in chat surfaces: users can either let OMH route for them or directly invoke a workflow, and both paths should be fast and predictable.

### User / Operator Impact

- Direct workflow selection is faster and less noisy in Hermes/Discord/Slack-style wrappers.
- `Use OMH web-research for: research loop engineering` now opens the `web-research` workflow instead of the generic OMH picker.
- `./omh`, `/omh`, `./skills`, and `/skills` still open the workflow picker; this PR does not remove the compact manual picker path.
- Prepared-vs-observed boundaries remain unchanged. A direct route is still only routing intent, not proof that research, planning, coding, verification, review, CI, or delivery happened.

### How It Works

- `src/routing/chat.py` now checks `explicit_skill_invocation()` after maintenance-command fast paths and before catalog/picker routing.
- The fast path builds a `ChatRouteDecision` from the selected `SkillDefinition` and `recommendation_for_definition()` metadata.
- Router feedback and maintenance override behavior remain intact, and `oh-my-hermes` picker aliases are excluded so `./omh` keeps opening the picker.
- Loop invocations still compute the loop-specific next action, such as `start_loop_cycle` or `ask_goal_boundary`.

### Files And Contracts Touched

- Routing: `src/routing/chat.py`
- Router regression tests: `tests/test_chat_router.py`
- User-facing CLI interaction coverage: `tests/test_cli.py`

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — 1016 tests passed
- [x] `uv run python -m compileall -q src tests`
- [x] `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check`
- [x] `PYTHONPATH=tests uv run python -m omh.cli harness validate`
- [ ] `python3 -m omh.cli release checklist --json` — not run; this PR does not change release packaging or release checklist surfaces
- [ ] `python3 -m omh.cli release hermes-smoke` — not run; live Hermes smoke is outside this deterministic router change
- [ ] `omh --help` — not run; command help output is unchanged
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` — not run; setup/release install path is unchanged
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable
- [x] Relevant dry-run or smoke command: `PYTHONPATH=tests uv run python -m omh.cli demo routing-precision --summary` and `PYTHONPATH=tests uv run python -m omh.cli demo hermes-ux-quality --summary`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; covered by deterministic router/CLI contract tests

Additional observed results:

- Explicit direct-selection measurement: direct invocation cases now show `recommend=0` and `plan=0`, while normal implementation requests still use the full route path.
- Routing precision: `41/41` negative-control cases, `52/52` expected interventions, `0` overroutes
- Hermes UX quality: `100/100`, routing average `10.0`, `5/5` gates passed
- `git diff --check` passed

## Risk

- Moderate but bounded. This changes ordering for explicit workflow selections only.
- The fast path deliberately excludes `oh-my-hermes` picker aliases and defers to task-card override rules for maintenance and router-design feedback, preserving existing safety boundaries.

## Compatibility / Rollout

- Backward-compatible for route payload consumers.
- Removes unnecessary `workflow_route_plan/v1` from explicit direct-invocation payloads because direct selection is already the plan decision boundary.
- No schema version changes and no new dependencies.

## Release / Claims

- [x] Release-channel impact considered (`preview` behavior improvement; no packaging change)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Known manual Hermes checks are listed, including any live Hermes gap

## Follow-Up

- Future route-quality demos could add a dedicated direct-invocation performance rollup so this stays visible beside routing precision and Hermes UX quality.
