### PR TITLE
feat: add source-bound quality evidence governance

### DIFF
--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -3350,6 +3350,66 @@ These surfaces are generated command references, not installed Hermes workflow s
   - Do not imply hidden Hermes runtime behavior.
   - Use the smallest verification that can prove the claim.
 
+### quality-evidence-loop
+
+[omh] Prepare QA scenarios, independent review requirements, and source-bound quality evidence assessments.
+
+- Category: `verification`
+- Phase: `quality-evidence-loop`
+- Hermes role: `reviewer`
+- Quality tier: `evidence-gated`
+- Exposure: `workflow_reference`
+- Install visibility: `false`
+- Docs visibility: `operator_reference`
+- Compatibility alias: `false`
+- Preferred usage: Use as agent-facing catalog guidance for QA scenarios, independent review, and source-bound assessment; invoke the quality-evidence CLI only as a backend/operator control plane.
+- Handoff policy: Keep scenario design, review independence, and evidence-boundary narration in Hermes; prepare a selected executor handoff only when concrete coding work is accepted.
+- Why this exists: Quality work needs an inspectable preparation and assessment loop without letting a prepared package masquerade as executed QA or review.
+- Use when: Use for an agent-facing quality loop that turns QA scenarios, independent review, and claims into inspectable source-bound evidence requirements.
+- Do not use when:
+  - The request is only a direct answer or plan with no quality evidence requirements.
+  - The user needs implementation, test execution, review, CI, or merge actions; route those to the selected executor/runtime owner.
+- Strong routing signals: `quality-evidence-loop`, `quality evidence loop`, `quality evidence`, `QA scenarios review claims`, `source-bound assessment`, `품질 증거`
+- Good example:
+  - Prompt: quality-evidence-loop prepare QA scenarios and independent review requirements for this source revision.
+  - Expected behavior: Create a quality_evidence_package/v1 and assess only source-bound observations that are explicitly supplied.
+  - Why: The request needs deterministic quality gates while preserving the prepared-versus-observed boundary.
+- Bad example:
+  - Prompt: quality-evidence-loop run the tests and say the PR is ready.
+  - Expected behavior: Prepare requirements and report that execution, review, CI, and merge readiness remain unobserved.
+  - Why: Preparation cannot create external execution or merge evidence.
+- Quality bar:
+  - Route QA scenarios, independent review, and claim coverage through one source-bound package.
+  - Assess only deterministic evidence consistency; never dispatch a runtime or execute tests.
+  - Report unknown or unsatisfied dimensions and the smallest next observation action.
+- Completion checklist:
+  - The package source identity matches repository, commit, and tree inputs.
+  - QA scenarios, review requirements, and claim requirements have stable IDs.
+  - Assessment output names each dimension and keeps prepared_not_observed explicit.
+  - No output claims that tests, review, CI, or merge ran without observed records.
+- Recovery notes:
+  - If package inputs are malformed, fail closed with deterministic validation errors.
+  - If observations are absent or supplied_unverified, report unknown and request source-bound observations.
+- Required inputs:
+  - repository, commit, and tree identity
+  - task title and executor target
+  - QA scenarios
+  - independent review requirements
+  - claim requirements
+- Expected outputs:
+  - quality_evidence_package/v1
+  - quality_evidence_assessment/v1
+  - source-bound next action
+  - prepared-versus-observed boundary
+- Artifact expectations:
+  - prepared_not_observed quality evidence package
+  - optional source-bound observations supplied by an OMH observer
+  - deterministic assessment with dimension reason codes
+- Safety rules:
+  - Do not treat quality evidence preparation as test execution, review, CI, PR, merge-readiness, or merge evidence.
+  - Require source identity matching and independent review provenance before marking dimensions satisfied.
+  - Keep supplied_unverified observations distinct from omh_observed_record evidence.
+
 ### github-event-ops
 
 [omh] Hermes GitHub event operations workflow: route PR, issue, CI, and review webhook events into triage, review, or fix handoff cards.

--- a/skills/oh-my-hermes/SKILL.md
+++ b/skills/oh-my-hermes/SKILL.md
@@ -138,4 +138,4 @@ Load these only when exact detail matters:
 - If evidence or target topology is disputed, load `references/evidence-boundaries.md`.
 - If the right skill was not loaded, call `skills_list` or `skill_view`.
 - If a slash command exists, use the explicit slash skill such as `/ralph`.
-- If a skill name collides, ask the user whether to use the Hermes-native skill or the oh-my-hermes adapted skill.
+- If a skill name collides, keep the OMH-selected policy in control and present the Hermes-native skill only as an explicit recommendation; do not let a native candidate override routing.

--- a/src/commands/chat.py
+++ b/src/commands/chat.py
@@ -58,8 +58,15 @@ def cmd_chat_route(args: argparse.Namespace) -> int:
         raise OmhError("--summary and --json cannot be used together")
     message = _chat_message(args)
     try:
-        decision = route_chat_message(message, source=args.source, limit=args.limit, min_confidence=args.min_confidence)
-    except ValueError as exc:
+        policy = _chat_route_skill_policy(args)
+        decision = route_chat_message(
+            message,
+            source=args.source,
+            limit=args.limit,
+            min_confidence=args.min_confidence,
+            skill_policy=policy,
+        )
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
         raise OmhError(str(exc)) from exc
     payload = {"route": public_route_payload(decision, include_message=args.include_message)}
     if args.record:
@@ -98,6 +105,20 @@ def cmd_chat_route(args: argparse.Namespace) -> int:
     else:
         _print_chat_route_summary(payload)
     return 0
+
+
+def _chat_route_skill_policy(args: argparse.Namespace) -> dict[str, object] | None:
+    inline = getattr(args, "skill_policy_json", None)
+    path = getattr(args, "skill_policy_file", None)
+    if inline is not None and path is not None:
+        raise ValueError("skill policy accepts either inline JSON or a file, not both")
+    if inline is None and path is None:
+        return None
+    raw = inline if inline is not None else Path(path).expanduser().read_text(encoding="utf-8")
+    policy = json.loads(raw)
+    if not isinstance(policy, dict):
+        raise ValueError("skill policy JSON must be an object")
+    return policy
 
 
 def cmd_chat_route_hint(args: argparse.Namespace) -> int:
@@ -148,6 +169,7 @@ def cmd_chat_interact(args: argparse.Namespace) -> int:
                 source_metadata=source_metadata,
                 target_notice=_target_notice(args, source_metadata),
                 paths=_paths(args),
+                skill_policy=_chat_route_skill_policy(args),
             )
     except FileNotFoundError as exc:
         raise OmhError(f"runtime run not found: {args.run_id}") from exc
@@ -939,6 +961,14 @@ def _add_chat_commands(sub) -> None:
     )
     route.add_argument("--limit", type=int, default=3, help="Maximum catalog recommendations to include.")
     route.add_argument(
+        "--skill-policy-json",
+        help="Agent-facing OMH-first skill governance policy JSON; native Hermes skills remain recommendations.",
+    )
+    route.add_argument(
+        "--skill-policy-file",
+        help="Path to an agent-facing OMH-first skill governance policy JSON object.",
+    )
+    route.add_argument(
         "--min-confidence",
         choices=CONFIDENCE_LEVELS,
         default="high",
@@ -1024,6 +1054,14 @@ def _add_chat_commands(sub) -> None:
         choices=CONFIDENCE_LEVELS,
         default="high",
         help="Minimum confidence for automatic workflow dispatch.",
+    )
+    interact.add_argument(
+        "--skill-policy-json",
+        help="Agent-facing OMH-first skill governance policy JSON; native Hermes skills remain recommendations.",
+    )
+    interact.add_argument(
+        "--skill-policy-file",
+        help="Path to an agent-facing OMH-first skill governance policy JSON object.",
     )
     interact.add_argument(
         "--executor",

--- a/src/commands/main.py
+++ b/src/commands/main.py
@@ -173,6 +173,7 @@ from .state import _add_state_commands, cmd_state_clear, cmd_state_finish, cmd_s
 from .use_cases import _add_cases_commands, cmd_cases_inspect, cmd_cases_list, cmd_cases_recommend
 from .visual import _add_visual_commands, cmd_visual_observe, cmd_visual_prompt_card
 from .adapter_quality import _add_adapter_quality_commands
+from .quality_evidence import _add_quality_evidence_commands
 from .web_qa import _add_web_qa_commands, cmd_web_qa_observe_capture, cmd_web_qa_package, cmd_web_qa_record_verdict
 from .worktree import cmd_worktree_bind, cmd_worktree_list, cmd_worktree_prepare, _add_worktree_commands
 
@@ -281,6 +282,7 @@ def build_parser() -> argparse.ArgumentParser:
     _add_materials_commands(sub)
     _add_visual_commands(sub)
     _add_adapter_quality_commands(sub)
+    _add_quality_evidence_commands(sub)
     _add_web_qa_commands(sub)
     _add_worktree_commands(sub)
     _add_runtime_commands(sub)

--- a/src/commands/quality_evidence.py
+++ b/src/commands/quality_evidence.py
@@ -1,0 +1,115 @@
+"""Agent-facing preparation and assessment for source-bound quality evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Mapping
+
+from ..installer import OmhError
+from ..quality.evidence_records import assess_quality_evidence, build_quality_evidence_package
+from .common import _paths, _print_json
+
+
+def cmd_quality_evidence_prepare(args: argparse.Namespace) -> int:
+    """Prepare QA, review, and claim requirements without executing them."""
+    try:
+        package = build_quality_evidence_package(
+            repository_id=args.repository,
+            commit_sha=args.commit,
+            tree_sha=args.tree,
+            title=args.title,
+            executor_target=args.executor,
+            scenarios=_json_list(args.scenarios_json, args.scenarios_file, "scenarios"),
+            review_requirements=_json_list(args.reviews_json, args.reviews_file, "review requirements"),
+            claim_requirements=_json_list(args.claims_json, args.claims_file, "claim requirements"),
+            self_critique_questions=_json_strings(args.self_critique_json, args.self_critique_file, "self-critique questions"),
+        )
+    except (OSError, json.JSONDecodeError, TypeError, ValueError) as exc:
+        raise OmhError(str(exc)) from exc
+    _print_json(package)
+    return 0
+
+
+def cmd_quality_evidence_assess(args: argparse.Namespace) -> int:
+    """Assess a package and optional observations; never execute external work."""
+    try:
+        package = _json_object(args.package)
+        observations = _json_list(args.observations_json, args.observations_file, "observations")
+        assessment = assess_quality_evidence(package, observations, omh_home=_paths(args).omh_home)
+    except (OSError, json.JSONDecodeError, TypeError, ValueError) as exc:
+        raise OmhError(str(exc)) from exc
+    _print_json(assessment)
+    return 0
+
+
+def _add_quality_evidence_commands(sub: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
+    """Register the operator-only quality evidence control-plane commands."""
+    quality = sub.add_parser(
+        "quality-evidence",
+        help="Prepare or assess source-bound quality evidence (operator/backend; no execution).",
+        description=(
+            "Operator/backend commands for prepared quality evidence. Preparation and assessment "
+            "do not run tests, review, CI, merge, or any runtime dispatch."
+        ),
+    )
+    commands = quality.add_subparsers(dest="quality_evidence_command", required=True)
+    prepare = commands.add_parser(
+        "prepare",
+        help="Create a prepared_not_observed package from source and JSON requirements.",
+        description="Create requirements only; this does not execute tests or perform review/CI.",
+    )
+    prepare.add_argument("--repository", "--repository-id", dest="repository", required=True)
+    prepare.add_argument("--commit", "--commit-sha", dest="commit", required=True)
+    prepare.add_argument("--tree", "--tree-sha", dest="tree", required=True)
+    prepare.add_argument("--title", required=True)
+    prepare.add_argument("--executor", "--executor-target", dest="executor", required=True)
+    _add_json_input(prepare, "scenarios", "QA scenarios")
+    _add_json_input(prepare, "reviews", "review requirements")
+    _add_json_input(prepare, "claims", "claim requirements")
+    prepare.add_argument("--self-critique-json", "--self-critique", dest="self_critique_json", help="Inline self-critique question JSON array.")
+    prepare.add_argument("--self-critique-file", dest="self_critique_file", help="Path to self-critique question JSON array.")
+    prepare.set_defaults(func=cmd_quality_evidence_prepare)
+
+    assess = commands.add_parser(
+        "assess",
+        help="Assess a package plus optional observations without claiming execution.",
+        description="Assessment checks source-bound evidence consistency; it does not run tests or merge.",
+    )
+    assess.add_argument("--package", required=True, help="Path to a prepared quality evidence package JSON.")
+    assess.add_argument("--observations-json", "--observations", dest="observations_json", help="Inline observations JSON.")
+    assess.add_argument("--observations-file", help="Path to observations JSON.")
+    assess.set_defaults(func=cmd_quality_evidence_assess)
+
+
+def _add_json_input(parser: argparse.ArgumentParser, name: str, label: str) -> None:
+    parser.add_argument(f"--{name}-json", f"--{name}", dest=f"{name}_json", help=f"Inline {label} JSON array.")
+    parser.add_argument(f"--{name}-file", dest=f"{name}_file", help=f"Path to {label} JSON array.")
+
+
+def _json_object(path: str) -> dict[str, object]:
+    value = json.loads(Path(path).expanduser().read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError("package JSON must be an object")
+    return value
+
+
+def _json_list(inline: str | None, path: str | None, label: str) -> list[Mapping[str, object]]:
+    if inline is not None and path is not None:
+        raise ValueError(f"{label} accepts either inline JSON or a file, not both")
+    raw = inline if inline is not None else Path(path).expanduser().read_text(encoding="utf-8") if path else "[]"
+    value = json.loads(raw)
+    if not isinstance(value, list) or not all(isinstance(item, dict) for item in value):
+        raise ValueError(f"{label} JSON must be an array of objects")
+    return value
+
+
+def _json_strings(inline: str | None, path: str | None, label: str) -> list[str]:
+    if inline is not None and path is not None:
+        raise ValueError(f"{label} accepts either inline JSON or a file, not both")
+    raw = inline if inline is not None else Path(path).expanduser().read_text(encoding="utf-8") if path else "[]"
+    value = json.loads(raw)
+    if not isinstance(value, list) or not all(isinstance(item, str) and item.strip() for item in value):
+        raise ValueError(f"{label} JSON must be an array of nonblank strings")
+    return value

--- a/src/quality/evidence_records.py
+++ b/src/quality/evidence_records.py
@@ -1,0 +1,349 @@
+"""Deterministic, source-bound quality evidence records.
+
+The module deliberately deals in metadata only.  It never runs a command or
+upgrades a supplied assertion into observed execution evidence.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Mapping, Sequence
+
+from ..local_store import read_json_object_result
+
+QUALITY_EVIDENCE_PACKAGE_SCHEMA = "quality_evidence_package/v1"
+QUALITY_EVIDENCE_OBSERVATION_SCHEMA = "quality_evidence_observation/v1"
+QUALITY_EVIDENCE_ASSESSMENT_SCHEMA = "quality_evidence_assessment/v1"
+PREPARED_NOT_OBSERVED = "prepared_not_observed"
+PROVENANCES = frozenset({"omh_observed_record", "supplied_unverified"})
+EVIDENCE_KINDS = frozenset({"test", "visual", "performance", "review", "ci", "pr"})
+RESULTS = frozenset({"passed", "failed", "unknown"})
+DIMENSION_STATES = frozenset({"satisfied", "unsatisfied", "unknown", "not_applicable"})
+_PACKAGE_FIELDS = frozenset({"schema_version", "status", "subject", "qa_scenarios", "review_requirements", "claim_requirements", "self_critique_questions", "claim_boundary"})
+
+
+def source_identity(repository_id: str, commit_sha: str, tree_sha: str) -> dict[str, str]:
+    """Return the canonical identity used for every package and observation."""
+    values = (repository_id, commit_sha, tree_sha)
+    if not all(isinstance(value, str) and value.strip() for value in values):
+        raise ValueError("repository_id, commit_sha, and tree_sha are required")
+    return {"repository_id": repository_id, "commit_sha": commit_sha, "tree_sha": tree_sha}
+
+
+def build_quality_evidence_package(
+    *,
+    repository_id: str,
+    commit_sha: str,
+    tree_sha: str,
+    title: str,
+    executor_target: str,
+    scenarios: Sequence[Mapping[str, object]] = (),
+    review_requirements: Sequence[Mapping[str, object]] = (),
+    claim_requirements: Sequence[Mapping[str, object]] = (),
+    self_critique_questions: Sequence[str] = (),
+) -> dict[str, object]:
+    """Prepare a compact package; preparation is never observed evidence."""
+    identity = source_identity(repository_id, commit_sha, tree_sha)
+    normalized_scenarios = _with_deterministic_ids(scenarios, "scenario")
+    normalized_reviews = _with_deterministic_ids(review_requirements, "review")
+    normalized_claims = _with_deterministic_ids(claim_requirements, "claim")
+    package = {
+        "schema_version": QUALITY_EVIDENCE_PACKAGE_SCHEMA,
+        "status": PREPARED_NOT_OBSERVED,
+        "subject": {"title": title, "executor_target": executor_target, "source": identity},
+        "qa_scenarios": normalized_scenarios,
+        "review_requirements": normalized_reviews,
+        "claim_requirements": normalized_claims,
+        "self_critique_questions": list(self_critique_questions),
+        "claim_boundary": "Prepared quality requirements are not observed QA, review, CI, PR, merge-readiness, or completion evidence.",
+    }
+    errors = validate_quality_evidence_package(package)
+    if errors:
+        raise ValueError("invalid quality evidence package: " + ", ".join(errors))
+    return package
+
+
+def validate_quality_evidence_package(package: Mapping[str, object]) -> list[str]:
+    """Validate prepared-record shape without treating it as observed work."""
+    errors: list[str] = []
+    if not isinstance(package, Mapping):
+        return ["invalid_package"]
+    if set(package) != _PACKAGE_FIELDS:
+        errors.append("invalid_top_level_fields")
+    if package.get("schema_version") != QUALITY_EVIDENCE_PACKAGE_SCHEMA:
+        errors.append("unknown_schema")
+    if package.get("status") != PREPARED_NOT_OBSERVED:
+        errors.append("invalid_prepared_status")
+    subject = package.get("subject")
+    if (
+        not isinstance(subject, Mapping)
+        or not isinstance(subject.get("title"), str)
+        or not subject["title"].strip()
+        or not isinstance(subject.get("executor_target"), str)
+        or not subject["executor_target"].strip()
+    ):
+        errors.append("invalid_subject")
+    try:
+        _source_from_package(package)
+    except ValueError:
+        errors.append("invalid_source_identity")
+    for field in ("qa_scenarios", "review_requirements", "claim_requirements", "self_critique_questions"):
+        if not isinstance(package.get(field), list):
+            errors.append(f"invalid_{field}")
+    if not isinstance(package.get("claim_boundary"), str) or not package.get("claim_boundary", "").strip():
+        errors.append("missing_claim_boundary")
+    questions = package.get("self_critique_questions", [])
+    if isinstance(questions, list) and any(not isinstance(item, str) or not item.strip() for item in questions):
+        errors.append("invalid_self_critique_questions")
+    for field in ("qa_scenarios", "review_requirements", "claim_requirements"):
+        values = package.get(field, [])
+        if not isinstance(values, list):
+            continue
+        ids = [str(item.get("id")) for item in values if isinstance(item, Mapping) and item.get("id")]
+        if len(ids) != len(set(ids)):
+            errors.append(f"duplicate_{field}_id")
+        if len(ids) != len(values):
+            errors.append(f"missing_{field}_id")
+    return list(dict.fromkeys(errors))
+
+
+def build_quality_evidence_observation(
+    package: Mapping[str, object], *, evidence_id: str, evidence_kind: str, result: str,
+    reference: str, observed_at: str, reporter: str, provenance: str = "supplied_unverified",
+    record_ref: str | None = None, scenario_ids: Sequence[str] = (),
+    review_requirement_ids: Sequence[str] = (), claim_ids: Sequence[str] = (), independence: str | None = None,
+) -> dict[str, object]:
+    """Build an observation bound to the package's canonical source identity."""
+    observation = {"schema_version": QUALITY_EVIDENCE_OBSERVATION_SCHEMA, "evidence_id": evidence_id,
+        "evidence_kind": evidence_kind, "result": result, "reference": reference,
+        "observed_at": observed_at, "reporter": reporter, "source": _source_from_package(package),
+        "provenance": provenance, "record_ref": record_ref, "scenario_ids": list(scenario_ids),
+        "review_requirement_ids": list(review_requirement_ids), "claim_ids": list(claim_ids)}
+    if independence is not None:
+        observation["independence"] = independence
+    errors = validate_quality_evidence_observation(observation, package)
+    if errors:
+        raise ValueError("invalid quality evidence observation: " + ", ".join(errors))
+    return observation
+
+
+def validate_quality_evidence_observation(
+    observation: Mapping[str, object],
+    package: Mapping[str, object],
+) -> list[str]:
+    """Return deterministic reason codes; no external work is performed."""
+    if not isinstance(observation, Mapping):
+        return ["invalid_observation"]
+    errors: list[str] = []
+    if observation.get("schema_version") != QUALITY_EVIDENCE_OBSERVATION_SCHEMA:
+        errors.append("unknown_schema")
+    kind = observation.get("evidence_kind")
+    if kind not in EVIDENCE_KINDS:
+        errors.append("invalid_evidence_kind")
+    if observation.get("result") not in RESULTS:
+        errors.append("invalid_result")
+    provenance = observation.get("provenance")
+    if provenance not in PROVENANCES:
+        errors.append("unknown_provenance")
+    source = _source_from_package(package)
+    observed_source = observation.get("source")
+    if not isinstance(observed_source, Mapping) or dict(observed_source) != source:
+        errors.append("source_mismatch")
+    if not str(observation.get("evidence_id") or "").strip():
+        errors.append("missing_evidence_id")
+    if not isinstance(observation.get("reporter"), str) or not observation.get("reporter", "").strip():
+        errors.append("missing_reporter")
+    if not str(observation.get("reference") or "").strip():
+        errors.append("missing_reference")
+    if not _parse_timestamp(observation.get("observed_at")):
+        errors.append("missing_or_invalid_observed_at")
+    if provenance == "omh_observed_record" and not str(observation.get("record_ref") or "").strip():
+        errors.append("missing_observed_record_ref")
+    if kind == "review" and observation.get("independence") not in {"independent", "self_review_only"}:
+        errors.append("missing_review_independence")
+    valid_ids = _package_ids(package)
+    for field in ("scenario_ids", "review_requirement_ids", "claim_ids"):
+        values = observation.get(field, [])
+        if not isinstance(values, (list, tuple)):
+            errors.append("invalid_requirement_ids")
+            continue
+        if any(item not in valid_ids[field] for item in values):
+            errors.append("unknown_requirement_id")
+    return list(dict.fromkeys(errors))
+
+
+def assess_quality_evidence(
+    package: Mapping[str, object], observations: Sequence[Mapping[str, object]] = (), *, now: datetime | None = None,
+    omh_home: str | Path | None = None,
+) -> dict[str, object]:
+    """Derive independent dimensions and fail closed on drift or self-review."""
+    package_errors = validate_quality_evidence_package(package)
+    if package_errors:
+        raise ValueError("invalid quality evidence package: " + ", ".join(package_errors))
+    source = _source_from_package(package)
+    valid: list[Mapping[str, object]] = []
+    reasons: list[str] = []
+    for item in observations:
+        errors = validate_quality_evidence_observation(item, package)
+        if errors:
+            reasons.extend(errors)
+            continue
+        if item.get("independence") == "self_review_only":
+            reasons.append("self_review_only_not_admissible")
+            continue
+        if item.get("provenance") == "omh_observed_record":
+            executor_target = str(package["subject"]["executor_target"])
+            if _record_is_admissible(item, source, executor_target, omh_home):
+                valid.append(item)
+            else:
+                reasons.append("unresolved_observed_record")
+        else:
+            reasons.append("supplied_unverified_not_admissible")
+    scenarios = _package_ids(package)["scenario_ids"]
+    observed_scenarios = {sid for item in valid if item.get("result") == "passed" for sid in item.get("scenario_ids", [])}
+    scenario_state = "not_applicable" if not scenarios else "satisfied" if observed_scenarios >= scenarios else "unknown" if not valid else "unsatisfied"
+    if any(item.get("result") == "failed" and item.get("scenario_ids") for item in valid):
+        scenario_state = "unsatisfied"
+    scenario_results: dict[str, set[object]] = {}
+    for item in valid:
+        for scenario_id in item.get("scenario_ids", []):
+            scenario_results.setdefault(str(scenario_id), set()).add(item.get("result"))
+    if any(len(results) > 1 for results in scenario_results.values()):
+        reasons.append("contradictory_observations")
+        scenario_state = "unsatisfied"
+    freshness = "satisfied" if valid and all(dict(item.get("source", {})) == source for item in valid) else "unsatisfied" if "source_mismatch" in reasons else "unknown"
+    reviews = _package_ids(package)["review_requirement_ids"]
+    independent = {rid for item in valid if item.get("evidence_kind") == "review" and item.get("independence") == "independent" and item.get("result") == "passed" for rid in item.get("review_requirement_ids", [])}
+    review_state = "not_applicable" if not reviews else "satisfied" if independent >= reviews else "unknown" if not valid else "unsatisfied"
+    ci_state, ci_items = _explicit_requirement_state(package, valid, "ci")
+    pr_state, pr_items = _explicit_requirement_state(package, valid, "pr")
+    claim_ids = _package_ids(package)["claim_ids"]
+    observed_claims = {cid for item in valid if item.get("result") == "passed" for cid in item.get("claim_ids", [])}
+    claim_state = "not_applicable" if not claim_ids else "satisfied" if observed_claims >= claim_ids else "unknown" if not valid else "unsatisfied"
+    evidence_ids = {
+        "scenario_coverage": [str(item["evidence_id"]) for item in valid if item.get("scenario_ids")],
+        "source_freshness": [str(item["evidence_id"]) for item in valid],
+        "review_independence": [str(item["evidence_id"]) for item in valid if item.get("evidence_kind") == "review" and item.get("independence") == "independent"],
+        "ci_status": [str(item["evidence_id"]) for item in valid if item.get("evidence_kind") == "ci"],
+        "pr_status": [str(item["evidence_id"]) for item in valid if item.get("evidence_kind") == "pr"],
+        "claim_coverage": [str(item["evidence_id"]) for item in valid if item.get("claim_ids")],
+    }
+    states = {"scenario_coverage": scenario_state, "source_freshness": freshness, "review_independence": review_state, "ci_status": ci_state, "pr_status": pr_state, "claim_coverage": claim_state}
+    dimensions = {name: _dimension(state, reasons, evidence_ids[name]) for name, state in states.items()}
+    complete = all(item["status"] in {"satisfied", "not_applicable"} for item in dimensions.values())
+    return {"schema_version": QUALITY_EVIDENCE_ASSESSMENT_SCHEMA, "source": source, "dimensions": dimensions, "ready_for_completion": complete, "next_action": "record_source_bound_observations" if not complete else "none", "reasons": list(dict.fromkeys(reasons)), "claim_boundary": "Assessment validates evidence consistency only; it does not prove external execution."}
+
+
+def _source_from_package(package: Mapping[str, object]) -> dict[str, str]:
+    subject = package.get("subject")
+    source = subject.get("source") if isinstance(subject, Mapping) else None
+    if not isinstance(source, Mapping):
+        raise ValueError("package subject.source is required")
+    repository_id = source.get("repository_id")
+    commit_sha = source.get("commit_sha")
+    tree_sha = source.get("tree_sha")
+    if set(source) != {"repository_id", "commit_sha", "tree_sha"}:
+        raise ValueError("package subject.source has invalid fields")
+    if not all(isinstance(value, str) for value in (repository_id, commit_sha, tree_sha)):
+        raise ValueError("package subject.source values must be strings")
+    return source_identity(repository_id, commit_sha, tree_sha)
+
+
+def _with_deterministic_ids(values: Sequence[Mapping[str, object]], prefix: str) -> list[dict[str, object]]:
+    result: list[dict[str, object]] = []
+    for index, item in enumerate(values, start=1):
+        normalized = dict(item)
+        if not str(normalized.get("id") or "").strip():
+            normalized["id"] = f"{prefix}-{index}"
+        result.append(normalized)
+    return result
+
+
+def resolve_omh_record_ref(omh_home: str | Path, record_ref: str) -> dict[str, object] | None:
+    """Resolve one OMH-owned JSON record without following symlinks or escaping home."""
+    if not isinstance(record_ref, str) or not record_ref.strip():
+        return None
+    root = Path(omh_home).expanduser().resolve()
+    raw_candidate = root / record_ref.strip()
+    if raw_candidate.is_symlink():
+        return None
+    candidate = raw_candidate.resolve()
+    try:
+        candidate.relative_to(root)
+    except ValueError:
+        return None
+    if not candidate.is_file():
+        return None
+    record, error = read_json_object_result(candidate)
+    return record if error is None and isinstance(record, dict) else None
+
+
+def _record_is_admissible(
+    observation: Mapping[str, object], source: Mapping[str, str], executor_target: str, omh_home: str | Path | None
+) -> bool:
+    if not omh_home or not isinstance(observation.get("record_ref"), str):
+        return False
+    record = resolve_omh_record_ref(omh_home, observation["record_ref"])
+    if record is None:
+        return False
+    record_source = record.get("source")
+    if record_source != dict(source):
+        return False
+    if record.get("record_type") not in {
+        "quality_evidence_observation",
+        "runtime_observation",
+        "review",
+        "ci",
+        "merge",
+    }:
+        return False
+    executor_fields = [record.get(key) for key in ("executor", "executor_target") if key in record]
+    if not executor_fields or any(not isinstance(value, str) or not value.strip() or value.strip() != executor_target for value in executor_fields):
+        return False
+    kind = record.get("evidence_kind", record.get("kind"))
+    if kind != observation.get("evidence_kind"):
+        return False
+    result = record.get("result", record.get("status"))
+    if result != observation.get("result"):
+        return False
+    if record.get("observed") is not True or record.get("provenance") != "omh_observed_record":
+        return False
+    for key in ("evidence_id", "reference", "reporter", "observed_at", "scenario_ids", "review_requirement_ids", "claim_ids"):
+        if record.get(key) != observation.get(key):
+            return False
+    if "independence" in observation and record.get("independence") != observation.get("independence"):
+        return False
+    return True
+
+
+def _explicit_requirement_state(package: Mapping[str, object], valid: Sequence[Mapping[str, object]], kind: str) -> tuple[str, list[Mapping[str, object]]]:
+    requirements = [item for item in package.get("review_requirements", []) if isinstance(item, Mapping) and item.get("kind") == kind]
+    if not requirements:
+        return "not_applicable", []
+    requirement_ids = {str(item["id"]) for item in requirements if item.get("id")}
+    items = [item for item in valid if item.get("evidence_kind") == kind and requirement_ids.intersection(str(value) for value in item.get("review_requirement_ids", []))]
+    matching = {rid: [item for item in items if rid in {str(value) for value in item.get("review_requirement_ids", [])}] for rid in requirement_ids}
+    if any(any(item.get("result") == "failed" for item in rows) for rows in matching.values()):
+        return "unsatisfied", items
+    if all(any(item.get("result") == "passed" for item in rows) for rows in matching.values()):
+        return "satisfied", items
+    return ("unsatisfied" if items else "unknown"), items
+
+
+def _package_ids(package: Mapping[str, object]) -> dict[str, set[str]]:
+    return {"scenario_ids": {str(item.get("id")) for item in package.get("qa_scenarios", []) if isinstance(item, Mapping) and item.get("id")}, "review_requirement_ids": {str(item.get("id")) for item in package.get("review_requirements", []) if isinstance(item, Mapping) and item.get("id")}, "claim_ids": {str(item.get("id")) for item in package.get("claim_requirements", []) if isinstance(item, Mapping) and item.get("id")}}
+
+
+def _dimension(status: str, reasons: Sequence[str], evidence_ids: Sequence[str]) -> dict[str, object]:
+    return {"status": status if status in DIMENSION_STATES else "unknown", "reason_codes": list(dict.fromkeys(reasons)), "evidence_ids": list(dict.fromkeys(evidence_ids))}
+
+
+def _parse_timestamp(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed.astimezone(timezone.utc) if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)

--- a/src/quality/skill_governance.py
+++ b/src/quality/skill_governance.py
@@ -1,0 +1,242 @@
+"""Deterministic, fail-closed governance for OMH and native Hermes skills."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+import hashlib
+import json
+from typing import Final, TypeAlias
+
+from .evidence_records import resolve_omh_record_ref
+
+
+SCHEMA_VERSION: Final = "skill_governance_policy/v1"
+_FIELDS: Final = frozenset({"skills", "priority", "runtime_priority", "omh_observed_record"})
+_POLICY_TOP_FIELDS: Final = frozenset({"schema_version", "project", "user", "builtin_omh", "native_hermes", "source"})
+_SOURCE_FIELDS: Final = frozenset({"repository_id", "commit_sha", "tree_sha"})
+_OBSERVED_RECORD_FIELDS: Final = frozenset({"provenance", "ref", "record_type", "policy_digest", "executor", "runtime_priority", "source", "policy_identity", "observed"})
+_PolicyInput: TypeAlias = Mapping[str, object] | Sequence[Mapping[str, object]] | None
+
+
+def _as_levels(value: _PolicyInput) -> tuple[Mapping[str, object], ...] | None:
+    if value is None:
+        return ()
+    if isinstance(value, Mapping):
+        return (value,)
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        if all(isinstance(item, Mapping) for item in value):
+            return tuple(value)
+    return None
+
+
+def _merge_level(value: _PolicyInput) -> tuple[dict[str, object] | None, list[str]]:
+    levels = _as_levels(value)
+    if levels is None:
+        return None, ["malformed_policy"]
+    merged: dict[str, object] = {}
+    errors: list[str] = []
+    for level in levels:
+        unknown = set(level) - _FIELDS
+        if unknown:
+            errors.append("unknown_fields")
+        for key, candidate in level.items():
+            if key not in _FIELDS:
+                continue
+            if key in merged and merged[key] != candidate:
+                errors.append("conflicting_values")
+            if key == "skills" and (
+                not isinstance(candidate, Sequence)
+                or isinstance(candidate, (str, bytes, bytearray))
+                or not candidate
+                or not all(isinstance(skill, str) and skill.strip() for skill in candidate)
+                or len(set(candidate)) != len(candidate)
+            ):
+                errors.append("malformed_policy")
+            if key in {"priority", "runtime_priority"} and (
+                not isinstance(candidate, str) or not candidate.strip()
+            ):
+                errors.append("malformed_policy")
+            if key == "omh_observed_record" and (
+                not isinstance(candidate, Mapping) or not isinstance(candidate.get("ref"), str)
+                or not candidate.get("ref")
+                or set(candidate) - _OBSERVED_RECORD_FIELDS
+                or candidate.get("provenance") != "omh_observed_record"
+                or candidate.get("record_type") != "policy_applied"
+                or not _is_sha256(candidate.get("policy_digest"))
+                or not isinstance(candidate.get("executor"), str)
+                or not candidate.get("executor", "").strip()
+                or candidate.get("runtime_priority") != candidate.get("executor")
+                or not _valid_source(candidate.get("source"))
+                or ("observed" in candidate and candidate.get("observed") is not True)
+                or ("policy_identity" in candidate and not isinstance(candidate.get("policy_identity"), Mapping))
+            ):
+                errors.append("malformed_policy")
+            merged[key] = candidate
+    return merged, errors
+
+
+def validate_skill_governance_policy(policy: object) -> dict[str, object]:
+    """Validate a v1 policy without selecting or executing any skill."""
+    if not isinstance(policy, Mapping):
+        return {"valid": False, "errors": ["malformed_policy"]}
+    errors: list[str] = []
+    if policy.get("schema_version") != SCHEMA_VERSION:
+        errors.append("unknown_policy_version")
+    unknown = set(policy) - _POLICY_TOP_FIELDS
+    if unknown:
+        errors.append("unknown_fields")
+    for name in ("project", "user", "builtin_omh", "native_hermes"):
+        if name in policy and policy[name] is None:
+            errors.append("malformed_policy")
+            continue
+        merged, level_errors = _merge_level(policy.get(name))
+        if name == "native_hermes" and merged is not None:
+            if set(merged) - {"skills"}:
+                level_errors.append("native_recommendation_fields")
+        errors.extend(level_errors)
+    if "source" in policy and not _valid_source(policy.get("source")):
+        errors.append("invalid_source_identity")
+    return {"valid": not errors, "errors": sorted(set(errors))}
+
+
+def build_skill_governance_policy(
+    project: _PolicyInput = None,
+    user: _PolicyInput = None,
+    builtin_omh: _PolicyInput = None,
+    native_hermes: _PolicyInput = None,
+    *,
+    native_hermes_recommendation: _PolicyInput = None,
+    source: Mapping[str, object] | None = None,
+) -> dict[str, object]:
+    """Build a schema-versioned policy artifact from four governance levels."""
+    native = native_hermes if native_hermes_recommendation is None else native_hermes_recommendation
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "project": project if project is not None else {},
+        "user": user if user is not None else {},
+        "builtin_omh": builtin_omh if builtin_omh is not None else {},
+        "native_hermes": native if native is not None else {},
+        **({"source": dict(source)} if source is not None else {}),
+    }
+
+
+def resolve_skill_governance(
+    policy: object, *, omh_home: str | None = None
+) -> dict[str, object]:
+    """Resolve OMH policy precedence; native Hermes values remain recommendations."""
+    validation = validate_skill_governance_policy(policy)
+    if not validation["valid"] or not isinstance(policy, Mapping):
+        return {
+            "status": "fail_closed",
+            "selected_skills": [],
+            "selected_native_skills": [],
+            "native_recommendations": [],
+            "runtime_priority_observed": False,
+            "policy_prepared": False,
+            "prepared_status": "fail_closed",
+            "evidence_boundary": "fail_closed",
+            "errors": validation["errors"],
+        }
+    selected: dict[str, object] = {}
+    for name in ("builtin_omh", "user", "project"):
+        merged, _ = _merge_level(policy.get(name))
+        if merged:
+            selected.update(merged)
+    native, _ = _merge_level(policy.get("native_hermes"))
+    recommendations = [] if native is None else native.get("skills", [])
+    observed = selected.get("omh_observed_record")
+    runtime_priority = selected.get("runtime_priority")
+    source = policy.get("source")
+    decision_identity = policy_decision_identity(selected, executor=runtime_priority, source=source)
+    decision_digest = policy_decision_digest(selected, executor=runtime_priority, source=source)
+    resolved_observation = None
+    if isinstance(observed, Mapping):
+        ref = observed.get("ref")
+        if isinstance(ref, str) and ref.strip() and omh_home is not None:
+            resolved_observation = resolve_omh_record_ref(omh_home, ref)
+    runtime_observed = _matching_observation(resolved_observation, selected, runtime_priority, source, decision_digest)
+    if observed is not None and not runtime_observed:
+        return {
+            "status": "fail_closed",
+            "selected_skills": [],
+            "selected_native_skills": [],
+            "native_recommendations": [],
+            "runtime_priority_observed": False,
+            "policy_prepared": False,
+            "prepared_status": "fail_closed",
+            "evidence_boundary": "fail_closed",
+            "errors": ["unmatched_policy_applied_record"],
+        }
+    return {
+        "status": "resolved",
+        "selected_skills": selected.get("skills", []),
+        "selected_policy": selected,
+        "selected_native_skills": [],
+        "native_recommendations": recommendations,
+        "runtime_priority_observed": runtime_observed,
+        "policy_prepared": True,
+        "prepared_status": "policy_prepared",
+        "evidence_boundary": "runtime_priority_observed" if runtime_observed else "prepared_not_observed",
+        "errors": [],
+        "policy_decision_identity": decision_identity,
+        "policy_decision_digest": decision_digest,
+    }
+
+
+def policy_decision_identity(
+    selected_policy: Mapping[str, object], *, executor: object = None, source: object = None
+) -> dict[str, object]:
+    """Return the canonical, metadata-only identity for a selected policy."""
+    normalized = {key: value for key, value in selected_policy.items() if key != "omh_observed_record"}
+    return {
+        "policy": normalized,
+        "executor": executor if isinstance(executor, str) else "",
+        "source": dict(source) if isinstance(source, Mapping) else {},
+    }
+
+
+def policy_decision_digest(
+    selected_policy: Mapping[str, object], *, executor: object = None, source: object = None
+) -> str:
+    payload = json.dumps(
+        policy_decision_identity(selected_policy, executor=executor, source=source),
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _is_sha256(value: object) -> bool:
+    if not isinstance(value, str) or len(value) != 64:
+        return False
+    try:
+        int(value, 16)
+    except ValueError:
+        return False
+    return value == value.lower()
+
+
+def _valid_source(value: object) -> bool:
+    return (
+        isinstance(value, Mapping)
+        and set(value) == _SOURCE_FIELDS
+        and all(isinstance(item, str) and item.strip() for item in value.values())
+    )
+
+
+def _matching_observation(observed: object, selected_policy: Mapping[str, object], executor: object, source: object, digest: str) -> bool:
+    return (
+        isinstance(executor, str)
+        and bool(executor.strip())
+        and _valid_source(source)
+        and isinstance(observed, Mapping)
+        and observed.get("provenance") == "omh_observed_record"
+        and bool(observed.get("ref"))
+        and observed.get("record_type") == "policy_applied"
+        and observed.get("policy_digest") == digest
+        and observed.get("executor") == executor
+        and observed.get("runtime_priority") == executor
+        and observed.get("observed") is True
+        and dict(observed.get("source", {})) == dict(source)
+        and observed.get("policy_identity") == policy_decision_identity(selected_policy, executor=executor, source=source)
+    )

--- a/src/routing/chat.py
+++ b/src/routing/chat.py
@@ -42,6 +42,7 @@ from .visual_qa_cues import (
     contains_cue_phrase,
 )
 from ..learning_candidate import build_learning_candidate_card
+from ..quality.skill_governance import build_skill_governance_policy, resolve_skill_governance
 from ..surfaces.evidence_copy import not_evidence_action_suffix, not_evidence_reply_suffix
 from ..skills.catalog import SkillDefinition, primary_harness_for_skill, routable_definitions
 
@@ -1317,6 +1318,7 @@ def route_chat_message(
     source: str = "generic",
     limit: int = 3,
     min_confidence: str = "high",
+    skill_policy: dict[str, object] | None = None,
 ) -> dict[str, object]:
     message = message.strip()
     if not message:
@@ -1328,7 +1330,8 @@ def route_chat_message(
     if min_confidence not in CONFIDENCE_LEVELS:
         raise ValueError(f"unsupported chat route confidence threshold: {min_confidence}")
 
-    return _clone_jsonish(_route_chat_message_cached(message, source, limit, min_confidence))
+    route = _clone_jsonish(_route_chat_message_cached(message, source, limit, min_confidence))
+    return _apply_skill_governance(route, skill_policy)
 
 
 def public_chat_route_payload(
@@ -1338,6 +1341,7 @@ def public_chat_route_payload(
     limit: int = 3,
     min_confidence: str = "high",
     include_message: bool = False,
+    skill_policy: dict[str, object] | None = None,
 ) -> dict[str, object]:
     message = message.strip()
     if not message:
@@ -1348,6 +1352,17 @@ def public_chat_route_payload(
         raise ValueError("chat route --limit must be at least 1")
     if min_confidence not in CONFIDENCE_LEVELS:
         raise ValueError(f"unsupported chat route confidence threshold: {min_confidence}")
+    if skill_policy is not None:
+        return public_route_payload(
+            route_chat_message(
+                message,
+                source=source,
+                limit=limit,
+                min_confidence=min_confidence,
+                skill_policy=skill_policy,
+            ),
+            include_message=include_message,
+        )
     return _copy_public_route_payload(
         _public_chat_route_payload_cached(
             message,
@@ -2005,6 +2020,45 @@ def _explicit_skill_fast_path_decision(
 def _has_explicit_invocation_prefix(message: str) -> bool:
     first = message.strip().split(maxsplit=1)[0].strip(":,").lower()
     return first.startswith(("$", "/", "./", "@"))
+
+
+def _apply_skill_governance(
+    route: dict[str, object],
+    skill_policy: dict[str, object] | None,
+) -> dict[str, object]:
+    """Apply OMH policy at the dispatch boundary; native skills stay advisory."""
+    if route["action"] != "dispatch":
+        return route
+    selected_skill = str(route["selected_skill"])
+    policy = skill_policy or build_skill_governance_policy(
+        builtin_omh={"skills": [selected_skill]},
+    )
+    governance = resolve_skill_governance(policy)
+    route["skill_governance"] = governance
+    route["native_skill_recommendations"] = list(governance["native_recommendations"])
+    governed_skills = governance["selected_skills"]
+    if governance["status"] != "resolved" or not governed_skills:
+        return _fail_closed_skill_governance(route)
+    governed_skill = str(governed_skills[0])
+    try:
+        definition = _skill_definition_by_name(governed_skill)
+    except RuntimeError:
+        return _fail_closed_skill_governance(route)
+    route["selected_skill"] = definition.name
+    route["selected_harness"] = primary_harness_for_skill(definition.name)
+    if definition.name != selected_skill:
+        route["reason"] = f"{route['reason']} OMH skill policy selected `{definition.name}`."
+    return route
+
+
+def _fail_closed_skill_governance(route: dict[str, object]) -> dict[str, object]:
+    """Keep an invalid policy from selecting an arbitrary or native skill."""
+    definition = _router_skill_definition()
+    route["action"] = "clarify"
+    route["selected_skill"] = definition.name
+    route["selected_harness"] = primary_harness_for_skill(definition.name)
+    route["reason"] = f"{route['reason']} OMH skill policy could not select an installed workflow."
+    return route
 
 
 def _catalog_fast_path_decision(
@@ -4657,8 +4711,15 @@ def route_chat_event(
     source: str = "generic",
     limit: int = 3,
     min_confidence: str = "high",
+    skill_policy: dict[str, object] | None = None,
 ) -> dict[str, object]:
-    return route_chat_message(extract_message_text(event), source=source, limit=limit, min_confidence=min_confidence)
+    return route_chat_message(
+        extract_message_text(event),
+        source=source,
+        limit=limit,
+        min_confidence=min_confidence,
+        skill_policy=skill_policy,
+    )
 
 
 def public_route_payload(decision: dict[str, object], *, include_message: bool = False) -> dict[str, object]:

--- a/src/skills/catalog.py
+++ b/src/skills/catalog.py
@@ -6438,11 +6438,79 @@ _FEATURE_SURFACE_SKILLS = (
 )
 
 
+_DEFINITIONS.append(
+    SkillDefinition(
+        "quality-evidence-loop",
+        "Prepare QA scenarios, independent review requirements, and source-bound quality evidence assessments.",
+        (
+            "quality-evidence-loop",
+            "quality evidence loop",
+            "quality evidence",
+            "QA scenarios review claims",
+            "source-bound assessment",
+            "품질 증거",
+        ),
+        "Use for an agent-facing quality loop that turns QA scenarios, independent review, and claims into inspectable source-bound evidence requirements.",
+        category="verification",
+        phase="quality-evidence-loop",
+        hermes_role="reviewer",
+        delegation_boundary="retained-catalog-intent",
+        handoff_policy="Keep scenario design, review independence, and evidence-boundary narration in Hermes; prepare a selected executor handoff only when concrete coding work is accepted.",
+        required_inputs=("repository, commit, and tree identity", "task title and executor target", "QA scenarios", "independent review requirements", "claim requirements"),
+        expected_outputs=("quality_evidence_package/v1", "quality_evidence_assessment/v1", "source-bound next action", "prepared-versus-observed boundary"),
+        artifact_expectations=("prepared_not_observed quality evidence package", "optional source-bound observations supplied by an OMH observer", "deterministic assessment with dimension reason codes"),
+        safety_rules=(
+            "Do not treat quality evidence preparation as test execution, review, CI, PR, merge-readiness, or merge evidence.",
+            "Require source identity matching and independent review provenance before marking dimensions satisfied.",
+            "Keep supplied_unverified observations distinct from omh_observed_record evidence.",
+        ),
+        quality_tier="evidence-gated",
+        quality_bar=(
+            "Route QA scenarios, independent review, and claim coverage through one source-bound package.",
+            "Assess only deterministic evidence consistency; never dispatch a runtime or execute tests.",
+            "Report unknown or unsatisfied dimensions and the smallest next observation action.",
+        ),
+        why_this_exists="Quality work needs an inspectable preparation and assessment loop without letting a prepared package masquerade as executed QA or review.",
+        do_not_use_when=(
+            "The request is only a direct answer or plan with no quality evidence requirements.",
+            "The user needs implementation, test execution, review, CI, or merge actions; route those to the selected executor/runtime owner.",
+        ),
+        good_example=SkillExample(
+            prompt="quality-evidence-loop prepare QA scenarios and independent review requirements for this source revision.",
+            expected="Create a quality_evidence_package/v1 and assess only source-bound observations that are explicitly supplied.",
+            why="The request needs deterministic quality gates while preserving the prepared-versus-observed boundary.",
+        ),
+        bad_example=SkillExample(
+            prompt="quality-evidence-loop run the tests and say the PR is ready.",
+            expected="Prepare requirements and report that execution, review, CI, and merge readiness remain unobserved.",
+            why="Preparation cannot create external execution or merge evidence.",
+        ),
+        final_checklist=(
+            "The package source identity matches repository, commit, and tree inputs.",
+            "QA scenarios, review requirements, and claim requirements have stable IDs.",
+            "Assessment output names each dimension and keeps prepared_not_observed explicit.",
+            "No output claims that tests, review, CI, or merge ran without observed records.",
+        ),
+        recovery_notes=(
+            "If package inputs are malformed, fail closed with deterministic validation errors.",
+            "If observations are absent or supplied_unverified, report unknown and request source-bound observations.",
+        ),
+    )
+)
+
 _DEFINITIONS.extend(_FEATURE_SURFACE_SKILLS)
 
 
 _DEFAULT_SURFACE_PROJECTIONS = ("routable", "installable", "workflow_reference", "capability")
 _SURFACE_EXPOSURES = (
+    SurfaceExposure(
+        "quality-evidence-loop",
+        "workflow_reference",
+        ("workflow_reference",),
+        False,
+        "operator_reference",
+        "Use as agent-facing catalog guidance for QA scenarios, independent review, and source-bound assessment; invoke the quality-evidence CLI only as a backend/operator control plane.",
+    ),
     SurfaceExposure(
         "source-finder",
         "workflow_skill",

--- a/src/skills/render.py
+++ b/src/skills/render.py
@@ -198,6 +198,8 @@ def _harness_registry(harnesses: list[HarnessDefinition]) -> str:
 def _role_registry(definitions: list[SkillDefinition]) -> str:
     grouped: dict[str, list[str]] = {}
     for definition in definitions:
+        if not skill_exposure_payload(definition.name)["install_visibility"]:
+            continue
         grouped.setdefault(definition.hermes_role, []).append(definition.name)
     lines = [
         f"- `{role}`: {', '.join(f'`{name}`' for name in names)}"
@@ -343,6 +345,11 @@ def _router_reference_templates_cached() -> tuple[SkillReferenceTemplate, ...]:
 
 
 def _router_workflow_registry_reference(definitions: list[SkillDefinition]) -> str:
+    installed_definitions = [
+        definition
+        for definition in definitions
+        if skill_exposure_payload(definition.name)["install_visibility"]
+    ]
     return f"""# OMH Workflow Registry
 
 This generated reference is loaded only when exact workflow routing detail matters.
@@ -352,13 +359,13 @@ The always-on `oh-my-hermes` skill keeps only the compact lane map and recovery 
 
 ## Role Registry
 
-{_role_registry(definitions)}
+{_role_registry(installed_definitions)}
 
 ## Automatic Routing Registry
 
 When Hermes exposes installed skill descriptions to the model, use this registry as the routing map:
 
-{_trigger_table(definitions)}
+{_trigger_table(installed_definitions)}
 
 Routing is conservative: route only on explicit invocation, strong keyword evidence, or a clear workflow-shaped request. A bare common word such as `team`, `ask`, `wiki`, or `review` is not enough when it could mean normal conversation.
 """.rstrip() + "\n"
@@ -683,7 +690,7 @@ Load these only when exact detail matters:
 - If evidence or target topology is disputed, load `references/evidence-boundaries.md`.
 - If the right skill was not loaded, call `skills_list` or `skill_view`.
 - If a slash command exists, use the explicit slash skill such as `/ralph`.
-- If a skill name collides, ask the user whether to use the Hermes-native skill or the oh-my-hermes adapted skill.
+- If a skill name collides, keep the OMH-selected policy in control and present the Hermes-native skill only as an explicit recommendation; do not let a native candidate override routing.
 """
     return SkillTemplate("oh-my-hermes", _frontmatter("oh-my-hermes", DESCRIPTIONS["oh-my-hermes"]) + "\n" + body)
 

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -2677,6 +2677,7 @@ def build_chat_interaction_payload(
     source_metadata: dict[str, str] | None = None,
     target_notice: dict[str, object] | None = None,
     paths: OmhPaths | None = None,
+    skill_policy: dict[str, object] | None = None,
 ) -> dict[str, object]:
     if source not in CHAT_SOURCES:
         raise ValueError(f"unsupported chat interaction source: {source}")
@@ -2692,6 +2693,7 @@ def build_chat_interaction_payload(
         source_metadata=source_metadata,
         target_notice=target_notice,
         paths=paths,
+        skill_policy=skill_policy,
     ):
         return _copy_chat_interaction_payload(
             _build_chat_interaction_payload_cached(
@@ -2715,6 +2717,7 @@ def build_chat_interaction_payload(
         source_metadata=source_metadata,
         target_notice=target_notice,
         paths=paths,
+        skill_policy=skill_policy,
     )
 
 
@@ -2725,6 +2728,7 @@ def _can_use_chat_interaction_cache(
     source_metadata: dict[str, str] | None,
     target_notice: dict[str, object] | None,
     paths: OmhPaths | None,
+    skill_policy: dict[str, object] | None,
 ) -> bool:
     return (
         isinstance(event_or_message, str)
@@ -2732,6 +2736,7 @@ def _can_use_chat_interaction_cache(
         and source_metadata is None
         and target_notice is None
         and paths is None
+        and skill_policy is None
     )
 
 
@@ -3179,6 +3184,7 @@ def _build_chat_interaction_payload_cached(
         source_metadata=None,
         target_notice=None,
         paths=None,
+        skill_policy=None,
     )
 
 
@@ -3194,6 +3200,7 @@ def _build_chat_interaction_payload_uncached(
     source_metadata: dict[str, str] | None,
     target_notice: dict[str, object] | None,
     paths: OmhPaths | None,
+    skill_policy: dict[str, object] | None,
 ) -> dict[str, object]:
     message = extract_message_text(event_or_message)
     metadata = _source_metadata(event_or_message, source_metadata)
@@ -3203,6 +3210,7 @@ def _build_chat_interaction_payload_uncached(
         limit=limit,
         min_confidence=min_confidence,
         include_message=include_message,
+        skill_policy=skill_policy,
     )
     resolved_mode = _resolve_mode(mode, route_payload, message=message)
     base = _base_interaction(message, source=source, source_metadata=metadata, mode=resolved_mode, include_message=include_message)

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -58,6 +58,7 @@ from omh.skills.catalog import (
     catalog_intent_delegation_skill_names,
     coding_skills_for_intent,
     explicit_memory_context_skill_names,
+    installable_skill_definitions,
     memory_context_policy_for_skill,
     retained_delegation_skill_names,
 )
@@ -176,7 +177,7 @@ class EfficiencyContractTests(unittest.TestCase):
             if isinstance(lane, dict)
             for skill in lane.get("skills", [])
         }
-        installable_skills = {definition.name for definition in builtin_definitions()}
+        installable_skills = {definition.name for definition in installable_skill_definitions()}
 
         self.assertFalse(installable_skills - lane_skills)
         retained_lane = next(lane for lane in payload["lanes"] if lane["id"] == "retained_knowledge")
@@ -223,7 +224,9 @@ class EfficiencyContractTests(unittest.TestCase):
             self.assertIn("evidence", card["first_response_shape"])
 
     def test_workflow_context_cards_cover_installable_workflow_families(self) -> None:
-        workflow_skills = {definition.name for definition in builtin_definitions()} - {"oh-my-hermes", "cancel"}
+        workflow_skills = {
+            definition.name for definition in installable_skill_definitions()
+        } - {"oh-my-hermes", "cancel"}
         unmapped = sorted(name for name in workflow_skills if not workflow_context_card_for_workflow(name))
 
         self.assertEqual(unmapped, [])

--- a/tests/test_quality_evidence_cli.py
+++ b/tests/test_quality_evidence_cli.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+
+from _cli_harness import run_cli
+from omh.skills.catalog import builtin_definitions
+
+
+class QualityEvidenceCliTests(unittest.TestCase):
+    def test_prepare_rejects_empty_inline_when_file_is_also_given(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "scenarios.json"
+            path.write_text("[]", encoding="utf-8")
+            status, _, stderr = run_cli([
+                "--omh-home", str(Path(tmp) / ".omh"), "--hermes-home", str(Path(tmp) / ".hermes"),
+                "quality-evidence", "prepare", "--repository", "r", "--commit", "c", "--tree", "t",
+                "--title", "gate", "--executor", "executor", "--scenarios-json", "", "--scenarios-file", str(path),
+            ])
+        self.assertNotEqual(status, 0)
+        self.assertIn("either inline JSON or a file", stderr)
+    def test_prepare_prints_prepared_boundary_from_inline_requirements(self) -> None:
+        with TemporaryDirectory() as tmp:
+            status, stdout, stderr = run_cli(
+                [
+                    "--omh-home", str(Path(tmp) / ".omh"), "--hermes-home", str(Path(tmp) / ".hermes"),
+                    "quality-evidence", "prepare", "--repository", "local/omh", "--commit", "abc",
+                    "--tree", "tree", "--title", "quality gate", "--executor", "claude-code",
+                    "--scenarios", '[{"id":"qa-1","name":"smoke"}]',
+                    "--reviews", '[{"id":"review-1","kind":"review"}]',
+                    "--claims", '[{"id":"claim-1","statement":"safe"}]',
+                ]
+            )
+        self.assertEqual(status, 0, stderr)
+        package = json.loads(stdout)
+        self.assertEqual(package["status"], "prepared_not_observed")
+        self.assertEqual(package["subject"]["source"]["commit_sha"], "abc")
+        self.assertIn("not observed QA", package["claim_boundary"])
+
+    def test_prepare_accepts_self_critique_and_assigns_deterministic_requirement_ids(self) -> None:
+        with TemporaryDirectory() as tmp:
+            status, stdout, stderr = run_cli([
+                "--omh-home", str(Path(tmp) / ".omh"), "--hermes-home", str(Path(tmp) / ".hermes"),
+                "quality-evidence", "prepare", "--repository", "r", "--commit", "c", "--tree", "t",
+                "--title", "gate", "--executor", "executor", "--scenarios", "[{\"name\":\"smoke\"}]",
+                "--self-critique", "[\"What is unobserved?\"]",
+            ])
+        self.assertEqual(status, 0, stderr)
+        package = json.loads(stdout)
+        self.assertEqual(package["qa_scenarios"][0]["id"], "scenario-1")
+        self.assertEqual(package["self_critique_questions"], ["What is unobserved?"])
+
+    def test_assess_keeps_missing_observations_unknown(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            package = root / "package.json"
+            package.write_text(json.dumps({
+                "schema_version": "quality_evidence_package/v1", "status": "prepared_not_observed",
+                "subject": {"title": "gate", "executor_target": "codex", "source": {"repository_id": "r", "commit_sha": "c", "tree_sha": "t"}},
+                "qa_scenarios": [{"id": "qa-1"}], "review_requirements": [{"id": "review-1"}],
+                "claim_requirements": [{"id": "claim-1"}], "self_critique_questions": [],
+                "claim_boundary": "Prepared requirements are not observed execution evidence.",
+            }), encoding="utf-8")
+            status, stdout, stderr = run_cli([
+                "quality-evidence", "assess", "--package", str(package), "--observations", "[]",
+            ])
+        self.assertEqual(status, 0, stderr)
+        assessment = json.loads(stdout)
+        self.assertFalse(assessment["ready_for_completion"])
+        self.assertEqual(assessment["dimensions"]["scenario_coverage"]["status"], "unknown")
+        self.assertIn("does not prove external execution", assessment["claim_boundary"])
+
+    def test_catalog_quality_evidence_loop_preserves_boundary(self) -> None:
+        definition = next(item for item in builtin_definitions() if item.name == "quality-evidence-loop")
+        text = " ".join((*definition.safety_rules, *definition.quality_bar, *definition.final_checklist))
+        self.assertIn("preparation as test execution", text)
+        self.assertIn("independent review", text)
+        self.assertIn("never dispatch", text)

--- a/tests/test_quality_evidence_records.py
+++ b/tests/test_quality_evidence_records.py
@@ -1,0 +1,293 @@
+from __future__ import annotations
+
+import unittest
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from omh.quality.evidence_records import (
+    QUALITY_EVIDENCE_OBSERVATION_SCHEMA,
+    assess_quality_evidence,
+    build_quality_evidence_observation,
+    build_quality_evidence_package,
+    validate_quality_evidence_observation,
+    validate_quality_evidence_package,
+)
+
+
+class QualityEvidenceRecordsTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = TemporaryDirectory()
+        self.omh_home = Path(self._tmp.name)
+        self.package = build_quality_evidence_package(
+            repository_id="local/omh",
+            commit_sha="abc123",
+            tree_sha="tree123",
+            title="quality records",
+            executor_target="generic-executor",
+            scenarios=({"id": "scenario-pass", "risk": "high"},),
+            review_requirements=({"id": "review-independent", "kind": "review"},),
+            self_critique_questions=("What changed without direct evidence?",),
+        )
+
+    def _observation(self, **changes: object) -> dict[str, object]:
+        observation = {
+            "schema_version": QUALITY_EVIDENCE_OBSERVATION_SCHEMA,
+            "evidence_id": "e1",
+            "evidence_kind": "test",
+            "result": "passed",
+            "reference": "tests/test_quality_evidence_records.py",
+            "observed_at": "2026-07-16T00:00:00+00:00",
+            "reporter": "executor",
+            "source": {"repository_id": "local/omh", "commit_sha": "abc123", "tree_sha": "tree123"},
+            "provenance": "omh_observed_record",
+            "record_ref": "runtime/observation-1",
+            "scenario_ids": ["scenario-pass"],
+            "review_requirement_ids": [],
+            "claim_ids": [],
+        }
+        observation.update(changes)
+        observation["record_ref"] = f"runtime/{observation['evidence_id']}.json"
+        self._write_record(observation)
+        return observation
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def _write_record(self, observation: dict[str, object]) -> None:
+        ref = str(observation.get("record_ref") or "")
+        if not ref.startswith("runtime/"):
+            return
+        path = self.omh_home / ref
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({
+            "record_type": "quality_evidence_observation",
+            "source": observation["source"],
+            "evidence_id": observation["evidence_id"],
+            "evidence_kind": observation["evidence_kind"],
+            "result": observation["result"],
+            "reference": observation["reference"],
+            "observed_at": observation["observed_at"],
+            "reporter": observation["reporter"],
+            "scenario_ids": observation.get("scenario_ids", []),
+            "review_requirement_ids": observation.get("review_requirement_ids", []),
+            "claim_ids": observation.get("claim_ids", []),
+            **({"independence": observation["independence"]} if "independence" in observation else {}),
+            "executor_target": self.package["subject"]["executor_target"],
+            "observed": True,
+            "provenance": "omh_observed_record",
+        }), encoding="utf-8")
+
+    def test_prepared_package_has_explicit_boundary_and_source_identity(self) -> None:
+        self.assertEqual(self.package["status"], "prepared_not_observed")
+        self.assertEqual(self.package["subject"]["source"]["tree_sha"], "tree123")
+        self.assertIn("not observed", self.package["claim_boundary"])
+
+    def test_invalid_prepared_package_returns_deterministic_errors(self) -> None:
+        invalid = dict(self.package)
+        invalid["status"] = "observed"
+        invalid["subject"] = {"title": "missing source"}
+        self.assertEqual(validate_quality_evidence_package(invalid), ["invalid_prepared_status", "invalid_subject", "invalid_source_identity"])
+
+    def test_package_requires_exact_fields_boundary_and_string_questions(self) -> None:
+        missing_boundary = dict(self.package)
+        missing_boundary.pop("claim_boundary")
+        self.assertIn("invalid_top_level_fields", validate_quality_evidence_package(missing_boundary))
+        self.assertIn("missing_claim_boundary", validate_quality_evidence_package(missing_boundary))
+        forged = dict(self.package)
+        forged["extra"] = True
+        forged["self_critique_questions"] = ["ok", 42]
+        errors = validate_quality_evidence_package(forged)
+        self.assertIn("invalid_top_level_fields", errors)
+        self.assertIn("invalid_self_critique_questions", errors)
+        with self.assertRaises(ValueError):
+            assess_quality_evidence(forged)
+
+    def test_observation_builder_binds_source_and_validates_ids(self) -> None:
+        observation = build_quality_evidence_observation(
+            self.package, evidence_id="built", evidence_kind="test", result="passed",
+            reference="tests", observed_at="2026-07-16T00:00:00Z", reporter="executor",
+            provenance="omh_observed_record", record_ref="runtime/built.json", scenario_ids=["scenario-pass"],
+        )
+        self.assertEqual(observation["source"], self.package["subject"]["source"])
+        with self.assertRaises(ValueError):
+            build_quality_evidence_observation(
+                self.package, evidence_id="bad", evidence_kind="test", result="passed", reference="tests",
+                observed_at="2026-07-16T00:00:00Z", reporter="executor", scenario_ids=["nope"],
+            )
+
+    def test_supplied_unverified_evidence_cannot_satisfy_scenario(self) -> None:
+        supplied = self._observation(provenance="supplied_unverified", record_ref=None)
+        self.assertEqual(validate_quality_evidence_observation(supplied, self.package), [])
+        assessment = assess_quality_evidence(self.package, [supplied], omh_home=self.omh_home)
+        self.assertEqual(assessment["dimensions"]["scenario_coverage"]["status"], "unknown")
+        self.assertFalse(assessment["ready_for_completion"])
+        self.assertIn("supplied_unverified_not_admissible", assessment["reasons"])
+
+    def test_observed_record_must_resolve_inside_omh_and_match_source(self) -> None:
+        observation = self._observation()
+        observation["record_ref"] = "runtime/missing.json"
+        assessment = assess_quality_evidence(self.package, [observation], omh_home=self.omh_home)
+        self.assertFalse(assessment["ready_for_completion"])
+        self.assertIn("unresolved_observed_record", assessment["reasons"])
+        self._write_record(observation)
+        record = self.omh_home / str(observation["record_ref"])
+        payload = json.loads(record.read_text(encoding="utf-8"))
+        payload["source"]["tree_sha"] = "wrong-tree"
+        record.write_text(json.dumps(payload), encoding="utf-8")
+        self.assertIn("unresolved_observed_record", assess_quality_evidence(self.package, [observation], omh_home=self.omh_home)["reasons"])
+
+    def test_observed_record_requires_explicit_observed_and_matching_executor(self) -> None:
+        observation = self._observation()
+        record = self.omh_home / str(observation["record_ref"])
+        payload = json.loads(record.read_text(encoding="utf-8"))
+        payload.pop("observed")
+        record.write_text(json.dumps(payload), encoding="utf-8")
+        self.assertIn("unresolved_observed_record", assess_quality_evidence(self.package, [observation], omh_home=self.omh_home)["reasons"])
+        payload["observed"] = True
+        payload["executor_target"] = "other-executor"
+        record.write_text(json.dumps(payload), encoding="utf-8")
+        self.assertIn("unresolved_observed_record", assess_quality_evidence(self.package, [observation], omh_home=self.omh_home)["reasons"])
+
+    def test_observation_requires_nonblank_reporter_and_string_source(self) -> None:
+        missing_reporter = self._observation(reporter=" ")
+        self.assertIn("missing_reporter", validate_quality_evidence_observation(missing_reporter, self.package))
+        nonstring_source = self._observation(source={"repository_id": 1, "commit_sha": "abc123", "tree_sha": "tree123"})
+        self.assertIn("source_mismatch", validate_quality_evidence_observation(nonstring_source, self.package))
+
+    def test_non_mapping_observation_fails_closed_without_raising(self) -> None:
+        errors = validate_quality_evidence_observation("not-an-observation", self.package)
+        assessment = assess_quality_evidence(self.package, ["not-an-observation"], omh_home=self.omh_home)
+
+        self.assertEqual(errors, ["invalid_observation"])
+        self.assertFalse(assessment["ready_for_completion"])
+        self.assertIn("invalid_observation", assessment["reasons"])
+
+    def test_package_rejects_extra_source_fields_and_malformed_lists(self) -> None:
+        extra_source = dict(self.package)
+        extra_source["subject"] = dict(self.package["subject"])
+        extra_source["subject"]["source"] = {**self.package["subject"]["source"], "extra": "nope"}
+        self.assertIn("invalid_source_identity", validate_quality_evidence_package(extra_source))
+        malformed = dict(self.package)
+        malformed["qa_scenarios"] = None
+        malformed["review_requirements"] = 1
+        malformed["claim_requirements"] = None
+        errors = validate_quality_evidence_package(malformed)
+        self.assertIn("invalid_qa_scenarios", errors)
+        self.assertIn("invalid_review_requirements", errors)
+        self.assertIn("invalid_claim_requirements", errors)
+
+    def test_observed_record_requires_exact_provenance_executor_and_binding(self) -> None:
+        observation = self._observation()
+        record = self.omh_home / str(observation["record_ref"])
+        payload = json.loads(record.read_text(encoding="utf-8"))
+        payload.pop("provenance")
+        record.write_text(json.dumps(payload), encoding="utf-8")
+        self.assertIn("unresolved_observed_record", assess_quality_evidence(self.package, [observation], omh_home=self.omh_home)["reasons"])
+        payload["provenance"] = "omh_observed_record"
+        payload.pop("executor_target")
+        record.write_text(json.dumps(payload), encoding="utf-8")
+        self.assertIn("unresolved_observed_record", assess_quality_evidence(self.package, [observation], omh_home=self.omh_home)["reasons"])
+        payload["executor_target"] = self.package["subject"]["executor_target"]
+        payload["reporter"] = "different"
+        record.write_text(json.dumps(payload), encoding="utf-8")
+        self.assertIn("unresolved_observed_record", assess_quality_evidence(self.package, [observation], omh_home=self.omh_home)["reasons"])
+
+    def test_self_review_only_is_not_admissible_for_any_dimension(self) -> None:
+        observation = self._observation(independence="self_review_only", claim_ids=[])
+        assessment = assess_quality_evidence(self.package, [observation], omh_home=self.omh_home)
+        self.assertFalse(assessment["ready_for_completion"])
+        self.assertIn("self_review_only_not_admissible", assessment["reasons"])
+
+    def test_source_drift_fails_closed(self) -> None:
+        drifted = self._observation(source={"repository_id": "local/omh", "commit_sha": "new", "tree_sha": "tree123"})
+        self.assertIn("source_mismatch", validate_quality_evidence_observation(drifted, self.package))
+        assessment = assess_quality_evidence(self.package, [drifted], omh_home=self.omh_home)
+        self.assertEqual(assessment["dimensions"]["source_freshness"]["status"], "unsatisfied")
+        self.assertFalse(assessment["ready_for_completion"])
+
+    def test_self_review_does_not_satisfy_independent_review(self) -> None:
+        review = self._observation(
+            evidence_id="review-self",
+            evidence_kind="review",
+            independence="self_review_only",
+            review_requirement_ids=["review-independent"],
+            scenario_ids=[],
+        )
+        assessment = assess_quality_evidence(self.package, [review], omh_home=self.omh_home)
+        self.assertEqual(assessment["dimensions"]["review_independence"]["status"], "unknown")
+        self.assertFalse(assessment["ready_for_completion"])
+
+    def test_independent_observed_review_and_test_are_separate_dimensions(self) -> None:
+        test = self._observation()
+        review = self._observation(
+            evidence_id="review-independent",
+            evidence_kind="review",
+            independence="independent",
+            review_requirement_ids=["review-independent"],
+            scenario_ids=[],
+        )
+        assessment = assess_quality_evidence(self.package, [test, review], omh_home=self.omh_home)
+        self.assertEqual(assessment["dimensions"]["scenario_coverage"]["status"], "satisfied")
+        self.assertEqual(assessment["dimensions"]["review_independence"]["status"], "satisfied")
+        self.assertNotIn("score", assessment)
+        self.assertEqual(assessment["dimensions"]["scenario_coverage"]["evidence_ids"], ["e1"])
+
+    def test_claim_coverage_is_meaningful_when_claims_are_declared(self) -> None:
+        package = build_quality_evidence_package(
+            repository_id="local/omh", commit_sha="abc123", tree_sha="tree123", title="claims", executor_target="generic-executor",
+            claim_requirements=({"id": "claim-1"},),
+        )
+        observation = build_quality_evidence_observation(
+            package, evidence_id="claim-evidence", evidence_kind="test", result="passed", reference="tests",
+            observed_at="2026-07-16T00:00:00Z", reporter="executor", claim_ids=["claim-1"],
+            provenance="omh_observed_record", record_ref="runtime/claim.json",
+        )
+        self._write_record(observation)
+        assessment = assess_quality_evidence(package, [observation], omh_home=self.omh_home)
+        self.assertEqual(assessment["dimensions"]["claim_coverage"]["status"], "satisfied")
+        self.assertEqual(assessment["dimensions"]["claim_coverage"]["evidence_ids"], ["claim-evidence"])
+
+    def test_builder_and_assessment_reject_invalid_packages(self) -> None:
+        with self.assertRaises(ValueError):
+            build_quality_evidence_package(
+                repository_id="local/omh", commit_sha="abc123", tree_sha="tree123", title="", executor_target="executor"
+            )
+        invalid = dict(self.package)
+        invalid["status"] = "observed"
+        with self.assertRaises(ValueError):
+            assess_quality_evidence(invalid)
+
+    def test_mixed_ci_pass_and_fail_remains_unsatisfied(self) -> None:
+        package = build_quality_evidence_package(
+            repository_id="local/omh", commit_sha="abc123", tree_sha="tree123", title="ci", executor_target="generic-executor",
+            review_requirements=({"id": "ci-required", "kind": "ci"},),
+        )
+        observations = [
+            build_quality_evidence_observation(
+                package, evidence_id="ci-pass", evidence_kind="ci", result="passed", reference="ci", observed_at="2026-07-16T00:00:00Z",
+                reporter="ci", provenance="omh_observed_record", record_ref="runtime/ci-pass.json",
+                review_requirement_ids=["ci-required"],
+            ),
+            build_quality_evidence_observation(
+                package, evidence_id="ci-fail", evidence_kind="ci", result="failed", reference="ci", observed_at="2026-07-16T00:00:00Z",
+                reporter="ci", provenance="omh_observed_record", record_ref="runtime/ci-fail.json",
+                review_requirement_ids=["ci-required"],
+            ),
+        ]
+        for item in observations:
+            self._write_record(item)
+        self.assertEqual(assess_quality_evidence(package, observations, omh_home=self.omh_home)["dimensions"]["ci_status"]["status"], "unsatisfied")
+
+    def test_self_review_never_counts_with_independent_review(self) -> None:
+        reviews = [
+            self._observation(evidence_id="self", evidence_kind="review", independence="self_review_only", review_requirement_ids=["review-independent"], scenario_ids=[]),
+            self._observation(evidence_id="independent", evidence_kind="review", independence="independent", review_requirement_ids=["review-independent"], scenario_ids=[]),
+        ]
+        assessment = assess_quality_evidence(self.package, reviews, omh_home=self.omh_home)
+        self.assertEqual(assessment["dimensions"]["review_independence"]["status"], "satisfied")
+        self.assertEqual(assessment["dimensions"]["review_independence"]["evidence_ids"], ["independent"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -326,6 +326,23 @@ class RouterContentTests(unittest.TestCase):
                     self.assertNotIn("installable", payload["projections"])
                     self.assertTrue(payload["compatibility_alias"])
 
+    def test_quality_evidence_reference_is_not_a_chat_routing_target(self) -> None:
+        routable_names = {definition.name for definition in routable_definitions()}
+        self.assertNotIn("quality-evidence-loop", routable_names)
+        exposure = skill_exposure_payload("quality-evidence-loop")
+        self.assertEqual(exposure["exposure"], "workflow_reference")
+        self.assertEqual(exposure["projections"], ["workflow_reference"])
+        self.assertFalse(exposure["install_visibility"])
+
+        for message in ("quality-evidence-loop prepare QA scenarios", "quality evidence"):
+            with self.subTest(message=message):
+                decision = chat_module.route_chat_message(message, source="discord")
+                self.assertNotEqual(decision["selected_skill"], "quality-evidence-loop")
+                self.assertNotIn(
+                    "quality-evidence-loop",
+                    {recommendation["skill"] for recommendation in decision["recommendations"]},
+                )
+
     def test_feature_surface_exposure_contract_is_explicit_for_every_generated_surface(self) -> None:
         feature_surface_names = {
             definition.name

--- a/tests/test_skill_governance.py
+++ b/tests/test_skill_governance.py
@@ -1,0 +1,174 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from omh.quality.skill_governance import (
+    build_skill_governance_policy,
+    resolve_skill_governance,
+    policy_decision_digest,
+    validate_skill_governance_policy,
+)
+from omh.routing.chat import route_chat_message
+
+
+class SkillGovernanceTests(unittest.TestCase):
+    def test_project_precedes_user_builtin_and_native_per_field(self) -> None:
+        policy = build_skill_governance_policy(
+            project={"skills": ["project"], "priority": "project"},
+            user={"skills": ["user"], "priority": "user", "runtime_priority": "user"},
+            builtin_omh={"skills": ["builtin"], "runtime_priority": "builtin"},
+            native_hermes={"skills": ["native"]},
+        )
+        result = resolve_skill_governance(policy)
+        self.assertEqual(result["selected_skills"], ["project"])
+        self.assertEqual(result["selected_policy"]["priority"], "project")
+        self.assertEqual(result["selected_policy"]["runtime_priority"], "user")
+        self.assertEqual(result["runtime_priority_observed"], False)
+        self.assertEqual(result["native_recommendations"], ["native"])
+        self.assertEqual(result["selected_native_skills"], [])
+
+    def test_native_cannot_override_omh(self) -> None:
+        result = resolve_skill_governance(
+            build_skill_governance_policy(builtin_omh={"skills": ["omh"]}, native_hermes={"skills": ["native"]})
+        )
+        self.assertEqual(result["selected_skills"], ["omh"])
+        self.assertEqual(result["selected_native_skills"], [])
+
+    def test_unknown_and_conflicting_policy_fail_closed(self) -> None:
+        unknown = {"schema_version": "skill_governance_policy/v9", "project": {"typo": 1}}
+        self.assertFalse(validate_skill_governance_policy(unknown)["valid"])
+        conflict = build_skill_governance_policy(project=[{"skills": ["a"]}, {"skills": ["b"]}])
+        result = resolve_skill_governance(conflict)
+        self.assertEqual(result["status"], "fail_closed")
+        self.assertEqual(result["selected_native_skills"], [])
+
+    def test_prepared_policy_is_not_observed_without_explicit_record(self) -> None:
+        prepared = resolve_skill_governance(build_skill_governance_policy(builtin_omh={"priority": "high"}))
+        self.assertTrue(prepared["policy_prepared"])
+        self.assertEqual(prepared["prepared_status"], "policy_prepared")
+        self.assertEqual(prepared["evidence_boundary"], "prepared_not_observed")
+        self.assertFalse(prepared["runtime_priority_observed"])
+        policy = build_skill_governance_policy(
+                builtin_omh={
+                    "runtime_priority": "high",
+                    "omh_observed_record": {
+                        "provenance": "omh_observed_record", "ref": "obs-1",
+                        "record_type": "policy_applied", "executor": "high", "runtime_priority": "high",
+                        "source": {"repository_id": "repo", "commit_sha": "commit", "tree_sha": "tree"},
+                        "policy_digest": policy_decision_digest(
+                            {"runtime_priority": "high"}, executor="high",
+                            source={"repository_id": "repo", "commit_sha": "commit", "tree_sha": "tree"},
+                        ),
+                    },
+                },
+                source={"repository_id": "repo", "commit_sha": "commit", "tree_sha": "tree"},
+            )
+        self.assertEqual(resolve_skill_governance(policy)["status"], "fail_closed")
+
+    def test_policy_applied_record_must_match_winning_policy(self) -> None:
+        source = {"repository_id": "repo", "commit_sha": "commit", "tree_sha": "tree"}
+        record = {
+            "provenance": "omh_observed_record", "ref": "obs-1", "record_type": "policy_applied",
+            "executor": "project", "runtime_priority": "project", "source": source,
+            "policy_digest": policy_decision_digest({"runtime_priority": "builtin"}, executor="builtin", source=source),
+        }
+        result = resolve_skill_governance(build_skill_governance_policy(
+            project={"runtime_priority": "project"}, builtin_omh={"runtime_priority": "builtin", "omh_observed_record": record}, source=source,
+        ))
+        self.assertEqual(result["status"], "fail_closed")
+        self.assertFalse(result["runtime_priority_observed"])
+
+    def test_policy_applied_record_requires_source_executor_and_priority(self) -> None:
+        source = {"repository_id": "repo", "commit_sha": "commit", "tree_sha": "tree"}
+        for record in ({"provenance": "omh_observed_record", "ref": "obs"}, {
+            "provenance": "omh_observed_record", "ref": "obs", "record_type": "policy_applied",
+            "executor": "high", "source": source, "policy_digest": "0" * 64,
+        }):
+            result = resolve_skill_governance(build_skill_governance_policy(
+                builtin_omh={"omh_observed_record": record}, source=source,
+            ))
+            self.assertEqual(result["status"], "fail_closed")
+            self.assertFalse(result["runtime_priority_observed"])
+
+    def test_local_omh_record_is_required_for_observation(self) -> None:
+        source = {"repository_id": "repo", "commit_sha": "commit", "tree_sha": "tree"}
+        record = {
+            "provenance": "omh_observed_record", "ref": "records/policy.json", "record_type": "policy_applied", "observed": True,
+            "executor": "high", "runtime_priority": "high", "source": source,
+            "policy_digest": policy_decision_digest({"runtime_priority": "high"}, executor="high", source=source),
+        }
+        record["policy_identity"] = {
+            "policy": {"runtime_priority": "high"}, "executor": "high", "source": source,
+        }
+        policy = build_skill_governance_policy(builtin_omh={"runtime_priority": "high", "omh_observed_record": record}, source=source)
+        with tempfile.TemporaryDirectory() as home:
+            target = Path(home) / record["ref"]
+            target.parent.mkdir()
+            target.write_text(json.dumps(record), encoding="utf-8")
+            self.assertTrue(resolve_skill_governance(policy, omh_home=home)["runtime_priority_observed"])
+            self.assertEqual(resolve_skill_governance(policy, omh_home=home + "/missing")["status"], "fail_closed")
+
+    def test_bare_or_foreign_observation_data_cannot_upgrade_prepared_policy(self) -> None:
+        for record in (
+            {"ref": "bare"},
+            {"provenance": "config", "ref": "config"},
+            {"provenance": "omh_observed_record", "ref": ""},
+            {"provenance": "omh_observed_record", "ref": "x", "extra": True},
+        ):
+            result = resolve_skill_governance(build_skill_governance_policy(builtin_omh={"omh_observed_record": record}))
+            self.assertEqual(result["status"], "fail_closed")
+            self.assertFalse(result["runtime_priority_observed"])
+
+    def test_skills_are_nonempty_unique_strings(self) -> None:
+        result = resolve_skill_governance(build_skill_governance_policy(project={"skills": ["same", "same"]}))
+        self.assertEqual(result["status"], "fail_closed")
+
+    def test_native_recommendations_cannot_supply_governance_fields(self) -> None:
+        result = resolve_skill_governance(
+            build_skill_governance_policy(native_hermes={"skills": ["native"], "priority": "native"})
+        )
+        self.assertEqual(result["status"], "fail_closed")
+
+    def test_governed_values_reject_whitespace(self) -> None:
+        result = resolve_skill_governance(
+            build_skill_governance_policy(project={"skills": [" "], "priority": " "})
+        )
+        self.assertEqual(result["status"], "fail_closed")
+
+    def test_falsey_malformed_levels_do_not_become_empty_policy(self) -> None:
+        result = resolve_skill_governance(build_skill_governance_policy(project=""))
+        self.assertEqual(result["status"], "fail_closed")
+        self.assertEqual(result["errors"], ["malformed_policy"])
+
+    def test_explicit_null_policy_levels_fail_closed(self) -> None:
+        for level in ("project", "user", "builtin_omh", "native_hermes"):
+            with self.subTest(level=level):
+                policy = {
+                    "schema_version": "skill_governance_policy/v1",
+                    level: None,
+                }
+                result = resolve_skill_governance(policy)
+                self.assertEqual(result["status"], "fail_closed")
+                self.assertEqual(result["errors"], ["malformed_policy"])
+
+    def test_chat_route_applies_omh_policy_and_keeps_native_as_recommendation(self) -> None:
+        policy = build_skill_governance_policy(
+            project={"skills": ["code-review"]},
+            native_hermes={"skills": ["native-browser"]},
+        )
+
+        route = route_chat_message(
+            "plan a product change",
+            source="discord",
+            skill_policy=policy,
+        )
+
+        self.assertEqual(route["selected_skill"], "code-review")
+        self.assertEqual(route["skill_governance"]["status"], "resolved")
+        self.assertEqual(route["native_skill_recommendations"], ["native-browser"])
+        self.assertNotEqual(route["selected_skill"], "native-browser")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wrapper_contract.py
+++ b/tests/test_wrapper_contract.py
@@ -47,6 +47,23 @@ class WrapperContractTests(unittest.TestCase):
         self.assertEqual(payload["redaction_policy"], "stdout_includes_message")
         self.assertEqual(payload["plan"]["plan"]["task_statement"], message)
 
+    def test_interaction_applies_omh_skill_policy_before_native_recommendations(self) -> None:
+        policy = {
+            "schema_version": "skill_governance_policy/v1",
+            "project": {"skills": ["code-review"]},
+            "native_hermes": {"skills": ["native-browser"]},
+        }
+
+        payload = build_chat_interaction_payload(
+            "plan a product change",
+            source="discord",
+            skill_policy=policy,
+        )
+
+        self.assertEqual(payload["route"]["selected_skill"], "code-review")
+        self.assertEqual(payload["route"]["native_skill_recommendations"], ["native-browser"])
+        self.assertNotEqual(payload["route"]["selected_skill"], "native-browser")
+
     def test_event_metadata_is_canonical_and_thread_key_is_stable(self) -> None:
         event = {
             "event": {


### PR DESCRIPTION
## Feature Report

### What Changed

Added a source-bound quality-evidence control plane and an OMH-first skill-governance gate. `omh quality-evidence prepare` produces explicit prepared-only QA/review/claim requirements, and `assess` accepts only locally resolved, source/executor-bound observed records. Chat route and normal Hermes interaction paths now accept a policy that applies project > user > built-in OMH precedence while exposing native Hermes skills only as advisory recommendations.

### Why This Exists

Prepared handoffs, self-attestation, stale observations, or native-skill collisions could otherwise be mistaken for execution/review/CI readiness, or allow a native candidate to bypass OMH workflow policy. The new contracts make those states deterministic and fail closed.

### User / Operator Impact

Agent-facing wrappers can supply `--skill-policy-json` or `--skill-policy-file` to `omh chat route` and `omh chat interact`. The selected OMH workflow is authoritative; native Hermes skills are returned in `native_skill_recommendations` and are never selected automatically. Operators can also prepare and assess source-bound quality requirements without any command dispatching an executor or claiming QA/CI/merge completion.

### How It Works

- Quality packages bind repository, commit SHA, and tree SHA; assessments require exact OMH-local observed-record bindings and reject self-review from all completion dimensions.
- Governance resolves field precedence project > user > built-in OMH, preserves native skills as recommendations, and falls back to clarification for invalid or uninstalled selections.
- The policy is threaded through route, public route payload, route-event, and Hermes interaction surfaces.
- `quality-evidence-loop` is generated as documentation/operator-reference-only and excluded from installed/routable skill registries.

### Files And Contracts Touched

- `src/quality/evidence_records.py`, `src/quality/skill_governance.py`
- `src/commands/quality_evidence.py`, `src/commands/chat.py`
- `src/routing/chat.py`, `src/wrapper/contract.py`
- Generated skill/catalog references and regression tests.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -q`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `git diff --check`
- [x] Targeted routing/governance/evidence/wrapper tests (256 tests)
- [x] Manual `quality-evidence prepare`, `assess`, `--help`, and invalid dual-input rejection
- [x] Manual `chat route` and `chat interact` policy propagation, confirming OMH selection with native recommendations retained as advisory
- [x] Independent code review `APPROVE` and architecture review `CLEAR` for commit `2e8aaaf2d13434352a2020281aafbacfc94ef512`
- [ ] Live Hermes runtime loading, external executor dispatch, CI, and merge behavior (intentionally out of scope)

## Risk

This is a local metadata-only control plane. It deliberately does not prove that Hermes loaded a skill or that an executor ran. A supplied policy without a valid installed OMH selection fails closed to clarification.

## Compatibility / Rollout

Existing callers retain default routing behavior. Agent/wrapper callers may opt into explicit policy input; no Hermes core patch, network service, or new dependency is introduced.

## Release / Claims

- [x] Release-channel impact considered: local control-plane feature; no channel change required
- [x] Runtime/native capability claims are marked prepared/advisory unless observed evidence exists
- [x] Known live Hermes runtime gap is documented

## Follow-Up

Future work may wire genuine Hermes runtime skill-loading observations into the same local record contract, without relaxing the prepared-versus-observed boundary.