### PR TITLE
Add OMH site favicon

### DIFF
--- a/site/docs/executor-handoff/index.html
+++ b/site/docs/executor-handoff/index.html
@@ -5,6 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>OMH Executor-Ready Handoff</title>
     <meta name="description" content="OMH executor-ready handoff docs for Codex, Claude Code, oh-my runtimes, Hermes coding skills, and executor-neutral implementation plans.">
+    <link rel="icon" href="../../favicon.svg" type="image/svg+xml">
+    <meta name="theme-color" content="#155fff">
     <link rel="stylesheet" href="../../styles.css">
   </head>
   <body class="docs-page feature-page">

--- a/site/docs/hermes-agent-architecture/index.html
+++ b/site/docs/hermes-agent-architecture/index.html
@@ -8,6 +8,8 @@
       name="description"
       content="A bilingual visual guide to how Hermes Agent is structured: surfaces, prompt assembly, agent loop, memory, skills, tools, cron, gateway, and evidence boundaries."
     >
+    <link rel="icon" href="../../favicon.svg" type="image/svg+xml">
+    <meta name="theme-color" content="#155fff">
     <link rel="stylesheet" href="../../styles.css">
   </head>
   <body class="docs-page architecture-post-page">

--- a/site/docs/image-gen/index.html
+++ b/site/docs/image-gen/index.html
@@ -8,6 +8,8 @@
       name="description"
       content="OMH Image gen docs for img-summary prompt cards, source-specific card formats, poster archetypes, connected image tools, and observed-only image evidence."
     >
+    <link rel="icon" href="../../favicon.svg" type="image/svg+xml">
+    <meta name="theme-color" content="#155fff">
     <link rel="stylesheet" href="../../styles.css">
   </head>
   <body class="docs-page feature-page">

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -8,6 +8,8 @@
       name="description"
       content="OMH documentation for installing once, keeping Hermes chat-first, and using workflow contracts without breaking existing setups."
     >
+    <link rel="icon" href="../favicon.svg" type="image/svg+xml">
+    <meta name="theme-color" content="#155fff">
     <link rel="stylesheet" href="../styles.css">
   </head>
   <body class="docs-page">

--- a/site/docs/intent-to-plan/index.html
+++ b/site/docs/intent-to-plan/index.html
@@ -5,6 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>OMH Intent to Plan</title>
     <meta name="description" content="OMH intent-to-plan docs for deep-interview, ralplan, ultragoal, and loop workflows.">
+    <link rel="icon" href="../../favicon.svg" type="image/svg+xml">
+    <meta name="theme-color" content="#155fff">
     <link rel="stylesheet" href="../../styles.css">
   </head>
   <body class="docs-page feature-page">

--- a/site/docs/loop/index.html
+++ b/site/docs/loop/index.html
@@ -8,6 +8,8 @@
       name="description"
       content="Loop Engineering docs for OMH: loopability-gated goal cycles for Hermes Agent with interview, research, plan, runtime tick queue, handoff, feedback, and evidence boundaries."
     >
+    <link rel="icon" href="../../favicon.svg" type="image/svg+xml">
+    <meta name="theme-color" content="#155fff">
     <link rel="stylesheet" href="../../styles.css">
   </head>
   <body class="docs-page feature-page">

--- a/site/docs/product-ops/index.html
+++ b/site/docs/product-ops/index.html
@@ -5,6 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>OMH Company and Product Ops</title>
     <meta name="description" content="OMH company and product operations docs for feedback triage, research briefs, meeting briefs, strategy briefs, and material packages.">
+    <link rel="icon" href="../../favicon.svg" type="image/svg+xml">
+    <meta name="theme-color" content="#155fff">
     <link rel="stylesheet" href="../../styles.css">
   </head>
   <body class="docs-page feature-page">

--- a/site/favicon.svg
+++ b/site/favicon.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="OMH favicon">
+  <defs>
+    <linearGradient id="bg" x1="10" x2="56" y1="8" y2="58" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0b122e"/>
+      <stop offset=".55" stop-color="#155fff"/>
+      <stop offset="1" stop-color="#19d2bd"/>
+    </linearGradient>
+    <linearGradient id="wing" x1="13" x2="53" y1="18" y2="44" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#ffffff"/>
+      <stop offset=".45" stop-color="#dce9ff"/>
+      <stop offset="1" stop-color="#80f1e0"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="150%">
+      <feDropShadow dx="0" dy="4" stdDeviation="4" flood-color="#071036" flood-opacity=".28"/>
+    </filter>
+  </defs>
+  <rect width="64" height="64" rx="17" fill="url(#bg)"/>
+  <path d="M15 23c5-7 13-11 23-10-2 4-6 7-11 9 6-1 12-1 18 1-5 5-12 8-21 8h-7c-2 0-3-2-2-4l0-4Z" fill="url(#wing)" opacity=".95"/>
+  <path d="M49 23c-4-6-10-9-18-9 2 4 6 7 11 9-4 0-8 1-12 3 5 4 11 6 18 5 3 0 4-4 1-8Z" fill="#f6fbff" opacity=".82"/>
+  <g filter="url(#shadow)">
+    <path d="M20 34c0-9 6-16 13-16s13 7 13 16v4c0 7-5 12-13 12s-13-5-13-12v-4Z" fill="#f8fbff"/>
+    <path d="M24 31c1-7 5-11 9-11s8 4 9 11c-4-3-7-4-9-4s-5 1-9 4Z" fill="#07123f"/>
+    <path d="M23 36c2 5 5 7 10 7s8-2 10-7v4c0 6-4 10-10 10s-10-4-10-10v-4Z" fill="#dce9ff"/>
+    <circle cx="28" cy="35" r="2" fill="#07123f"/>
+    <circle cx="38" cy="35" r="2" fill="#07123f"/>
+    <path d="M30 41c2 1 4 1 6 0" fill="none" stroke="#0c205e" stroke-width="2" stroke-linecap="round"/>
+  </g>
+  <path d="M20 25c4-10 22-10 26 0-4-3-8-4-13-4s-9 1-13 4Z" fill="#0b122e"/>
+  <path d="M33 9l3 8h-6l3-8Z" fill="#f2b84b"/>
+  <path d="M16 49l5 5M48 49l-5 5" stroke="#9ff5e7" stroke-width="3" stroke-linecap="round"/>
+</svg>

--- a/site/index.html
+++ b/site/index.html
@@ -8,6 +8,8 @@
       name="description"
       content="OMH keeps Hermes chat-first while turning natural requests into safe next steps, local contracts, and evidence-aware executor handoffs."
     >
+    <link rel="icon" href="favicon.svg" type="image/svg+xml">
+    <meta name="theme-color" content="#155fff">
     <link rel="stylesheet" href="styles.css">
   </head>
   <body class="home-page">


### PR DESCRIPTION
## Summary

Adds a lightweight OMH favicon for the static site and wires it into every public HTML entry point.

## Why

The site did not have a favicon, so browser tabs and saved links had no recognizable OMH identity. This adds a compact Hermes-inspired mark: a small face, wings, OMH blue/cyan gradient, and a gold messenger accent.

## What changed

- Added `site/favicon.svg` as the shared favicon asset.
- Linked the favicon from the home page, docs index, and all feature docs pages.
- Added a matching `theme-color` meta value for browser chrome surfaces.

## Verification

Observed locally:

- `python3` parsed `site/favicon.svg` as valid XML/SVG.
- A local coverage check confirmed all 8 static site HTML pages include `rel="icon"`.
- `qlmanage -t -s 512 -o /tmp/omh-favicon-preview site/favicon.svg` rendered a preview PNG successfully.
- `uv run python -m omh.cli docs workflows --check` passed with 54/54 tap skills checked.
- `git diff --cached --check` passed.

## Notes

The favicon is SVG-only for now to keep the change small and crisp across sizes. Browser favicon caches may need a hard refresh after deploy.