### PR TITLE
feat: prepare redacted channel QA cards

### DIFF
--- a/src/commands/web_qa.py
+++ b/src/commands/web_qa.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from omh.installer import OmhError
 from omh.web_visual_qa import (
     WebVisualQaCaptureFileImport,
+    build_web_visual_qa_channel_delivery_card,
     build_web_visual_qa_message_card,
     build_web_visual_qa_package,
     import_web_visual_qa_capture_file,
@@ -149,10 +150,13 @@ def cmd_web_qa_show(args: argparse.Namespace) -> int:
         package_errors = validate_web_visual_qa_package(current)
         if package_errors:
             raise ValueError("; ".join(package_errors))
-        card = build_web_visual_qa_message_card(current)
-        errors = validate_web_visual_qa_message_card(card)
-        if errors:
-            raise ValueError("; ".join(errors))
+        if args.renderer_target:
+            card = build_web_visual_qa_channel_delivery_card(current, renderer_target=args.renderer_target)
+        else:
+            card = build_web_visual_qa_message_card(current)
+            errors = validate_web_visual_qa_message_card(card)
+            if errors:
+                raise ValueError("; ".join(errors))
     except (OSError, ValueError) as exc:
         raise OmhError(str(exc)) from exc
     _print_card_or_summarize(args, card)
@@ -267,6 +271,16 @@ def _print_card_or_summarize(args: argparse.Namespace, card: JsonObject) -> None
     if _wants_json(args):
         _print_json(card)
         return
+    if card.get("schema_version") == "web_visual_qa_channel_delivery/v1":
+        print("Web visual QA channel delivery card")
+        print(f"Renderer: {card['renderer_target']}")
+        print(f"Package: {card['package_id']}")
+        print(f"Target: {card['target']}")
+        print(f"Attachments: {len(object_list(card.get('attachments')))} prepared")
+        print(f"Blocked captures: {len(object_list(card.get('blocked_captures')))}")
+        print("Delivery: not observed; adapter upload is required.")
+        print("Use --json for the full channel-delivery projection.")
+        return
     route = card["route"] if isinstance(card.get("route"), dict) else {}
     attachment_summary = card["attachment_summary"] if isinstance(card.get("attachment_summary"), dict) else {}
     print("Web visual QA message card")
@@ -357,6 +371,7 @@ def _add_web_qa_commands(sub) -> None:
 
     show = web_qa_sub.add_parser("show", help="Show a message-card projection for a recorded package.")
     show.add_argument("--package-id", required=True)
+    show.add_argument("--renderer-target", choices=("discord", "slack", "telegram"))
     show.add_argument("--json", action="store_true")
     show.set_defaults(func=cmd_web_qa_show)
 

--- a/src/omh/web_visual_qa.py
+++ b/src/omh/web_visual_qa.py
@@ -17,6 +17,7 @@ from .workflows.web_visual_qa_contracts import (
     WEB_VISUAL_QA_PACKAGE_SCHEMA_VERSION,
 )
 from .workflows.web_visual_qa_message_card import build_web_visual_qa_message_card
+from .workflows.web_visual_qa_message_card import build_web_visual_qa_channel_delivery_card
 from .workflows.web_visual_qa_validation import (
     validate_web_visual_qa_message_card,
     validate_web_visual_qa_package,
@@ -28,6 +29,7 @@ __all__ = (
     "WEB_VISUAL_QA_PACKAGE_SCHEMA_VERSION",
     "WebVisualQaCaptureFileImport",
     "build_web_visual_qa_message_card",
+    "build_web_visual_qa_channel_delivery_card",
     "build_web_visual_qa_package",
     "import_web_visual_qa_capture_file",
     "list_web_visual_qa_packages",

--- a/src/workflows/web_visual_qa_contracts.py
+++ b/src/workflows/web_visual_qa_contracts.py
@@ -17,6 +17,7 @@ WEB_VISUAL_QA_PACKAGES_INDEX_SCHEMA_VERSION: Final = "omh_web_visual_qa_packages
 MESSAGE_ATTACHMENT_PROJECTION_SCHEMA_VERSION: Final = "message_attachment_projection/v1"
 WEB_VISUAL_QA_MESSAGE_CARD_SCHEMA_VERSION: Final = "web_visual_qa_message_card/v1"
 WEB_VISUAL_QA_MESSAGE_ROUTE_SCHEMA_VERSION: Final = "web_visual_qa_message_route/v1"
+WEB_VISUAL_QA_CHANNEL_DELIVERY_SCHEMA_VERSION: Final = "web_visual_qa_channel_delivery/v1"
 WEB_VISUAL_QA_CLAIM_BOUNDARY: Final = (
     "OMH records supplied web visual QA evidence only; it does not capture browsers, call multimodal models, upload "
     "messages, or prove delivery."
@@ -34,6 +35,7 @@ SUPPORTED_VERDICTS: Final = ("pass", "hold", "fail", "not_observed")
 SUPPORTED_LIFECYCLE_STATUSES: Final = ("prepared", "captures_observed", "criteria_recorded", "verdict_recorded")
 SUPPORTED_RESULT_STATUSES: Final = ("pass", "hold", "fail", "not_observed")
 SUPPORTED_SOURCES: Final = ("discord", "slack", "hermes", "generic")
+SUPPORTED_RENDERER_TARGETS: Final = ("discord", "slack", "telegram")
 SUPPORTED_COST_TIERS: Final = ("none", "low", "medium", "high", "unknown")
 SUPPORTED_CONFIDENCE: Final = ("low", "medium", "high", "unknown")
 SUPPORTED_RISK_LEVELS: Final = ("low", "medium", "high", "critical", "unknown")

--- a/src/workflows/web_visual_qa_message_card.py
+++ b/src/workflows/web_visual_qa_message_card.py
@@ -5,12 +5,57 @@ from .web_visual_qa_contracts import (
     WEB_VISUAL_QA_MESSAGE_CARD_DOES_NOT_PROVE,
     WEB_VISUAL_QA_MESSAGE_CARD_SCHEMA_VERSION,
     WEB_VISUAL_QA_MESSAGE_ROUTE_SCHEMA_VERSION,
+    WEB_VISUAL_QA_CHANNEL_DELIVERY_SCHEMA_VERSION,
+    SUPPORTED_RENDERER_TARGETS,
     JsonObject,
     JsonValue,
     object_list,
     object_value,
     text,
 )
+
+
+def build_web_visual_qa_channel_delivery_card(package: JsonObject, *, renderer_target: str) -> JsonObject:
+    if renderer_target not in SUPPORTED_RENDERER_TARGETS:
+        raise ValueError("renderer_target must be discord, slack, or telegram")
+    projection = object_value(package.get("attachment_projection"))
+    captures_by_id = {text(capture.get("capture_id")): capture for capture in object_list(package.get("captures"))}
+    attachments = [
+        {
+            "capture_id": text(item.get("capture_id")),
+            "alt_text": "Web QA screenshot",
+            "display_order": item.get("display_order"),
+        }
+        for item in object_list(projection.get("items"))
+        if text(object_value(captures_by_id.get(text(item.get("capture_id")))).get("redaction_status")) in {"not_needed", "redacted"}
+    ]
+    blocked_captures = [
+        {
+            "capture_id": text(item.get("capture_id")),
+            "reason": text(item.get("reason")),
+        }
+        for item in object_list(projection.get("blocked_items"))
+    ]
+    blocked_ids = {text(item.get("capture_id")) for item in blocked_captures}
+    for item in object_list(projection.get("items")):
+        capture_id = text(item.get("capture_id"))
+        redaction_status = text(object_value(captures_by_id.get(capture_id)).get("redaction_status"))
+        if redaction_status not in {"not_needed", "redacted"} and capture_id not in blocked_ids:
+            blocked_captures.append({"capture_id": capture_id, "reason": "redaction_not_confirmed"})
+    return {
+        "schema_version": WEB_VISUAL_QA_CHANNEL_DELIVERY_SCHEMA_VERSION,
+        "renderer_target": renderer_target,
+        "source": text(package.get("source")) or "generic",
+        "package_id": text(package.get("package_id")),
+        "target": text(package.get("target")),
+        "status": "prepared_not_observed",
+        "delivery_observed": False,
+        "attachments": attachments,
+        "blocked_captures": blocked_captures,
+        "adapter_action": "adapter_upload_and_record_delivery_observation",
+        "does_not_prove": ["message_sent", "attachment_uploaded", "platform_delivery"],
+        "claim_boundary": "This is a redacted prepared card. The channel adapter owns upload and observed delivery evidence.",
+    }
 
 
 def build_web_visual_qa_message_card(package: JsonObject) -> JsonObject:

--- a/tests/test_web_visual_qa_channel_delivery.py
+++ b/tests/test_web_visual_qa_channel_delivery.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from omh.web_visual_qa import build_web_visual_qa_channel_delivery_card, build_web_visual_qa_package
+from tests.test_cli import run_cli
+
+
+class WebVisualQaChannelDeliveryTests(unittest.TestCase):
+    def test_channel_card_prepares_redacted_attachment_candidates(self) -> None:
+        package = build_web_visual_qa_package(
+            package_id="checkout-qa",
+            target="Checkout",
+            source="hermes",
+            criteria=({"criterion_id": "layout", "label": "Layout", "pass_rule": "fits", "severity": "blocking"},),
+            captures=(
+                {"capture_id": "desktop", "path_or_uri": "/tmp/desktop.png", "mime_type": "image/png", "viewport": "desktop", "evidence_summary": "Desktop capture", "redaction_status": "not_needed"},
+                {"capture_id": "secret", "path_or_uri": "/tmp/secret.png", "mime_type": "image/png", "viewport": "mobile", "evidence_summary": "Sensitive capture", "redaction_status": "contains_sensitive_content"},
+            ),
+        )
+
+        card = build_web_visual_qa_channel_delivery_card(package, renderer_target="slack")
+
+        self.assertEqual(card["schema_version"], "web_visual_qa_channel_delivery/v1")
+        self.assertEqual(card["renderer_target"], "slack")
+        self.assertEqual(card["source"], "hermes")
+        self.assertEqual(card["status"], "prepared_not_observed")
+        self.assertFalse(card["delivery_observed"])
+        self.assertEqual(card["attachments"][0]["capture_id"], "desktop")
+        self.assertNotIn("path_or_uri", card["blocked_captures"][0])
+        self.assertNotIn("evidence_summary", card["blocked_captures"][0])
+        self.assertIn("platform_delivery", card["does_not_prove"])
+
+    def test_channel_card_rejects_unknown_renderer(self) -> None:
+        package = build_web_visual_qa_package(
+            package_id="checkout-qa",
+            target="Checkout",
+            criteria=({"criterion_id": "layout", "label": "Layout", "pass_rule": "fits", "severity": "blocking"},),
+        )
+
+        with self.assertRaises(ValueError):
+            build_web_visual_qa_channel_delivery_card(package, renderer_target="unknown")
+
+    def test_channel_card_blocks_unknown_redaction(self) -> None:
+        package = build_web_visual_qa_package(
+            package_id="checkout-qa",
+            target="Checkout",
+            criteria=({"criterion_id": "layout", "label": "Layout", "pass_rule": "fits", "severity": "blocking"},),
+            captures=({"capture_id": "unknown", "path_or_uri": "/tmp/unknown.png", "mime_type": "image/png", "viewport": "desktop", "evidence_summary": "Unreviewed capture"},),
+        )
+
+        card = build_web_visual_qa_channel_delivery_card(package, renderer_target="discord")
+
+        self.assertEqual(card["attachments"], [])
+        self.assertEqual(card["blocked_captures"][0]["capture_id"], "unknown")
+
+    def test_channel_card_does_not_forward_redacted_capture_summary(self) -> None:
+        package = build_web_visual_qa_package(
+            package_id="checkout-qa",
+            target="Checkout",
+            criteria=({"criterion_id": "layout", "label": "Layout", "pass_rule": "fits", "severity": "blocking"},),
+            captures=({"capture_id": "redacted", "path_or_uri": "/tmp/redacted.png", "mime_type": "image/png", "viewport": "desktop", "evidence_summary": "token=sk-live-example", "redaction_status": "redacted"},),
+        )
+
+        card = build_web_visual_qa_channel_delivery_card(package, renderer_target="telegram")
+
+        self.assertNotIn("sk-live-example", str(card))
+        self.assertEqual(card["attachments"][0]["alt_text"], "Web QA screenshot")
+        self.assertNotIn("caption", card["attachments"][0])
+        self.assertNotIn("role", card["attachments"][0])
+
+    def test_show_renders_prepared_channel_card_without_delivery_claim(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = ["--omh-home", str(root / ".omh"), "web-qa"]
+            self.assertEqual(run_cli(base + ["package", "--package-id", "checkout-qa", "--target", "Checkout", "--criterion", "layout:Layout:fits:blocking"])[0], 0)
+            self.assertEqual(run_cli(base + ["observe-capture", "--package-id", "checkout-qa", "--capture-id", "desktop", "--path", str(root / "desktop.png"), "--mime-type", "image/png", "--viewport", "desktop", "--summary", "Desktop capture", "--redaction-status", "not_needed"])[0], 0)
+
+            status, stdout, stderr = run_cli(base + ["show", "--package-id", "checkout-qa", "--renderer-target", "slack", "--json"], output_json=False)
+
+            self.assertEqual(status, 0, stderr)
+            self.assertIn('"schema_version": "web_visual_qa_channel_delivery/v1"', stdout)
+        self.assertIn('"delivery_observed": false', stdout)
+        self.assertNotIn("attachment_uploaded", stdout.split('"does_not_prove"')[0])


### PR DESCRIPTION
## Feature Report

Adds pure-data Discord, Slack, and Telegram renderer cards for observed Web QA captures. Channel cards keep upload and delivery adapter-owned, report `prepared_not_observed`, and omit sensitive/raw capture metadata.

## Validation

- 274 focused CLI and channel-card tests passed.
- compileall and git diff --check passed.
- Manual Discord, Slack, Telegram CLI card scenarios passed; invalid renderer rejected.
- Independent security review approved.