### PR TITLE
Add managed web QA capture imports

### DIFF
--- a/src/commands/web_qa.py
+++ b/src/commands/web_qa.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 import argparse
+from pathlib import Path
 
 from omh.installer import OmhError
 from omh.web_visual_qa import (
+    WebVisualQaCaptureFileImport,
     build_web_visual_qa_message_card,
     build_web_visual_qa_package,
+    import_web_visual_qa_capture_file,
     read_web_visual_qa_package,
     save_web_visual_qa_package,
     validate_web_visual_qa_message_card,
@@ -87,6 +90,35 @@ def cmd_web_qa_observe_capture(args: argparse.Namespace) -> int:
             updated_at=observed_at,
         )
         saved = save_web_visual_qa_package(_paths(args), updated)
+    except (OSError, ValueError) as exc:
+        raise OmhError(str(exc)) from exc
+    _print_or_summarize(args, saved)
+    return 0
+
+
+def cmd_web_qa_capture_file(args: argparse.Namespace) -> int:
+    try:
+        request = WebVisualQaCaptureFileImport(
+            package_id=args.package_id,
+            capture_id=args.capture_id,
+            source_path=Path(args.source_path),
+            role=args.role,
+            viewport=args.viewport,
+            summary=args.summary,
+            observer=args.observer,
+            redaction_status=_require_choice(
+                args.redaction_status,
+                SUPPORTED_REDACTION_STATUSES,
+                "--redaction-status",
+            ),
+            attachment=_require_choice(
+                args.attachment,
+                SUPPORTED_ATTACHMENT_STATES,
+                "--attachment",
+            ),
+            mime_type=args.mime_type,
+        )
+        saved = import_web_visual_qa_capture_file(_paths(args), request)
     except (OSError, ValueError) as exc:
         raise OmhError(str(exc)) from exc
     _print_or_summarize(args, saved)
@@ -284,6 +316,23 @@ def _add_web_qa_commands(sub) -> None:
     package.add_argument("--json", action="store_true")
     package.set_defaults(func=cmd_web_qa_package)
 
+    capture_file = web_qa_sub.add_parser(
+        "capture-file",
+        help="Copy a local screenshot/image into OMH capture storage and attach it to a package.",
+    )
+    capture_file.add_argument("--package-id", required=True)
+    capture_file.add_argument("--capture-id", required=True)
+    capture_file.add_argument("--source-path", required=True)
+    capture_file.add_argument("--role", default="current")
+    capture_file.add_argument("--mime-type", default="")
+    capture_file.add_argument("--viewport", default="unspecified")
+    capture_file.add_argument("--summary", required=True)
+    capture_file.add_argument("--observer", default="wrapper_or_user")
+    capture_file.add_argument("--redaction-status", default="unknown")
+    capture_file.add_argument("--attachment", default="eligible")
+    capture_file.add_argument("--json", action="store_true")
+    capture_file.set_defaults(func=cmd_web_qa_capture_file)
+
     observe = web_qa_sub.add_parser("observe-capture", help="Add supplied screenshot/capture metadata to a package.")
     observe.add_argument("--package-id", required=True)
     observe.add_argument("--capture-id", required=True)
@@ -315,6 +364,7 @@ def _add_web_qa_commands(sub) -> None:
 __all__ = [
     "_add_web_qa_commands",
     "cmd_web_qa_observe_capture",
+    "cmd_web_qa_capture_file",
     "cmd_web_qa_package",
     "cmd_web_qa_record_verdict",
     "cmd_web_qa_show",

--- a/src/omh/web_visual_qa.py
+++ b/src/omh/web_visual_qa.py
@@ -7,6 +7,10 @@ from .workflows.web_visual_qa import (
     save_web_visual_qa_package,
     write_web_visual_qa_package,
 )
+from .workflows.web_visual_qa_captures import (
+    WebVisualQaCaptureFileImport,
+    import_web_visual_qa_capture_file,
+)
 from .workflows.web_visual_qa_contracts import (
     MESSAGE_ATTACHMENT_PROJECTION_SCHEMA_VERSION,
     WEB_VISUAL_QA_MESSAGE_CARD_SCHEMA_VERSION,
@@ -22,8 +26,10 @@ __all__ = (
     "MESSAGE_ATTACHMENT_PROJECTION_SCHEMA_VERSION",
     "WEB_VISUAL_QA_MESSAGE_CARD_SCHEMA_VERSION",
     "WEB_VISUAL_QA_PACKAGE_SCHEMA_VERSION",
+    "WebVisualQaCaptureFileImport",
     "build_web_visual_qa_message_card",
     "build_web_visual_qa_package",
+    "import_web_visual_qa_capture_file",
     "list_web_visual_qa_packages",
     "read_web_visual_qa_package",
     "save_web_visual_qa_package",

--- a/src/workflows/web_visual_qa_captures.py
+++ b/src/workflows/web_visual_qa_captures.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from pathlib import Path
+
+from omh.local_store import ensure_dir
+from omh.paths import OmhPaths
+
+from .web_visual_qa import (
+    build_web_visual_qa_package,
+    read_web_visual_qa_package,
+    save_web_visual_qa_package,
+)
+from .web_visual_qa_contracts import (
+    SUPPORTED_IMAGE_MIME_TYPES,
+    JsonObject,
+    ids,
+    now,
+    object_list,
+    text,
+    valid_id,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class WebVisualQaCaptureFileImport:
+    package_id: str
+    capture_id: str
+    source_path: Path
+    role: str
+    viewport: str
+    summary: str
+    observer: str
+    redaction_status: str
+    attachment: str
+    mime_type: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class _ManagedCaptureTarget:
+    package_id: str
+    capture_id: str
+    mime_type: str
+
+
+def import_web_visual_qa_capture_file(paths: OmhPaths, request: WebVisualQaCaptureFileImport) -> JsonObject:
+    current = read_web_visual_qa_package(paths, request.package_id)
+    capture_id = request.capture_id.strip()
+    if not valid_id(capture_id):
+        raise ValueError("capture_id must contain only letters, digits, and hyphens")
+    if capture_id in ids(object_list(current.get("captures")), "capture_id"):
+        raise ValueError(f"web visual QA capture already exists: {capture_id}")
+    source_path = request.source_path.expanduser()
+    if not source_path.is_file():
+        raise ValueError("--source-path must reference an existing local file")
+    data = source_path.read_bytes()
+    detected_mime = _capture_mime_from_bytes(data)
+    if not detected_mime:
+        raise ValueError("--source-path must contain PNG, JPEG, or WebP image bytes")
+    supplied_mime = request.mime_type.strip().lower()
+    if supplied_mime and supplied_mime not in SUPPORTED_IMAGE_MIME_TYPES:
+        raise ValueError(f"--mime-type must be one of {', '.join(SUPPORTED_IMAGE_MIME_TYPES)}")
+    if supplied_mime and supplied_mime != detected_mime:
+        raise ValueError("--mime-type must match the detected image bytes")
+    observed_at = now()
+    package_id = text(current.get("package_id"))
+    destination = _managed_capture_path(
+        paths,
+        _ManagedCaptureTarget(package_id=package_id, capture_id=capture_id, mime_type=detected_mime),
+    )
+    _write_capture_bytes(destination, data)
+    updated = build_web_visual_qa_package(
+        package_id=package_id,
+        target=text(current.get("target")),
+        source=text(current.get("source")) or "generic",
+        risk_level=text(current.get("risk_level")) or "unknown",
+        estimated_cost_tier=text(current.get("estimated_cost_tier")) or "none",
+        criteria=object_list(current.get("criteria")),
+        captures=object_list(current.get("captures"))
+        + [
+            {
+                "capture_id": capture_id,
+                "role": request.role.strip() or "current",
+                "path_or_uri": str(destination),
+                "mime_type": detected_mime,
+                "viewport": request.viewport.strip() or "unspecified",
+                "captured_at": observed_at,
+                "evidence_summary": request.summary.strip(),
+                "observer": request.observer.strip() or "wrapper_or_user",
+                "redaction_status": request.redaction_status,
+                "attachment": request.attachment,
+                "capture_origin": "imported_local_file",
+                "byte_size": len(data),
+                "sha256": hashlib.sha256(data).hexdigest(),
+            }
+        ],
+        criteria_results=object_list(current.get("criteria_results")),
+        multimodal_reviews=object_list(current.get("multimodal_reviews")),
+        interaction_traces=object_list(current.get("interaction_traces")),
+        verdict=text(current.get("verdict")) or "not_observed",
+        created_at=text(current.get("created_at")),
+        updated_at=observed_at,
+    )
+    return save_web_visual_qa_package(paths, updated)
+
+
+def _managed_capture_path(paths: OmhPaths, target: _ManagedCaptureTarget) -> Path:
+    extension = _capture_extension(target.mime_type)
+    directory = paths.web_visual_qa_dir / "captures" / target.package_id
+    destination = directory / f"{target.capture_id}{extension}"
+    root = directory.resolve()
+    resolved = destination.resolve()
+    if resolved.parent != root:
+        raise ValueError("capture_id escapes web visual QA capture storage")
+    if resolved.exists():
+        raise ValueError(f"managed web visual QA capture already exists: {target.capture_id}")
+    return resolved
+
+
+def _write_capture_bytes(path: Path, data: bytes) -> None:
+    ensure_dir(path.parent, private=True)
+    tmp = path.with_name(f".{path.name}.tmp")
+    try:
+        tmp.write_bytes(data)
+        tmp.chmod(0o600)
+        tmp.replace(path)
+        path.chmod(0o600)
+    except OSError:
+        if tmp.exists():
+            tmp.unlink()
+        raise
+
+
+def _capture_mime_from_bytes(data: bytes) -> str:
+    if data.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "image/png"
+    if data.startswith(b"\xff\xd8\xff"):
+        return "image/jpeg"
+    if len(data) >= 12 and data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+        return "image/webp"
+    return ""
+
+
+def _capture_extension(mime_type: str) -> str:
+    match mime_type:
+        case "image/png":
+            return ".png"
+        case "image/jpeg":
+            return ".jpg"
+        case "image/webp":
+            return ".webp"
+        case _:
+            raise ValueError(f"unsupported image MIME type: {mime_type}")

--- a/src/workflows/web_visual_qa_captures.py
+++ b/src/workflows/web_visual_qa_captures.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import hashlib
+from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
 
-from omh.local_store import ensure_dir
 from omh.paths import OmhPaths
 
 from .web_visual_qa import (
@@ -21,6 +21,10 @@ from .web_visual_qa_contracts import (
     text,
     valid_id,
 )
+from .web_visual_qa_validation import validate_web_visual_qa_package
+
+
+MAX_CAPTURE_FILE_BYTES = 25 * 1024 * 1024
 
 
 @dataclass(frozen=True, slots=True)
@@ -54,6 +58,9 @@ def import_web_visual_qa_capture_file(paths: OmhPaths, request: WebVisualQaCaptu
     source_path = request.source_path.expanduser()
     if not source_path.is_file():
         raise ValueError("--source-path must reference an existing local file")
+    source_size = source_path.stat().st_size
+    if source_size > MAX_CAPTURE_FILE_BYTES:
+        raise ValueError("--source-path must be 25 MiB or smaller")
     data = source_path.read_bytes()
     detected_mime = _capture_mime_from_bytes(data)
     if not detected_mime:
@@ -69,7 +76,6 @@ def import_web_visual_qa_capture_file(paths: OmhPaths, request: WebVisualQaCaptu
         paths,
         _ManagedCaptureTarget(package_id=package_id, capture_id=capture_id, mime_type=detected_mime),
     )
-    _write_capture_bytes(destination, data)
     updated = build_web_visual_qa_package(
         package_id=package_id,
         target=text(current.get("target")),
@@ -102,27 +108,49 @@ def import_web_visual_qa_capture_file(paths: OmhPaths, request: WebVisualQaCaptu
         created_at=text(current.get("created_at")),
         updated_at=observed_at,
     )
-    return save_web_visual_qa_package(paths, updated)
+    errors = validate_web_visual_qa_package(updated)
+    if errors:
+        raise ValueError("; ".join(errors))
+    _write_capture_bytes(destination, data)
+    try:
+        return save_web_visual_qa_package(paths, updated)
+    except (OSError, ValueError):
+        _remove_unreferenced_capture(paths, package_id, destination)
+        raise
 
 
 def _managed_capture_path(paths: OmhPaths, target: _ManagedCaptureTarget) -> Path:
     extension = _capture_extension(target.mime_type)
-    directory = paths.web_visual_qa_dir / "captures" / target.package_id
+    root = paths.web_visual_qa_dir / "captures"
+    if root.is_symlink():
+        raise ValueError("web visual QA capture storage must not be a symlink")
+    _ensure_private_real_directory(root)
+    root_resolved = root.resolve()
+    directory = root / target.package_id
+    if directory.is_symlink():
+        raise ValueError("web visual QA package capture storage must not be a symlink")
+    directory_resolved = directory.resolve(strict=False)
+    if directory_resolved.parent != root_resolved:
+        raise ValueError("package_id escapes web visual QA capture storage")
     destination = directory / f"{target.capture_id}{extension}"
-    root = directory.resolve()
-    resolved = destination.resolve()
-    if resolved.parent != root:
+    if destination.is_symlink():
+        raise ValueError("managed web visual QA capture path must not be a symlink")
+    resolved = destination.resolve(strict=False)
+    if resolved.parent != directory_resolved:
         raise ValueError("capture_id escapes web visual QA capture storage")
-    if resolved.exists():
+    if destination.exists():
         raise ValueError(f"managed web visual QA capture already exists: {target.capture_id}")
-    return resolved
+    return destination
 
 
 def _write_capture_bytes(path: Path, data: bytes) -> None:
-    ensure_dir(path.parent, private=True)
+    _ensure_private_real_directory(path.parent)
     tmp = path.with_name(f".{path.name}.tmp")
+    if tmp.exists() or tmp.is_symlink():
+        raise ValueError("managed web visual QA capture temp path already exists")
     try:
-        tmp.write_bytes(data)
+        with tmp.open("xb") as handle:
+            handle.write(data)
         tmp.chmod(0o600)
         tmp.replace(path)
         path.chmod(0o600)
@@ -130,6 +158,31 @@ def _write_capture_bytes(path: Path, data: bytes) -> None:
         if tmp.exists():
             tmp.unlink()
         raise
+
+
+def _ensure_private_real_directory(path: Path) -> None:
+    if path.is_symlink():
+        raise ValueError("web visual QA capture storage must not be a symlink")
+    try:
+        path.mkdir(parents=True, mode=0o700)
+    except FileExistsError:
+        pass
+    if path.is_symlink() or not path.is_dir():
+        raise ValueError("web visual QA capture storage must be a directory")
+    path.chmod(0o700)
+
+
+def _remove_unreferenced_capture(paths: OmhPaths, package_id: str, path: Path) -> None:
+    try:
+        saved = read_web_visual_qa_package(paths, package_id)
+    except ValueError:
+        saved = {}
+    for capture in object_list(saved.get("captures")):
+        if text(capture.get("path_or_uri")) == str(path):
+            return
+    if path.exists() and not path.is_symlink():
+        with suppress(OSError):
+            path.unlink()
 
 
 def _capture_mime_from_bytes(data: bytes) -> str:

--- a/src/workflows/web_visual_qa_contracts.py
+++ b/src/workflows/web_visual_qa_contracts.py
@@ -39,6 +39,7 @@ SUPPORTED_CONFIDENCE: Final = ("low", "medium", "high", "unknown")
 SUPPORTED_RISK_LEVELS: Final = ("low", "medium", "high", "critical", "unknown")
 SUPPORTED_REDACTION_STATUSES: Final = ("not_needed", "redacted", "contains_sensitive_content", "unknown")
 SUPPORTED_ATTACHMENT_STATES: Final = ("eligible", "blocked", "not_requested")
+SUPPORTED_CAPTURE_ORIGINS: Final = ("supplied_metadata", "imported_local_file")
 OBSERVED_REVIEW_STATUSES: Final = ("observed", "prepared", "not_observed")
 SUPPORTED_AUTO_ROUTES: Final = (
     "prepare_capture",
@@ -98,6 +99,7 @@ PLUGIN_REWRITE_PATTERNS: Final = (
     },
 )
 _ID_RE: Final = re.compile(r"^[A-Za-z0-9][A-Za-z0-9-]{0,120}$")
+_SHA256_RE: Final = re.compile(r"^[a-f0-9]{64}$")
 _MIME_BY_SUFFIX: Final = {".png": "image/png", ".jpg": "image/jpeg", ".jpeg": "image/jpeg", ".webp": "image/webp"}
 
 
@@ -116,6 +118,9 @@ def capture_record(item: Mapping[str, JsonValue], index: int, now: str) -> JsonO
         "evidence_summary": text(record.get("evidence_summary")),
         "redaction_status": choice(text(record.get("redaction_status")), SUPPORTED_REDACTION_STATUSES, "unknown"),
         "attachment": choice(text(record.get("attachment")), SUPPORTED_ATTACHMENT_STATES, "eligible"),
+        "capture_origin": choice(text(record.get("capture_origin")), SUPPORTED_CAPTURE_ORIGINS, "supplied_metadata"),
+        "byte_size": optional_non_negative_int(record.get("byte_size")),
+        "sha256": text(record.get("sha256")),
     }
 
 
@@ -283,6 +288,9 @@ def attachment_projection(captures: list[JsonObject]) -> JsonObject:
             "caption": f"{role or 'capture'} web QA capture",
             "alt_text": text(capture.get("evidence_summary")) or f"{role or 'web'} capture",
             "role": role,
+            "capture_origin": text(capture.get("capture_origin")),
+            "byte_size": optional_non_negative_int(capture.get("byte_size")),
+            "sha256": text(capture.get("sha256")),
             "display_order": index,
             "platform_upload_observed": False,
         })
@@ -396,6 +404,12 @@ def bool_value(value: JsonValue | None, *, default: bool) -> bool:
     return value if isinstance(value, bool) else default
 
 
+def optional_non_negative_int(value: JsonValue | None) -> int | None:
+    if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+        return value
+    return None
+
+
 def choice(value: str, choices: Sequence[str], fallback: str) -> str:
     return value if value in choices else fallback
 
@@ -420,6 +434,10 @@ def valid_path_or_uri(value: str) -> bool:
 
 def valid_id(value: str) -> bool:
     return bool(_ID_RE.match(value)) and "/" not in value and "\\" not in value and ".." not in value
+
+
+def valid_sha256(value: str) -> bool:
+    return bool(_SHA256_RE.match(value))
 
 
 def now() -> str:

--- a/src/workflows/web_visual_qa_message_card.py
+++ b/src/workflows/web_visual_qa_message_card.py
@@ -128,6 +128,9 @@ def _capture_cards(package: JsonObject) -> list[JsonValue]:
             "evidence_summary": text(capture.get("evidence_summary")),
             "redaction_status": text(capture.get("redaction_status")),
             "attachment": text(capture.get("attachment")),
+            "capture_origin": text(capture.get("capture_origin")),
+            "byte_size": capture.get("byte_size"),
+            "sha256": text(capture.get("sha256")),
         }
         for capture in object_list(package.get("captures"))
     ]

--- a/src/workflows/web_visual_qa_validation.py
+++ b/src/workflows/web_visual_qa_validation.py
@@ -97,6 +97,11 @@ def _validate_captures(captures: list[JsonObject], errors: list[str]) -> None:
         sha256 = text(capture.get("sha256"))
         if sha256 and not valid_sha256(sha256):
             errors.append(f"captures[{index}].sha256 must be a lowercase SHA-256 hex digest")
+        if capture_origin == "imported_local_file":
+            if not byte_size_is_positive_int:
+                errors.append(f"captures[{index}].byte_size is required for imported_local_file captures")
+            if not valid_sha256(sha256):
+                errors.append(f"captures[{index}].sha256 is required for imported_local_file captures")
 
 
 def _validate_results(

--- a/src/workflows/web_visual_qa_validation.py
+++ b/src/workflows/web_visual_qa_validation.py
@@ -4,6 +4,8 @@ from .web_visual_qa_contracts import (
     MESSAGE_ATTACHMENT_PROJECTION_SCHEMA_VERSION,
     PLUGIN_REWRITE_PATTERNS,
     SUPPORTED_AUTO_ROUTES,
+    SUPPORTED_ATTACHMENT_STATES,
+    SUPPORTED_CAPTURE_ORIGINS,
     SUPPORTED_MESSAGE_DELIVERY_STATES,
     SUPPORTED_MULTIMODAL_STRATEGIES,
     SUPPORTED_ROUTING_SAFETY_FLAGS,
@@ -26,6 +28,7 @@ from .web_visual_qa_contracts import (
     text,
     valid_id,
     valid_path_or_uri,
+    valid_sha256,
 )
 
 
@@ -81,6 +84,19 @@ def _validate_captures(captures: list[JsonObject], errors: list[str]) -> None:
             errors.append(f"captures[{index}].evidence_summary is required")
         if text(capture.get("redaction_status")) not in SUPPORTED_REDACTION_STATUSES:
             errors.append(f"captures[{index}].redaction_status is unsupported")
+        attachment = text(capture.get("attachment"))
+        if attachment and attachment not in SUPPORTED_ATTACHMENT_STATES:
+            errors.append(f"captures[{index}].attachment is unsupported")
+        capture_origin = text(capture.get("capture_origin"))
+        if capture_origin and capture_origin not in SUPPORTED_CAPTURE_ORIGINS:
+            errors.append(f"captures[{index}].capture_origin is unsupported")
+        byte_size = capture.get("byte_size")
+        byte_size_is_positive_int = isinstance(byte_size, int) and not isinstance(byte_size, bool) and byte_size > 0
+        if byte_size is not None and not byte_size_is_positive_int:
+            errors.append(f"captures[{index}].byte_size must be a positive integer when supplied")
+        sha256 = text(capture.get("sha256"))
+        if sha256 and not valid_sha256(sha256):
+            errors.append(f"captures[{index}].sha256 must be a lowercase SHA-256 hex digest")
 
 
 def _validate_results(

--- a/tests/test_web_visual_qa_capture_file_safety.py
+++ b/tests/test_web_visual_qa_capture_file_safety.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from _cli_harness import run_cli
+from _local_package import load_local_package
+
+load_local_package()
+
+from omh.workflows.web_visual_qa_captures import MAX_CAPTURE_FILE_BYTES
+from omh.web_visual_qa import build_web_visual_qa_package, validate_web_visual_qa_package
+
+
+PNG_BYTES = b"\x89PNG\r\n\x1a\nweb-qa-screenshot"
+
+
+class WebVisualQaCaptureFileSafetyTests(unittest.TestCase):
+    def test_capture_file_rejects_symlinked_managed_package_directory(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source_path = root / "desktop.png"
+            source_path.write_bytes(PNG_BYTES)
+            base = _base(root)
+            _create_package(base)
+            captures_root = root / ".omh" / "web-visual-qa" / "captures"
+            outside = root / "outside-captures"
+            captures_root.mkdir(parents=True)
+            outside.mkdir()
+            try:
+                (captures_root / "checkout-qa").symlink_to(outside, target_is_directory=True)
+            except (NotImplementedError, OSError) as exc:
+                self.skipTest(f"symlink creation unavailable: {exc}")
+
+            status, stdout, stderr = run_cli(
+                base
+                + [
+                    "capture-file",
+                    "--package-id",
+                    "checkout-qa",
+                    "--capture-id",
+                    "desktop",
+                    "--source-path",
+                    str(source_path),
+                    "--summary",
+                    "Desktop checkout screenshot.",
+                    "--json",
+                ]
+            )
+
+            self.assertEqual(status, 2)
+            self.assertEqual(stdout, "")
+            self.assertIn("package capture storage must not be a symlink", stderr)
+            self.assertFalse((outside / "desktop.png").exists())
+
+    def test_capture_file_failed_validation_does_not_leave_managed_bytes(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source_path = root / "desktop.png"
+            source_path.write_bytes(PNG_BYTES)
+            base = _base(root)
+            _create_package(base)
+
+            status, stdout, stderr = run_cli(
+                base
+                + [
+                    "capture-file",
+                    "--package-id",
+                    "checkout-qa",
+                    "--capture-id",
+                    "desktop",
+                    "--source-path",
+                    str(source_path),
+                    "--summary",
+                    "   ",
+                    "--json",
+                ]
+            )
+
+            managed_path = root / ".omh" / "web-visual-qa" / "captures" / "checkout-qa" / "desktop.png"
+            self.assertEqual(status, 2)
+            self.assertEqual(stdout, "")
+            self.assertIn("captures[0].evidence_summary is required", stderr)
+            self.assertFalse(managed_path.exists())
+
+    def test_capture_file_rejects_large_sources_before_importing(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source_path = root / "desktop.png"
+            source_path.write_bytes(PNG_BYTES)
+            with source_path.open("ab") as handle:
+                handle.truncate(MAX_CAPTURE_FILE_BYTES + 1)
+            base = _base(root)
+            _create_package(base)
+
+            status, stdout, stderr = run_cli(
+                base
+                + [
+                    "capture-file",
+                    "--package-id",
+                    "checkout-qa",
+                    "--capture-id",
+                    "desktop",
+                    "--source-path",
+                    str(source_path),
+                    "--summary",
+                    "Desktop checkout screenshot.",
+                    "--json",
+                ]
+            )
+
+            managed_path = root / ".omh" / "web-visual-qa" / "captures" / "checkout-qa" / "desktop.png"
+            self.assertEqual(status, 2)
+            self.assertEqual(stdout, "")
+            self.assertIn("--source-path must be 25 MiB or smaller", stderr)
+            self.assertFalse(managed_path.exists())
+
+    def test_imported_local_file_requires_managed_provenance_metadata(self) -> None:
+        package = build_web_visual_qa_package(
+            package_id="checkout-qa",
+            target="Checkout page",
+            criteria=[
+                {
+                    "criterion_id": "layout",
+                    "label": "Layout fits",
+                    "pass_rule": "No overlap",
+                    "severity": "blocking",
+                }
+            ],
+            captures=[
+                {
+                    "capture_id": "desktop",
+                    "role": "desktop",
+                    "path_or_uri": "/tmp/desktop.png",
+                    "mime_type": "image/png",
+                    "viewport": "desktop-1440",
+                    "evidence_summary": "Desktop checkout screenshot.",
+                    "capture_origin": "imported_local_file",
+                }
+            ],
+        )
+
+        errors = validate_web_visual_qa_package(package)
+
+        self.assertIn("captures[0].byte_size is required for imported_local_file captures", errors)
+        self.assertIn("captures[0].sha256 is required for imported_local_file captures", errors)
+
+
+def _base(root: Path) -> list[str]:
+    return ["--omh-home", str(root / ".omh"), "web-qa"]
+
+
+def _create_package(base: list[str]) -> None:
+    status, stdout, stderr = run_cli(
+        base
+        + [
+            "package",
+            "--package-id",
+            "checkout-qa",
+            "--target",
+            "Checkout page",
+            "--criterion",
+            "layout:Layout fits:No overlap:blocking",
+            "--json",
+        ]
+    )
+    if status != 0:
+        raise AssertionError(stderr)
+    package = json.loads(stdout)
+    if package["status"] != "prepared":
+        raise AssertionError(f"unexpected package status: {package['status']}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_web_visual_qa_message_card.py
+++ b/tests/test_web_visual_qa_message_card.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import unittest
 from pathlib import Path
@@ -309,6 +310,118 @@ class WebVisualQaMessageCardTests(unittest.TestCase):
             self.assertEqual(status, 2)
             self.assertEqual(stdout, "")
             self.assertIn("--capture-attachment must be one of eligible, blocked, not_requested", stderr)
+
+    def test_capture_file_command_imports_local_screenshot_as_managed_attachment(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source_path = root / "desktop.png"
+            screenshot_bytes = b"\x89PNG\r\n\x1a\nweb-qa-screenshot"
+            source_path.write_bytes(screenshot_bytes)
+            base = ["--omh-home", str(root / ".omh"), "web-qa"]
+
+            status, stdout, stderr = run_cli(
+                base
+                + [
+                    "package",
+                    "--package-id",
+                    "checkout-qa",
+                    "--target",
+                    "Checkout page",
+                    "--source",
+                    "discord",
+                    "--criterion",
+                    "layout:Layout fits:No overlap:blocking",
+                    "--json",
+                ]
+            )
+            self.assertEqual(status, 0, stderr)
+            self.assertEqual(json.loads(stdout)["status"], "prepared")
+
+            status, stdout, stderr = run_cli(
+                base
+                + [
+                    "capture-file",
+                    "--package-id",
+                    "checkout-qa",
+                    "--capture-id",
+                    "desktop",
+                    "--source-path",
+                    str(source_path),
+                    "--role",
+                    "desktop",
+                    "--viewport",
+                    "desktop-1440",
+                    "--summary",
+                    "Desktop checkout screenshot imported from browser QA.",
+                    "--redaction-status",
+                    "not_needed",
+                    "--attachment",
+                    "eligible",
+                    "--json",
+                ]
+            )
+
+            self.assertEqual(status, 0, stderr)
+            package = json.loads(stdout)
+            capture = package["captures"][0]
+            managed_path = Path(capture["path_or_uri"])
+            self.assertTrue(managed_path.is_file())
+            self.assertEqual(managed_path.read_bytes(), screenshot_bytes)
+            self.assertEqual(capture["capture_origin"], "imported_local_file")
+            self.assertEqual(capture["byte_size"], len(screenshot_bytes))
+            self.assertEqual(capture["sha256"], hashlib.sha256(screenshot_bytes).hexdigest())
+            self.assertEqual(capture["mime_type"], "image/png")
+
+            status, stdout, stderr = run_cli(base + ["show", "--package-id", "checkout-qa", "--json"])
+
+            self.assertEqual(status, 0, stderr)
+            card = json.loads(stdout)
+            attachment = card["attachment_projection"]["items"][0]
+            self.assertEqual(attachment["path_or_uri"], str(managed_path))
+            self.assertEqual(attachment["capture_origin"], "imported_local_file")
+            self.assertEqual(card["attachment_summary"]["eligible_count"], 1)
+
+    def test_capture_file_command_rejects_non_image_bytes(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source_path = root / "desktop.png"
+            source_path.write_text("not an image", encoding="utf-8")
+            base = ["--omh-home", str(root / ".omh"), "web-qa"]
+
+            status, _stdout, stderr = run_cli(
+                base
+                + [
+                    "package",
+                    "--package-id",
+                    "checkout-qa",
+                    "--target",
+                    "Checkout page",
+                    "--criterion",
+                    "layout:Layout fits:No overlap:blocking",
+                    "--json",
+                ]
+            )
+            self.assertEqual(status, 0, stderr)
+
+            status, stdout, stderr = run_cli(
+                base
+                + [
+                    "capture-file",
+                    "--package-id",
+                    "checkout-qa",
+                    "--capture-id",
+                    "desktop",
+                    "--source-path",
+                    str(source_path),
+                    "--summary",
+                    "Desktop checkout screenshot.",
+                    "--json",
+                ]
+            )
+
+            self.assertEqual(status, 2)
+            self.assertEqual(stdout, "")
+            self.assertIn("--source-path must contain PNG, JPEG, or WebP image bytes", stderr)
 
     def test_show_command_rejects_stale_package_with_sensitive_attachment_projection(self) -> None:
         with TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary

Adds an OMH-native managed capture import path for web visual QA. This follows the message-card routing work by letting operators import actual local screenshot bytes into an OMH-owned artifact directory, then carry that evidence through package validation and message-card attachment projection.

## Why

The previous web QA capability could describe screenshot evidence and recommend message delivery routes, but OMH did not own the screenshot bytes. That made visual QA reports depend on external temp paths and could not prove that a later message card referenced a durable, local artifact. The user goal is broader than routing: OMH should be able to preserve screenshot evidence locally, describe what is being reviewed, and expose enough metadata for downstream multimodal or platform delivery surfaces without hiding browser/model/upload side effects in core OMH.

## What changed

- Adds `omh web-qa capture-file` for importing local PNG, JPEG, or WebP captures into `.omh/web-visual-qa/captures/<package-id>/<capture-id>.<ext>`.
- Validates image bytes by magic bytes instead of trusting the file extension alone.
- Records `capture_origin=imported_local_file`, `byte_size`, and `sha256` on the capture record.
- Projects managed capture metadata into message-card attachments so downstream delivery layers can distinguish OMH-managed evidence from supplied metadata.
- Keeps `observe-capture` as the metadata-only path for externally observed captures.
- Extends validation so optional capture origin, byte size, SHA-256, and attachment metadata are contract-checked while older packages remain compatible.

## User/operator capability

After this change, an operator can run a local evidence flow such as:

```sh
omh web-qa package --package-id visual-check --target-url https://example.com --intent "validate Discord-style visual QA report"
omh web-qa capture-file --package-id visual-check --capture-id desktop-home --source-path /tmp/screenshot.png --role baseline --summary "Desktop reference state"
omh web-qa show --package-id visual-check --json
```

The resulting package includes a managed local attachment path plus byte size and hash metadata that can be used by a host/runtime to prepare a Discord, Slack, GitHub, or multimodal-review message without OMH pretending that delivery or model review already happened.

## Boundary notes

This remains intentionally local and deterministic:

- No browser automation is launched by core OMH.
- No multimodal model call is made.
- No Discord, Slack, GitHub, or network upload is performed.
- Platform delivery and model review remain separate observed host/runtime actions.

## Implementation notes

- `src/workflows/web_visual_qa_captures.py` owns local capture import, byte validation, managed artifact writes, and hash calculation.
- `src/commands/web_qa.py` wires the new CLI command.
- `src/workflows/web_visual_qa_contracts.py` extends the capture/message-card contracts.
- `src/workflows/web_visual_qa_validation.py` validates the new optional metadata.
- `src/workflows/web_visual_qa_message_card.py` includes the managed evidence metadata in card attachments.
- `src/omh/web_visual_qa.py` exports the new facade API.
- `tests/test_web_visual_qa_message_card.py` covers successful import and rejection of non-image bytes.

## Verification

Observed locally:

- `PYTHONPATH=tests uv run python -m unittest tests/test_web_visual_qa_message_card.py -v`
- `PYTHONPATH=tests uv run python -m unittest tests/test_web_visual_qa_message_card.py tests/test_web_visual_qa.py -v`
- `PYTHONPATH=tests uv run python -m unittest tests/test_web_visual_qa_message_card.py tests/test_web_visual_qa.py tests/test_cli.py -v`
- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- `uv run python -m compileall -q src tests`
- `uv run python -m omh.cli docs workflows --check`
- `git diff --check`
- Manual smoke: `omh web-qa package`, `omh web-qa capture-file`, and `omh web-qa show --json` confirmed `imported_local_file`, managed attachment path, matching capture/attachment SHA-256, and message delivery route preparation.

Not run:

- `uv run basedpyright ...` because `basedpyright` is not installed in this environment.
- `uv run ruff check ...` because `ruff` is not installed in this environment.
- Live browser automation, live multimodal model calls, and live Discord/Slack upload because this feature records local artifacts and intentionally avoids those side effects.

## Risks and follow-up

- This PR imports existing local screenshots; it does not yet provide a host-owned browser capture runner.
- This PR prepares attachment metadata; it does not yet deliver the card to Discord/Slack or run a multimodal visual reviewer.
- Large image-file policy is still minimal because the current contract is local artifact preservation; a future host/runtime capture runner may need explicit size limits and redaction workflows.
