### PR TITLE
Speed up product shaping routing

### DIFF
--- a/src/routing/chat.py
+++ b/src/routing/chat.py
@@ -165,6 +165,32 @@ _FEEDBACK_TRIAGE_FAST_PATH_TERMS = (
     "로그인하고 크래시",
     "대시보드 500",
 )
+_PRODUCT_SHAPING_FAST_PATH_BLOCKERS = _FEEDBACK_TRIAGE_FAST_PATH_BLOCKERS + (
+    "bug",
+    "issue",
+    "broken",
+    "create a pr",
+    "open a pr",
+    "pull request",
+    "버그",
+    "이슈",
+    "pr 만들어",
+    "pr 열어",
+)
+_PRODUCT_SHAPING_FAST_PATH_TERMS = (
+    "improve our onboarding",
+    "improve onboarding",
+    "make onboarding smoother",
+    "make onboarding feel smoother",
+    "make the user experience smoother",
+    "make the product experience better",
+    "not sure where to start",
+    "where to start",
+    "온보딩을 더 부드럽게",
+    "온보딩 개선",
+    "어디서 시작",
+    "어디부터 시작",
+)
 _LEARNING_CANDIDATE_FAST_PATH_BLOCKERS = (
     "learn this",
     "make a skill from this",
@@ -1182,6 +1208,14 @@ def _route_chat_message_cached(
     )
     if fast_feedback_triage_decision is not None:
         return fast_feedback_triage_decision.to_dict()
+    fast_product_shaping_decision = _product_shaping_fast_path_decision(
+        message,
+        routing_message=routing_message,
+        source=source,
+        min_confidence=min_confidence,
+    )
+    if fast_product_shaping_decision is not None:
+        return fast_product_shaping_decision.to_dict()
     fast_workflow_learning_decision = _workflow_learning_feedback_fast_path_decision(
         message,
         routing_message=routing_message,
@@ -2591,6 +2625,64 @@ def _feedback_triage_fast_path_signal(text: str) -> bool:
     return any(term in text or _fast_path_compact(term) in compact for term in _FEEDBACK_TRIAGE_FAST_PATH_TERMS)
 
 
+def _product_shaping_fast_path_decision(
+    message: str,
+    *,
+    routing_message: str,
+    source: str,
+    min_confidence: str,
+) -> ChatRouteDecision | None:
+    if _has_explicit_invocation_prefix(routing_message):
+        return None
+    if is_skill_catalog_question(routing_message):
+        return None
+    if _is_fast_plain_direct_answer_question(routing_message):
+        return None
+    fast_text = _fast_path_text(routing_message)
+    if _product_shaping_fast_path_blocked(fast_text):
+        return None
+    if not _product_shaping_fast_path_signal(fast_text):
+        return None
+
+    selected_skill = "deep-interview"
+    selected_harness = primary_harness_for_skill(selected_skill)
+    reason = "Matched fuzzy product-shaping language; ask one clarifying question before planning or execution."
+    score = 30
+    recommendation = recommendation_for_definition(
+        _skill_definition_by_name(selected_skill),
+        message,
+        matched=("guard:product_shaping", "product_shaping_fast_path"),
+        score=score,
+        why=reason,
+    )
+    return ChatRouteDecision(
+        schema_version=1,
+        source=source,
+        action="dispatch",
+        selected_skill=selected_skill,
+        selected_harness=selected_harness,
+        candidate_skill=selected_skill,
+        candidate_harness=selected_harness,
+        confidence="high",
+        score=score,
+        threshold=min_confidence,
+        explicit=False,
+        ambiguous=False,
+        reason=reason,
+        clarification="",
+        routing_prompt=_routing_prompt("dispatch", selected_skill, selected_skill, reason, message),
+        task_card=None,
+        workflow_route_plan=None,
+        learning_candidate_card=None,
+        recommendations=(recommendation,),
+    )
+
+
+def _product_shaping_fast_path_signal(text: str) -> bool:
+    compact = _fast_path_compact(text)
+    return any(term in text or _fast_path_compact(term) in compact for term in _PRODUCT_SHAPING_FAST_PATH_TERMS)
+
+
 def _workflow_learning_feedback_fast_path_decision(
     message: str,
     *,
@@ -2737,6 +2829,12 @@ def _feedback_triage_fast_path_blocked(message: str) -> bool:
     text = _fast_path_text(message)
     compact = _fast_path_compact(text)
     return any(blocker in text or _fast_path_compact(blocker) in compact for blocker in _FEEDBACK_TRIAGE_FAST_PATH_BLOCKERS)
+
+
+def _product_shaping_fast_path_blocked(message: str) -> bool:
+    text = _fast_path_text(message)
+    compact = _fast_path_compact(text)
+    return any(blocker in text or _fast_path_compact(blocker) in compact for blocker in _PRODUCT_SHAPING_FAST_PATH_BLOCKERS)
 
 
 def _first_guarded_operator_fast_path_index(guards: tuple[Any, ...]) -> int | None:

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -977,6 +977,51 @@ class EfficiencyContractTests(unittest.TestCase):
                     self.assertIn("feedback_triage_fast_path", decision["recommendations"][0]["matched"])
                     self.assertIsNone(decision["workflow_route_plan"])
 
+    def test_product_shaping_fast_paths_skip_full_recommendation_scan(self) -> None:
+        chat_module._route_chat_message_cached.cache_clear()
+        cases = (
+            "make onboarding feel smoother",
+            "make the user experience smoother",
+            "온보딩을 더 부드럽게 만들고 싶어",
+        )
+
+        with patch.object(
+            chat_module,
+            "recommend_skills",
+            side_effect=AssertionError("product-shaping fast path should skip scoring"),
+        ), patch.object(
+            chat_module,
+            "build_workflow_route_plan",
+            side_effect=AssertionError("product-shaping fast path should not build route plans"),
+        ):
+            for message in cases:
+                chat_module._route_chat_message_cached.cache_clear()
+                with self.subTest(message=message):
+                    decision = chat_module.route_chat_message(message, source="discord")
+
+                    self.assertEqual(decision["selected_skill"], "deep-interview")
+                    self.assertEqual(decision["action"], "dispatch")
+                    self.assertEqual(decision["confidence"], "high")
+                    self.assertIn("product_shaping_fast_path", decision["recommendations"][0]["matched"])
+                    self.assertIsNone(decision["workflow_route_plan"])
+
+    def test_product_shaping_fast_path_does_not_steal_compound_requests(self) -> None:
+        chat_module._route_chat_message_cached.cache_clear()
+        cases = (
+            ("make onboarding feel smoother and implement it", "oh-my-hermes", "start_ultraprocess"),
+            ("improve onboarding conversion with a plan and implementation", "plan", "present_plan"),
+            ("fix onboarding bug", "ultraprocess", "start_ultraprocess"),
+        )
+
+        for message, expected_skill, expected_action in cases:
+            chat_module._route_chat_message_cached.cache_clear()
+            with self.subTest(message=message):
+                decision = chat_module.route_chat_message(message, source="discord")
+
+                self.assertEqual(decision["selected_skill"], expected_skill)
+                self.assertEqual(decision["recommendations"][0]["next_action"], expected_action)
+                self.assertNotIn("product_shaping_fast_path", decision["recommendations"][0]["matched"])
+
     def test_single_workflow_operator_fast_paths_skip_route_plan_build(self) -> None:
         chat_module._route_chat_message_cached.cache_clear()
         cases = (


### PR DESCRIPTION
## Summary
- Add a narrow deterministic fast path for common fuzzy product-shaping prompts such as onboarding and UX improvement requests.
- Route those simple prompts directly to `deep-interview` without running the full recommendation scan or building a route plan.
- Keep implementation, PR, bug-fix, and planning compound requests on the existing full router path.

## Why
A common Hermes chat request is product shaping: “make onboarding feel smoother” or “온보딩을 더 부드럽게 만들고 싶어.” The router already chose `deep-interview`, but it paid the full scoring path first. This PR makes that high-frequency path feel immediate while preserving the safer full route for work that asks for implementation, PRs, bug fixes, or plans.

## What Users Can Do Now
Hermes can ask the first useful clarification faster for vague onboarding/UX/product-experience requests. That improves the chat-first feel without changing the observed evidence boundary: this is still a prepared routing decision, not execution, review, CI, or delivery evidence.

## How It Works
- `src/routing/chat.py` adds product-shaping fast-path terms and blockers.
- Simple shaping prompts return `deep-interview` with `product_shaping_fast_path` and `guard:product_shaping`.
- Blocker terms such as implementation, PR, bug, fix, review, and plan force the existing full router path.
- `tests/test_efficiency.py` proves the fast path skips `recommend_skills` and `build_workflow_route_plan`, and verifies compound requests are not stolen.

## Performance Evidence
Representative cold route timings from the local router:
- `make onboarding feel smoother`: about 6.8ms before, about 1.2ms after
- `make the user experience smoother`: about 0.3ms after
- `온보딩을 더 부드럽게 만들고 싶어`: about 0.3ms after
- compound requests such as `make onboarding feel smoother and implement it` still avoid the fast path

## Verification
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` -> 1026 tests OK
- `uv run python -m compileall -q src tests` -> pass
- `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check` -> pass, 49/49 tap skills in sync
- `PYTHONPATH=tests uv run python -m omh.cli harness validate` -> pass, 50 skills / 36 harnesses
- `PYTHONPATH=tests uv run python -m omh.cli demo hermes-ux-quality --summary` -> passed, 100/100
- `PYTHONPATH=tests uv run python -m omh.cli demo grounded-score --summary` -> passed, 47/47 scenarios at 10/10
- `PYTHONPATH=tests uv run python -m omh.cli demo routing-precision --summary` -> passed, 41/41 negative controls and 52/52 interventions
- `git diff --check` -> pass

## Risks And Rollout Notes
- The phrase list is intentionally conservative. New shaping phrases should be added only with explicit negative controls for adjacent implementation, PR, bug, and planning requests.
- Live Hermes chat rendering and platform delivery were not exercised; this PR verifies deterministic local routing contracts only.
