### PR TITLE
Cover router subagent fallback guidance

### DIFF
--- a/skills/oh-my-hermes/SKILL.md
+++ b/skills/oh-my-hermes/SKILL.md
@@ -105,6 +105,17 @@ When a wrapper prepares coding work, check `executor_readiness/v1` for Codex, Cl
 
 Record only what is observed. A task card, route, plan, `coding_delegation.json`, or `prepared_coding_delegation` run envelope proves preparation, not execution. Executor-choice, prompt-only, and runtime handoffs do not create lifecycle runtime runs.
 
+## Hermes Compatibility Contract
+
+- Use Hermes-native tools, file operations, and subagent/delegation features when available.
+- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
+- Translate runtime-specific mechanisms to Hermes-native artifacts:
+  - goal tools -> `.omh/goals/` ledgers, goal status cards, or explicit checklists with named next actions,
+  - question renderers -> one concise question in the current Hermes interface,
+  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
+  - shell bridge commands -> optional bridge mode only.
+- Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
+
 ## Progressive Disclosure References
 
 Load these only when exact detail matters:

--- a/src/skills/render.py
+++ b/src/skills/render.py
@@ -592,6 +592,17 @@ When a wrapper prepares coding work, check `executor_readiness/v1` for Codex, Cl
 
 Record only what is observed. A task card, route, plan, `coding_delegation.json`, or `prepared_coding_delegation` run envelope proves preparation, not execution. Executor-choice, prompt-only, and runtime handoffs do not create lifecycle runtime runs.
 
+## Hermes Compatibility Contract
+
+- Use Hermes-native tools, file operations, and subagent/delegation features when available.
+- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
+- Translate runtime-specific mechanisms to Hermes-native artifacts:
+  - goal tools -> `.omh/goals/` ledgers, goal status cards, or explicit checklists with named next actions,
+  - question renderers -> one concise question in the current Hermes interface,
+  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
+  - shell bridge commands -> optional bridge mode only.
+- Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
+
 ## Progressive Disclosure References
 
 Load these only when exact detail matters:

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -411,6 +411,28 @@ class RouterContentTests(unittest.TestCase):
         for name in hidden:
             self.assertFalse((Path("skills") / name / "SKILL.md").exists(), f"{name} should stay routable only")
 
+    def test_all_tap_skills_include_subagent_fallback_contract(self) -> None:
+        required_fragments = (
+            "subagent/delegation features when available",
+            "native subagents -> Hermes delegation when available, otherwise sequential lanes",
+            "Record observed delegation results",
+            "not_observed",
+        )
+        templates = {template.name: template.content for template in builtin_skill_templates()}
+        rendered_files = {
+            path.parent.name: path.read_text(encoding="utf-8")
+            for path in Path("skills").glob("*/SKILL.md")
+        }
+
+        for source, contents in (("template", templates), ("tap", rendered_files)):
+            with self.subTest(source=source):
+                missing = {
+                    name: [fragment for fragment in required_fragments if fragment not in content]
+                    for name, content in sorted(contents.items())
+                }
+                missing = {name: fragments for name, fragments in missing.items() if fragments}
+                self.assertEqual(missing, {})
+
     def test_router_renders_representative_harness_registry(self) -> None:
         references = {
             str(Path(template.skill_name) / template.relative_path): template.content


### PR DESCRIPTION
## Feature Report

### What Changed

- Added the Hermes compatibility/subagent fallback contract to the top-level `oh-my-hermes` router skill.
- Added an all-skill regression test that checks both generated templates and repo tap `SKILL.md` files for subagent fallback, observed delegation, and `not_observed` boundary language.

### Why This Exists

- The installed workflow skills already told Hermes how to translate native subagents into Hermes delegation or sequential lanes, but the top-level router skill did not carry the same explicit contract.
- That gap meant a user asking whether all skills support subagent-related behavior could not be answered with a true catalog-wide test.

### User / Operator Impact

- Operators can now rely on every installed skill surface, including `oh-my-hermes`, to preserve the same rule: use Hermes-native subagent/delegation features when available, otherwise fall back to sequential lanes.
- The generated skill pack no longer implies that subagent support is uneven across the top-level router and workflow skills.

### How It Works

- `src/skills/render.py` now renders a `Hermes Compatibility Contract` section in the router skill.
- `skills/oh-my-hermes/SKILL.md` is refreshed from that contract.
- `tests/test_router_content.py` checks all installable skill templates and the checked-in tap files for the required contract fragments.

### Files And Contracts Touched

- `src/skills/render.py`: router skill rendering contract.
- `skills/oh-my-hermes/SKILL.md`: generated tap skill output.
- `tests/test_router_content.py`: all-skill subagent fallback regression coverage.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_router_content.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [ ] `python3 -m omh.cli harness validate`
- [ ] `python3 -m omh.cli release checklist --json`
- [ ] `python3 -m omh.cli release hermes-smoke`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable; no learning contract changed.
- [ ] Relevant dry-run or smoke command: `uv run python -m omh.cli docs workflows --check` covered generated docs/tap consistency.
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; this is generated skill text plus deterministic unittest coverage, not a live Hermes runtime change.

## Risk

- Narrow. The change adds guidance text and a regression test; it does not change routing decisions, runtime execution, or wrapper artifact schemas.
- Main risk is wording drift in generated skill content, now covered by the all-skill check.

## Compatibility / Rollout

- Compatible with current tap and setup installs.
- Existing Hermes runtimes that do not expose subagents continue to use the explicit sequential-lane fallback.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`): local/tap skill text only.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap.

## Follow-Up

- None required for this scope.