### PR TITLE
Localize Hermes chat card framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@
 [Hermes](https://github.com/NousResearch/hermes-agent), and let the added
 skills, contracts, and status cards make the next action obvious without
 replacing your existing setup.
+Common Japanese, Chinese, Spanish, French, German, Korean, and English operator
+requests stay local and deterministic: OMH can route them and frame the first
+chat card without calling a translation API.
 
 ```text
 user says a natural-language request in Hermes

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -285,6 +285,10 @@ returns `dispatch`, `clarify`, or `fallback` decisions from local catalog data.
 non-English operator requests. It preserves the raw message, adds only canonical
 scoring hints, and makes locale-match metadata available to scored
 recommendations without calling translation services.
+`wrapper/localized_copy.py` owns the separate human-facing chat copy catalog for
+common localized card frames. It can mirror the user's language for supported
+operator-facing cards, but it does not translate raw prompts, change routing
+scores, or turn prepared states into observed evidence.
 `routing/policy.py` owns shared confidence and ambiguity policy, and
 `routing/recommend.py` owns local catalog recommendation scoring.
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -420,7 +420,12 @@ surfaces such as `omh recommend`, `omh playbook recommend`, and
 Chinese, Spanish, French, and German operator requests. The layer expands known
 phrases into canonical routing signals, includes `locale:<code>:<label>` in the
 matched evidence for scored recommendations, and never calls external
-translation services.
+translation services. Renderable chat cards also use a small local copy catalog
+for common English, Korean, Japanese, Chinese, Spanish, French, and German
+operator-facing frames such as the skill picker, source finder, paper learning,
+web research, image summary, and workflow-learning missed-route cards. If a
+phrase or card locale is not covered, OMH falls back to the normal English
+clarify or planning path instead of pretending to translate.
 
 From the user's point of view, the intended final state matches the Hermes tap
 path: Hermes can discover OMH skills and the user talks to Hermes. `omh setup`
@@ -867,6 +872,9 @@ Before calling the bot integration ready, verify these points:
   `feedback-triage`, French safe-feature requests route to a plan surface, and
   Spanish, French, or German issue-to-PR requests route to `github-event-ops`
   without claiming machine translation happened.
+- Common non-English card frames should use the local wrapper copy catalog when
+  available, while keeping contract terms such as `Route for me`,
+  `source-finder plan`, and evidence boundaries visible for adapters.
 - The rendered `chat_response` does not expose `omh`, argv arrays, or shell
   command text to the end user.
 - Clarification and fallback interactions do not expose `send_to_executor` or

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -39,7 +39,8 @@ from .hermes_runtime import (
 )
 from .localized_copy import (
     chat_copy,
-    prefers_korean_copy,
+    detect_copy_locale,
+    is_localized_locale,
     skill_picker_body as localized_skill_picker_body,
     skill_picker_headline,
 )
@@ -2421,7 +2422,8 @@ def build_chat_response_from_route(
     include_message: bool = False,
 ) -> dict[str, object]:
     action = str(decision.get("action", "fallback"))
-    korean_copy = prefers_korean_copy(message)
+    copy_locale = detect_copy_locale(message)
+    localized_copy = is_localized_locale(copy_locale)
     if _is_command_preview_invocation(message):
         return _command_preview_response(decision, thread_key=thread_key, message=message)
     if (
@@ -2767,7 +2769,7 @@ def build_chat_response_from_route(
             )
         if selected == "img-summary" or policy_next_action == "prepare_visual_prompt_card":
             evidence_boundary = str(policy.get("evidence_boundary", "")) or "A prepared image-card brief is not generated image evidence."
-            copy = chat_copy("img_summary", korean=korean_copy)
+            copy = chat_copy("img_summary", locale=copy_locale)
             return _chat_response(
                 kind="img_summary",
                 headline=copy.headline,
@@ -2814,7 +2816,7 @@ def build_chat_response_from_route(
             )
         if selected == "paper-learning" or policy_next_action == "prepare_paper_learning":
             evidence_boundary = str(policy.get("evidence_boundary", "")) or "A paper-learning card is not paper validation evidence."
-            copy = chat_copy("paper_learning", korean=korean_copy)
+            copy = chat_copy("paper_learning", locale=copy_locale)
             return _chat_response(
                 kind="paper_learning",
                 headline=copy.headline,
@@ -2859,7 +2861,7 @@ def build_chat_response_from_route(
             )
         if selected == "source-finder" or policy_next_action == "prepare_source_finder_plan":
             evidence_boundary = str(policy.get("evidence_boundary", "")) or "A source-finder plan is not source retrieval evidence."
-            copy = chat_copy("source_finder", korean=korean_copy)
+            copy = chat_copy("source_finder", locale=copy_locale)
             return _chat_response(
                 kind="source_finder",
                 headline=copy.headline,
@@ -2905,7 +2907,7 @@ def build_chat_response_from_route(
             )
         if selected == "web-research" or policy_next_action == "run_hermes_research":
             evidence_boundary = str(policy.get("evidence_boundary", "")) or "A web research card is not source retrieval evidence."
-            copy = chat_copy("web_research", korean=korean_copy)
+            copy = chat_copy("web_research", locale=copy_locale)
             return _chat_response(
                 kind="web_research",
                 headline=copy.headline,
@@ -3033,7 +3035,7 @@ def build_chat_response_from_route(
             primary_learning_action = "record_missed_route" if missed_route_feedback else "audit_learning_readiness"
             copy = chat_copy(
                 "workflow_learning_missed_route" if missed_route_feedback else "workflow_learning_readiness",
-                korean=korean_copy,
+                locale=copy_locale,
             )
             evidence_boundary = str(policy.get("evidence_boundary", "")) or (
                 "Workflow learning records are process-review evidence only; they are not automatic improvement evidence."
@@ -3139,8 +3141,8 @@ def build_chat_response_from_route(
             },
         )
     if action == "clarify":
-        copy = chat_copy("clarify", korean=korean_copy)
-        body = copy.body if korean_copy else str(decision.get("clarification") or copy.body)
+        copy = chat_copy("clarify", locale=copy_locale)
+        body = copy.body if localized_copy else str(decision.get("clarification") or copy.body)
         return _chat_response(
             kind="clarification",
             headline=copy.headline,
@@ -3153,8 +3155,8 @@ def build_chat_response_from_route(
             extra_state={"route_action": action, "confidence": decision.get("confidence", "low")},
         )
     if action == "fallback" and _is_file_lookup_fallback(decision):
-        copy = chat_copy("file_lookup", korean=korean_copy)
-        body = copy.body if korean_copy else str(decision.get("clarification") or copy.body)
+        copy = chat_copy("file_lookup", locale=copy_locale)
+        body = copy.body if localized_copy else str(decision.get("clarification") or copy.body)
         return _chat_response(
             kind="clarification",
             headline=copy.headline,
@@ -3175,8 +3177,8 @@ def build_chat_response_from_route(
             },
         )
     if action == "fallback" and _is_direct_answer_fallback(decision):
-        copy = chat_copy("direct_answer", korean=korean_copy)
-        body = copy.body if korean_copy else str(decision.get("clarification") or copy.body)
+        copy = chat_copy("direct_answer", locale=copy_locale)
+        body = copy.body if localized_copy else str(decision.get("clarification") or copy.body)
         return _chat_response(
             kind="clarification",
             headline=copy.headline,
@@ -3196,7 +3198,7 @@ def build_chat_response_from_route(
                 "routing_instruction": decision.get("routing_instruction", ""),
             },
         )
-    copy = chat_copy("generic_clarify", korean=korean_copy)
+    copy = chat_copy("generic_clarify", locale=copy_locale)
     return _chat_response(
         kind="clarification",
         headline=copy.headline,
@@ -4759,7 +4761,7 @@ def _command_preview_prefix(token: str) -> str:
 def _skill_picker_response(decision: dict[str, object], *, thread_key: str = "", message: str = "") -> dict[str, object]:
     picker = _skill_picker_state(message, source=str(decision.get("source", "generic")))
     catalog_question = _is_skill_catalog_question(message) and not _is_skill_picker_invocation(message)
-    korean_copy = prefers_korean_copy(message)
+    copy_locale = detect_copy_locale(message)
     primer = _context_primer_state()
     extra_state = {
         "route_action": decision.get("action", "dispatch"),
@@ -4774,8 +4776,8 @@ def _skill_picker_response(decision: dict[str, object], *, thread_key: str = "",
         extra_state["capability_summary"] = _catalog_capability_summary()
     return _chat_response(
         kind="skill_picker",
-        headline=skill_picker_headline(catalog_question=catalog_question, korean=korean_copy),
-        body=_skill_picker_body(catalog_question=catalog_question, korean_copy=korean_copy),
+        headline=skill_picker_headline(catalog_question=catalog_question, locale=copy_locale),
+        body=_skill_picker_body(catalog_question=catalog_question, copy_locale=copy_locale),
         phase="skill_selection",
         next_action="choose_skill",
         thread_key=thread_key,
@@ -4801,10 +4803,10 @@ def _skill_picker_response(decision: dict[str, object], *, thread_key: str = "",
     )
 
 
-def _skill_picker_body(*, catalog_question: bool, korean_copy: bool = False) -> str:
+def _skill_picker_body(*, catalog_question: bool, copy_locale: str = "en") -> str:
     return localized_skill_picker_body(
         catalog_question=catalog_question,
-        korean=korean_copy,
+        locale=copy_locale,
         family_lines=_skill_picker_family_body_lines(),
     )
 

--- a/src/wrapper/localized_copy.py
+++ b/src/wrapper/localized_copy.py
@@ -3,14 +3,51 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 
+SUPPORTED_COPY_LOCALES = ("en", "ko", "ja", "zh", "es", "fr", "de")
+
+
 @dataclass(frozen=True)
 class ChatCopy:
     headline: str
     body: str
 
 
+def detect_copy_locale(message: str) -> str:
+    """Return the best local chat-copy locale without external translation."""
+    if any("\uac00" <= char <= "\ud7a3" for char in message):
+        return "ko"
+    if any("\u3040" <= char <= "\u30ff" for char in message):
+        return "ja"
+    if any("\u4e00" <= char <= "\u9fff" for char in message):
+        return "zh"
+
+    normalized = f" {message.lower()} "
+    if any(hint in normalized for hint in ("¿", "¡", " qué ", " quiero ", " necesito ", " puedes ", " fallo ", " resumen ")):
+        return "es"
+    if any(
+        hint in normalized
+        for hint in (" quelle ", " quelles ", " peux-tu ", " je veux ", " trouve ", " explique ", " recherche ", " dépôt ", " résumé ")
+    ):
+        return "fr"
+    if any(hint in normalized for hint in (" welche ", " kannst du ", " bitte ", " zusammenfassung ", " fehler ", " arbeitsablauf ")):
+        return "de"
+    return "en"
+
+
 def prefers_korean_copy(message: str) -> bool:
-    return any("\uac00" <= char <= "\ud7a3" for char in message)
+    return detect_copy_locale(message) == "ko"
+
+
+def is_localized_locale(locale: str) -> bool:
+    return _normalize_locale(locale) != "en"
+
+
+def _normalize_locale(locale: str | None, *, korean: bool | None = None) -> str:
+    if korean is not None:
+        return "ko" if korean else "en"
+    if locale in SUPPORTED_COPY_LOCALES:
+        return str(locale)
+    return "en"
 
 
 _CARD_COPY: dict[str, dict[str, ChatCopy]] = {
@@ -31,6 +68,41 @@ _CARD_COPY: dict[str, dict[str, ChatCopy]] = {
                 "말하지 않고 어떤 도구를 쓸지 먼저 고릅니다."
             ),
         ),
+        "ja": ChatCopy(
+            headline="共有用の画像カード案を準備できます。",
+            body=(
+                "素材を画像カード向けの image-card brief として整理します。対象読者、レイアウト、画像内コピー、生成プロンプト、"
+                "ネガティブプロンプト、簡単なQAチェックを分けます。画像ツールが未接続なら、生成済みとは言わず先に使うツールを確認します。"
+            ),
+        ),
+        "zh": ChatCopy(
+            headline="我可以先准备一张可分享的图片卡片方案。",
+            body=(
+                "我会把素材整理成 image-card brief：受众、版式、图片内文案、生成提示词、负面提示词和快速 QA。"
+                "如果还没有连接图片工具，我会先询问要用哪个工具，不会假装图片已经生成。"
+            ),
+        ),
+        "es": ChatCopy(
+            headline="Puedo preparar una tarjeta visual compartible.",
+            body=(
+                "Convertiré la fuente en un image-card brief: audiencia, layout, texto dentro de la imagen, prompt de generación, "
+                "negative prompt y QA rápido. Si no hay herramienta de imagen conectada, preguntaré cuál usar en vez de fingir que la imagen ya existe."
+            ),
+        ),
+        "fr": ChatCopy(
+            headline="Je peux préparer une carte image partageable.",
+            body=(
+                "Je vais transformer la source en image-card brief: audience, mise en page, texte dans l'image, prompt de génération, "
+                "negative prompt et QA rapide. Si aucun outil image n'est connecté, je demanderai lequel utiliser au lieu de prétendre que l'image existe."
+            ),
+        ),
+        "de": ChatCopy(
+            headline="Ich kann eine teilbare Bildkarte vorbereiten.",
+            body=(
+                "Ich erstelle daraus ein image-card brief: Zielgruppe, Layout, Text im Bild, Generierungs-Prompt, Negative Prompt "
+                "und kurze QA. Wenn kein Bildtool verbunden ist, frage ich zuerst nach dem Tool und behaupte nicht, dass ein Bild erzeugt wurde."
+            ),
+        ),
     },
     "paper_learning": {
         "en": ChatCopy(
@@ -47,6 +119,41 @@ _CARD_COPY: dict[str, dict[str, ChatCopy]] = {
                 "paper-learning 카드로 설명 수준, PDF/출처 상태, 섹션별 커버리지, 핵심 주장, "
                 "다시 봐야 할 그림/수식, 누락 범위를 정리하겠습니다. 전문 추출, 인용 검증, "
                 "수학 검증, 재현, 피어 리뷰는 관측되기 전까지 완료됐다고 말하지 않습니다."
+            ),
+        ),
+        "ja": ChatCopy(
+            headline="この論文を希望する深さで解説できます。",
+            body=(
+                "paper-learning card として、解説レベル、PDF/出典の状態、章ごとのカバー範囲、主要主張、"
+                "見直す図表や数式、未確認範囲を整理します。抽出、引用確認、数式検証、再現、査読は観測されるまで完了扱いしません。"
+            ),
+        ),
+        "zh": ChatCopy(
+            headline="我可以按需要的深度讲解这篇论文。",
+            body=(
+                "我会准备 paper-learning card：讲解难度、PDF/来源状态、章节覆盖、核心主张、需要回看的图表或公式、覆盖清单。"
+                "全文抽取、引用核验、数学验证、复现和同行评审在被观测前不会被说成已完成。"
+            ),
+        ),
+        "es": ChatCopy(
+            headline="Puedo explicar este paper con la profundidad adecuada.",
+            body=(
+                "Prepararé una paper-learning card: nivel de explicación, estado del PDF/fuente, cobertura por sección, claims clave, "
+                "figuras o ecuaciones a revisar y cobertura faltante. No diré que hubo extracción completa, verificación de citas, matemáticas, reproducción o revisión externa hasta observarlo."
+            ),
+        ),
+        "fr": ChatCopy(
+            headline="Je peux expliquer ce papier au bon niveau.",
+            body=(
+                "Je prépare une paper-learning card: niveau d'explication, état PDF/source, couverture des sections, thèses clés, "
+                "figures ou équations à revoir et registre de couverture. Je ne dirai pas que l'extraction complète, les citations, les maths, la reproduction ou la revue sont validées avant observation."
+            ),
+        ),
+        "de": ChatCopy(
+            headline="Ich kann dieses Paper in der passenden Tiefe erklären.",
+            body=(
+                "Ich bereite eine paper-learning card vor: Erklärniveau, PDF-/Quellenstatus, Abschnittsabdeckung, Kernthesen, "
+                "zu prüfende Abbildungen oder Formeln und Coverage-Ledger. Vollständige Extraktion, Zitatprüfung, mathematische Validierung, Reproduktion oder Review gelten erst nach Beobachtung."
             ),
         ),
     },
@@ -67,6 +174,41 @@ _CARD_COPY: dict[str, dict[str, ChatCopy]] = {
                 "실제 웹 검색, 다운로드, 클론, 추출, 검증, 후속 처리는 관측되기 전까지 완료됐다고 말하지 않습니다."
             ),
         ),
+        "ja": ChatCopy(
+            headline="探すべき資料を取得計画にできます。",
+            body=(
+                "source-finder plan として、論文、リンク、データセット、リポジトリ、公開スライドなどの候補カテゴリ、"
+                "検索/取得状態、出典・ライセンス確認、次のworkflowを整理します。検索、ダウンロード、clone、抽出、検証は観測されるまで完了扱いしません。"
+            ),
+        ),
+        "zh": ChatCopy(
+            headline="我可以把资料查找变成来源获取计划。",
+            body=(
+                "我会准备 source-finder plan：论文、链接、数据集、代码库、公开演示等候选类别，搜索/获取状态，来源和许可检查，"
+                "以及后续 workflow。网页搜索、下载、clone、抽取、验证和后续处理在被观测前不会被说成已完成。"
+            ),
+        ),
+        "es": ChatCopy(
+            headline="Puedo convertir esto en un plan de búsqueda de fuentes.",
+            body=(
+                "Prepararé un source-finder plan: categorías candidatas como papers, enlaces, datasets, repositorios o presentaciones, "
+                "estado de búsqueda/adquisición, procedencia, licencia/acceso y el mejor workflow siguiente. No afirmaré búsqueda web, descarga, clone, extracción o verificación hasta observarlo."
+            ),
+        ),
+        "fr": ChatCopy(
+            headline="Je peux transformer cela en plan d'acquisition de sources.",
+            body=(
+                "Je prépare un source-finder plan: catégories candidates comme papiers, liens, datasets, dépôts ou présentations, "
+                "état de recherche/acquisition, provenance, licence/accès et meilleur workflow suivant. Je ne dirai pas que la recherche web, le téléchargement, le clone, l'extraction ou la vérification sont faits avant observation."
+            ),
+        ),
+        "de": ChatCopy(
+            headline="Ich kann daraus einen Quellenbeschaffungsplan machen.",
+            body=(
+                "Ich bereite einen source-finder plan vor: Kandidaten wie Paper, Links, Datasets, Repositories oder Präsentationen, "
+                "Such-/Beschaffungsstatus, Herkunft, Lizenz/Zugriff und nächster workflow. Websuche, Download, Clone, Extraktion und Verifikation gelten erst nach Beobachtung."
+            ),
+        ),
     },
     "web_research": {
         "en": ChatCopy(
@@ -82,6 +224,41 @@ _CARD_COPY: dict[str, dict[str, ChatCopy]] = {
             body=(
                 "조사 범위, 최신성 기준, 출처 다양성, 인용 신뢰도, 검색 공백을 먼저 잡고 그 다음 "
                 "계획, 리포트, 코딩 handoff로 넘기겠습니다. 실제 출처 수집이나 검증은 관측되기 전까지 완료됐다고 말하지 않습니다."
+            ),
+        ),
+        "ja": ChatCopy(
+            headline="最新根拠の調査として整理できます。",
+            body=(
+                "Hermes側の research として、出典範囲、鮮度、出典の多様性、引用信頼度、検索ギャップを先に定めます。"
+                "出典取得や検証は観測されるまで完了扱いせず、その後に計画、レポート、coding handoffへ渡します。"
+            ),
+        ),
+        "zh": ChatCopy(
+            headline="我可以按有来源支撑的最新研究来整理。",
+            body=(
+                "我会把它作为 Hermes 侧 research：先定义来源边界、时效窗口、来源多样性、引用可信度和检索缺口，"
+                "再把发现转成计划、报告或 coding handoff。来源抓取或验证在被观测前不会被说成已完成。"
+            ),
+        ),
+        "es": ChatCopy(
+            headline="Puedo reunir evidencia actual con fuentes.",
+            body=(
+                "Lo trataré como research dentro de Hermes: límites de fuente, ventana de actualidad, diversidad, confianza de citas y huecos de búsqueda "
+                "antes de convertir hallazgos en plan, reporte o coding handoff. No afirmaré que las fuentes fueron obtenidas o verificadas hasta observarlo."
+            ),
+        ),
+        "fr": ChatCopy(
+            headline="Je peux rassembler des preuves actuelles sourcées.",
+            body=(
+                "Je garde cela comme research côté Hermes: périmètre des sources, fraîcheur, diversité, confiance des citations et trous de recherche "
+                "avant de transformer les résultats en plan, rapport ou coding handoff. Je ne dirai pas que les sources sont récupérées ou vérifiées avant observation."
+            ),
+        ),
+        "de": ChatCopy(
+            headline="Ich kann aktuelle, quellenbasierte Evidenz vorbereiten.",
+            body=(
+                "Ich behandle das als Hermes-side research: Quellenrahmen, Aktualität, Quellenvielfalt, Zitiervertrauen und Suchlücken zuerst, "
+                "danach Plan, Bericht oder coding handoff. Quellenabruf oder Verifikation gelten erst nach Beobachtung."
             ),
         ),
     },
@@ -102,6 +279,26 @@ _CARD_COPY: dict[str, dict[str, ChatCopy]] = {
                 "라우팅/스킬 변경은 사람 리뷰 뒤에만 반영합니다."
             ),
         ),
+        "ja": ChatCopy(
+            headline="見逃した OMH route を改善候補として記録できます。",
+            body="これは missed-route feedback として扱い、raw promptを保存せずmetadata trace、レビュー可能なbundle、最小回帰ケースを用意します。routingやskill変更は人のレビュー後だけです。",
+        ),
+        "zh": ChatCopy(
+            headline="我可以把这次漏掉的 OMH route 记录为改进候选。",
+            body="我会把它作为 missed-route feedback：不保存原始 prompt，只记录 metadata trace、可 review 的 bundle 和最小回归用例。routing 或 skill 改动仍需要人工 review。",
+        ),
+        "es": ChatCopy(
+            headline="Puedo registrar esta ruta OMH perdida.",
+            body="Lo trataré como missed-route feedback: metadata trace sin prompt crudo, bundle revisable y caso mínimo de regresión. Cualquier cambio de routing o skill queda detrás de revisión humana.",
+        ),
+        "fr": ChatCopy(
+            headline="Je peux enregistrer cette route OMH manquée.",
+            body="Je traite cela comme missed-route feedback: metadata trace sans prompt brut, bundle révisable et cas de régression minimal. Tout changement de routing ou skill reste soumis à revue humaine.",
+        ),
+        "de": ChatCopy(
+            headline="Ich kann diese verpasste OMH route erfassen.",
+            body="Ich behandle das als missed-route feedback: metadata trace ohne raw prompt, reviewbares bundle und minimaler Regressionstest. Routing- oder Skill-Änderungen bleiben hinter Human Review.",
+        ),
     },
     "workflow_learning_readiness": {
         "en": ChatCopy(
@@ -119,6 +316,26 @@ _CARD_COPY: dict[str, dict[str, ChatCopy]] = {
                 "회귀 케이스, readiness audit, redacted review bundle을 만들며, 스킬이나 라우팅 개선은 여전히 사람 리뷰가 필요합니다."
             ),
         ),
+        "ja": ChatCopy(
+            headline="この workflow を学習可能か点検できます。",
+            body="raw promptを保存せず、trace、deterministic eval、回帰ケース、readiness audit、redacted review bundleに整理します。skillやrouting改善は人のレビューが必要です。",
+        ),
+        "zh": ChatCopy(
+            headline="我可以检查这个 workflow 是否适合改进。",
+            body="我会在不保存原始 prompt 的前提下整理 trace、deterministic eval、回归用例、readiness audit 和 redacted review bundle。skill 或 routing 改进仍需人工 review。",
+        ),
+        "es": ChatCopy(
+            headline="Puedo revisar si este workflow está listo para aprender.",
+            body="Sin guardar prompts crudos, registraré trace, deterministic eval, caso de regresión, readiness audit y redacted review bundle. Mejoras de skill o routing requieren revisión humana.",
+        ),
+        "fr": ChatCopy(
+            headline="Je peux vérifier si ce workflow peut s'améliorer.",
+            body="Sans stocker de prompt brut, je prépare trace, deterministic eval, cas de régression, readiness audit et redacted review bundle. Toute amélioration de skill ou routing exige une revue humaine.",
+        ),
+        "de": ChatCopy(
+            headline="Ich kann prüfen, ob dieser workflow lernbereit ist.",
+            body="Ohne raw prompts zu speichern, erstelle ich trace, deterministic eval, Regression Case, readiness audit und redacted review bundle. Skill- oder Routing-Verbesserungen brauchen Human Review.",
+        ),
     },
     "clarify": {
         "en": ChatCopy(
@@ -129,6 +346,11 @@ _CARD_COPY: dict[str, dict[str, ChatCopy]] = {
             headline="라우팅 전에 한 가지 확인이 필요합니다.",
             body="라우팅 전에 목표를 조금 더 확인해야 합니다. 원하는 결과, 입력 자료, 멈춰야 할 기준을 한 문장으로 알려주세요.",
         ),
+        "ja": ChatCopy(headline="route 前に一つ確認が必要です。", body="続ける前に、欲しい結果、入力資料、止める条件を一文で教えてください。"),
+        "zh": ChatCopy(headline="route 前我需要再确认一点。", body="继续前，请用一句话说明目标、输入材料和停止条件。"),
+        "es": ChatCopy(headline="Necesito una aclaración antes de enrutar.", body="Confirma en una frase el resultado, los insumos y la condición de parada."),
+        "fr": ChatCopy(headline="J'ai besoin d'une précision avant la route.", body="Indiquez en une phrase le résultat voulu, les entrées et la condition d'arrêt."),
+        "de": ChatCopy(headline="Vor dem Routing brauche ich eine Klärung.", body="Bitte nenne Ergebnis, Eingaben und Stop-Bedingung in einem Satz."),
     },
     "file_lookup": {
         "en": ChatCopy(
@@ -139,6 +361,11 @@ _CARD_COPY: dict[str, dict[str, ChatCopy]] = {
             headline="파일이나 텍스트 확인 요청으로 보입니다.",
             body="파일/텍스트 확인으로 바로 답하거나, 대상 파일·경로가 없으면 먼저 물어보세요. OMH workflow 실행은 시작하지 않습니다.",
         ),
+        "ja": ChatCopy(headline="ファイルまたはテキスト確認に見えます。", body="対象ファイル/パスがあれば直接確認し、なければ先に尋ねます。OMH workflowは開始しません。"),
+        "zh": ChatCopy(headline="这看起来是文件或文本查找。", body="如果有目标文件/路径就直接回答；缺少目标时先询问。不会启动 OMH workflow。"),
+        "es": ChatCopy(headline="Parece una consulta de archivo o texto.", body="Responde como lookup de archivo/texto, o pide la ruta si falta. No abras un OMH workflow."),
+        "fr": ChatCopy(headline="Cela ressemble à une vérification de fichier ou texte.", body="Répondez comme lookup fichier/texte, ou demandez le chemin si absent. Ne lancez pas de workflow OMH."),
+        "de": ChatCopy(headline="Das wirkt wie eine Datei- oder Textsuche.", body="Antworte als Datei-/Text-Lookup oder frage nach dem Pfad. Kein OMH workflow starten."),
     },
     "direct_answer": {
         "en": ChatCopy(
@@ -149,6 +376,11 @@ _CARD_COPY: dict[str, dict[str, ChatCopy]] = {
             headline="이건 OMH workflow 없이 바로 답하면 됩니다.",
             body="현재 채팅에서 바로 답하세요. 사용자가 직접 요청하지 않는 한 OMH workflow, picker, coding handoff를 열지 않습니다.",
         ),
+        "ja": ChatCopy(headline="これは OMH workflow なしで直接答えられます。", body="このチャットで直接答えてください。ユーザーが求めない限りworkflow、picker、coding handoffは開きません。"),
+        "zh": ChatCopy(headline="这个不需要 OMH workflow。", body="直接在当前聊天中回答。除非用户要求，不要打开 workflow、picker 或 coding handoff。"),
+        "es": ChatCopy(headline="Esto no necesita un OMH workflow.", body="Responde directamente en el chat actual; no abras workflow, picker ni coding handoff salvo que el usuario lo pida."),
+        "fr": ChatCopy(headline="Cela ne nécessite pas de workflow OMH.", body="Répondez directement dans ce chat; n'ouvrez pas de workflow, picker ou coding handoff sauf demande explicite."),
+        "de": ChatCopy(headline="Dafür braucht es keinen OMH workflow.", body="Direkt im aktuellen Chat antworten; workflow, picker oder coding handoff nur öffnen, wenn der Nutzer es verlangt."),
     },
     "generic_clarify": {
         "en": ChatCopy(
@@ -159,74 +391,109 @@ _CARD_COPY: dict[str, dict[str, ChatCopy]] = {
             headline="라우팅 전에 목표를 조금 더 알아야 합니다.",
             body="원하는 결과를 한 문장으로 알려주면, 그에 맞는 workflow를 고르겠습니다.",
         ),
+        "ja": ChatCopy(headline="route 前に目標をもう少し知る必要があります。", body="望む結果を一文で教えてください。適切なworkflowを選びます。"),
+        "zh": ChatCopy(headline="route 前我需要先理解目标。", body="请用一句话说明你想要的结果，我会选择合适的 workflow。"),
+        "es": ChatCopy(headline="Necesito entender el objetivo antes de enrutar.", body="Dime en una frase el resultado que quieres y elegiré el workflow adecuado."),
+        "fr": ChatCopy(headline="Je dois comprendre l'objectif avant la route.", body="Dites en une phrase le résultat voulu et je choisirai le bon workflow."),
+        "de": ChatCopy(headline="Vor dem Routing muss ich das Ziel verstehen.", body="Sag mir das gewünschte Ergebnis in einem Satz; ich wähle den passenden workflow."),
     },
 }
 
 
-def chat_copy(copy_id: str, *, korean: bool) -> ChatCopy:
-    locale = "ko" if korean else "en"
-    return _CARD_COPY[copy_id][locale]
+def chat_copy(copy_id: str, *, locale: str | None = None, korean: bool | None = None) -> ChatCopy:
+    selected_locale = _normalize_locale(locale, korean=korean)
+    copy = _CARD_COPY[copy_id]
+    return copy.get(selected_locale) or copy["en"]
 
 
-def skill_picker_headline(*, catalog_question: bool, korean: bool) -> str:
-    if korean and catalog_question:
-        return "OMH workflow 목록입니다."
-    if korean:
-        return "OMH workflow를 바로 고를 수 있습니다."
+def skill_picker_headline(*, catalog_question: bool, locale: str | None = None, korean: bool | None = None) -> str:
+    selected_locale = _normalize_locale(locale, korean=korean)
+    if selected_locale == "ko":
+        return "OMH workflow 목록입니다." if catalog_question else "OMH workflow를 바로 고를 수 있습니다."
+    if selected_locale == "ja":
+        return "OMH workflow 一覧です。" if catalog_question else "OMH workflowを選べます。"
+    if selected_locale == "zh":
+        return "这是 OMH workflow 列表。" if catalog_question else "可以选择 OMH workflow。"
+    if selected_locale == "es":
+        return "Estos son los workflows de OMH." if catalog_question else "Elige un workflow de OMH."
+    if selected_locale == "fr":
+        return "Voici les workflows OMH." if catalog_question else "Choisissez un workflow OMH."
+    if selected_locale == "de":
+        return "Hier sind die OMH workflows." if catalog_question else "Wähle einen OMH workflow."
     return "Here are the OMH workflows." if catalog_question else "Choose an OMH workflow."
 
 
-def skill_picker_body(*, catalog_question: bool, korean: bool, family_lines: list[str]) -> str:
+def skill_picker_body(
+    *,
+    catalog_question: bool,
+    family_lines: list[str],
+    locale: str | None = None,
+    korean: bool | None = None,
+) -> str:
+    selected_locale = _normalize_locale(locale, korean=korean)
     family_heading = "Capability families:" if catalog_question else "Families:"
-    if korean and catalog_question:
-        return "\n".join(
-            [
-                "`omh list` 같은 shell 명령 승인을 받지 않아도 됩니다. OMH는 계획, 운영, 자료/이미지, 코딩 위임, loop, 상태 확인 workflow를 Hermes 채팅 안에서 고를 수 있게 해줍니다.",
-                "",
-                "먼저 이렇게 시작하세요:",
-                "- Route for me: 요청을 그대로 보내면 Hermes가 안전한 workflow를 고릅니다.",
-                "- Choose workflow: OMH capability family에서 직접 고릅니다.",
-                "- Search workflows: 하고 싶은 일이 분명할 때 맞는 skill을 찾습니다.",
-                "",
-                family_heading,
-                *family_lines,
-            ]
+    if selected_locale == "ko":
+        intro = (
+            "`omh list` 같은 shell 명령 승인을 받지 않아도 됩니다. OMH는 계획, 운영, 자료/이미지, 코딩 위임, loop, 상태 확인 workflow를 Hermes 채팅 안에서 고를 수 있게 해줍니다."
+            if catalog_question
+            else "시작 방식을 고르세요. 잘 모르겠으면 Route for me를 고르면 Hermes가 요청에서 가장 안전한 다음 workflow를 고릅니다."
         )
-    if korean:
-        return "\n".join(
-            [
-                "시작 방식을 고르세요. 잘 모르겠으면 Route for me를 고르면 Hermes가 요청에서 가장 안전한 다음 workflow를 고릅니다.",
-                "",
-                "추천 시작점:",
-                "- Route for me: 요청을 붙여 넣고 Hermes가 workflow를 고르게 합니다.",
-                "",
-                family_heading,
-                *family_lines,
-            ]
+        start_label = "먼저 이렇게 시작하세요:" if catalog_question else "추천 시작점:"
+    elif selected_locale == "ja":
+        intro = (
+            "shell command の承認なしで使えます。OMHは計画、運用、deliverables、coding handoffs、loop、statusをHermesチャット内で選べるようにします。"
+            if catalog_question
+            else "開始方法を選んでください。迷ったら Route for me でHermesが安全なworkflowを選びます。"
         )
+        start_label = "まずここから:"
+    elif selected_locale == "zh":
+        intro = (
+            "不需要先批准 shell command。OMH 让 Hermes 在聊天里选择 planning、ops、deliverables、coding handoffs、loops 和 status workflow。"
+            if catalog_question
+            else "请选择开始方式。不确定时选 Route for me，让 Hermes 选择最安全的 workflow。"
+        )
+        start_label = "从这里开始:"
+    elif selected_locale == "es":
+        intro = (
+            "No necesitas aprobar un shell command. OMH permite elegir planning, ops, deliverables, coding handoffs, loops y status desde el chat de Hermes."
+            if catalog_question
+            else "Elige cómo empezar. Si no estás seguro, Route for me deja que Hermes seleccione el workflow más seguro."
+        )
+        start_label = "Empieza aquí:"
+    elif selected_locale == "fr":
+        intro = (
+            "Pas besoin d'approuver un shell command. OMH permet de choisir planning, ops, deliverables, coding handoffs, loops et status depuis le chat Hermes."
+            if catalog_question
+            else "Choisissez comment commencer. En cas de doute, Route for me laisse Hermes choisir le workflow le plus sûr."
+        )
+        start_label = "Commencez ici:"
+    elif selected_locale == "de":
+        intro = (
+            "Du musst keinen shell command freigeben. OMH macht planning, ops, deliverables, coding handoffs, loops und status direkt im Hermes-Chat auswählbar."
+            if catalog_question
+            else "Wähle den Start. Wenn du unsicher bist, lässt Route for me Hermes den sichersten workflow wählen."
+        )
+        start_label = "Start hier:"
+    else:
+        intro = (
+            "You do not need to run a shell command for this. OMH covers planning, ops, deliverables, coding handoffs, loops, and status."
+            if catalog_question
+            else "Pick how to start, or choose Route for me and Hermes will select the safest next step from the request."
+        )
+        start_label = "Start here:" if catalog_question else "Best default:"
+
+    lines = [
+        intro,
+        "",
+        start_label,
+        "- Route for me: let Hermes choose the safest workflow from your message.",
+    ]
     if catalog_question:
-        return "\n".join(
+        lines.extend(
             [
-                "You do not need to run a shell command for this. OMH covers planning, ops, deliverables, coding handoffs, loops, and status.",
-                "",
-                "Start here:",
-                "- Route for me: let Hermes choose the safest workflow from your message.",
                 "- Choose workflow: pick from the OMH capability families.",
                 "- Search workflows: find the exact skill when you already know the job.",
-                "",
-                family_heading,
-                *family_lines,
             ]
         )
-    return "\n".join(
-        [
-            "Pick how to start, or choose Route for me and Hermes will select the safest next step from the request.",
-            "",
-            "Best default:",
-            "- Route for me: paste the request and let Hermes choose the workflow.",
-            "",
-            family_heading,
-            *family_lines,
-        ]
-    )
-
+    lines.extend(["", family_heading, *family_lines])
+    return "\n".join(lines)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,6 +20,9 @@ from omh.config_adapter import external_dirs
 from omh.paths import resolve_paths
 from omh.routing.intent import classify_omh_quality_intent
 from omh.skill_pack import builtin_skill_reference_templates, builtin_skill_templates
+from omh.wrapper.localized_copy import detect_copy_locale
+
+
 class CliTests(unittest.TestCase):
     def test_no_arg_cli_shows_welcome_instead_of_error(self) -> None:
         status, stdout, stderr = run_cli([], output_json=False)
@@ -5248,9 +5251,19 @@ class CliTests(unittest.TestCase):
                 self.assertEqual(payload["next_action"], "choose_skill")
                 self.assertEqual(payload["chat_response"]["kind"], "skill_picker")
                 self.assertTrue(payload["chat_response"]["state"]["catalog_question"])
-                if any("\uac00" <= char <= "\ud7a3" for char in message):
-                    self.assertIn("shell 명령 승인을 받지 않아도", payload["chat_response"]["body"])
-                    self.assertIn("먼저 이렇게 시작하세요:", payload["chat_response"]["body"])
+                copy_locale = detect_copy_locale(message)
+                localized_start_markers = {
+                    "ko": ("shell 명령 승인을 받지 않아도", "먼저 이렇게 시작하세요:"),
+                    "ja": ("shell command の承認なし", "まずここから:"),
+                    "zh": ("不需要先批准 shell command", "从这里开始:"),
+                    "es": ("No necesitas aprobar un shell command", "Empieza aquí:"),
+                    "fr": ("Pas besoin d'approuver un shell command", "Commencez ici:"),
+                    "de": ("Du musst keinen shell command freigeben", "Start hier:"),
+                }
+                if copy_locale in localized_start_markers:
+                    intro_marker, start_marker = localized_start_markers[copy_locale]
+                    self.assertIn(intro_marker, payload["chat_response"]["body"])
+                    self.assertIn(start_marker, payload["chat_response"]["body"])
                 else:
                     self.assertIn("shell command", payload["chat_response"]["body"])
                     self.assertIn("Start here:", payload["chat_response"]["body"])

--- a/tests/test_wrapper_contract.py
+++ b/tests/test_wrapper_contract.py
@@ -18,6 +18,7 @@ from omh.wrapper_contract import (
     build_status_card_from_status,
     messenger_rendering_contract,
 )
+from omh.wrapper.localized_copy import detect_copy_locale
 from omh.wrapper.native_commands import build_native_command_surface, render_native_command_response
 from omh.wrapper.route_hints import build_chat_route_hint_payload
 
@@ -1412,10 +1413,19 @@ class WrapperContractTests(unittest.TestCase):
                 self.assertEqual(payload["next_action"], "choose_skill")
                 self.assertEqual(payload["chat_response"]["kind"], "skill_picker")
                 self.assertTrue(payload["chat_response"]["state"]["catalog_question"])
-                if any("\uac00" <= char <= "\ud7a3" for char in message):
-                    self.assertIn("shell 명령 승인을 받지 않아도", payload["chat_response"]["body"])
-                    self.assertIn("계획, 운영, 자료/이미지, 코딩 위임", payload["chat_response"]["body"])
-                    self.assertIn("먼저 이렇게 시작하세요:", payload["chat_response"]["body"])
+                copy_locale = detect_copy_locale(message)
+                localized_markers = {
+                    "ko": ("shell 명령 승인을 받지 않아도", "먼저 이렇게 시작하세요:"),
+                    "ja": ("shell command の承認なし", "まずここから:"),
+                    "zh": ("不需要先批准 shell command", "从这里开始:"),
+                    "es": ("No necesitas aprobar un shell command", "Empieza aquí:"),
+                    "fr": ("Pas besoin d'approuver un shell command", "Commencez ici:"),
+                    "de": ("Du musst keinen shell command freigeben", "Start hier:"),
+                }
+                if copy_locale in localized_markers:
+                    intro_marker, start_marker = localized_markers[copy_locale]
+                    self.assertIn(intro_marker, payload["chat_response"]["body"])
+                    self.assertIn(start_marker, payload["chat_response"]["body"])
                 else:
                     self.assertIn("shell command", payload["chat_response"]["body"])
                     self.assertIn("planning, ops, deliverables, coding handoffs, loops, and status", payload["chat_response"]["body"])

--- a/tests/test_wrapper_localized_copy.py
+++ b/tests/test_wrapper_localized_copy.py
@@ -2,6 +2,8 @@ import unittest
 
 from omh.wrapper.localized_copy import (
     chat_copy,
+    detect_copy_locale,
+    is_localized_locale,
     prefers_korean_copy,
     skill_picker_body,
     skill_picker_headline,
@@ -9,42 +11,68 @@ from omh.wrapper.localized_copy import (
 
 
 class WrapperLocalizedCopyTests(unittest.TestCase):
-    def test_korean_detection_is_hangul_based_and_local_only(self) -> None:
+    def test_locale_detection_is_local_and_deterministic(self) -> None:
+        cases = {
+            "OMH가 어떤 스킬 있는지 알려줘": "ko",
+            "OMHで使えるスキルは？": "ja",
+            "OMH 有哪些工作流？": "zh",
+            "¿Qué comandos de OMH están disponibles?": "es",
+            "Quelles commandes OMH sont disponibles ?": "fr",
+            "Welche OMH Workflows gibt es?": "de",
+            "what OMH workflows are available?": "en",
+        }
+
+        for message, locale in cases.items():
+            with self.subTest(message=message):
+                self.assertEqual(detect_copy_locale(message), locale)
+                self.assertEqual(is_localized_locale(locale), locale != "en")
+
         self.assertTrue(prefers_korean_copy("OMH가 어떤 스킬 있는지 알려줘"))
-        self.assertFalse(prefers_korean_copy("what OMH workflows are available?"))
         self.assertFalse(prefers_korean_copy("OMH 有哪些工作流？"))
 
-    def test_core_cards_keep_english_and_korean_copy_in_catalog(self) -> None:
+    def test_core_cards_keep_multilingual_copy_in_catalog(self) -> None:
         cases = (
-            ("img_summary", "shareable image-card brief", "이미지 안 문구"),
-            ("paper_learning", "paper-learning card", "섹션별 커버리지"),
-            ("source_finder", "source-finder plan", "데이터셋"),
-            ("web_research", "source boundaries", "조사 범위"),
-            ("workflow_learning_missed_route", "missed-route feedback", "missed-route 피드백"),
-            ("file_lookup", "file or text lookup", "파일/텍스트 확인"),
+            ("img_summary", "en", "shareable image-card brief"),
+            ("img_summary", "ja", "画像カード"),
+            ("paper_learning", "fr", "paper-learning card"),
+            ("source_finder", "zh", "source-finder plan"),
+            ("web_research", "es", "research"),
+            ("workflow_learning_missed_route", "de", "missed-route feedback"),
+            ("file_lookup", "ko", "파일/텍스트 확인"),
         )
 
-        for copy_id, english_text, korean_text in cases:
-            with self.subTest(copy_id=copy_id):
-                self.assertIn(english_text, chat_copy(copy_id, korean=False).body)
-                self.assertIn(korean_text, chat_copy(copy_id, korean=True).body)
+        for copy_id, locale, expected_text in cases:
+            with self.subTest(copy_id=copy_id, locale=locale):
+                self.assertIn(expected_text, chat_copy(copy_id, locale=locale).body)
+
+        self.assertIn("shareable image-card brief", chat_copy("img_summary", locale="unsupported").body)
+        self.assertIn("이미지 안 문구", chat_copy("img_summary", korean=True).body)
 
     def test_skill_picker_copy_keeps_machine_contract_terms_visible(self) -> None:
         family_lines = ["- Plan and decide: deep-interview, ralplan."]
 
-        english_body = skill_picker_body(catalog_question=True, korean=False, family_lines=family_lines)
-        korean_body = skill_picker_body(catalog_question=True, korean=True, family_lines=family_lines)
+        english_body = skill_picker_body(catalog_question=True, locale="en", family_lines=family_lines)
+        korean_body = skill_picker_body(catalog_question=True, locale="ko", family_lines=family_lines)
+        japanese_body = skill_picker_body(catalog_question=True, locale="ja", family_lines=family_lines)
+        chinese_body = skill_picker_body(catalog_question=True, locale="zh", family_lines=family_lines)
 
-        self.assertEqual(skill_picker_headline(catalog_question=True, korean=False), "Here are the OMH workflows.")
-        self.assertEqual(skill_picker_headline(catalog_question=True, korean=True), "OMH workflow 목록입니다.")
+        self.assertEqual(skill_picker_headline(catalog_question=True, locale="en"), "Here are the OMH workflows.")
+        self.assertEqual(skill_picker_headline(catalog_question=True, locale="ko"), "OMH workflow 목록입니다.")
+        self.assertEqual(skill_picker_headline(catalog_question=True, locale="ja"), "OMH workflow 一覧です。")
+        self.assertEqual(skill_picker_headline(catalog_question=True, locale="zh"), "这是 OMH workflow 列表。")
         self.assertIn("shell command", english_body)
         self.assertIn("shell 명령 승인을 받지 않아도", korean_body)
+        self.assertIn("shell command", japanese_body)
+        self.assertIn("shell command", chinese_body)
         self.assertIn("Route for me:", english_body)
         self.assertIn("Route for me:", korean_body)
+        self.assertIn("Route for me:", japanese_body)
+        self.assertIn("Route for me:", chinese_body)
         self.assertIn(family_lines[0], english_body)
         self.assertIn(family_lines[0], korean_body)
+        self.assertIn(family_lines[0], japanese_body)
+        self.assertIn(family_lines[0], chinese_body)
 
 
 if __name__ == "__main__":
     unittest.main()
-


### PR DESCRIPTION
## Feature Report

### What Changed

- Expanded the wrapper chat copy catalog from English/Korean-only framing to deterministic local card framing for common Japanese, Chinese, Spanish, French, and German operator requests.
- Added local locale detection for chat-copy selection without changing router scoring, route decisions, action ids, schema versions, or evidence boundaries.
- Updated skill-picker, source-finder, paper-learning, web-research, image-summary, workflow-learning, clarify, file-lookup, direct-answer, and generic clarify card copy to fall back safely when a locale is unsupported.
- Updated README and installation/architecture docs to explain that setup terminal localization and chat-card localization are separate deterministic local layers.

### Why This Exists

- OMH already had deterministic multilingual routing hints, but rendered chat cards still mostly framed non-Korean, non-English requests in English. That makes Hermes feel less aware of the user's language even when the router picked the right workflow.
- Chat-first UX should make the first card feel like Hermes understood the operator while still preserving adapter-visible contract terms such as `Route for me`, `source-finder plan`, and evidence boundaries.

### User / Operator Impact

- Users asking catalog questions in Japanese, Chinese, Spanish, French, or German now see localized skill-picker framing instead of default English-only framing.
- French source-finder and paper-learning style requests keep the same workflow/action behavior but get localized human-facing card text.
- Unsupported phrasing still falls back to the normal English clarify/planning path; OMH does not claim machine translation.

### How It Works

- `src/wrapper/localized_copy.py` now owns `detect_copy_locale`, supported locale constants, local fallback behavior, and multilingual `ChatCopy` entries.
- `src/wrapper/contract.py` detects the copy locale once per chat response and asks the catalog for human-facing wording after route selection is already complete.
- Tests assert deterministic locale detection, multilingual card copy, localized picker bodies, and unchanged wrapper route/action contracts.

### Files And Contracts Touched

- `src/wrapper/localized_copy.py`: expanded local copy catalog and locale detection.
- `src/wrapper/contract.py`: switched response rendering from a Korean boolean to locale-aware copy lookup.
- `tests/test_wrapper_localized_copy.py`, `tests/test_wrapper_contract.py`, `tests/test_cli.py`: coverage for multilingual picker/card contracts.
- `README.md`, `docs/INSTALLATION.md`, `docs/ARCHITECTURE.md`: conservative docs sync for local routing/copy boundaries.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests` — 1035 tests passed.
- [x] `PYTHONPATH=tests uv run python -m compileall -q src tests`
- [x] `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check`
- [x] `PYTHONPATH=tests uv run python -m omh.cli harness validate`
- [ ] `python3 -m omh.cli release checklist --json` — not run; no release checklist or packaging behavior changed.
- [ ] `python3 -m omh.cli release hermes-smoke` — not run; no install or live Hermes integration behavior changed.
- [ ] `omh --help` — not run; no CLI help surface changed.
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` — not run; no setup/install surface changed.
- [x] Relevant dry-run or smoke command: `PYTHONPATH=tests uv run python -m omh.cli demo hermes-ux-quality --json` — status passed, score 100, 5/5 gates passed.
- [x] Localized chat smoke: `PYTHONPATH=tests uv run python -m omh.cli chat interact --source discord --json 'OMH 有哪些工作流？'` — rendered Chinese picker framing and `choose_skill`.
- [x] Localized chat smoke: `PYTHONPATH=tests uv run python -m omh.cli chat interact --source discord --json '¿Qué comandos de OMH están disponibles?'` — rendered Spanish picker framing and `choose_skill`.
- [x] Static whitespace check: `git diff --check`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; this is deterministic local wrapper rendering and does not claim live Hermes chat or messenger rendering.

## Risk

- Risk is moderate because this touches user-facing copy for several languages. The underlying route/action/evidence contracts remain unchanged and tests keep adapter contract terms visible.
- Locale detection is intentionally small and local; ambiguous or unsupported phrasing can still fall back to English rather than over-claiming translation.

## Compatibility / Rollout

- Backward compatible for schemas and command behavior.
- Existing Korean and English copy behavior remains supported through the same catalog, and old `korean=...` helper calls still work.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`): local wrapper rendering improvement only; no release-channel mechanics changed.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap.

## Follow-Up

- Keep future language expansions in `src/wrapper/localized_copy.py` and avoid external translation unless a separate explicit integration is designed.