### PR TITLE
Extract Hermes chat copy catalog

### DIFF
--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -37,6 +37,12 @@ from .hermes_runtime import (
     hermes_coding_team_claim_boundary,
     hermes_coding_team_extra_action_specs,
 )
+from .localized_copy import (
+    chat_copy,
+    prefers_korean_copy,
+    skill_picker_body as localized_skill_picker_body,
+    skill_picker_headline,
+)
 
 
 CHAT_INTERACTION_SCHEMA_VERSION = "chat_interaction/v1"
@@ -52,11 +58,6 @@ RENDER_PROFILE_LIMITED_MARKDOWN = "limited_markdown"
 RENDER_PROFILE_RICH_MARKDOWN = "rich_markdown"
 RENDER_PROFILES = (RENDER_PROFILE_LIMITED_MARKDOWN, RENDER_PROFILE_RICH_MARKDOWN)
 _LIMITED_MARKDOWN_SOURCES = frozenset({"discord", "slack", "telegram"})
-
-
-def _prefers_korean_copy(message: str) -> bool:
-    return any("\uac00" <= char <= "\ud7a3" for char in message)
-
 INTERACTION_MODES = ("auto", "route", "plan", "delegate")
 VISIBLE_ACTIONS = (
     "answer:clarify",
@@ -2420,7 +2421,7 @@ def build_chat_response_from_route(
     include_message: bool = False,
 ) -> dict[str, object]:
     action = str(decision.get("action", "fallback"))
-    korean_copy = _prefers_korean_copy(message)
+    korean_copy = prefers_korean_copy(message)
     if _is_command_preview_invocation(message):
         return _command_preview_response(decision, thread_key=thread_key, message=message)
     if (
@@ -2766,26 +2767,11 @@ def build_chat_response_from_route(
             )
         if selected == "img-summary" or policy_next_action == "prepare_visual_prompt_card":
             evidence_boundary = str(policy.get("evidence_boundary", "")) or "A prepared image-card brief is not generated image evidence."
-            headline = (
-                "공유용 이미지 카드 초안을 준비할 수 있습니다."
-                if korean_copy
-                else "I can prepare a shareable image card for this."
-            )
-            body = (
-                "원본 내용을 청중, 레이아웃, 이미지 안 문구, 생성 프롬프트, 네거티브 프롬프트, "
-                "간단한 QA 체크리스트로 정리하겠습니다. 연결된 이미지 생성 도구가 없으면 생성했다고 "
-                "말하지 않고 어떤 도구를 쓸지 먼저 고릅니다."
-                if korean_copy
-                else (
-                    "I will turn the source into a shareable image-card brief: audience, layout, on-image copy, "
-                    "generation prompt, negative prompt, and a quick QA checklist. If no image tool is connected, "
-                    "I will ask which tool to use instead of pretending an image was generated."
-                )
-            )
+            copy = chat_copy("img_summary", korean=korean_copy)
             return _chat_response(
                 kind="img_summary",
-                headline=headline,
-                body=body,
+                headline=copy.headline,
+                body=copy.body,
                 phase="visual_prompt_prepared",
                 next_action="prepare_visual_prompt_card",
                 thread_key=thread_key,
@@ -2828,26 +2814,11 @@ def build_chat_response_from_route(
             )
         if selected == "paper-learning" or policy_next_action == "prepare_paper_learning":
             evidence_boundary = str(policy.get("evidence_boundary", "")) or "A paper-learning card is not paper validation evidence."
-            headline = (
-                "논문을 원하는 난이도로 풀어 설명할 수 있습니다."
-                if korean_copy
-                else "I can explain this paper with the right depth."
-            )
-            body = (
-                "paper-learning 카드로 설명 수준, PDF/출처 상태, 섹션별 커버리지, 핵심 주장, "
-                "다시 봐야 할 그림/수식, 누락 범위를 정리하겠습니다. 전문 추출, 인용 검증, "
-                "수학 검증, 재현, 피어 리뷰는 관측되기 전까지 완료됐다고 말하지 않습니다."
-                if korean_copy
-                else (
-                    "I will prepare a paper-learning card: explanation level, source/PDF state, section coverage, "
-                    "key claims, figures or equations to revisit, and a coverage ledger. I will not claim full extraction, "
-                    "citation checking, math validation, reproduction, or peer review until those are observed."
-                )
-            )
+            copy = chat_copy("paper_learning", korean=korean_copy)
             return _chat_response(
                 kind="paper_learning",
-                headline=headline,
-                body=body,
+                headline=copy.headline,
+                body=copy.body,
                 phase="paper_learning_prepared",
                 next_action="prepare_paper_learning",
                 thread_key=thread_key,
@@ -2888,26 +2859,11 @@ def build_chat_response_from_route(
             )
         if selected == "source-finder" or policy_next_action == "prepare_source_finder_plan":
             evidence_boundary = str(policy.get("evidence_boundary", "")) or "A source-finder plan is not source retrieval evidence."
-            headline = (
-                "자료 탐색을 출처 확보 계획으로 정리할 수 있습니다."
-                if korean_copy
-                else "I can turn this into a source acquisition plan."
-            )
-            body = (
-                "source-finder 계획으로 논문, 링크, 데이터셋, 저장소, 발표자료 같은 후보 범주와 "
-                "탐색/확보 상태, 출처·라이선스 확인, 다음에 넘길 workflow를 정리하겠습니다. "
-                "실제 웹 검색, 다운로드, 클론, 추출, 검증, 후속 처리는 관측되기 전까지 완료됐다고 말하지 않습니다."
-                if korean_copy
-                else (
-                    "I will prepare a source-finder plan: typed candidate categories, search/acquisition status, "
-                    "missing provenance, license or access checks, and the best downstream workflow. I will not claim "
-                    "web search, download, clone, extraction, verification, or downstream processing until observed."
-                )
-            )
+            copy = chat_copy("source_finder", korean=korean_copy)
             return _chat_response(
                 kind="source_finder",
-                headline=headline,
-                body=body,
+                headline=copy.headline,
+                body=copy.body,
                 phase="source_finder_prepared",
                 next_action="prepare_source_finder_plan",
                 thread_key=thread_key,
@@ -2949,25 +2905,11 @@ def build_chat_response_from_route(
             )
         if selected == "web-research" or policy_next_action == "run_hermes_research":
             evidence_boundary = str(policy.get("evidence_boundary", "")) or "A web research card is not source retrieval evidence."
-            headline = (
-                "최신 근거 조사를 Hermes 연구 흐름으로 정리할 수 있습니다."
-                if korean_copy
-                else "I can gather source-backed current evidence for this."
-            )
-            body = (
-                "조사 범위, 최신성 기준, 출처 다양성, 인용 신뢰도, 검색 공백을 먼저 잡고 그 다음 "
-                "계획, 리포트, 코딩 handoff로 넘기겠습니다. 실제 출처 수집이나 검증은 관측되기 전까지 완료됐다고 말하지 않습니다."
-                if korean_copy
-                else (
-                    "I will keep this as Hermes-side research: define the source boundaries, freshness window, source diversity, "
-                    "citation confidence, and retrieval gaps before turning findings into a plan, report, or coding handoff. "
-                    "I will not claim sources were fetched or verified until observed."
-                )
-            )
+            copy = chat_copy("web_research", korean=korean_copy)
             return _chat_response(
                 kind="web_research",
-                headline=headline,
-                body=body,
+                headline=copy.headline,
+                body=copy.body,
                 phase="web_research_prepared",
                 next_action="run_hermes_research",
                 thread_key=thread_key,
@@ -3089,47 +3031,17 @@ def build_chat_response_from_route(
         if selected == "workflow-learning":
             missed_route_feedback = _is_missed_route_feedback(message)
             primary_learning_action = "record_missed_route" if missed_route_feedback else "audit_learning_readiness"
-            headline = (
-                "놓친 OMH 라우팅을 학습 후보로 기록할 수 있습니다."
-                if korean_copy and missed_route_feedback
-                else "I can record this missed OMH route."
-                if missed_route_feedback
-                else (
-                    "이 workflow가 개선 가능한지 점검할 수 있습니다."
-                    if korean_copy
-                    else "I can inspect this workflow for learning readiness."
-                )
+            copy = chat_copy(
+                "workflow_learning_missed_route" if missed_route_feedback else "workflow_learning_readiness",
+                korean=korean_copy,
             )
             evidence_boundary = str(policy.get("evidence_boundary", "")) or (
                 "Workflow learning records are process-review evidence only; they are not automatic improvement evidence."
             )
-            if missed_route_feedback:
-                body = (
-                    "이 요청을 missed-route 피드백으로 다루겠습니다. 원문을 그대로 저장하지 않고 "
-                    "메타데이터 trace와 리뷰 가능한 bundle을 만들고, 최소 회귀 케이스를 추가하거나 요청합니다. "
-                    "라우팅/스킬 변경은 사람 리뷰 뒤에만 반영합니다."
-                    if korean_copy
-                    else (
-                        "I will treat this as missed-route feedback: record a metadata-only trace, create a reviewable "
-                        "missed-route bundle, add or request a minimized regression fixture, and keep any routing or skill "
-                        "change behind human review."
-                    )
-                )
-            else:
-                body = (
-                    "workflow 실행을 학습 재료로 정리하겠습니다. raw prompt를 저장하지 않고 trace, deterministic eval, "
-                    "회귀 케이스, readiness audit, redacted review bundle을 만들며, 스킬이나 라우팅 개선은 여전히 사람 리뷰가 필요합니다."
-                    if korean_copy
-                    else (
-                        "I will turn the workflow attempt into learning material without storing raw prompts: "
-                        "record the trace, run deterministic evals, add a regression case, audit readiness, "
-                        "and export a redacted review bundle when useful. Any skill or routing improvement still needs human review."
-                    )
-                )
             return _chat_response(
                 kind="workflow_learning",
-                headline=headline,
-                body=body,
+                headline=copy.headline,
+                body=copy.body,
                 phase="workflow_learning_prepared",
                 next_action=primary_learning_action,
                 thread_key=thread_key,
@@ -3227,14 +3139,11 @@ def build_chat_response_from_route(
             },
         )
     if action == "clarify":
-        body = (
-            "라우팅 전에 목표를 조금 더 확인해야 합니다. 원하는 결과, 입력 자료, 멈춰야 할 기준을 한 문장으로 알려주세요."
-            if korean_copy
-            else str(decision.get("clarification") or "Please confirm the intended workflow before I continue.")
-        )
+        copy = chat_copy("clarify", korean=korean_copy)
+        body = copy.body if korean_copy else str(decision.get("clarification") or copy.body)
         return _chat_response(
             kind="clarification",
-            headline="라우팅 전에 한 가지 확인이 필요합니다." if korean_copy else "I need one clarification before routing this.",
+            headline=copy.headline,
             body=body,
             phase="clarifying",
             next_action="answer_clarification",
@@ -3244,17 +3153,11 @@ def build_chat_response_from_route(
             extra_state={"route_action": action, "confidence": decision.get("confidence", "low")},
         )
     if action == "fallback" and _is_file_lookup_fallback(decision):
-        body = (
-            "파일/텍스트 확인으로 바로 답하거나, 대상 파일·경로가 없으면 먼저 물어보세요. OMH workflow 실행은 시작하지 않습니다."
-            if korean_copy
-            else str(
-                decision.get("clarification")
-                or "Answer this as a file or text lookup, or ask for the target file/path if it is missing."
-            )
-        )
+        copy = chat_copy("file_lookup", korean=korean_copy)
+        body = copy.body if korean_copy else str(decision.get("clarification") or copy.body)
         return _chat_response(
             kind="clarification",
-            headline="파일이나 텍스트 확인 요청으로 보입니다." if korean_copy else "This looks like a file or text lookup.",
+            headline=copy.headline,
             body=body,
             phase="clarifying",
             next_action="answer_file_lookup",
@@ -3272,17 +3175,11 @@ def build_chat_response_from_route(
             },
         )
     if action == "fallback" and _is_direct_answer_fallback(decision):
-        body = (
-            "현재 채팅에서 바로 답하세요. 사용자가 직접 요청하지 않는 한 OMH workflow, picker, coding handoff를 열지 않습니다."
-            if korean_copy
-            else str(
-                decision.get("clarification")
-                or "Answer directly in the current chat; do not open an OMH workflow unless the user asks for one."
-            )
-        )
+        copy = chat_copy("direct_answer", korean=korean_copy)
+        body = copy.body if korean_copy else str(decision.get("clarification") or copy.body)
         return _chat_response(
             kind="clarification",
-            headline="이건 OMH workflow 없이 바로 답하면 됩니다." if korean_copy else "This does not need an OMH workflow.",
+            headline=copy.headline,
             body=body,
             phase="clarifying",
             next_action="answer_directly",
@@ -3299,14 +3196,11 @@ def build_chat_response_from_route(
                 "routing_instruction": decision.get("routing_instruction", ""),
             },
         )
+    copy = chat_copy("generic_clarify", korean=korean_copy)
     return _chat_response(
         kind="clarification",
-        headline="라우팅 전에 목표를 조금 더 알아야 합니다." if korean_copy else "I need to understand the goal before routing this.",
-        body=(
-            "원하는 결과를 한 문장으로 알려주면, 그에 맞는 workflow를 고르겠습니다."
-            if korean_copy
-            else "Tell me the outcome you want, and I will choose the right workflow."
-        ),
+        headline=copy.headline,
+        body=copy.body,
         phase="clarifying",
         next_action="answer_clarification",
         thread_key=thread_key,
@@ -4865,7 +4759,7 @@ def _command_preview_prefix(token: str) -> str:
 def _skill_picker_response(decision: dict[str, object], *, thread_key: str = "", message: str = "") -> dict[str, object]:
     picker = _skill_picker_state(message, source=str(decision.get("source", "generic")))
     catalog_question = _is_skill_catalog_question(message) and not _is_skill_picker_invocation(message)
-    korean_copy = _prefers_korean_copy(message)
+    korean_copy = prefers_korean_copy(message)
     primer = _context_primer_state()
     extra_state = {
         "route_action": decision.get("action", "dispatch"),
@@ -4880,15 +4774,7 @@ def _skill_picker_response(decision: dict[str, object], *, thread_key: str = "",
         extra_state["capability_summary"] = _catalog_capability_summary()
     return _chat_response(
         kind="skill_picker",
-        headline=(
-            "OMH workflow 목록입니다."
-            if korean_copy and catalog_question
-            else "OMH workflow를 바로 고를 수 있습니다."
-            if korean_copy
-            else "Here are the OMH workflows."
-            if catalog_question
-            else "Choose an OMH workflow."
-        ),
+        headline=skill_picker_headline(catalog_question=catalog_question, korean=korean_copy),
         body=_skill_picker_body(catalog_question=catalog_question, korean_copy=korean_copy),
         phase="skill_selection",
         next_action="choose_skill",
@@ -4916,58 +4802,10 @@ def _skill_picker_response(decision: dict[str, object], *, thread_key: str = "",
 
 
 def _skill_picker_body(*, catalog_question: bool, korean_copy: bool = False) -> str:
-    family_heading = "Capability families:" if catalog_question else "Families:"
-    family_lines = _skill_picker_family_body_lines()
-    if korean_copy and catalog_question:
-        return "\n".join(
-            [
-                "`omh list` 같은 shell 명령 승인을 받지 않아도 됩니다. OMH는 계획, 운영, 자료/이미지, 코딩 위임, loop, 상태 확인 workflow를 Hermes 채팅 안에서 고를 수 있게 해줍니다.",
-                "",
-                "먼저 이렇게 시작하세요:",
-                "- Route for me: 요청을 그대로 보내면 Hermes가 안전한 workflow를 고릅니다.",
-                "- Choose workflow: OMH capability family에서 직접 고릅니다.",
-                "- Search workflows: 하고 싶은 일이 분명할 때 맞는 skill을 찾습니다.",
-                "",
-                family_heading,
-                *family_lines,
-            ]
-        )
-    if korean_copy:
-        return "\n".join(
-            [
-                "시작 방식을 고르세요. 잘 모르겠으면 Route for me를 고르면 Hermes가 요청에서 가장 안전한 다음 workflow를 고릅니다.",
-                "",
-                "추천 시작점:",
-                "- Route for me: 요청을 붙여 넣고 Hermes가 workflow를 고르게 합니다.",
-                "",
-                family_heading,
-                *family_lines,
-            ]
-        )
-    if catalog_question:
-        return "\n".join(
-            [
-                "You do not need to run a shell command for this. OMH covers planning, ops, deliverables, coding handoffs, loops, and status.",
-                "",
-                "Start here:",
-                "- Route for me: let Hermes choose the safest workflow from your message.",
-                "- Choose workflow: pick from the OMH capability families.",
-                "- Search workflows: find the exact skill when you already know the job.",
-                "",
-                family_heading,
-                *family_lines,
-            ]
-        )
-    return "\n".join(
-        [
-            "Pick how to start, or choose Route for me and Hermes will select the safest next step from the request.",
-            "",
-            "Best default:",
-            "- Route for me: paste the request and let Hermes choose the workflow.",
-            "",
-            family_heading,
-            *family_lines,
-        ]
+    return localized_skill_picker_body(
+        catalog_question=catalog_question,
+        korean=korean_copy,
+        family_lines=_skill_picker_family_body_lines(),
     )
 
 

--- a/src/wrapper/localized_copy.py
+++ b/src/wrapper/localized_copy.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ChatCopy:
+    headline: str
+    body: str
+
+
+def prefers_korean_copy(message: str) -> bool:
+    return any("\uac00" <= char <= "\ud7a3" for char in message)
+
+
+_CARD_COPY: dict[str, dict[str, ChatCopy]] = {
+    "img_summary": {
+        "en": ChatCopy(
+            headline="I can prepare a shareable image card for this.",
+            body=(
+                "I will turn the source into a shareable image-card brief: audience, layout, on-image copy, "
+                "generation prompt, negative prompt, and a quick QA checklist. If no image tool is connected, "
+                "I will ask which tool to use instead of pretending an image was generated."
+            ),
+        ),
+        "ko": ChatCopy(
+            headline="공유용 이미지 카드 초안을 준비할 수 있습니다.",
+            body=(
+                "원본 내용을 청중, 레이아웃, 이미지 안 문구, 생성 프롬프트, 네거티브 프롬프트, "
+                "간단한 QA 체크리스트로 정리하겠습니다. 연결된 이미지 생성 도구가 없으면 생성했다고 "
+                "말하지 않고 어떤 도구를 쓸지 먼저 고릅니다."
+            ),
+        ),
+    },
+    "paper_learning": {
+        "en": ChatCopy(
+            headline="I can explain this paper with the right depth.",
+            body=(
+                "I will prepare a paper-learning card: explanation level, source/PDF state, section coverage, "
+                "key claims, figures or equations to revisit, and a coverage ledger. I will not claim full extraction, "
+                "citation checking, math validation, reproduction, or peer review until those are observed."
+            ),
+        ),
+        "ko": ChatCopy(
+            headline="논문을 원하는 난이도로 풀어 설명할 수 있습니다.",
+            body=(
+                "paper-learning 카드로 설명 수준, PDF/출처 상태, 섹션별 커버리지, 핵심 주장, "
+                "다시 봐야 할 그림/수식, 누락 범위를 정리하겠습니다. 전문 추출, 인용 검증, "
+                "수학 검증, 재현, 피어 리뷰는 관측되기 전까지 완료됐다고 말하지 않습니다."
+            ),
+        ),
+    },
+    "source_finder": {
+        "en": ChatCopy(
+            headline="I can turn this into a source acquisition plan.",
+            body=(
+                "I will prepare a source-finder plan: typed candidate categories, search/acquisition status, "
+                "missing provenance, license or access checks, and the best downstream workflow. I will not claim "
+                "web search, download, clone, extraction, verification, or downstream processing until observed."
+            ),
+        ),
+        "ko": ChatCopy(
+            headline="자료 탐색을 출처 확보 계획으로 정리할 수 있습니다.",
+            body=(
+                "source-finder 계획으로 논문, 링크, 데이터셋, 저장소, 발표자료 같은 후보 범주와 "
+                "탐색/확보 상태, 출처·라이선스 확인, 다음에 넘길 workflow를 정리하겠습니다. "
+                "실제 웹 검색, 다운로드, 클론, 추출, 검증, 후속 처리는 관측되기 전까지 완료됐다고 말하지 않습니다."
+            ),
+        ),
+    },
+    "web_research": {
+        "en": ChatCopy(
+            headline="I can gather source-backed current evidence for this.",
+            body=(
+                "I will keep this as Hermes-side research: define the source boundaries, freshness window, source diversity, "
+                "citation confidence, and retrieval gaps before turning findings into a plan, report, or coding handoff. "
+                "I will not claim sources were fetched or verified until observed."
+            ),
+        ),
+        "ko": ChatCopy(
+            headline="최신 근거 조사를 Hermes 연구 흐름으로 정리할 수 있습니다.",
+            body=(
+                "조사 범위, 최신성 기준, 출처 다양성, 인용 신뢰도, 검색 공백을 먼저 잡고 그 다음 "
+                "계획, 리포트, 코딩 handoff로 넘기겠습니다. 실제 출처 수집이나 검증은 관측되기 전까지 완료됐다고 말하지 않습니다."
+            ),
+        ),
+    },
+    "workflow_learning_missed_route": {
+        "en": ChatCopy(
+            headline="I can record this missed OMH route.",
+            body=(
+                "I will treat this as missed-route feedback: record a metadata-only trace, create a reviewable "
+                "missed-route bundle, add or request a minimized regression fixture, and keep any routing or skill "
+                "change behind human review."
+            ),
+        ),
+        "ko": ChatCopy(
+            headline="놓친 OMH 라우팅을 학습 후보로 기록할 수 있습니다.",
+            body=(
+                "이 요청을 missed-route 피드백으로 다루겠습니다. 원문을 그대로 저장하지 않고 "
+                "메타데이터 trace와 리뷰 가능한 bundle을 만들고, 최소 회귀 케이스를 추가하거나 요청합니다. "
+                "라우팅/스킬 변경은 사람 리뷰 뒤에만 반영합니다."
+            ),
+        ),
+    },
+    "workflow_learning_readiness": {
+        "en": ChatCopy(
+            headline="I can inspect this workflow for learning readiness.",
+            body=(
+                "I will turn the workflow attempt into learning material without storing raw prompts: "
+                "record the trace, run deterministic evals, add a regression case, audit readiness, "
+                "and export a redacted review bundle when useful. Any skill or routing improvement still needs human review."
+            ),
+        ),
+        "ko": ChatCopy(
+            headline="이 workflow가 개선 가능한지 점검할 수 있습니다.",
+            body=(
+                "workflow 실행을 학습 재료로 정리하겠습니다. raw prompt를 저장하지 않고 trace, deterministic eval, "
+                "회귀 케이스, readiness audit, redacted review bundle을 만들며, 스킬이나 라우팅 개선은 여전히 사람 리뷰가 필요합니다."
+            ),
+        ),
+    },
+    "clarify": {
+        "en": ChatCopy(
+            headline="I need one clarification before routing this.",
+            body="Please confirm the intended workflow before I continue.",
+        ),
+        "ko": ChatCopy(
+            headline="라우팅 전에 한 가지 확인이 필요합니다.",
+            body="라우팅 전에 목표를 조금 더 확인해야 합니다. 원하는 결과, 입력 자료, 멈춰야 할 기준을 한 문장으로 알려주세요.",
+        ),
+    },
+    "file_lookup": {
+        "en": ChatCopy(
+            headline="This looks like a file or text lookup.",
+            body="Answer this as a file or text lookup, or ask for the target file/path if it is missing.",
+        ),
+        "ko": ChatCopy(
+            headline="파일이나 텍스트 확인 요청으로 보입니다.",
+            body="파일/텍스트 확인으로 바로 답하거나, 대상 파일·경로가 없으면 먼저 물어보세요. OMH workflow 실행은 시작하지 않습니다.",
+        ),
+    },
+    "direct_answer": {
+        "en": ChatCopy(
+            headline="This does not need an OMH workflow.",
+            body="Answer directly in the current chat; do not open an OMH workflow unless the user asks for one.",
+        ),
+        "ko": ChatCopy(
+            headline="이건 OMH workflow 없이 바로 답하면 됩니다.",
+            body="현재 채팅에서 바로 답하세요. 사용자가 직접 요청하지 않는 한 OMH workflow, picker, coding handoff를 열지 않습니다.",
+        ),
+    },
+    "generic_clarify": {
+        "en": ChatCopy(
+            headline="I need to understand the goal before routing this.",
+            body="Tell me the outcome you want, and I will choose the right workflow.",
+        ),
+        "ko": ChatCopy(
+            headline="라우팅 전에 목표를 조금 더 알아야 합니다.",
+            body="원하는 결과를 한 문장으로 알려주면, 그에 맞는 workflow를 고르겠습니다.",
+        ),
+    },
+}
+
+
+def chat_copy(copy_id: str, *, korean: bool) -> ChatCopy:
+    locale = "ko" if korean else "en"
+    return _CARD_COPY[copy_id][locale]
+
+
+def skill_picker_headline(*, catalog_question: bool, korean: bool) -> str:
+    if korean and catalog_question:
+        return "OMH workflow 목록입니다."
+    if korean:
+        return "OMH workflow를 바로 고를 수 있습니다."
+    return "Here are the OMH workflows." if catalog_question else "Choose an OMH workflow."
+
+
+def skill_picker_body(*, catalog_question: bool, korean: bool, family_lines: list[str]) -> str:
+    family_heading = "Capability families:" if catalog_question else "Families:"
+    if korean and catalog_question:
+        return "\n".join(
+            [
+                "`omh list` 같은 shell 명령 승인을 받지 않아도 됩니다. OMH는 계획, 운영, 자료/이미지, 코딩 위임, loop, 상태 확인 workflow를 Hermes 채팅 안에서 고를 수 있게 해줍니다.",
+                "",
+                "먼저 이렇게 시작하세요:",
+                "- Route for me: 요청을 그대로 보내면 Hermes가 안전한 workflow를 고릅니다.",
+                "- Choose workflow: OMH capability family에서 직접 고릅니다.",
+                "- Search workflows: 하고 싶은 일이 분명할 때 맞는 skill을 찾습니다.",
+                "",
+                family_heading,
+                *family_lines,
+            ]
+        )
+    if korean:
+        return "\n".join(
+            [
+                "시작 방식을 고르세요. 잘 모르겠으면 Route for me를 고르면 Hermes가 요청에서 가장 안전한 다음 workflow를 고릅니다.",
+                "",
+                "추천 시작점:",
+                "- Route for me: 요청을 붙여 넣고 Hermes가 workflow를 고르게 합니다.",
+                "",
+                family_heading,
+                *family_lines,
+            ]
+        )
+    if catalog_question:
+        return "\n".join(
+            [
+                "You do not need to run a shell command for this. OMH covers planning, ops, deliverables, coding handoffs, loops, and status.",
+                "",
+                "Start here:",
+                "- Route for me: let Hermes choose the safest workflow from your message.",
+                "- Choose workflow: pick from the OMH capability families.",
+                "- Search workflows: find the exact skill when you already know the job.",
+                "",
+                family_heading,
+                *family_lines,
+            ]
+        )
+    return "\n".join(
+        [
+            "Pick how to start, or choose Route for me and Hermes will select the safest next step from the request.",
+            "",
+            "Best default:",
+            "- Route for me: paste the request and let Hermes choose the workflow.",
+            "",
+            family_heading,
+            *family_lines,
+        ]
+    )
+

--- a/tests/test_wrapper_localized_copy.py
+++ b/tests/test_wrapper_localized_copy.py
@@ -1,0 +1,50 @@
+import unittest
+
+from omh.wrapper.localized_copy import (
+    chat_copy,
+    prefers_korean_copy,
+    skill_picker_body,
+    skill_picker_headline,
+)
+
+
+class WrapperLocalizedCopyTests(unittest.TestCase):
+    def test_korean_detection_is_hangul_based_and_local_only(self) -> None:
+        self.assertTrue(prefers_korean_copy("OMH가 어떤 스킬 있는지 알려줘"))
+        self.assertFalse(prefers_korean_copy("what OMH workflows are available?"))
+        self.assertFalse(prefers_korean_copy("OMH 有哪些工作流？"))
+
+    def test_core_cards_keep_english_and_korean_copy_in_catalog(self) -> None:
+        cases = (
+            ("img_summary", "shareable image-card brief", "이미지 안 문구"),
+            ("paper_learning", "paper-learning card", "섹션별 커버리지"),
+            ("source_finder", "source-finder plan", "데이터셋"),
+            ("web_research", "source boundaries", "조사 범위"),
+            ("workflow_learning_missed_route", "missed-route feedback", "missed-route 피드백"),
+            ("file_lookup", "file or text lookup", "파일/텍스트 확인"),
+        )
+
+        for copy_id, english_text, korean_text in cases:
+            with self.subTest(copy_id=copy_id):
+                self.assertIn(english_text, chat_copy(copy_id, korean=False).body)
+                self.assertIn(korean_text, chat_copy(copy_id, korean=True).body)
+
+    def test_skill_picker_copy_keeps_machine_contract_terms_visible(self) -> None:
+        family_lines = ["- Plan and decide: deep-interview, ralplan."]
+
+        english_body = skill_picker_body(catalog_question=True, korean=False, family_lines=family_lines)
+        korean_body = skill_picker_body(catalog_question=True, korean=True, family_lines=family_lines)
+
+        self.assertEqual(skill_picker_headline(catalog_question=True, korean=False), "Here are the OMH workflows.")
+        self.assertEqual(skill_picker_headline(catalog_question=True, korean=True), "OMH workflow 목록입니다.")
+        self.assertIn("shell command", english_body)
+        self.assertIn("shell 명령 승인을 받지 않아도", korean_body)
+        self.assertIn("Route for me:", english_body)
+        self.assertIn("Route for me:", korean_body)
+        self.assertIn(family_lines[0], english_body)
+        self.assertIn(family_lines[0], korean_body)
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Feature Report

### What Changed

- Extracted Hermes-facing localized chat copy out of `src/wrapper/contract.py` into a dedicated `src/wrapper/localized_copy.py` catalog.
- Kept routing/action/evidence behavior stable while moving image, paper, source-finder, web-research, workflow-learning, clarify, file-lookup, direct-answer, generic clarify, and skill-picker copy into reusable helpers.
- Added focused tests that lock Korean detection, bilingual card copy presence, and skill-picker copy terms that wrappers rely on.

### Why This Exists

- The wrapper contract had become responsible for both routing decisions and long human-facing copy. That made future Korean/English copy updates harder to review and made routing changes noisier than necessary.
- OMH is increasingly chat-first, so localized copy needs a clear extension point that does not disturb schema versions, action ids, or prepared-vs-observed boundaries.

### User / Operator Impact

- Hermes chat cards keep the same visible behavior, but future copy refinements can be made in one catalog instead of editing deep routing branches.
- Korean operator copy remains available for common workflow cards without changing wrapper action semantics.
- Operators asking about OMH workflows still get the picker path without needing shell approval.

### How It Works

- `localized_copy.py` defines a small `ChatCopy` value object, Hangul-based Korean preference detection, card copy lookup, and skill-picker copy helpers.
- `contract.py` now asks the copy catalog for wording after the route/action decision has already been made.
- Tests import the catalog directly and assert that important English and Korean strings remain present and wrapper-visible contract terms stay intact.

### Files And Contracts Touched

- `src/wrapper/contract.py`: delegates copy selection to the new catalog while preserving response kinds, phases, next actions, state payloads, and evidence boundaries.
- `src/wrapper/localized_copy.py`: new local catalog for Hermes-facing bilingual chat copy.
- `tests/test_wrapper_localized_copy.py`: direct coverage for the copy catalog and picker wording.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests` — 1035 tests passed.
- [x] `PYTHONPATH=tests uv run python -m compileall -q src tests`
- [x] `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check`
- [x] `PYTHONPATH=tests uv run python -m omh.cli harness validate`
- [ ] `python3 -m omh.cli release checklist --json` — not run; no release checklist or packaging behavior changed.
- [ ] `python3 -m omh.cli release hermes-smoke` — not run; no install or live Hermes integration behavior changed.
- [ ] `omh --help` — not run; no CLI help surface changed.
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` — not run; no install smoke surface changed.
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable; copy-only extraction for existing workflow-learning card text.
- [x] Relevant dry-run or smoke command: `PYTHONPATH=tests uv run python -m omh.cli demo hermes-ux-quality --json` — status passed, score 100, 5/5 gates passed.
- [x] Relevant focused test: `PYTHONPATH=tests uv run python -m unittest tests/test_wrapper_localized_copy.py tests/test_wrapper_contract.py tests/test_chat_router.py` — 169 tests passed.
- [x] Static whitespace check: `git diff --check`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; this is a deterministic local copy/catalog refactor and does not claim live Hermes chat rendering.

## Risk

- Risk is narrow: copy lookup keys could drift from route branches if future cards are added without tests. The new catalog test makes core copy ids explicit, and existing wrapper/router tests still cover rendered responses.

## Compatibility / Rollout

- Backward compatible. No schema versions, public action ids, CLI commands, generated skills, setup output, or runtime artifact shapes changed.
- Existing English and Korean response semantics are preserved as catalog data.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`): local code refactor only; no release-channel behavior changed.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap.

## Follow-Up

- Add future human-facing chat copy through `src/wrapper/localized_copy.py` unless the route/action contract itself changes.