### PR TITLE
Add dynamic coding workflow contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,10 @@ understand first; the rest live in [Workflow Reference](docs/WORKFLOWS.md) and
 
 - Coding-heavy work can be prepared for Codex, Claude Code, Hermes runtime, or
   another selected executor while preserving the prepared-vs-observed boundary.
+- `omh coding dynamic-workflow` can prepare a dynamic typed-target workflow and
+  SVG chart across model, runtime, wrapper, tool, and agent surfaces. The chart
+  names each planned agent, target type, model, cost tier, and evidence gate
+  before any target is selected or runtime is dispatched.
 - When Hermes itself owns the coding work, the Hermes coding harness shows the
   builder, verifier, reviewer, docs, and PR lanes without claiming unobserved
   execution.

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -55,7 +55,7 @@ normal chat surfaces:
 | Plan and decide | Clarify goals, prepare plans, and make loop or decision paths explicit. |
 | Learn and gather | Find sources, explain papers, triage signals, and prepare source-backed briefs. |
 | Create materials and visuals | Shape files, reports, packages, and image-card prompts before generation is claimed. |
-| Delegate coding and ship | Prepare scoped handoffs for Codex, Claude Code, Hermes, or another runtime after scope is clear. |
+| Delegate coding and ship | Prepare scoped handoffs and dynamic typed target workflow charts across model, runtime, wrapper, tool, and agent surfaces after scope is clear. |
 | Operate and observe | Show setup health, automation, workflow learning, memory review, status, and repair next steps. |
 
 Capability families are the public, user-facing front door. The older lanes and
@@ -71,7 +71,7 @@ the family layer.
 | `skills` | Skill capabilities, triggers, harnesses, quality bars, handoff policy, and orchestration eligibility derived from the generated skill catalog. |
 | `hooks` | Plugin tools/hooks plus wrapper event contracts and whether each surface is only supported or actually observed. |
 | `keywords` | Explicit invocation prefixes, natural-language routing rules, locale aliases, conflict policy, and guard rules. |
-| `orchestration_patterns` | Safe workflow patterns such as clarify-then-plan, plan-execute-verify, team pipeline, worktree isolation, loop tick, and executor session handoff. |
+| `orchestration_patterns` | Safe workflow patterns such as clarify-then-plan, plan-execute-verify, team pipeline, dynamic typed target workflow, worktree isolation, loop tick, and executor session handoff. |
 | `playbooks` | Situation-level workflow maps such as request-to-handoff, feedback triage, research department, materials processing, and idea-to-deploy, including owner/action hints for the first wrapper card. |
 | `tool_requirements` | Tool/MCP requirements when derivable, plus setup guidance for the optional allowlisted OMH MCP bridge. |
 | `evidence_boundaries` | The shared prepared-vs-observed claim rule. |
@@ -81,6 +81,18 @@ the family layer.
 Capability presence means OMH can prepare guidance, status, or a handoff. It
 does not mean Hermes loaded a plugin, a worker ran, code changed, review passed,
 CI passed, or a PR was merged.
+
+`omh coding dynamic-workflow` prepares `dynamic_coding_workflow/v1` and an SVG
+`dynamic_coding_workflow_chart/v1` image attachment that names each prepared
+stage's role, target, target type, model, cost tier, and gate. The artifact is
+a workflow proposal for a wrapper or operator to show in chat; it is not target
+selection, runtime dispatch, model invocation, review, verification, CI, or
+merge evidence until matching observed records exist.
+
+Model, runtime, wrapper, tool, and agent targets are distinct. A GLM-like entry
+is a model target; a Pi-like entry is a runtime or agent surface target.
+Defaults describe dynamic planning, implementation, and review target pools
+instead of preselecting concrete models, runtime agents, tools, or wrappers.
 
 Those claims require matching local wrapper or runtime artifacts such as
 `runtime_observation/v1`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -82,7 +82,7 @@ separate profile pack is explicitly selected.
 ![OMH flagship command sets poster](../assets/omh-flagship-workflows-poster.png)
 
 The full skill catalog is intentionally larger than the public story. Start
-with these 10 modes; then use [WORKFLOWS.md](WORKFLOWS.md) and
+with these 11 modes; then use [WORKFLOWS.md](WORKFLOWS.md) and
 [CAPABILITIES.md](CAPABILITIES.md) for the complete reference.
 
 <!-- Intent-to-plan anchor: `deep-interview` / `ralplan` / `ultragoal` / `loop` / `ultraprocess`. -->
@@ -112,6 +112,11 @@ with these 10 modes; then use [WORKFLOWS.md](WORKFLOWS.md) and
 
 - **Idea To Deploy** (`idea-to-deploy`) - prepare scoped coding work for the
   selected runtime without claiming unobserved execution.
+
+- **Dynamic Workflow** (`coding dynamic-workflow`) - prepare a dynamic typed
+  target workflow and SVG chart across model, runtime, wrapper, tool, and agent
+  surfaces, naming each stage's agent, target type, model, cost tier, and
+  evidence gate.
 
 - **Workflow Learning** (`workflow-learning`) - turn weak workflow attempts into
   traces, evals, review queues, regression cases, and patch proposals.

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -12,6 +12,22 @@ When wrapper metadata reports `omh_target_topology/v1`, skills bind workflow sta
 `memory_review_card/v1` is separate from `status_card/v1`; `handoff_context_pack/v1` may be attached to executor handoffs only when unresolved conflicts are absent.
 `goal_status_card/v1` and `goal_continuation/v1` are goal-execution payloads separate from generic `status_card/v1`; they must name the next action instead of merely summarizing work.
 
+## CLI Reference Surfaces
+
+These surfaces are generated command references, not installed Hermes workflow skills.
+
+### dynamic-workflow
+
+`omh coding dynamic-workflow` prepares `dynamic_coding_workflow/v1`, `workflow.json`, and `workflow-chart.svg` under `.omh/coding/dynamic-workflows/`.
+
+- Exposure: `cli_reference`
+- Install visibility: `false`
+- Docs visibility: `public_cli_reference`
+- Status: `prepared_not_observed`
+- Expected outputs: `dynamic_coding_workflow/v1` metadata-only contract and SVG chart attachment
+- Safety boundary: the generated workflow and chart are not execution, target selection, runtime dispatch, model invocation, implementation, review, CI, PR, merge-readiness, or merge evidence.
+- Privacy boundary: goals are stored as digest metadata; supported source metadata is compacted through the standard source metadata allowlist.
+
 ## Skills
 
 ### oh-my-hermes

--- a/skills/oh-my-hermes/references/workflow-registry.md
+++ b/skills/oh-my-hermes/references/workflow-registry.md
@@ -3,6 +3,22 @@
 This generated reference is loaded only when exact workflow routing detail matters.
 The always-on `oh-my-hermes` skill keeps only the compact lane map and recovery rules.
 
+## CLI Reference Surfaces
+
+These surfaces are generated command references, not installed Hermes workflow skills.
+
+### dynamic-workflow
+
+`omh coding dynamic-workflow` prepares `dynamic_coding_workflow/v1`, `workflow.json`, and `workflow-chart.svg` under `.omh/coding/dynamic-workflows/`.
+
+- Exposure: `cli_reference`
+- Install visibility: `false`
+- Docs visibility: `public_cli_reference`
+- Status: `prepared_not_observed`
+- Expected outputs: `dynamic_coding_workflow/v1` metadata-only contract and SVG chart attachment
+- Safety boundary: the generated workflow and chart are not execution, target selection, runtime dispatch, model invocation, implementation, review, CI, PR, merge-readiness, or merge evidence.
+- Privacy boundary: goals are stored as digest metadata; supported source metadata is compacted through the standard source metadata allowlist.
+
 ## Role Registry
 
 - `guide`: `oh-my-hermes`, `gateway-intent-card`, `voice-operator`, `browser-operator`, `workspace-file-operator`, `command-operator`, `connector-operator`, `live-info-operator`, `external-connector-readiness`, `prompt-import-readiness`, `content-operator`, `media-input-operator`, `data-analysis`

--- a/src/capabilities/families.py
+++ b/src/capabilities/families.py
@@ -12,6 +12,7 @@ CONCEPTUAL_WORKFLOW_SURFACES = {
     "request-to-handoff",
     "executor selection",
     "coding runtime handoff",
+    "dynamic-workflow",
 }
 
 _FAMILY_DEFINITIONS = (
@@ -87,11 +88,15 @@ _FAMILY_DEFINITIONS = (
         "label": "Delegate coding and ship",
         "owner_role": "handoff-guide",
         "source_lanes": ("coding_handoff",),
-        "use_for": "Scoped coding handoffs, executor choice, review, QA, CI, and merge readiness.",
+        "use_for": (
+            "Scoped coding handoffs, dynamic typed target choice across model, runtime, wrapper, tool, and agent "
+            "surfaces, review, QA, CI, and merge readiness."
+        ),
         "primary_workflows": (
             "idea-to-deploy",
             "ultraprocess",
             "executor-runtime-readiness",
+            "dynamic-workflow",
             "code-review",
             "build-failure-triage",
             "verification-gate",
@@ -104,7 +109,10 @@ _FAMILY_DEFINITIONS = (
         "next_action": "prepare_scoped_coding_handoff",
         "example_prompt": "Turn this issue into a PR-ready plan and hand it to implementation.",
         "not_evidence_until_observed": ("executor dispatch", "implementation", "review", "CI", "merge"),
-        "route_summary": "Choose the coding owner only after scope is concrete, then track observed evidence separately.",
+        "route_summary": (
+            "Choose model, runtime, and coding-owner targets only after scope is concrete, then track observed "
+            "evidence separately."
+        ),
     },
     {
         "id": "operate_and_observe",
@@ -205,6 +213,7 @@ _WORKFLOW_FAMILY_OVERRIDES = {
     "ultraqa": "delegate_coding_and_ship",
     "ai-slop-cleaner": "delegate_coding_and_ship",
     "executor-runtime-readiness": "delegate_coding_and_ship",
+    "dynamic-workflow": "delegate_coding_and_ship",
     "request-to-handoff": "delegate_coding_and_ship",
     "executor selection": "delegate_coding_and_ship",
     "coding runtime handoff": "delegate_coding_and_ship",

--- a/src/capabilities/orchestration.py
+++ b/src/capabilities/orchestration.py
@@ -79,6 +79,26 @@ def orchestration_patterns() -> list[dict[str, object]]:
             tuple(f"{event}_observed" for event in HERMES_CODING_TEAM_STATUS_LADDER),
         ),
         _pattern(
+            "dynamic_runtime_workflow",
+            (
+                "Use when OMH should prepare a charted plan/critique/fan-out/review workflow across model, "
+                "runtime, wrapper, tool, and agent targets."
+            ),
+            "Do not claim any model, runtime, wrapper, tool, or agent target was selected or invoked from the prepared chart.",
+            "handoff-guide",
+            ("ralplan", "team", "ultragoal", "ultrawork", "code-review"),
+            ("choose_executor", "prepare_handoff", "show_status"),
+            actions,
+            (
+                "operator_acceptance_observed",
+                "target_selection_observed",
+                "runtime_dispatch_observed",
+                "worker_result_observed",
+                "review_observed",
+                "verification_observed",
+            ),
+        ),
+        _pattern(
             "swarm_batch",
             "Use for high-throughput batches only when lanes are independent and ownership is clear.",
             "Do not use for tightly coupled edits or unbounded scope.",
@@ -179,6 +199,14 @@ def _pattern(
 
 
 def _required_decisions(pattern_id: str) -> list[str]:
+    if pattern_id == "dynamic_runtime_workflow":
+        return [
+            "workflow_graph",
+            "typed_target_routing_policy",
+            "target_type_assignments",
+            "approval_gates",
+            "verification_gate",
+        ]
     if pattern_id in {"executor_session_handoff", "team_staged_pipeline", "hermes_coding_team_path", "swarm_batch", "worktree_isolated_workers"}:
         return ["executor_or_runtime_profile", "authority_scope", "verification_gate"]
     if pattern_id == "loop_run_once":
@@ -197,6 +225,7 @@ def _prepared_artifacts(pattern_id: str) -> list[str]:
         "research_department_workflow": ["research_department_plan/v1", "source_inbox/v1", "briefing_status/v1"],
         "materials_generation_handoff": ["material_artifact/v1"],
         "worktree_isolated_workers": ["runtime_observation/v1 when observed"],
+        "dynamic_runtime_workflow": ["dynamic_coding_workflow/v1", "dynamic_coding_workflow_chart/v1"],
     }
     return mapping.get(pattern_id, ["chat_interaction/v1", "status_card/v1"])
 

--- a/src/coding/dynamic_workflow.py
+++ b/src/coding/dynamic_workflow.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+from hashlib import sha256
+import json
+from typing import Mapping, Sequence
+
+from ..ingress import compact_source_metadata
+from .dynamic_workflow_contracts import (
+    CLAIM_BOUNDARY,
+    DYNAMIC_WORKFLOW_CHART_SCHEMA_VERSION,
+    DYNAMIC_WORKFLOW_LANES,
+    DYNAMIC_WORKFLOW_MESSAGE_PROJECTION_SCHEMA_VERSION,
+    DYNAMIC_WORKFLOW_SCHEMA_VERSION,
+    PREPARED_NOT_OBSERVED,
+)
+from .dynamic_workflow_privacy import goal_payload
+from .dynamic_workflow_specs import (
+    DEFAULT_CRITICS,
+    DEFAULT_IMPLEMENTERS,
+    DEFAULT_PLANNERS,
+    DEFAULT_REPORTER,
+    DEFAULT_REVIEWERS,
+    SUPPORTED_TARGET_TYPES,
+    AgentSpec,
+    agent_specs,
+    parse_agent_spec,
+)
+
+
+def build_dynamic_coding_workflow(
+    goal: str,
+    *,
+    source: str = "generic",
+    planners: Sequence[str] | None = None,
+    critics: Sequence[str] | None = None,
+    implementers: Sequence[str] | None = None,
+    reviewers: Sequence[str] | None = None,
+    reporter: str | None = None,
+    source_metadata: Mapping[str, object] | None = None,
+) -> dict[str, object]:
+    normalized_goal = " ".join(goal.split())
+    if not normalized_goal:
+        raise ValueError("dynamic workflow goal is required")
+    metadata = _source_metadata(source_metadata)
+
+    planner_specs = agent_specs(planners, default_specs=DEFAULT_PLANNERS)
+    critic_specs = agent_specs(critics, default_specs=DEFAULT_CRITICS)
+    implementer_specs = agent_specs(implementers, default_specs=DEFAULT_IMPLEMENTERS)
+    reviewer_specs = agent_specs(reviewers, default_specs=DEFAULT_REVIEWERS)
+    reporter_spec = parse_agent_spec(reporter or DEFAULT_REPORTER)
+
+    stages = _build_stages(planner_specs, critic_specs, implementer_specs, reviewer_specs, reporter_spec)
+    edges = _build_edges(stages)
+    workflow_id = _workflow_id(normalized_goal, stages, edges, source=source, source_metadata=metadata)
+    alt_text = "Dynamic coding workflow chart with typed orchestration target assignments."
+    payload: dict[str, object] = {
+        "schema_version": DYNAMIC_WORKFLOW_SCHEMA_VERSION,
+        "workflow_id": workflow_id,
+        "status": PREPARED_NOT_OBSERVED,
+        "source": source,
+        "goal": goal_payload(normalized_goal),
+        "routing_policy": {
+            "strategy": "cost_risk_capability_target_routing",
+            "status": PREPARED_NOT_OBSERVED,
+            "decision_inputs": [
+                "stage_role",
+                "target_type",
+                "model_capability",
+                "runtime_capability",
+                "cost_tier",
+                "risk_gate",
+            ],
+            "claim_boundary": (
+                "Routing policy is a prepared recommendation until target selection and dispatch evidence are "
+                "recorded."
+            ),
+        },
+        "target_selection": {
+            "selection_unit": "typed_orchestration_target",
+            "status": PREPARED_NOT_OBSERVED,
+            "supported_target_types": list(SUPPORTED_TARGET_TYPES),
+            "default_policy": (
+                "Defaults describe dynamic target pools; no concrete model, runtime, wrapper, tool, or agent is "
+                "selected until an operator or runtime records target evidence."
+            ),
+            "decision_inputs": [
+                "stage_role",
+                "target_type",
+                "model_capability",
+                "runtime_capability",
+                "cost_tier",
+                "risk_gate",
+            ],
+            "claim_boundary": (
+                "Target selection is prepared guidance until dispatch evidence records the chosen model, runtime, "
+                "wrapper, tool, or agent surface."
+            ),
+        },
+        "stages": stages,
+        "edges": edges,
+        "chart": {
+            "schema_version": DYNAMIC_WORKFLOW_CHART_SCHEMA_VERSION,
+            "format": "svg",
+            "status": PREPARED_NOT_OBSERVED,
+            "chart_path": "",
+            "alt_text": alt_text,
+        },
+        "message_projection": {
+            "schema_version": DYNAMIC_WORKFLOW_MESSAGE_PROJECTION_SCHEMA_VERSION,
+            "status": PREPARED_NOT_OBSERVED,
+            "attachments": [{"kind": "image", "format": "svg", "path": "", "alt_text": alt_text}],
+        },
+        "observed_evidence_required": [
+            "operator_acceptance_observed",
+            "target_selection_observed",
+            "runtime_dispatch_observed",
+            "worker_result_observed",
+            "review_observed",
+            "verification_observed",
+        ],
+        "prepared_is_not": [
+            "not execution",
+            "not model selection",
+            "not model invocation",
+            "not target selection",
+            "not runtime dispatch",
+            "not implementation",
+            "not code review",
+            "not CI",
+            "not merge-readiness",
+            "not merge evidence",
+        ],
+        "claim_boundary": CLAIM_BOUNDARY,
+        "next_action": "record_runtime_observations_when_dispatch_happens",
+    }
+    if metadata:
+        payload["source_metadata"] = metadata
+    return payload
+
+
+def _build_stages(
+    planners: Sequence[AgentSpec],
+    critics: Sequence[AgentSpec],
+    implementers: Sequence[AgentSpec],
+    reviewers: Sequence[AgentSpec],
+    reporter: AgentSpec,
+) -> list[dict[str, object]]:
+    intake = AgentSpec("hermes", "omh", "Hermes/OMH intake", "wrapper", "wrapper")
+    stages = [intake.stage(stage_id="intake-1", lane="intake", role="goal_intake", gate="goal_received", order=0)]
+    stages.extend(
+        _stages_for(planners, lane="planning", role="planner", gate="plan_prepared", prefix="plan", offset=10)
+    )
+    stages.extend(
+        _stages_for(
+            critics,
+            lane="critique",
+            role="critic",
+            gate="critic_approval_required",
+            prefix="critique",
+            offset=20,
+        )
+    )
+    stages.extend(
+        _stages_for(
+            implementers,
+            lane="implementation",
+            role="implementation_owner",
+            gate="handoff_prepared_after_critique",
+            prefix="implement",
+            offset=30,
+        )
+    )
+    stages.extend(
+        _stages_for(
+            reviewers,
+            lane="review",
+            role="independent_reviewer",
+            gate="independent_review_required",
+            prefix="review",
+            offset=40,
+        )
+    )
+    stages.append(
+        reporter.stage(stage_id="report-1", lane="report", role="report_owner", gate="report_prepared", order=50)
+    )
+    return stages
+
+
+def _stages_for(
+    specs: Sequence[AgentSpec], *, lane: str, role: str, gate: str, prefix: str, offset: int
+) -> list[dict[str, object]]:
+    return [
+        spec.stage(stage_id=f"{prefix}-{index}", lane=lane, role=role, gate=gate, order=offset + index)
+        for index, spec in enumerate(specs, start=1)
+    ]
+
+
+def _build_edges(stages: Sequence[dict[str, object]]) -> list[dict[str, str]]:
+    by_lane = {lane: [str(stage["id"]) for stage in stages if stage["lane"] == lane] for lane in DYNAMIC_WORKFLOW_LANES}
+    edges: list[dict[str, str]] = []
+    _connect(edges, by_lane["intake"], by_lane["planning"], "goal_to_plan")
+    _connect(edges, by_lane["planning"], by_lane["critique"], "plan_to_critique")
+    _connect(edges, by_lane["critique"], by_lane["implementation"], "approved_plan_to_fanout")
+    _connect(edges, by_lane["implementation"], by_lane["review"], "implementation_to_review")
+    _connect(edges, by_lane["review"], by_lane["report"], "review_to_report")
+    return edges
+
+
+def _connect(edges: list[dict[str, str]], sources: Sequence[str], targets: Sequence[str], label: str) -> None:
+    for source in sources:
+        for target in targets:
+            edges.append({"from": source, "to": target, "label": label})
+
+
+def _source_metadata(metadata: Mapping[str, object] | None) -> dict[str, str]:
+    return compact_source_metadata(metadata)
+
+
+def _workflow_id(
+    goal: str,
+    stages: Sequence[dict[str, object]],
+    edges: Sequence[dict[str, str]],
+    *,
+    source: str,
+    source_metadata: dict[str, str],
+) -> str:
+    raw = json.dumps(
+        {"goal": goal, "source": source, "source_metadata": source_metadata, "stages": stages, "edges": edges},
+        sort_keys=True,
+    ).encode("utf-8")
+    return "dynamic-" + sha256(raw).hexdigest()[:12]

--- a/src/coding/dynamic_workflow_artifacts.py
+++ b/src/coding/dynamic_workflow_artifacts.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+import re
+
+from ..system.local_store import atomic_write_json, atomic_write_text, ensure_dir
+from ..system.paths import OmhPaths
+from .dynamic_workflow_svg import render_dynamic_workflow_svg
+
+_WORKFLOW_ID_RE = re.compile(r"^dynamic-[0-9a-f]{12}$")
+
+
+def write_dynamic_coding_workflow(paths: OmhPaths, workflow: dict[str, object]) -> dict[str, object]:
+    workflow_id = _validated_workflow_id(workflow.get("workflow_id"))
+    workflow_dir = _managed_workflow_dir(paths, workflow_id)
+    workflow_path = workflow_dir / "workflow.json"
+    chart_path = workflow_dir / "workflow-chart.svg"
+    ensure_dir(paths.dynamic_coding_workflows_dir, private=True)
+    ensure_dir(workflow_dir, private=True)
+
+    payload = deepcopy(workflow)
+    _attach_artifact_paths(payload, workflow_path=str(workflow_path), chart_path=str(chart_path))
+    chart_svg = render_dynamic_workflow_svg(payload)
+    workflow_preexisted = workflow_path.exists() or workflow_path.is_symlink()
+    atomic_write_json(workflow_path, payload, private=True)
+    try:
+        atomic_write_text(chart_path, chart_svg, private=True)
+    except OSError:
+        if not workflow_preexisted and workflow_path.exists() and not workflow_path.is_symlink():
+            workflow_path.unlink()
+        raise
+    return payload
+
+
+def _managed_workflow_dir(paths: OmhPaths, workflow_id: str) -> Path:
+    root = paths.dynamic_coding_workflows_dir
+    if root.is_symlink():
+        raise ValueError("dynamic coding workflow storage must not be a symlink")
+    root_resolved = root.resolve(strict=False)
+    if not root_resolved.is_relative_to(paths.omh_home.resolve(strict=False)):
+        raise ValueError("dynamic coding workflow storage must resolve under OMH home")
+
+    workflow_dir = root / workflow_id
+    if workflow_dir.is_symlink():
+        raise ValueError("dynamic workflow artifact directory must not be a symlink")
+    workflow_dir_resolved = workflow_dir.resolve(strict=False)
+    if workflow_dir_resolved.parent != root_resolved:
+        raise ValueError("workflow_id must resolve under dynamic coding workflows directory")
+    return workflow_dir
+
+
+def _attach_artifact_paths(payload: dict[str, object], *, workflow_path: str, chart_path: str) -> None:
+    chart = payload.get("chart")
+    if isinstance(chart, dict):
+        chart["chart_path"] = chart_path
+
+    projection = payload.get("message_projection")
+    if isinstance(projection, dict):
+        attachments = projection.get("attachments")
+        if isinstance(attachments, list) and attachments and isinstance(attachments[0], dict):
+            attachments[0]["path"] = chart_path
+
+    payload["artifacts"] = {
+        "workflow_path": workflow_path,
+        "chart_path": chart_path,
+        "chart_format": "svg",
+        "privacy": "metadata_only",
+    }
+
+
+def _validated_workflow_id(value: object) -> str:
+    workflow_id = str(value or "")
+    if not _WORKFLOW_ID_RE.fullmatch(workflow_id):
+        raise ValueError("workflow_id must match dynamic-<12 lowercase hex chars>")
+    return workflow_id

--- a/src/coding/dynamic_workflow_contracts.py
+++ b/src/coding/dynamic_workflow_contracts.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+
+DYNAMIC_WORKFLOW_SCHEMA_VERSION = "dynamic_coding_workflow/v1"
+DYNAMIC_WORKFLOW_CHART_SCHEMA_VERSION = "dynamic_coding_workflow_chart/v1"
+DYNAMIC_WORKFLOW_MESSAGE_PROJECTION_SCHEMA_VERSION = "dynamic_coding_workflow_message_projection/v1"
+PREPARED_NOT_OBSERVED = "prepared_not_observed"
+CLAIM_BOUNDARY = (
+    "Dynamic workflow plans and charts are prepared orchestration artifacts only. "
+    "They are not model invocation, runtime dispatch, implementation, review, CI, merge-readiness, or merge evidence."
+)
+DYNAMIC_WORKFLOW_LANES = ("intake", "planning", "critique", "implementation", "review", "report")

--- a/src/coding/dynamic_workflow_privacy.py
+++ b/src/coding/dynamic_workflow_privacy.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from hashlib import sha256
+
+
+def goal_payload(normalized_goal: str) -> dict[str, object]:
+    digest = sha256(normalized_goal.encode("utf-8")).hexdigest()
+    return {
+        "summary": f"Dynamic coding workflow request ({len(normalized_goal)} chars, sha256:{digest[:12]})",
+        "summary_kind": "digest_reference",
+        "input_chars": len(normalized_goal),
+        "sha256": digest,
+        "raw_prompt_stored": False,
+        "content_preview_stored": False,
+    }

--- a/src/coding/dynamic_workflow_specs.py
+++ b/src/coding/dynamic_workflow_specs.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final, Sequence
+
+from .dynamic_workflow_contracts import PREPARED_NOT_OBSERVED
+
+DEFAULT_PLANNERS: Final[tuple[str, ...]] = ("planning-model-pool:auto:Planning model pool:adaptive:model",)
+DEFAULT_CRITICS: Final[tuple[str, ...]] = ("critique-model-pool:auto:Critique model pool:adaptive:model",)
+DEFAULT_IMPLEMENTERS: Final[tuple[str, ...]] = (
+    "implementation-model-pool:auto:Implementation model pool:adaptive:model",
+    "executor-runtime-pool:auto:Executor runtime pool:runtime-variable:runtime",
+)
+DEFAULT_REVIEWERS: Final[tuple[str, ...]] = (
+    "review-model-pool:auto:Review model pool:adaptive:model",
+    "review-runtime-pool:auto:Review runtime pool:runtime-variable:runtime",
+)
+DEFAULT_REPORTER: Final[str] = "hermes:omh:Hermes/OMH report:wrapper:wrapper"
+SUPPORTED_TARGET_TYPES: Final[tuple[str, ...]] = ("model", "runtime", "wrapper", "tool", "agent")
+_COST_TIERS: Final[dict[str, str]] = {
+    "planning-model-pool": "adaptive",
+    "critique-model-pool": "adaptive",
+    "implementation-model-pool": "adaptive",
+    "executor-runtime-pool": "runtime-variable",
+    "review-model-pool": "adaptive",
+    "review-runtime-pool": "runtime-variable",
+    "gpt": "operator-selected",
+    "claude-code": "operator-selected",
+    "glm": "medium",
+    "codex": "operator-selected",
+    "pi": "low",
+    "omp-runtime": "runtime-variable",
+    "omx-runtime": "runtime-variable",
+    "hermes": "wrapper",
+}
+_TARGET_TYPES: Final[dict[str, str]] = {
+    "planning-model-pool": "model",
+    "critique-model-pool": "model",
+    "implementation-model-pool": "model",
+    "review-model-pool": "model",
+    "model-router": "model",
+    "gpt": "model",
+    "glm": "model",
+    "claude": "model",
+    "openai": "model",
+    "anthropic": "model",
+    "gemini": "model",
+    "qwen": "model",
+    "kimi": "model",
+    "mistral": "model",
+    "executor-runtime-pool": "runtime",
+    "review-runtime-pool": "runtime",
+    "codex": "runtime",
+    "claude-code": "runtime",
+    "pi": "runtime",
+    "omp-runtime": "runtime",
+    "omx-runtime": "runtime",
+    "generic-runtime": "runtime",
+    "hermes": "wrapper",
+}
+_MODEL_TARGET_PREFIXES: Final[tuple[str, ...]] = (
+    "gpt-",
+    "glm-",
+    "claude-",
+    "openai-",
+    "anthropic-",
+    "gemini-",
+    "qwen-",
+    "kimi-",
+    "mistral-",
+    "llama-",
+    "deepseek-",
+    "codestral-",
+)
+_RUNTIME_TARGET_SUFFIXES: Final[tuple[str, ...]] = ("-runtime", "-executor")
+_TOOL_TARGET_SUFFIXES: Final[tuple[str, ...]] = ("-tool", "-mcp")
+_AGENT_TARGET_SUFFIXES: Final[tuple[str, ...]] = ("-agent", "-tool-agent")
+
+
+@dataclass(frozen=True, slots=True)
+class AgentSpec:
+    target: str
+    model: str
+    label: str
+    cost_tier: str
+    target_type: str
+
+    def stage(self, *, stage_id: str, lane: str, role: str, gate: str, order: int) -> dict[str, object]:
+        return {
+            "id": stage_id,
+            "lane": lane,
+            "role": role,
+            "agent": self.label,
+            "target": self.target,
+            "target_type": self.target_type,
+            "runtime": self.target if self.target_type == "runtime" else "",
+            "model": self.model,
+            "cost_tier": self.cost_tier,
+            "gate": gate,
+            "status": PREPARED_NOT_OBSERVED,
+            "order": order,
+        }
+
+
+def agent_specs(values: Sequence[str] | None, *, default_specs: Sequence[str]) -> list[AgentSpec]:
+    specs = tuple(values) if values else tuple(default_specs)
+    return [parse_agent_spec(spec) for spec in specs]
+
+
+def parse_agent_spec(raw: str) -> AgentSpec:
+    parts = [part.strip() for part in raw.split(":", 4)]
+    target = parts[0] if parts else ""
+    if not target:
+        raise ValueError("agent spec requires target in target[:model[:label[:cost_tier[:target_type]]]] form")
+    model = parts[1] if len(parts) > 1 and parts[1] else "auto"
+    label = parts[2] if len(parts) > 2 and parts[2] else _label_for_target(target)
+    cost_tier = parts[3] if len(parts) > 3 and parts[3] else _cost_tier(target)
+    target_type = _target_type(target, parts[4] if len(parts) > 4 else "")
+    return AgentSpec(target=target, model=model, label=label, cost_tier=cost_tier, target_type=target_type)
+
+
+def _target_type(target: str, explicit: str) -> str:
+    target_type = explicit or _inferred_target_type(target)
+    if target_type not in SUPPORTED_TARGET_TYPES:
+        supported = ", ".join(SUPPORTED_TARGET_TYPES)
+        raise ValueError(f"target_type must be one of: {supported}")
+    return target_type
+
+
+def _inferred_target_type(target: str) -> str:
+    normalized = target.lower()
+    if normalized in _TARGET_TYPES:
+        return _TARGET_TYPES[normalized]
+    if normalized.startswith(_MODEL_TARGET_PREFIXES):
+        return "model"
+    if normalized.endswith(_RUNTIME_TARGET_SUFFIXES):
+        return "runtime"
+    if normalized.endswith(_TOOL_TARGET_SUFFIXES):
+        return "tool"
+    if normalized.endswith(_AGENT_TARGET_SUFFIXES):
+        return "agent"
+    return "agent"
+
+
+def _cost_tier(target: str) -> str:
+    normalized = target.lower()
+    if normalized in _COST_TIERS:
+        return _COST_TIERS[normalized]
+    if normalized.startswith("glm-"):
+        return "medium"
+    if normalized.startswith(_MODEL_TARGET_PREFIXES):
+        return "operator-selected"
+    if normalized.endswith(_RUNTIME_TARGET_SUFFIXES):
+        return "runtime-variable"
+    return "unknown"
+
+
+def _label_for_target(target: str) -> str:
+    return target.replace("-", " ").title()

--- a/src/coding/dynamic_workflow_svg.py
+++ b/src/coding/dynamic_workflow_svg.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from html import escape
+from typing import Sequence
+
+from .dynamic_workflow_contracts import DYNAMIC_WORKFLOW_CHART_SCHEMA_VERSION, DYNAMIC_WORKFLOW_LANES
+
+
+_LANE_COLORS = {
+    "intake": "#f4f4f5",
+    "planning": "#dbeafe",
+    "critique": "#fee2e2",
+    "implementation": "#dcfce7",
+    "review": "#fef3c7",
+    "report": "#ede9fe",
+}
+_CARD_WIDTH = 220
+_CARD_HEIGHT = 112
+_LEFT_MARGIN = 40
+_RIGHT_MARGIN = 40
+_LANE_GAP = 44
+
+
+def render_dynamic_workflow_svg(workflow: dict[str, object]) -> str:
+    stages = _stage_objects(workflow)
+    lanes = [lane for lane in DYNAMIC_WORKFLOW_LANES if any(_stage_text(stage, "lane") == lane for stage in stages)]
+    lane_counts = {lane: sum(1 for stage in stages if _stage_text(stage, "lane") == lane) for lane in lanes}
+    width = max(960, _LEFT_MARGIN + _RIGHT_MARGIN + len(lanes) * _CARD_WIDTH + max(0, len(lanes) - 1) * _LANE_GAP)
+    height = max(360, 150 + (_CARD_HEIGHT + 28) * max(lane_counts.values(), default=1))
+    layout = _svg_layout(stages, lanes)
+    body: list[str] = [
+        (
+            f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" '
+            f'viewBox="0 0 {width} {height}" role="img" aria-labelledby="dynamic-workflow-title dynamic-workflow-desc">'
+        ),
+        '<title id="dynamic-workflow-title">Dynamic coding workflow</title>',
+        (
+            '<desc id="dynamic-workflow-desc">'
+            "Prepared typed target workflow chart across model, runtime, wrapper, tool, and agent surfaces. "
+            "It shows planned agents, targets, models, and gates, but it is not execution, review, CI, or merge "
+            "evidence."
+            "</desc>"
+        ),
+        f"<metadata>{DYNAMIC_WORKFLOW_CHART_SCHEMA_VERSION}</metadata>",
+        "<defs>",
+        '<marker id="arrow" markerWidth="10" markerHeight="8" refX="9" refY="4" orient="auto">',
+        '<path d="M 0 0 L 10 4 L 0 8 z" fill="#475569"/>',
+        "</marker>",
+        "</defs>",
+        '<rect width="100%" height="100%" fill="#ffffff"/>',
+        _svg_text(32, 38, "Dynamic coding workflow", size=20, weight="700"),
+        _svg_text(32, 64, "status: prepared_not_observed | chart is not execution/review/CI/merge evidence", size=13),
+    ]
+    body.extend(_svg_edges(_edge_objects(workflow), layout))
+    for stage in stages:
+        xy = layout.get(_stage_text(stage, "id"))
+        if xy:
+            body.extend(_svg_stage(stage, xy))
+    body.append("</svg>")
+    return "\n".join(body) + "\n"
+
+
+def _svg_edges(edges: Sequence[dict[str, object]], layout: dict[str, tuple[int, int]]) -> list[str]:
+    lines: list[str] = []
+    for edge in edges:
+        start = layout.get(str(edge.get("from", "")))
+        end = layout.get(str(edge.get("to", "")))
+        if start and end:
+            lines.append(_svg_edge(start, end))
+    return lines
+
+
+def _stage_objects(workflow: dict[str, object]) -> list[dict[str, object]]:
+    stages = workflow.get("stages")
+    if not isinstance(stages, list):
+        return []
+    return [stage for stage in stages if isinstance(stage, dict)]
+
+
+def _edge_objects(workflow: dict[str, object]) -> list[dict[str, object]]:
+    edges = workflow.get("edges")
+    if not isinstance(edges, list):
+        return []
+    return [edge for edge in edges if isinstance(edge, dict)]
+
+
+def _svg_layout(stages: Sequence[dict[str, object]], lanes: Sequence[str]) -> dict[str, tuple[int, int]]:
+    if not lanes:
+        return {}
+    x_by_lane = {lane: _LEFT_MARGIN + index * (_CARD_WIDTH + _LANE_GAP) for index, lane in enumerate(lanes)}
+    layout: dict[str, tuple[int, int]] = {}
+    for lane in lanes:
+        lane_stages = [stage for stage in stages if _stage_text(stage, "lane") == lane]
+        for index, stage in enumerate(lane_stages):
+            stage_id = _stage_text(stage, "id")
+            if stage_id:
+                layout[stage_id] = (x_by_lane[lane], 100 + index * (_CARD_HEIGHT + 28))
+    return layout
+
+
+def _svg_edge(start: tuple[int, int], end: tuple[int, int]) -> str:
+    x1, y1 = start[0] + _CARD_WIDTH - 2, start[1] + 48
+    x2, y2 = end[0] - 8, end[1] + 38
+    return (
+        f'<line x1="{x1}" y1="{y1}" x2="{x2}" y2="{y2}" '
+        'stroke="#475569" stroke-width="1.5" marker-end="url(#arrow)"/>'
+    )
+
+
+def _svg_stage(stage: dict[str, object], xy: tuple[int, int]) -> list[str]:
+    x, y = xy
+    lane = str(stage.get("lane", ""))
+    color = _LANE_COLORS.get(lane, "#f8fafc")
+    target = _stage_text(stage, "target") or _stage_text(stage, "runtime") or "target"
+    target_type = _stage_text(stage, "target_type") or "target"
+    return [
+        f'<rect x="{x}" y="{y}" width="{_CARD_WIDTH}" height="{_CARD_HEIGHT}" rx="8" fill="{color}" stroke="#334155" stroke-width="1"/>',
+        _svg_text(x + 12, y + 22, str(stage.get("agent", "agent")), size=13, weight="700"),
+        _svg_text(x + 12, y + 42, f"target: {target} ({target_type})", size=11),
+        _svg_text(x + 12, y + 58, f"model: {stage.get('model', 'model')}", size=11),
+        _svg_text(x + 12, y + 74, f"role: {stage.get('role', 'role')}", size=10, fill="#475569"),
+        _svg_text(x + 12, y + 90, f"cost: {stage.get('cost_tier', 'unknown')}", size=10, fill="#475569"),
+        _svg_text(x + 12, y + 106, f"gate: {stage.get('gate', 'gate')}", size=9, fill="#475569"),
+    ]
+
+
+def _svg_text(x: int, y: int, value: str, *, size: int, weight: str = "400", fill: str = "#0f172a") -> str:
+    return (
+        f'<text x="{x}" y="{y}" font-family="Inter, Arial, sans-serif" '
+        f'font-size="{size}" font-weight="{weight}" fill="{fill}">{_xml_text(value)}</text>'
+    )
+
+
+def _xml_text(value: str) -> str:
+    for character in value:
+        if not _is_xml_10_character(character):
+            raise ValueError("SVG text contains a character that is not valid in XML 1.0")
+    return escape(value)
+
+
+def _is_xml_10_character(character: str) -> bool:
+    codepoint = ord(character)
+    return (
+        codepoint in (0x09, 0x0A, 0x0D)
+        or 0x20 <= codepoint <= 0xD7FF
+        or 0xE000 <= codepoint <= 0xFFFD
+        or 0x10000 <= codepoint <= 0x10FFFF
+    )
+
+
+def _stage_text(stage: dict[str, object], key: str) -> str:
+    value = stage.get(key)
+    return str(value) if value is not None else ""

--- a/src/commands/coding.py
+++ b/src/commands/coding.py
@@ -28,6 +28,7 @@ from ..wrapper.lifecycle import (
     start_codex_delegation_lifecycle,
 )
 from .common import _chat_input_and_metadata, _explicit_source_metadata, _paths, _print_json, _resolved_executor
+from .dynamic_workflow import _add_dynamic_workflow_command, cmd_coding_dynamic_workflow
 
 
 def cmd_coding_delegate(args: argparse.Namespace) -> int:
@@ -486,6 +487,8 @@ def _add_coding_commands(sub) -> None:
     delegate.add_argument("--channel-ref", default="", help="Optional channel reference to store as metadata.")
     delegate.add_argument("--user-ref", default="", help="Optional user reference to store as metadata.")
     delegate.set_defaults(func=cmd_coding_delegate)
+
+    _add_dynamic_workflow_command(coding_sub)
 
     lifecycle = coding_sub.add_parser("lifecycle")
     lifecycle_sub = lifecycle.add_subparsers(dest="lifecycle_command", required=True)

--- a/src/commands/dynamic_workflow.py
+++ b/src/commands/dynamic_workflow.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import argparse
+import json
+
+from ..dynamic_workflow import (
+    build_dynamic_coding_workflow,
+    render_dynamic_workflow_svg,
+    write_dynamic_coding_workflow,
+)
+from ..ingress import CHAT_SOURCES, extract_message_text
+from ..installer import OmhError
+from .common import _chat_input_and_metadata, _paths, _print_json
+
+
+def cmd_coding_dynamic_workflow(args: argparse.Namespace) -> int:
+    try:
+        event_or_message, source_metadata = _chat_input_and_metadata(args)
+        message = extract_message_text(event_or_message)
+        payload = build_dynamic_coding_workflow(
+            message,
+            source=args.source,
+            planners=args.planner,
+            critics=args.critic,
+            implementers=args.implementer,
+            reviewers=args.reviewer,
+            reporter=args.reporter,
+            source_metadata=source_metadata,
+        )
+        if args.write:
+            payload = write_dynamic_coding_workflow(_paths(args), payload)
+        if args.include_svg:
+            payload["chart_svg"] = render_dynamic_workflow_svg(payload)
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        raise OmhError(str(exc)) from exc
+    _print_json(payload)
+    return 0
+
+
+def _add_dynamic_workflow_command(coding_sub) -> None:
+    dynamic = coding_sub.add_parser(
+        "dynamic-workflow",
+        help="Prepare a typed target workflow JSON contract and SVG chart.",
+    )
+    dynamic.add_argument("message", nargs="*", help="Coding goal to convert into a dynamic workflow plan.")
+    dynamic.add_argument(
+        "--source",
+        choices=CHAT_SOURCES,
+        default="generic",
+        help="Source surface that received the coding request.",
+    )
+    dynamic.add_argument("--stdin", action="store_true", help="Read the raw coding goal from stdin.")
+    dynamic.add_argument(
+        "--event-json",
+        default=None,
+        help="Read a Slack/Discord/Hermes-like JSON event from this path, or '-' for stdin.",
+    )
+    dynamic.add_argument(
+        "--planner",
+        action="append",
+        help=(
+            "Planner spec as target[:model[:label[:cost_tier[:target_type]]]]. "
+            "Defaults to the dynamic planning model pool."
+        ),
+    )
+    dynamic.add_argument(
+        "--critic",
+        action="append",
+        help=(
+            "Critic spec as target[:model[:label[:cost_tier[:target_type]]]]. "
+            "Defaults to the dynamic critique model pool."
+        ),
+    )
+    dynamic.add_argument(
+        "--implementer",
+        action="append",
+        help=(
+            "Implementation target spec as target[:model[:label[:cost_tier[:target_type]]]]. "
+            "Repeat for fan-out lanes."
+        ),
+    )
+    dynamic.add_argument(
+        "--reviewer",
+        action="append",
+        help=(
+            "Review target spec as target[:model[:label[:cost_tier[:target_type]]]]. "
+            "Repeat for independent reviewers."
+        ),
+    )
+    dynamic.add_argument(
+        "--reporter",
+        default=None,
+        help="Final report owner spec as target[:model[:label[:cost_tier[:target_type]]]].",
+    )
+    dynamic.add_argument("--write", action="store_true", help="Write workflow.json and workflow-chart.svg under .omh.")
+    dynamic.add_argument(
+        "--include-svg",
+        action="store_true",
+        help="Include SVG text in stdout in addition to artifact paths.",
+    )
+    dynamic.add_argument("--source-event-id", default="", help="Optional source message/event id to store as metadata.")
+    dynamic.add_argument("--channel-ref", default="", help="Optional channel reference to store as metadata.")
+    dynamic.add_argument("--user-ref", default="", help="Optional user reference to store as metadata.")
+    dynamic.set_defaults(func=cmd_coding_dynamic_workflow)

--- a/src/commands/main.py
+++ b/src/commands/main.py
@@ -34,6 +34,7 @@ from .chat import (
 from .coding import (
     _add_coding_commands,
     cmd_coding_delegate,
+    cmd_coding_dynamic_workflow,
     cmd_coding_executor_readiness,
     cmd_coding_lifecycle_dispatch,
     cmd_coding_lifecycle_report,

--- a/src/omh/dynamic_workflow.py
+++ b/src/omh/dynamic_workflow.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from .coding.dynamic_workflow_artifacts import write_dynamic_coding_workflow
+from .coding.dynamic_workflow import *  # noqa: F401,F403
+from .coding.dynamic_workflow_svg import render_dynamic_workflow_svg

--- a/src/plugin_bundle/omh/tools/capability_tool.py
+++ b/src/plugin_bundle/omh/tools/capability_tool.py
@@ -137,11 +137,15 @@ STANDALONE_CAPABILITY_FAMILIES = (
         "label": "Delegate coding and ship",
         "owner_role": "handoff-guide",
         "source_lanes": ("coding_handoff",),
-        "use_for": "Scoped coding handoffs, executor choice, review, QA, CI, and merge readiness.",
+        "use_for": (
+            "Scoped coding handoffs, dynamic typed target choice across model, runtime, wrapper, tool, and agent "
+            "surfaces, review, QA, CI, and merge readiness."
+        ),
         "primary_workflows": (
             "idea-to-deploy",
             "ultraprocess",
             "executor-runtime-readiness",
+            "dynamic-workflow",
             "code-review",
             "build-failure-triage",
             "verification-gate",
@@ -159,7 +163,10 @@ STANDALONE_CAPABILITY_FAMILIES = (
         "executor_choices": ("Codex", "Claude Code", "Hermes", "generic runtime"),
         "next_action": "prepare_scoped_coding_handoff",
         "example_prompt": "Turn this issue into a PR-ready plan and hand it to implementation.",
-        "route_summary": "Choose the coding owner only after scope is concrete, then track observed evidence separately.",
+        "route_summary": (
+            "Choose model, runtime, and coding-owner targets only after scope is concrete, then track observed "
+            "evidence separately."
+        ),
         "not_evidence_until_observed": ("executor dispatch", "implementation", "review", "CI", "merge"),
     },
     {

--- a/src/skills/render.py
+++ b/src/skills/render.py
@@ -348,6 +348,8 @@ def _router_workflow_registry_reference(definitions: list[SkillDefinition]) -> s
 This generated reference is loaded only when exact workflow routing detail matters.
 The always-on `oh-my-hermes` skill keeps only the compact lane map and recovery rules.
 
+{_cli_reference_surfaces_markdown()}
+
 ## Role Registry
 
 {_role_registry(definitions)}
@@ -360,6 +362,24 @@ When Hermes exposes installed skill descriptions to the model, use this registry
 
 Routing is conservative: route only on explicit invocation, strong keyword evidence, or a clear workflow-shaped request. A bare common word such as `team`, `ask`, `wiki`, or `review` is not enough when it could mean normal conversation.
 """.rstrip() + "\n"
+
+
+def _cli_reference_surfaces_markdown() -> str:
+    return """## CLI Reference Surfaces
+
+These surfaces are generated command references, not installed Hermes workflow skills.
+
+### dynamic-workflow
+
+`omh coding dynamic-workflow` prepares `dynamic_coding_workflow/v1`, `workflow.json`, and `workflow-chart.svg` under `.omh/coding/dynamic-workflows/`.
+
+- Exposure: `cli_reference`
+- Install visibility: `false`
+- Docs visibility: `public_cli_reference`
+- Status: `prepared_not_observed`
+- Expected outputs: `dynamic_coding_workflow/v1` metadata-only contract and SVG chart attachment
+- Safety boundary: the generated workflow and chart are not execution, target selection, runtime dispatch, model invocation, implementation, review, CI, PR, merge-readiness, or merge evidence.
+- Privacy boundary: goals are stored as digest metadata; supported source metadata is compacted through the standard source metadata allowlist.""".rstrip()
 
 
 def _router_harness_registry_reference(harnesses: list[HarnessDefinition]) -> str:
@@ -762,6 +782,8 @@ def _workflow_reference_markdown_cached() -> str:
         TARGET_TOPOLOGY_REFERENCE_CONTEXT,
         MEMORY_CONTEXT_REFERENCE_CONTEXT,
         GOAL_STATUS_REFERENCE_CONTEXT,
+        "",
+        *_cli_reference_surfaces_markdown().splitlines(),
         "",
         "## Skills",
         "",

--- a/src/system/local_store.py
+++ b/src/system/local_store.py
@@ -38,15 +38,20 @@ def can_write_dir(path: Path, *, probe_name: str = ".write-test", private: bool 
 def atomic_write_text(path: Path, text: str, *, private: bool = False) -> None:
     ensure_dir(path.parent, private=private)
     tmp = path.with_name(f".{path.name}.tmp")
+    if tmp.exists() or tmp.is_symlink():
+        raise FileExistsError(f"atomic write temp path already exists: {tmp}")
+    created_tmp = False
     try:
-        tmp.write_text(text, encoding="utf-8")
+        with tmp.open("x", encoding="utf-8") as handle:
+            created_tmp = True
+            handle.write(text)
         if private:
             tmp.chmod(0o600)
         tmp.replace(path)
         if private:
             path.chmod(0o600)
     except OSError:
-        if tmp.exists():
+        if created_tmp and tmp.exists() and not tmp.is_symlink():
             tmp.unlink()
         raise
 

--- a/src/system/paths.py
+++ b/src/system/paths.py
@@ -167,6 +167,10 @@ class OmhPaths:
         return self.runtime_dir / "executor-readiness.json"
 
     @property
+    def dynamic_coding_workflows_dir(self) -> Path:
+        return self.omh_home / "coding" / "dynamic-workflows"
+
+    @property
     def target_registry_path(self) -> Path:
         return self.omh_home / "targets.json"
 

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -68,7 +68,7 @@ class CapabilityManifestTests(unittest.TestCase):
         }
         generated_skills = set(installable_skill_names())
         catalog_surfaces = {definition.name for definition in builtin_definitions()}
-        conceptual_surfaces = {"request-to-handoff", "executor selection", "coding runtime handoff"}
+        conceptual_surfaces = {"request-to-handoff", "executor selection", "coding runtime handoff", "dynamic-workflow"}
 
         self.assertFalse(generated_skills - lane_skills)
         self.assertLessEqual(lane_skills - catalog_surfaces, conceptual_surfaces)
@@ -101,6 +101,7 @@ class CapabilityManifestTests(unittest.TestCase):
         self.assertNotIn("wiki", families["create_materials_and_visuals"]["primary_workflows"])
         self.assertIn("ultraprocess", families["delegate_coding_and_ship"]["primary_workflows"])
         self.assertIn("executor-runtime-readiness", families["delegate_coding_and_ship"]["primary_workflows"])
+        self.assertIn("dynamic-workflow", families["delegate_coding_and_ship"]["primary_workflows"])
         self.assertIn("build-failure-triage", families["delegate_coding_and_ship"]["primary_workflows"])
         self.assertIn("verification-gate", families["delegate_coding_and_ship"]["primary_workflows"])
         self.assertIn("doctor", families["operate_and_observe"]["primary_workflows"])
@@ -132,6 +133,7 @@ class CapabilityManifestTests(unittest.TestCase):
         self.assertEqual(projection["workflow_to_family"]["data-analysis"], "learn_and_gather")
         self.assertEqual(projection["workflow_to_family"]["ultraprocess"], "delegate_coding_and_ship")
         self.assertEqual(projection["workflow_to_family"]["executor-runtime-readiness"], "delegate_coding_and_ship")
+        self.assertEqual(projection["workflow_to_family"]["dynamic-workflow"], "delegate_coding_and_ship")
         self.assertEqual(projection["workflow_to_family"]["build-failure-triage"], "delegate_coding_and_ship")
         self.assertEqual(projection["workflow_to_family"]["verification-gate"], "delegate_coding_and_ship")
         self.assertEqual(projection["workflow_to_family"]["github-event-ops"], "operate_and_observe")
@@ -154,6 +156,7 @@ class CapabilityManifestTests(unittest.TestCase):
         self.assertEqual(family_for_workflow("wiki")["id"], "retain_knowledge")
         self.assertEqual(family_for_workflow("code-review")["id"], "delegate_coding_and_ship")
         self.assertEqual(family_for_workflow("executor-runtime-readiness")["id"], "delegate_coding_and_ship")
+        self.assertEqual(family_for_workflow("dynamic-workflow")["id"], "delegate_coding_and_ship")
         self.assertEqual(family_for_workflow("accessibility-audit")["id"], "create_materials_and_visuals")
         self.assertEqual(family_for_workflow("workflow-learning")["id"], "operate_and_observe")
         self.assertEqual(family_for_workflow("gateway-intent-card")["id"], "operate_and_observe")

--- a/tests/test_dynamic_workflow.py
+++ b/tests/test_dynamic_workflow.py
@@ -1,0 +1,374 @@
+from __future__ import annotations
+
+import json
+import re
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from _cli_harness import run_cli
+from _local_package import load_local_package
+
+load_local_package()
+
+from omh.dynamic_workflow import (
+    DYNAMIC_WORKFLOW_CHART_SCHEMA_VERSION,
+    DYNAMIC_WORKFLOW_SCHEMA_VERSION,
+    build_dynamic_coding_workflow,
+    render_dynamic_workflow_svg,
+    write_dynamic_coding_workflow,
+)
+from omh.paths import resolve_paths
+
+
+class DynamicWorkflowTests(unittest.TestCase):
+    def test_default_workflow_prepares_dynamic_target_plan_without_claiming_execution(self) -> None:
+        workflow = build_dynamic_coding_workflow("Build the dynamic coding orchestration feature")
+
+        self.assertEqual(workflow["schema_version"], DYNAMIC_WORKFLOW_SCHEMA_VERSION)
+        self.assertEqual(workflow["status"], "prepared_not_observed")
+        targets = {stage["target"] for stage in workflow["stages"]}
+        target_types = {stage["target_type"] for stage in workflow["stages"]}
+
+        for concrete_target in {"gpt", "claude-code", "glm", "codex", "pi", "omp-runtime", "omx-runtime"}:
+            self.assertNotIn(concrete_target, targets)
+        for expected in {"planning-model-pool", "implementation-model-pool", "executor-runtime-pool", "hermes"}:
+            self.assertIn(expected, targets)
+        for expected_type in {"model", "runtime", "wrapper"}:
+            self.assertIn(expected_type, target_types)
+
+        gates = {stage["gate"] for stage in workflow["stages"]}
+        self.assertIn("critic_approval_required", gates)
+        self.assertIn("independent_review_required", gates)
+        self.assertIn("model invocation", " ".join(workflow["prepared_is_not"]))
+        self.assertIn("model selection", " ".join(workflow["prepared_is_not"]))
+        self.assertIn("target_selection_observed", workflow["observed_evidence_required"])
+        self.assertIn("runtime_dispatch_observed", workflow["observed_evidence_required"])
+        self.assertEqual(workflow["goal"]["summary_kind"], "digest_reference")
+        self.assertFalse(workflow["goal"]["raw_prompt_stored"])
+        self.assertEqual(workflow["target_selection"]["selection_unit"], "typed_orchestration_target")
+
+    def test_workflow_goal_payload_stores_digest_not_prompt_text(self) -> None:
+        workflow = build_dynamic_coding_workflow(
+            "Deploy with token sk-test-secret-123, password hunter2, and private email user@example.com"
+        )
+        serialized = json.dumps(workflow, sort_keys=True)
+
+        self.assertNotIn("sk-test-secret-123", serialized)
+        self.assertNotIn("hunter2", serialized)
+        self.assertNotIn("user@example.com", serialized)
+        self.assertIn("sha256:", workflow["goal"]["summary"])
+        self.assertEqual(workflow["goal"]["summary_kind"], "digest_reference")
+        self.assertFalse(workflow["goal"]["raw_prompt_stored"])
+        self.assertFalse(workflow["goal"]["content_preview_stored"])
+        self.assertEqual(
+            workflow["goal"]["input_chars"],
+            len("Deploy with token sk-test-secret-123, password hunter2, and private email user@example.com"),
+        )
+        self.assertRegex(workflow["goal"]["sha256"], r"^[0-9a-f]{64}$")
+
+    def test_explicit_glm_and_pi_specs_keep_model_and_runtime_targets_distinct(self) -> None:
+        workflow = build_dynamic_coding_workflow(
+            "Ship a reviewed multi-agent implementation",
+            implementers=("glm:auto:GLM model target", "pi:auto:Pi runtime target"),
+        )
+        stages = {stage["target"]: stage for stage in workflow["stages"]}
+
+        self.assertEqual(stages["glm"]["target_type"], "model")
+        self.assertEqual(stages["pi"]["target_type"], "runtime")
+        self.assertEqual(stages["glm"]["runtime"], "")
+        self.assertEqual(stages["pi"]["runtime"], "pi")
+
+        svg = render_dynamic_workflow_svg(workflow)
+
+        self.assertTrue(svg.startswith("<svg "))
+        self.assertIn("<title", svg)
+        self.assertIn("<desc", svg)
+        self.assertIn(DYNAMIC_WORKFLOW_CHART_SCHEMA_VERSION, svg)
+        self.assertIn("GLM model target", svg)
+        self.assertIn("target: glm (model)", svg)
+        self.assertIn("target: pi (runtime)", svg)
+        self.assertIn("model: auto", svg)
+        self.assertIn("role: implementation_owner", svg)
+        self.assertIn("cost: medium", svg)
+        self.assertIn("gate: handoff_prepared_after_critique", svg)
+        self.assertIn("Pi runtime target", svg)
+        self.assertIn("prepared_not_observed", svg)
+
+    def test_svg_chart_viewbox_contains_rightmost_stage(self) -> None:
+        workflow = build_dynamic_coding_workflow("Render a complete chart without clipping")
+        svg = render_dynamic_workflow_svg(workflow)
+
+        width_match = re.search(r'viewBox="0 0 ([0-9]+) ([0-9]+)"', svg)
+        rect_matches = [
+            (int(x), int(width))
+            for x, width in re.findall(r'<rect x="([0-9]+)" y="[0-9]+" width="([0-9]+)" height="112"', svg)
+        ]
+
+        self.assertIsNotNone(width_match)
+        self.assertTrue(rect_matches)
+        self.assertLessEqual(max(x + width for x, width in rect_matches), int(width_match.group(1)))
+
+    def test_glm_like_targets_infer_model_without_exact_id_match(self) -> None:
+        workflow = build_dynamic_coding_workflow(
+            "Route model-family targets without collapsing them to runtimes",
+            implementers=("glm-4.5:auto:GLM 4.5", "glm-pro:auto:GLM Pro", "gpt-5.5:auto:GPT 5.5"),
+        )
+        stages = {stage["target"]: stage for stage in workflow["stages"]}
+
+        self.assertEqual(stages["glm-4.5"]["target_type"], "model")
+        self.assertEqual(stages["glm-pro"]["target_type"], "model")
+        self.assertEqual(stages["gpt-5.5"]["target_type"], "model")
+        self.assertEqual(stages["glm-4.5"]["runtime"], "")
+        self.assertEqual(stages["glm-4.5"]["cost_tier"], "medium")
+
+    def test_pi_like_targets_remain_runtime_or_agent_surfaces(self) -> None:
+        workflow = build_dynamic_coding_workflow(
+            "Route Pi-like surfaces without treating them as model families",
+            implementers=("pi:auto:Pi runtime", "pi-runtime:auto:Pi runtime profile", "pi-agent:auto:Pi agent"),
+        )
+        stages = {stage["target"]: stage for stage in workflow["stages"]}
+
+        self.assertEqual(stages["pi"]["target_type"], "runtime")
+        self.assertEqual(stages["pi-runtime"]["target_type"], "runtime")
+        self.assertEqual(stages["pi-agent"]["target_type"], "agent")
+        self.assertEqual(stages["pi-agent"]["runtime"], "")
+
+    def test_svg_chart_tolerates_malformed_stage_dicts(self) -> None:
+        svg = render_dynamic_workflow_svg({"stages": [{"id": "missing-lane"}, {"lane": "planning"}], "edges": []})
+
+        self.assertTrue(svg.startswith("<svg "))
+        self.assertIn("Dynamic coding workflow", svg)
+
+    def test_svg_chart_rejects_xml_control_characters(self) -> None:
+        workflow = build_dynamic_coding_workflow(
+            "Prepare a dynamic workflow safely",
+            implementers=("glm:auto:Bad\x01Label",),
+        )
+
+        with self.assertRaisesRegex(ValueError, "XML 1.0"):
+            render_dynamic_workflow_svg(workflow)
+
+    def test_cli_writes_workflow_json_and_svg_image_artifact(self) -> None:
+        with TemporaryDirectory() as tmp:
+            omh_home = Path(tmp) / ".omh"
+
+            status, stdout, stderr = run_cli(
+                [
+                    "--omh-home",
+                    str(omh_home),
+                    "coding",
+                    "dynamic-workflow",
+                    "--write",
+                    "--planner",
+                    "planning-model-pool:auto:Planning model pool:adaptive:model",
+                    "--critic",
+                    "critique-model-pool:auto:Critique model pool:adaptive:model",
+                    "--implementer",
+                    "implementation-model-pool:auto:Implementation model pool:adaptive:model",
+                    "--implementer",
+                    "executor-runtime-pool:auto:Executor runtime pool:runtime-variable:runtime",
+                    "--reviewer",
+                    "review-model-pool:auto:Review model pool:adaptive:model",
+                    "Build this feature with adversarial review",
+                ]
+            )
+
+            self.assertEqual(status, 0, stderr)
+            self.assertEqual(stderr, "")
+            payload = json.loads(stdout)
+            workflow_path = Path(payload["artifacts"]["workflow_path"])
+            chart_path = Path(payload["artifacts"]["chart_path"])
+
+            self.assertTrue(workflow_path.exists())
+            self.assertTrue(chart_path.exists())
+            self.assertEqual(payload["status"], "prepared_not_observed")
+            self.assertEqual(payload["chart"]["format"], "svg")
+            self.assertEqual(payload["message_projection"]["attachments"][0]["kind"], "image")
+            self.assertEqual(payload["target_selection"]["selection_unit"], "typed_orchestration_target")
+            self.assertIn("target_type", payload["stages"][0])
+            self.assertFalse((omh_home / "runtime" / "runs").exists())
+            self.assertIn("not execution", " ".join(payload["prepared_is_not"]))
+            self.assertIn("<svg ", chart_path.read_text(encoding="utf-8"))
+
+    def test_cli_source_metadata_partitions_persisted_workflow_paths(self) -> None:
+        with TemporaryDirectory() as tmp:
+            omh_home = Path(tmp) / ".omh"
+            base_args = [
+                "--omh-home",
+                str(omh_home),
+                "coding",
+                "dynamic-workflow",
+                "--write",
+                "--source",
+                "discord",
+                "--channel-ref",
+                "channel-a",
+                "Build the dynamic workflow feature",
+            ]
+
+            first_status, first_stdout, first_stderr = run_cli(base_args + ["--source-event-id", "event-1"])
+            second_status, second_stdout, second_stderr = run_cli(base_args + ["--source-event-id", "event-2"])
+
+            self.assertEqual(first_status, 0, first_stderr)
+            self.assertEqual(second_status, 0, second_stderr)
+            first_payload = json.loads(first_stdout)
+            second_payload = json.loads(second_stdout)
+
+            self.assertNotEqual(first_payload["workflow_id"], second_payload["workflow_id"])
+            self.assertNotEqual(first_payload["artifacts"]["workflow_path"], second_payload["artifacts"]["workflow_path"])
+            self.assertEqual(first_payload["source_metadata"]["source_event_id"], "event-1")
+            self.assertEqual(second_payload["source_metadata"]["source_event_id"], "event-2")
+            self.assertTrue(Path(first_payload["artifacts"]["workflow_path"]).exists())
+            self.assertTrue(Path(second_payload["artifacts"]["workflow_path"]).exists())
+
+    def test_source_metadata_allowlist_drops_raw_or_secret_like_keys(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            workflow = build_dynamic_coding_workflow(
+                "Prepare a dynamic workflow safely",
+                source_metadata={
+                    "source_event_id": "event-safe",
+                    "channel_ref": "channel-safe",
+                    "raw_message": "token sk-live-secret",
+                    "password": "hunter2",
+                },
+            )
+
+            payload = write_dynamic_coding_workflow(paths, workflow)
+            workflow_path = Path(payload["artifacts"]["workflow_path"])
+            serialized = json.dumps(payload, sort_keys=True) + workflow_path.read_text(encoding="utf-8")
+
+            self.assertEqual(payload["source_metadata"], {"source_event_id": "event-safe", "channel_ref": "channel-safe"})
+            self.assertNotIn("raw_message", serialized)
+            self.assertNotIn("sk-live-secret", serialized)
+            self.assertNotIn("hunter2", serialized)
+
+    def test_cli_stdout_and_persisted_artifacts_redact_secret_like_goal(self) -> None:
+        with TemporaryDirectory() as tmp:
+            omh_home = Path(tmp) / ".omh"
+            secret_goal = "Deploy with token sk-test-secret-123, password hunter2, and private email user@example.com"
+
+            status, stdout, stderr = run_cli(
+                ["--omh-home", str(omh_home), "coding", "dynamic-workflow", "--write", secret_goal]
+            )
+
+            self.assertEqual(status, 0, stderr)
+            self.assertEqual(stderr, "")
+            payload = json.loads(stdout)
+            workflow_path = Path(payload["artifacts"]["workflow_path"])
+            serialized = stdout + workflow_path.read_text(encoding="utf-8")
+
+            self.assertNotIn("sk-test-secret-123", serialized)
+            self.assertNotIn("hunter2", serialized)
+            self.assertNotIn("user@example.com", serialized)
+            self.assertIn("sha256:", payload["goal"]["summary"])
+            self.assertFalse(payload["goal"]["content_preview_stored"])
+
+    def test_writer_rejects_workflow_id_path_traversal(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            workflow = build_dynamic_coding_workflow("Prepare a dynamic workflow safely")
+            workflow["workflow_id"] = "../../../../outside-omh-audit"
+
+            with self.assertRaisesRegex(ValueError, "workflow_id"):
+                write_dynamic_coding_workflow(paths, workflow)
+
+            self.assertFalse((root / "outside-omh-audit").exists())
+
+    def test_writer_rejects_symlinked_dynamic_workflow_storage(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            storage = paths.dynamic_coding_workflows_dir
+            outside = root / "outside-workflows"
+            storage.parent.mkdir(parents=True)
+            outside.mkdir()
+            try:
+                storage.symlink_to(outside, target_is_directory=True)
+            except (NotImplementedError, OSError) as exc:
+                self.skipTest(f"symlink creation unavailable: {exc}")
+
+            workflow = build_dynamic_coding_workflow("Prepare a dynamic workflow safely")
+
+            with self.assertRaisesRegex(ValueError, "storage must not be a symlink"):
+                write_dynamic_coding_workflow(paths, workflow)
+
+            self.assertFalse((outside / workflow["workflow_id"] / "workflow.json").exists())
+
+    def test_writer_rejects_symlinked_dynamic_workflow_parent_escape(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            coding_dir = paths.dynamic_coding_workflows_dir.parent
+            outside = root / "outside-coding"
+            coding_dir.parent.mkdir(parents=True)
+            outside.mkdir()
+            try:
+                coding_dir.symlink_to(outside, target_is_directory=True)
+            except (NotImplementedError, OSError) as exc:
+                self.skipTest(f"symlink creation unavailable: {exc}")
+
+            workflow = build_dynamic_coding_workflow("Prepare a dynamic workflow safely")
+
+            with self.assertRaisesRegex(ValueError, "storage must resolve under OMH home"):
+                write_dynamic_coding_workflow(paths, workflow)
+
+            self.assertFalse((outside / "dynamic-workflows" / workflow["workflow_id"] / "workflow.json").exists())
+
+    def test_writer_stores_private_workflow_artifacts(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            workflow = build_dynamic_coding_workflow("Prepare a dynamic workflow privately")
+
+            payload = write_dynamic_coding_workflow(paths, workflow)
+            workflow_path = Path(payload["artifacts"]["workflow_path"])
+            chart_path = Path(payload["artifacts"]["chart_path"])
+
+            self.assertEqual(workflow_path.stat().st_mode & 0o777, 0o600)
+            self.assertEqual(chart_path.stat().st_mode & 0o777, 0o600)
+            self.assertEqual(workflow_path.parent.stat().st_mode & 0o777, 0o700)
+
+    def test_writer_does_not_leave_chart_when_workflow_json_write_is_blocked(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            workflow = build_dynamic_coding_workflow("Prepare a dynamic workflow atomically")
+            workflow_dir = paths.dynamic_coding_workflows_dir / str(workflow["workflow_id"])
+            workflow_dir.mkdir(parents=True)
+            (workflow_dir / ".workflow.json.tmp").write_text("blocked", encoding="utf-8")
+
+            with self.assertRaisesRegex(FileExistsError, "atomic write temp path already exists"):
+                write_dynamic_coding_workflow(paths, workflow)
+
+            self.assertFalse((workflow_dir / "workflow-chart.svg").exists())
+            self.assertFalse((workflow_dir / "workflow.json").exists())
+
+    def test_writer_rejects_preexisting_temp_symlink_escape(self) -> None:
+        for filename, outside_name in (
+            (".workflow-chart.svg.tmp", "outside-chart.svg"),
+            (".workflow.json.tmp", "outside-workflow.json"),
+        ):
+            with self.subTest(filename=filename), TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                paths = resolve_paths(root / ".omh", root / ".hermes")
+                workflow = build_dynamic_coding_workflow("Prepare a dynamic workflow safely")
+                workflow_dir = paths.dynamic_coding_workflows_dir / str(workflow["workflow_id"])
+                outside = root / outside_name
+                workflow_dir.mkdir(parents=True)
+                try:
+                    (workflow_dir / filename).symlink_to(outside)
+                except (NotImplementedError, OSError) as exc:
+                    self.skipTest(f"symlink creation unavailable: {exc}")
+
+                with self.assertRaisesRegex(FileExistsError, "atomic write temp path already exists"):
+                    write_dynamic_coding_workflow(paths, workflow)
+
+                self.assertFalse(outside.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_orchestration_patterns.py
+++ b/tests/test_orchestration_patterns.py
@@ -25,6 +25,7 @@ class OrchestrationPatternTests(unittest.TestCase):
             "research_department_workflow",
             "executor_session_handoff",
             "hermes_coding_team_path",
+            "dynamic_runtime_workflow",
             "materials_generation_handoff",
         }:
             self.assertIn(expected, patterns)
@@ -52,3 +53,12 @@ class OrchestrationPatternTests(unittest.TestCase):
         hermes_team = patterns["hermes_coding_team_path"]
         self.assertIn("record_runtime_observation", hermes_team["wrapper_actions"])
         self.assertIn("merge_observed", hermes_team["observed_evidence_required"])
+
+        dynamic = patterns["dynamic_runtime_workflow"]
+        self.assertIn("typed_target_routing_policy", dynamic["required_decisions"])
+        self.assertIn("target_type_assignments", dynamic["required_decisions"])
+        self.assertIn("dynamic_coding_workflow_chart/v1", dynamic["prepared_artifacts"])
+        self.assertIn("target_selection_observed", dynamic["observed_evidence_required"])
+        self.assertIn("runtime_dispatch_observed", dynamic["observed_evidence_required"])
+        self.assertIn("model, runtime, wrapper, tool, and agent targets", dynamic["use_when"])
+        self.assertIn("Do not claim any model, runtime, wrapper, tool, or agent target was selected", dynamic["do_not_use_when"])

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -2210,6 +2210,11 @@ class RouterContentTests(unittest.TestCase):
         self.assertIn("omh_target_topology/v1", reference)
         self.assertIn("Exposure is the install contract", reference)
         self.assertIn("router-only, harness-only, and agent-context surfaces stay routable references", reference)
+        self.assertIn("## CLI Reference Surfaces", reference)
+        self.assertIn("### dynamic-workflow", reference)
+        self.assertIn("- Exposure: `cli_reference`", reference)
+        self.assertIn("- Install visibility: `false`", reference)
+        self.assertIn("`dynamic_coding_workflow/v1` metadata-only contract", reference)
         for definition in builtin_definitions():
             exposure = skill_exposure_payload(definition.name)
             self.assertIn(f"### {definition.name}", reference)


### PR DESCRIPTION
## Feature Report

### What Changed

- Added `omh coding dynamic-workflow` to prepare a typed `dynamic_coding_workflow/v1` contract and SVG workflow chart for coding requests.
- Added dynamic workflow builders, target specs, privacy helpers, artifact writers, and SVG rendering under `src/coding/`.
- Exposed the surface in capabilities, command wiring, generated workflow docs, and the installed `oh-my-hermes` reference registry as a CLI reference, not an installable workflow skill.

### Why This Exists

- OMH needs to cover more Hermes agentic coding requests by preparing a readable, metadata-only execution plan that can be handed to selected coding owners without pretending execution has already happened.
- The recovered xhigh/sol work had no PR yet and needed review fixes for source metadata privacy and generated reference exposure before merge.

### User / Operator Impact

- Operators can run `omh coding dynamic-workflow ... --write --include-svg` and get a `workflow.json` plus `workflow-chart.svg` under `.omh/coding/dynamic-workflows/`.
- The output remains `prepared_not_observed`, so it cannot be mistaken for dispatch, implementation, review, CI, PR, or merge evidence.
- Slack/Discord/Hermes-style source metadata is compacted through the standard allowlist before persistence.

### How It Works

- `src/commands/dynamic_workflow.py` reads plain, stdin, or event JSON input and passes compact source metadata into the workflow builder.
- `src/coding/dynamic_workflow.py` builds deterministic dynamic workflow ids, role lanes, target assignments, message projection, and metadata-only status.
- `src/coding/dynamic_workflow_artifacts.py` writes private artifacts, rejects unmanaged/symlinked storage paths, and cleans partial writes on chart failure.
- `src/coding/dynamic_workflow_svg.py` renders the chart and rejects invalid XML control characters before escaping.
- `src/skills/render.py` now generates a shared CLI Reference Surfaces block into both `docs/WORKFLOWS.md` and `skills/oh-my-hermes/references/workflow-registry.md`.

### Files And Contracts Touched

- New contract: `dynamic_coding_workflow/v1`.
- New command: `omh coding dynamic-workflow`.
- New artifact directory property: `.omh/coding/dynamic-workflows/`.
- Updated capability reporting and orchestration patterns for dynamic workflow preparation.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` passed, 1290 tests.
- [x] `uv run python -m compileall -q src tests` passed.
- [x] `uv run python -m omh.cli docs workflows --check` passed, including 88 expected tap skill/reference files.
- [x] `uv run python -m omh.cli release skill-content-smoke --json` passed with `ok=true` and no failed checks.
- [x] `git diff --check` and `git diff --staged --check` passed.
- [x] Manual CLI happy path generated workflow/chart artifacts with mode `0600`, `prepared_not_observed`, SVG in stdout, compact metadata keys only, and no persisted event token.
- [x] Manual CLI bad input returned rc 2 with `omh: dynamic workflow goal is required`.
- [x] Follow-up code-reviewer pass confirmed source metadata/privacy/artifact permission risk was fixed.
- [x] Follow-up code-reviewer pass confirmed generated CLI reference exposure in both workflow docs and installed registry, without registering an installable `dynamic-workflow` skill.
- [ ] LSP diagnostics: not run because `basedpyright` is not installed and prior installation was declined.
- [ ] Manual Hermes/TUI check: not applicable; this change prepares local CLI artifacts and does not dispatch Hermes runtime work.

## Risk

- Moderate scope because this adds a new command and generated docs surface, but runtime side effects are local metadata-only artifacts.
- Main safety risk is confusing prepared plans with execution evidence; docs, payload status, tests, and PR text preserve the boundary.

## Compatibility / Rollout

- Compatible with existing skill install surfaces because `dynamic-workflow` is documented as `cli_reference` with `Install visibility: false`.
- No network, platform SDK, Hermes core patching, or runtime dispatch was added.

## Release / Claims

- [x] Release-channel impact considered: local/preview capability addition, no stable runtime execution claim.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] Known manual Hermes checks are listed; no live `omh release hermes-smoke --live` was run because this is a local CLI artifact-preparation change.

## Follow-Up

- None required for this goal.