### PR TITLE
Retry Pages deploy once after transient service failures

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -57,8 +57,13 @@ jobs:
       id-token: write
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      url: ${{ steps.deployment.outputs.page_url || steps.deployment_retry.outputs.page_url }}
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
+        uses: actions/deploy-pages@v5
+        continue-on-error: true
+      - name: Retry deploy after transient Pages failure
+        if: steps.deployment.outcome == 'failure'
+        id: deployment_retry
         uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Feature Report

### What Changed

- The `deploy` job in `.github/workflows/pages.yml` now retries `actions/deploy-pages@v5` once when the first attempt fails, and resolves the environment URL from whichever attempt produced it.

### Why This Exists

- The Pages run on the #534 merge failed with `Deployment failed, try again later` even though the uploaded artifact was byte-identical to the previous successful run (7,799,475 vs 7,799,473 bytes). A manual rerun (attempt 2) succeeded with zero changes, confirming a transient GitHub Pages service failure. This retry removes the need for a human to notice and rerun those.

### User / Operator Impact

- Service-side Pages flakes self-heal; genuine misconfigurations still fail the run after two attempts.

### How It Works

- First deploy step gets `continue-on-error: true`; a second `deploy-pages` step runs only `if: steps.deployment.outcome == 'failure'`. Environment URL uses `steps.deployment.outputs.page_url || steps.deployment_retry.outputs.page_url`.

### Files And Contracts Touched

- `.github/workflows/pages.yml` only. No package or site content changes.

## Validation

- [x] YAML parse check (`yaml.safe_load`)
- [x] Failed run 28691373398 rerun succeeded (attempt 2), confirming the transient failure mode this targets
- [x] The Pages workflow triggers on `pages.yml` changes, so merging this PR exercises the modified deploy job end-to-end
- [ ] Retry branch itself: only executes on the next transient Pages failure (cannot be forced)

## Risk

- Worst case: a persistent Pages outage costs one extra deploy attempt before failing.

## Compatibility / Rollout

- No site content or build changes; merge triggers a fresh deploy that verifies the workflow.

## Release / Claims

- [x] Release-channel impact considered — CI-only change, no package release impact
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Known manual Hermes checks are listed — not applicable to a CI workflow change

## Follow-Up

- None.
