### PR TITLE
Make web visual QA routing natively absorb plugin patterns

### DIFF
--- a/src/commands/web_qa.py
+++ b/src/commands/web_qa.py
@@ -12,7 +12,14 @@ from omh.web_visual_qa import (
     validate_web_visual_qa_package,
     write_web_visual_qa_package,
 )
-from omh.workflows.web_visual_qa_contracts import JsonObject, now, object_list, text
+from omh.workflows.web_visual_qa_contracts import (
+    SUPPORTED_ATTACHMENT_STATES,
+    SUPPORTED_REDACTION_STATUSES,
+    JsonObject,
+    now,
+    object_list,
+    text,
+)
 
 from .common import _paths, _print_json, _wants_json
 
@@ -26,7 +33,22 @@ def cmd_web_qa_package(args: argparse.Namespace) -> int:
             risk_level=args.risk_level,
             estimated_cost_tier=args.estimated_cost_tier,
             criteria=[_parse_criterion(value) for value in args.criterion],
-            captures=[_parse_capture(value) for value in args.capture or []],
+            captures=[
+                _parse_capture(
+                    value,
+                    redaction_status=_require_choice(
+                        args.capture_redaction_status,
+                        SUPPORTED_REDACTION_STATUSES,
+                        "--capture-redaction-status",
+                    ),
+                    attachment=_require_choice(
+                        args.capture_attachment,
+                        SUPPORTED_ATTACHMENT_STATES,
+                        "--capture-attachment",
+                    ),
+                )
+                for value in args.capture or []
+            ],
             criteria_results=[_parse_criteria_result(value) for value in args.criteria_result or []],
             multimodal_reviews=[_parse_multimodal_review(value) for value in args.multimodal_review or []],
             verdict=args.verdict,
@@ -54,7 +76,12 @@ def cmd_web_qa_observe_capture(args: argparse.Namespace) -> int:
                     "captured_at": observed_at,
                     "evidence_summary": args.summary,
                     "observer": args.observer,
-                    "redaction_status": args.redaction_status,
+                    "redaction_status": _require_choice(
+                        args.redaction_status,
+                        SUPPORTED_REDACTION_STATUSES,
+                        "--redaction-status",
+                    ),
+                    "attachment": _require_choice(args.attachment, SUPPORTED_ATTACHMENT_STATES, "--attachment"),
                 }
             ],
             updated_at=observed_at,
@@ -131,8 +158,16 @@ def _parse_criterion(value: str) -> JsonObject:
     return {"criterion_id": criterion_id, "label": label, "pass_rule": pass_rule, "severity": severity}
 
 
-def _parse_capture(value: str) -> JsonObject:
-    capture_id, role, path, mime_type, viewport, summary = _split(value, 6, "capture")
+def _parse_capture(value: str, *, redaction_status: str = "unknown", attachment: str = "eligible") -> JsonObject:
+    head = value.split(":", 5)
+    if len(head) != 6:
+        raise ValueError("--capture must contain at least 6 colon-separated fields")
+    capture_id, role, path, mime_type, viewport = [part.strip() for part in head[:5]]
+    if any(not part for part in (capture_id, role, path, mime_type, viewport)):
+        raise ValueError("--capture must contain at least 6 colon-separated fields")
+    summary = head[5].strip()
+    if not summary:
+        raise ValueError("--capture summary is required")
     return {
         "capture_id": capture_id,
         "role": role,
@@ -140,6 +175,8 @@ def _parse_capture(value: str) -> JsonObject:
         "mime_type": mime_type,
         "viewport": viewport,
         "evidence_summary": summary,
+        "redaction_status": redaction_status,
+        "attachment": attachment,
     }
 
 
@@ -173,6 +210,13 @@ def _split(value: str, count: int, label: str) -> list[str]:
     if len(parts) != count or any(not part for part in parts):
         raise ValueError(f"--{label} must contain exactly {count} colon-separated fields")
     return parts
+
+
+def _require_choice(value: str, choices: tuple[str, ...], label: str) -> str:
+    candidate = value.strip()
+    if candidate not in choices:
+        raise ValueError(f"{label} must be one of {', '.join(choices)}")
+    return candidate
 
 
 def _print_or_summarize(args: argparse.Namespace, package: JsonObject) -> None:
@@ -232,6 +276,8 @@ def _add_web_qa_commands(sub) -> None:
     package.add_argument("--estimated-cost-tier", choices=("none", "low", "medium", "high", "unknown"), default="none")
     package.add_argument("--criterion", action="append", required=True, metavar="ID:LABEL:PASS_RULE:SEVERITY")
     package.add_argument("--capture", action="append", metavar="ID:ROLE:PATH:MIME:VIEWPORT:SUMMARY")
+    package.add_argument("--capture-redaction-status", default="unknown")
+    package.add_argument("--capture-attachment", default="eligible")
     package.add_argument("--criteria-result", action="append", metavar="CRITERION:STATUS:REFS:CHECKED_BY:SUMMARY:BLOCKING")
     package.add_argument("--multimodal-review", action="append", metavar="ID:STATUS:REVIEWER:COST:CONFIDENCE:REFS:SUMMARY")
     package.add_argument("--verdict", choices=("pass", "hold", "fail", "not_observed"), default="not_observed")
@@ -248,6 +294,7 @@ def _add_web_qa_commands(sub) -> None:
     observe.add_argument("--summary", required=True)
     observe.add_argument("--observer", default="wrapper_or_user")
     observe.add_argument("--redaction-status", default="unknown")
+    observe.add_argument("--attachment", default="eligible")
     observe.add_argument("--json", action="store_true")
     observe.set_defaults(func=cmd_web_qa_observe_capture)
 

--- a/src/workflows/web_visual_qa_contracts.py
+++ b/src/workflows/web_visual_qa_contracts.py
@@ -40,6 +40,63 @@ SUPPORTED_RISK_LEVELS: Final = ("low", "medium", "high", "critical", "unknown")
 SUPPORTED_REDACTION_STATUSES: Final = ("not_needed", "redacted", "contains_sensitive_content", "unknown")
 SUPPORTED_ATTACHMENT_STATES: Final = ("eligible", "blocked", "not_requested")
 OBSERVED_REVIEW_STATUSES: Final = ("observed", "prepared", "not_observed")
+SUPPORTED_AUTO_ROUTES: Final = (
+    "prepare_capture",
+    "redact_before_message",
+    "request_operator_review",
+    "use_observed_multimodal_review",
+    "lightweight_capture_review",
+)
+SUPPORTED_MULTIMODAL_STRATEGIES: Final = (
+    "capture_first",
+    "redact_before_multimodal_or_attachment",
+    "operator_first_due_to_risk",
+    "operator_review_due_to_cost_or_unresolved_criteria",
+    "use_observed_host_multimodal_review",
+    "operator_review_before_low_cost_multimodal",
+    "prepared_review_needs_observation",
+    "text_and_capture_review_without_model_call",
+)
+SUPPORTED_MESSAGE_DELIVERY_STATES: Final = (
+    "prepare_message_card_with_attachments",
+    "prepare_message_card_without_attachments",
+)
+SUPPORTED_ROUTING_SAFETY_FLAGS: Final = (
+    "sensitive_capture_requires_redaction",
+    "high_risk_requires_operator_review",
+    "cost_requires_operator_or_text_only_review",
+    "blocking_criteria_unresolved",
+    "no_additional_safety_flag",
+)
+SUPPORTED_SUGGESTED_ACTIONS: Final = (
+    "record_capture",
+    "record_redacted_capture",
+    "record_operator_review",
+    "record_host_multimodal_review",
+    "record_visual_qa_verdict",
+)
+PLUGIN_REWRITE_PATTERNS: Final = (
+    {
+        "id": "cost_guard_before_multimodal",
+        "source_repos": ("evey-cost-guard", "evey-delegate-model"),
+        "native_rule": "Treat multimodal review as host-supplied evidence and route by risk plus estimated cost before asking for it.",
+    },
+    {
+        "id": "explicit_action_reason_for_message_delivery",
+        "source_repos": ("hermes-tweet", "evey-verification"),
+        "native_rule": "Prepare message cards and attachment projections locally; platform upload remains a separate observed action.",
+    },
+    {
+        "id": "redaction_before_recall_or_attachment",
+        "source_repos": ("mem9-hermes-plugin", "scope-recall-hermes"),
+        "native_rule": "Never attach sensitive captures until the wrapper/user supplies redacted evidence.",
+    },
+    {
+        "id": "normalized_visual_evidence",
+        "source_repos": ("hermes-brave-search-plugin", "hermes-kagi-plugin", "yantrikdb-hermes-plugin"),
+        "native_rule": "Normalize source, capture, viewport, and review metadata before generating a shareable QA card.",
+    },
+)
 _ID_RE: Final = re.compile(r"^[A-Za-z0-9][A-Za-z0-9-]{0,120}$")
 _MIME_BY_SUFFIX: Final = {".png": "image/png", ".jpg": "image/jpeg", ".jpeg": "image/jpeg", ".webp": "image/webp"}
 
@@ -110,6 +167,7 @@ def auto_routing(
     canonical_risk = choice(risk_level, SUPPORTED_RISK_LEVELS, "unknown")
     canonical_cost = choice(estimated_cost_tier, SUPPORTED_COST_TIERS, "none")
     observed_multimodal = [item for item in multimodal_reviews if item.get("status") == "observed"]
+    prepared_multimodal = [item for item in multimodal_reviews if item.get("status") == "prepared"]
     blocking_criteria_ids = [text(item.get("criterion_id")) for item in criteria if text(item.get("severity")) == "blocking"]
     results_by_criterion = {text(item.get("criterion_id")): item for item in criteria_results}
     unresolved_blocking = [
@@ -117,31 +175,85 @@ def auto_routing(
         for criterion_id in blocking_criteria_ids
         if criterion_id not in results_by_criterion or results_by_criterion[criterion_id].get("status") != "pass"
     ]
+    sensitive_capture_count = sum(
+        1 for item in captures if text(item.get("redaction_status")) == "contains_sensitive_content"
+    )
+    attachment_eligible_count = sum(
+        1
+        for item in captures
+        if text(item.get("attachment")) == "eligible"
+        and text(item.get("redaction_status")) != "contains_sensitive_content"
+    )
+    low_cost_multimodal_possible = canonical_cost in {"none", "low"}
+    suggested_actions: list[JsonValue] = []
     route = "prepare_capture"
+    multimodal_strategy = "capture_first"
     if not captures:
         route = "prepare_capture"
+        suggested_actions.append("record_capture")
+    elif sensitive_capture_count:
+        route = "redact_before_message"
+        multimodal_strategy = "redact_before_multimodal_or_attachment"
+        suggested_actions.append("record_redacted_capture")
     elif canonical_risk in {"high", "critical"}:
         route = "request_operator_review"
+        multimodal_strategy = "operator_first_due_to_risk"
+        suggested_actions.append("record_operator_review")
     elif unresolved_blocking:
         route = "request_operator_review"
+        multimodal_strategy = (
+            "operator_review_before_low_cost_multimodal"
+            if low_cost_multimodal_possible
+            else "operator_review_due_to_cost_or_unresolved_criteria"
+        )
+        suggested_actions.append("record_operator_review")
+        if low_cost_multimodal_possible:
+            suggested_actions.append("record_host_multimodal_review")
     elif observed_multimodal:
         route = "use_observed_multimodal_review"
-    elif canonical_risk in {"medium", "unknown"} and canonical_cost in {"none", "low"}:
+        multimodal_strategy = "use_observed_host_multimodal_review"
+        suggested_actions.append("record_visual_qa_verdict")
+    elif canonical_risk in {"medium", "unknown"} and low_cost_multimodal_possible:
         route = "request_operator_review"
+        multimodal_strategy = "operator_review_before_low_cost_multimodal"
+        suggested_actions.extend(("record_operator_review", "record_host_multimodal_review"))
+    elif prepared_multimodal:
+        route = "request_operator_review"
+        multimodal_strategy = "prepared_review_needs_observation"
+        suggested_actions.append("record_operator_review")
     elif captures:
         route = "lightweight_capture_review"
+        multimodal_strategy = "text_and_capture_review_without_model_call"
+        suggested_actions.append("record_visual_qa_verdict")
     return {
         "schema_version": "web_visual_qa_auto_routing/v1",
         "route": route,
         "cost_policy": "risk_first_cost_aware_host_observed_only",
         "estimated_cost_tier": canonical_cost,
+        "multimodal_strategy": multimodal_strategy,
+        "message_delivery": (
+            "prepare_message_card_with_attachments"
+            if attachment_eligible_count and not sensitive_capture_count
+            else "prepare_message_card_without_attachments"
+        ),
+        "suggested_actions": _unique_suggested_actions(suggested_actions),
         "decision_inputs": {
             "risk_level": canonical_risk,
             "capture_count": len(captures),
+            "attachment_eligible_count": attachment_eligible_count,
+            "sensitive_capture_count": sensitive_capture_count,
             "criteria_count": len(criteria),
             "blocking_unresolved_count": len(unresolved_blocking),
             "observed_multimodal_review_count": len(observed_multimodal),
+            "prepared_multimodal_review_count": len(prepared_multimodal),
         },
+        "routing_basis": [_plugin_rewrite_pattern(item) for item in PLUGIN_REWRITE_PATTERNS],
+        "safety_flags": _safety_flags(
+            captures=captures,
+            canonical_risk=canonical_risk,
+            canonical_cost=canonical_cost,
+            unresolved_blocking=unresolved_blocking,
+        ),
         "does_not_authorize": ["model_call", "browser_launch", "platform_upload"],
     }
 
@@ -181,6 +293,49 @@ def attachment_projection(captures: list[JsonObject]) -> JsonObject:
         "blocked_items": blocked_items,
         "does_not_prove": ["platform_upload", "platform_delivery"],
     }
+
+
+def _safety_flags(
+    *,
+    captures: list[JsonObject],
+    canonical_risk: str,
+    canonical_cost: str,
+    unresolved_blocking: list[str],
+) -> list[JsonValue]:
+    flags: list[JsonValue] = []
+    if any(text(item.get("redaction_status")) == "contains_sensitive_content" for item in captures):
+        flags.append("sensitive_capture_requires_redaction")
+    if canonical_risk in {"high", "critical"}:
+        flags.append("high_risk_requires_operator_review")
+    if canonical_cost in {"medium", "high", "unknown"}:
+        flags.append("cost_requires_operator_or_text_only_review")
+    if unresolved_blocking:
+        flags.append("blocking_criteria_unresolved")
+    if not flags:
+        flags.append("no_additional_safety_flag")
+    return flags
+
+
+def _plugin_rewrite_pattern(item: Mapping[str, object]) -> JsonObject:
+    raw_sources = item.get("source_repos")
+    sources = raw_sources if isinstance(raw_sources, (list, tuple)) else ()
+    return {
+        "id": text(item.get("id")),
+        "source_repos": [text(value) for value in sources if text(value)],
+        "native_rule": text(item.get("native_rule")),
+    }
+
+
+def _unique_suggested_actions(actions: list[JsonValue]) -> list[JsonValue]:
+    seen: set[str] = set()
+    output: list[JsonValue] = []
+    for action in actions:
+        action_text = text(action)
+        if action_text not in SUPPORTED_SUGGESTED_ACTIONS or action_text in seen:
+            continue
+        seen.add(action_text)
+        output.append(action_text)
+    return output
 
 
 def lifecycle_status(captures: list[JsonObject], criteria_results: list[JsonObject], verdict: str) -> str:

--- a/src/workflows/web_visual_qa_message_card.py
+++ b/src/workflows/web_visual_qa_message_card.py
@@ -63,7 +63,12 @@ def _route_summary(routing: JsonObject) -> JsonObject:
         "reason": reason,
         "cost_policy": text(routing.get("cost_policy")),
         "estimated_cost_tier": text(routing.get("estimated_cost_tier")) or "unknown",
+        "multimodal_strategy": text(routing.get("multimodal_strategy")),
+        "message_delivery": text(routing.get("message_delivery")),
         "decision_inputs": decision_inputs,
+        "safety_flags": _strings(routing.get("safety_flags")),
+        "suggested_actions": _strings(routing.get("suggested_actions")),
+        "routing_basis": _routing_basis_cards(routing),
     }
 
 
@@ -71,8 +76,18 @@ def _route_copy(route: str) -> tuple[str, str, str]:
     match route:
         case "prepare_capture":
             return ("Capture needed", "record_capture", "No screenshot or visual capture evidence is recorded yet.")
+        case "redact_before_message":
+            return (
+                "Redaction required",
+                "record_redacted_capture",
+                "At least one capture is marked sensitive, so attachment and multimodal review must wait.",
+            )
         case "request_operator_review":
-            return ("Operator review required", "record_operator_review", "Risk, unresolved criteria, or low-cost review policy requires human/host review.")
+            return (
+                "Operator review required",
+                "record_operator_review",
+                "Risk, unresolved criteria, sensitivity, or cost policy requires human/host review.",
+            )
         case "use_observed_multimodal_review":
             return ("Use observed multimodal review", "record_visual_qa_verdict", "A host-supplied multimodal review exists after risk and blocking gates.")
         case "lightweight_capture_review":
@@ -158,6 +173,7 @@ def _message_blocks(
     blocks: list[JsonValue] = [
         {"type": "header", "text": headline},
         {"type": "section", "text": f"Route: {text(route.get('label'))}. Next action: {text(route.get('next_action'))}."},
+        {"type": "section", "text": _route_detail_text(route)},
         {"type": "section", "text": _criteria_text(criteria)},
         {"type": "section", "text": _attachment_text(attachment_summary)},
         {"type": "section", "text": _multimodal_text(multimodal)},
@@ -185,6 +201,39 @@ def _attachment_text(summary: JsonObject) -> str:
 
 def _multimodal_text(summary: JsonObject) -> str:
     return f"Multimodal review: {summary['observed_count']} observed of {summary['review_count']} recorded"
+
+
+def _route_detail_text(route: JsonObject) -> str:
+    details = [
+        f"Reason: {text(route.get('reason'))}",
+        f"Multimodal strategy: {text(route.get('multimodal_strategy')) or 'not specified'}",
+        f"Message delivery: {text(route.get('message_delivery')) or 'not specified'}",
+    ]
+    safety_flags = _strings(route.get("safety_flags"))
+    if safety_flags:
+        details.append(f"Safety flags: {', '.join(safety_flags)}")
+    suggested_actions = _strings(route.get("suggested_actions"))
+    if suggested_actions:
+        details.append(f"Suggested actions: {', '.join(suggested_actions)}")
+    basis = object_list(route.get("routing_basis"))
+    if basis:
+        basis_ids = [text(item.get("id")) for item in basis[:4] if text(item.get("id"))]
+        if basis_ids:
+            details.append(f"Native rewrite basis: {', '.join(basis_ids)}")
+    return "\n".join(details)
+
+
+def _routing_basis_cards(routing: JsonObject) -> list[JsonValue]:
+    cards: list[JsonValue] = []
+    for item in object_list(routing.get("routing_basis")):
+        cards.append(
+            {
+                "id": text(item.get("id")),
+                "source_repos": _strings(item.get("source_repos")),
+                "native_rule": text(item.get("native_rule")),
+            }
+        )
+    return cards
 
 
 def _does_not_prove(package: JsonObject) -> list[JsonValue]:

--- a/src/workflows/web_visual_qa_validation.py
+++ b/src/workflows/web_visual_qa_validation.py
@@ -2,6 +2,12 @@ from __future__ import annotations
 
 from .web_visual_qa_contracts import (
     MESSAGE_ATTACHMENT_PROJECTION_SCHEMA_VERSION,
+    PLUGIN_REWRITE_PATTERNS,
+    SUPPORTED_AUTO_ROUTES,
+    SUPPORTED_MESSAGE_DELIVERY_STATES,
+    SUPPORTED_MULTIMODAL_STRATEGIES,
+    SUPPORTED_ROUTING_SAFETY_FLAGS,
+    SUPPORTED_SUGGESTED_ACTIONS,
     SUPPORTED_IMAGE_MIME_TYPES,
     SUPPORTED_LIFECYCLE_STATUSES,
     SUPPORTED_REDACTION_STATUSES,
@@ -165,14 +171,37 @@ def _validate_message_route(raw_route: JsonValue | None, errors: list[str]) -> N
     route = object_value(raw_route)
     if route.get("schema_version") != WEB_VISUAL_QA_MESSAGE_ROUTE_SCHEMA_VERSION:
         errors.append("route.schema_version must be web_visual_qa_message_route/v1")
-    if not text(route.get("route")):
-        errors.append("route.route is required")
+    if text(route.get("route")) not in SUPPORTED_AUTO_ROUTES:
+        errors.append("route.route is unsupported")
     if not text(route.get("label")):
         errors.append("route.label is required")
     if not text(route.get("next_action")):
         errors.append("route.next_action is required")
     if not text(route.get("reason")):
         errors.append("route.reason is required")
+    if text(route.get("multimodal_strategy")) not in SUPPORTED_MULTIMODAL_STRATEGIES:
+        errors.append("route.multimodal_strategy is unsupported")
+    if text(route.get("message_delivery")) not in SUPPORTED_MESSAGE_DELIVERY_STATES:
+        errors.append("route.message_delivery is unsupported")
+    for index, flag in enumerate(strings(route.get("safety_flags"))):
+        if flag not in SUPPORTED_ROUTING_SAFETY_FLAGS:
+            errors.append(f"route.safety_flags[{index}] is unsupported")
+    for index, action in enumerate(strings(route.get("suggested_actions"))):
+        if action not in SUPPORTED_SUGGESTED_ACTIONS:
+            errors.append(f"route.suggested_actions[{index}] is unsupported")
+    _validate_routing_basis(object_list(route.get("routing_basis")), errors)
+
+
+def _validate_routing_basis(items: list[JsonObject], errors: list[str]) -> None:
+    allowed_ids = {text(item.get("id")) for item in PLUGIN_REWRITE_PATTERNS}
+    for index, item in enumerate(items):
+        item_id = text(item.get("id"))
+        if item_id not in allowed_ids:
+            errors.append(f"route.routing_basis[{index}].id is unsupported")
+        if not strings(item.get("source_repos")):
+            errors.append(f"route.routing_basis[{index}].source_repos must list source repo ids")
+        if not text(item.get("native_rule")):
+            errors.append(f"route.routing_basis[{index}].native_rule is required")
 
 
 def _validate_card_attachment_summary(raw_summary: JsonValue | None, errors: list[str]) -> None:

--- a/tests/test_web_visual_qa_message_card.py
+++ b/tests/test_web_visual_qa_message_card.py
@@ -51,6 +51,106 @@ class WebVisualQaMessageCardTests(unittest.TestCase):
         self.assertIn("attachment_summary.schema_version must be message_attachment_projection/v1", errors)
         self.assertIn("does_not_prove must include platform_delivery", errors)
 
+    def test_message_card_validation_rejects_overclaiming_route_fields(self) -> None:
+        card = build_web_visual_qa_message_card(_reviewed_package("/tmp/desktop.png"))
+        card["route"]["message_delivery"] = "sent_to_discord"
+        card["route"]["multimodal_strategy"] = "called_omh_model"
+        card["route"]["safety_flags"] = ["uploaded_attachment"]
+        card["route"]["suggested_actions"] = ["platform_delivery_observed"]
+        card["route"]["routing_basis"] = [
+            {
+                "id": "external-plugin-runtime",
+                "source_repos": ["unknown"],
+                "native_rule": "Loaded an external plugin.",
+            }
+        ]
+
+        errors = validate_web_visual_qa_message_card(card)
+
+        self.assertIn("route.message_delivery is unsupported", errors)
+        self.assertIn("route.multimodal_strategy is unsupported", errors)
+        self.assertIn("route.safety_flags[0] is unsupported", errors)
+        self.assertIn("route.suggested_actions[0] is unsupported", errors)
+        self.assertIn("route.routing_basis[0].id is unsupported", errors)
+
+    def test_low_cost_unresolved_capture_keeps_operator_route_with_multimodal_suggestion(self) -> None:
+        package = build_web_visual_qa_package(
+            package_id="checkout-qa",
+            target="Checkout page",
+            source="discord",
+            risk_level="medium",
+            estimated_cost_tier="low",
+            criteria=[
+                {
+                    "criterion_id": "layout",
+                    "label": "Layout fits",
+                    "pass_rule": "No overlap",
+                    "severity": "blocking",
+                }
+            ],
+            captures=[
+                {
+                    "capture_id": "desktop",
+                    "role": "desktop",
+                    "path_or_uri": "/tmp/desktop.png",
+                    "mime_type": "image/png",
+                    "viewport": "desktop-1440",
+                    "evidence_summary": "Desktop checkout viewport captured.",
+                    "redaction_status": "not_needed",
+                }
+            ],
+        )
+
+        card = build_web_visual_qa_message_card(package)
+
+        self.assertEqual(package["routing"]["route"], "request_operator_review")
+        self.assertEqual(package["routing"]["multimodal_strategy"], "operator_review_before_low_cost_multimodal")
+        self.assertIn("record_host_multimodal_review", package["routing"]["suggested_actions"])
+        self.assertIn("model_call", package["routing"]["does_not_authorize"])
+        self.assertEqual(card["route"]["label"], "Operator review required")
+        self.assertEqual(card["route"]["message_delivery"], "prepare_message_card_with_attachments")
+        self.assertIn("record_host_multimodal_review", card["route"]["suggested_actions"])
+        self.assertTrue(any("Native rewrite basis" in block["text"] for block in card["message_blocks"]))
+        self.assertEqual(validate_web_visual_qa_message_card(card), [])
+
+    def test_sensitive_capture_is_blocked_from_message_attachments(self) -> None:
+        package = build_web_visual_qa_package(
+            package_id="checkout-qa",
+            target="Checkout page",
+            source="discord",
+            risk_level="low",
+            estimated_cost_tier="low",
+            criteria=[
+                {
+                    "criterion_id": "layout",
+                    "label": "Layout fits",
+                    "pass_rule": "No overlap",
+                    "severity": "blocking",
+                }
+            ],
+            captures=[
+                {
+                    "capture_id": "desktop",
+                    "role": "desktop",
+                    "path_or_uri": "/tmp/desktop.png",
+                    "mime_type": "image/png",
+                    "viewport": "desktop-1440",
+                    "evidence_summary": "Desktop checkout viewport captured with account details visible.",
+                    "redaction_status": "contains_sensitive_content",
+                }
+            ],
+        )
+
+        card = build_web_visual_qa_message_card(package)
+
+        self.assertEqual(package["routing"]["route"], "redact_before_message")
+        self.assertEqual(package["routing"]["message_delivery"], "prepare_message_card_without_attachments")
+        self.assertEqual(card["route"]["label"], "Redaction required")
+        self.assertEqual(card["attachment_summary"]["eligible_count"], 0)
+        self.assertEqual(card["attachment_summary"]["blocked_count"], 1)
+        self.assertIn("sensitive_capture_requires_redaction", card["route"]["safety_flags"])
+        self.assertEqual(validate_web_visual_qa_message_card(card), [])
+
     def test_facade_exports_only_stable_web_qa_contract_symbols(self) -> None:
         self.assertIn("build_web_visual_qa_message_card", web_visual_qa_facade.__all__)
         self.assertIn("validate_web_visual_qa_message_card", web_visual_qa_facade.__all__)
@@ -110,6 +210,105 @@ class WebVisualQaMessageCardTests(unittest.TestCase):
             self.assertIn("Attachments: 1 eligible, 0 blocked; delivery not observed", stdout)
             self.assertIn("Layout fits: hold - Desktop captured; mobile still needs review", stdout)
             self.assertIn("Boundary:", stdout)
+
+    def test_package_command_accepts_redaction_and_attachment_capture_fields(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            capture_path = root / "desktop.png"
+            base = ["--omh-home", str(root / ".omh"), "web-qa"]
+
+            status, stdout, stderr = run_cli(
+                base
+                + [
+                    "package",
+                    "--package-id",
+                    "checkout-qa",
+                    "--target",
+                    "Checkout page",
+                    "--source",
+                    "discord",
+                    "--risk-level",
+                    "low",
+                    "--estimated-cost-tier",
+                    "low",
+                    "--criterion",
+                    "layout:Layout fits:No overlap:blocking",
+                    "--capture",
+                    f"desktop:desktop:{capture_path}:image/png:desktop-1440:Desktop checkout viewport captured.",
+                    "--capture-redaction-status",
+                    "contains_sensitive_content",
+                    "--capture-attachment",
+                    "eligible",
+                    "--json",
+                ]
+            )
+
+            self.assertEqual(status, 0, stderr)
+            package = json.loads(stdout)
+            self.assertEqual(package["captures"][0]["redaction_status"], "contains_sensitive_content")
+            self.assertEqual(package["captures"][0]["attachment"], "eligible")
+            self.assertEqual(package["routing"]["route"], "redact_before_message")
+
+    def test_package_command_preserves_colons_and_enum_words_in_capture_summary(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            capture_path = root / "desktop.png"
+            base = ["--omh-home", str(root / ".omh"), "web-qa"]
+
+            status, stdout, stderr = run_cli(
+                base
+                + [
+                    "package",
+                    "--package-id",
+                    "checkout-qa",
+                    "--target",
+                    "Checkout page",
+                    "--criterion",
+                    "layout:Layout fits:No overlap:blocking",
+                    "--capture",
+                    (
+                        f"desktop:desktop:{capture_path}:image/png:desktop-1440:"
+                        "Status: checkout still overlaps:redacted:eligible"
+                    ),
+                    "--json",
+                ]
+            )
+
+            self.assertEqual(status, 0, stderr)
+            package = json.loads(stdout)
+            self.assertEqual(package["captures"][0]["evidence_summary"], "Status: checkout still overlaps:redacted:eligible")
+            self.assertEqual(package["captures"][0]["redaction_status"], "unknown")
+            self.assertEqual(package["captures"][0]["attachment"], "eligible")
+
+    def test_package_command_rejects_malformed_capture_metadata_flags(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            capture_path = root / "desktop.png"
+            base = ["--omh-home", str(root / ".omh"), "web-qa"]
+
+            status, stdout, stderr = run_cli(
+                base
+                + [
+                    "package",
+                    "--package-id",
+                    "checkout-qa",
+                    "--target",
+                    "Checkout page",
+                    "--criterion",
+                    "layout:Layout fits:No overlap:blocking",
+                    "--capture",
+                    f"desktop:desktop:{capture_path}:image/png:desktop-1440:Desktop checkout viewport captured.",
+                    "--capture-redaction-status",
+                    "contains_sensitive_content",
+                    "--capture-attachment",
+                    "eligble",
+                    "--json",
+                ]
+            )
+
+            self.assertEqual(status, 2)
+            self.assertEqual(stdout, "")
+            self.assertIn("--capture-attachment must be one of eligible, blocked, not_requested", stderr)
 
     def test_show_command_rejects_stale_package_with_sensitive_attachment_projection(self) -> None:
         with TemporaryDirectory() as tmp:


### PR DESCRIPTION
## What changed

This PR turns the public Hermes plugin audit into an OMH-native web visual QA capability instead of depending on any external plugin code.

The `web-qa` package/show flow now produces richer Discord/Slack-style message-card metadata for screenshot-backed QA packages:

- cost/risk-aware auto-routing for prepared operator review, host-supplied multimodal review, and sensitive capture handling;
- explicit multimodal strategy and message delivery state fields;
- attachment eligibility/redaction metadata for supplied screenshots;
- suggested next actions such as recording a host multimodal review or redacting before message delivery;
- native rewrite-basis metadata that records which audited plugin pattern shaped the local rule, without importing or executing those plugins;
- schema validation that rejects overclaimed routes, delivery states, actions, or plugin-basis IDs.

## Why

The user wanted OMH to learn from the practical Hermes plugin ecosystem, especially visual QA flows that can capture screenshots and send understandable status cards through message UIs. The correction was important: OMH should not depend on those plugin repositories. It should inspect their behavior and rewrite the useful ideas into OMH's own local contracts.

This closes that product gap while preserving OMH's prepared-versus-observed boundary: package/show can describe supplied evidence and recommended next actions, but it does not claim a browser capture, model call, Discord upload, Slack upload, or external plugin execution unless that evidence is actually recorded elsewhere.

## User/operator capability

After this change an operator can prepare a web QA package with screenshots and get a clearer message-card surface that answers:

- whether the current evidence is enough for operator review;
- whether a low-cost multimodal review should be recorded by the host;
- whether screenshot attachments are eligible or must be redacted first;
- what safety/cost flags drove the route;
- which native rule family came from the external plugin audit.

The CLI also has explicit capture metadata flags:

- `--capture-redaction-status`
- `--capture-attachment`

Those replace ambiguous optional suffix parsing on `--capture`, so human summaries containing colons or words like `redacted:eligible` remain intact.

## Implementation notes

- `src/workflows/web_visual_qa_contracts.py` adds native route vocabularies, multimodal/message-delivery fields, safety flags, suggested actions, and audited-pattern metadata.
- `src/workflows/web_visual_qa_message_card.py` renders those route decisions in the message-card summary and blocks, including sensitive-redaction guidance.
- `src/workflows/web_visual_qa_validation.py` locks the public schema so future cards cannot invent values like `sent_to_discord` or `called_omh_model`.
- `src/commands/web_qa.py` keeps `--capture` positional metadata unambiguous and adds explicit package/capture metadata flags.
- `tests/test_web_visual_qa_message_card.py` covers unresolved blocking criteria, sensitive captures, schema rejection, and summary-preserving CLI parsing.

## Verification observed

- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — 1266 tests passed.
- `PYTHONPATH=tests uv run python -m unittest tests/test_web_visual_qa_message_card.py tests/test_web_visual_qa.py -v` — passed.
- `PYTHONPATH=tests uv run python -m unittest tests/test_cli.py -v` — passed.
- `uv run python -m compileall -q src tests` — passed.
- `uv run python -m omh.cli docs workflows --check` — passed.
- `git diff --check` — passed.
- Manual `omh web-qa package/show` redaction smoke confirmed sensitive captures route to `redact_before_message`, block message attachments, and preserve colon-heavy evidence summaries.

## Risks and boundaries

This is a local metadata/message-card capability. It intentionally does not perform live browser screenshot capture, live multimodal model calls, or live Discord/Slack uploads. Those remain host/runtime responsibilities that must be observed and recorded separately before OMH can claim them as done.
