### PR TITLE
Improve localized quality demo efficiency

### DIFF
--- a/src/quality/localized_chat_copy.py
+++ b/src/quality/localized_chat_copy.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+from copy import deepcopy
 from dataclasses import dataclass, field
 import hashlib
+from functools import lru_cache
 from typing import Mapping, Sequence
 
 from ..ingress import CHAT_SOURCES
@@ -106,6 +108,11 @@ LOCALIZED_CHAT_COPY_CASES: tuple[LocalizedChatCopyCase, ...] = (
 def build_localized_chat_copy_demo(*, source: str = "discord") -> dict[str, object]:
     if source not in CHAT_SOURCES:
         raise ValueError(f"unsupported demo source: {source}")
+    return deepcopy(_build_localized_chat_copy_demo_cached(source))
+
+
+@lru_cache(maxsize=None)
+def _build_localized_chat_copy_demo_cached(source: str) -> dict[str, object]:
     rows = [_evaluate_case(case, source=source) for case in LOCALIZED_CHAT_COPY_CASES]
     passing_count = sum(1 for row in rows if bool(row["passed"]))
     return {

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -63,6 +63,8 @@ from omh.skills.catalog import (
 )
 from omh.quality import grounded_score as grounded_score_module
 from omh.quality import context_brief_coverage as context_brief_coverage_module
+from omh.quality import hermes_ux_quality as hermes_ux_quality_module
+from omh.quality import localized_chat_copy as localized_chat_copy_module
 from omh.quality import routing_precision as routing_precision_module
 from omh.quality import route_hint_alignment as route_hint_alignment_module
 from omh.quality.grounded_score import GroundedScenario
@@ -530,6 +532,141 @@ class EfficiencyContractTests(unittest.TestCase):
         self.assertEqual(payload["summary"]["aligned_count"], 1)
         self.assertEqual(payload["cases"][0]["observed"]["route_workflow"], "synthetic-workflow")
         self.assertEqual(payload["cases"][0]["observed"]["route_confidence"], "precomputed")
+
+    def test_localized_chat_copy_demo_cache_is_reused_without_payload_poisoning(self) -> None:
+        localized_chat_copy_module._build_localized_chat_copy_demo_cached.cache_clear()
+
+        first = localized_chat_copy_module.build_localized_chat_copy_demo(source="discord")
+        first["summary"]["case_count"] = "mutated"
+        first["cases"][0]["observed"]["locale"] = "mutated"
+
+        second = localized_chat_copy_module.build_localized_chat_copy_demo(source="discord")
+        cache_info = localized_chat_copy_module._build_localized_chat_copy_demo_cached.cache_info()
+
+        self.assertNotEqual(second["summary"]["case_count"], "mutated")
+        self.assertNotEqual(second["cases"][0]["observed"]["locale"], "mutated")
+        self.assertEqual(cache_info.misses, 1)
+        self.assertGreaterEqual(cache_info.hits, 1)
+
+    def test_hermes_ux_quality_reuses_precomputed_gate_payloads(self) -> None:
+        grounded_payload = {
+            "summary": {
+                "all_10": True,
+                "scenario_count": 1,
+                "minimum_score": 10,
+                "average_score": 10,
+                "maximum_score": 10,
+            },
+            "scenarios": [],
+            "claim_boundary": "grounded boundary",
+        }
+        chat_card_payload = {
+            "summary": {
+                "all_passing": True,
+                "case_count": 1,
+                "passing_count": 1,
+                "generic_ack_count": 0,
+            },
+            "cases": [],
+            "claim_boundary": "chat card boundary",
+        }
+        route_hint_payload = {
+            "summary": {
+                "all_aligned": True,
+                "case_count": 1,
+                "aligned_count": 1,
+                "missing_hint_count": 0,
+                "mismatch_count": 0,
+            },
+            "cases": [],
+            "claim_boundary": "route hint boundary",
+        }
+        context_payload = {
+            "summary": {
+                "all_passing": True,
+                "case_count": 2,
+                "passing_count": 2,
+                "route_hint_count": 1,
+                "catalog_question_count": 1,
+            },
+            "cases": [],
+            "claim_boundary": "context boundary",
+        }
+        precision_payload = {
+            "schema_version": routing_precision_module.ROUTING_PRECISION_SCHEMA_VERSION,
+            "summary": {
+                "all_passing": True,
+                "case_count": 1,
+                "passing_count": 1,
+                "overroute_count": 0,
+                "catalog_picker_count": 0,
+                "generic_ack_count": 0,
+                "intervention_case_count": 1,
+                "intervention_passing_count": 1,
+                "missed_intervention_count": 0,
+                "intervention_generic_ack_count": 0,
+            },
+            "cases": [],
+            "intervention_cases": [],
+            "claim_boundary": "precision boundary",
+        }
+        localized_payload = {
+            "schema_version": localized_chat_copy_module.LOCALIZED_CHAT_COPY_SCHEMA_VERSION,
+            "summary": {
+                "all_passing": True,
+                "case_count": 1,
+                "passing_count": 1,
+                "locale_count": 1,
+            },
+            "cases": [],
+            "claim_boundary": "localized boundary",
+        }
+
+        with (
+            patch.object(
+                hermes_ux_quality_module,
+                "build_grounded_score_demo",
+                side_effect=AssertionError("precomputed grounded payload should be reused"),
+            ),
+            patch.object(
+                hermes_ux_quality_module,
+                "build_chat_card_coverage_demo",
+                side_effect=AssertionError("precomputed chat-card payload should be reused"),
+            ),
+            patch.object(
+                hermes_ux_quality_module,
+                "build_route_hint_alignment_demo",
+                side_effect=AssertionError("precomputed route-hint payload should be reused"),
+            ),
+            patch.object(
+                hermes_ux_quality_module,
+                "build_context_brief_coverage_demo",
+                side_effect=AssertionError("precomputed context payload should be reused"),
+            ),
+            patch.object(
+                hermes_ux_quality_module,
+                "build_routing_precision_demo",
+                side_effect=AssertionError("precomputed precision payload should be reused"),
+            ),
+            patch.object(
+                hermes_ux_quality_module,
+                "build_localized_chat_copy_demo",
+                side_effect=AssertionError("precomputed localized payload should be reused"),
+            ),
+        ):
+            payload = hermes_ux_quality_module.build_hermes_ux_quality_demo(
+                source="discord",
+                grounded_score=grounded_payload,
+                chat_card_coverage=chat_card_payload,
+                route_hint_alignment=route_hint_payload,
+                context_brief_coverage=context_payload,
+                routing_precision=precision_payload,
+                localized_chat_copy=localized_payload,
+            )
+
+        self.assertEqual(payload["status"], "passed")
+        self.assertEqual(payload["summary"]["passing_gate_count"], 6)
+        self.assertEqual(payload["summary"]["localized_chat_copy_passing_count"], 1)
 
     def test_capability_context_is_strong_but_bounded(self) -> None:
         full_items = skill_capabilities()


### PR DESCRIPTION
## Feature Report

### What Changed

- Added mutation-safe caching for the deterministic `localized_chat_copy/v1` quality demo.
- Added efficiency regression tests proving the localized demo cache is reused without payload poisoning.
- Added a Hermes UX quality regression test proving all six gate payloads, including localized chat copy, can be injected and reused without rebuilding sub-demos.

### Why This Exists

- OMH's visible UX quality suite now includes more routing, card, context, precision, and localized copy checks.
- As the gate corpus grows, release evidence and demo commands should stay fast and deterministic instead of rebuilding the same localized chat interactions repeatedly.
- The change keeps the quality path scalable without changing any routing behavior, public schema, chat copy, or evidence claims.

### User / Operator Impact

- Operators still see the same `omh demo localized-chat-copy` and `omh demo hermes-ux-quality` results.
- Repeated evidence/demo calls can reuse the localized copy payload safely.
- Future quality gates have a clearer contract: pass precomputed payloads into the rollup when they already exist, and do not silently recompute expensive subchecks.

### How It Works

- `build_localized_chat_copy_demo()` now returns a deep copy of an internal `lru_cache` payload keyed by source.
- The cached payload is never handed out directly, so callers/tests can mutate returned JSON without corrupting later calls.
- The Hermes UX quality rollup test patches every sub-demo builder to fail if called, then passes precomputed payloads for all six gates and verifies the rollup still passes.

### Files And Contracts Touched

- `src/quality/localized_chat_copy.py`
  - Adds the mutation-safe cached builder for `localized_chat_copy/v1`.
- `tests/test_efficiency.py`
  - Locks localized-copy cache reuse.
  - Locks precomputed Hermes UX gate payload reuse.
- Public schemas, CLI arguments, workflow routing, docs, generated skills, and runtime artifacts are unchanged.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_efficiency.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_localized_chat_copy.py tests/test_hermes_ux_quality.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `PYTHONPATH=tests uv run python -m compileall -q src tests`
- [x] `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check`
- [x] `PYTHONPATH=tests uv run python -m omh.cli harness validate`
- [ ] `python3 -m omh.cli release checklist --json`
- [ ] `python3 -m omh.cli release hermes-smoke`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable; no learning contract changed.
- [x] Relevant dry-run or smoke command: `PYTHONPATH=tests uv run python -m omh.cli demo localized-chat-copy --summary`; `PYTHONPATH=tests uv run python -m omh.cli demo hermes-ux-quality --summary`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; this PR changes deterministic local demo caching only, not live Hermes rendering or TUI behavior.

## Risk

- Low. The public function still returns the same JSON shape and validates the same deterministic cases.
- The main risk is accidental mutation of cached nested data; the new tests cover that by mutating returned payloads and checking the next call remains clean.

## Compatibility / Rollout

- Compatible with existing CLI/demo callers.
- No migration required.
- No docs regeneration needed because user-facing command output and schemas are unchanged.

## Release / Claims

- [x] Release-channel impact considered (`preview` quality/performance refinement; no stable contract change)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

This PR proves local quality-demo efficiency and mutation-safety only. It does not claim live Hermes rendering, platform delivery, plugin load, image generation, executor dispatch, implementation, review, CI, merge, or delivery evidence.

## Follow-Up

- If future quality gates add heavier fixtures, prefer the same shape: cached deterministic payloads plus mutation-safety tests, then inject precomputed payloads into rollups.
