### PR TITLE
Add first-value quickstart packs

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,25 @@ hermes skills install rlaope/oh-my-hermes/skills/oh-my-hermes --yes
 Use OMH request-to-handoff for: I want to safely add a feature to this repo.
 ```
 
+First-value packs after setup:
+
+- **Frontend Rescue** - make a web UI feel natural, fix fragile responsive
+  layout, and require visual QA before claiming the frontend is ready.
+- **Repo First-Win** - map a new repository and identify the safest valuable
+  PR-sized improvement.
+- **Failure-to-Fix** - classify failing CI, deploy, Pages, DCO, build, or test
+  signals and prepare the smallest verified fix path.
+- **Visual Deliverable** - turn a PR, release, report, deck, or PDF into a
+  polished shareable artifact plan.
+- **Toolbelt Readiness** - check whether local tools, MCP hosts, credentials,
+  and executor surfaces are ready before a workflow depends on them.
+- **CTO/Product Loop** - review roadmap, architecture, delivery, QA, security,
+  and ops tradeoffs before launch.
+
+These packs are prepared routing and handoff guidance, not observed execution
+evidence. Browser QA, CI, deployment, publication, and merge proof still have
+to be recorded by the responsible runtime.
+
 [Website](https://rlaope.github.io/oh-my-hermes/) -
 [Documentation](docs/README.md) -
 [Installation](docs/INSTALLATION.md) -

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -27,6 +27,24 @@ First-run expectation:
 3. You restart or reload Hermes Agent.
 4. You ask Hermes: `Use OMH request-to-handoff for: I want to safely add a feature to this repo.`
 
+First-value packs are the stronger first-use paths once setup is done:
+
+- **Frontend Rescue** for natural frontend layout, anti-AI polish, responsive
+  repair, accessibility checks, and visual QA handoff.
+- **Repo First-Win** for mapping a new repository and finding the first safe
+  valuable improvement.
+- **Failure-to-Fix** for failing deploys, Pages, CI, DCO, builds, and tests.
+- **Visual Deliverable** for polished PR, release, report, deck, PDF, or image
+  summary packages.
+- **Toolbelt Readiness** for local CLIs, MCP hosts, credentials, connectors,
+  and executor runtime readiness.
+- **CTO/Product Loop** for roadmap, architecture, launch, QA, security, and
+  operations tradeoff review.
+
+These packs prepare routes, handoffs, and evidence boundaries. They do not
+claim execution, visual QA, CI, deployment, publication, credential validity, or
+merge evidence until Hermes or the selected runtime observes those steps.
+
 If the next step is still unclear, ask Hermes:
 
 ```text

--- a/site/index.html
+++ b/site/index.html
@@ -135,6 +135,59 @@ omh setup</code>
         </div>
       </section>
 
+      <section class="home-section first-value-section" id="first-value" aria-labelledby="first-value-title">
+        <div class="section-heading section-heading--split">
+          <div>
+            <p class="home-kicker">First-value packs</p>
+            <h2 id="first-value-title">Useful immediately after install.</h2>
+          </div>
+          <p>
+            OMH surfaces problem-shaped packs instead of leaving a new install
+            as an empty catalog. Each pack prepares the route, handoff, and
+            evidence boundary; prepared guidance is not observed execution
+            evidence until the selected runtime records proof.
+          </p>
+        </div>
+        <div class="first-value-grid" aria-label="OMH first-value packs">
+          <article class="first-value-card first-value-card--accent">
+            <span>Frontend Rescue</span>
+            <h3>Make the interface feel real.</h3>
+            <p>Natural layout, responsive repair, accessibility audit, and visual QA handoff for frontend work.</p>
+            <code>frontend + visual-qa</code>
+          </article>
+          <article class="first-value-card">
+            <span>Repo First-Win</span>
+            <h3>Find the first safe improvement.</h3>
+            <p>Repo map, risk scan, reading path, verification command, and PR-sized runway.</p>
+            <code>codebase-onboarding</code>
+          </article>
+          <article class="first-value-card">
+            <span>Failure-to-Fix</span>
+            <h3>Turn a broken signal into a fix path.</h3>
+            <p>Deploy, Pages, CI, DCO, build, and test failures become a classified minimal rerun plan.</p>
+            <code>build-failure-triage</code>
+          </article>
+          <article class="first-value-card">
+            <span>Visual Deliverable</span>
+            <h3>Package work for sharing.</h3>
+            <p>PR, release, report, deck, PDF, and image-summary requests get a polished delivery plan.</p>
+            <code>img-summary</code>
+          </article>
+          <article class="first-value-card">
+            <span>Toolbelt Readiness</span>
+            <h3>Check the tools before depending on them.</h3>
+            <p>Local CLIs, MCP hosts, credentials, connectors, and executor surfaces get readiness boundaries.</p>
+            <code>toolbelt-readiness</code>
+          </article>
+          <article class="first-value-card first-value-card--dark">
+            <span>CTO/Product Loop</span>
+            <h3>Review the launch like a system.</h3>
+            <p>Roadmap, architecture, QA, security, delivery, and operations tradeoffs stay visible before release.</p>
+            <code>cto-loop</code>
+          </article>
+        </div>
+      </section>
+
       <section class="home-section lane-section" id="capabilities">
         <div class="section-heading section-heading--split">
           <div>

--- a/site/styles.css
+++ b/site/styles.css
@@ -5583,6 +5583,92 @@ body.home-page {
     monospace;
 }
 
+.first-value-section {
+  background: #ffffff;
+}
+
+.first-value-section .section-heading p {
+  color: var(--home-muted);
+}
+
+.first-value-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1px;
+  overflow: hidden;
+  border: 1px solid var(--home-black);
+  border-radius: 8px;
+  background: var(--home-black);
+}
+
+.first-value-card {
+  display: grid;
+  align-content: space-between;
+  min-height: 270px;
+  padding: 20px;
+  background: #ffffff;
+  color: var(--home-black);
+}
+
+.first-value-card span {
+  color: var(--home-teal);
+  font-size: 0.75rem;
+  font-weight: 900;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.first-value-card h3 {
+  margin: 18px 0 0;
+  color: inherit;
+  font-size: 1.38rem;
+  line-height: 1.12;
+  letter-spacing: 0;
+}
+
+.first-value-card p {
+  margin: 14px 0 20px;
+  color: var(--home-muted);
+}
+
+.first-value-card code {
+  justify-self: start;
+  padding: 6px 8px;
+  border: 1px solid rgba(22, 214, 182, 0.28);
+  border-radius: 8px;
+  background: rgba(22, 214, 182, 0.08);
+  color: #087263;
+  font-size: 0.82rem;
+}
+
+.first-value-card--accent {
+  background: var(--home-teal);
+}
+
+.first-value-card--accent span,
+.first-value-card--accent p {
+  color: rgba(0, 0, 0, 0.68);
+}
+
+.first-value-card--accent code {
+  border-color: rgba(0, 0, 0, 0.16);
+  background: rgba(0, 0, 0, 0.08);
+  color: var(--home-black);
+}
+
+.first-value-card--dark {
+  background: var(--home-black);
+  color: #ffffff;
+}
+
+.first-value-card--dark p {
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.first-value-card--dark code {
+  color: #b8fff2;
+}
+
 .lane-section,
 .wrapper-section {
   background: var(--home-black);
@@ -6283,6 +6369,7 @@ body.docs-page {
 }
 
 .message-board,
+.first-value-section,
 .truth-section,
 .wrapper-section,
 .artifact-section,
@@ -6308,6 +6395,7 @@ body.docs-page {
   }
 
   .value-grid,
+  .first-value-grid,
   .lane-grid,
   .docs-value-rail,
   .docs-lane-map,
@@ -6351,6 +6439,7 @@ body.docs-page {
   }
 
   .value-grid,
+  .first-value-grid,
   .lane-grid,
   .truth-grid,
   .docs-start-grid,
@@ -6363,6 +6452,7 @@ body.docs-page {
   }
 
   .value-card,
+  .first-value-card,
   .lane-card,
   .truth-grid article,
   .docs-value-rail article,

--- a/src/commands/quickstart.py
+++ b/src/commands/quickstart.py
@@ -54,6 +54,14 @@ def _print_quickstart_card(card: dict[str, object]) -> None:
     for line in _string_list(card.get("first_five_minutes", [])):
         print(f"  - {line}")
 
+    print(_color("First-value packs", "1;32", use_color))
+    for pack in _dict_list(card.get("first_value_packs", [])):
+        label = str(pack.get("label", "pack")).strip()
+        outcome = str(pack.get("outcome", "")).strip()
+        workflows = ", ".join(_string_list(pack.get("primary_workflows", []))[:3])
+        suffix = f" ({workflows})" if workflows else ""
+        print(f"  - {label}: {outcome}{suffix}")
+
     print(_color("Try one prompt", "1;32", use_color))
     for prompt in _dict_list(card.get("chat_prompts", []))[:3]:
         print(f"  - {prompt.get('label', 'prompt')}: {prompt.get('prompt', '')}")

--- a/src/surfaces/quickstart.py
+++ b/src/surfaces/quickstart.py
@@ -8,6 +8,129 @@ from ..probe import probe_capabilities
 
 QUICKSTART_CARD_SCHEMA_VERSION = "omh_quickstart_card/v1"
 
+FIRST_VALUE_PACKS: tuple[dict[str, object], ...] = (
+    {
+        "id": "frontend_rescue",
+        "label": "Frontend Rescue",
+        "problem": (
+            "A web UI feels generic, AI-looking, broken, inaccessible, "
+            "or fragile across viewports."
+        ),
+        "prompt": (
+            "Use OMH frontend for: make this page feel natural, "
+            "fix broken responsive layout, and require visual QA."
+        ),
+        "primary_workflows": ("frontend", "design-quality-gate", "visual-qa", "accessibility-audit"),
+        "harness_surfaces": (),
+        "conceptual_surfaces": (),
+        "family_ids": ("create_materials_and_visuals",),
+        "outcome": (
+            "Frontend brief, design-system contract, state/viewport matrix, "
+            "implementation handoff, and visual QA gate."
+        ),
+        "evidence_boundary": (
+            "Prepared frontend guidance is not implementation, browser verification, "
+            "accessibility PASS, deployment, or visual QA evidence."
+        ),
+    },
+    {
+        "id": "repo_first_win",
+        "label": "Repo First-Win",
+        "problem": (
+            "A new repo is installed but the user does not know the first "
+            "valuable, safe PR-sized task."
+        ),
+        "prompt": (
+            "Use OMH codebase-onboarding for: find the first safe high-value "
+            "improvement in this repo."
+        ),
+        "primary_workflows": ("codebase-onboarding", "codegraph-refresh", "verification-gate"),
+        "harness_surfaces": (),
+        "conceptual_surfaces": ("request-to-handoff",),
+        "family_ids": ("plan_and_decide", "delegate_coding_and_ship"),
+        "outcome": "Repo map, reading path, risk map, first-task runway, verification commands, and handoff readiness.",
+        "evidence_boundary": (
+            "A first-task runway is planning evidence; it is not code execution, "
+            "tests, review, CI, or merge evidence."
+        ),
+    },
+    {
+        "id": "failure_to_fix",
+        "label": "Failure-to-Fix",
+        "problem": "Builds, deploys, Pages, CI, DCO, tests, or hidden failures keep blocking delivery.",
+        "prompt": (
+            "Use OMH build-failure-triage for: diagnose this failing deploy "
+            "or CI log and prepare the smallest fix path."
+        ),
+        "primary_workflows": ("build-failure-triage", "failure-signal-audit", "agent-debug", "verification-gate"),
+        "harness_surfaces": (),
+        "conceptual_surfaces": (),
+        "family_ids": ("operate_and_observe", "delegate_coding_and_ship"),
+        "outcome": (
+            "Failure classification, minimal fix plan, regression command, "
+            "and evidence-aware implementation handoff."
+        ),
+        "evidence_boundary": (
+            "Triage is not a fix, rerun, CI pass, deployment, or merge until "
+            "observed evidence proves those steps."
+        ),
+    },
+    {
+        "id": "visual_deliverable",
+        "label": "Visual Deliverable",
+        "problem": "A PR, release, report, deck, PDF, or package needs to become a polished shareable artifact.",
+        "prompt": (
+            "Use OMH img-summary for: turn this PR or release into a shareable "
+            "image card and delivery package."
+        ),
+        "primary_workflows": ("img-summary", "materials-package", "report-package", "deliverable-package"),
+        "harness_surfaces": (),
+        "conceptual_surfaces": (),
+        "family_ids": ("create_materials_and_visuals",),
+        "outcome": "Prompt card, package plan, export checklist, delivery boundary, and visual/publishing readiness.",
+        "evidence_boundary": (
+            "A prompt or package plan is not generated media, exported files, "
+            "visual QA, publication, or delivery evidence."
+        ),
+    },
+    {
+        "id": "toolbelt_readiness",
+        "label": "Toolbelt Readiness",
+        "problem": "A workflow depends on MCP, CLIs, connectors, credentials, executors, or local host readiness.",
+        "prompt": (
+            "Use OMH toolbelt-readiness for: tell me what tools, MCP hosts, "
+            "or credentials are missing before this workflow."
+        ),
+        "primary_workflows": ("doctor", "ops-observability-card"),
+        "harness_surfaces": ("toolbelt-readiness", "executor-runtime-readiness"),
+        "conceptual_surfaces": (),
+        "family_ids": ("operate_and_observe", "delegate_coding_and_ship"),
+        "outcome": "Installed/missing/credential matrix, safe next setup action, and readiness evidence boundary.",
+        "evidence_boundary": (
+            "A readiness card is not connector invocation, credential validity, "
+            "host load, or workflow execution evidence."
+        ),
+    },
+    {
+        "id": "cto_product_loop",
+        "label": "CTO/Product Loop",
+        "problem": "A roadmap, launch, risky feature, or product operation needs leadership-level tradeoff review.",
+        "prompt": (
+            "Use OMH cto-loop for: review this launch across roadmap, "
+            "architecture, delivery risk, QA, security, and ops."
+        ),
+        "primary_workflows": ("cto-loop", "strategy-brief", "feedback-triage", "deploy-and-monitor"),
+        "harness_surfaces": (),
+        "conceptual_surfaces": (),
+        "family_ids": ("learn_and_gather", "delegate_coding_and_ship", "operate_and_observe"),
+        "outcome": "Leadership loop, risks, decisions, follow-up handoffs, release readiness, and status boundaries.",
+        "evidence_boundary": (
+            "A leadership loop is not executor dispatch, implementation, "
+            "production deploy, monitoring proof, or release approval evidence."
+        ),
+    },
+)
+
 
 def build_quickstart_card(paths: OmhPaths, *, source: str = "hermes") -> dict[str, object]:
     checks = run_doctor(paths)
@@ -44,6 +167,7 @@ def build_quickstart_card(paths: OmhPaths, *, source: str = "hermes") -> dict[st
             "Ask Hermes what OMH can do, or paste a plain request and let Hermes route it.",
             "For coding work, ask for request-to-handoff after the scope is clear.",
         ],
+        "first_value_packs": first_value_packs(),
         "first_use_family_cards": capability_family_cards(),
         "chat_prompts": [
             {
@@ -58,7 +182,10 @@ def build_quickstart_card(paths: OmhPaths, *, source: str = "hermes") -> dict[st
             },
             {
                 "label": "ambitious loop",
-                "prompt": "Use OMH loop for: improve this repo's first-run experience until the next bottleneck is verified.",
+                "prompt": (
+                    "Use OMH loop for: improve this repo's first-run experience "
+                    "until the next bottleneck is verified."
+                ),
                 "expected_workflow": "loop",
             },
         ],
@@ -94,6 +221,31 @@ def build_quickstart_card(paths: OmhPaths, *, source: str = "hermes") -> dict[st
         "capability_gap_roadmap": probe.get("capability_gap_roadmap", {}),
         "claim_boundary": probe.get("claim_boundary", ""),
     }
+
+
+def first_value_packs() -> list[dict[str, object]]:
+    return [_pack_payload(pack) for pack in FIRST_VALUE_PACKS]
+
+
+def _pack_payload(pack: dict[str, object]) -> dict[str, object]:
+    return {
+        "id": str(pack["id"]),
+        "label": str(pack["label"]),
+        "problem": str(pack["problem"]),
+        "prompt": str(pack["prompt"]),
+        "primary_workflows": _string_tuple(pack.get("primary_workflows", ()), field="primary_workflows"),
+        "harness_surfaces": _string_tuple(pack.get("harness_surfaces", ()), field="harness_surfaces"),
+        "conceptual_surfaces": _string_tuple(pack.get("conceptual_surfaces", ()), field="conceptual_surfaces"),
+        "family_ids": _string_tuple(pack.get("family_ids", ()), field="family_ids"),
+        "outcome": str(pack["outcome"]),
+        "evidence_boundary": str(pack["evidence_boundary"]),
+    }
+
+
+def _string_tuple(value: object, *, field: str) -> list[str]:
+    if not isinstance(value, tuple):
+        raise TypeError(f"first-value pack {field} must be a tuple")
+    return [str(item) for item in value if str(item)]
 
 
 def _capabilities_by_name(capabilities: object) -> dict[str, dict[str, object]]:

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -4464,6 +4464,16 @@ def build_chat_response_from_omh_quickstart(
     evidence_gap = str(evidence_gaps[0]) if isinstance(evidence_gaps, list) and evidence_gaps else _default_overclaim_guard()
     roadmap = _nested(card, "capability_gap_roadmap")
     next_actions = _roadmap_next_actions(roadmap, limit=3)
+    packs = card.get("first_value_packs", [])
+    pack_lines: list[str] = []
+    if isinstance(packs, list):
+        for pack in packs[:3]:
+            if not isinstance(pack, dict):
+                continue
+            label = str(pack.get("label", "")).strip()
+            outcome = str(pack.get("outcome", "")).strip()
+            if label and outcome:
+                pack_lines.append(f"- {label}: {outcome}")
 
     body_lines = [
         (
@@ -4478,6 +4488,7 @@ def build_chat_response_from_omh_quickstart(
         "",
         "Next in Hermes:",
         f"- {first_prompt}" if first_prompt else "- Ask Hermes what you want to do with OMH.",
+        *(["", "High-value things to try:", *pack_lines] if pack_lines else []),
         "- Open the workflow picker with ./omh when you want to choose manually.",
         "- Use Show detailed status only when setup or registration looks wrong.",
         "",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,10 +16,12 @@ from omh.cli import OmhError, cmd_runtime_merge
 from omh.commands import setup as setup_commands
 from omh.commands.main import build_parser
 from omh.commands.language import LANGUAGE_CODES, MESSAGES
+from omh.capabilities.families import CONCEPTUAL_WORKFLOW_SURFACES, capability_family_projection
 from omh.config_adapter import external_dirs
 from omh.paths import resolve_paths
 from omh.routing.intent import classify_omh_quality_intent
 from omh.skill_pack import builtin_skill_reference_templates, builtin_skill_templates
+from omh.skills.catalog import builtin_harnesses, installable_skill_names
 from omh.wrapper.localized_copy import detect_copy_locale
 
 
@@ -998,10 +1000,15 @@ class CliTests(unittest.TestCase):
             self.assertIn("Plugin bridge: ready locally", stdout)
             self.assertIn("Live Hermes plugin use: not observed yet", stdout)
             self.assertIn("Wrapper usage: not recorded yet", stdout)
+            self.assertIn("First-value packs", stdout)
+            self.assertIn("Frontend Rescue", stdout)
+            self.assertIn("Failure-to-Fix", stdout)
+            self.assertIn("Toolbelt Readiness", stdout)
             self.assertIn("Use OMH request-to-handoff", stdout)
             self.assertIn("A ready local plugin bridge is not proof", stdout)
             self.assertIn("For machine-readable output, rerun with `--json`.", stdout)
             self.assertFalse((root / ".omh" / "runtime" / "wrapper_sessions").exists())
+            self.assertFalse((root / ".omh" / "runtime" / "plugin_runtime_observations.jsonl").exists())
 
             with patch("omh.command_path.shutil.which", return_value="/usr/local/bin/omh"):
                 status, stdout, stderr = run_cli(base + ["quickstart", "--source", "discord", "--json"], output_json=False)
@@ -1016,6 +1023,55 @@ class CliTests(unittest.TestCase):
             self.assertIn("paper-learning", family_cards["learn_and_gather"]["primary_workflows"])
             self.assertIn("img-summary", family_cards["create_materials_and_visuals"]["primary_workflows"])
             self.assertIn("Claude Code", family_cards["delegate_coding_and_ship"]["executor_choices"])
+            pack_ids = {pack["id"] for pack in payload["first_value_packs"]}
+            self.assertEqual(
+                {
+                    "frontend_rescue",
+                    "repo_first_win",
+                    "failure_to_fix",
+                    "visual_deliverable",
+                    "toolbelt_readiness",
+                    "cto_product_loop",
+                },
+                pack_ids,
+            )
+            pack_labels = {pack["label"] for pack in payload["first_value_packs"]}
+            self.assertEqual(
+                {
+                    "Frontend Rescue",
+                    "Repo First-Win",
+                    "Failure-to-Fix",
+                    "Visual Deliverable",
+                    "Toolbelt Readiness",
+                    "CTO/Product Loop",
+                },
+                pack_labels,
+            )
+            pack_required_fields = {
+                "id",
+                "label",
+                "problem",
+                "prompt",
+                "primary_workflows",
+                "harness_surfaces",
+                "conceptual_surfaces",
+                "family_ids",
+                "outcome",
+                "evidence_boundary",
+            }
+            installable = set(installable_skill_names())
+            harnesses = {harness.name for harness in builtin_harnesses()}
+            conceptual = set(CONCEPTUAL_WORKFLOW_SURFACES)
+            families = set(capability_family_projection()["family_order"])
+            for pack in payload["first_value_packs"]:
+                with self.subTest(pack=pack["id"]):
+                    self.assertLessEqual(pack_required_fields, set(pack))
+                    self.assertLessEqual(set(pack["primary_workflows"]), installable)
+                    self.assertLessEqual(set(pack["harness_surfaces"]), harnesses)
+                    self.assertLessEqual(set(pack["conceptual_surfaces"]), conceptual)
+                    self.assertLessEqual(set(pack["family_ids"]), families)
+                    self.assertTrue(pack["prompt"].startswith("Use OMH "))
+                    self.assertIn("not", pack["evidence_boundary"])
             self.assertEqual(payload["local_status"]["plugin_bridge"]["status"], "ready_locally")
             self.assertFalse(payload["local_status"]["plugin_runtime_observed"])
             self.assertFalse(payload["local_status"]["plugin_runtime_active"])

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -1877,6 +1877,17 @@ class RouterContentTests(unittest.TestCase):
         self.assertIn("omh setup", quick_start)
         self.assertLess(quick_start.index("omh setup"), quick_start.index("omh doctor"))
         self.assertIn("Use OMH request-to-handoff for: I want to safely add a feature to this repo.", quick_start)
+        self.assertIn("First-value packs after setup", quick_start)
+        for label in (
+            "Frontend Rescue",
+            "Repo First-Win",
+            "Failure-to-Fix",
+            "Visual Deliverable",
+            "Toolbelt Readiness",
+            "CTO/Product Loop",
+        ):
+            self.assertIn(label, quick_start)
+        self.assertIn("not observed execution", quick_start)
         self.assertIn("hermes skills tap add", quick_start)
         self.assertNotIn("That is the normal path", quick_start)
         self.assertNotIn("name the responsible role", quick_start)
@@ -1908,6 +1919,12 @@ class RouterContentTests(unittest.TestCase):
         self.assertIn("isolated OMH virtual environment", installation)
         self.assertIn("add the printed directory to", installation)
         self.assertIn("Use OMH request-to-handoff for: I want to safely add a feature to this repo.", installation)
+        self.assertIn("First-value packs are the stronger first-use paths once setup is done", installation)
+        self.assertIn("Frontend Rescue", installation)
+        self.assertIn("Failure-to-Fix", installation)
+        self.assertIn("Toolbelt Readiness", installation)
+        self.assertIn("They do not", installation)
+        self.assertIn("execution, visual QA, CI, deployment", installation)
         self.assertIn("omh chat native-command --source discord", installation)
         self.assertIn("omh_command_fallback_card/v1", installation)
         self.assertIn("chat_response.state.command_preview.suggestions", installation)
@@ -2062,6 +2079,12 @@ class RouterContentTests(unittest.TestCase):
         self.assertIn("request-to-handoff", site)
         self.assertIn("planner", site)
         self.assertIn("Prepared is not observed", site)
+        self.assertIn("First-value packs", site)
+        self.assertIn("Useful immediately after install.", site)
+        self.assertIn("Frontend Rescue", site)
+        self.assertIn("Failure-to-Fix", site)
+        self.assertIn("Toolbelt Readiness", site)
+        self.assertIn("prepared guidance is not observed execution", site)
         self.assertIn("Reference pages when the lane needs detail.", site)
         self.assertIn("Loop</span>", site)
         self.assertIn("Source-specific prompt cards for meetings, PRs, issues, releases, and research.", site)

--- a/tests/test_wrapper_contract.py
+++ b/tests/test_wrapper_contract.py
@@ -1431,6 +1431,10 @@ class WrapperContractTests(unittest.TestCase):
                     self.assertIn("Local status:", payload["chat_response"]["body"])
                     self.assertIn("Next in Hermes:", payload["chat_response"]["body"])
                     self.assertIn("Use OMH request-to-handoff", payload["chat_response"]["body"])
+                    self.assertIn("High-value things to try:", payload["chat_response"]["body"])
+                    self.assertIn("Frontend Rescue", payload["chat_response"]["body"])
+                    self.assertIn("Repo First-Win", payload["chat_response"]["body"])
+                    self.assertIn("Failure-to-Fix", payload["chat_response"]["body"])
                     self.assertIn("Boundary:", payload["chat_response"]["body"])
                     rendering_blocks = payload["chat_response"]["messenger_rendering"]["body_blocks"]
                     self.assertGreaterEqual(
@@ -1441,6 +1445,11 @@ class WrapperContractTests(unittest.TestCase):
                     self.assertEqual(state["status_source"], "omh_quickstart")
                     self.assertEqual(state["quickstart_card"]["schema_version"], "omh_quickstart_card/v1")
                     self.assertEqual(state["quickstart_card"]["source"], "discord")
+                    self.assertEqual(len(state["quickstart_card"]["first_value_packs"]), 6)
+                    self.assertEqual(
+                        state["quickstart_card"]["first_value_packs"][0]["label"],
+                        "Frontend Rescue",
+                    )
                     roadmap = state["capability_gap_roadmap"]
                     self.assertEqual(roadmap["schema_version"], "omh_capability_gap_roadmap/v1")
                     self.assertGreaterEqual(roadmap["summary"]["baseline_product_gaps"], 1)


### PR DESCRIPTION
## Feature Report

### What Changed

- Added six install-immediate first-value packs to `omh_quickstart_card/v1`: Frontend Rescue, Repo First-Win, Failure-to-Fix, Visual Deliverable, Toolbelt Readiness, and CTO/Product Loop.
- Rendered the packs in `omh quickstart` and surfaced the top three in wrapper quickstart responses under `High-value things to try`.
- Updated the README, installation guide, and Pages homepage so new users see concrete high-value problems to ask OMH about right after setup.
- Added regression coverage for pack schema fields, typed catalog references, wrapper rendering, public copy, and no runtime-evidence side effects.

### Why This Exists

- A fresh OMH install was technically ready but still felt like a catalog: users had to know which workflow name to ask for before feeling value.
- The first-run surface now points to strong outcomes immediately: frontend repair and visual QA, safe repo onboarding, failure triage, polished deliverables, tool readiness, and product/CTO review.
- The change keeps OMH's prepared-versus-observed boundary intact, so quickstart guidance does not overclaim execution, CI, visual QA, deployment, or merge evidence.

### User / Operator Impact

- New users can install OMH and immediately ask for a problem-shaped pack instead of browsing dozens of workflow names.
- Wrappers can render the same first-value pack data from the quickstart card without scraping docs or inventing copy.
- Operators get typed drift protection: every pack reference is checked against the installable skill catalog, builtin harness surfaces, conceptual surfaces, and capability family projection.

### How It Works

- `src/surfaces/quickstart.py` owns the static first-value pack table and emits it as `first_value_packs` on the existing quickstart card.
- `src/commands/quickstart.py` prints a compact human section with pack outcomes and representative workflows.
- `src/wrapper/contract.py` uses the same card data to render the top three high-value suggestions in quickstart chat responses.
- Public docs and site copy describe the packs as prepared routing and handoff guidance, not observed runtime proof.

### Files And Contracts Touched

- `omh_quickstart_card/v1`: additive `first_value_packs` field only.
- CLI surface: `omh quickstart` human output.
- Wrapper surface: quickstart chat response body and state payload.
- Public surfaces: `README.md`, `docs/INSTALLATION.md`, `site/index.html`, `site/styles.css`.
- Tests: `tests/test_cli.py`, `tests/test_wrapper_contract.py`, `tests/test_router_content.py`.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — 1164 tests passed.
- [x] `uv run python -m compileall -q src tests`
- [x] `PYTHONPATH=tests uv run python -m omh.cli docs workflows --check`
- [x] `PYTHONPATH=tests uv run python -m omh.cli harness validate`
- [ ] `python3 -m omh.cli release checklist --json` — not run; this PR changes quickstart/docs/site copy, not release packaging.
- [ ] `python3 -m omh.cli release hermes-smoke` — not run; no live Hermes install smoke in this branch.
- [x] `PYTHONPATH=src uv run python -m omh.cli --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` — not run; live install path unchanged.
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable.
- [x] Relevant dry-run or smoke command: `PYTHONPATH=src uv run python -m omh.cli quickstart`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run; wrapper contract and CLI quickstart tests cover this prepared card path.

## Risk

- Static pack definitions duplicate a little catalog knowledge. The PR mitigates that with typed reference tests that fail if a referenced workflow, harness, conceptual surface, or family id drifts.
- The quickstart schema version remains unchanged because the field is additive. Existing consumers that ignore unknown fields should continue to work.

## Compatibility / Rollout

- Existing quickstart fields and wrapper actions are preserved.
- The new field is additive and local-only; no network, credential, Hermes core patch, or runtime dispatch behavior is introduced.
- Pages rollout happens after merge through the existing GitHub Pages workflow.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`): applies to the next branch merge/release that ships quickstart surfaces.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap.

## Follow-Up

- Consider deriving packs from catalog metadata later if the pack list grows or needs localization.
