### PR TITLE
Harden operator fast paths for merge constraints

### DIFF
--- a/src/plugin_bundle/omh/awareness.py
+++ b/src/plugin_bundle/omh/awareness.py
@@ -2451,6 +2451,8 @@ def _awareness_route_hint_cached(message: str, max_hints: int) -> dict[str, obje
             next_action = str(rule["next_action"])
             if workflow == "loop":
                 next_action = _loop_route_hint_next_action(message, next_action)
+            if rule["id"] == "coding_delivery":
+                next_action = _coding_delivery_route_hint_next_action(message, next_action)
             hints.append(
                 {
                     "id": str(rule["id"]),
@@ -2933,6 +2935,19 @@ def _loop_route_hint_next_action(message: str, default_action: str) -> str:
             return "record_external_wait"
         return "start_loop_cycle"
     return next_action or default_action
+
+
+def _coding_delivery_route_hint_next_action(message: str, default_action: str) -> str:
+    normalized = unicodedata.normalize("NFKC", message).casefold().strip()
+    compact = re.sub(r"[\s\?\!\.,;:~…？]+", "", normalized)
+    has_friren = "friren" in normalized or "프리렌" in normalized
+    has_authority_or_merge_context = any(
+        marker in normalized or marker in compact
+        for marker in ("author", "merge", "commit", "머지", "커밋")
+    )
+    if has_friren and has_authority_or_merge_context:
+        return "show_coding_handoff_status"
+    return default_action
 
 
 def _direct_workflow_invocation_hint(intent: object, routing_normalized: str, message: str) -> dict[str, object]:

--- a/src/routing/chat.py
+++ b/src/routing/chat.py
@@ -2240,6 +2240,16 @@ _OPERATOR_SURFACE_FAST_PATH_RULES: tuple[tuple[str, tuple[str, ...], str, str], 
             "코덱스로 이 이슈 pr",
             "코덱스로 이슈 pr",
             "코덱스로 이 이슈 pr 만들어",
+            "merge as friren",
+            "merge with friren author",
+            "friren author",
+            "friren author로",
+            "프리렌 author",
+            "프리렌 author로",
+            "프리렌 author로 머지",
+            "프리렌 author로 커밋",
+            "프리렌으로 머지",
+            "프리렌으로 커밋",
             "improve readme",
             "update readme",
             "readme improvement",
@@ -2423,6 +2433,25 @@ _OPERATOR_SURFACE_FAST_PATH_RULES: tuple[tuple[str, tuple[str, ...], str, str], 
         "operator_surface_fast_path:automation",
         "Clear automation request; prepare the scheduled-ops blueprint without scoring every workflow.",
     ),
+    (
+        "agent-board",
+        (
+            "multiple hermes agents",
+            "multiple hermes profiles",
+            "multi agent topology",
+            "target topology",
+            "agent topology",
+            "hermes agent 여러",
+            "헤르메스 agent 여러",
+            "헤르메스 에이전트 여러",
+            "에이전트가 한개가 아니라 여러개",
+            "에이전트가 한 개가 아니라 여러 개",
+            "agent가 한개가 아니라 여러개",
+            "agent가 한 개가 아니라 여러 개",
+        ),
+        "operator_surface_fast_path:agent_board",
+        "Clear multi-Hermes-agent topology request; prepare the board/status contract without scoring every workflow.",
+    ),
 )
 
 
@@ -2461,6 +2490,10 @@ def _operator_surface_fast_path_decision(
         score=score,
         why=why,
     )
+    route_next_action = ""
+    if "guard:merge_author_constraint" in extra_markers:
+        route_next_action = "show_coding_handoff_status"
+        recommendation = {**recommendation, "next_action": route_next_action}
     workflow_route_plan = None
     if _operator_surface_needs_route_plan(selected_skill, extra_markers, routing_message):
         route_plan_recommendations = _operator_surface_route_plan_recommendations(
@@ -2495,6 +2528,7 @@ def _operator_surface_fast_path_decision(
         workflow_route_plan=workflow_route_plan,
         learning_candidate_card=None,
         recommendations=(recommendation,),
+        route_next_action=route_next_action,
     )
 
 
@@ -2520,8 +2554,11 @@ def _operator_surface_fast_path_patterns() -> tuple[tuple[str, str, str, str, st
 
 def _operator_surface_extra_markers(skill: str, phrase: str) -> tuple[str, ...]:
     normalized = _fast_path_text(phrase)
-    if skill == "ultraprocess" and any(marker in normalized for marker in ("codex", "코덱스")):
-        return ("guard:coding_handoff_status",)
+    if skill == "ultraprocess":
+        if any(marker in normalized for marker in ("codex", "코덱스")):
+            return ("guard:coding_handoff_status",)
+        if any(marker in normalized for marker in ("friren", "프리렌", "author", "merge", "머지", "커밋")):
+            return ("guard:coding_handoff_status", "guard:merge_author_constraint")
     if skill == "img-summary":
         return ("guard:img_summary",)
     if skill == "paper-learning":
@@ -2601,6 +2638,8 @@ def _operator_surface_phrase_marker(marker: str, phrase: str) -> str:
         return "phrase:materials_request"
     if marker == "operator_surface_fast_path:automation":
         return "phrase:automation_request"
+    if marker == "operator_surface_fast_path:agent_board":
+        return "phrase:agent_topology_request"
     return "phrase:operator_surface"
 
 

--- a/tests/test_chat_router.py
+++ b/tests/test_chat_router.py
@@ -98,6 +98,18 @@ class ChatRouterTests(unittest.TestCase):
                 None,
             ),
             (
+                "merge할때도 프리렌 author로 머지해",
+                "ultraprocess",
+                "show_coding_handoff_status",
+                None,
+            ),
+            (
+                "프리렌 author로 커밋하고 머지해",
+                "ultraprocess",
+                "show_coding_handoff_status",
+                None,
+            ),
+            (
                 "setup이 잘 됐는지 확인해줘",
                 "doctor",
                 "run_local_operator_check",
@@ -1640,6 +1652,18 @@ class ChatRouterTests(unittest.TestCase):
                 "operator_surface_fast_path:performance",
             ),
             ("리드미 개선해줘", "ultraprocess", "start_ultraprocess", "operator_surface_fast_path:delivery"),
+            (
+                "merge할때도 프리렌 author로 머지해",
+                "ultraprocess",
+                "show_coding_handoff_status",
+                "operator_surface_fast_path:delivery",
+            ),
+            (
+                "hermes agent가 한개가 아니라 여러개일땐 어떻게 동작해?",
+                "agent-board",
+                "prepare_agent_board_card",
+                "operator_surface_fast_path:agent_board",
+            ),
         )
 
         with mock.patch.object(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5111,6 +5111,7 @@ class CliTests(unittest.TestCase):
             ("Codex 작업이 어디까지 진행됐는지 알려줘", "ultraprocess", "handoff", "show_coding_handoff_status"),
             ("지금 PR 머지 준비 됐는지 알려줘", "ultraprocess", "handoff", "show_coding_handoff_status"),
             ("이 PR 리뷰어 코멘트 반영됐는지 보고 머지 준비해줘", "ultraprocess", "handoff", "show_coding_handoff_status"),
+            ("merge할때도 프리렌 author로 머지해", "ultraprocess", "handoff", "show_coding_handoff_status"),
             ("今何してる？", "agent-ops-review", "agent_ops_review", "refresh_agent_ops_status"),
             ("现在在做什么？", "agent-ops-review", "agent_ops_review", "refresh_agent_ops_status"),
             ("qué está pasando?", "agent-ops-review", "agent_ops_review", "refresh_agent_ops_status"),
@@ -5131,6 +5132,7 @@ class CliTests(unittest.TestCase):
             ("루프 비용이랑 지연시간 상태 보여줘", "ops-observability-card", "ops_observability", "prepare_ops_observability_card"),
             ("설치 잘 됐어?", "doctor", "doctor_health", "run_local_operator_check"),
             ("우리 팀 Hermes agent 여러 명이 같이 일할 때 역할과 보드를 잡아줘", "agent-board", "agent_board", "prepare_agent_board_card"),
+            ("hermes agent가 한개가 아니라 여러개일땐 어떻게 동작해?", "agent-board", "agent_board", "prepare_agent_board_card"),
             ("릴리즈 전에 README 주장과 실제 기능이 맞는지 검토해줘", "code-review", "review_check", "prepare_review_or_followup_handoff"),
             (
                 "I want Hermes to learn from this workflow and improve the skill next time",

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -1040,10 +1040,14 @@ class EfficiencyContractTests(unittest.TestCase):
             ("claude code로 새 세션 시작하게 해줘", "executor-runtime-readiness"),
             ("claude code 세션 연결해서 이어서 보게 해줘", "executor-runtime-readiness"),
             ("codex 세션 열고 방금 핸드오프 이어서 진행해줘", "executor-runtime-readiness"),
+            ("merge할때도 프리렌 author로 머지해", "ultraprocess"),
+            ("프리렌 author로 커밋하고 머지해", "ultraprocess"),
             ("github oss repo 찾아서 비교해줘", "source-finder"),
             ("코덱스로 이 이슈 PR 만들어줘", "ultraprocess"),
             ("오늘 아침 경쟁사 뉴스 요약 자동화해줘", "automation-blueprint"),
             ("매일 아침 리서치 요약을 보내게 준비해줘", "automation-blueprint"),
+            ("hermes agent가 한개가 아니라 여러개일땐 어떻게 동작해?", "agent-board"),
+            ("multiple Hermes agents target topology 어떻게 관리해?", "agent-board"),
             ("workflow trace 보고 다음에 스킬 고칠점 알려줘", "workflow-learning"),
         )
 
@@ -1198,6 +1202,8 @@ class EfficiencyContractTests(unittest.TestCase):
                 "memory-curation-review",
                 "operator_surface_fast_path:memory",
             ),
+            ("merge할때도 프리렌 author로 머지해", "ultraprocess", "operator_surface_fast_path:delivery"),
+            ("hermes agent가 한개가 아니라 여러개일땐 어떻게 동작해?", "agent-board", "operator_surface_fast_path:agent_board"),
             ("리드미 개선해줘", "ultraprocess", "operator_surface_fast_path:delivery"),
             ("workflow trace 보고 다음에 스킬 고칠점 알려줘", "workflow-learning", "workflow_learning_fast_path"),
         )


### PR DESCRIPTION
## Summary

This PR tightens two chat-first operator paths that surfaced during real use:

- Friren merge/commit author constraints now route to the coding handoff status surface instead of starting a generic delivery cycle.
- Multi-Hermes-agent topology questions now route directly to the agent-board contract.
- The Hermes plugin awareness hint mirrors the Friren merge-author boundary so wrappers can show the right next action.

## Why

Users often issue follow-up operational constraints after an implementation lane already exists, such as asking that the merge author be Friren. That should not be interpreted as a fresh coding request. It should show the current handoff/status path and preserve the evidence boundary.

Multi-agent Hermes topology questions are similarly operational, not general planning prompts. They need the agent-board/status contract fast path.

## How

- Extended operator fast-path phrases in `src/routing/chat.py`.
- Added a `guard:merge_author_constraint` marker that changes the next action to `show_coding_handoff_status`.
- Added agent topology fast-path markers for `agent-board`.
- Added plugin awareness logic in `src/plugin_bundle/omh/awareness.py` so route hints agree with the chat router.
- Locked the behavior with router, CLI golden, and efficiency tests.

## Verification

Observed locally:

- `PYTHONPATH=tests uv run python -m unittest tests/test_chat_router.py -v`
- `PYTHONPATH=tests uv run python -m unittest tests/test_efficiency.py -v`
- `PYTHONPATH=tests uv run python -m unittest tests/test_cli.py -v`
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- `PYTHONPATH=tests uv run python -m compileall -q src tests`
- `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check`
- `PYTHONPATH=tests uv run python -m omh.cli harness validate`
- `PYTHONPATH=tests uv run python -m omh.cli demo hermes-ux-quality --summary`
- `PYTHONPATH=tests uv run python -m omh.cli demo routing-precision --summary`
- `git diff --check`
- `uv run python -m omh.cli chat interact --source discord "merge할때도 프리렌 author로 머지해" --json`
- `uv run python -m omh.cli chat interact --source discord "hermes agent가 한개가 아니라 여러개일땐 어떻게 동작해?" --json`

Result highlights:

- Hermes UX quality: 100/100, 5/5 gates.
- Routing precision: 41/41 negative controls, 73/73 expected interventions, 0 overroutes, 0 missed interventions.
- Full unittest discover: 1028 tests OK.

## Risks And Boundaries

This proves deterministic local routing and plugin awareness contracts only. It does not prove live Hermes gateway rendering, platform delivery, executor dispatch, implementation, review, CI, merge, or plugin-load evidence.
