### PR TITLE
Centralize browser QA routing cues

### DIFF
--- a/src/plugin_bundle/omh/awareness.py
+++ b/src/plugin_bundle/omh/awareness.py
@@ -61,18 +61,6 @@ _OMH_DIAGNOSTIC_EVALUATION_CUES = (
     "플랜으로 잡",
     "반복해서 강화",
 )
-_BROWSER_VISUAL_QA_HINT_PHRASES = (
-    "browser qa",
-    "browser interaction qa",
-    "click path",
-    "click-path audit",
-    "dead link check",
-    "console error check",
-    "network failure check",
-    "keyboard navigation check",
-    "screenshot qa",
-    "visual qa",
-)
 _RELEASE_CLAIM_REVIEW_HINT_PHRASES = (
     "claim",
     "claims",
@@ -83,24 +71,51 @@ _RELEASE_CLAIM_REVIEW_HINT_PHRASES = (
     "claim이",
     "주장",
 )
-_CUSTOMER_SYMPTOM_REPORT_HINT_PHRASES = (
-    "customers say",
-    "customers report",
-    "customer says",
-    "customer reports",
-    "customer feedback says",
-    "customer feedback reports",
-    "users say",
-    "users report",
-    "user says",
-    "user reports",
-    "고객이 말",
-    "고객이 제보",
-    "고객 제보",
-    "사용자가 말",
-    "사용자가 제보",
-    "사용자 제보",
-)
+
+try:
+    from ...routing.visual_qa_cues import (
+        BROWSER_VISUAL_QA_PHRASES as _BROWSER_VISUAL_QA_HINT_PHRASES,
+        CUSTOMER_SYMPTOM_REPORT_PHRASES as _CUSTOMER_SYMPTOM_REPORT_HINT_PHRASES,
+        contains_cue_phrase as _contains_route_cue_phrase,
+    )
+except ImportError:  # pragma: no cover - exercised by standalone plugin hosts.
+    _BROWSER_VISUAL_QA_HINT_PHRASES = (
+        "browser qa",
+        "browser interaction qa",
+        "click path",
+        "click-path audit",
+        "dead link check",
+        "console error check",
+        "network failure check",
+        "keyboard navigation check",
+        "screenshot qa",
+        "visual qa",
+    )
+    _CUSTOMER_SYMPTOM_REPORT_HINT_PHRASES = (
+        "customers say",
+        "customers report",
+        "customer says",
+        "customer reports",
+        "customer feedback says",
+        "customer feedback reports",
+        "users say",
+        "users report",
+        "user says",
+        "user reports",
+        "고객이 말",
+        "고객이 제보",
+        "고객 제보",
+        "사용자가 말",
+        "사용자가 제보",
+        "사용자 제보",
+    )
+
+    def _contains_route_cue_phrase(message: str, phrases: tuple[str, ...]) -> bool:
+        compact = "".join(character for character in message if character.isalnum())
+        return any(
+            phrase in message or "".join(character for character in phrase if character.isalnum()) in compact
+            for phrase in phrases
+        )
 
 try:  # Keep installed plugin bundles usable even when the full package is absent.
     from ...routing.intent import META_OR_FEEDBACK_INTENTS, classify_omh_quality_intent, classify_workflow_intent
@@ -1257,20 +1272,11 @@ _ROUTE_HINT_RULES = (
         "reason": "The user is asking for rendered visual QA, browser interaction QA, screenshots, pixel diff, viewport checks, CJK/text clipping, or broken-layout verification.",
         "fallback_action": "request_fresh_render_capture_after_last_edit",
         "phrases": (
-            "visual qa",
             "visual-qa",
-            "browser qa",
-            "browser interaction qa",
-            "screenshot qa",
+            *_BROWSER_VISUAL_QA_HINT_PHRASES,
             "pixel diff",
             "visual diff",
             "render qa",
-            "click path",
-            "click-path audit",
-            "dead link check",
-            "console error check",
-            "network failure check",
-            "keyboard navigation check",
             "viewport check",
             "text clipping",
             "cjk layout",
@@ -2465,20 +2471,9 @@ _ROUTE_HINT_RULES = (
             "bug report",
             "issue triage",
             "user feedback",
-            "customers say",
-            "customers report",
-            "customer says",
-            "customer reports",
-            "customer feedback says",
-            "customer feedback reports",
-            "users say",
-            "users report",
-            "user says",
-            "user reports",
+            *_CUSTOMER_SYMPTOM_REPORT_HINT_PHRASES,
             "결제 실패",
             "고객 피드백",
-            "고객 제보",
-            "사용자 제보",
             "버그",
             "이슈",
             "피드백",
@@ -3841,17 +3836,17 @@ def _rule_suppressed_by_context(rule: dict[str, object], text: str) -> bool:
 
 
 def _browser_visual_qa_hint_suppresses_release_gate(text: str) -> bool:
-    has_browser_visual_qa = any(phrase in text for phrase in _BROWSER_VISUAL_QA_HINT_PHRASES)
+    has_browser_visual_qa = _contains_route_cue_phrase(text, _BROWSER_VISUAL_QA_HINT_PHRASES)
     if not has_browser_visual_qa:
         return False
     return not any(phrase in text for phrase in _RELEASE_CLAIM_REVIEW_HINT_PHRASES)
 
 
 def _customer_symptom_report_hint_suppresses_visual_qa(text: str) -> bool:
-    has_browser_visual_qa = any(phrase in text for phrase in _BROWSER_VISUAL_QA_HINT_PHRASES)
+    has_browser_visual_qa = _contains_route_cue_phrase(text, _BROWSER_VISUAL_QA_HINT_PHRASES)
     if not has_browser_visual_qa:
         return False
-    return any(phrase in text for phrase in _CUSTOMER_SYMPTOM_REPORT_HINT_PHRASES)
+    return _contains_route_cue_phrase(text, _CUSTOMER_SYMPTOM_REPORT_HINT_PHRASES)
 
 
 def _unique_strings(values: object) -> list[str]:

--- a/src/routing/catalog_questions.py
+++ b/src/routing/catalog_questions.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from functools import lru_cache
 import unicodedata
 
+from .visual_qa_cues import BROWSER_VISUAL_QA_PHRASES
 
 _EXPLICIT_CATALOG_PHRASES = (
     "what commands are available",
@@ -496,18 +497,7 @@ _FILE_OR_TEXT_MARKERS = (
     "찾아",
     "검색",
 )
-_VISUAL_QA_PATH_REQUEST_MARKERS = (
-    "browser qa",
-    "browser interaction qa",
-    "click path",
-    "click-path audit",
-    "dead link check",
-    "console error check",
-    "network failure check",
-    "keyboard navigation check",
-    "screenshot qa",
-    "visual qa",
-)
+_VISUAL_QA_PATH_REQUEST_MARKERS = BROWSER_VISUAL_QA_PHRASES
 _REPO_LOOKUP_CONTEXT_MARKERS = (
     "repo",
     "repository",

--- a/src/routing/chat.py
+++ b/src/routing/chat.py
@@ -32,6 +32,12 @@ from .policy import (
 from .recommend import recommendation_for_definition, recommend_skills
 from .route_plan import build_workflow_route_plan, compact_workflow_route_plan
 from .task_cards import classify_task, task_card_recommendation
+from .visual_qa_cues import (
+    BROWSER_VISUAL_QA_COMMAND_PHRASES,
+    BROWSER_VISUAL_QA_PHRASES,
+    CUSTOMER_SYMPTOM_REPORT_PHRASES,
+    contains_cue_phrase,
+)
 from ..learning_candidate import build_learning_candidate_card
 from ..surfaces.evidence_copy import not_evidence_action_suffix, not_evidence_reply_suffix
 from ..skills.catalog import SkillDefinition, primary_harness_for_skill, routable_definitions
@@ -153,16 +159,7 @@ _FEEDBACK_TRIAGE_FAST_PATH_BLOCKERS = (
     "reproduction",
     "plan",
     "pr",
-    "browser qa",
-    "browser interaction qa",
-    "click path",
-    "click-path audit",
-    "dead link check",
-    "console error check",
-    "network failure check",
-    "keyboard navigation check",
-    "screenshot qa",
-    "visual qa",
+    *BROWSER_VISUAL_QA_PHRASES,
     "코덱스",
     "클로드 코드",
     "핸드오프",
@@ -176,36 +173,8 @@ _FEEDBACK_TRIAGE_FAST_PATH_BLOCKERS = (
     "계획",
     "pr",
 )
-_BROWSER_VISUAL_QA_FAST_PATH_TERMS = (
-    "browser qa",
-    "browser interaction qa",
-    "click path audit",
-    "click-path audit",
-    "dead link check",
-    "console error check",
-    "network failure check",
-    "keyboard navigation check",
-    "screenshot qa",
-    "visual qa",
-)
-_CUSTOMER_SYMPTOM_REPORT_FAST_PATH_TERMS = (
-    "customers say",
-    "customers report",
-    "customer says",
-    "customer reports",
-    "customer feedback says",
-    "customer feedback reports",
-    "users say",
-    "users report",
-    "user says",
-    "user reports",
-    "고객이 말",
-    "고객이 제보",
-    "고객 제보",
-    "사용자가 말",
-    "사용자가 제보",
-    "사용자 제보",
-)
+_BROWSER_VISUAL_QA_FAST_PATH_TERMS = BROWSER_VISUAL_QA_COMMAND_PHRASES
+_CUSTOMER_SYMPTOM_REPORT_FAST_PATH_TERMS = CUSTOMER_SYMPTOM_REPORT_PHRASES
 _FEEDBACK_TRIAGE_FAST_PATH_TERMS = (
     "payment failure",
     "payment failures",
@@ -3008,15 +2977,11 @@ def _feedback_triage_fast_path_signal(text: str) -> bool:
 
 
 def _browser_visual_qa_fast_path_signal(message: str) -> bool:
-    text = _fast_path_text(message)
-    compact = _fast_path_compact(text)
-    return any(term in text or _fast_path_compact(term) in compact for term in _BROWSER_VISUAL_QA_FAST_PATH_TERMS)
+    return contains_cue_phrase(message, _BROWSER_VISUAL_QA_FAST_PATH_TERMS)
 
 
 def _customer_symptom_report_fast_path_signal(message: str) -> bool:
-    text = _fast_path_text(message)
-    compact = _fast_path_compact(text)
-    return any(term in text or _fast_path_compact(term) in compact for term in _CUSTOMER_SYMPTOM_REPORT_FAST_PATH_TERMS)
+    return contains_cue_phrase(message, _CUSTOMER_SYMPTOM_REPORT_FAST_PATH_TERMS)
 
 
 def _product_shaping_fast_path_decision(

--- a/src/routing/policy.py
+++ b/src/routing/policy.py
@@ -6,6 +6,7 @@ from functools import lru_cache
 from .intent import classify_omh_quality_intent
 from .localization import normalized_phrase, routing_tokens
 from .missed_route import has_normalized_missed_omh_workflow_context
+from .visual_qa_cues import BROWSER_VISUAL_QA_PHRASES, CUSTOMER_SYMPTOM_REPORT_PHRASES
 
 
 ROUTE_ACTIONS = ("dispatch", "clarify", "fallback")
@@ -1038,36 +1039,6 @@ _FEEDBACK_TRIAGE_PHRASES = (
     "체크아웃이 깨",
     "체크아웃 실패",
     "로그인 후 크래시",
-)
-_BROWSER_VISUAL_QA_PHRASES = (
-    "browser qa",
-    "browser interaction qa",
-    "click path",
-    "click-path audit",
-    "dead link check",
-    "console error check",
-    "network failure check",
-    "keyboard navigation check",
-    "screenshot qa",
-    "visual qa",
-)
-_CUSTOMER_SYMPTOM_REPORT_PHRASES = (
-    "customers say",
-    "customers report",
-    "customer says",
-    "customer reports",
-    "customer feedback says",
-    "customer feedback reports",
-    "users say",
-    "users report",
-    "user says",
-    "user reports",
-    "고객이 말",
-    "고객이 제보",
-    "고객 제보",
-    "사용자가 말",
-    "사용자가 제보",
-    "사용자 제보",
 )
 _FEEDBACK_TRIAGE_SOURCE_TOKENS = _normalized_token_set(
     {
@@ -3695,9 +3666,9 @@ def _feedback_before_coding_guard_applies(
     *,
     direct_coding_task_applies: bool | None = None,
 ) -> bool:
-    if _contains_phrase(normalized_query, _BROWSER_VISUAL_QA_PHRASES) and not _contains_phrase(
+    if _contains_phrase(normalized_query, BROWSER_VISUAL_QA_PHRASES) and not _contains_phrase(
         normalized_query,
-        _CUSTOMER_SYMPTOM_REPORT_PHRASES,
+        CUSTOMER_SYMPTOM_REPORT_PHRASES,
     ):
         return False
     if _gateway_intent_guard_applies(normalized_query, query_tokens):

--- a/src/routing/visual_qa_cues.py
+++ b/src/routing/visual_qa_cues.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from functools import lru_cache
+import unicodedata
+
+
+BROWSER_VISUAL_QA_PHRASES = (
+    "browser qa",
+    "browser interaction qa",
+    "click path",
+    "click-path audit",
+    "dead link check",
+    "console error check",
+    "network failure check",
+    "keyboard navigation check",
+    "screenshot qa",
+    "visual qa",
+)
+BROWSER_VISUAL_QA_COMMAND_PHRASES = (
+    "browser qa",
+    "browser interaction qa",
+    "click path audit",
+    "click-path audit",
+    "dead link check",
+    "console error check",
+    "network failure check",
+    "keyboard navigation check",
+    "screenshot qa",
+    "visual qa",
+)
+CUSTOMER_SYMPTOM_REPORT_PHRASES = (
+    "customers say",
+    "customers report",
+    "customer says",
+    "customer reports",
+    "customer feedback says",
+    "customer feedback reports",
+    "users say",
+    "users report",
+    "user says",
+    "user reports",
+    "고객이 말",
+    "고객이 제보",
+    "고객 제보",
+    "사용자가 말",
+    "사용자가 제보",
+    "사용자 제보",
+)
+
+
+def contains_cue_phrase(message: str, phrases: tuple[str, ...]) -> bool:
+    text = _cue_text(message)
+    compact = _compact_cue_text(text)
+    return any(phrase in text or _compact_cue_text(phrase) in compact for phrase in phrases)
+
+
+@lru_cache(maxsize=4096)
+def _cue_text(message: str) -> str:
+    lowered = message.strip().lower()
+    folded = "".join(
+        character for character in unicodedata.normalize("NFKD", lowered) if not unicodedata.combining(character)
+    )
+    return folded
+
+
+@lru_cache(maxsize=4096)
+def _compact_cue_text(text: str) -> str:
+    return "".join(character for character in text if character.isalnum())

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -12,6 +12,7 @@ load_local_package()
 from omh.routing import recommend as recommend_module
 from omh.routing import chat as chat_module
 from omh.routing.action_copy import next_action_label
+from omh.routing.visual_qa_cues import BROWSER_VISUAL_QA_PHRASES, CUSTOMER_SYMPTOM_REPORT_PHRASES
 from omh.capabilities.orchestration import orchestration_patterns
 from omh.wrapper.contract import VISIBLE_ACTIONS
 from omh.roles import role_definitions, role_file_markdown, roles_reference_markdown
@@ -25,7 +26,7 @@ from omh.skill_pack import (
     skill_exposure_payload,
 )
 from omh.playbooks import inspect_playbook, list_playbooks
-from omh.plugin_bundle.omh.awareness import ROUTER_KEYWORD_SKILLS, router_keyword_summary
+from omh.plugin_bundle.omh.awareness import ROUTER_KEYWORD_SKILLS, _ROUTE_HINT_RULES, router_keyword_summary
 from omh.quality.grounded_score import GROUNDED_SCENARIOS
 from omh.runtime.records import validate_harness_quality
 from omh.skills.catalog import (
@@ -802,6 +803,7 @@ class RouterContentTests(unittest.TestCase):
         self.assertIn("dual_oracle_visual_review/v1 when observed", definitions["visual-qa"].expected_outputs)
         self.assertIn("browser qa", definitions["visual-qa"].triggers)
         self.assertIn("click path", definitions["visual-qa"].triggers)
+        self.assertTrue(set(BROWSER_VISUAL_QA_PHRASES).issubset(set(definitions["visual-qa"].triggers)))
         self.assertIn("fresh rendered evidence", " ".join(definitions["visual-qa"].safety_rules))
         self.assertIn("sample only one good page", " ".join(definitions["visual-qa"].safety_rules))
         self.assertIn("settled frames", " ".join(definitions["visual-qa"].safety_rules))
@@ -856,6 +858,10 @@ class RouterContentTests(unittest.TestCase):
         self.assertIn("dual_oracle_visual_review/v1", templates["visual-qa"].content)
         self.assertIn("fresh rendered evidence", templates["visual-qa"].content)
         self.assertIn("Preferred harness for this skill: `visual-qa`", templates["visual-qa"].content)
+
+        route_rules = {str(rule["id"]): rule for rule in _ROUTE_HINT_RULES}
+        self.assertTrue(set(BROWSER_VISUAL_QA_PHRASES).issubset(set(route_rules["visual_qa_gate"]["phrases"])))
+        self.assertTrue(set(CUSTOMER_SYMPTOM_REPORT_PHRASES).issubset(set(route_rules["customer_signal"]["phrases"])))
 
     def test_ecc_inspired_operator_skill_contracts_stay_in_sync(self) -> None:
         definitions = {definition.name: definition for definition in builtin_definitions()}


### PR DESCRIPTION
## Feature Report

### What Changed

- Added a shared `routing.visual_qa_cues` module for browser visual-QA phrases, explicit browser-QA command phrases, and customer symptom report phrases.
- Reused that shared cue pack from chat routing, routing policy guards, file/text lookup blockers, and plugin awareness hints.
- Added content tests that ensure visual-qa catalog triggers and awareness route-hint rules include the shared cue sets.

### Why This Exists

- The browser QA work added the same phrase lists across several routing surfaces. That made future vocabulary changes fragile: a new click-path or customer-report phrase could be updated in one place while drifting in another.
- The previous PR review already found two real precedence bugs from that duplication, so this follow-up removes the duplication before the browser QA surface grows again.

### User / Operator Impact

- Operators keep the same behavior: explicit browser QA and click-path audit requests still route to `visual-qa`; customer symptom reports that mention click paths or console errors still route to `feedback-triage`.
- Future browser-QA vocabulary additions now have a single source of truth for normal OMH runtime routing, reducing the chance of AI-ish routing drift or broken workflow selection.

### How It Works

- `src/routing/visual_qa_cues.py` owns `BROWSER_VISUAL_QA_PHRASES`, `BROWSER_VISUAL_QA_COMMAND_PHRASES`, `CUSTOMER_SYMPTOM_REPORT_PHRASES`, and `contains_cue_phrase()`.
- `src/routing/chat.py`, `src/routing/policy.py`, and `src/routing/catalog_questions.py` import the shared cue pack instead of maintaining local copies.
- `src/plugin_bundle/omh/awareness.py` imports the shared cue pack when the full OMH package is available and keeps a standalone fallback for plugin-host compatibility.

### Files And Contracts Touched

- `src/routing/visual_qa_cues.py`: new shared cue module.
- `src/routing/chat.py`: visual-QA precedence and feedback fast-path blockers now use shared cues.
- `src/routing/policy.py`: feedback-before-coding guard uses shared browser/customer cues.
- `src/routing/catalog_questions.py`: file/text lookup exclusion uses shared browser-QA cues.
- `src/plugin_bundle/omh/awareness.py`: route-hint rules and suppressors reuse shared cues with fallback.
- `tests/test_router_content.py`: locks shared cue projection into catalog triggers and awareness hint rules.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_chat_router.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_catalog_questions.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_router_content.py -v`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `PYTHONPATH=tests uv run python -m compileall -q src tests`
- [x] `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check`
- [x] `PYTHONPATH=tests uv run python -m omh.cli harness validate`
- [x] `PYTHONPATH=tests uv run python -m omh.cli release checklist --json`
- [x] `PYTHONPATH=tests uv run python -m omh.cli release hermes-smoke`
- [x] `PYTHONPATH=tests uv run python -m omh.cli --help`
- [x] `git diff --check`
- [ ] Manual Hermes/TUI check: not run; this is deterministic local routing metadata only and does not mutate a Hermes profile.

## Risk

- Low. This is a cue-pack refactor with regression coverage for the browser-QA / feedback-triage / release-review boundaries.
- The plugin awareness file keeps its fallback constants so standalone plugin hosts are not forced to import the full routing package.

## Compatibility / Rollout

- No schema or CLI contract changes.
- No generated workflow docs changed; `docs workflows --check` confirms catalog docs are still in sync.

## Release / Claims

- [x] Release-channel impact considered: no channel-specific behavior change.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] Known manual Hermes checks are listed: live Hermes smoke was not run for this metadata-only refactor.

## Follow-Up

- Keep future browser QA and customer-report vocabulary additions in `src/routing/visual_qa_cues.py` first, then project into generated/static surfaces as needed.
