### PR TITLE
Harden Pages deploy retries

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -17,7 +17,7 @@ permissions:
 
 concurrency:
   group: "pages"
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -57,13 +57,24 @@ jobs:
       id-token: write
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url || steps.deployment_retry.outputs.page_url }}
+      url: ${{ steps.deployment.outputs.page_url || steps.deployment_retry.outputs.page_url || steps.deployment_final_retry.outputs.page_url }}
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v5
         continue-on-error: true
+      - name: Wait before Pages deploy retry
+        if: steps.deployment.outcome == 'failure'
+        run: sleep 60
       - name: Retry deploy after transient Pages failure
         if: steps.deployment.outcome == 'failure'
         id: deployment_retry
+        uses: actions/deploy-pages@v5
+        continue-on-error: true
+      - name: Wait before final Pages deploy retry
+        if: steps.deployment.outcome == 'failure' && steps.deployment_retry.outcome == 'failure'
+        run: sleep 120
+      - name: Final retry deploy after transient Pages failure
+        if: steps.deployment.outcome == 'failure' && steps.deployment_retry.outcome == 'failure'
+        id: deployment_final_retry
         uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Feature Report

### What Changed

- Hardened the GitHub Pages workflow against transient deploy backend failures.
- Pages workflow now cancels stale in-progress Pages runs when a newer `main` push arrives.
- Deploy now waits before retrying: first retry after 60 seconds, final retry after another 120 seconds.

### Why This Exists

- Pages run `28706493518` failed after PR #552 even though the build job succeeded, docs checked, harness validation passed, static site preparation succeeded, and the Pages artifact uploaded.
- The failure was isolated to `actions/deploy-pages@v5`, which returned `Deployment failed, try again later.`
- The existing workflow retried immediately, so it hit the same transient Pages backend state again.

### User / Operator Impact

- Pages deploy failures from temporary GitHub Pages backend instability should be less noisy.
- Rapid successive main merges will focus on deploying the latest main state instead of spending deploy attempts on stale intermediate commits.
- The site remains available; the latest observed site response returned HTTP 200 at `https://rlaope.github.io/oh-my-hermes/`.

### How It Works

- `concurrency.cancel-in-progress` is now `true` for the Pages workflow group.
- The first `deploy-pages` step remains soft-failing so the workflow can back off.
- A second deploy attempt runs after 60 seconds if the first attempt fails.
- A final deploy attempt runs after another 120 seconds if both earlier attempts fail.
- The environment URL now resolves from whichever deploy attempt produces `page_url`.

### Files And Contracts Touched

- `.github/workflows/pages.yml`

## Validation

- [ ] `python3 -m unittest discover -s tests`
- [ ] `python3 -m compileall src`
- [ ] `python3 -m omh.cli docs workflows --check`
- [ ] `python3 -m omh.cli harness validate`
- [ ] `python3 -m omh.cli release checklist --json`
- [ ] `python3 -m omh.cli release hermes-smoke`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable.
- [x] Relevant dry-run or smoke command: `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/pages.yml")'`
- [x] Relevant dry-run or smoke command: `git diff --check`
- [x] Relevant dry-run or smoke command: `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/pages.yml`
- [x] Manual failure-log review: `gh run view 28706493518 --log-failed`
- [x] Manual Pages availability check: `curl -I -L --max-time 20 https://rlaope.github.io/oh-my-hermes/`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not applicable; this is GitHub Pages workflow reliability only.

## Risk

- This does not guarantee success during a long GitHub Pages outage; it only avoids immediate duplicate transient failures and gives the backend time to recover.
- `cancel-in-progress: true` can cancel stale intermediate Pages runs, which is intentional because the Pages site should reflect the latest `main` commit.
- The final proof is a main-branch Pages workflow run after merge.

## Compatibility / Rollout

- No runtime, package, skill, or CLI contract changes.
- Compatible with the existing GitHub Pages action flow and artifact upload.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- If GitHub Pages backend failures continue after this, consider replacing the two explicit retry steps with a dedicated retry wrapper or opening an upstream issue with Pages deployment IDs.
