### PR TITLE
Fast path common OMH intent routing

### DIFF
--- a/src/routing/chat.py
+++ b/src/routing/chat.py
@@ -1823,11 +1823,23 @@ _OPERATOR_SURFACE_FAST_PATH_RULES: tuple[tuple[str, tuple[str, ...], str, str], 
     (
         "img-summary",
         (
+            "meeting image card",
+            "meeting summary image",
+            "pr summary image",
+            "issue summary card",
+            "release announcement card",
+            "image card",
             "make a thumbnail",
             "create a thumbnail",
             "generate a thumbnail",
             "thumbnail card",
             "release thumbnail",
+            "이미지 생성해줘",
+            "이미지로 만들어줘",
+            "회의록을 세로 카드",
+            "회의록 요약 이미지",
+            "pr 요약 이미지",
+            "이슈 요약 카드",
             "썸네일 만들어줘",
             "썸네일 생성해줘",
             "썸네일로 만들어줘",
@@ -1835,6 +1847,44 @@ _OPERATOR_SURFACE_FAST_PATH_RULES: tuple[tuple[str, tuple[str, ...], str, str], 
         ),
         "operator_surface_fast_path:visual",
         "Clear thumbnail or release-thumbnail request; prepare the image prompt-card workflow without scoring every workflow.",
+    ),
+    (
+        "paper-learning",
+        (
+            "paper summary",
+            "explain this paper",
+            "explain this pdf",
+            "paper pdf explanation",
+            "paper at beginner level",
+            "논문 요약",
+            "논문 pdf 이해",
+            "논문 pdf 설명",
+            "논문 쉽게 설명",
+            "pdf 쉽게 설명",
+            "이 pdf 쉽게 설명",
+        ),
+        "operator_surface_fast_path:paper",
+        "Clear paper or paper-PDF explanation request; prepare paper-learning without scoring every workflow.",
+    ),
+    (
+        "web-research",
+        (
+            "web search",
+            "web research",
+            "latest sources",
+            "latest evidence",
+            "current sources",
+            "source backed research",
+            "웹서치",
+            "웹 리서치",
+            "최신 자료",
+            "최신 근거",
+            "최신 정보",
+            "근거 찾아",
+            "자료 조사",
+        ),
+        "operator_surface_fast_path:research",
+        "Clear web/current-source research request; start Hermes-owned source-backed research without scoring every workflow.",
     ),
     (
         "source-finder",
@@ -1876,6 +1926,47 @@ _OPERATOR_SURFACE_FAST_PATH_RULES: tuple[tuple[str, tuple[str, ...], str, str], 
         "Clear executor-backed issue-to-PR request; prepare the one-cycle delivery path.",
     ),
     (
+        "executor-runtime-readiness",
+        (
+            "open in codex",
+            "open codex",
+            "start codex session",
+            "open in claude code",
+            "claude code connected",
+            "codex로 열어줘",
+            "codex 세션 열어",
+            "codex 세션 켜",
+            "codex 세션 시작",
+            "코덱스 세션 열어",
+            "코덱스 세션 켜",
+            "코덱스 세션 시작",
+            "코덱스로 열어줘",
+            "claude code로 이어서",
+            "claude code 연결",
+            "클로드 코드 연결",
+            "클로드 코드로 이어서",
+        ),
+        "operator_surface_fast_path:executor",
+        "Clear coding-agent readiness request; show the selected executor/runtime path without scoring every workflow.",
+    ),
+    (
+        "materials-package",
+        (
+            "make a ppt",
+            "make slides",
+            "turn into slides",
+            "make a deck",
+            "export to pdf and ppt",
+            "ppt 만들어줘",
+            "발표자료로 만들어줘",
+            "발표 자료로 만들어줘",
+            "엑셀을 월간 보고서",
+            "pdf랑 ppt",
+        ),
+        "operator_surface_fast_path:materials",
+        "Clear materials or document-package request; prepare the file/package workflow without scoring every workflow.",
+    ),
+    (
         "automation-blueprint",
         (
             "automate this",
@@ -1906,6 +1997,11 @@ def _operator_surface_fast_path_decision(
         return None
     selected_skill, phrase, marker, reason = match
     if selected_skill == "ralplan" and _is_fast_plain_direct_answer_question(routing_message):
+        return None
+    if selected_skill == "paper-learning" and (
+        _is_paper_learning_citation_research_request(routing_message)
+        or _is_paper_learning_materials_request(routing_message)
+    ):
         return None
     selected_harness = primary_harness_for_skill(selected_skill)
     definition = _skill_definition_by_name(selected_skill)
@@ -1979,6 +2075,12 @@ def _operator_surface_extra_markers(skill: str, phrase: str) -> tuple[str, ...]:
     normalized = _fast_path_text(phrase)
     if skill == "ultraprocess" and any(marker in normalized for marker in ("codex", "코덱스")):
         return ("guard:coding_handoff_status",)
+    if skill == "img-summary":
+        return ("guard:img_summary",)
+    if skill == "paper-learning":
+        return ("guard:paper_learning",)
+    if skill == "executor-runtime-readiness":
+        return ("guard:executor_runtime_readiness",)
     if skill != "ralplan":
         return ()
     if any(marker in normalized for marker in ("safe", "safely", "안전")):
@@ -1991,6 +2093,33 @@ def _operator_surface_extra_markers(skill: str, phrase: str) -> tuple[str, ...]:
     return ()
 
 
+def _is_paper_learning_citation_research_request(message: str) -> bool:
+    normalized = _fast_path_text(message)
+    return (
+        "citation" in normalized
+        and any(marker in normalized for marker in ("verify", "validate", "check", "검증", "확인"))
+    )
+
+
+def _is_paper_learning_materials_request(message: str) -> bool:
+    normalized = _fast_path_text(message)
+    return any(
+        marker in normalized
+        for marker in (
+            "make a ppt",
+            "make a deck",
+            "as a deck",
+            "export a pdf",
+            "export to pdf",
+            "package it as a pdf",
+            "ppt",
+            "deck",
+            "발표자료",
+            "발표 자료",
+        )
+    )
+
+
 def _operator_surface_phrase_marker(marker: str, phrase: str) -> str:
     if marker == "operator_surface_fast_path:planning":
         normalized = _fast_path_text(phrase)
@@ -1999,10 +2128,18 @@ def _operator_surface_phrase_marker(marker: str, phrase: str) -> str:
         return "phrase:planning_safe_change"
     if marker == "operator_surface_fast_path:visual":
         return "phrase:visual_request"
+    if marker == "operator_surface_fast_path:paper":
+        return "phrase:paper_learning_request"
+    if marker == "operator_surface_fast_path:research":
+        return "phrase:web_research_request"
     if marker == "operator_surface_fast_path:source":
         return "phrase:source_request"
     if marker == "operator_surface_fast_path:delivery":
         return "phrase:delivery_request"
+    if marker == "operator_surface_fast_path:executor":
+        return "phrase:executor_request"
+    if marker == "operator_surface_fast_path:materials":
+        return "phrase:materials_request"
     if marker == "operator_surface_fast_path:automation":
         return "phrase:automation_request"
     return "phrase:operator_surface"

--- a/tests/test_chat_router.py
+++ b/tests/test_chat_router.py
@@ -602,6 +602,34 @@ class ChatRouterTests(unittest.TestCase):
             public = public_route_payload(decision)
             self.assertNotIn("workflow_route_plan", public)
 
+    def test_common_single_workflow_requests_skip_full_recommendation_scoring(self) -> None:
+        chat_router_impl._route_chat_message_cached.cache_clear()
+        chat_router_impl._public_chat_route_payload_cached.cache_clear()
+
+        cases = (
+            ("논문 요약해줘", "paper-learning", "prepare_paper_learning", "operator_surface_fast_path:paper"),
+            ("이 PDF 쉽게 설명해줘", "paper-learning", "prepare_paper_learning", "operator_surface_fast_path:paper"),
+            ("웹서치해서 최신 자료 정리해줘", "web-research", "run_hermes_research", "operator_surface_fast_path:research"),
+            ("이미지 생성해줘. 회의록을 세로 카드로 요약해줘", "img-summary", "prepare_visual_prompt_card", "operator_surface_fast_path:visual"),
+            ("PPT 만들어줘", "materials-package", "prepare_material_package", "operator_surface_fast_path:materials"),
+            ("codex로 열어줘", "executor-runtime-readiness", "prepare_executor_runtime_readiness", "operator_surface_fast_path:executor"),
+        )
+
+        for message, selected_skill, next_action, marker in cases:
+            with self.subTest(message=message), mock.patch.object(
+                chat_router_impl,
+                "recommend_skills",
+                side_effect=AssertionError("common single-workflow requests should skip full recommendation scoring"),
+            ):
+                decision = route_chat_message(message, source="discord")
+
+            self.assertEqual(decision["action"], "dispatch")
+            self.assertEqual(decision["selected_skill"], selected_skill)
+            self.assertEqual(decision["selected_harness"], primary_harness_for_skill(selected_skill))
+            self.assertIn(marker, decision["recommendations"][0]["matched"])
+            public = public_route_payload(decision)
+            self.assertEqual(public["route_explanation"]["next_action"], next_action)
+
     def test_direct_picker_alias_uses_fast_catalog_route(self) -> None:
         for message in ("./omh", "/omh", "./skills", "/skills"):
             with self.subTest(message=message):


### PR DESCRIPTION
## Feature Report

### What Changed

- Added deterministic operator-surface fast paths for common single-workflow chat requests: paper/PDF explanation, web research/current-source research, image summary cards, materials packages, and coding-agent readiness/open requests.
- Preserved existing semantic guard markers such as `guard:paper_learning`, `guard:img_summary`, and `guard:executor_runtime_readiness` so route-quality reports and wrapper diagnostics keep the same meaning.
- Narrowed edge cases so citation verification still routes to `web-research`, paper-to-PPT/PDF packaging still routes to `materials-package`, and Codex session status questions still route to `ultraprocess` progress/status instead of executor readiness.

### Why This Exists

- OMH chat routing had already been made fast for explicit workflow invocations and maintenance commands, but frequent natural requests like `논문 요약해줘`, `웹서치해서 최신 자료 정리해줘`, `PPT 만들어줘`, and `codex로 열어줘` still paid the full recommendation-scoring path.
- These are clear one-workflow operator intents. Routing them deterministically improves responsiveness without changing execution, evidence, review, CI, or live Hermes claims.

### User / Operator Impact

- Hermes-facing chats can route obvious paper, research, image, material, and coding-agent setup requests faster and with less scoring overhead.
- Ambiguous or multi-step requests still use the normal recommendation and route-plan machinery.
- Status follow-ups such as `codex 세션 지금 실행 중이야?` continue to show coding-agent progress instead of incorrectly preparing a new executor readiness card.

### How It Works

- `src/routing/chat.py` extends `_OPERATOR_SURFACE_FAST_PATH_RULES` with narrowly-scoped phrase sets for high-frequency operator surfaces.
- The fast-path decision builds the normal `ChatRouteDecision`, recommendation card, and route plan from catalog metadata, but skips `recommend_skills` for clear single-workflow phrases.
- Paper fast-path handling explicitly yields back to the normal router when the request asks for citation verification or export/package output.
- Guard markers are attached as extra matched metadata so downstream quality gates and wrapper contracts remain stable.

### Files And Contracts Touched

- `src/routing/chat.py`: deterministic fast-path phrase sets, guard marker compatibility, and paper/materials/citation boundary checks.
- `tests/test_chat_router.py`: regression coverage proving common single-workflow requests skip full recommendation scoring while preserving public route payloads.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check`
- [x] `PYTHONPATH=tests uv run python -m omh.cli harness validate`
- [ ] `python3 -m omh.cli release checklist --json` - not run; this change is router-only and covered by full unittest plus docs/harness/demo gates.
- [ ] `python3 -m omh.cli release hermes-smoke` - not run; no install or Hermes live integration changed.
- [ ] `omh --help` - not run; no command help surface changed.
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` - not run; no setup/install path changed.
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable; no workflow-learning schema changed.
- [x] Relevant dry-run or smoke command: `PYTHONPATH=tests uv run python -m omh.cli demo routing-precision --summary`; `PYTHONPATH=tests uv run python -m omh.cli demo hermes-ux-quality --summary`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; deterministic local routing contracts were changed, not live Hermes rendering.

## Risk

- Phrase fast paths can overmatch if they are too broad. This PR mitigates that by keeping explicit boundary checks for paper citation verification, paper-to-material export, and coding-session status.
- New fast paths are advisory routing metadata only. They do not dispatch executors, generate images, retrieve sources, verify citations, or claim observed runtime evidence.

## Compatibility / Rollout

- Backward compatible with existing router payload shape and existing guard markers.
- No new dependencies, network calls, Hermes core patches, or platform SDKs.
- Safe to roll out through the normal preview/main workflow because ambiguous requests still fall back to the existing recommendation path.

## Release / Claims

- [x] Release-channel impact considered (`preview`/main routing behavior only)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- Continue watching route-quality reports for additional high-frequency one-workflow phrases that can be made deterministic without stealing adjacent workflows.
