### PR TITLE
Harden hot chat routing paths

### DIFF
--- a/src/routing/chat.py
+++ b/src/routing/chat.py
@@ -2203,6 +2203,12 @@ _OPERATOR_SURFACE_FAST_PATH_RULES: tuple[tuple[str, tuple[str, ...], str, str], 
             "find public presentations",
             "find arxiv link",
             "find arxiv paper",
+            "paper pdf 찾아",
+            "paper pdf를 찾아",
+            "paper pdf 찾아서",
+            "pdf 자료 찾아",
+            "public pdf sources",
+            "find public pdf",
             "arxiv link",
             "github oss repo",
             "github repos and public presentations",
@@ -2257,6 +2263,61 @@ _OPERATOR_SURFACE_FAST_PATH_RULES: tuple[tuple[str, tuple[str, ...], str, str], 
         ),
         "operator_surface_fast_path:performance",
         "Clear performance-improvement request; prepare the measured performance goal without scoring every workflow.",
+    ),
+    (
+        "doctor",
+        (
+            "did update work",
+            "update worked",
+            "update version unchanged",
+            "version unchanged after update",
+            "omh update worked",
+            "omh update 했는데 잘",
+            "update 했는데 잘",
+            "update 했는데 버전",
+            "업데이트 했는데 잘",
+            "업데이트했는데 잘",
+            "업데이트 했는데 버전",
+            "업데이트했는데 버전",
+        ),
+        "operator_surface_fast_path:doctor",
+        "Clear OMH setup/update health question; run diagnostics without scoring every workflow.",
+    ),
+    (
+        "github-event-ops",
+        (
+            "pr opened ci failed",
+            "pr opened and ci failed",
+            "ci failed on pr",
+            "ci failed on my pr",
+            "pr opened review failed",
+            "github pr ci failed",
+            "pr 열렸는데 ci 실패",
+            "pr이 열렸는데 ci 실패",
+            "ci 실패했어 정리",
+            "ci 실패 원인",
+            "pr ci 실패",
+        ),
+        "operator_surface_fast_path:github_event",
+        "Clear PR/CI event request; prepare GitHub event ops without scoring every workflow.",
+    ),
+    (
+        "memory-curation-review",
+        (
+            "hermes remembers incorrectly",
+            "hermes remembered incorrectly",
+            "hermes is remembering wrong",
+            "hermes remembers this wrong",
+            "hermes memory is wrong",
+            "hermes가 내 기억을 잘못",
+            "헤르메스가 내 기억을 잘못",
+            "hermes가 기억을 잘못",
+            "헤르메스가 기억을 잘못",
+            "내 메모리 뭐가 저장",
+            "내 기억 뭐가 저장",
+        ),
+        "operator_surface_fast_path:memory",
+        "Clear Hermes memory-context review request; prepare memory curation without scoring every workflow.",
     ),
     (
         "executor-runtime-readiness",
@@ -2459,6 +2520,12 @@ def _operator_surface_extra_markers(skill: str, phrase: str) -> tuple[str, ...]:
         return ("guard:img_summary",)
     if skill == "paper-learning":
         return ("guard:paper_learning",)
+    if skill == "doctor":
+        return ("guard:doctor_health", "guard_fast_path:doctor_health_before_skill_catalog")
+    if skill == "github-event-ops":
+        return ("guard:github_event_ops",)
+    if skill == "memory-curation-review":
+        return ("guard:memory_curation", "guard_fast_path:memory_curation_before_generic_clarification")
     if skill == "executor-runtime-readiness":
         return ("guard:executor_runtime_readiness",)
     if skill != "ralplan":
@@ -2516,6 +2583,12 @@ def _operator_surface_phrase_marker(marker: str, phrase: str) -> str:
         return "phrase:source_request"
     if marker == "operator_surface_fast_path:delivery":
         return "phrase:delivery_request"
+    if marker == "operator_surface_fast_path:doctor":
+        return "phrase:doctor_health"
+    if marker == "operator_surface_fast_path:github_event":
+        return "phrase:github_event"
+    if marker == "operator_surface_fast_path:memory":
+        return "phrase:memory_curation"
     if marker == "operator_surface_fast_path:executor":
         return "phrase:executor_request"
     if marker == "operator_surface_fast_path:materials":

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -1188,8 +1188,16 @@ class EfficiencyContractTests(unittest.TestCase):
             ("paper pdf expert explanation please", "paper-learning", "operator_surface_fast_path:paper"),
             ("회의록 정리해줘", "operating-rhythm", "operator_surface_fast_path:operating"),
             ("논문 링크 찾아줘", "source-finder", "operator_surface_fast_path:source"),
+            ("paper pdf를 찾아서 쉽게 설명해줘", "source-finder", "operator_surface_fast_path:source"),
             ("자료 찾아줘", "web-research", "operator_surface_fast_path:research"),
             ("성능 최적화해줘", "performance-goal", "operator_surface_fast_path:performance"),
+            ("omh update 했는데 잘 된건지 모르겠어", "doctor", "operator_surface_fast_path:doctor"),
+            ("PR 열렸는데 CI 실패했어 정리해줘", "github-event-ops", "operator_surface_fast_path:github_event"),
+            (
+                "Hermes가 내 기억을 잘못 기억하는 것 같아",
+                "memory-curation-review",
+                "operator_surface_fast_path:memory",
+            ),
             ("리드미 개선해줘", "ultraprocess", "operator_surface_fast_path:delivery"),
             ("workflow trace 보고 다음에 스킬 고칠점 알려줘", "workflow-learning", "workflow_learning_fast_path"),
         )


### PR DESCRIPTION
## Summary

This PR tightens OMH chat routing for real operator phrases that were already semantically supported but still took heavier recommendation paths. It keeps OMH chat-first behavior predictable while shaving the common hot path for update-health checks, PR/CI event triage, Hermes memory-context review, and paper/source lookup.

## What Changed

- Added narrow operator fast-path phrases for:
  - `doctor` update-health questions such as `omh update 했는데 잘 된건지 모르겠어`
  - `github-event-ops` PR/CI failure event requests
  - `memory-curation-review` Hermes wrong-memory reports
  - `source-finder` mixed paper/PDF/source-finding requests
- Preserved existing guarded marker contracts by keeping `guard:doctor_health` / `guard_fast_path:*` style markers visible where downstream wrappers and tests expect them.
- Extended efficiency regression coverage so these hot-path phrases skip full `recommend_skills` scans and avoid route-plan generation when no route plan is needed.

## Why

Recent real usage showed these phrases are common in Hermes/Discord-style chat. The route result was correct, but the path could still be heavier or less explicit than necessary. This keeps the behavior deterministic and makes the fast path reflect the user-facing intent more directly.

## User Impact

Hermes can answer these practical OMH questions faster and with less routing ambiguity:

- "Did `omh update` actually work?" -> `doctor`
- "PR opened and CI failed" -> `github-event-ops`
- "Hermes is remembering this wrong" -> `memory-curation-review`
- "Find the paper PDF and explain it" -> `source-finder` first

No execution, source retrieval, platform delivery, or coding dispatch is claimed by this change.

## Verification

Observed locally:

- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` -> 1028 tests passed
- `uv run python -m compileall -q src tests` -> passed
- `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check` -> passed
- `PYTHONPATH=tests uv run python -m omh.cli harness validate` -> passed
- `PYTHONPATH=tests uv run python -m omh.cli demo routing-precision --summary` -> 41/41 negative controls, 70/70 interventions, 0 overroutes
- `PYTHONPATH=tests uv run python -m omh.cli demo hermes-ux-quality --summary` -> 100/100, gates 5/5, routing avg 10.0
- `git diff --check` -> passed

Representative local timing sample after the change: cold average `2.142 ms`, warm average `0.0143 ms/message` across ten chat prompts.

## Risk

Low. The new phrases are intentionally narrow and backed by regression tests. The only compatibility-sensitive part was preserving guarded marker contracts, which is now covered by existing and updated tests.