### PR TITLE
Sweep dead src/omh flat shims and publish contract-sunset candidate list

### DIFF
--- a/docs/CONTRACT_SUNSET_CANDIDATES.md
+++ b/docs/CONTRACT_SUNSET_CANDIDATES.md
@@ -1,0 +1,46 @@
+# Contract Sunset Candidates
+
+**Candidates only — no removal decided; each needs its own goal PR.**
+
+This is a starter list produced by PR-9 (omh flat-shim sweep). It enumerates
+schema-versioned (`*/vN`) contract IDs whose grep footprint is **≤ 2 source
+files** (typically the defining module plus at most one consumer/command),
+which makes them low-blast-radius candidates for a future deprecation pass.
+
+Selection rule: a candidate qualifies only when the exact contract token (e.g.
+`\bcomparative_quality_rubric/v1\b`, word-boundary matched) appears in **at most
+two files under `src/`**. Footprints below were verified individually with
+`grep -rEln`. Test-file references are reported separately and do **not** count
+toward the ≤2 `src/` footprint.
+
+**This PR removes zero contracts and zero code.** Any actual sunset must be its
+own goal PR with its own consumer re-verification and migration/telemetry review.
+
+## Candidates
+
+| Contract ID | Defining file | src footprint | Consumer count (src) | Test refs | Sunset rationale |
+|---|---|---|---|---|---|
+| `agent_operator_productivity/v1` | `src/workflows/operator_productivity.py` | 2 files | 1 (`src/skills/catalog.py`) | 0 | Operator-productivity index feature has a single catalog consumer; low adoption surface. |
+| `agent_operator_productivity_index/v1` | `src/workflows/operator_productivity.py` | 1 file | 0 | 0 | Defined but never consumed outside its own module; pure internal sub-contract. |
+| `agent_operator_productivity_validation/v1` | `src/workflows/operator_productivity.py` | 1 file | 0 | 0 | Validation schema paired with the above; no external reader. |
+| `product_evidence_loop/v1` | `src/workflows/product_evidence_loop.py` | 2 files | 1 (`src/skills/catalog.py`) | 2 (`test_cli.py`, `test_router_content.py`) | Single catalog consumer; product-evidence-loop workflow is narrowly wired. |
+| `comparative_quality_rubric/v1` | _(none — prescriptive only)_ | 2 files | 2 (`src/routing/recommend.py`, `src/skills/catalog.py`) | 1 (`test_router_content.py`) | No owning module: referenced only as a prescribed artifact string in a route hint and catalog copy; candidate for consolidation into the design-quality-gate contract. |
+
+## Mandate examples evaluated but NOT qualifying (>2 src files)
+
+Verified and excluded so the list stays honest — these exceed the ≤2 threshold
+and are therefore **not** low-blast-radius:
+
+| Contract ID | src footprint | Files |
+|---|---|---|
+| `research_department_plan/v1` | 5 | `capabilities/orchestration.py`, `catalogs/playbooks.py`, `routing/recommend.py`, `skills/catalog.py`, `workflows/research_department.py` |
+| `paper_learning_card/v1` | 4 | `routing/recommend.py`, `skills/catalog.py`, `workflows/paper_learning.py`, `wrapper/contract.py` |
+| `menubar_app/v1` | 3 | `commands/menubar.py`, `commands/setup.py`, `surfaces/menubar_app.py` |
+
+## Next steps (per candidate, in its own PR)
+
+1. Re-run the word-boundary footprint grep across `src/`, `tests/`, `examples/`,
+   `docs/`, `scripts/`, and `plugin_bundle` — footprints drift.
+2. Confirm no runtime record/handoff validator keys on the contract ID.
+3. Decide replace vs. remove; if replacing, ship the successor contract first.
+4. Update `docs/WORKFLOWS.md` regeneration output and any skill-catalog copy.

--- a/src/omh/hermes_achievements.py
+++ b/src/omh/hermes_achievements.py
@@ -1,3 +1,0 @@
-from __future__ import annotations
-
-from .workflows.hermes_achievements import *  # noqa: F401,F403

--- a/src/omh/product_family_templates.py
+++ b/src/omh/product_family_templates.py
@@ -1,3 +1,0 @@
-from __future__ import annotations
-
-from .coding.product_family_templates import *  # noqa: F401,F403

--- a/src/omh/product_quality_harnesses.py
+++ b/src/omh/product_quality_harnesses.py
@@ -1,3 +1,0 @@
-from __future__ import annotations
-
-from .coding.product_quality_harnesses import *  # noqa: F401,F403

--- a/src/omh/project_governance.py
+++ b/src/omh/project_governance.py
@@ -1,3 +1,0 @@
-from __future__ import annotations
-
-from .coding.project_governance import *  # noqa: F401,F403

--- a/src/omh/specialist_work.py
+++ b/src/omh/specialist_work.py
@@ -1,3 +1,0 @@
-from __future__ import annotations
-
-from .quality.specialist_work import *  # noqa: F401,F403

--- a/src/omh/specialists.py
+++ b/src/omh/specialists.py
@@ -1,3 +1,0 @@
-from __future__ import annotations
-
-from .catalogs.specialists import *  # noqa: F401,F403

--- a/src/workflows/web_visual_qa.py
+++ b/src/workflows/web_visual_qa.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 
-from omh.local_store import atomic_write_json, ensure_dir, read_json_object_result
-from omh.paths import OmhPaths
+from omh.system.local_store import atomic_write_json, ensure_dir, read_json_object_result
+from omh.system.paths import OmhPaths
 
 from .web_visual_qa_contracts import (
     SUPPORTED_COST_TIERS,

--- a/tests/test_omh_shim_sweep.py
+++ b/tests/test_omh_shim_sweep.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import importlib
+import unittest
+
+from _local_package import load_local_package
+
+load_local_package()
+
+import omh.system.local_store as canonical_local_store
+import omh.system.paths as canonical_paths
+import omh.workflows.web_visual_qa as web_visual_qa
+
+
+class OmhShimSweepTests(unittest.TestCase):
+    def test_repointed_web_visual_qa_uses_canonical_system_modules(self) -> None:
+        # The straggler was repointed off the flat omh.local_store / omh.paths
+        # shims onto the canonical omh.system.* modules. The re-exported symbols
+        # must still resolve to the canonical implementations.
+        self.assertIs(
+            web_visual_qa.atomic_write_json,
+            canonical_local_store.atomic_write_json,
+        )
+        self.assertIs(
+            web_visual_qa.ensure_dir,
+            canonical_local_store.ensure_dir,
+        )
+        self.assertIs(
+            web_visual_qa.OmhPaths,
+            canonical_paths.OmhPaths,
+        )
+
+    def test_deleted_flat_shims_are_gone_but_canonical_paths_import(self) -> None:
+        # Each swept flat shim had zero flat-path consumers; the canonical deep
+        # module must still import cleanly after the shim was removed.
+        swept = {
+            "hermes_achievements": "omh.workflows.hermes_achievements",
+            "product_family_templates": "omh.coding.product_family_templates",
+            "product_quality_harnesses": "omh.coding.product_quality_harnesses",
+            "project_governance": "omh.coding.project_governance",
+            "specialist_work": "omh.quality.specialist_work",
+            "specialists": "omh.catalogs.specialists",
+        }
+        for flat_name, canonical in swept.items():
+            with self.subTest(shim=flat_name):
+                self.assertIsNotNone(importlib.import_module(canonical))
+                with self.assertRaises(ModuleNotFoundError):
+                    importlib.import_module(f"omh.{flat_name}")
+
+    def test_retained_facades_still_import(self) -> None:
+        # A representative slice of the compatibility facades that stay (they are
+        # locked by test_architecture_layout and/or have flat consumers).
+        for flat_name in ("paths", "local_store", "learning_candidate", "chat_router"):
+            with self.subTest(facade=flat_name):
+                module = importlib.import_module(f"omh.{flat_name}")
+                self.assertIsNotNone(module)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What & Why

The harness audit (E2/O6) flagged `src/omh/` as a legacy dual-import surface — ~91 files, most of them dotted-subpath star re-export shims (`from .system.local_store import *`) that keep two import paths alive for the same code — plus 638 schema-versioned contracts, many with a 2-file consumption footprint. This PR pays down that debt at the safe, evidence-backed grain the consensus review mandated: per-shim consumer proof, skip anything ambiguous, and a sunset LIST (no removals) for near-dead contracts.

## What changed

**Packaging model established first** (this bounds everything): `pyproject.toml` maps `omh` → `src/omh` while domain subpackages map `omh.system`/`omh.workflows`/… → `src/<pkg>`, and `tests/test_architecture_layout.py::test_root_compatibility_facades_stay_thin` byte-asserts ~67 facades. Those shims are load-bearing **by test contract** — so the honest conservative outcome is a small kill list, not a purge.

- **6 truly-dead flat shims deleted**, each with zero-flat-consumer grep evidence (word-boundary sweep over src/tests/examples/docs/scripts): `hermes_achievements`, `product_family_templates`, `product_quality_harnesses`, `project_governance`, `specialist_work`, `specialists`.
- **Straggler repointed**: `src/workflows/web_visual_qa.py` now imports canonical `omh.system.local_store` / `omh.system.paths` instead of flat shims.
- **Skipped with recorded reasons**: 67 facade-locked shims + `menubar_app` (test contract), `learning_candidate` (live flat consumers in `contract.py`/`chat.py`), 8 shims with flat consumers in tests.
- **`docs/CONTRACT_SUNSET_CANDIDATES.md`** (list only, zero removals): 5 verified `*/v1` contracts with ≤2 src-file footprint (`agent_operator_productivity/v1` family, `product_evidence_loop/v1`, `comparative_quality_rubric/v1`), each with defining file, consumer count, rationale; 3 evaluated-but-excluded candidates recorded with why. Header states each sunset needs its own goal PR.
- **`tests/test_omh_shim_sweep.py`**: import-smoke — deleted shims raise `ModuleNotFoundError` while canonical modules import; repointed symbols resolve canonically; retained facades still import.

## Verification (observed)

- Full suite: 1447 tests OK (1 pre-existing skip; baseline 1444 + 3 new)
- `compileall` clean; `omh.cli docs workflows --check` ok; `git diff --check` clean
- Per-deleted-shim consumer-grep evidence recorded in the commit body

## Risks / Follow-ups

- The 67 facade shims remain until the facade test contract itself is deliberately renegotiated (own goal PR).
- Contract sunsets are candidates only; each needs its own PR with a consumer-impact pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLULEvSNhQg48Ay49dEoaT
