### PR TITLE
Add wrapper_delivery_obligation/v1 contract shape for messenger push notifications (schema + fixtures only)

### DIFF
--- a/examples/wrapper-golden/delivery-obligation.json
+++ b/examples/wrapper-golden/delivery-obligation.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": "wrapper_delivery_obligation_golden_examples/v1",
+  "description": "Deterministic examples of the wrapper_delivery_obligation/v1 contract: a prepared-not-delivered push obligation (\"tell me in the thread when it is done\") across discord, slack, and telegram origins. OMH has no live proactive/push path; every obligation is pinned at prepared_not_delivered and nothing here implies OMH sent a message. Concept-aligned with the upstream v0.19.0 delivery-obligation ledger, named locally.",
+  "obligation_state_invariant": "prepared_not_delivered",
+  "no_live_trigger_wiring": true,
+  "future_trigger_hook_sites": {
+    "handoff_ci_pass": "src/runtime/artifacts.py:279 write_ci_record (ci_recorded event at src/runtime/artifacts.py:285); command caller src/commands/runtime.py:224",
+    "loop_iteration_complete": "src/workflows/goal_loop.py:556 record_loop_feedback (cycle appended at src/workflows/goal_loop.py:597); command caller src/commands/loop.py:137"
+  },
+  "scenarios": [
+    {
+      "scenario": "discord_push_obligation_ci_pass",
+      "source": "discord",
+      "trigger": "handoff_ci_pass",
+      "expected_obligation": {
+        "schema_version": "wrapper_delivery_obligation/v1",
+        "origin_thread_key": "discord:guild:chan:thread-1",
+        "trigger": "handoff_ci_pass",
+        "obligation_state": "prepared_not_delivered",
+        "not_delivered_until_wrapper_observed": true,
+        "evidence_policy": "metadata_only",
+        "evidence_refs": [
+          "ci_recorded:run-abc",
+          "status:passed"
+        ]
+      },
+      "claim_boundary": "A delivery obligation is prepared, not delivered: OMH has not sent any message and delivery stays unobserved until a wrapper records an actual delivery in the origin thread.",
+      "observed_evidence": [
+        "handoff CI pass observed (metadata ref)"
+      ],
+      "not_evidence": [
+        "delivered message",
+        "thread reply sent",
+        "user notified",
+        "wrapper-observed delivery"
+      ]
+    },
+    {
+      "scenario": "slack_push_obligation_loop_iteration",
+      "source": "slack",
+      "trigger": "loop_iteration_complete",
+      "expected_obligation": {
+        "schema_version": "wrapper_delivery_obligation/v1",
+        "origin_thread_key": "slack:team:chan:ts-1700000000.000100",
+        "trigger": "loop_iteration_complete",
+        "obligation_state": "prepared_not_delivered",
+        "not_delivered_until_wrapper_observed": true,
+        "evidence_policy": "metadata_only",
+        "evidence_refs": [
+          "loop:loop-xyz",
+          "cycle:cycle-7"
+        ]
+      },
+      "claim_boundary": "A delivery obligation is prepared, not delivered: OMH has not sent any message and delivery stays unobserved until a wrapper records an actual delivery in the origin thread.",
+      "observed_evidence": [
+        "loop iteration completion observed (metadata ref)"
+      ],
+      "not_evidence": [
+        "delivered message",
+        "thread reply sent",
+        "user notified",
+        "wrapper-observed delivery"
+      ]
+    },
+    {
+      "scenario": "telegram_push_obligation_ci_pass",
+      "source": "telegram",
+      "trigger": "handoff_ci_pass",
+      "expected_obligation": {
+        "schema_version": "wrapper_delivery_obligation/v1",
+        "origin_thread_key": "telegram:chat:-1001:thread-42",
+        "trigger": "handoff_ci_pass",
+        "obligation_state": "prepared_not_delivered",
+        "not_delivered_until_wrapper_observed": true,
+        "evidence_policy": "metadata_only",
+        "evidence_refs": [
+          "ci_recorded:run-def",
+          "status:passed"
+        ]
+      },
+      "claim_boundary": "A delivery obligation is prepared, not delivered: OMH has not sent any message and delivery stays unobserved until a wrapper records an actual delivery in the origin thread.",
+      "observed_evidence": [
+        "handoff CI pass observed (metadata ref)"
+      ],
+      "not_evidence": [
+        "delivered message",
+        "thread reply sent",
+        "user notified",
+        "wrapper-observed delivery"
+      ]
+    }
+  ]
+}

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -59,6 +59,9 @@ CONTEXT_PRIMER_SCHEMA_VERSION = "omh_context_primer/v1"
 USAGE_TRACE_SCHEMA_VERSION = "omh_usage_trace/v1"
 WORKFLOW_EXPLANATION_SCHEMA_VERSION = "omh_workflow_explanation/v1"
 MESSENGER_RENDERING_SCHEMA_VERSION = "omh_messenger_rendering/v1"
+DELIVERY_OBLIGATION_SCHEMA_VERSION = "wrapper_delivery_obligation/v1"
+DELIVERY_OBLIGATION_TRIGGERS = ("handoff_ci_pass", "loop_iteration_complete")
+DELIVERY_OBLIGATION_STATE = "prepared_not_delivered"
 RENDER_PROFILE_LIMITED_MARKDOWN = "limited_markdown"
 RENDER_PROFILE_RICH_MARKDOWN = "rich_markdown"
 RENDER_PROFILES = (RENDER_PROFILE_LIMITED_MARKDOWN, RENDER_PROFILE_RICH_MARKDOWN)
@@ -6808,6 +6811,76 @@ def messenger_rendering_contract(
         "body_preview": _short_text(body_text, limit=180),
         "claim_boundary": claim_boundary,
     }
+
+
+def build_wrapper_delivery_obligation(
+    *,
+    origin_thread_key: str,
+    trigger: str,
+    evidence_refs: object = None,
+    claim_boundary: str = "",
+) -> dict[str, object]:
+    """Build a prepared-not-delivered push/delivery obligation contract.
+
+    OMH has no live proactive/push path today: this contract only records that a
+    "tell me in the thread when it is done" obligation has been *prepared*, never
+    that OMH delivered a message. The obligation is pinned at
+    ``prepared_not_delivered`` and carries a
+    ``not_delivered_until_wrapper_observed`` marker, so no field can imply OMH
+    sent anything until a wrapper observes and records an actual delivery in a
+    future gated follow-up. The shape is executor-neutral (codex, claude-code,
+    and hermes produce an identical payload) and surface-neutral (valid for
+    discord, slack, and telegram origins).
+
+    Concept-aligned with the upstream v0.19.0 delivery-obligation ledger, but
+    named for OMH locally; no upstream wire field names are mirrored.
+    """
+    if trigger not in DELIVERY_OBLIGATION_TRIGGERS:
+        raise ValueError(f"unsupported delivery obligation trigger: {trigger!r}")
+    refs = _delivery_obligation_evidence_refs(evidence_refs)
+    boundary = claim_boundary.strip() or _default_delivery_obligation_claim_boundary()
+    return {
+        "schema_version": DELIVERY_OBLIGATION_SCHEMA_VERSION,
+        "origin_thread_key": str(origin_thread_key),
+        "trigger": trigger,
+        "obligation_state": DELIVERY_OBLIGATION_STATE,
+        "not_delivered_until_wrapper_observed": True,
+        "evidence_policy": "metadata_only",
+        "evidence_refs": refs,
+        "observed_evidence": _delivery_obligation_observed_evidence(trigger),
+        "not_evidence": [
+            "delivered message",
+            "thread reply sent",
+            "user notified",
+            "wrapper-observed delivery",
+        ],
+        "claim_boundary": boundary,
+    }
+
+
+def _delivery_obligation_evidence_refs(value: object) -> list[str]:
+    if not isinstance(value, (list, tuple)):
+        return []
+    refs: list[str] = []
+    for item in value:
+        ref = _short_text(str(item).strip(), limit=180)
+        if ref and ref not in refs:
+            refs.append(ref)
+    return refs
+
+
+def _delivery_obligation_observed_evidence(trigger: str) -> list[str]:
+    if trigger == "handoff_ci_pass":
+        return ["handoff CI pass observed (metadata ref)"]
+    return ["loop iteration completion observed (metadata ref)"]
+
+
+def _default_delivery_obligation_claim_boundary() -> str:
+    return (
+        "A delivery obligation is prepared, not delivered: OMH has not sent any "
+        "message and delivery stays unobserved until a wrapper records an actual "
+        "delivery in the origin thread."
+    )
 
 
 def render_profile_for_source(source: str, source_metadata: dict[str, object] | None = None) -> str:

--- a/tests/test_wrapper_notification_contract.py
+++ b/tests/test_wrapper_notification_contract.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import unittest
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.wrapper_contract import (
+    DELIVERY_OBLIGATION_SCHEMA_VERSION,
+    DELIVERY_OBLIGATION_STATE,
+    DELIVERY_OBLIGATION_TRIGGERS,
+    build_wrapper_delivery_obligation,
+)
+
+SOURCE_ROOT = Path(__file__).resolve().parents[1] / "src"
+GOLDEN_FIXTURE = Path(__file__).resolve().parents[1] / "examples" / "wrapper-golden" / "delivery-obligation.json"
+
+
+class WrapperDeliveryObligationContractTests(unittest.TestCase):
+    def test_obligation_is_pinned_prepared_not_delivered(self) -> None:
+        obligation = build_wrapper_delivery_obligation(
+            origin_thread_key="discord:guild:chan:thread-1",
+            trigger="handoff_ci_pass",
+            evidence_refs=["ci_recorded:run-abc", "status:passed"],
+        )
+
+        self.assertEqual(obligation["schema_version"], DELIVERY_OBLIGATION_SCHEMA_VERSION)
+        self.assertEqual(obligation["schema_version"], "wrapper_delivery_obligation/v1")
+        self.assertEqual(obligation["obligation_state"], "prepared_not_delivered")
+        self.assertEqual(DELIVERY_OBLIGATION_STATE, "prepared_not_delivered")
+        self.assertTrue(obligation["not_delivered_until_wrapper_observed"])
+        self.assertEqual(obligation["evidence_policy"], "metadata_only")
+
+    def test_payload_never_carries_a_delivered_state(self) -> None:
+        for trigger in DELIVERY_OBLIGATION_TRIGGERS:
+            obligation = build_wrapper_delivery_obligation(
+                origin_thread_key="slack:team:chan:ts-1",
+                trigger=trigger,
+                evidence_refs=["loop:loop-1"],
+            )
+            serialized = json.dumps(obligation).lower()
+            with self.subTest(trigger=trigger):
+                self.assertNotIn("delivery_confirmed", serialized)
+                self.assertNotIn("sent_at", serialized)
+                # No affirmative delivered state (prepared_not_delivered is the pin).
+                self.assertEqual(obligation["obligation_state"], "prepared_not_delivered")
+                self.assertNotIn(obligation["obligation_state"], {"delivered", "delivery_observed"})
+
+    def test_no_field_implies_omh_sent_a_message(self) -> None:
+        obligation = build_wrapper_delivery_obligation(
+            origin_thread_key="telegram:chat:-1001:thread-42",
+            trigger="handoff_ci_pass",
+        )
+
+        self.assertIn("delivered message", obligation["not_evidence"])
+        self.assertIn("thread reply sent", obligation["not_evidence"])
+        self.assertIn("user notified", obligation["not_evidence"])
+        self.assertIn("wrapper-observed delivery", obligation["not_evidence"])
+        boundary = str(obligation["claim_boundary"]).lower()
+        self.assertIn("not delivered", boundary)
+        self.assertIn("unobserved until a wrapper records", boundary)
+
+    def test_rejects_unsupported_trigger(self) -> None:
+        with self.assertRaises(ValueError):
+            build_wrapper_delivery_obligation(
+                origin_thread_key="discord:guild:chan:thread-1",
+                trigger="message_received",
+            )
+
+    def test_shape_is_executor_neutral(self) -> None:
+        # The builder takes no executor input, so codex, claude-code, and hermes
+        # runs that reach the same trigger must produce byte-identical shapes.
+        payloads = [
+            build_wrapper_delivery_obligation(
+                origin_thread_key="discord:guild:chan:thread-1",
+                trigger="loop_iteration_complete",
+                evidence_refs=["loop:loop-xyz", "cycle:cycle-7"],
+            )
+            for _executor in ("codex", "claude-code", "hermes")
+        ]
+
+        first = json.dumps(payloads[0], sort_keys=True)
+        for payload in payloads[1:]:
+            self.assertEqual(json.dumps(payload, sort_keys=True), first)
+
+    def test_evidence_refs_are_metadata_only_bounded_strings(self) -> None:
+        obligation = build_wrapper_delivery_obligation(
+            origin_thread_key="slack:team:chan:ts-1",
+            trigger="loop_iteration_complete",
+            evidence_refs=["loop:loop-xyz", "loop:loop-xyz", "", "  ", "x" * 500],
+        )
+        refs = obligation["evidence_refs"]
+
+        self.assertIsInstance(refs, list)
+        self.assertEqual(refs.count("loop:loop-xyz"), 1)  # deduplicated
+        self.assertNotIn("", refs)
+        self.assertTrue(all(len(ref) <= 181 for ref in refs))  # bounded, no raw logs
+
+    def test_no_live_trigger_emission_in_runtime_or_observation_code(self) -> None:
+        # Guard: this PR ships the contract SHAPE only. The builder must not be
+        # called from any runtime/observation/workflow/command code path. Its
+        # only reference under src/ is its own definition in wrapper/contract.py.
+        callable_name = "build_wrapper_delivery_obligation"
+        referencing_files: list[str] = []
+        for path in SOURCE_ROOT.rglob("*.py"):
+            text = path.read_text(encoding="utf-8")
+            if callable_name in text:
+                referencing_files.append(str(path.relative_to(SOURCE_ROOT)))
+
+        self.assertEqual(
+            referencing_files,
+            ["wrapper/contract.py"],
+            msg=f"delivery-obligation builder leaked into live code paths: {referencing_files}",
+        )
+
+        # Nothing in runtime/observation writers may emit the obligation schema.
+        for subtree in ("runtime", "workflows", "commands", "plugin_bundle"):
+            for path in (SOURCE_ROOT / subtree).rglob("*.py"):
+                self.assertNotIn(
+                    DELIVERY_OBLIGATION_SCHEMA_VERSION,
+                    path.read_text(encoding="utf-8"),
+                    msg=f"{path} references the delivery-obligation schema; wiring is a gated follow-up",
+                )
+
+
+class WrapperDeliveryObligationGoldenTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.payload = json.loads(GOLDEN_FIXTURE.read_text(encoding="utf-8"))
+
+    def test_golden_metadata(self) -> None:
+        self.assertEqual(self.payload["schema_version"], "wrapper_delivery_obligation_golden_examples/v1")
+        self.assertEqual(self.payload["obligation_state_invariant"], "prepared_not_delivered")
+        self.assertTrue(self.payload["no_live_trigger_wiring"])
+
+    def test_golden_covers_all_three_surfaces(self) -> None:
+        sources = {item["source"] for item in self.payload["scenarios"]}
+        self.assertEqual(sources, {"discord", "slack", "telegram"})
+
+    def test_every_scenario_is_prepared_not_delivered(self) -> None:
+        for item in self.payload["scenarios"]:
+            obligation = item["expected_obligation"]
+            with self.subTest(item["scenario"]):
+                self.assertEqual(obligation["schema_version"], "wrapper_delivery_obligation/v1")
+                self.assertEqual(obligation["obligation_state"], "prepared_not_delivered")
+                self.assertTrue(obligation["not_delivered_until_wrapper_observed"])
+                self.assertEqual(obligation["evidence_policy"], "metadata_only")
+                self.assertIn(obligation["trigger"], DELIVERY_OBLIGATION_TRIGGERS)
+                self.assertTrue(item["claim_boundary"])
+                self.assertTrue(item["observed_evidence"])
+                self.assertTrue(item["not_evidence"])
+                self.assertNotIn(obligation["obligation_state"], {"delivered", "delivery_observed"})
+
+    def test_golden_matches_live_builder_output(self) -> None:
+        for item in self.payload["scenarios"]:
+            expected = item["expected_obligation"]
+            live = build_wrapper_delivery_obligation(
+                origin_thread_key=expected["origin_thread_key"],
+                trigger=expected["trigger"],
+                evidence_refs=expected["evidence_refs"],
+                claim_boundary=item["claim_boundary"],
+            )
+            with self.subTest(item["scenario"]):
+                self.assertEqual(live["schema_version"], expected["schema_version"])
+                self.assertEqual(live["origin_thread_key"], expected["origin_thread_key"])
+                self.assertEqual(live["trigger"], expected["trigger"])
+                self.assertEqual(live["obligation_state"], expected["obligation_state"])
+                self.assertEqual(
+                    live["not_delivered_until_wrapper_observed"],
+                    expected["not_delivered_until_wrapper_observed"],
+                )
+                self.assertEqual(live["evidence_policy"], expected["evidence_policy"])
+                self.assertEqual(live["evidence_refs"], expected["evidence_refs"])
+                self.assertEqual(live["observed_evidence"], item["observed_evidence"])
+                self.assertEqual(live["not_evidence"], item["not_evidence"])
+                self.assertEqual(live["claim_boundary"], item["claim_boundary"])
+
+    def test_golden_records_future_trigger_hook_sites(self) -> None:
+        hooks = self.payload["future_trigger_hook_sites"]
+        self.assertIn("handoff_ci_pass", hooks)
+        self.assertIn("loop_iteration_complete", hooks)
+        self.assertIn("write_ci_record", hooks["handoff_ci_pass"])
+        self.assertIn("record_loop_feedback", hooks["loop_iteration_complete"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What & Why

Messenger users (Discord/Slack/Telegram — the primary OMH audience) have no "tell me in the thread when it's done" story: every OMH delivery-adjacent clause is render-on-request, and nothing models a proactive update when a prepared handoff's CI passes or a loop iteration completes. Mobile users are forced to poll.

This PR ships the **contract shape and fixtures only** for wrapper-initiated notifications — `wrapper_delivery_obligation/v1` — deliberately downgraded from live wiring by consensus review (Planner→Architect→Critic) so the first outbound-initiating contract cannot violate the prepared-vs-observed boundary.

## What changed

- `src/wrapper/contract.py`: new `build_wrapper_delivery_obligation(...)` builder. Fields: `origin_thread_key`, `trigger ∈ {handoff_ci_pass, loop_iteration_complete}`, `obligation_state: "prepared_not_delivered"` (pinned), `not_delivered_until_wrapper_observed: true`, `evidence_policy: "metadata_only"`, bounded/deduped `evidence_refs`, `observed_evidence` / `not_evidence` / `claim_boundary` per existing evidence conventions. Executor-neutral and surface-neutral; concept-aligned with upstream v0.19.0's delivery-obligation ledger with OMH-local naming (no wire-mirror).
- `examples/wrapper-golden/delivery-obligation.json`: golden fixture showing the obligation across discord, slack, and telegram — all `prepared_not_delivered`, derived from the live builder.
- `tests/test_wrapper_notification_contract.py`: 12 tests — boundary (no affirmative delivered/sent state anywhere; `not_evidence` explicitly names "delivered message / thread reply sent / user notified"), guard (the builder and schema string appear in zero runtime/workflow/command code paths — nothing can fire it yet), executor-neutrality, metadata-only refs, golden/live parity.

## Trigger wiring is a gated follow-up — call sites traced and named

Per the consensus precondition, the concrete observed-evidence hooks where a follow-up PR would wire triggers are:

- **handoff_ci_pass**: `src/runtime/artifacts.py:279` `write_ci_record()` (emits `ci_recorded` at `:285`); builder `build_ci_record` at `src/runtime/records.py:609`; CLI gate `status == "passed"` at `src/commands/runtime.py:218-224`.
- **loop_iteration_complete**: `src/workflows/goal_loop.py:556` `record_loop_feedback()` (cycle appended at `:597`); CLI caller `cmd_loop_feedback` at `src/commands/loop.py:137`.

## Verification (observed)

- Full suite: 1456 tests OK (1 pre-existing skip); new file: 12/12 OK
- `compileall` clean; `omh.cli docs workflows --check` ok; `git diff --check` clean

## Risks / Follow-ups

- No runtime behavior changes in this PR by design; the schema has no producer yet — the guard test enforces that explicitly until the gated wiring PR lands with real observed-evidence triggers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLULEvSNhQg48Ay49dEoaT
