### PR TITLE
Skip route plan work for single workflow fast paths

### DIFF
--- a/src/routing/chat.py
+++ b/src/routing/chat.py
@@ -2016,18 +2016,20 @@ def _operator_surface_fast_path_decision(
         score=score,
         why=why,
     )
-    route_plan_recommendations = _operator_surface_route_plan_recommendations(
-        recommendation,
-        selected_skill=selected_skill,
-        extra_markers=extra_markers,
-        message=message,
-    )
-    workflow_route_plan = build_workflow_route_plan(
-        message,
-        route_plan_recommendations,
-        selected_skill=selected_skill,
-        action="dispatch",
-    )
+    workflow_route_plan = None
+    if _operator_surface_needs_route_plan(selected_skill, extra_markers, routing_message):
+        route_plan_recommendations = _operator_surface_route_plan_recommendations(
+            recommendation,
+            selected_skill=selected_skill,
+            extra_markers=extra_markers,
+            message=message,
+        )
+        workflow_route_plan = build_workflow_route_plan(
+            message,
+            route_plan_recommendations,
+            selected_skill=selected_skill,
+            action="dispatch",
+        )
     return ChatRouteDecision(
         schema_version=1,
         source=source,
@@ -2159,6 +2161,50 @@ def _operator_surface_reason(default_reason: str, extra_markers: tuple[str, ...]
     if "guard:risky_refactor_before_cleanup" in extra_markers:
         return "Matched guard/trigger metadata; risky code-change requests should get a reviewed plan before cleanup."
     return default_reason
+
+
+def _operator_surface_needs_route_plan(selected_skill: str, extra_markers: tuple[str, ...], message: str) -> bool:
+    if selected_skill != "ralplan":
+        return False
+    if "guard:safe_feature_change" in extra_markers:
+        return True
+    if "guard:risky_refactor_before_cleanup" in extra_markers:
+        return _operator_surface_has_multi_stage_signals(message)
+    return False
+
+
+def _operator_surface_has_multi_stage_signals(message: str) -> bool:
+    normalized = _fast_path_text(message)
+    signals = (
+        "implementation",
+        "implement",
+        "review",
+        "code review",
+        "docs",
+        "documentation",
+        "pull request",
+        "research",
+        "plan",
+        "조사",
+        "계획",
+        "구현",
+        "리뷰",
+        "문서",
+    )
+    return any(signal in normalized for signal in signals) or _operator_surface_has_pr_signal(normalized)
+
+
+def _operator_surface_has_pr_signal(normalized: str) -> bool:
+    return bool(re.search(r"(^|[^a-z0-9])pr([^a-z0-9]|$)", normalized)) or any(
+        phrase in normalized
+        for phrase in (
+            "pr까지",
+            "pr 까지",
+            "pr로",
+            "pr 로",
+            "pr 만들",
+        )
+    )
 
 
 def _operator_surface_route_plan_recommendations(

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -949,6 +949,44 @@ class EfficiencyContractTests(unittest.TestCase):
                         )
                     )
 
+    def test_single_workflow_operator_fast_paths_skip_route_plan_build(self) -> None:
+        chat_module._route_chat_message_cached.cache_clear()
+        cases = (
+            ("risky refactor", "ralplan"),
+            ("논문 요약해줘", "paper-learning"),
+            ("웹서치해서 최신 자료 정리해줘", "web-research"),
+            ("이미지 생성해줘. 회의록을 세로 카드로 요약해줘", "img-summary"),
+            ("PPT 만들어줘", "materials-package"),
+            ("codex로 열어줘", "executor-runtime-readiness"),
+            ("github oss repo 찾아서 비교해줘", "source-finder"),
+            ("코덱스로 이 이슈 PR 만들어줘", "ultraprocess"),
+            ("오늘 아침 경쟁사 뉴스 요약 자동화해줘", "automation-blueprint"),
+        )
+
+        with patch.object(
+            chat_module,
+            "build_workflow_route_plan",
+            side_effect=AssertionError("single-workflow fast paths should not build route plans"),
+        ):
+            for message, expected_skill in cases:
+                chat_module._route_chat_message_cached.cache_clear()
+                with self.subTest(message=message):
+                    decision = chat_module.route_chat_message(message, source="discord")
+
+                    self.assertEqual(decision["selected_skill"], expected_skill)
+                    self.assertIsNone(decision["workflow_route_plan"])
+
+    def test_safe_feature_operator_fast_path_keeps_route_plan_when_visible(self) -> None:
+        chat_module._route_chat_message_cached.cache_clear()
+        original_build_route_plan = chat_module.build_workflow_route_plan
+
+        with patch.object(chat_module, "build_workflow_route_plan", wraps=original_build_route_plan) as build_route_plan:
+            decision = chat_module.route_chat_message("how can I safely add a feature to this repo?", source="discord")
+
+        self.assertEqual(decision["selected_skill"], "ralplan")
+        self.assertIsNotNone(decision["workflow_route_plan"])
+        self.assertEqual(build_route_plan.call_count, 1)
+
     def test_generic_catalog_fast_paths_skip_full_recommendation_scan(self) -> None:
         chat_module._route_chat_message_cached.cache_clear()
         cases = (


### PR DESCRIPTION
## Feature Report

### What Changed

- Skipped `build_workflow_route_plan` for deterministic single-workflow operator fast paths when the public route payload would not expose a workflow route plan.
- Kept route-plan building for fast paths that still need visible staged guidance, especially safe feature work and risky refactor requests that include research, planning, implementation, review, docs, or PR delivery signals.
- Added efficiency regression tests proving common single-workflow fast paths do not call the route-plan builder, while safe feature work still preserves its visible plan.

### Why This Exists

- PR #489 removed full recommendation scoring from high-frequency natural requests such as paper learning, web research, image summary, materials packaging, and coding-agent readiness.
- Follow-up measurement showed those requests still called the route-plan builder even though `compact_workflow_route_plan` removed the result from the public payload.
- This PR removes that hidden compute path without reducing the visible user-facing routing card.

### User / Operator Impact

- Clear one-workflow requests feel lighter: Hermes can route them without recommendation scoring and without unnecessary route-plan construction.
- Multi-stage requests keep their plan ladder, so users still see research -> plan -> delivery -> review guidance when the prompt actually asks for staged work.
- Prepared-vs-observed boundaries are unchanged. This change only removes unnecessary local planning work for direct fast paths.

### How It Works

- `src/routing/chat.py` now gates route-plan construction behind `_operator_surface_needs_route_plan`.
- The gate returns true for safe feature planning and risky-refactor fast paths with explicit multi-stage signals.
- PR detection inside the multi-stage check uses a bounded PR signal helper so short `pr` matching does not accidentally trigger on words like `project` or `prepare`.

### Files And Contracts Touched

- `src/routing/chat.py`: fast-path route-plan gating and multi-stage signal detection.
- `tests/test_efficiency.py`: regression tests for skipping route-plan work on single-workflow fast paths and preserving it for visible safe-feature plans.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check`
- [x] `PYTHONPATH=tests uv run python -m omh.cli harness validate`
- [ ] `python3 -m omh.cli release checklist --json` - not run; this is a local router efficiency change covered by full unittest and routing quality demos.
- [ ] `python3 -m omh.cli release hermes-smoke` - not run; no install or live Hermes integration changed.
- [ ] `omh --help` - not run; no command help surface changed.
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` - not run; no setup/install path changed.
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable; no workflow-learning contract changed.
- [x] Relevant dry-run or smoke command: `PYTHONPATH=tests uv run python -m omh.cli demo routing-precision --summary`; `PYTHONPATH=tests uv run python -m omh.cli demo hermes-ux-quality --summary`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; deterministic local routing internals changed, not live Hermes rendering.

## Risk

- Over-skipping route plans could hide useful staged guidance. The tests and gate preserve route plans for safe feature work and multi-stage risky refactor requests.
- Multi-stage signal detection is intentionally conservative; ambiguous requests can still use the normal scoring/planning path.

## Compatibility / Rollout

- Backward compatible with public route payloads. Single-workflow fast paths already had no public `workflow_route_plan`; this only avoids building the discarded data.
- No new dependencies, network calls, Hermes core patches, or platform SDKs.

## Release / Claims

- [x] Release-channel impact considered (`preview`/main routing internals only)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- Continue measuring route and wrapper paths for hidden work that does not affect the public user-facing payload.
