### PR TITLE
feat: diagnose potential external skill collisions

### DIFF
--- a/src/commands/setup.py
+++ b/src/commands/setup.py
@@ -565,7 +565,7 @@ def _doctor_operator_summary(checks: list[object]) -> dict[str, object]:
             _doctor_group("command", check_dicts, ("command_path",)),
             _doctor_group("managed_skills", check_dicts, ("manifest", "manifest_skills_dir", "local_modifications", "skills_dir", "skill:")),
             _doctor_group("runtime", check_dicts, ("runtime_artifacts", "workflow_state", "runtime_state")),
-            _doctor_group("hermes_registration", check_dicts, ("hermes_config", "external_dir", "runtime_context")),
+            _doctor_group("hermes_registration", check_dicts, ("hermes_config", "external_dir", "skill_shadowing", "runtime_context")),
             _doctor_group("targets", check_dicts, ("target_registry", "target_topology")),
             _doctor_group("optional_surfaces", check_dicts, ("plugin_", "team_profile_packs")),
         ],
@@ -1722,7 +1722,7 @@ def _print_doctor_summary(payload: dict[str, object], *, language: str = "en") -
     if isinstance(state_log, dict) and state_log.get("path") and state_log.get("entry"):
         print(f"  {tr(language, 'state_log', path=state_log.get('path'), entry=state_log.get('entry'))}")
     for check in checks:
-        if not isinstance(check, dict) or check.get("ok"):
+        if not isinstance(check, dict) or (check.get("ok") and check.get("severity") != "warning"):
             continue
         name = check.get("name", "unknown")
         message = check.get("message", "")

--- a/src/maintenance/doctor.py
+++ b/src/maintenance/doctor.py
@@ -117,6 +117,7 @@ def run_doctor(paths: OmhPaths) -> list[Check]:
     checks.append(Check("hermes_config", paths.hermes_config_path.exists(), f"{paths.hermes_config_path}"))
     external_registered = str(paths.skills_dir) in dirs
     checks.append(Check("external_dir", external_registered, f"{paths.skills_dir} in skills.external_dirs"))
+    checks.append(_skill_shadowing_check(paths, dirs))
     checks.append(
         Check(
             "runtime_context",
@@ -272,6 +273,67 @@ def run_doctor(paths: OmhPaths) -> list[Check]:
             )
         )
     return checks
+
+
+def _skill_shadowing_check(paths: OmhPaths, configured_dirs: list[str]) -> Check:
+    """Report immediate foreign skill-directory name collisions without loading them."""
+    foreign_dirs: list[Path] = []
+    seen_dirs: set[Path] = set()
+    unreadable: list[str] = []
+    try:
+        managed_dir = paths.skills_dir.expanduser().resolve(strict=False)
+    except (OSError, RuntimeError) as error:
+        managed_dir = None
+        unreadable.append(f"managed skill directory {paths.skills_dir}: {error}")
+    for raw_dir in configured_dirs:
+        try:
+            candidate = Path(raw_dir).expanduser().resolve(strict=False)
+        except (OSError, RuntimeError) as error:
+            unreadable.append(f"{raw_dir}: {error}")
+            continue
+        if candidate == managed_dir or candidate in seen_dirs:
+            continue
+        seen_dirs.add(candidate)
+        foreign_dirs.append(candidate)
+
+    collisions: list[str] = []
+    core_skill_names = frozenset(CORE_SKILLS)
+    for foreign_dir in foreign_dirs:
+        try:
+            children = list(foreign_dir.iterdir())
+        except OSError as error:
+            unreadable.append(f"{foreign_dir}: {error}")
+            continue
+        names = sorted(
+            child.name
+            for child in children
+            if not child.is_symlink() and child.is_dir() and child.name in core_skill_names
+        )
+        if names:
+            collisions.append(f"{foreign_dir}: {', '.join(names)}")
+
+    boundary = "This is a local configured-directory scan only; Hermes runtime precedence is not observed."
+    if unreadable or collisions:
+        details = [
+            *collisions,
+            *[f"scan incomplete: unreadable external directory {item}" for item in unreadable],
+        ]
+        return Check(
+            "skill_shadowing",
+            True,
+            f"potential OMH core skill-name collision or unreadable external directory: {'; '.join(details)}. {boundary}",
+            severity="warning",
+            remediation="Review configured external skill directories and rename, remove, or repair the reported entries before relying on their skill names.",
+            next_action="Resolve the reported external skill directory entries, then rerun `omh doctor`; Hermes runtime precedence still requires separate observation.",
+        )
+    return Check(
+        "skill_shadowing",
+        True,
+        (
+            f"no potential OMH core skill-name collisions across {len(foreign_dirs)} foreign configured skill "
+            f"{'directory' if len(foreign_dirs) == 1 else 'directories'}. {boundary}"
+        ),
+    )
 
 
 def doctor_ok(checks: list[Check]) -> bool:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,7 +17,8 @@ from omh.commands import setup as setup_commands
 from omh.commands.main import build_parser
 from omh.commands.language import LANGUAGE_CODES, MESSAGES
 from omh.capabilities.families import CONCEPTUAL_WORKFLOW_SURFACES, capability_family_projection
-from omh.config_adapter import external_dirs
+from omh.config_adapter import ensure_external_dir, external_dirs
+from omh.maintenance.doctor import _skill_shadowing_check
 from omh.paths import resolve_paths
 from omh.routing.intent import classify_omh_quality_intent
 from omh.skill_pack import builtin_skill_reference_templates, builtin_skill_templates
@@ -1416,6 +1417,94 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
             self.assertEqual(checks["command_path"]["severity"], "warning")
             self.assertFalse(checks["command_path"]["observed"])
             self.assertIn("absolute command path", payload["recommended_next_action"])
+
+    def test_doctor_warns_about_potential_external_skill_name_collisions_without_claiming_runtime_precedence(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            base = ["--omh-home", str(paths.omh_home), "--hermes-home", str(paths.hermes_home)]
+
+            status, _stdout, stderr = run_cli(base + ["setup", "--no-interactive"], output_json=False)
+            self.assertEqual(status, 0, stderr)
+
+            foreign_skills = root / "foreign-skills"
+            foreign_skills.mkdir()
+            config = paths.hermes_config_path.read_text(encoding="utf-8")
+            configured = ensure_external_dir(config, foreign_skills)
+            paths.hermes_config_path.write_text(configured.text, encoding="utf-8")
+
+            with patch("omh.command_path.shutil.which", return_value="/usr/local/bin/omh"):
+                status, stdout, stderr = run_cli(base + ["doctor", "--json"], output_json=False)
+
+            self.assertEqual(status, 0, stderr)
+            clean_payload = json.loads(stdout)
+            clean_checks = {check["name"]: check for check in clean_payload["checks"]}
+            self.assertTrue(clean_payload["ok"])
+            self.assertEqual(clean_checks["skill_shadowing"]["severity"], "ok")
+            self.assertTrue(clean_checks["skill_shadowing"]["observed"])
+
+            collision_name = installable_skill_names()[0]
+            (foreign_skills / collision_name).mkdir(parents=True)
+            (foreign_skills / f"{collision_name}.txt").write_text("not a skill directory", encoding="utf-8")
+            (foreign_skills / f"{collision_name}-different-case").mkdir()
+            (foreign_skills / "nested" / collision_name).mkdir(parents=True)
+            (foreign_skills / f"{collision_name}-link").symlink_to(foreign_skills / collision_name, target_is_directory=True)
+            alias_config = ensure_external_dir(paths.hermes_config_path.read_text(encoding="utf-8"), foreign_skills / ".." / "foreign-skills")
+            paths.hermes_config_path.write_text(alias_config.text, encoding="utf-8")
+
+            with patch("omh.command_path.shutil.which", return_value="/usr/local/bin/omh"):
+                status, stdout, stderr = run_cli(base + ["doctor"], output_json=False)
+
+            self.assertEqual(status, 0, stderr)
+            self.assertIn("skill_shadowing:", stdout)
+            self.assertIn(collision_name, stdout)
+            self.assertIn("Hermes runtime precedence is not observed", stdout)
+
+            with patch("omh.command_path.shutil.which", return_value="/usr/local/bin/omh"):
+                status, stdout, stderr = run_cli(base + ["doctor", "--json"], output_json=False)
+
+            self.assertEqual(status, 0, stderr)
+            payload = json.loads(stdout)
+            checks = {check["name"]: check for check in payload["checks"]}
+            collision = checks["skill_shadowing"]
+            self.assertTrue(payload["ok"])
+            self.assertEqual(collision["severity"], "warning")
+            self.assertTrue(collision["ok"])
+            self.assertTrue(collision["observed"])
+            self.assertEqual(collision["message"].count(collision_name), 1)
+            self.assertIn("Hermes runtime precedence is not observed", collision["message"])
+            groups = {group["name"]: group for group in payload["summary"]["groups"]}
+            self.assertEqual(groups["hermes_registration"]["status"], "warning")
+
+    def test_doctor_reports_unreadable_external_skill_directory_as_an_advisory_warning(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            foreign_skills = root / "foreign-skills"
+            foreign_skills.mkdir()
+
+            with patch("omh.maintenance.doctor.Path.iterdir", side_effect=OSError("permission denied")):
+                check = _skill_shadowing_check(paths, [str(foreign_skills)])
+
+        self.assertTrue(check.ok)
+        self.assertEqual(check.severity, "warning")
+        self.assertTrue(check.observed)
+        self.assertIn("scan incomplete", check.message)
+        self.assertIn("unreadable external directory", check.message)
+        self.assertIn("Hermes runtime precedence is not observed", check.message)
+
+    def test_doctor_reports_external_skill_path_resolution_failure_as_an_advisory_warning(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+
+            with patch("omh.maintenance.doctor.Path.resolve", side_effect=RuntimeError("symlink loop")):
+                check = _skill_shadowing_check(paths, [str(root / "foreign-skills")])
+
+        self.assertTrue(check.ok)
+        self.assertEqual(check.severity, "warning")
+        self.assertIn("scan incomplete", check.message)
+        self.assertIn("symlink loop", check.message)
 
     def test_operator_catalog_commands_default_to_human_summary_with_json_escape_hatch(self) -> None:
         cases = (


### PR DESCRIPTION
## What changed

`omh doctor` now performs a local, read-only diagnostic for potential OMH core skill-name collisions in configured external skill directories.

## Why

An OMH-managed skill directory can coexist with other configured skill directories. Before this change, doctor confirmed registration but gave no indication when an immediate foreign directory used the same skill name. That left a likely source of ambiguous skill discovery invisible to the operator.

## What operators can do now

`omh doctor` reports a visible advisory warning when a configured foreign directory has an immediate, non-symlink directory whose exact name matches an OMH core skill. It also reports an incomplete local scan when a path cannot be resolved or enumerated.

The check is intentionally advisory: doctor remains successful, and the output explicitly says that Hermes runtime precedence is not observed.

## Implementation

- Canonicalizes configured directory aliases and excludes the OMH-managed directory.
- Inspects only immediate non-symlink directory names; it does not recurse or read `SKILL.md` contents.
- Adds the advisory check to the Hermes-registration display group and renders advisory warning details in human doctor output.
- Covers clean, collision, alias, file, nested directory, symlink, enumeration failure, and path-resolution failure cases.

## Verification

- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- `uv run python -m omh.cli docs workflows --check`
- `uv run python -m compileall -q src tests`
- `git diff --check`
- Independent code review: APPROVE
- Independent architecture review: CLEAR after incomplete-scan/path-resolution handling was added

## Risks and rollout

This is a conservative local diagnostic, not a runtime precedence detector. It may identify a potential name collision even where Hermes resolves the names safely; operators should use it as a configuration prompt, not execution or runtime evidence.
