### PR TITLE
Add prepared agentic playbook

### DIFF
--- a/docs/ROLES.md
+++ b/docs/ROLES.md
@@ -132,6 +132,21 @@ prepared handoffs, and observed evidence:
 - Wrapper actions: `choose_executor`, `show_prompt_handoff`, `show_runtime_handoff`, `start_team`, `start_swarm`, `prepare_worktree`, `send_to_executor`, `show_status`
 - Evidence boundary: A prepared coding handoff is not executor/runtime dispatch, worker start, worktree creation, result, verification, review, CI, merge readiness, or merge evidence. Hermes/OMX/OMO/OMC runtime handoffs must record separate `runtime_observation/v1` events before the status can move from prepared to observed.
 
+### Builder
+
+- ID: `builder`
+- Display name: Builder
+- Legacy aliases: `implementation-owner`
+- Purpose: Name the implementation responsibility inside a prepared Hermes-facing playbook while the selected executor/runtime remains the actual work owner.
+- Owns:
+  - Presentation-layer implementation step in the prepared playbook
+  - selected executor/runtime ownership narration
+  - Expected implementation artifact boundary before observed evidence exists
+- Primary skills: `ultragoal`, `ultrawork`, `ralph`
+- Primary harnesses: `goal-execution`, `coding-handling`
+- Wrapper actions: `choose_executor`, `show_prompt_handoff`, `show_runtime_handoff`, `send_to_executor`, `show_status`
+- Evidence boundary: A builder role label is not hidden coding execution, executor/runtime dispatch, worker start, implementation result, verification, review, CI, merge readiness, or merge evidence. The selected executor/runtime owns implementation only after observed evidence exists.
+
 ### Tracker
 
 - ID: `tracker`

--- a/roles/builder.md
+++ b/roles/builder.md
@@ -1,0 +1,46 @@
+# Builder
+
+This OMH role is a responsibility descriptor, not a runtime agent.
+
+Name the implementation responsibility inside a prepared Hermes-facing playbook while the selected executor/runtime remains the actual work owner.
+
+## OMH Role Context
+
+Use this role as OMH workflow-layer responsibility context: route the user's request to the nearest skill, name adjacent OMH workflows when the work crosses lanes, and keep status/evidence boundaries visible.
+
+Normal users talk to Hermes; role names help Hermes explain ownership and next action without making the user learn backend OMH commands.
+
+Role selection is prepared guidance only. It is not worker dispatch, tool execution, file generation, delivery, review, CI, merge-readiness, or merge evidence.
+
+## Legacy Aliases
+
+- `implementation-owner`
+
+## Owns
+
+- Presentation-layer implementation step in the prepared playbook
+- selected executor/runtime ownership narration
+- Expected implementation artifact boundary before observed evidence exists
+
+## Primary Skills
+
+- `ultragoal`
+- `ultrawork`
+- `ralph`
+
+## Primary Harnesses
+
+- `goal-execution`
+- `coding-handling`
+
+## Wrapper Actions
+
+- `choose_executor`
+- `show_prompt_handoff`
+- `show_runtime_handoff`
+- `send_to_executor`
+- `show_status`
+
+## Evidence Boundary
+
+A builder role label is not hidden coding execution, executor/runtime dispatch, worker start, implementation result, verification, review, CI, merge readiness, or merge evidence. The selected executor/runtime owns implementation only after observed evidence exists.

--- a/src/catalogs/roles.py
+++ b/src/catalogs/roles.py
@@ -156,6 +156,21 @@ _ROLES = (
         legacy_ids=("coding-handoff", "runtime-handoff-guidance", "codex-handoff-guidance"),
     ),
     RoleDefinition(
+        id="builder",
+        title="Builder",
+        purpose="Name the implementation responsibility inside a prepared Hermes-facing playbook while the selected executor/runtime remains the actual work owner.",
+        owns=(
+            "Presentation-layer implementation step in the prepared playbook",
+            "selected executor/runtime ownership narration",
+            "Expected implementation artifact boundary before observed evidence exists",
+        ),
+        primary_skills=("ultragoal", "ultrawork", "ralph"),
+        primary_harnesses=("goal-execution", "coding-handling"),
+        wrapper_actions=("choose_executor", "show_prompt_handoff", "show_runtime_handoff", "send_to_executor", "show_status"),
+        evidence_boundary="A builder role label is not hidden coding execution, executor/runtime dispatch, worker start, implementation result, verification, review, CI, merge readiness, or merge evidence. The selected executor/runtime owns implementation only after observed evidence exists.",
+        legacy_ids=("implementation-owner",),
+    ),
+    RoleDefinition(
         id="tracker",
         title="Tracker",
         purpose="Own runtime status, target topology, executor session, measurement, tool readiness, and observability narration.",

--- a/src/coding/agentic_playbook.py
+++ b/src/coding/agentic_playbook.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import re
+from typing import Final
+
+from .agentic_playbook_contract import (
+    AGENTIC_PLAYBOOK_SCHEMA_VERSION,
+    JsonObject,
+    JsonValue,
+    PayloadObject,
+    bool_at,
+    build_agentic_playbook,
+    dict_at,
+    string_at,
+)
+from ..workflows.hermes_planning import is_coding_shaped_task
+
+
+_CLARIFICATION: Final = "Do you want a quick answer, or should I prepare the staged implementation workflow?"
+_CLASSIFICATION_BOUNDARY: Final = "Classification is routing guidance only; it is not execution evidence."
+_LIGHT_ANTI_SIGNAL_TERMS: Final = (
+    ("non_coding_troubleshooting", ("trackpad", "scroll", "mouse", "keyboard", "터치패드", "마우스")),
+    ("status_only_question", ("status", "상태", "진행상황")),
+    ("simple_explanation", ("why", "what does", "explain", "왜", "뭐야", "설명")),
+    ("skill_catalog_question", ("skills", "workflows", "available", "스킬", "워크플로우")),
+)
+_ATTACH_SUPPORT_TERMS: Final = (
+    ("release_or_merge_signal", ("merge", "release", "ci", "pr", "릴리즈", "머지")),
+    ("review_signal", ("review", "code review", "fix-after-review", "리뷰")),
+    ("handoff_signal", ("handoff", "delegate", "executor", "runtime", "team", "swarm", "서브", "에이전트")),
+)
+_CODING_DELEGATE_WORK_OWNER_MODES: Final = ("external_executor", "prompt_only_handoff", "runtime_handoff")
+
+
+class _ClassificationEvidence:
+    __slots__: tuple[str, ...] = ("anti_signals", "clarification", "reasons", "source_contracts")
+
+    def __init__(self) -> None:
+        self.reasons: list[str] = []
+        self.anti_signals: list[str] = []
+        self.source_contracts: list[str] = []
+        self.clarification: str = ""
+
+    def clarified(self, question: str) -> _ClassificationEvidence:
+        evidence = _ClassificationEvidence()
+        evidence.reasons = list(self.reasons)
+        evidence.anti_signals = list(self.anti_signals)
+        evidence.source_contracts = list(self.source_contracts)
+        evidence.clarification = question
+        return evidence
+
+
+def classify_agentic_playbook(
+    message: str,
+    *,
+    route_payload: PayloadObject | None = None,
+    delegation_payload: PayloadObject | None = None,
+) -> JsonObject:
+    evidence = _ClassificationEvidence()
+    route_action = _record_route_contracts(route_payload, evidence)
+    delegation_action = _record_delegation_contracts(delegation_payload, evidence)
+    coding_shaped = _record_message_signals(message, evidence)
+
+    if route_action == "clarify":
+        return _classification("clarify", "low", evidence.clarified(_CLARIFICATION))
+
+    if (delegation_action == "delegate" or _has_coding_delegate_contract(evidence)) and (
+        coding_shaped or _has_attach_signal(evidence)
+    ):
+        return _classification("attach_playbook", "high", evidence)
+
+    if not coding_shaped:
+        return _classification("light_path", "high", evidence)
+
+    if evidence.anti_signals:
+        return _classification("light_path", "medium", evidence)
+
+    return _classification("clarify", "low", evidence.clarified(_CLARIFICATION))
+
+
+def maybe_build_agentic_playbook(
+    message: str,
+    *,
+    route_payload: PayloadObject | None = None,
+    delegation_payload: PayloadObject | None = None,
+) -> JsonObject | None:
+    classification = classify_agentic_playbook(
+        message,
+        route_payload=route_payload,
+        delegation_payload=delegation_payload,
+    )
+    if classification["decision"] != "attach_playbook":
+        return None
+    return build_agentic_playbook(classification, delegation_payload=delegation_payload)
+
+
+def _classification(decision: str, confidence: str, evidence: _ClassificationEvidence) -> JsonObject:
+    payload: JsonObject = {
+        "schema_version": AGENTIC_PLAYBOOK_SCHEMA_VERSION,
+        "decision": decision,
+        "confidence": confidence,
+        "reasons": _json_strings(unique(evidence.reasons)),
+        "matched_signals": _json_strings(unique(evidence.reasons)),
+        "anti_signals": _json_strings(unique(evidence.anti_signals)),
+        "source_contracts": _json_strings(unique(evidence.source_contracts)),
+        "claim_boundary": _CLASSIFICATION_BOUNDARY,
+    }
+    if evidence.clarification:
+        payload["clarification"] = evidence.clarification
+    return payload
+
+
+def _record_route_contracts(route_payload: PayloadObject | None, evidence: _ClassificationEvidence) -> str:
+    route_action = string_at(route_payload, "action")
+    if route_action:
+        evidence.source_contracts.append(f"route_action_{route_action}")
+    if string_at(route_payload, "selected_skill"):
+        evidence.source_contracts.append("route_selected_skill")
+    return route_action
+
+
+def _record_delegation_contracts(
+    delegation_payload: PayloadObject | None, evidence: _ClassificationEvidence
+) -> str:
+    delegation_action = string_at(dict_at(delegation_payload, "delegation"), "action")
+    if delegation_action:
+        evidence.source_contracts.append(f"delegation_action_{delegation_action}")
+    selected_executor = string_at(delegation_payload, "selected_executor_profile")
+    if selected_executor:
+        evidence.reasons.append("selected_executor_profile")
+        evidence.source_contracts.append("selected_executor_profile")
+    if bool_at(dict_at(delegation_payload, "executor_selection"), "choice_required"):
+        evidence.source_contracts.append("executor_choice_required")
+    if bool_at(delegation_payload, "available"):
+        evidence.reasons.append("coding_delegate_available")
+        evidence.source_contracts.append("coding_delegate_available")
+    if bool_at(delegation_payload, "executor_choice_required"):
+        evidence.reasons.append("executor_choice_required")
+        evidence.source_contracts.append("executor_choice_required")
+    work_owner_mode = string_at(delegation_payload, "work_owner_mode")
+    if work_owner_mode in _CODING_DELEGATE_WORK_OWNER_MODES:
+        evidence.reasons.append(f"{work_owner_mode}_work_owner")
+        evidence.source_contracts.append(f"work_owner_mode_{work_owner_mode}")
+    if delegation_action == "delegate":
+        evidence.reasons.append("delegation_action_delegate")
+    return delegation_action
+
+
+def _record_message_signals(message: str, evidence: _ClassificationEvidence) -> bool:
+    coding_shaped = is_coding_shaped_task(message)
+    if coding_shaped:
+        evidence.reasons.append("coding_shaped_task")
+        evidence.source_contracts.append("hermes_planning.is_coding_shaped_task")
+    lowered = f" {message.lower()} "
+    tokens = set(re.findall(r"[0-9a-z가-힣]+", lowered))
+    _append_matching_terms(lowered, tokens, _ATTACH_SUPPORT_TERMS, evidence.reasons)
+    _append_matching_terms(lowered, tokens, _LIGHT_ANTI_SIGNAL_TERMS, evidence.anti_signals)
+    return coding_shaped
+
+
+def _append_matching_terms(
+    lowered: str,
+    tokens: set[str],
+    terms_by_signal: tuple[tuple[str, tuple[str, ...]], ...],
+    target: list[str],
+) -> None:
+    for signal, terms in terms_by_signal:
+        if any(_term_matches(lowered, tokens, term) for term in terms):
+            target.append(signal)
+
+
+def _has_attach_signal(evidence: _ClassificationEvidence) -> bool:
+    attach_reasons = {"release_or_merge_signal", "review_signal", "handoff_signal"}
+    return any(reason in attach_reasons for reason in evidence.reasons)
+
+
+def _has_coding_delegate_contract(evidence: _ClassificationEvidence) -> bool:
+    contract_reasons = {
+        "coding_delegate_available",
+        "executor_choice_required",
+        "external_executor_work_owner",
+        "prompt_only_handoff_work_owner",
+        "runtime_handoff_work_owner",
+    }
+    return any(reason in contract_reasons for reason in evidence.reasons)
+
+
+def _term_matches(lowered: str, tokens: set[str], term: str) -> bool:
+    return term in tokens if len(term) <= 2 else term in lowered
+
+
+def unique(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        if not value or value in seen:
+            continue
+        seen.add(value)
+        result.append(value)
+    return result
+
+
+def _json_strings(values: list[str]) -> list[JsonValue]:
+    result: list[JsonValue] = []
+    for value in values:
+        result.append(value)
+    return result

--- a/src/coding/agentic_playbook_contract.py
+++ b/src/coding/agentic_playbook_contract.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Final, NamedTuple, TypeAlias, TypeGuard
+
+from .executors import executor_label
+
+
+JsonValue: TypeAlias = str | int | float | bool | None | list["JsonValue"] | dict[str, "JsonValue"]
+JsonObject: TypeAlias = dict[str, JsonValue]
+PayloadObject: TypeAlias = Mapping[str, object]
+
+AGENTIC_PLAYBOOK_SCHEMA_VERSION: Final = "agentic_playbook/v1"
+PREPARED_STATUS: Final = "prepared_not_observed"
+CLAIM_BOUNDARY: Final = (
+    "Prepared agentic playbook status remains prepared_not_observed; it is not execution, worker/subagent launch, "
+    "implementation, review, CI, merge-readiness, or merge evidence."
+)
+BLOCKED_BEFORE_OBSERVATION: Final = (
+    "worker_or_subagent_launch",
+    "executor_dispatch",
+    "implementation",
+    "verification",
+    "review_completion",
+    "ci",
+    "merge_readiness",
+    "merge",
+)
+ROLE_FLOW: Final = ("interviewer", "pre_build_reviewer", "builder", "post_build_reviewer")
+
+
+class _StepSpec(NamedTuple):
+    step_id: str
+    label: str
+    owner: str
+    owner_kind: str
+    expected_inputs: tuple[str, ...]
+    expected_outputs: tuple[str, ...]
+
+
+_STEP_SPECS: Final[tuple[_StepSpec, ...]] = (
+    _StepSpec(
+        step_id="interviewer",
+        label="Interviewer",
+        owner="Hermes / OMH planning surface",
+        owner_kind="planning_surface",
+        expected_inputs=("user request", "route/delegation source contracts"),
+        expected_outputs=("clarified scope", "acceptance criteria"),
+    ),
+    _StepSpec(
+        step_id="pre_build_reviewer",
+        label="Reviewer",
+        owner="Hermes / OMH review gate",
+        owner_kind="prepared_review_gate",
+        expected_inputs=("scope", "risks", "handoff readiness"),
+        expected_outputs=("reviewed prepared plan", "known blockers"),
+    ),
+    _StepSpec(
+        step_id="builder",
+        label="Builder",
+        owner="",
+        owner_kind="selected_executor_runtime",
+        expected_inputs=("accepted handoff", "selected executor/runtime owner"),
+        expected_outputs=("implementation evidence from the selected owner",),
+    ),
+    _StepSpec(
+        step_id="post_build_reviewer",
+        label="Reviewer",
+        owner="reviewer / verifier",
+        owner_kind="observed_evidence_consumer",
+        expected_inputs=("observed implementation", "tests", "review evidence"),
+        expected_outputs=("review findings", "merge-readiness boundary"),
+    ),
+)
+
+
+def build_agentic_playbook(
+    classification: PayloadObject,
+    *,
+    delegation_payload: PayloadObject | None = None,
+) -> JsonObject:
+    selected_executor = string_at(delegation_payload, "selected_executor_profile")
+    choice_required = bool_at(dict_at(delegation_payload, "executor_selection"), "choice_required")
+    builder_owner = selected_executor if selected_executor else "executor_choice_required"
+    builder_label = executor_label(selected_executor) if selected_executor else "executor choice required"
+    return {
+        "schema_version": AGENTIC_PLAYBOOK_SCHEMA_VERSION,
+        "status": PREPARED_STATUS,
+        "classification": public_classification(classification),
+        "steps": _steps(builder_owner),
+        "builder": _builder_payload(builder_owner, builder_label),
+        "selected_executor_profile": selected_executor or "",
+        "observation_contract": {
+            "required_schema": "runtime_observation/v1",
+            "status_before_observation": PREPARED_STATUS,
+            "claim_boundary": "Prepared playbook status cannot advance without observed runtime or executor evidence.",
+        },
+        "not_observed": _json_strings(BLOCKED_BEFORE_OBSERVATION),
+        "next_action": "choose_executor" if choice_required or not selected_executor else "prepare_selected_executor_handoff",
+        "claim_boundary": CLAIM_BOUNDARY,
+    }
+
+
+def chat_response_with_agentic_playbook(response: PayloadObject, playbook: PayloadObject) -> JsonObject:
+    updated = _json_object(response)
+    state = _json_object(dict_at(updated, "state"))
+    state["agentic_playbook"] = _response_projection(playbook)
+    updated["state"] = state
+
+    summary = render_agentic_playbook_summary(playbook)
+    body = str(updated.get("body", "")).strip()
+    updated["body"] = f"{body}\n\n{summary}" if body else summary
+
+    boundary = str(updated.get("claim_boundary", "")).strip()
+    updated["claim_boundary"] = f"{boundary} {CLAIM_BOUNDARY}".strip()
+    return updated
+
+
+def render_agentic_playbook_summary(playbook: PayloadObject) -> str:
+    builder = dict_at(playbook, "builder")
+    owner_label = string_at(builder, "owner_label") or string_at(builder, "owner")
+    return (
+        "Prepared staged workflow: Interviewer -> Reviewer -> Builder -> Reviewer. "
+        f"Builder owner: {owner_label}. Status: prepared_not_observed."
+    )
+
+
+def public_classification(classification: PayloadObject) -> JsonObject:
+    return {
+        "decision": string_at(classification, "decision"),
+        "confidence": string_at(classification, "confidence"),
+        "reasons": string_list_at(classification, "reasons"),
+        "anti_signals": string_list_at(classification, "anti_signals"),
+        "source_contracts": string_list_at(classification, "source_contracts"),
+        "claim_boundary": string_at(classification, "claim_boundary"),
+    }
+
+
+def dict_at(payload: PayloadObject | None, key: str) -> PayloadObject:
+    value = payload.get(key) if payload else None
+    if not _is_payload_mapping(value):
+        return {}
+    return {str(item_key): item_value for item_key, item_value in value.items()}
+
+
+def string_at(payload: PayloadObject | None, key: str) -> str:
+    value = payload.get(key) if payload else None
+    return str(value) if value else ""
+
+
+def bool_at(payload: PayloadObject | None, key: str) -> bool:
+    value = payload.get(key) if payload else None
+    return bool(value)
+
+
+def string_list_at(payload: PayloadObject, key: str) -> list[JsonValue]:
+    value = payload.get(key)
+    if not _is_object_list(value):
+        return []
+    result: list[JsonValue] = []
+    for item in value:
+        if item:
+            result.append(str(item))
+    return result
+
+
+def unique(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        if not value or value in seen:
+            continue
+        seen.add(value)
+        result.append(value)
+    return result
+
+
+def _steps(builder_owner: str) -> list[JsonValue]:
+    return [_step_from_spec(spec, builder_owner) for spec in _STEP_SPECS]
+
+
+def _step_from_spec(spec: _StepSpec, builder_owner: str) -> JsonObject:
+    owner = builder_owner if spec.step_id == "builder" else spec.owner
+    return {
+        "id": spec.step_id,
+        "label": spec.label,
+        "owner": owner,
+        "owner_kind": spec.owner_kind,
+        "expected_inputs": _json_strings(spec.expected_inputs),
+        "expected_outputs": _json_strings(spec.expected_outputs),
+        "status": PREPARED_STATUS,
+        "claim_boundary": CLAIM_BOUNDARY,
+    }
+
+
+def _builder_payload(builder_owner: str, builder_label: str) -> JsonObject:
+    return {
+        "id": "builder",
+        "label": "Builder",
+        "owner": builder_owner,
+        "owner_label": builder_label,
+        "owner_kind": "selected_executor_runtime",
+        "claim_boundary": (
+            "Builder is a Hermes-visible role label; implementation belongs to the selected executor/runtime "
+            "and requires observed evidence."
+        ),
+    }
+
+
+def _response_projection(playbook: PayloadObject) -> JsonObject:
+    builder = dict_at(playbook, "builder")
+    return {
+        "schema_version": string_at(playbook, "schema_version") or AGENTIC_PLAYBOOK_SCHEMA_VERSION,
+        "status": string_at(playbook, "status") or PREPARED_STATUS,
+        "role_flow": _json_strings(ROLE_FLOW),
+        "builder_owner": string_at(builder, "owner"),
+        "builder_owner_kind": string_at(builder, "owner_kind"),
+        "claim_boundary": string_at(playbook, "claim_boundary") or CLAIM_BOUNDARY,
+    }
+
+
+def _json_strings(values: Iterable[str]) -> list[JsonValue]:
+    result: list[JsonValue] = []
+    for value in values:
+        result.append(value)
+    return result
+
+
+def _json_object(payload: PayloadObject) -> JsonObject:
+    result: JsonObject = {}
+    for key, value in payload.items():
+        result[str(key)] = _json_value(value)
+    return result
+
+
+def _json_value(value: object) -> JsonValue:
+    if value is None or isinstance(value, str | int | float | bool):
+        return value
+    if _is_object_list(value):
+        array_result: list[JsonValue] = []
+        for item in value:
+            array_result.append(_json_value(item))
+        return array_result
+    if _is_payload_mapping(value):
+        object_result: JsonObject = {}
+        for key, item in value.items():
+            object_result[str(key)] = _json_value(item)
+        return object_result
+    return str(value)
+
+
+def _is_object_list(value: object) -> TypeGuard[list[object]]:
+    return isinstance(value, list)
+
+
+def _is_payload_mapping(value: object) -> TypeGuard[Mapping[object, object]]:
+    return isinstance(value, Mapping)

--- a/src/coding/coding_delegation.py
+++ b/src/coding/coding_delegation.py
@@ -27,6 +27,7 @@ from ..executor_readiness import (
     executor_readiness_for_selection,
     with_executor_readiness_options,
 )
+from .agentic_playbook import maybe_build_agentic_playbook
 from ..harness_quality import with_wrapper_actions
 from ..ingress import CHAT_SOURCES, extract_message_text, extract_source_metadata
 from ..isolation import build_isolation_plan
@@ -341,6 +342,9 @@ def build_coding_delegation_payload(
         runtime_handoff = payload.get("runtime_handoff")
         if isinstance(runtime_handoff, dict) and "prompt_template" in runtime_handoff:
             payload["runtime_handoff_prompt"] = str(runtime_handoff["prompt_template"]).replace("{message}", message)
+    agentic_playbook = maybe_build_agentic_playbook(message, delegation_payload=payload)
+    if agentic_playbook:
+        payload["agentic_playbook"] = agentic_playbook
     return payload
 
 

--- a/src/omh/agentic_playbook.py
+++ b/src/omh/agentic_playbook.py
@@ -1,0 +1,3 @@
+from __future__ import annotations
+
+from .coding.agentic_playbook import *  # noqa: F401,F403

--- a/src/plugin_bundle/omh/omh_roles.py
+++ b/src/plugin_bundle/omh/omh_roles.py
@@ -14,6 +14,7 @@ _ROLE_ALIASES = {
     "hybrid-measurement": "tracker",
     "hybrid-review": "reviewer",
     "hybrid-verification": "reviewer",
+    "implementation-owner": "builder",
     "planning-lead": "planner",
     "research-lead": "researcher",
     "retained-knowledge": "memory-keeper",

--- a/src/plugin_bundle/omh/references/role-builder.md
+++ b/src/plugin_bundle/omh/references/role-builder.md
@@ -1,0 +1,46 @@
+# Builder
+
+This OMH role is a responsibility descriptor, not a runtime agent.
+
+Name the implementation responsibility inside a prepared Hermes-facing playbook while the selected executor/runtime remains the actual work owner.
+
+## OMH Role Context
+
+Use this role as OMH workflow-layer responsibility context: route the user's request to the nearest skill, name adjacent OMH workflows when the work crosses lanes, and keep status/evidence boundaries visible.
+
+Normal users talk to Hermes; role names help Hermes explain ownership and next action without making the user learn backend OMH commands.
+
+Role selection is prepared guidance only. It is not worker dispatch, tool execution, file generation, delivery, review, CI, merge-readiness, or merge evidence.
+
+## Legacy Aliases
+
+- `implementation-owner`
+
+## Owns
+
+- Presentation-layer implementation step in the prepared playbook
+- selected executor/runtime ownership narration
+- Expected implementation artifact boundary before observed evidence exists
+
+## Primary Skills
+
+- `ultragoal`
+- `ultrawork`
+- `ralph`
+
+## Primary Harnesses
+
+- `goal-execution`
+- `coding-handling`
+
+## Wrapper Actions
+
+- `choose_executor`
+- `show_prompt_handoff`
+- `show_runtime_handoff`
+- `send_to_executor`
+- `show_status`
+
+## Evidence Boundary
+
+A builder role label is not hidden coding execution, executor/runtime dispatch, worker start, implementation result, verification, review, CI, merge readiness, or merge evidence. The selected executor/runtime owns implementation only after observed evidence exists.

--- a/src/plugin_bundle/omh/tools/capability_tool.py
+++ b/src/plugin_bundle/omh/tools/capability_tool.py
@@ -544,6 +544,15 @@ def _standalone_sections() -> dict[str, object]:
             },
             {
                 "schema_version": "agent_role_capability/v1",
+                "id": "builder",
+                "display_name": "Builder",
+                "legacy_ids": ["implementation-owner"],
+                "runtime_claim": "descriptor_not_runtime_agent",
+                "owns": ["prepared playbook implementation step", "selected executor/runtime ownership narration"],
+                "does_not_own": ["hidden runtime execution", "unobserved worker dispatch", "review", "CI", "merge"],
+            },
+            {
+                "schema_version": "agent_role_capability/v1",
                 "id": "tracker",
                 "display_name": "Tracker",
                 "legacy_ids": ["hybrid-measurement"],

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -6,6 +6,8 @@ from pathlib import Path
 from typing import Any
 
 from ..context_safety import compact_progress_events
+from ..coding.agentic_playbook import maybe_build_agentic_playbook
+from ..coding.agentic_playbook_contract import chat_response_with_agentic_playbook
 from ..ingress import CHAT_SOURCES, compact_source_metadata, extract_message_text, extract_source_metadata
 from ..routing.catalog_questions import is_skill_catalog_question as _is_skill_catalog_question
 from ..routing.chat import public_chat_route_payload, route_explanation_payload
@@ -1967,6 +1969,9 @@ def _build_chat_interaction_payload_uncached(
         delegation["executor_resolution"] = executor_resolution
         base["delegation"] = delegation
         base["executor_resolution"] = executor_resolution
+        agentic_playbook = delegation.get("agentic_playbook")
+        if isinstance(agentic_playbook, dict):
+            base["agentic_playbook"] = agentic_playbook
         base["next_action"] = _delegation_next_action(delegation)
         base["chat_response"] = build_chat_response_from_delegation(delegation, thread_key=str(base["thread_key"]))
         return _finish_interaction(base, target_notice)
@@ -1978,6 +1983,9 @@ def _build_chat_interaction_payload_uncached(
             message=message,
             include_message=include_message,
         )
+        agentic_playbook = maybe_build_agentic_playbook(message, route_payload=route_payload)
+        if agentic_playbook:
+            base["agentic_playbook"] = agentic_playbook
         base["next_action"] = str(_nested(base["chat_response"], "state").get("next_action", "answer_clarification"))
         return _finish_interaction(base, target_notice)
 
@@ -2024,6 +2032,14 @@ def _build_chat_interaction_payload_uncached(
         base["executor_resolution"] = executor_resolution
     base["plan"] = _public_plan_payload(plan, include_message=include_message)
     contract = _nested(plan, "wrapper_contract")
+    coding_delegate = _nested(contract, "coding_delegate")
+    agentic_playbook = maybe_build_agentic_playbook(
+        message,
+        route_payload=route_payload,
+        delegation_payload=coding_delegate if coding_delegate else None,
+    )
+    if agentic_playbook:
+        base["agentic_playbook"] = agentic_playbook
     next_action = str(contract.get("next_action", "present_plan"))
     base["next_action"] = "present_plan" if next_action == "prepare_coding_delegation_after_plan_acceptance" else next_action
     base["chat_response"] = build_chat_response_from_plan(plan, thread_key=str(base["thread_key"]))
@@ -2119,6 +2135,9 @@ def _attach_coding_owner_handoff(
         "coding_status_request": _route_is_coding_status_request(route_payload),
         "claim_boundary": "Route context explains why the wrapper shaped this handoff; it is not dispatch or runtime evidence.",
     }
+    agentic_playbook = delegation.get("agentic_playbook")
+    if isinstance(agentic_playbook, dict):
+        base["agentic_playbook"] = agentic_playbook
     base["delegation"] = delegation
     base["executor_resolution"] = executor_resolution
     base["next_action"] = _delegation_next_action(delegation)
@@ -4253,6 +4272,9 @@ def _finish_interaction(payload: dict[str, object], target_notice: dict[str, obj
         response = _chat_response_with_route_explanation(response, _nested(payload, "route"))
         if target_notice:
             response = _chat_response_with_target_notice(response, target_notice)
+        agentic_playbook = payload.get("agentic_playbook")
+        if isinstance(agentic_playbook, dict):
+            response = chat_response_with_agentic_playbook(response, agentic_playbook)
         payload["chat_response"] = _chat_response_with_render_profile(
             response,
             source=str(payload.get("source", "generic")),

--- a/tests/test_agentic_playbook.py
+++ b/tests/test_agentic_playbook.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import json
+import unittest
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.agentic_playbook import AGENTIC_PLAYBOOK_SCHEMA_VERSION, classify_agentic_playbook
+from omh.coding_delegation import build_coding_delegation_payload
+from omh.routing.chat import public_chat_route_payload
+
+
+class AgenticPlaybookTests(unittest.TestCase):
+    def test_classifier_attaches_for_coding_delegation_with_selected_executor(self) -> None:
+        message = "risky refactor with tests"
+        route_payload = public_chat_route_payload(message, source="discord")
+        delegation_payload = build_coding_delegation_payload(message, source="discord", executor_target="codex")
+
+        classification = classify_agentic_playbook(
+            message,
+            route_payload=route_payload,
+            delegation_payload=delegation_payload,
+        )
+
+        self.assertEqual(classification["schema_version"], AGENTIC_PLAYBOOK_SCHEMA_VERSION)
+        self.assertEqual(classification["decision"], "attach_playbook")
+        self.assertEqual(classification["confidence"], "high")
+        self.assertIn("delegation_action_delegate", classification["reasons"])
+        self.assertIn("selected_executor_profile", classification["source_contracts"])
+        self.assertNotIn(message, json.dumps(classification))
+
+    def test_builder_expected_outputs_stays_single_contract_item(self) -> None:
+        delegation_payload = build_coding_delegation_payload(
+            "risky refactor with tests",
+            source="discord",
+            executor_target="codex",
+        )
+
+        playbook = delegation_payload["agentic_playbook"]
+        steps = {step["id"]: step for step in playbook["steps"]}
+
+        self.assertEqual(
+            steps["builder"]["expected_outputs"],
+            ["implementation evidence from the selected owner"],
+        )
+
+    def test_classifier_keeps_trackpad_question_on_light_path(self) -> None:
+        message = "why does my trackpad scroll feel reversed?"
+        route_payload = public_chat_route_payload(message, source="discord")
+
+        classification = classify_agentic_playbook(message, route_payload=route_payload)
+
+        self.assertEqual(classification["decision"], "light_path")
+        self.assertEqual(classification["confidence"], "high")
+        self.assertIn("non_coding_troubleshooting", classification["anti_signals"])
+        self.assertNotIn("clarification", classification)
+
+    def test_classifier_uses_existing_clarification_for_boundary_code_tweak(self) -> None:
+        message = "can you check if this needs a small code tweak?"
+        route_payload = public_chat_route_payload(message, source="discord")
+
+        classification = classify_agentic_playbook(message, route_payload=route_payload)
+
+        self.assertEqual(classification["decision"], "clarify")
+        self.assertEqual(classification["confidence"], "low")
+        self.assertIn("route_action_clarify", classification["source_contracts"])
+        self.assertEqual(
+            classification["clarification"],
+            "Do you want a quick answer, or should I prepare the staged implementation workflow?",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_architecture_layout.py
+++ b/tests/test_architecture_layout.py
@@ -165,6 +165,7 @@ class ArchitectureLayoutTests(unittest.TestCase):
             "src/omh/isolation.py": "from .coding.isolation import *  # noqa: F401,F403",
             "src/omh/team_readiness.py": "from .coding.team_readiness import *  # noqa: F401,F403",
             "src/omh/work_reporting.py": "from .coding.work_reporting import *  # noqa: F401,F403",
+            "src/omh/agentic_playbook.py": "from .coding.agentic_playbook import *  # noqa: F401,F403",
             "src/omh/worktree_creator.py": "from .coding.worktree_creator import *  # noqa: F401,F403",
             "src/omh/installer.py": "from .install.installer import *  # noqa: F401,F403",
             "src/omh/manifest.py": "from .install.manifest import *  # noqa: F401,F403",

--- a/tests/test_plugin_capabilities.py
+++ b/tests/test_plugin_capabilities.py
@@ -23,6 +23,7 @@ from test_plugin_distribution import FakeHermesContext, load_installed_plugin
 
 LEGACY_ROLE_ALIASES = {
     "coding-handoff": "handoff-guide",
+    "implementation-owner": "builder",
     "planning-lead": "planner",
     "research-lead": "researcher",
     "review-gate": "reviewer",
@@ -68,12 +69,20 @@ class PluginCapabilitiesTests(unittest.TestCase):
             self.assertIn("img-summary", summary_cards["materials_and_visuals"]["representative_workflows"])
 
             inspected = json.loads(handler({"action": "inspect", "id": "handoff-guide"}))
+            builder = json.loads(handler({"action": "inspect", "id": "builder", "section": "agent_roles"}))
+            builder_alias = json.loads(handler({"action": "inspect", "id": "implementation-owner", "section": "agent_roles"}))
             inspected_by_alias_section = json.loads(handler({"action": "inspect", "id": "handoff-guide", "section": "roles"}))
             legacy_inspected = json.loads(handler({"action": "inspect", "id": "coding-handoff"}))
             self.assertEqual(inspected["section"], "agent_roles")
             self.assertEqual(inspected_by_alias_section["section"], "agent_roles")
             self.assertEqual(inspected_by_alias_section["resolved_id"], "handoff-guide")
             self.assertEqual(inspected["capability"]["runtime_claim"], "descriptor_not_runtime_agent")
+            self.assertEqual(builder["resolved_id"], "builder")
+            self.assertEqual(builder["capability"]["runtime_claim"], "descriptor_not_runtime_agent")
+            self.assertIn("selected executor/runtime", " ".join(builder["capability"]["owns"]))
+            self.assertIn("hidden runtime execution", builder["capability"]["does_not_own"])
+            self.assertIn("unobserved worker dispatch", builder["capability"]["does_not_own"])
+            self.assertEqual(builder_alias["resolved_id"], "builder")
             self.assertEqual(legacy_inspected["section"], "agent_roles")
             self.assertEqual(legacy_inspected["requested_id"], "coding-handoff")
             self.assertEqual(legacy_inspected["resolved_id"], "handoff-guide")

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -196,8 +196,11 @@ class RouterContentTests(unittest.TestCase):
         self.assertIn("roles are responsibility descriptors, not runtime agents", roles_doc.lower())
         for role in role_definitions():
             role_file = Path("roles") / f"{role.id}.md"
+            plugin_role_file = Path("src/plugin_bundle/omh/references") / f"role-{role.id}.md"
             text = role_file.read_text(encoding="utf-8")
             self.assertEqual(text, role_file_markdown(role))
+            if plugin_role_file.exists():
+                self.assertEqual(plugin_role_file.read_text(encoding="utf-8"), role_file_markdown(role))
             self.assertIn("responsibility descriptor, not a runtime agent", text)
             self.assertIn("OMH Role Context", text)
             self.assertIn("prepared guidance only", text)
@@ -1075,6 +1078,7 @@ class RouterContentTests(unittest.TestCase):
             Path("roles/operator.md"),
             Path("roles/memory-keeper.md"),
             Path("roles/handoff-guide.md"),
+            Path("roles/builder.md"),
             Path("roles/tracker.md"),
             Path("roles/reviewer.md"),
             Path("docs/RELEASE.md"),

--- a/tests/test_wrapper_contract.py
+++ b/tests/test_wrapper_contract.py
@@ -385,6 +385,71 @@ class WrapperContractTests(unittest.TestCase):
         self.assertIn("send_to_executor", actions)
         self.assertIn("send_to_codex", actions)
 
+    def test_delegate_mode_attaches_prepared_agentic_playbook_projection(self) -> None:
+        payload = build_chat_interaction_payload("risky refactor", mode="delegate", source="discord", executor_target="codex")
+
+        playbook = payload["agentic_playbook"]
+        response = payload["chat_response"]
+        response_playbook = response["state"]["agentic_playbook"]
+        delegation_playbook = payload["delegation"]["agentic_playbook"]
+
+        self.assertEqual(playbook["schema_version"], "agentic_playbook/v1")
+        self.assertEqual(playbook["status"], "prepared_not_observed")
+        self.assertEqual([step["id"] for step in playbook["steps"]], ["interviewer", "pre_build_reviewer", "builder", "post_build_reviewer"])
+        self.assertEqual(playbook["builder"]["owner"], "codex")
+        self.assertEqual(playbook["builder"]["owner_kind"], "selected_executor_runtime")
+        self.assertEqual(response_playbook["schema_version"], "agentic_playbook/v1")
+        self.assertEqual(delegation_playbook["schema_version"], "agentic_playbook/v1")
+        self.assertIn("Interviewer", response["body"])
+        self.assertIn("Builder", response["body"])
+        self.assertIn("prepared_not_observed", response["claim_boundary"])
+        self.assertNotIn("omh ", json.dumps(response).lower())
+
+    def test_plan_mode_attaches_playbook_without_executor_choice_overclaiming(self) -> None:
+        payload = build_chat_interaction_payload("risky refactor with tests", source="discord", mode="plan")
+
+        playbook = payload["agentic_playbook"]
+        response = payload["chat_response"]
+
+        self.assertEqual(playbook["classification"]["decision"], "attach_playbook")
+        self.assertEqual(playbook["builder"]["owner"], "executor_choice_required")
+        self.assertEqual(playbook["builder"]["owner_kind"], "selected_executor_runtime")
+        self.assertEqual(response["state"]["agentic_playbook"]["status"], "prepared_not_observed")
+        self.assertIn("staged workflow", response["body"])
+        self.assertIn("not execution", response["claim_boundary"])
+
+    def test_plan_mode_attaches_playbook_for_executor_neutral_owners(self) -> None:
+        for executor_target in ("claude-code", "hermes", "omx-runtime"):
+            with self.subTest(executor_target=executor_target):
+                payload = build_chat_interaction_payload(
+                    "risky refactor with tests",
+                    source="discord",
+                    mode="plan",
+                    executor_target=executor_target,
+                )
+
+                playbook = payload["agentic_playbook"]
+                coding_delegate = payload["plan"]["wrapper_contract"]["coding_delegate"]
+
+                self.assertTrue(coding_delegate["available"])
+                self.assertEqual(playbook["classification"]["decision"], "attach_playbook")
+                self.assertEqual(playbook["builder"]["owner"], executor_target)
+                self.assertEqual(playbook["builder"]["owner_kind"], "selected_executor_runtime")
+                self.assertEqual(payload["chat_response"]["state"]["agentic_playbook"]["status"], "prepared_not_observed")
+
+    def test_light_path_trackpad_question_does_not_attach_agentic_playbook(self) -> None:
+        payload = build_chat_interaction_payload("why does my trackpad scroll feel reversed?", source="discord")
+
+        self.assertNotIn("agentic_playbook", payload)
+        self.assertNotIn("agentic_playbook", payload["chat_response"]["state"])
+
+    def test_explicit_delegate_trackpad_question_does_not_attach_agentic_playbook(self) -> None:
+        payload = build_chat_interaction_payload("why does my trackpad scroll feel reversed?", mode="delegate", source="discord")
+
+        self.assertNotIn("agentic_playbook", payload)
+        self.assertNotIn("agentic_playbook", payload["delegation"])
+        self.assertNotIn("agentic_playbook", payload["chat_response"]["state"])
+
     def test_delegate_mode_defaults_to_executor_choice(self) -> None:
         payload = build_chat_interaction_payload("risky refactor", mode="delegate", source="discord")
 


### PR DESCRIPTION
## Feature Report

### What Changed

- Added a prepared Hermes-facing agentic playbook for implementation-shaped requests.
- The playbook presents `Interviewer -> Reviewer -> Builder -> Reviewer` through `chat_response/v1` while staying strictly `prepared_not_observed`.
- Added a Builder role surface across role catalog, root role docs, plugin roles, capability inspection, and plugin role references.

### Why This Exists

- OMH needed a human-readable default agentic workflow for coding-shaped requests without implying that Hermes, Codex, Claude Code, or runtime workers had actually started.
- The change makes the intended flow visible in chat while preserving the prepared-versus-observed boundary and executor neutrality.

### User / Operator Impact

- Operators now see the staged playbook directly in wrapper chat responses when a coding handoff or accepted coding plan is prepared.
- Simple questions, status/catalog questions, and non-coding troubleshooting stay on the light path.
- Plan-mode owners remain executor-neutral: `codex`, `claude-code`, `hermes`, and runtime profiles such as `omx-runtime` can all be represented as the Builder owner.

### How It Works

- `src/coding/agentic_playbook.py` classifies whether to attach the playbook using route/delegation contract evidence first, with message terms only as supporting signals.
- `src/coding/agentic_playbook_contract.py` builds the prepared-only JSON contract and injects the chat response projection.
- `src/coding/coding_delegation.py` and `src/wrapper/contract.py` attach the playbook to delegate, plan, clarify, and coding-owner wrapper surfaces only when the classifier allows it.
- Role/catalog/plugin surfaces expose `builder` as a responsibility descriptor, not a runtime agent.

### Files And Contracts Touched

- `agentic_playbook/v1`
- `chat_response/v1` state projection
- `coding_delegate` / selected executor metadata
- Role catalog and plugin role reference surfaces
- Wrapper contract tests and router content contract tests

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_agentic_playbook.py tests/test_wrapper_contract.py tests/test_router_content.py -v` (131 tests OK)
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` (1060 tests OK)
- [x] `uvx basedpyright src/coding/agentic_playbook.py src/coding/agentic_playbook_contract.py` (0 errors, 0 warnings)
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check` (49/49 tap skills checked, no stale/missing/extra)
- [x] `git diff --check`
- [x] Relevant dry-run or smoke command: runtime smoke confirmed delegate codex and plan choose/claude/hermes/omx-runtime attach, while trackpad and retained business prompts do not attach.
- [ ] `python3 -m omh.cli harness validate` - not run; this PR changes wrapper/playbook contracts, not harness registry behavior.
- [ ] `python3 -m omh.cli release checklist --json` - not run; this is not a release PR.
- [ ] `python3 -m omh.cli release hermes-smoke` - not run; prepared-only wrapper behavior was validated locally instead.
- [ ] `omh --help` - not run; no CLI help surface changed.
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; no live Hermes runtime dispatch is part of this prepared-only contract.

## Risk

- Main risk is classifier drift that attaches the playbook too broadly or too narrowly. Regression tests cover coding delegate, plan choose, executor-neutral plan owners, trackpad light path, explicit delegate non-coding light path, and retained workflow false positives.
- Another risk is overclaiming execution. The contract keeps `prepared_not_observed` status, explicit not-observed claims, and chat response claim boundaries.

## Compatibility / Rollout

- Additive wrapper metadata and chat response projection.
- No new dependencies.
- No executor dispatch, network calls, GitHub actions, Hermes core patches, or runtime state writes.

## Release / Claims

- [x] Release-channel impact considered (`local` contract change; no release packaging change).
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] Known manual Hermes checks are listed, including the live Hermes gap above.

## Follow-Up

- Watch future classifier additions to keep attachment grounded in route/delegation contracts rather than broad keyword routing.