### PR TITLE
feat: guide adaptive OMH orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ capability, a useful next step, and an honest statement of what has or has not
 happened. It strengthens the Hermes workflow you already use instead of
 replacing Hermes or hiding a coding executor behind it.
 
+OMH is the operating layer above individual Hermes-native skills: it frames the
+problem, selects the workflow and evidence gates, and uses native skills as
+capabilities within that governed path rather than as competing top-level
+owners.
+
 ```text
 plain request
   -> choose one of six capability families
@@ -49,6 +54,8 @@ plain request
 > <p align="center">
 >   <img src="assets/friren-agent-omh-callout.png" alt="Friren Agent explaining OMH in Art&Engine" width="720">
 > </p>
+
+<br>
 
 ## Quick Start
 
@@ -92,6 +99,8 @@ knowledge work.
 If a wrapper or operator needs an explicit workflow selection, it can still
 send `Use OMH request-to-handoff for: I want to safely add a feature to this repo.`
 
+<br>
+
 ## What OMH Adds
 
 OMH packages **82 installable workflow skills** behind six human-readable
@@ -109,6 +118,8 @@ available when a wrapper or operator needs precise control.
 
 The full generated catalog, triggers, harnesses, and evidence rules live in
 [Workflow Reference](docs/WORKFLOWS.md).
+
+<br>
 
 ## Built For Real Work
 
@@ -132,6 +143,8 @@ video, and connector systems sit behind explicit external-provider contracts.
 OMH can validate and analyze supplied data without pretending that a provider
 was connected or called.
 
+<br>
+
 ## Evidence Before Claims
 
 OMH separates useful preparation from observed results:
@@ -147,6 +160,8 @@ review, CI, deployment, merge readiness, or a merge. Capability impact is
 reported across separate dimensions rather than collapsed into one marketing
 score. See [Capability Impact](docs/CAPABILITY_IMPACT.md).
 
+<br>
+
 ## Documentation
 
 - [Documentation map](docs/README.md)
@@ -158,6 +173,8 @@ score. See [Capability Impact](docs/CAPABILITY_IMPACT.md).
 - [Roles](docs/ROLES.md)
 - [Application cases](docs/APPLICATION_CASES.md)
 - [Release and development](docs/RELEASE.md)
+
+<br>
 
 ## Development
 

--- a/skills/oh-my-hermes/SKILL.md
+++ b/skills/oh-my-hermes/SKILL.md
@@ -68,6 +68,15 @@ Compact lane map:
 - Operations and evidence gates: `workspace-audit`, `production-audit`, `verification-gate`, `agent-evaluation`, `rules-distill`, `agent-ops-review`, `harness-session-inventory`, `ops-observability-card`, `instinct-ledger`, `workflow-learning`.
 - Coding handoff and review: `idea-to-deploy`, `code-review`, `ultraprocess`, `team`, `ultrawork`, `ultraqa`.
 
+## OMH Orchestration Posture
+
+Treat OMH as the operating layer above individual Hermes-native skills. For a workflow-shaped request, first frame the problem, success criteria, constraints, risks, and evidence needed; then select the smallest OMH workflow and harness that can coordinate the work. Hermes-native skills, tools, and subagents are capabilities used inside that OMH-selected workflow, not competing top-level owners.
+
+- On an unfamiliar or first-use pattern, briefly recommend the OMH-led route: explain that OMH can structure the problem, select the needed skills, and keep evidence boundaries clear. A user may confirm with a natural reply such as “yes, do it”, but safe local framing, research preparation, and planning do not wait for ceremonial confirmation.
+- After repeated accepted local patterns for the same user and workflow, continue OMH-led exploration, problem framing, skill composition, and prepared planning automatically. Keep the current workflow, next action, and prepared-versus-observed boundary visible.
+- Never let that autonomy bypass existing confirmation gates for destructive changes, credentials, external writes, deployment, or executor dispatch. Do not claim that a native skill, subagent, review, CI, or merge ran unless matching observation exists.
+- If a native Hermes capability is relevant, present it as an optional subordinate capability under the selected OMH workflow. OMH policy remains responsible for selecting and governing the workflow.
+
 ## Priority Rules
 
 1. Exact or near-exact OMH maintenance commands (`omh update`, `omh setup`, `omh doctor`, `omh uninstall`, `omh install`, `omh list`, and Korean equivalents such as `omh 업데이트해줘`, `omh 닥터 돌려줘`, `omh 삭제해줘`, `omh 셋업해줘`) route as `operator_maintenance_command`. Run the requested command, report observed output, and avoid repo mutation unless the user separately asks for code changes.

--- a/src/skills/render.py
+++ b/src/skills/render.py
@@ -620,6 +620,15 @@ Compact lane map:
 - Operations and evidence gates: `workspace-audit`, `production-audit`, `verification-gate`, `agent-evaluation`, `rules-distill`, `agent-ops-review`, `harness-session-inventory`, `ops-observability-card`, `instinct-ledger`, `workflow-learning`.
 - Coding handoff and review: `idea-to-deploy`, `code-review`, `ultraprocess`, `team`, `ultrawork`, `ultraqa`.
 
+## OMH Orchestration Posture
+
+Treat OMH as the operating layer above individual Hermes-native skills. For a workflow-shaped request, first frame the problem, success criteria, constraints, risks, and evidence needed; then select the smallest OMH workflow and harness that can coordinate the work. Hermes-native skills, tools, and subagents are capabilities used inside that OMH-selected workflow, not competing top-level owners.
+
+- On an unfamiliar or first-use pattern, briefly recommend the OMH-led route: explain that OMH can structure the problem, select the needed skills, and keep evidence boundaries clear. A user may confirm with a natural reply such as “yes, do it”, but safe local framing, research preparation, and planning do not wait for ceremonial confirmation.
+- After repeated accepted local patterns for the same user and workflow, continue OMH-led exploration, problem framing, skill composition, and prepared planning automatically. Keep the current workflow, next action, and prepared-versus-observed boundary visible.
+- Never let that autonomy bypass existing confirmation gates for destructive changes, credentials, external writes, deployment, or executor dispatch. Do not claim that a native skill, subagent, review, CI, or merge ran unless matching observation exists.
+- If a native Hermes capability is relevant, present it as an optional subordinate capability under the selected OMH workflow. OMH policy remains responsible for selecting and governing the workflow.
+
 ## Priority Rules
 
 1. Exact or near-exact OMH maintenance commands (`omh update`, `omh setup`, `omh doctor`, `omh uninstall`, `omh install`, `omh list`, and Korean equivalents such as `omh 업데이트해줘`, `omh 닥터 돌려줘`, `omh 삭제해줘`, `omh 셋업해줘`) route as `operator_maintenance_command`. Run the requested command, report observed output, and avoid repo mutation unless the user separately asks for code changes.

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -47,6 +47,7 @@ from .localized_copy import (
     skill_picker_body as localized_skill_picker_body,
     skill_picker_headline,
 )
+from .orchestration_guidance import build_omh_orchestration_guidance
 
 
 CHAT_INTERACTION_SCHEMA_VERSION = "chat_interaction/v1"
@@ -3212,14 +3213,19 @@ def _build_chat_interaction_payload_uncached(
         include_message=include_message,
         skill_policy=skill_policy,
     )
+    orchestration_guidance = build_omh_orchestration_guidance(
+        route_payload,
+        source_metadata=metadata,
+        paths=paths,
+    )
     resolved_mode = _resolve_mode(mode, route_payload, message=message)
     base = _base_interaction(message, source=source, source_metadata=metadata, mode=resolved_mode, include_message=include_message)
-    if (
-        _is_generic_skill_catalog_route(message, route_payload)
-        and _route_recommendation_next_action(route_payload) != "show_command_preview"
-    ):
+    is_catalog_question = _is_generic_skill_catalog_route(message, route_payload)
+    if is_catalog_question and _route_recommendation_next_action(route_payload) != "show_command_preview":
         route_payload = _catalog_question_route_payload(route_payload)
     base["route"] = route_payload
+    if not _is_omh_intro_question(message) and not is_catalog_question:
+        base["omh_orchestration_guidance"] = orchestration_guidance
     if isinstance(route_payload.get("task_card"), dict):
         base["task_card"] = route_payload["task_card"]
     learning_candidate_card = build_learning_candidate_card(

--- a/src/wrapper/orchestration_guidance.py
+++ b/src/wrapper/orchestration_guidance.py
@@ -1,0 +1,97 @@
+"""Local, metadata-only guidance for OMH-led Hermes task orchestration."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from ..local_store import read_json_object
+from ..paths import OmhPaths
+from ..runtime.records import validate_wrapper_session_record
+
+
+ORCHESTRATION_GUIDANCE_SCHEMA_VERSION = "omh_orchestration_guidance/v1"
+_AUTONOMY_PATTERN_THRESHOLD = 2
+_ACCEPTED_SESSION_STATUSES = frozenset(
+    {
+        "plan_accepted",
+        "executor_selected",
+        "prompt_handoff_prepared",
+        "runtime_handoff_prepared",
+        "handoff_prepared",
+    }
+)
+
+
+def build_omh_orchestration_guidance(
+    route: Mapping[str, object],
+    *,
+    source_metadata: Mapping[str, str],
+    paths: OmhPaths | None,
+) -> dict[str, object]:
+    """Recommend OMH-led problem solving without claiming work was executed."""
+    selected_skill = _nonempty_text(route.get("selected_skill")) or "oh-my-hermes"
+    selected_harness = _nonempty_text(route.get("selected_harness"))
+    user_ref = _nonempty_text(source_metadata.get("user_ref"))
+    accepted_count = _accepted_pattern_count(paths, user_ref, selected_skill)
+    autonomous = accepted_count >= _AUTONOMY_PATTERN_THRESHOLD
+    native_candidates = _string_list(route.get("native_skill_recommendations"))
+    return {
+        "schema_version": ORCHESTRATION_GUIDANCE_SCHEMA_VERSION,
+        "mode": "autonomous_pattern" if autonomous else "guided_first_use",
+        "selected_workflow": selected_skill,
+        "selected_harness": selected_harness,
+        "accepted_pattern_count": accepted_count,
+        "next_action": "continue_omh_orchestration" if autonomous else "recommend_omh_orchestration",
+        "confirmation": {
+            "required": False,
+            "policy": "optional_first_use" if not autonomous else "pattern_based_autonomy",
+            "boundary": "Gates still apply to destructive, credentialed, external-write, deploy, and executor-dispatch actions.",
+        },
+        "problem_solving_contract": {
+            "steps": [
+                "frame_problem_and_success_criteria",
+                "select_omh_workflow_and_harness",
+                "use_native_hermes_capabilities_as_needed",
+                "preserve_prepared_and_observed_evidence_boundary",
+            ],
+            "boundary": "Prepared guidance only; not research, execution, review, CI, or merge evidence.",
+        },
+        "native_skill_governance": {
+            "role": "subordinate_capability",
+            "candidate_skills": native_candidates,
+            "can_override_omh": False,
+            "selection_policy": "OMH selects the workflow; Hermes-native skills are optional capabilities within that workflow.",
+        },
+    }
+
+
+def _accepted_pattern_count(paths: OmhPaths | None, user_ref: str, selected_skill: str) -> int:
+    if paths is None or not user_ref or not paths.runtime_wrapper_sessions_dir.exists():
+        return 0
+    count = 0
+    for session_path in paths.runtime_wrapper_sessions_dir.glob("*/session.json"):
+        session = read_json_object(session_path)
+        if (
+            not session
+            or validate_wrapper_session_record(session)
+            or session.get("status") not in _ACCEPTED_SESSION_STATUSES
+            or session.get("decision") != "plan_accepted"
+        ):
+            continue
+        metadata = session.get("source_metadata")
+        route = session.get("route")
+        if not isinstance(metadata, Mapping) or not isinstance(route, Mapping):
+            continue
+        if metadata.get("user_ref") == user_ref and route.get("selected_skill") == selected_skill:
+            count += 1
+    return count
+
+
+def _nonempty_text(value: object) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _string_list(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str) and item.strip()]

--- a/tests/test_wrapper_contract.py
+++ b/tests/test_wrapper_contract.py
@@ -11,6 +11,7 @@ load_local_package()
 from omh.context_safety import CONTEXT_ARTIFACT_REF_SCHEMA_VERSION
 from omh.paths import OmhPaths, resolve_paths
 from omh.profiles.setup import write_setup_profile
+from omh.runtime.records import build_wrapper_session_record
 from omh.wrapper_contract import (
     build_chat_interaction_payload,
     build_chat_response_from_status,
@@ -21,9 +22,75 @@ from omh.wrapper_contract import (
 from omh.wrapper.localized_copy import detect_copy_locale
 from omh.wrapper.native_commands import build_native_command_surface, render_native_command_response
 from omh.wrapper.route_hints import build_chat_route_hint_payload
+from omh.wrapper.orchestration_guidance import build_omh_orchestration_guidance
 
 
 class WrapperContractTests(unittest.TestCase):
+    def test_omh_orchestration_guidance_is_optional_for_first_use(self) -> None:
+        route = {
+            "selected_skill": "ralplan",
+            "selected_harness": "planning",
+            "native_skill_recommendations": ["native-browser"],
+        }
+
+        guidance = build_omh_orchestration_guidance(
+            route,
+            source_metadata={"user_ref": "u1"},
+            paths=None,
+        )
+
+        self.assertEqual(guidance["mode"], "guided_first_use")
+        self.assertFalse(guidance["confirmation"]["required"])
+        self.assertEqual(guidance["native_skill_governance"]["candidate_skills"], ["native-browser"])
+        self.assertFalse(guidance["native_skill_governance"]["can_override_omh"])
+
+    def test_omh_orchestration_guidance_becomes_autonomous_after_repeated_acceptance(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(omh_home=Path(tmp) / ".omh", hermes_home=Path(tmp) / ".hermes")
+            for index in range(2):
+                session_path = paths.runtime_wrapper_sessions_dir / f"ws-{index}" / "session.json"
+                session_path.parent.mkdir(parents=True)
+                session_path.write_text(json.dumps(build_wrapper_session_record({
+                    "session_id": f"ws-{index}",
+                    "thread_key": f"discord:channel:{index}",
+                    "source": "discord",
+                    "source_metadata": {"user_ref": "u1"},
+                    "message_sha256": "0" * 64,
+                    "message_length": 1,
+                    "status": "plan_accepted",
+                    "decision": "plan_accepted",
+                    "route": {"selected_skill": "ralplan", "selected_harness": "planning", "action": "dispatch", "confidence": "high", "score": 12},
+                })), encoding="utf-8")
+
+            guidance = build_omh_orchestration_guidance(
+                {"selected_skill": "ralplan", "selected_harness": "planning"},
+                source_metadata={"user_ref": "u1"},
+                paths=paths,
+            )
+
+        self.assertEqual(guidance["mode"], "autonomous_pattern")
+        self.assertEqual(guidance["next_action"], "continue_omh_orchestration")
+        self.assertEqual(guidance["accepted_pattern_count"], 2)
+
+    def test_omh_orchestration_guidance_rejects_forged_or_cancelled_session_records(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(omh_home=Path(tmp) / ".omh", hermes_home=Path(tmp) / ".hermes")
+            for index, session in enumerate((
+                {"status": "plan_accepted", "source_metadata": {"user_ref": "u1"}, "route": {"selected_skill": "ralplan"}},
+                {"status": "cancelled", "decision": "plan_cancelled", "source_metadata": {"user_ref": "u1"}, "route": {"selected_skill": "ralplan"}},
+            )):
+                session_path = paths.runtime_wrapper_sessions_dir / f"forged-{index}" / "session.json"
+                session_path.parent.mkdir(parents=True)
+                session_path.write_text(json.dumps(session), encoding="utf-8")
+
+            guidance = build_omh_orchestration_guidance(
+                {"selected_skill": "ralplan", "selected_harness": "planning"},
+                source_metadata={"user_ref": "u1"},
+                paths=paths,
+            )
+
+        self.assertEqual(guidance["mode"], "guided_first_use")
+        self.assertEqual(guidance["accepted_pattern_count"], 0)
     def test_chat_interaction_omits_raw_message_by_default(self) -> None:
         message = "risky refactor with private-token-123"
 


### PR DESCRIPTION
## Feature Report

### What Changed

Added an adaptive OMH orchestration guidance contract to Hermes interactions. OMH now presents itself as the operating layer that frames a workflow-shaped problem, selects the workflow and harness, and uses Hermes-native skills as subordinate capabilities. The core generated `oh-my-hermes` skill carries the same operating posture.

### Why This Exists

A large skill catalog should not require users to understand which skill to invoke or let native candidates become competing top-level controllers. Users need a clear OMH-led route at first use and a safe way for Hermes to become more proactive only after local evidence of repeated acceptance.

### User / Operator Impact

`chat_interaction/v1` now includes `omh_orchestration_guidance/v1`. First use emits non-blocking `guided_first_use` guidance; after two validated, same-user, same-workflow accepted wrapper-session records it emits `autonomous_pattern`. Native Hermes candidates stay in a capability list and cannot override OMH policy.

### How It Works

- Counts only schema-valid `wrapper_session/v1` records whose decision is exactly `plan_accepted`.
- Scopes pattern inference to the same `user_ref` and selected workflow.
- Rejects malformed, forged, stale-shape, cancelled, and mismatched session records.
- Keeps destructive, credentialed, external-write, deployment, and executor-dispatch confirmation gates unchanged.
- Updates generated Hermes router guidance and README layout.

### Files And Contracts Touched

- `src/wrapper/orchestration_guidance.py`
- `src/wrapper/contract.py`
- `src/skills/render.py` and generated `skills/oh-my-hermes/SKILL.md`
- `README.md`, wrapper contract regressions

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -q`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `git diff --check`
- [x] Manual `chat interact` inspection for first-use guidance and native capability subordination
- [x] Independent review APPROVE for `3bca4a69ca41bcdd9c8dbfa900bcff1947895272`
- [ ] Live Hermes native-skill loading or external executor dispatch (intentionally out of scope)

## Risk

Autonomy is guidance-only and metadata-only. It does not dispatch work or create execution, review, CI, or merge evidence. Invalid or cancelled session records remain first-use guidance instead of elevating autonomy.

## Compatibility / Rollout

Existing interaction behavior remains intact; consumers receive an additive guidance object. No new dependency, Hermes-core patch, network service, or executor is introduced.

## Release / Claims

- [x] Native capability claims remain advisory unless separately observed
- [x] Existing confirmation and prepared-versus-observed boundaries are preserved

## Follow-Up

A future observed Hermes runtime contract can enrich this local guidance without trusting opaque native skill state.