### PR TITLE
Polish common request chat cards

### DIFF
--- a/src/quality/common_request_coverage.py
+++ b/src/quality/common_request_coverage.py
@@ -173,7 +173,7 @@ COMMON_REQUEST_COVERAGE_CASES: tuple[CommonRequestCoverageCase, ...] = (
         "prepare meeting agenda decision slots and follow-up template",
         "dispatch",
         "meeting-brief",
-        "ack",
+        "meeting_brief",
         "prepare_meeting_brief",
     ),
     CommonRequestCoverageCase(
@@ -223,7 +223,7 @@ COMMON_REQUEST_COVERAGE_CASES: tuple[CommonRequestCoverageCase, ...] = (
         "웹페이지 디자인 레이아웃 QA 해줘",
         "dispatch",
         "design-quality-gate",
-        "ack",
+        "design_quality_gate",
         "prepare_design_quality_gate",
     ),
     CommonRequestCoverageCase(
@@ -233,7 +233,7 @@ COMMON_REQUEST_COVERAGE_CASES: tuple[CommonRequestCoverageCase, ...] = (
         "프론트엔드 구현 handoff 준비해줘",
         "dispatch",
         "frontend",
-        "ack",
+        "frontend_handoff",
         "prepare_frontend_handoff",
     ),
     CommonRequestCoverageCase(
@@ -243,7 +243,7 @@ COMMON_REQUEST_COVERAGE_CASES: tuple[CommonRequestCoverageCase, ...] = (
         "visual QA로 화면 깨지는지 봐줘",
         "dispatch",
         "visual-qa",
-        "ack",
+        "visual_qa",
         "prepare_visual_qa",
     ),
     CommonRequestCoverageCase(
@@ -253,7 +253,7 @@ COMMON_REQUEST_COVERAGE_CASES: tuple[CommonRequestCoverageCase, ...] = (
         "접근성 WCAG 체크해줘",
         "dispatch",
         "accessibility-audit",
-        "ack",
+        "accessibility_audit",
         "prepare_accessibility_audit",
     ),
     CommonRequestCoverageCase(
@@ -323,7 +323,7 @@ COMMON_REQUEST_COVERAGE_CASES: tuple[CommonRequestCoverageCase, ...] = (
         "production readiness audit with rollback health checks",
         "dispatch",
         "production-audit",
-        "ack",
+        "production_audit",
         "prepare_production_audit",
     ),
     CommonRequestCoverageCase(
@@ -363,7 +363,7 @@ COMMON_REQUEST_COVERAGE_CASES: tuple[CommonRequestCoverageCase, ...] = (
         "audit this workspace prompts skills plugins and hooks for stale config",
         "dispatch",
         "workspace-audit",
-        "ack",
+        "workspace_audit",
         "prepare_workspace_audit",
     ),
     CommonRequestCoverageCase(
@@ -373,7 +373,7 @@ COMMON_REQUEST_COVERAGE_CASES: tuple[CommonRequestCoverageCase, ...] = (
         "검증 게이트 열고 테스트 CI 증거 확인해줘",
         "dispatch",
         "verification-gate",
-        "ack",
+        "verification_gate",
         "prepare_verification_gate",
     ),
     CommonRequestCoverageCase(
@@ -383,7 +383,7 @@ COMMON_REQUEST_COVERAGE_CASES: tuple[CommonRequestCoverageCase, ...] = (
         "CI build failure logs triage root cause and minimal fix handoff",
         "dispatch",
         "build-failure-triage",
-        "ack",
+        "build_failure_triage",
         "prepare_build_failure_triage",
     ),
     CommonRequestCoverageCase(
@@ -393,7 +393,7 @@ COMMON_REQUEST_COVERAGE_CASES: tuple[CommonRequestCoverageCase, ...] = (
         "compare agent outputs with rubric and metrics",
         "dispatch",
         "agent-evaluation",
-        "ack",
+        "agent_evaluation",
         "prepare_agent_evaluation",
     ),
     CommonRequestCoverageCase(
@@ -403,7 +403,7 @@ COMMON_REQUEST_COVERAGE_CASES: tuple[CommonRequestCoverageCase, ...] = (
         "이 반복 실수를 AGENTS.md 규칙 후보로 정리해줘",
         "dispatch",
         "rules-distill",
-        "ack",
+        "rules_distill",
         "prepare_rules_distillation",
     ),
     CommonRequestCoverageCase(
@@ -413,7 +413,7 @@ COMMON_REQUEST_COVERAGE_CASES: tuple[CommonRequestCoverageCase, ...] = (
         "처음 보는 repo 온보딩 reading path 만들어줘",
         "dispatch",
         "codebase-onboarding",
-        "ack",
+        "codebase_onboarding",
         "prepare_codebase_onboarding",
     ),
     CommonRequestCoverageCase(
@@ -423,7 +423,7 @@ COMMON_REQUEST_COVERAGE_CASES: tuple[CommonRequestCoverageCase, ...] = (
         "codegraph refresh 상태 점검해줘",
         "dispatch",
         "codegraph-refresh",
-        "ack",
+        "codegraph_refresh",
         "prepare_codegraph_refresh",
     ),
     CommonRequestCoverageCase(
@@ -493,7 +493,7 @@ COMMON_REQUEST_COVERAGE_CASES: tuple[CommonRequestCoverageCase, ...] = (
         "context budget 압박이 있는지 검토해줘",
         "dispatch",
         "context-budget-review",
-        "ack",
+        "context_budget_review",
         "prepare_context_budget_review",
     ),
     CommonRequestCoverageCase(
@@ -503,7 +503,7 @@ COMMON_REQUEST_COVERAGE_CASES: tuple[CommonRequestCoverageCase, ...] = (
         "security safety review prompt injection secrets destructive action check",
         "dispatch",
         "security-safety-review",
-        "ack",
+        "security_safety_review",
         "prepare_security_safety_review",
     ),
     CommonRequestCoverageCase(

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -910,6 +910,36 @@ _OPERATING_BRIEF_CHAT_CARDS: dict[str, dict[str, object]] = {
             "verification",
         ],
     },
+    "meeting-brief": {
+        "kind": "meeting_brief",
+        "headline": "I can prepare the meeting brief and follow-up slots.",
+        "body": (
+            "I will prepare the agenda, context prompts, decision slots, owner follow-ups, and meeting record template. "
+            "Prepared material is not evidence that the meeting happened or that owners accepted follow-ups."
+        ),
+        "phase": "meeting_brief_prepared",
+        "next_action": "prepare_meeting_brief",
+        "artifact_schema": "meeting_brief_card/v1",
+        "actions": [
+            {"id": "prepare_meeting_brief", "label": "Prepare brief", "style": "primary"},
+            {"id": "prepare_report_package", "label": "Prepare report", "style": "secondary"},
+            {"id": "show_status", "label": "Show status", "style": "secondary"},
+        ],
+        "recommended_flow": [
+            "prepare_agenda",
+            "name_decision_slots",
+            "assign_follow_up_slots",
+            "separate_prepared_material_from_meeting_evidence",
+        ],
+        "evidence_not_observed": [
+            "meeting completion",
+            "attendee approval",
+            "decision acceptance",
+            "owner acceptance",
+            "follow-up completion",
+            "delivery",
+        ],
+    },
     "report-package": {
         "kind": "report_package",
         "headline": "I can package this into a report people can review.",
@@ -1060,6 +1090,163 @@ _REVIEW_QUALITY_CHAT_CARDS: dict[str, dict[str, object]] = {
             "review",
             "CI",
             "merge",
+        ],
+    },
+    "production-audit": {
+        "kind": "production_audit",
+        "headline": "I can prepare a production-readiness audit.",
+        "body": (
+            "I will prepare the production-readiness audit: release scope, build, test, CI, security, observability, "
+            "rollback, support handoff, and a GO/HOLD/BLOCK verdict. Deploy and live-health claims still need observed evidence."
+        ),
+        "phase": "production_audit_prepared",
+        "next_action": "prepare_production_audit",
+        "artifact_schema": "production_readiness_audit/v1",
+        "claim_boundary_suffix": "It is not deployment, live health, rollback readiness, support readiness, or release approval evidence.",
+        "actions": [
+            {"id": "prepare_production_audit", "label": "Audit production", "style": "primary"},
+            {"id": "prepare_reliability_review", "label": "Review reliability", "style": "secondary"},
+            {"id": "show_status", "label": "Show status", "style": "secondary"},
+        ],
+        "recommended_flow": [
+            "scope_release_surface",
+            "check_build_test_ci_security_evidence",
+            "review_observability_and_rollback",
+            "record_go_hold_block_verdict",
+        ],
+        "evidence_not_observed": [
+            "deployment",
+            "live health check",
+            "rollback readiness",
+            "support readiness",
+            "release approval",
+            "CI rerun",
+        ],
+    },
+    "verification-gate": {
+        "kind": "verification_gate",
+        "headline": "I can prepare the verification gate before completion claims.",
+        "body": (
+            "I will prepare required checks, observed result freshness, generated-output checks, CI/DCO boundaries, "
+            "and a PASS/HOLD/BLOCK claim verdict before completion, release, or merge claims."
+        ),
+        "phase": "verification_gate_prepared",
+        "next_action": "prepare_verification_gate",
+        "artifact_schema": "verification_gate/v1",
+        "claim_boundary_suffix": "It is not test execution, CI pass, review completion, merge-readiness, or merge evidence.",
+        "actions": [
+            {"id": "prepare_verification_gate", "label": "Prepare gate", "style": "primary"},
+            {"id": "prepare_review_or_followup_handoff", "label": "Prepare review", "style": "secondary"},
+            {"id": "show_status", "label": "Show status", "style": "secondary"},
+        ],
+        "recommended_flow": [
+            "name_claims_to_verify",
+            "list_required_checks",
+            "record_observed_freshness",
+            "issue_pass_hold_block_verdict",
+        ],
+        "evidence_not_observed": [
+            "test execution",
+            "CI pass",
+            "review completion",
+            "merge readiness",
+            "merge",
+        ],
+    },
+    "build-failure-triage": {
+        "kind": "build_failure_triage",
+        "headline": "I can triage the build failure before proposing a fix.",
+        "body": (
+            "I will prepare a failure-log digest, cluster likely failure modes, rank root-cause hypotheses, "
+            "and outline a minimal fix handoff only when the evidence supports it. The build is not fixed until observed."
+        ),
+        "phase": "build_failure_triage_prepared",
+        "next_action": "prepare_build_failure_triage",
+        "artifact_schema": "build_failure_triage_plan/v1",
+        "claim_boundary_suffix": "It is not log retrieval, root-cause proof, fix implementation, rerun success, CI pass, or merge evidence.",
+        "actions": [
+            {"id": "prepare_build_failure_triage", "label": "Triage build failure", "style": "primary"},
+            {
+                "id": "prepare_coding_handoff",
+                "label": "Prepare fix handoff",
+                "style": "secondary",
+                "enabled": False,
+                "payload": {"requires": "ranked root-cause evidence and accepted remediation scope"},
+            },
+            {"id": "show_status", "label": "Show status", "style": "secondary"},
+        ],
+        "recommended_flow": [
+            "digest_failure_logs",
+            "cluster_failure_modes",
+            "rank_root_cause_hypotheses",
+            "prepare_minimal_fix_handoff_when_supported",
+        ],
+        "evidence_not_observed": [
+            "log retrieval",
+            "root-cause proof",
+            "fix implementation",
+            "rerun success",
+            "CI pass",
+            "merge",
+        ],
+    },
+    "context-budget-review": {
+        "kind": "context_budget_review",
+        "headline": "I can prepare a context budget review.",
+        "body": (
+            "I will prepare the must-keep context, checkpoint cadence, budget risks, overflow recovery path, "
+            "and provider-truth gaps. Exact billing or token usage still needs observed runtime or provider evidence."
+        ),
+        "phase": "context_budget_review_prepared",
+        "next_action": "prepare_context_budget_review",
+        "artifact_schema": "context_budget_review/v1",
+        "claim_boundary_suffix": "It is not provider billing truth, exact token usage, compaction success, or future context-safety evidence.",
+        "actions": [
+            {"id": "prepare_context_budget_review", "label": "Review context", "style": "primary"},
+            {"id": "show_status", "label": "Show status", "style": "secondary"},
+        ],
+        "recommended_flow": [
+            "identify_must_keep_context",
+            "set_checkpoint_cadence",
+            "name_overflow_recovery_path",
+            "separate_estimates_from_provider_truth",
+        ],
+        "evidence_not_observed": [
+            "provider billing truth",
+            "exact token usage",
+            "compaction success",
+            "future context safety",
+        ],
+    },
+    "security-safety-review": {
+        "kind": "security_safety_review",
+        "headline": "I can prepare a redacted security and safety review.",
+        "body": (
+            "I will prepare threat surfaces, prompt-injection risks, tool permissions, secret/dependency/destructive-action gates, "
+            "and safe remediation handoff options without exposing secrets."
+        ),
+        "phase": "security_safety_review_prepared",
+        "next_action": "prepare_security_safety_review",
+        "artifact_schema": "security_safety_review/v1",
+        "claim_boundary_suffix": "It is not secret access, dependency audit completion, vulnerability proof, remediation, CI, or security sign-off evidence.",
+        "actions": [
+            {"id": "prepare_security_safety_review", "label": "Review safety", "style": "primary"},
+            {"id": "prepare_review_or_followup_handoff", "label": "Prepare review", "style": "secondary"},
+            {"id": "show_status", "label": "Show status", "style": "secondary"},
+        ],
+        "recommended_flow": [
+            "redact_sensitive_context",
+            "map_prompt_injection_and_tool_risks",
+            "check_secret_dependency_destructive_gates",
+            "prepare_safe_remediation_handoff_options",
+        ],
+        "evidence_not_observed": [
+            "secret access",
+            "dependency audit completion",
+            "vulnerability proof",
+            "remediation",
+            "CI",
+            "security sign-off",
         ],
     },
 }
@@ -1273,6 +1460,130 @@ _WORKFLOW_OPERATIONS_CHAT_CARDS: dict[str, dict[str, object]] = {
             "completion",
         ],
     },
+    "design-quality-gate": {
+        "kind": "design_quality_gate",
+        "headline": "I can prepare the design quality gate before calling it polished.",
+        "body": (
+            "I will prepare the design quality gate: reference packet, layout and content checks, CJK/text-fit review, "
+            "surface quality matrix, comparative rubric, and visual QA evidence slots. Better-looking output still needs rendered evidence."
+        ),
+        "phase": "design_quality_gate_prepared",
+        "next_action": "prepare_design_quality_gate",
+        "artifact_schema": "design_quality_gate/v1",
+        "claim_boundary_suffix": "It is not rendered visual QA, comparative PASS, generated asset quality, publication, approval, or delivery evidence.",
+        "actions": [
+            {"id": "prepare_design_quality_gate", "label": "Prepare design gate", "style": "primary"},
+            {"id": "prepare_visual_qa", "label": "Prepare visual QA", "style": "secondary"},
+            {"id": "show_status", "label": "Show status", "style": "secondary"},
+        ],
+        "recommended_flow": [
+            "select_reference_packet",
+            "prepare_surface_quality_matrix",
+            "check_text_fit_cjk_and_layout",
+            "record_visual_qa_when_observed",
+        ],
+        "evidence_not_observed": [
+            "rendered visual QA",
+            "comparative PASS",
+            "generated asset quality",
+            "publication",
+            "approval",
+            "delivery",
+        ],
+    },
+    "frontend": {
+        "kind": "frontend_handoff",
+        "headline": "I can prepare the frontend handoff with visual QA gates.",
+        "body": (
+            "I will prepare the frontend brief: routes, states, responsive breakpoints, component inventory, design-system contract, "
+            "implementation owner, and visual QA follow-up. Implementation and screenshots remain observed-only."
+        ),
+        "phase": "frontend_handoff_prepared",
+        "next_action": "prepare_frontend_handoff",
+        "artifact_schema": "frontend_design_brief/v1",
+        "claim_boundary_suffix": "It is not frontend implementation, browser rendering, screenshot evidence, accessibility pass, or deployment evidence.",
+        "actions": [
+            {"id": "prepare_frontend_handoff", "label": "Prepare frontend", "style": "primary"},
+            {"id": "prepare_visual_qa", "label": "Prepare visual QA", "style": "secondary"},
+            {"id": "prepare_accessibility_audit", "label": "Audit accessibility", "style": "secondary"},
+            {"id": "show_status", "label": "Show status", "style": "secondary"},
+        ],
+        "recommended_flow": [
+            "define_routes_and_states",
+            "prepare_component_inventory",
+            "name_responsive_breakpoints",
+            "attach_visual_qa_requirement",
+        ],
+        "evidence_not_observed": [
+            "frontend implementation",
+            "browser rendering",
+            "screenshot capture",
+            "accessibility pass",
+            "deployment",
+        ],
+    },
+    "visual-qa": {
+        "kind": "visual_qa",
+        "headline": "I can prepare rendered visual QA without pretending screenshots exist.",
+        "body": (
+            "I will prepare viewport captures, screenshot/diff slots, console and network health checks, click-path traces, "
+            "accessibility keyboard trace, and a PASS/HOLD verdict. No visual pass exists until rendered evidence is recorded."
+        ),
+        "phase": "visual_qa_prepared",
+        "next_action": "prepare_visual_qa",
+        "artifact_schema": "visual_qa_plan/v1",
+        "claim_boundary_suffix": "It is not screenshot capture, pixel-diff evidence, browser interaction proof, accessibility pass, or visual PASS evidence.",
+        "actions": [
+            {"id": "prepare_visual_qa", "label": "Prepare visual QA", "style": "primary"},
+            {"id": "prepare_accessibility_audit", "label": "Audit accessibility", "style": "secondary"},
+            {"id": "show_status", "label": "Show status", "style": "secondary"},
+        ],
+        "recommended_flow": [
+            "define_viewport_matrix",
+            "prepare_render_capture_manifest",
+            "separate_screenshot_diff_and_interaction_evidence",
+            "record_pass_hold_verdict_only_after_rendered_evidence",
+        ],
+        "evidence_not_observed": [
+            "screenshot capture",
+            "pixel diff",
+            "browser interaction",
+            "console/network health",
+            "accessibility keyboard trace",
+            "visual PASS",
+        ],
+    },
+    "accessibility-audit": {
+        "kind": "accessibility_audit",
+        "headline": "I can prepare an accessibility audit without overclaiming WCAG PASS.",
+        "body": (
+            "I will prepare WCAG criteria, semantic structure review, focus and keyboard trace slots, screen-reader map, "
+            "target-size review, contrast/reflow checks, and the observed evidence needed before any PASS claim."
+        ),
+        "phase": "accessibility_audit_prepared",
+        "next_action": "prepare_accessibility_audit",
+        "artifact_schema": "accessibility_audit_plan/v1",
+        "claim_boundary_suffix": "It is not automated scan completion, screen-reader evidence, keyboard trace evidence, WCAG PASS, remediation, or deployment evidence.",
+        "actions": [
+            {"id": "prepare_accessibility_audit", "label": "Audit accessibility", "style": "primary"},
+            {"id": "prepare_visual_qa", "label": "Prepare visual QA", "style": "secondary"},
+            {"id": "show_status", "label": "Show status", "style": "secondary"},
+        ],
+        "recommended_flow": [
+            "map_wcag_success_criteria",
+            "review_semantic_structure",
+            "prepare_focus_keyboard_and_screen_reader_slots",
+            "separate_scan_output_from_pass_verdict",
+        ],
+        "evidence_not_observed": [
+            "automated scan completion",
+            "screen-reader evidence",
+            "keyboard trace evidence",
+            "WCAG PASS",
+            "remediation",
+            "deployment",
+        ],
+    },
     "memory-curation-review": {
         "kind": "memory_curation",
         "headline": "I can review memory and context before anything is changed.",
@@ -1412,6 +1723,158 @@ _WORKFLOW_OPERATIONS_CHAT_CARDS: dict[str, dict[str, object]] = {
             "CI",
             "merge",
             "future loop fix",
+        ],
+    },
+    "workspace-audit": {
+        "kind": "workspace_audit",
+        "headline": "I can prepare a read-only workspace audit.",
+        "body": (
+            "I will prepare the workspace audit: repo, skill, prompt, plugin, MCP/tool, hook, config, docs, and runtime surfaces, "
+            "with secrets redacted and any mutation routed to a separate follow-up workflow."
+        ),
+        "phase": "workspace_audit_prepared",
+        "next_action": "prepare_workspace_audit",
+        "artifact_schema": "workspace_audit_report/v1",
+        "claim_boundary_suffix": "It is not config mutation, secret inspection, plugin installation, MCP load proof, runtime dispatch, or repair evidence.",
+        "actions": [
+            {"id": "prepare_workspace_audit", "label": "Prepare audit", "style": "primary"},
+            {"id": "prepare_toolbelt_readiness", "label": "Check toolbelt", "style": "secondary"},
+            {"id": "show_status", "label": "Show status", "style": "secondary"},
+        ],
+        "recommended_flow": [
+            "inventory_workspace_surfaces",
+            "redact_secrets_and_credentials",
+            "classify_stale_or_missing_configs",
+            "route_repairs_to_follow_up_workflows",
+        ],
+        "evidence_not_observed": [
+            "config mutation",
+            "secret inspection",
+            "plugin installation",
+            "MCP load proof",
+            "runtime dispatch",
+            "repair completion",
+        ],
+    },
+    "agent-evaluation": {
+        "kind": "agent_evaluation",
+        "headline": "I can prepare a fair agent evaluation instead of anecdotal ranking.",
+        "body": (
+            "I will prepare tasks, fixtures, rubric, budgets, isolation, observed run matrix, and a scenario-specific recommendation. "
+            "No agent is declared better until comparable run evidence exists."
+        ),
+        "phase": "agent_evaluation_prepared",
+        "next_action": "prepare_agent_evaluation",
+        "artifact_schema": "agent_evaluation_plan/v1",
+        "claim_boundary_suffix": "It is not executor dispatch, benchmark execution, quality proof, cost truth, or final agent ranking evidence.",
+        "actions": [
+            {"id": "prepare_agent_evaluation", "label": "Prepare eval", "style": "primary"},
+            {"id": "prepare_report_package", "label": "Prepare report", "style": "secondary"},
+            {"id": "show_status", "label": "Show status", "style": "secondary"},
+        ],
+        "recommended_flow": [
+            "define_representative_tasks",
+            "freeze_rubric_and_budgets",
+            "isolate_executor_runs",
+            "compare_observed_outputs_before_recommendation",
+        ],
+        "evidence_not_observed": [
+            "executor dispatch",
+            "benchmark execution",
+            "quality proof",
+            "provider cost truth",
+            "final ranking",
+        ],
+    },
+    "rules-distill": {
+        "kind": "rules_distill",
+        "headline": "I can distill repeated lessons into reviewed rule candidates.",
+        "body": (
+            "I will prepare source-linked rule candidates, duplicates, conflicts, scope, approval state, and implementation path. "
+            "Nothing mutates AGENTS.md, skills, prompts, docs, or memory until approved and implemented."
+        ),
+        "phase": "rules_distillation_prepared",
+        "next_action": "prepare_rules_distillation",
+        "artifact_schema": "rules_distillation_candidate_set/v1",
+        "claim_boundary_suffix": "It is not AGENTS.md mutation, skill mutation, prompt mutation, memory write, approval, or future-behavior evidence.",
+        "actions": [
+            {"id": "prepare_rules_distillation", "label": "Distill rules", "style": "primary"},
+            {"id": "show_status", "label": "Show status", "style": "secondary"},
+        ],
+        "recommended_flow": [
+            "collect_source_failures",
+            "dedupe_rule_candidates",
+            "check_conflicts_and_scope",
+            "wait_for_review_before_mutation",
+        ],
+        "evidence_not_observed": [
+            "AGENTS.md mutation",
+            "skill mutation",
+            "prompt mutation",
+            "memory write",
+            "approval",
+            "future behavior change",
+        ],
+    },
+    "codebase-onboarding": {
+        "kind": "codebase_onboarding",
+        "headline": "I can prepare a codebase onboarding pack.",
+        "body": (
+            "I will prepare the observed repo map, reading path, glossary, risks, unknowns, and first-task runway. "
+            "Setup, code edits, executor dispatch, and verification stay separate."
+        ),
+        "phase": "codebase_onboarding_prepared",
+        "next_action": "prepare_codebase_onboarding",
+        "artifact_schema": "codebase_onboarding_pack/v1",
+        "claim_boundary_suffix": "It is not code inspection completion, setup, implementation, executor dispatch, verification, or CI evidence.",
+        "actions": [
+            {"id": "prepare_codebase_onboarding", "label": "Prepare onboarding", "style": "primary"},
+            {"id": "prepare_workspace_audit", "label": "Prepare audit", "style": "secondary"},
+            {"id": "show_status", "label": "Show status", "style": "secondary"},
+        ],
+        "recommended_flow": [
+            "map_repo_surfaces",
+            "prepare_reading_path",
+            "record_glossary_risks_and_unknowns",
+            "separate_onboarding_from_first_task_execution",
+        ],
+        "evidence_not_observed": [
+            "code inspection completion",
+            "setup",
+            "implementation",
+            "executor dispatch",
+            "verification",
+            "CI",
+        ],
+    },
+    "codegraph-refresh": {
+        "kind": "codegraph_refresh",
+        "headline": "I can prepare a CodeGraph refresh without claiming an index update.",
+        "body": (
+            "I will prepare the repo root, sync/status command choice, staleness scope, file-write policy, and observed-only summary slots. "
+            "Command execution and generated files stay separate until observed."
+        ),
+        "phase": "codegraph_refresh_prepared",
+        "next_action": "prepare_codegraph_refresh",
+        "artifact_schema": "codegraph_refresh_plan/v1",
+        "claim_boundary_suffix": "It is not command execution, index sync, generated file write, code intelligence freshness, or handoff evidence.",
+        "actions": [
+            {"id": "prepare_codegraph_refresh", "label": "Refresh codegraph", "style": "primary"},
+            {"id": "prepare_command_operator_card", "label": "Prepare command card", "style": "secondary"},
+            {"id": "show_status", "label": "Show status", "style": "secondary"},
+        ],
+        "recommended_flow": [
+            "confirm_repo_root",
+            "choose_status_or_sync_command",
+            "scope_staleness_and_write_policy",
+            "record_index_result_only_after_command_evidence",
+        ],
+        "evidence_not_observed": [
+            "command execution",
+            "index sync",
+            "generated file write",
+            "code intelligence freshness",
+            "handoff evidence",
         ],
     },
     "instinct-ledger": {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2712,7 +2712,7 @@ class CliTests(unittest.TestCase):
                 stdout,
             )
             self.assertIn("Localized chat copy: 8/8 (locales 6)", stdout)
-            self.assertIn("Common request coverage: 64/64 (100.0%; target 95.0%; generic ack 15)", stdout)
+            self.assertIn("Common request coverage: 64/64 (100.0%; target 95.0%; generic ack 0)", stdout)
             self.assertIn("Hermes UX quality: 100/100 (8/8 gates)", stdout)
             self.assertIn("Local artifact store: not_written", stdout)
             self.assertFalse((omh_home / "runtime" / "release-evidence" / "index.json").exists())
@@ -2753,7 +2753,7 @@ class CliTests(unittest.TestCase):
             self.assertEqual(payload["summary"]["common_request_coverage_total"], 64)
             self.assertEqual(payload["summary"]["common_request_coverage_percent"], 100.0)
             self.assertEqual(payload["summary"]["common_request_coverage_target"], 95.0)
-            self.assertEqual(payload["summary"]["common_request_generic_ack_count"], 15)
+            self.assertEqual(payload["summary"]["common_request_generic_ack_count"], 0)
             self.assertEqual(payload["summary"]["hermes_ux_quality_score"], 100)
             self.assertEqual(payload["summary"]["hermes_ux_quality_passing_gates"], 8)
             self.assertEqual(payload["summary"]["hermes_ux_quality_total_gates"], 8)

--- a/tests/test_hermes_ux_quality.py
+++ b/tests/test_hermes_ux_quality.py
@@ -45,6 +45,7 @@ class HermesUxQualityTests(unittest.TestCase):
         self.assertEqual(payload["summary"]["common_request_passing_count"], 64)
         self.assertEqual(payload["summary"]["common_request_coverage_percent"], 100.0)
         self.assertEqual(payload["summary"]["common_request_target_percent"], 95.0)
+        self.assertEqual(payload["summary"]["common_request_generic_ack_count"], 0)
         self.assertEqual(hermes_ux_quality_errors(payload), [])
 
         gates = {gate["id"]: gate for gate in payload["gates"]}

--- a/tests/test_release_smoke.py
+++ b/tests/test_release_smoke.py
@@ -423,7 +423,7 @@ class ReleaseSmokeTests(unittest.TestCase):
             self.assertEqual(payload["summary"]["common_request_coverage_total"], 64)
             self.assertEqual(payload["summary"]["common_request_coverage_percent"], 100.0)
             self.assertEqual(payload["summary"]["common_request_coverage_target"], 95.0)
-            self.assertEqual(payload["summary"]["common_request_generic_ack_count"], 15)
+            self.assertEqual(payload["summary"]["common_request_generic_ack_count"], 0)
             self.assertEqual(payload["summary"]["hermes_ux_quality_score"], 100)
             self.assertEqual(payload["summary"]["hermes_ux_quality_passing_gates"], 8)
             self.assertEqual(payload["summary"]["hermes_ux_quality_total_gates"], 8)

--- a/tests/test_wrapper_contract.py
+++ b/tests/test_wrapper_contract.py
@@ -125,6 +125,7 @@ class WrapperContractTests(unittest.TestCase):
 
         response = payload["chat_response"]
         actions = {action["id"]: action for action in response["actions"]}
+        self.assertEqual(response["kind"], "design_quality_gate")
         self.assertEqual(response["state"]["selected_workflow"], "design-quality-gate")
         self.assertEqual(response["state"]["next_action"], "prepare_design_quality_gate")
         self.assertIn("prepare_design_quality_gate", actions)
@@ -2462,8 +2463,8 @@ class WrapperContractTests(unittest.TestCase):
                 "refresh the codegraph and prepare a handoff for routing changes",
                 "codegraph-refresh",
                 "prepare_codegraph_refresh",
-                "codegraph refresh",
-                "ack",
+                "repo root",
+                "codegraph_refresh",
             ),
             (
                 "skill-scout find existing skill candidates before creating a release-note workflow",


### PR DESCRIPTION
## Feature Report

### What Changed

- Promoted the remaining 15 common-request generic `ack` responses to dedicated wrapper card kinds.
- Added dedicated card specs for meeting brief, design quality, frontend handoff, visual QA, accessibility audit, production audit, workspace audit, verification gate, build-failure triage, agent evaluation, rules distillation, codebase onboarding, CodeGraph refresh, context budget review, and security/safety review.
- Updated the common-request coverage corpus so those cases now expect dedicated card kinds instead of generic ack.
- Updated CLI, release evidence, Hermes UX, and wrapper contract tests so the common-request gate now locks `generic ack 0`.

### Why This Exists

- PR #558 made OMH's broad common-request coverage measurable and exposed the remaining user-facing quality gap: 64/64 routed correctly, but 15 common requests still rendered as generic acknowledgements.
- The goal is not just to route ordinary Hermes-agent asks correctly, but to make them feel like first-class OMH capabilities with clear next actions and evidence boundaries.
- This keeps the 95% breadth goal honest while raising the quality bar from "covered" to "covered with dedicated cards" for the curated corpus.

### User / Operator Impact

- `omh demo common-request-coverage --summary` now reports 64/64 cases passing with `generic ack 0`.
- `omh demo hermes-ux-quality --summary` now shows common requests 64/64 and all UX/card routes with zero generic ack in the common corpus.
- Operators get more specific cards for common frontend, design, ops, safety, onboarding, and evaluation requests instead of a generic "I know which workflow should handle this" response.
- The evidence boundary remains explicit: this is deterministic local wrapper-card evidence, not live Hermes rendering, connector execution, executor dispatch, review, CI, merge, or market telemetry.

### How It Works

- `src/wrapper/contract.py` extends the existing static chat-card spec tables used by `build_chat_response_from_route` before the generic ack fallback.
- The new specs preserve existing `next_action` values and visible primary actions, so routing contracts remain stable while card kind/body/state metadata become more specific.
- `src/quality/common_request_coverage.py` updates expected `kind` values for the 15 promoted cases.
- Release and UX tests now assert the common-request generic ack count is zero.

### Files And Contracts Touched

- `src/wrapper/contract.py`: dedicated wrapper card specs and evidence boundaries.
- `src/quality/common_request_coverage.py`: expected card kinds for the curated corpus.
- `tests/test_wrapper_contract.py`: route/chat response kind contract updates.
- `tests/test_cli.py`, `tests/test_hermes_ux_quality.py`, `tests/test_release_smoke.py`: common-request `generic ack 0` rollup contract.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -q` — 1178 tests passed.
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check` — 84/84 workflow skill docs checked.
- [x] `PYTHONPATH=tests uv run python -m omh.cli harness validate` — 63 harnesses / 78 skills, ok.
- [x] `PYTHONPATH=tests uv run python -m omh.cli demo common-request-coverage --summary` — 64/64 cases, 100.0%, target 95.0% met, generic ack 0.
- [x] `PYTHONPATH=tests uv run python -m omh.cli demo hermes-ux-quality --summary` — 8/8 gates, common requests 64/64, generic ack 0.
- [x] `uv run python -m omh.cli release product-readiness --version 1.0.2 --json` — ready, score 100, blocking failures 0.
- [x] `git diff --check`
- [ ] `python3 -m unittest discover -s tests` — covered by the `uv`/`PYTHONPATH` test environment above.
- [ ] `python3 -m compileall src` — covered by `uv run python -m compileall -q src tests`.
- [ ] `python3 -m omh.cli release checklist --json` — release checklist shape covered through product readiness and release smoke tests.
- [ ] `python3 -m omh.cli release hermes-smoke` — not run; no live Hermes profile mutation was needed for this deterministic wrapper-card contract.
- [ ] `omh --help` — not run; this PR does not change top-level CLI help.
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` — not run; install/live Hermes smoke is outside this local card-polish checkpoint.
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable.
- [ ] Relevant dry-run or smoke command: see checked common-request, Hermes UX, and product-readiness commands above.
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run because this PR changes deterministic local wrapper-card contracts, not a live Hermes profile.

## Risk

- Moderate wrapper surface area: several common workflows now have dedicated card kinds, so downstream tests that expected `ack` should update to the more specific kind.
- The card specs are local prepared guidance only; they must not be described as observed workflow execution or live Hermes rendering.
- The corpus is curated local evidence, not external plugin telemetry or market-share evidence.

## Compatibility / Rollout

- Additive wrapper-card improvement; no new dependencies, network calls, Hermes core patches, connector calls, or runtime mutations.
- Existing selected workflows and next actions are preserved.
- Common-request and release evidence summaries become stricter by reporting `generic ack 0`.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`): local deterministic UX/card readiness improvement for 1.0.2 evidence.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap.

## Follow-Up

- Add rendered Hermes/TUI smoke evidence separately when a target live Hermes profile is selected.
- Continue expanding the common-request corpus when new ordinary Hermes-agent request classes appear.
