### PR TITLE
Speed up feedback triage routing

### DIFF
--- a/src/routing/chat.py
+++ b/src/routing/chat.py
@@ -118,6 +118,53 @@ _GUARDED_OPERATOR_META_BLOCKERS = (
     "테스트",
     "요구사항은 없어",
 )
+_FEEDBACK_TRIAGE_FAST_PATH_BLOCKERS = (
+    "codex",
+    "claude code",
+    "handoff",
+    "implementation",
+    "implement",
+    "fix",
+    "review",
+    "track",
+    "repro",
+    "reproduction",
+    "plan",
+    "pr",
+    "코덱스",
+    "클로드 코드",
+    "핸드오프",
+    "구현",
+    "고쳐",
+    "고치",
+    "수정",
+    "리뷰",
+    "추적",
+    "재현",
+    "계획",
+    "pr",
+)
+_FEEDBACK_TRIAGE_FAST_PATH_TERMS = (
+    "payment failure",
+    "payment failures",
+    "checkout is broken",
+    "checkout broken",
+    "checkout timeout",
+    "checkout timeouts",
+    "refunds after checkout",
+    "app keeps crashing",
+    "crashing after login",
+    "dashboard 500",
+    "dashboard 500s",
+    "login 500",
+    "결제 실패",
+    "결제실패",
+    "체크아웃 실패",
+    "체크아웃 오류",
+    "로그인 후 크래시",
+    "로그인하고 크래시",
+    "대시보드 500",
+)
 _LEARNING_CANDIDATE_FAST_PATH_BLOCKERS = (
     "learn this",
     "make a skill from this",
@@ -1127,6 +1174,14 @@ def _route_chat_message_cached(
     )
     if fast_operator_surface_decision is not None:
         return fast_operator_surface_decision.to_dict()
+    fast_feedback_triage_decision = _feedback_triage_fast_path_decision(
+        message,
+        routing_message=routing_message,
+        source=source,
+        min_confidence=min_confidence,
+    )
+    if fast_feedback_triage_decision is not None:
+        return fast_feedback_triage_decision.to_dict()
     fast_workflow_learning_decision = _workflow_learning_feedback_fast_path_decision(
         message,
         routing_message=routing_message,
@@ -2439,6 +2494,8 @@ def _guarded_operator_fast_path_decision(
     if guard is None or not guard.preferred_skills:
         return None
     selected_skill = guard.preferred_skills[0]
+    if selected_skill == "feedback-triage" and _feedback_triage_fast_path_blocked(routing_message):
+        return None
     definition = _skill_definition_by_name(selected_skill)
     selected_harness = primary_harness_for_skill(selected_skill)
     matched = (guard.matched_label, f"guard_fast_path:{guard.id}")
@@ -2472,6 +2529,66 @@ def _guarded_operator_fast_path_decision(
         recommendations=(recommendation,),
     )
     return None
+
+
+def _feedback_triage_fast_path_decision(
+    message: str,
+    *,
+    routing_message: str,
+    source: str,
+    min_confidence: str,
+) -> ChatRouteDecision | None:
+    if _has_explicit_invocation_prefix(routing_message):
+        return None
+    if is_skill_catalog_question(routing_message):
+        return None
+    if _is_fast_plain_direct_answer_question(routing_message):
+        return None
+    fast_text = _fast_path_text(routing_message)
+    if _feedback_triage_fast_path_blocked(fast_text):
+        return None
+    if not _feedback_triage_fast_path_signal(fast_text):
+        return None
+
+    selected_skill = "feedback-triage"
+    selected_harness = primary_harness_for_skill(selected_skill)
+    reason = (
+        "Matched a concrete customer or product issue signal; triage the feedback before planning fixes."
+    )
+    score = 34
+    recommendation = recommendation_for_definition(
+        _skill_definition_by_name(selected_skill),
+        message,
+        matched=("guard:feedback_before_coding", "feedback_triage_fast_path"),
+        score=score,
+        why=reason,
+    )
+    return ChatRouteDecision(
+        schema_version=1,
+        source=source,
+        action="dispatch",
+        selected_skill=selected_skill,
+        selected_harness=selected_harness,
+        candidate_skill=selected_skill,
+        candidate_harness=selected_harness,
+        confidence="high",
+        score=score,
+        threshold=min_confidence,
+        explicit=False,
+        ambiguous=False,
+        reason=reason,
+        clarification="",
+        routing_prompt=_routing_prompt("dispatch", selected_skill, selected_skill, reason, message),
+        task_card=None,
+        workflow_route_plan=None,
+        learning_candidate_card=None,
+        recommendations=(recommendation,),
+    )
+
+
+def _feedback_triage_fast_path_signal(text: str) -> bool:
+    compact = _fast_path_compact(text)
+    return any(term in text or _fast_path_compact(term) in compact for term in _FEEDBACK_TRIAGE_FAST_PATH_TERMS)
 
 
 def _workflow_learning_feedback_fast_path_decision(
@@ -2614,6 +2731,12 @@ def _guarded_operator_fast_path_blocked(message: str) -> bool:
     if any(blocker in text for blocker in _GUARDED_OPERATOR_META_BLOCKERS):
         return True
     return any(blocker in text for blocker in _LEARNING_CANDIDATE_FAST_PATH_BLOCKERS)
+
+
+def _feedback_triage_fast_path_blocked(message: str) -> bool:
+    text = _fast_path_text(message)
+    compact = _fast_path_compact(text)
+    return any(blocker in text or _fast_path_compact(blocker) in compact for blocker in _FEEDBACK_TRIAGE_FAST_PATH_BLOCKERS)
 
 
 def _first_guarded_operator_fast_path_index(guards: tuple[Any, ...]) -> int | None:

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -949,6 +949,34 @@ class EfficiencyContractTests(unittest.TestCase):
                         )
                     )
 
+    def test_feedback_triage_fast_paths_skip_full_recommendation_scan(self) -> None:
+        chat_module._route_chat_message_cached.cache_clear()
+        cases = (
+            "결제 실패 이슈가 자주 나와",
+            "Payment failures keep coming up.",
+            "Users say checkout is broken.",
+        )
+
+        with patch.object(
+            chat_module,
+            "recommend_skills",
+            side_effect=AssertionError("feedback-triage fast path should skip scoring"),
+        ), patch.object(
+            chat_module,
+            "build_workflow_route_plan",
+            side_effect=AssertionError("feedback-triage fast path should not build route plans"),
+        ):
+            for message in cases:
+                chat_module._route_chat_message_cached.cache_clear()
+                with self.subTest(message=message):
+                    decision = chat_module.route_chat_message(message, source="discord")
+
+                    self.assertEqual(decision["selected_skill"], "feedback-triage")
+                    self.assertEqual(decision["action"], "dispatch")
+                    self.assertEqual(decision["confidence"], "high")
+                    self.assertIn("feedback_triage_fast_path", decision["recommendations"][0]["matched"])
+                    self.assertIsNone(decision["workflow_route_plan"])
+
     def test_single_workflow_operator_fast_paths_skip_route_plan_build(self) -> None:
         chat_module._route_chat_message_cached.cache_clear()
         cases = (


### PR DESCRIPTION
## Summary
- Add a narrow deterministic fast path for simple customer/product issue messages such as payment failures, checkout failures, and app crashes.
- Keep compound bug work, implementation requests, review requests, and source-backed research on the full router path so route plans and evidence boundaries are preserved.
- Add an efficiency contract test that proves the new simple feedback path skips full recommendation scoring and route-plan construction.

## Why
Simple operator messages like “결제 실패 이슈가 자주 나와” are common in Discord/Slack-style product channels. Before this change, they still fell through the full recommendation scan even though the outcome should be immediate feedback triage. That made a high-frequency chat path slower than needed.

## What Users Can Do Now
Hermes can answer common product-feedback signals faster and still route them to `feedback-triage` first. A simple payment or checkout issue opens investigation/triage, while a richer request such as “reproduce it, hand it to Codex, and review the fix” still gets the full staged route plan.

## How It Works
- `src/routing/chat.py` adds a small allowlist of concrete product issue terms and a blocker list for coding, review, reproduction, PR, and planning language.
- The fast path runs after operator-surface shortcuts but before the full recommendation scan.
- The decision records `feedback_triage_fast_path` plus `guard:feedback_before_coding`, returns `feedback-triage`, and intentionally omits `workflow_route_plan` for simple issue reports.
- Compound messages remain outside the fast path so existing route-plan behavior remains intact.

## Verification
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` -> 1024 tests OK
- `uv run python -m compileall -q src tests` -> pass
- `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check` -> pass, 49/49 tap skills in sync
- `PYTHONPATH=tests uv run python -m omh.cli harness validate` -> pass, 50 skills / 36 harnesses
- `PYTHONPATH=tests uv run python -m omh.cli demo hermes-ux-quality --summary` -> passed, 100/100
- `PYTHONPATH=tests uv run python -m omh.cli demo grounded-score --summary` -> passed, 47/47 scenarios at 10/10
- `PYTHONPATH=tests uv run python -m omh.cli demo routing-precision --summary` -> passed, 41/41 negative controls and 52/52 interventions
- `git diff --check` -> pass

## Risks And Rollout Notes
- The fast path is deliberately narrow. New product-feedback phrasings should be added only when they are concrete enough not to steal research, planning, or coding delegation requests.
- Live Hermes chat rendering and platform delivery were not exercised; this PR verifies the deterministic local routing contracts only.
