### PR TITLE
Speed up workflow learning chat routes

### DIFF
--- a/src/routing/chat.py
+++ b/src/routing/chat.py
@@ -125,6 +125,45 @@ _LEARNING_CANDIDATE_FAST_PATH_BLOCKERS = (
     "기억해:",
     "기억해",
 )
+_WORKFLOW_LEARNING_FAST_PATH_TERMS = (
+    "workflow trace",
+    "workflow traces",
+    "learning trace",
+    "skill improvement",
+    "skill patch",
+    "routing regression",
+    "regression case",
+    "route regression",
+    "workflow went wrong",
+    "improve a workflow",
+    "workflow learning",
+    "워크플로우",
+    "워크플로",
+    "스킬",
+    "라우팅",
+    "라우터",
+)
+_WORKFLOW_LEARNING_FAST_PATH_ACTION_TERMS = (
+    "improve",
+    "improvement",
+    "fix next time",
+    "next time",
+    "learn from",
+    "add regression",
+    "record",
+    "audit",
+    "patch",
+    "고칠",
+    "개선",
+    "다음엔",
+    "다음에는",
+    "학습",
+    "기록",
+    "회귀",
+    "틀렸",
+    "안 썼",
+    "안쓴",
+)
 _BOUNDARY_MARKER_LABELS: tuple[tuple[str, str], ...] = (
     ("meeting happened", "meeting occurrence"),
     ("meeting, scrum, sprint, retro", "meeting/scrum/sprint/retro occurrence"),
@@ -1088,6 +1127,14 @@ def _route_chat_message_cached(
     )
     if fast_operator_surface_decision is not None:
         return fast_operator_surface_decision.to_dict()
+    fast_workflow_learning_decision = _workflow_learning_feedback_fast_path_decision(
+        message,
+        routing_message=routing_message,
+        source=source,
+        min_confidence=min_confidence,
+    )
+    if fast_workflow_learning_decision is not None:
+        return fast_workflow_learning_decision.to_dict()
     fast_guarded_operator_decision = _guarded_operator_fast_path_decision(
         message,
         routing_message=routing_message,
@@ -2425,6 +2472,103 @@ def _guarded_operator_fast_path_decision(
         recommendations=(recommendation,),
     )
     return None
+
+
+def _workflow_learning_feedback_fast_path_decision(
+    message: str,
+    *,
+    routing_message: str,
+    source: str,
+    min_confidence: str,
+) -> ChatRouteDecision | None:
+    if _has_explicit_invocation_prefix(routing_message):
+        return None
+    if is_skill_catalog_question(routing_message):
+        return None
+    if _is_fast_plain_direct_answer_question(routing_message):
+        return None
+    fast_text = _fast_path_text(routing_message)
+    if any(blocker in fast_text for blocker in _LEARNING_CANDIDATE_FAST_PATH_BLOCKERS):
+        return None
+    if not _workflow_learning_fast_path_signal(fast_text):
+        return None
+
+    selected_skill = "workflow-learning"
+    selected_harness = primary_harness_for_skill(selected_skill)
+    route_next_action = _workflow_learning_fast_path_next_action(routing_message)
+    task_card = classify_task(routing_message)
+    short_feedback = len(fast_text) <= 240
+    if (
+        isinstance(task_card, dict)
+        and task_card.get("selected_workflow_rail") == selected_skill
+    ):
+        if not short_feedback:
+            return None
+        recommendation = _task_card_fast_path_recommendation(task_card, message)
+        reason = str(task_card.get("routing_reason", recommendation.get("why", "")))
+        score = _int_value(task_card.get("score", recommendation.get("score", 12)))
+        confidence = str(task_card.get("confidence", recommendation.get("confidence", "high")))
+        route_next_action = str(task_card.get("recommended_next_action", route_next_action))
+    else:
+        if not short_feedback:
+            return None
+        reason = (
+            "Matched workflow-learning feedback language; prepare a learning trace, review candidate, "
+            "or regression case without scanning every workflow definition."
+        )
+        score = 34
+        confidence = "high"
+        recommendation = recommendation_for_definition(
+            _skill_definition_by_name(selected_skill),
+            message,
+            matched=("guard:workflow_learning", "workflow_learning_fast_path"),
+            score=score,
+            why=reason,
+        )
+        if route_next_action and route_next_action != str(recommendation.get("next_action", "")):
+            recommendation = {**recommendation, "next_action": route_next_action}
+        task_card = None
+
+    return ChatRouteDecision(
+        schema_version=1,
+        source=source,
+        action="dispatch",
+        selected_skill=selected_skill,
+        selected_harness=selected_harness,
+        candidate_skill=selected_skill,
+        candidate_harness=selected_harness,
+        confidence=confidence,
+        score=score,
+        threshold=min_confidence,
+        explicit=False,
+        ambiguous=False,
+        reason=reason,
+        clarification="",
+        routing_prompt=_routing_prompt("dispatch", selected_skill, selected_skill, reason, message),
+        task_card=task_card,
+        workflow_route_plan=None,
+        learning_candidate_card=None,
+        recommendations=(recommendation,),
+        route_next_action=route_next_action,
+    )
+
+
+def _workflow_learning_fast_path_signal(text: str) -> bool:
+    compact = _fast_path_compact(text)
+    if not text:
+        return False
+    has_learning_subject = any(
+        term in text or _fast_path_compact(term) in compact for term in _WORKFLOW_LEARNING_FAST_PATH_TERMS
+    )
+    if not has_learning_subject:
+        return False
+    return any(
+        term in text or _fast_path_compact(term) in compact for term in _WORKFLOW_LEARNING_FAST_PATH_ACTION_TERMS
+    )
+
+
+def _workflow_learning_fast_path_next_action(message: str) -> str:
+    return "record_missed_route" if is_missed_route_feedback(message) else "audit_learning_readiness"
 
 
 def _preferred_guarded_operator_fast_path_guard(guards: tuple[Any, ...], message: str) -> Any | None:

--- a/tests/test_chat_router.py
+++ b/tests/test_chat_router.py
@@ -316,6 +316,8 @@ class ChatRouterTests(unittest.TestCase):
             "what is a research brief?",
             "research brief가 뭐야?",
             "what is an image summary?",
+            "what is workflow learning?",
+            "workflow trace가 뭐야?",
             "what is a memory leak?",
             "memory leak 설명해줘",
             "what is source control?",
@@ -613,6 +615,12 @@ class ChatRouterTests(unittest.TestCase):
             ("이미지 생성해줘. 회의록을 세로 카드로 요약해줘", "img-summary", "prepare_visual_prompt_card", "operator_surface_fast_path:visual"),
             ("PPT 만들어줘", "materials-package", "prepare_material_package", "operator_surface_fast_path:materials"),
             ("codex로 열어줘", "executor-runtime-readiness", "prepare_executor_runtime_readiness", "operator_surface_fast_path:executor"),
+            (
+                "workflow trace 보고 다음에 스킬 고칠점 알려줘",
+                "workflow-learning",
+                "audit_learning_readiness",
+                "workflow_learning_fast_path",
+            ),
         )
 
         for message, selected_skill, next_action, marker in cases:

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -961,6 +961,7 @@ class EfficiencyContractTests(unittest.TestCase):
             ("github oss repo 찾아서 비교해줘", "source-finder"),
             ("코덱스로 이 이슈 PR 만들어줘", "ultraprocess"),
             ("오늘 아침 경쟁사 뉴스 요약 자동화해줘", "automation-blueprint"),
+            ("workflow trace 보고 다음에 스킬 고칠점 알려줘", "workflow-learning"),
         )
 
         with patch.object(
@@ -1065,6 +1066,7 @@ class EfficiencyContractTests(unittest.TestCase):
             ("자료 찾아줘", "web-research", "operator_surface_fast_path:research"),
             ("성능 최적화해줘", "performance-goal", "operator_surface_fast_path:performance"),
             ("리드미 개선해줘", "ultraprocess", "operator_surface_fast_path:delivery"),
+            ("workflow trace 보고 다음에 스킬 고칠점 알려줘", "workflow-learning", "workflow_learning_fast_path"),
         )
 
         with patch.object(


### PR DESCRIPTION
## Summary
- Add a narrow `workflow-learning` chat fast path for short feedback turns such as `workflow trace 보고 다음에 스킬 고칠점 알려줘`.
- Keep concept questions like `workflow trace가 뭐야?` on the direct-answer path.
- Keep explicit `learn this:` skill-candidate requests and long pasted OMH awareness evaluations on the existing slower path so they can still produce review cards or visible route plans.

## Why
Short workflow-improvement prompts already routed correctly, but cold routing still paid the full recommendation-definition scan. That made the first reply slower for a common chat-first operator action: asking Hermes to inspect a workflow trace, suggest skill/routing improvement, or prepare a regression case.

## What Changed
- `src/routing/chat.py`
  - Adds a bounded workflow-learning fast path after catalog/operator-surface checks and before the full recommendation scan.
  - Uses subject + action term matching, blocks direct-answer/catalog/learning-candidate cases, and limits the fast path to short feedback turns.
  - Preserves `record_missed_route` vs `audit_learning_readiness` action copy.
- `tests/test_chat_router.py`
  - Locks direct-answer behavior for workflow-learning concept questions.
  - Locks the new short workflow-learning route and next action.
- `tests/test_efficiency.py`
  - Proves this route skips full recommendation scoring and route-plan construction.

## Evidence
Observed locally:
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` -> 1023 tests OK
- `uv run python -m compileall -q src tests` -> passed
- `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check` -> passed, 49/49 tap skills in sync
- `PYTHONPATH=tests uv run python -m omh.cli harness validate` -> passed, 50 skills / 36 harnesses
- `PYTHONPATH=tests uv run python -m omh.cli demo hermes-ux-quality --summary` -> passed, 100/100
- `PYTHONPATH=tests uv run python -m omh.cli demo grounded-score --summary` -> passed, 47/47 at 10/10
- `PYTHONPATH=tests uv run python -m omh.cli demo routing-precision --summary` -> passed, 41/41 negative controls and 52/52 interventions
- `git diff --check` -> passed

Performance spot check:
- Before: representative cold route for `workflow trace 보고 다음에 스킬 고칠점 알려줘` measured around 8.7ms.
- After: `cold_ms=1.133`, `warm_1000_ms=1.772`, selected `workflow-learning`, next action `audit_learning_readiness`.

## Boundaries
- No LLM/API/network calls.
- No Hermes runtime, plugin-load, platform-delivery, executor-dispatch, review, CI, or merge claims.
- The route remains deterministic local metadata only.
- Long pasted evaluations still build route plans and remain outside the fast path.

## Risks / Rollout
- Scope is deliberately narrow. Add new multilingual workflow-learning phrases only with direct-answer, learning-candidate, and long-evaluation regression tests.
