### PR TITLE
feat: add adapter quality observation controls

### DIFF
--- a/src/commands/adapter_quality.py
+++ b/src/commands/adapter_quality.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from omh.adapter_quality import build_adapter_quality_delivery_card, build_adapter_quality_observation, link_adapter_quality_session, prepare_adapter_quality_delivery, record_adapter_quality_delivery, write_adapter_quality_observation
+from omh.installer import OmhError
+
+from .common import _paths, _print_json
+
+
+def cmd_adapter_quality_observe(args: argparse.Namespace) -> int:
+    try:
+        payload = _json_file(args.manifest)
+        observation = write_adapter_quality_observation(_paths(args), build_adapter_quality_observation(
+            observation_id=_text(payload, "observation_id"),
+            subject_id=_text(payload, "subject_id"),
+            surface_kind=_text(payload, "surface_kind"),
+            adapter_id=_text(payload, "adapter_id"),
+            source_revision=_text(payload, "source_revision"),
+            debug_signals=_dict_list(payload, "debug_signals"),
+            checks=_dict_list(payload, "checks"),
+            layout_checks=_dict_list(payload, "layout_checks"),
+            metrics=_dict_list(payload, "metrics"),
+        ))
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        raise OmhError(str(exc)) from exc
+    _print_json(observation)
+    return 0
+
+
+def cmd_adapter_quality_prepare_delivery(args: argparse.Namespace) -> int:
+    try:
+        observation = _json_file(args.observation)
+        card = build_adapter_quality_delivery_card(observation, renderer_target=args.renderer_target)
+        preparation = prepare_adapter_quality_delivery(_paths(args), session_id=args.session_id, card=card)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        raise OmhError(str(exc)) from exc
+    _print_json({"card": card, "preparation": preparation})
+    return 0
+
+
+def cmd_adapter_quality_record_delivery(args: argparse.Namespace) -> int:
+    try:
+        preparation = _json_file(args.preparation)
+        record = record_adapter_quality_delivery(
+            _paths(args),
+            preparation=preparation,
+            adapter=args.adapter,
+            delivery_result=args.delivery_result,
+            external_message_ref=args.external_message_ref,
+        )
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        raise OmhError(str(exc)) from exc
+    _print_json(record)
+    return 0
+
+
+def cmd_adapter_quality_link(args: argparse.Namespace) -> int:
+    try:
+        record = link_adapter_quality_session(_paths(args), session_id=args.session_id, subject_id=args.subject_id, surface_kind=args.surface_kind, source_revision=args.source_revision, observation_id=args.observation_id, renderer_target=args.renderer_target)
+    except ValueError as exc:
+        raise OmhError(str(exc)) from exc
+    _print_json(record)
+    return 0
+
+
+def _add_adapter_quality_commands(sub: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
+    quality = sub.add_parser("adapter-quality", help="Record adapter-owned web, desktop, and app quality evidence.")
+    commands = quality.add_subparsers(dest="adapter_quality_command", required=True)
+    observe = commands.add_parser("observe", help="Validate a metadata-only adapter quality manifest.")
+    observe.add_argument("--manifest", required=True)
+    observe.set_defaults(func=cmd_adapter_quality_observe)
+    link = commands.add_parser("link", help="Link one wrapper session to adapter quality state.")
+    link.add_argument("--session-id", required=True)
+    link.add_argument("--subject-id", required=True)
+    link.add_argument("--surface-kind", choices=("web", "desktop", "app"), required=True)
+    link.add_argument("--source-revision", required=True)
+    link.add_argument("--observation-id", default="")
+    link.add_argument("--renderer-target", choices=("discord", "slack", "telegram"), default="")
+    link.set_defaults(func=cmd_adapter_quality_link)
+    prepare = commands.add_parser("prepare-delivery", help="Prepare a renderer-specific quality delivery card.")
+    prepare.add_argument("--session-id", required=True)
+    prepare.add_argument("--observation", required=True)
+    prepare.add_argument("--renderer-target", choices=("discord", "slack", "telegram"), required=True)
+    prepare.set_defaults(func=cmd_adapter_quality_prepare_delivery)
+    delivery = commands.add_parser("record-delivery", help="Record an adapter-observed quality delivery result.")
+    delivery.add_argument("--preparation", required=True)
+    delivery.add_argument("--adapter", required=True)
+    delivery.add_argument("--delivery-result", choices=("delivered", "failed", "blocked"), required=True)
+    delivery.add_argument("--external-message-ref", default="")
+    delivery.set_defaults(func=cmd_adapter_quality_record_delivery)
+
+
+def _json_file(path: str) -> dict[str, object]:
+    value = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError("JSON manifest must be an object")
+    return value
+
+
+def _text(value: dict[str, object], key: str) -> str:
+    return str(value.get(key, ""))
+
+
+def _dict_list(value: dict[str, object], key: str) -> list[dict[str, object]]:
+    entries = value.get(key, [])
+    if not isinstance(entries, list) or not all(isinstance(item, dict) for item in entries):
+        raise ValueError(f"{key} must be a list of objects")
+    return entries

--- a/src/commands/main.py
+++ b/src/commands/main.py
@@ -172,6 +172,7 @@ from .setup import (
 from .state import _add_state_commands, cmd_state_clear, cmd_state_finish, cmd_state_start, cmd_state_status
 from .use_cases import _add_cases_commands, cmd_cases_inspect, cmd_cases_list, cmd_cases_recommend
 from .visual import _add_visual_commands, cmd_visual_observe, cmd_visual_prompt_card
+from .adapter_quality import _add_adapter_quality_commands
 from .web_qa import _add_web_qa_commands, cmd_web_qa_observe_capture, cmd_web_qa_package, cmd_web_qa_record_verdict
 from .worktree import cmd_worktree_bind, cmd_worktree_list, cmd_worktree_prepare, _add_worktree_commands
 
@@ -279,6 +280,7 @@ def build_parser() -> argparse.ArgumentParser:
     _add_ops_commands(sub)
     _add_materials_commands(sub)
     _add_visual_commands(sub)
+    _add_adapter_quality_commands(sub)
     _add_web_qa_commands(sub)
     _add_worktree_commands(sub)
     _add_runtime_commands(sub)

--- a/src/omh/adapter_quality.py
+++ b/src/omh/adapter_quality.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-import hashlib
-import json
 import re
 from pathlib import Path
 
+from .adapter_quality_codec import canonical as _canonical
+from .adapter_quality_codec import fingerprint as _fingerprint
+from .adapter_quality_codec import semantic as _semantic
 from .local_store import atomic_write_json, ensure_dir, read_json_object_result, utc_now
 from .paths import OmhPaths
 
@@ -123,7 +124,7 @@ def link_adapter_quality_session(
         _identifier(observation_id, "observation_id")
     if renderer_target:
         _choice(renderer_target, "renderer_target", {"discord", "slack", "telegram"})
-    record = {"schema_version": "adapter_quality_session_link/v1", "session_id": session_id, "subject_id": subject_id, "surface_kind": surface_kind, "source_revision": source_revision, "selected_quality_observation_id": observation_id, "renderer_target": renderer_target, "status": "prepared_not_observed" if not observation_id else "observed"}
+    record = {"schema_version": "adapter_quality_session_link/v1", "session_id": session_id, "subject_id": subject_id, "surface_kind": surface_kind, "source_revision": source_revision, "selected_quality_observation_id": observation_id, "renderer_target": renderer_target, "status": "prepared_not_observed"}
     path = _record_path(paths, "links", session_id)
     ensure_dir(path.parent, private=True)
     atomic_write_json(path, record, private=True)
@@ -138,7 +139,7 @@ def quality_session_control(paths: OmhPaths, session_id: str) -> dict[str, objec
     if not observation_id:
         return {"status": "linked_no_observation", "link": record, "actions": [{"id": "request_adapter_quality_observation", "enabled": True, "owner": "adapter"}]}
     observation, observation_error = read_json_object_result(_record_path(paths, "observations", observation_id))
-    if observation_error or observation is None or str(observation.get("source_revision", "")) != str(record.get("source_revision", "")):
+    if observation_error or observation is None or any(str(observation.get(key, "")) != str(record.get(key, "")) for key in ("subject_id", "surface_kind", "source_revision")):
         return {"status": "stale", "link": record, "actions": [{"id": "request_adapter_quality_observation", "enabled": True, "owner": "adapter"}]}
     return {"status": "quality_observed", "link": record, "quality_summary": {"state": observation.get("overall_evidence_state", "partial_observed")}, "actions": [{"id": "show_quality_evidence", "enabled": True, "owner": "adapter"}, {"id": "prepare_channel_quality_delivery", "enabled": True, "owner": "adapter"}]}
 
@@ -162,8 +163,10 @@ def prepare_adapter_quality_delivery(paths: OmhPaths, *, session_id: str, card: 
     existing, error = read_json_object_result(path)
     if error:
         raise ValueError(f"invalid existing preparation: {error}")
-    if existing and _canonical(existing) != _canonical(record):
-        raise ValueError("delivery preparation already exists with different content")
+    if existing:
+        if _semantic(existing, {"prepared_at"}) != _semantic(record, {"prepared_at"}):
+            raise ValueError("delivery preparation already exists with different content")
+        return existing
     ensure_dir(path.parent, private=True)
     atomic_write_json(path, record, private=True)
     return record
@@ -205,6 +208,13 @@ def record_adapter_quality_delivery(
         "observation_status": "observed",
     }
     path = _record_path(paths, "deliveries", str(record["observation_id"]))
+    existing, error = read_json_object_result(path)
+    if error:
+        raise ValueError(f"invalid existing delivery: {error}")
+    if existing:
+        if _semantic(existing, {"observed_at"}) != _semantic(record, {"observed_at"}):
+            raise ValueError("delivery observation already exists with different content")
+        return existing
     ensure_dir(path.parent, private=True)
     atomic_write_json(path, record, private=True)
     return record
@@ -241,14 +251,6 @@ def _state(signals: list[dict[str, object]], checks: list[dict[str, object]], la
 def _record_path(paths: OmhPaths, kind: str, record_id: str) -> Path:
     _identifier(record_id, "record_id")
     return paths.omh_home / "adapter-quality" / kind / f"{record_id}.json"
-
-
-def _fingerprint(value: dict[str, object]) -> str:
-    return hashlib.sha256(_canonical(value).encode("utf-8")).hexdigest()
-
-
-def _canonical(value: dict[str, object]) -> str:
-    return json.dumps(value, sort_keys=True, ensure_ascii=False, separators=(",", ":"))
 
 
 def _identifier(value: str, field: str) -> str:

--- a/src/omh/adapter_quality.py
+++ b/src/omh/adapter_quality.py
@@ -1,0 +1,288 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from pathlib import Path
+
+from .local_store import atomic_write_json, ensure_dir, read_json_object_result, utc_now
+from .paths import OmhPaths
+
+
+QUALITY_SCHEMA_VERSION = "adapter_quality_observation/v1"
+QUALITY_CARD_SCHEMA_VERSION = "adapter_quality_channel_delivery_card/v1"
+QUALITY_PREPARATION_SCHEMA_VERSION = "adapter_quality_delivery_preparation/v1"
+QUALITY_DELIVERY_SCHEMA_VERSION = "adapter_quality_delivery_observation/v1"
+_IDENTIFIER = re.compile(r"^[A-Za-z0-9][A-Za-z0-9:_-]{0,127}$")
+_SAFE_TEXT = re.compile(r"^[^\x00-\x1f\x7f]{1,240}$")
+_SECRET = re.compile(r"(?i)(api[_-]?key|token=|secret=|password=|sk-[a-z0-9])")
+_URL = re.compile(r"(?i)(?:[a-z][a-z0-9+.-]*://|[/?#])")
+
+
+def build_adapter_quality_observation(
+    *,
+    observation_id: str,
+    subject_id: str,
+    surface_kind: str,
+    adapter_id: str,
+    source_revision: str,
+    debug_signals: list[dict[str, object]] | None = None,
+    checks: list[dict[str, object]],
+    layout_checks: list[dict[str, object]],
+    metrics: list[dict[str, object]],
+) -> dict[str, object]:
+    _identifier(observation_id, "observation_id")
+    _identifier(subject_id, "subject_id")
+    _choice(surface_kind, "surface_kind", {"web", "desktop", "app"})
+    _identifier(adapter_id, "adapter_id")
+    _identifier(source_revision, "source_revision")
+    signals = debug_signals or []
+    _limit(signals, "debug_signals")
+    _limit(checks, "checks")
+    _limit(layout_checks, "layout_checks")
+    _limit(metrics, "metrics")
+    normalized_signals = [_signal(item) for item in signals]
+    normalized_checks = [_check(item) for item in checks]
+    normalized_layout = [_layout(item) for item in layout_checks]
+    normalized_metrics = [_metric(item) for item in metrics]
+    return {
+        "schema_version": QUALITY_SCHEMA_VERSION,
+        "observation_id": observation_id,
+        "subject_id": subject_id,
+        "surface_kind": surface_kind,
+        "adapter_id": adapter_id,
+        "observed_at": utc_now(),
+        "source_revision": source_revision,
+        "debug_signals": normalized_signals,
+        "checks": normalized_checks,
+        "layout_checks": normalized_layout,
+        "metrics": normalized_metrics,
+        "evidence_refs": _refs([]),
+        "overall_evidence_state": _state(normalized_signals, normalized_checks, normalized_layout, normalized_metrics),
+        "does_not_prove": ["omh_executed_surface", "global_quality_pass", "root_cause", "message_delivery"],
+    }
+
+
+def build_adapter_quality_delivery_card(observation: dict[str, object], *, renderer_target: str) -> dict[str, object]:
+    _choice(renderer_target, "renderer_target", {"discord", "slack", "telegram"})
+    if observation.get("schema_version") != QUALITY_SCHEMA_VERSION:
+        raise ValueError("observation schema_version is invalid")
+    subject_id = _identifier(str(observation.get("subject_id", "")), "subject_id")
+    source_revision = _identifier(str(observation.get("source_revision", "")), "source_revision")
+    card = {
+        "schema_version": QUALITY_CARD_SCHEMA_VERSION,
+        "subject_id": subject_id,
+        "renderer_target": renderer_target,
+        "safe_display_label": subject_id,
+        "quality_observation_id": _identifier(str(observation.get("observation_id", "")), "observation_id"),
+        "source_revision": source_revision,
+        "quality_summary": {
+            "state": str(observation.get("overall_evidence_state", "not_observed")),
+            "debug_signal_count": len(_list(observation.get("debug_signals"))),
+            "check_count": len(_list(observation.get("checks"))),
+            "layout_check_count": len(_list(observation.get("layout_checks"))),
+            "metric_count": len(_list(observation.get("metrics"))),
+        },
+        "status": "prepared_not_observed",
+        "claim_boundary": "Adapter-owned delivery is unobserved until a matching delivery record exists.",
+        "does_not_prove": ["message_sent", "attachment_uploaded", "platform_delivery"],
+    }
+    return {**card, "card_fingerprint": _fingerprint(card)}
+
+
+def write_adapter_quality_observation(paths: OmhPaths, observation: dict[str, object]) -> dict[str, object]:
+    if observation.get("schema_version") != QUALITY_SCHEMA_VERSION:
+        raise ValueError("observation schema_version is invalid")
+    observation_id = _identifier(str(observation.get("observation_id", "")), "observation_id")
+    path = _record_path(paths, "observations", observation_id)
+    existing, error = read_json_object_result(path)
+    if error:
+        raise ValueError(f"invalid existing observation: {error}")
+    if existing and _canonical(existing) != _canonical(observation):
+        raise ValueError("quality observation already exists with different content")
+    ensure_dir(path.parent, private=True)
+    atomic_write_json(path, observation, private=True)
+    return observation
+
+
+def link_adapter_quality_session(
+    paths: OmhPaths,
+    *,
+    session_id: str,
+    subject_id: str,
+    surface_kind: str,
+    source_revision: str,
+    observation_id: str = "",
+    renderer_target: str = "",
+) -> dict[str, object]:
+    _identifier(session_id, "session_id")
+    _identifier(subject_id, "subject_id")
+    _choice(surface_kind, "surface_kind", {"web", "desktop", "app"})
+    _identifier(source_revision, "source_revision")
+    if observation_id:
+        _identifier(observation_id, "observation_id")
+    if renderer_target:
+        _choice(renderer_target, "renderer_target", {"discord", "slack", "telegram"})
+    record = {"schema_version": "adapter_quality_session_link/v1", "session_id": session_id, "subject_id": subject_id, "surface_kind": surface_kind, "source_revision": source_revision, "selected_quality_observation_id": observation_id, "renderer_target": renderer_target, "status": "prepared_not_observed" if not observation_id else "observed"}
+    path = _record_path(paths, "links", session_id)
+    ensure_dir(path.parent, private=True)
+    atomic_write_json(path, record, private=True)
+    return record
+
+
+def quality_session_control(paths: OmhPaths, session_id: str) -> dict[str, object]:
+    record, error = read_json_object_result(_record_path(paths, "links", session_id))
+    if error or record is None:
+        return {"status": "unlinked", "actions": [{"id": "link_quality_subject", "enabled": True, "owner": "adapter"}]}
+    observation_id = str(record.get("selected_quality_observation_id", ""))
+    if not observation_id:
+        return {"status": "linked_no_observation", "link": record, "actions": [{"id": "request_adapter_quality_observation", "enabled": True, "owner": "adapter"}]}
+    observation, observation_error = read_json_object_result(_record_path(paths, "observations", observation_id))
+    if observation_error or observation is None or str(observation.get("source_revision", "")) != str(record.get("source_revision", "")):
+        return {"status": "stale", "link": record, "actions": [{"id": "request_adapter_quality_observation", "enabled": True, "owner": "adapter"}]}
+    return {"status": "quality_observed", "link": record, "quality_summary": {"state": observation.get("overall_evidence_state", "partial_observed")}, "actions": [{"id": "show_quality_evidence", "enabled": True, "owner": "adapter"}, {"id": "prepare_channel_quality_delivery", "enabled": True, "owner": "adapter"}]}
+
+
+def prepare_adapter_quality_delivery(paths: OmhPaths, *, session_id: str, card: dict[str, object]) -> dict[str, object]:
+    _identifier(session_id, "session_id")
+    fingerprint = _digest(str(card.get("card_fingerprint", "")), "card_fingerprint")
+    preparation_id = f"prep-{fingerprint[:16]}"
+    record = {
+        "schema_version": QUALITY_PREPARATION_SCHEMA_VERSION,
+        "preparation_id": preparation_id,
+        "session_id": session_id,
+        "subject_id": _identifier(str(card.get("subject_id", "")), "subject_id"),
+        "renderer_target": str(card.get("renderer_target", "")),
+        "quality_observation_id": _identifier(str(card.get("quality_observation_id", "")), "quality_observation_id"),
+        "card_fingerprint": fingerprint,
+        "prepared_at": utc_now(),
+        "status": "prepared_not_observed",
+    }
+    path = _record_path(paths, "preparations", preparation_id)
+    existing, error = read_json_object_result(path)
+    if error:
+        raise ValueError(f"invalid existing preparation: {error}")
+    if existing and _canonical(existing) != _canonical(record):
+        raise ValueError("delivery preparation already exists with different content")
+    ensure_dir(path.parent, private=True)
+    atomic_write_json(path, record, private=True)
+    return record
+
+
+def record_adapter_quality_delivery(
+    paths: OmhPaths,
+    *,
+    preparation: dict[str, object],
+    adapter: str,
+    delivery_result: str,
+    external_message_ref: str = "",
+) -> dict[str, object]:
+    if preparation.get("schema_version") != QUALITY_PREPARATION_SCHEMA_VERSION:
+        raise ValueError("preparation schema_version is invalid")
+    _identifier(adapter, "adapter")
+    _choice(delivery_result, "delivery_result", {"delivered", "failed", "blocked"})
+    if delivery_result == "delivered" and not external_message_ref:
+        raise ValueError("external_message_ref is required for delivered")
+    if external_message_ref:
+        _identifier(external_message_ref, "external_message_ref")
+    preparation_id = _identifier(str(preparation.get("preparation_id", "")), "preparation_id")
+    stored, error = read_json_object_result(_record_path(paths, "preparations", preparation_id))
+    if error or stored is None or _canonical(stored) != _canonical(preparation):
+        raise ValueError("delivery preparation is missing or does not match stored record")
+    record = {
+        "schema_version": QUALITY_DELIVERY_SCHEMA_VERSION,
+        "observation_id": f"delivery-{preparation_id[5:]}",
+        "preparation_id": preparation_id,
+        "session_id": str(preparation["session_id"]),
+        "subject_id": str(preparation["subject_id"]),
+        "renderer_target": str(preparation["renderer_target"]),
+        "quality_observation_id": str(preparation["quality_observation_id"]),
+        "card_fingerprint": str(preparation["card_fingerprint"]),
+        "adapter": adapter,
+        "delivery_result": delivery_result,
+        "external_message_ref": external_message_ref,
+        "observed_at": utc_now(),
+        "observation_status": "observed",
+    }
+    path = _record_path(paths, "deliveries", str(record["observation_id"]))
+    ensure_dir(path.parent, private=True)
+    atomic_write_json(path, record, private=True)
+    return record
+
+
+def _signal(value: dict[str, object]) -> dict[str, object]:
+    return {"signal_id": _identifier(str(value.get("signal_id", "")), "signal_id"), "kind": _choice(str(value.get("kind", "")), "signal.kind", {"crash", "error", "warning", "assertion", "network_failure", "other"}), "severity": _choice(str(value.get("severity", "")), "signal.severity", {"info", "warning", "error"}), "status": _choice(str(value.get("status", "")), "signal.status", {"observed", "ignored", "resolved_by_adapter"}), "summary": _safe_text(str(value.get("summary", "")), "signal.summary"), "evidence_refs": _refs(_list(value.get("evidence_refs")))}
+
+
+def _check(value: dict[str, object]) -> dict[str, object]:
+    return {"check_id": _identifier(str(value.get("check_id", "")), "check_id"), "kind": _choice(str(value.get("kind", "")), "check.kind", {"functional", "accuracy", "regression"}), "status": _choice(str(value.get("status", "")), "check.status", {"pass", "fail", "blocked", "not_observed"}), "expected_summary": _safe_text(str(value.get("expected_summary", "")), "expected_summary"), "actual_summary": _safe_text(str(value.get("actual_summary", "")), "actual_summary"), "evidence_refs": _refs(_list(value.get("evidence_refs")))}
+
+
+def _layout(value: dict[str, object]) -> dict[str, object]:
+    return {"check_id": _identifier(str(value.get("check_id", "")), "layout.check_id"), "scope": _safe_text(str(value.get("scope", "")), "layout.scope"), "status": _choice(str(value.get("status", "")), "layout.status", {"pass", "fail", "blocked", "not_observed"}), "summary": _safe_text(str(value.get("summary", "")), "layout.summary"), "evidence_refs": _refs(_list(value.get("evidence_refs")))}
+
+
+def _metric(value: dict[str, object]) -> dict[str, object]:
+    status = _choice(str(value.get("status", "")), "metric.status", {"pass", "fail", "not_observed"})
+    number = float(value.get("value", -1))
+    threshold = float(value.get("threshold", -1))
+    if not 0 <= number <= 1_000_000_000 or not 0 <= threshold <= 1_000_000_000:
+        raise ValueError("metric value and threshold must be bounded")
+    return {"metric_id": _identifier(str(value.get("metric_id", "")), "metric_id"), "name": _safe_text(str(value.get("name", "")), "metric.name"), "value": number, "unit": _choice(str(value.get("unit", "")), "metric.unit", {"ms", "bytes", "percent", "count"}), "threshold": threshold, "comparison": _choice(str(value.get("comparison", "")), "metric.comparison", {"lte", "gte", "equal"}), "status": status, "evidence_refs": _refs(_list(value.get("evidence_refs")))}
+
+
+def _state(signals: list[dict[str, object]], checks: list[dict[str, object]], layouts: list[dict[str, object]], metrics: list[dict[str, object]]) -> str:
+    statuses = [str(item.get("status", "")) for item in [*checks, *layouts, *metrics]]
+    if "fail" in statuses or signals:
+        return "observed_with_failures"
+    return "observed_no_failures" if statuses else "partial_observed"
+
+
+def _record_path(paths: OmhPaths, kind: str, record_id: str) -> Path:
+    _identifier(record_id, "record_id")
+    return paths.omh_home / "adapter-quality" / kind / f"{record_id}.json"
+
+
+def _fingerprint(value: dict[str, object]) -> str:
+    return hashlib.sha256(_canonical(value).encode("utf-8")).hexdigest()
+
+
+def _canonical(value: dict[str, object]) -> str:
+    return json.dumps(value, sort_keys=True, ensure_ascii=False, separators=(",", ":"))
+
+
+def _identifier(value: str, field: str) -> str:
+    if not _IDENTIFIER.fullmatch(value):
+        raise ValueError(f"{field} must be a bounded identifier")
+    return value
+
+
+def _digest(value: str, field: str) -> str:
+    if not re.fullmatch(r"[0-9a-f]{64}", value):
+        raise ValueError(f"{field} must be sha256")
+    return value
+
+
+def _choice(value: str, field: str, allowed: set[str]) -> str:
+    if value not in allowed:
+        raise ValueError(f"{field} is invalid")
+    return value
+
+
+def _safe_text(value: str, field: str) -> str:
+    if not _SAFE_TEXT.fullmatch(value) or _URL.search(value) or _SECRET.search(value):
+        raise ValueError(f"{field} must be safe bounded text")
+    return value
+
+
+def _refs(values: list[object]) -> list[str]:
+    return [_identifier(str(value), "evidence_ref") for value in values]
+
+
+def _list(value: object) -> list[object]:
+    return value if isinstance(value, list) else []
+
+
+def _limit(values: list[dict[str, object]], field: str) -> None:
+    if len(values) > 50:
+        raise ValueError(f"{field} must have at most 50 items")

--- a/src/omh/adapter_quality_codec.py
+++ b/src/omh/adapter_quality_codec.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import hashlib
+import json
+
+
+def fingerprint(value: dict[str, object]) -> str:
+    return hashlib.sha256(canonical(value).encode("utf-8")).hexdigest()
+
+
+def canonical(value: dict[str, object]) -> str:
+    return json.dumps(value, sort_keys=True, ensure_ascii=False, separators=(",", ":"))
+
+
+def semantic(value: dict[str, object], excluded: set[str]) -> str:
+    return canonical({key: item for key, item in value.items() if key not in excluded})

--- a/src/wrapper/mission_control.py
+++ b/src/wrapper/mission_control.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from ..adapter_quality import quality_session_control
 from ..conformance.checker import check_runtime_run
 from ..paths import OmhPaths
 from .sessions import build_wrapper_session_status, read_wrapper_session
@@ -42,6 +43,7 @@ def build_mission_control(paths: OmhPaths, session_id: str) -> dict[str, object]
         "journey": {"state": journey_state},
         "execution": _execution(runtime_status, runtime_observation),
         "capability_observation": _capability_observation(session_status),
+        "adapter_quality": quality_session_control(paths, session_id),
         "recovery": recovery,
         "quality_evidence": quality_evidence,
         "merge_decision": _merge_decision(quality_evidence, next_action),

--- a/tests/test_adapter_quality.py
+++ b/tests/test_adapter_quality.py
@@ -78,10 +78,31 @@ class AdapterQualityTests(unittest.TestCase):
             self.assertEqual(quality_session_control(paths, "ws-quality")["status"], "linked_no_observation")
             observation = write_adapter_quality_observation(paths, build_adapter_quality_observation(observation_id="web-quality", subject_id="checkout", surface_kind="web", adapter_id="hermes-adapter", source_revision="build-42", checks=[], layout_checks=[], metrics=[]))
             self.assertEqual(observation["overall_evidence_state"], "partial_observed")
-            link_adapter_quality_session(paths, session_id="ws-quality", subject_id="checkout", surface_kind="web", source_revision="build-42", observation_id="web-quality")
+            linked = link_adapter_quality_session(paths, session_id="ws-quality", subject_id="checkout", surface_kind="web", source_revision="build-42", observation_id="web-quality")
+            self.assertEqual(linked["status"], "prepared_not_observed")
             self.assertEqual(quality_session_control(paths, "ws-quality")["status"], "quality_observed")
             link_adapter_quality_session(paths, session_id="ws-quality", subject_id="checkout", surface_kind="web", source_revision="build-43", observation_id="web-quality")
             self.assertEqual(quality_session_control(paths, "ws-quality")["status"], "stale")
+
+    def test_session_control_rejects_cross_subject_or_surface_observation(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            write_adapter_quality_observation(paths, build_adapter_quality_observation(observation_id="orders-quality", subject_id="orders", surface_kind="desktop", adapter_id="hermes-adapter", source_revision="build-42", checks=[], layout_checks=[], metrics=[]))
+            link_adapter_quality_session(paths, session_id="ws-quality", subject_id="checkout", surface_kind="web", source_revision="build-42", observation_id="orders-quality")
+            self.assertEqual(quality_session_control(paths, "ws-quality")["status"], "stale")
+
+    def test_delivery_and_preparation_retries_are_idempotent(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            observation = build_adapter_quality_observation(observation_id="web-quality", subject_id="checkout", surface_kind="web", adapter_id="hermes-adapter", source_revision="build-42", checks=[], layout_checks=[], metrics=[])
+            card = build_adapter_quality_delivery_card(observation, renderer_target="discord")
+            first = prepare_adapter_quality_delivery(paths, session_id="ws-quality", card=card)
+            second = prepare_adapter_quality_delivery(paths, session_id="ws-quality", card=card)
+            self.assertEqual(first, second)
+            delivered = record_adapter_quality_delivery(paths, preparation=first, adapter="discord-adapter", delivery_result="delivered", external_message_ref="discord:message-1")
+            self.assertEqual(delivered, record_adapter_quality_delivery(paths, preparation=first, adapter="discord-adapter", delivery_result="delivered", external_message_ref="discord:message-1"))
+            with self.assertRaises(ValueError):
+                record_adapter_quality_delivery(paths, preparation=first, adapter="discord-adapter", delivery_result="failed")
         with self.assertRaises(ValueError):
             build_adapter_quality_observation(
                 observation_id="bad-metric",

--- a/tests/test_adapter_quality.py
+++ b/tests/test_adapter_quality.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from _local_package import load_local_package
+
+load_local_package()
+
+from omh.adapter_quality import (
+    build_adapter_quality_observation,
+    build_adapter_quality_delivery_card,
+    link_adapter_quality_session,
+    prepare_adapter_quality_delivery,
+    quality_session_control,
+    record_adapter_quality_delivery,
+    write_adapter_quality_observation,
+)
+from omh.paths import resolve_paths
+
+
+class AdapterQualityTests(unittest.TestCase):
+    def test_web_desktop_and_app_observations_are_surface_neutral(self) -> None:
+        for surface_kind in ("web", "desktop", "app"):
+            observation = build_adapter_quality_observation(
+                observation_id=f"{surface_kind}-quality",
+                subject_id="checkout",
+                surface_kind=surface_kind,
+                adapter_id="hermes-adapter",
+                source_revision="build-42",
+                checks=[{"check_id": "checkout", "kind": "functional", "status": "pass", "expected_summary": "Checkout opens", "actual_summary": "Checkout opens", "evidence_refs": ["adapter:check-1"]}],
+                layout_checks=[{"check_id": "desktop", "scope": "desktop", "status": "pass", "summary": "No overlap", "evidence_refs": ["adapter:layout-1"]}],
+                metrics=[{"metric_id": "startup", "name": "Startup", "value": 120.0, "unit": "ms", "threshold": 250.0, "comparison": "lte", "status": "pass", "evidence_refs": ["adapter:metric-1"]}],
+            )
+            self.assertEqual(observation["surface_kind"], surface_kind)
+            self.assertEqual(observation["overall_evidence_state"], "observed_no_failures")
+
+    def test_delivery_requires_matching_prepared_card_and_stales_on_revision_change(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            observation = build_adapter_quality_observation(
+                observation_id="desktop-quality",
+                subject_id="checkout",
+                surface_kind="desktop",
+                adapter_id="hermes-adapter",
+                source_revision="build-42",
+                checks=[],
+                layout_checks=[],
+                metrics=[],
+            )
+            card = build_adapter_quality_delivery_card(observation, renderer_target="slack")
+            preparation = prepare_adapter_quality_delivery(paths, session_id="ws-quality", card=card)
+            delivery = record_adapter_quality_delivery(paths, preparation=preparation, adapter="slack-adapter", delivery_result="delivered", external_message_ref="slack:message-1")
+
+            self.assertEqual(delivery["observation_status"], "observed")
+            stale_card = build_adapter_quality_delivery_card({**observation, "source_revision": "build-43"}, renderer_target="slack")
+            self.assertNotEqual(stale_card["card_fingerprint"], delivery["card_fingerprint"])
+
+    def test_raw_log_and_unbounded_metric_do_not_validate(self) -> None:
+        with self.assertRaises(ValueError):
+            build_adapter_quality_observation(
+                observation_id="bad-quality",
+                subject_id="checkout",
+                surface_kind="web",
+                adapter_id="hermes-adapter",
+                source_revision="build-42",
+                debug_signals=[{"signal_id": "log", "kind": "error", "severity": "error", "status": "observed", "summary": "https://host/?token=secret", "evidence_refs": ["adapter:log-1"]}],
+                checks=[],
+                layout_checks=[],
+                metrics=[],
+            )
+
+    def test_session_control_fails_closed_until_selected_observation_is_current(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            link_adapter_quality_session(paths, session_id="ws-quality", subject_id="checkout", surface_kind="web", source_revision="build-42")
+            self.assertEqual(quality_session_control(paths, "ws-quality")["status"], "linked_no_observation")
+            observation = write_adapter_quality_observation(paths, build_adapter_quality_observation(observation_id="web-quality", subject_id="checkout", surface_kind="web", adapter_id="hermes-adapter", source_revision="build-42", checks=[], layout_checks=[], metrics=[]))
+            self.assertEqual(observation["overall_evidence_state"], "partial_observed")
+            link_adapter_quality_session(paths, session_id="ws-quality", subject_id="checkout", surface_kind="web", source_revision="build-42", observation_id="web-quality")
+            self.assertEqual(quality_session_control(paths, "ws-quality")["status"], "quality_observed")
+            link_adapter_quality_session(paths, session_id="ws-quality", subject_id="checkout", surface_kind="web", source_revision="build-43", observation_id="web-quality")
+            self.assertEqual(quality_session_control(paths, "ws-quality")["status"], "stale")
+        with self.assertRaises(ValueError):
+            build_adapter_quality_observation(
+                observation_id="bad-metric",
+                subject_id="checkout",
+                surface_kind="web",
+                adapter_id="hermes-adapter",
+                source_revision="build-42",
+                checks=[],
+                layout_checks=[],
+                metrics=[{"metric_id": "startup", "name": "Startup", "value": 120.0, "unit": "ms", "threshold": 1_000_000_001.0, "comparison": "lte", "status": "pass", "evidence_refs": ["adapter:metric-1"]}],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mission_control.py
+++ b/tests/test_mission_control.py
@@ -10,6 +10,7 @@ from _local_package import load_local_package
 load_local_package()
 from omh.coding_lifecycle import record_codex_dispatch, record_codex_result, record_codex_verification
 from omh.mission_control import build_mission_control
+from omh.adapter_quality import link_adapter_quality_session
 from omh.paths import resolve_paths
 from omh.runtime_artifacts import write_ci_record, write_merge_record, write_review_record, write_runtime_observation
 from omh.wrapper_sessions import (
@@ -21,6 +22,17 @@ from omh.wrapper_sessions import (
 
 
 class MissionControlTests(unittest.TestCase):
+    def test_quality_controls_are_additive_and_do_not_promote_coding_claims(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            started = create_or_resume_wrapper_session(paths, "inspect checkout layout", source="discord")
+            session_id = str(started["session"]["session_id"])
+            link_adapter_quality_session(paths, session_id=session_id, subject_id="checkout", surface_kind="web", source_revision="build-42")
+            mission_control = build_mission_control(paths, session_id)
+
+        self.assertEqual(mission_control["adapter_quality"]["status"], "linked_no_observation")
+        self.assertEqual(mission_control["quality_evidence"]["claim_state"], "handoff_prepared")
+
     def test_prepared_handoff_reports_next_safe_action_without_execution_claim(self) -> None:
         with TemporaryDirectory() as tmp:
             paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")


### PR DESCRIPTION
## Feature Report

Adds a local, adapter-owned quality evidence surface for web, desktop, and app work. Hermes adapters can record bounded debugging, correctness, layout, and performance observations; prepare a renderer-specific channel card; record delivery only after preparation; and project safe quality controls into Mission Control.

## Why

Hermes users need a visible quality loop without OMH becoming a browser runner, desktop-app runner, or Discord/Slack/Telegram client.

## What users can do

- Validate metadata-only quality manifests for web, desktop, and app surfaces.
- Prepare Discord, Slack, or Telegram delivery cards without send/upload claims.
- Record adapter-observed delivery immutably and fail closed for stale/mismatched session links.
- See additive quality controls in Mission Control without changing coding/merge claims.

## Verification

- Focused adapter-quality and Mission Control suites: 15 tests passed.
- Full unittest discovery, compileall, generated workflow-doc check, and diff check passed.
- Manual CLI: `adapter-quality observe` and `link --help` passed.
- Independent review approved after integrity fixes.

## Risks / gaps

OMH still does not execute browser/app/platform actions. Real Hermes adapter and channel API integrations remain adapter-owned and were not exercised here.