### PR TITLE
Retire OMH worktree creation in favor of upstream-native worktrees; keep observation, binding, and action vocabulary

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -471,9 +471,12 @@ worktrees were started. All coding handoff modes also include
 `worktree_session_isolation/v1`, which tells wrappers whether the current
 workspace is acceptable, an isolated worktree is recommended, or an isolated
 worktree is required before opening an executor. That record stores a compact
-snapshot of the generated workspace policy. When a wrapper or operator chooses
-the explicit workspace action, `omh worktree prepare` creates a local Git
-worktree and records `omh_worktree_observation/v1`; that observation is
+snapshot of the generated workspace policy. Worktree creation itself is deferred
+to native tooling — upstream Hermes manages worktrees for you (Kanban
+worktree-per-task since v0.15.0, Desktop Projects since v0.18.0), or you can run
+`git worktree add` manually — so OMH no longer creates worktrees and cannot
+collide with the one Hermes is already managing for a task. When a worktree
+exists, OMH records `omh_worktree_observation/v1`; that observation is
 workspace-isolation evidence only. `omh worktree bind` can then return a
 wrapper recipe for opening or attaching Codex, Claude Code, Hermes, or another
 runtime from that worktree; the recipe is still not executor dispatch or result
@@ -610,10 +613,10 @@ through `omh runtime team-readiness`: OMH can show the worker protocol, runtime
 templates, wrapper actions, installed skill visibility, and observed
 `runtime_observation/v1` ledger status. That readiness is still not worker
 launch, pane/session creation, worker result, review, CI, or merge evidence.
-Worktree isolation is available only for the explicit
-`omh worktree prepare/list/bind` backend and its local
-`omh_worktree_observation/v1` ledger plus wrapper binding recipes; it does not
-auto-launch an executor. MCP host load and plugin runtime events likewise
+Worktree isolation is observation-only: the `omh worktree list/bind` backend
+reads its local `omh_worktree_observation/v1` ledger and returns wrapper binding
+recipes for a worktree that native Hermes/Git tooling created; it neither
+creates worktrees nor auto-launches an executor. MCP host load and plugin runtime events likewise
 belong to Hermes, the selected executor, or another observed integration until
 the matching ledger records exist.
 

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -109,9 +109,11 @@ Those claims require matching local wrapper or runtime artifacts such as
 Workspace-isolation guidance uses `worktree_session_isolation/v1`. It can tell a
 wrapper to keep the same workspace, recommend a worktree, or require a worktree
 before opening a coding agent. It is still prepared guidance until a wrapper or
-operator invokes or observes the workspace action. `omh worktree prepare` is the
-explicit opt-in backend that can create a local Git worktree and record
-`omh_worktree_observation/v1`. `omh worktree bind` can then return
+operator invokes or observes the workspace action. Worktree creation is deferred
+to native tooling — upstream Hermes manages worktrees (Kanban worktree-per-task
+since v0.15.0, Desktop Projects since v0.18.0) or you can run `git worktree add`
+— and OMH records `omh_worktree_observation/v1` for the resulting worktree.
+`omh worktree bind` can then return
 `worktree_executor_binding/v1` so a wrapper can show open/attach/record actions
 for the selected coding agent. Those records prove workspace isolation and
 session-start guidance only, not executor dispatch, implementation, review, CI,

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -595,10 +595,11 @@ surface for that axis; live runtime actions still need separate observed
 evidence. The worktree row includes
 `worktree_session_isolation/v1` wrapper guidance when coding handoffs need same
 workspace, recommended worktree, or required worktree status before opening a
-coding agent. If a wrapper or operator chooses the explicit backend action,
-`omh worktree prepare` can create the local Git worktree and record
-`omh_worktree_observation/v1`; that still proves workspace isolation only, not
-executor dispatch or implementation.
+coding agent. Worktree creation is deferred to native tooling — upstream Hermes
+manages worktrees (Kanban worktree-per-task since v0.15.0, Desktop Projects
+since v0.18.0) or you run `git worktree add` — and OMH records
+`omh_worktree_observation/v1` for the resulting worktree; that still proves
+workspace isolation only, not executor dispatch or implementation.
 
 Use `omh probe --roadmap` when the question is "what should I do next?" rather
 than "what does OMH support?" It returns
@@ -989,8 +990,9 @@ Before calling the bot integration ready, verify these points:
 - Coding handoffs include `worktree_session_isolation/v1` so wrappers can show
   Prepare worktree before opening an executor when risk or parallelism calls for
   isolation. The plan remains `prepared_not_observed` until a wrapper invokes
-  or observes the workspace action. `omh worktree prepare --repo <repo> --task
-  "<task>"` is the explicit local backend action for creating the Git worktree;
+  or observes the workspace action. Worktree creation is deferred to native
+  Hermes tooling (Kanban worktree-per-task, Desktop Projects) or a manual `git
+  worktree add`; once the worktree exists,
   `omh worktree bind --path <worktree> --executor codex --session <session-id>`
   returns the safe wrapper recipe for opening or attaching the selected coding
   agent from that worktree. Linked runtime ladders still require separate

--- a/docs/MULTI_AGENT_OPERATIONS.md
+++ b/docs/MULTI_AGENT_OPERATIONS.md
@@ -86,10 +86,14 @@ The same boundary applies to worktree isolation guidance: `build_isolation_plan`
 prevent two agents editing the same workspace, and — per the
 [Upstream Basis](HERMES_AGENT_INTEGRATION_RUNBOOK.md#upstream-basis) note in
 the integration runbook — it can collide with a worktree Hermes's own Kanban
-board or Desktop Projects is already managing for the same task. Read
-prepared isolation guidance as a recommendation to check for an existing
-upstream-managed worktree before creating a new one, not as proof one does
-or does not exist.
+board or Desktop Projects is already managing for the same task. Because of that
+collision risk, OMH no longer creates worktrees: worktree preparation is
+deferred to native tooling (Hermes Kanban worktree-per-task since v0.15.0,
+Desktop Projects since v0.18.0, or a manual `git worktree add`). OMH only
+*observes* an existing worktree (`omh worktree list`) and binds a coding handoff
+to it (`omh worktree bind`). Read prepared isolation guidance as a recommendation
+to reuse or create a worktree with upstream-native tooling, not as proof one
+does or does not exist.
 
 ## Prefer Upstream-Native Coordination Primitives
 

--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -43,7 +43,7 @@ implementation or claim runtime behavior it did not observe.
 | Specialist role/profile system | Available | Skill catalog metadata, operating models, optional visible profile packs, wrapper role narration, plugin `omh_role`, and `[omh-role:name]` context injection. | Observed role execution still requires wrapper or runtime evidence; role context is not a hidden live agent. |
 | Bounded evidence probe | Available | Plugin `omh_gather_evidence` runs shell-free allowlisted local probes such as doctor, harness validation, docs checks, unittest, compileall, and whitespace checks. | It is not a general shell, executor dispatch, PR review, CI, merge, or live Hermes plugin-load signal. |
 | Team, swarm, and worker protocol | Available | `team`, `ultrawork`, `omh runtime team-readiness`, runtime handoff payloads, worker-protocol guidance, wrapper sessions, and runtime observations. | Live worker launch and pane/session management still require the selected host runtime to act and record observations. |
-| Worktree and project-session isolation | Available | `worktree_session_isolation/v1` plans in coding handoffs, wrapper Prepare worktree actions, `omh worktree prepare/list/bind`, executor-session status cards, loop queue metadata, and runtime observations for worktree creation. | OMH creates local Git worktrees only through the explicit opt-in backend command; binding recipes show how wrappers can open or attach host sessions but do not auto-launch executors or claim runtime evidence. |
+| Worktree and project-session isolation | Available | `worktree_session_isolation/v1` plans in coding handoffs, wrapper Prepare worktree actions, `omh worktree list/bind`, executor-session status cards, loop queue metadata, and runtime observations for worktree creation. | OMH defers worktree creation to native Hermes tooling (Kanban worktree-per-task v0.15.0, Desktop Projects v0.18.0) or manual `git worktree add`; it observes the resulting worktree, and binding recipes show how wrappers can open or attach host sessions but do not auto-launch executors or claim runtime evidence. |
 | HUD, status, and session observability | Available | `omh hud`, plugin `omh_interact`/`omh_recommend`/`omh_probe`/`omh_hud`/`omh_status`, wrapper sessions, runtime runs, roadmap cards, and status cards. | Live host HUD rendering depends on Hermes/plugin support; plugin chat/session output is metadata/status, not execution evidence. |
 | MCP and tool bridge | Available | `omh setup --with-mcp --mcp-host ...`, `omh mcp manifest`, `omh mcp config-recipe`, `omh mcp serve`, `omh mcp observe-host`, and `omh probe` preference/server/runtime/host-session/host-config separation. | OMH can write supported local host config entries, but it does not independently inspect live host sessions; the host or wrapper must record load/session evidence. |
 | Loop and autopilot workflow | Available | `loop`, `ultraprocess`, `ralplan`, `ultragoal`, loop queue ticks, verification tiers, and failure-mode cards. | Scheduling, connector I/O, worktree creation, and subagent execution remain prepared or delegated until observed. |
@@ -70,11 +70,12 @@ implementation or claim runtime behavior it did not observe.
 - `worktree_session_isolation/v1`, which gives coding handoffs and wrapper
   status cards a concrete same-workspace/worktree-recommended/worktree-required
   contract before any executor is opened.
-- `omh worktree prepare` and `omh worktree list`, which let wrappers or
-  operators explicitly create a local Git worktree and record
-  `omh_worktree_observation/v1` workspace-isolation evidence. That evidence is
-  still not executor dispatch, implementation, review, CI, merge-readiness, or
-  merge evidence.
+- `omh worktree list`, which lets wrappers or operators read the
+  `omh_worktree_observation/v1` workspace-isolation evidence recorded for a
+  worktree that native Hermes tooling (Kanban worktree-per-task, Desktop
+  Projects) or a manual `git worktree add` created. That evidence is still not
+  executor dispatch, implementation, review, CI, merge-readiness, or merge
+  evidence.
 - `omh worktree bind`, which returns `worktree_executor_binding/v1` so wrappers
   can render Open in Codex, Open in Claude Code, Attach session, and runtime
   observation record actions for a prepared worktree without launching the

--- a/src/coding/worktree_creator.py
+++ b/src/coding/worktree_creator.py
@@ -1,128 +1,30 @@
+"""Worktree observation ledger helpers.
+
+OMH no longer *creates* Git worktrees. Upstream Hermes Agent manages worktrees
+natively (Kanban worktree-per-task since v0.15.0, Desktop Projects since
+v0.18.0), so an OMH-owned creation path is redundant and can collide with the
+worktree Hermes is already managing for the same task. This module retains only
+the observation-side helpers: reading the local worktree ledger and recording
+observed worktree evidence when a wrapper or runtime reports it. Worktree
+preparation is deferred to the operator's native tooling (Hermes Kanban /
+Desktop Projects, or a manual `git worktree add`).
+"""
+
 from __future__ import annotations
 
 import json
-import re
-import subprocess
 from pathlib import Path
 from typing import Any
 
 from ..local_store import ensure_dir, ensure_file, read_jsonl_objects, utc_now
 from ..paths import OmhPaths, expand_path
-from ..runtime.artifacts import update_state
 
-WORKTREE_PREPARE_SCHEMA_VERSION = "omh_worktree_prepare/v1"
 WORKTREE_OBSERVATION_SCHEMA_VERSION = "omh_worktree_observation/v1"
 
 WORKTREE_CLAIM_BOUNDARY = (
-    "An OMH-created Git worktree is observed workspace-isolation evidence only. "
+    "An observed Git worktree is workspace-isolation evidence only. "
     "It is not executor dispatch, implementation, verification, review, CI, merge-readiness, or merge evidence."
 )
-
-RUNTIME_OBSERVATION_FOLLOWUP = {
-    "schema_version": "runtime_observation_followup/v1",
-    "event_type": "worktree_creation",
-    "record_with": (
-        "omh runtime observe --run <run-id> --runtime-profile <runtime-profile> --event worktree_creation "
-        "--status observed --worktree-ref <worktree_path> --evidence-ref git-worktree:<worktree_path>"
-    ),
-    "when": "Only when this worktree belongs to a prepared runtime or executor session that needs ladder evidence.",
-    "boundary": "The local worktree ledger is workspace-isolation evidence; runtime ladder evidence remains a separate wrapper/operator observation.",
-}
-
-
-def prepare_git_worktree(
-    paths: OmhPaths,
-    *,
-    repo: str | Path,
-    task: str = "",
-    branch: str = "",
-    worktree_path: str | Path | None = None,
-    base_dir: str | Path = ".worktrees",
-    from_ref: str = "HEAD",
-    dry_run: bool = False,
-    allow_dirty_source: bool = False,
-) -> dict[str, Any]:
-    repo_root = _repo_root(repo)
-    status_text = _git(repo_root, "status", "--porcelain", check=True).stdout.strip()
-    source_dirty = bool(status_text)
-    if source_dirty and not allow_dirty_source:
-        return _blocked_result(
-            paths,
-            repo_root=repo_root,
-            task=task,
-            branch=branch,
-            worktree_path=worktree_path,
-            base_dir=base_dir,
-            from_ref=from_ref,
-            reason="source_dirty",
-            message="Source worktree has uncommitted changes; rerun with --allow-dirty-source if this is intentional.",
-        )
-
-    resolved_branch = _branch_name(branch, task)
-    resolved_path = _worktree_path(repo_root, resolved_branch, worktree_path=worktree_path, base_dir=base_dir)
-    command = ["git", "-C", str(repo_root), "worktree", "add", "-b", resolved_branch, str(resolved_path), from_ref]
-    base_payload = {
-        "schema_version": WORKTREE_PREPARE_SCHEMA_VERSION,
-        "repo_root": str(repo_root),
-        "branch": resolved_branch,
-        "worktree_path": str(resolved_path),
-        "from_ref": from_ref,
-        "source_dirty": source_dirty,
-        "command": command,
-        "claim_boundary": WORKTREE_CLAIM_BOUNDARY,
-        "runtime_observation_followup": RUNTIME_OBSERVATION_FOLLOWUP,
-    }
-    if dry_run:
-        return {
-            **base_payload,
-            "status": "dry_run",
-            "observed": False,
-            "created": False,
-            "evidence_refs": [],
-            "next_action": "rerun_without_dry_run_to_create_worktree",
-        }
-    if resolved_path.exists():
-        return _blocked_result(
-            paths,
-            repo_root=repo_root,
-            task=task,
-            branch=resolved_branch,
-            worktree_path=resolved_path,
-            base_dir=base_dir,
-            from_ref=from_ref,
-            reason="path_exists",
-            message=f"Worktree path already exists: {resolved_path}",
-        )
-
-    completed = _git(repo_root, "worktree", "add", "-b", resolved_branch, str(resolved_path), from_ref, check=False)
-    if completed.returncode != 0:
-        return {
-            **base_payload,
-            "status": "blocked",
-            "observed": False,
-            "created": False,
-            "reason": "git_worktree_add_failed",
-            "stderr": completed.stderr.strip(),
-            "stdout": completed.stdout.strip(),
-            "evidence_refs": [],
-            "next_action": "inspect_git_error_before_opening_executor",
-        }
-
-    evidence_refs = [f"git-worktree:{resolved_path}", f"git-branch:{resolved_branch}"]
-    record = {
-        **base_payload,
-        "status": "created",
-        "observed": True,
-        "created": True,
-        "evidence_refs": evidence_refs,
-        "stdout": completed.stdout.strip(),
-        "stderr": completed.stderr.strip(),
-        "recorded_at": utc_now(),
-        "next_action": "open_executor_in_worktree_or_record_runtime_observation",
-    }
-    _append_worktree_record(paths, _observation_record(record))
-    update_state(paths, {"last_worktree_prepare": record})
-    return record
 
 
 def list_worktree_records(paths: OmhPaths, *, limit: int = 20) -> tuple[list[dict[str, Any]], list[str]]:
@@ -143,42 +45,6 @@ def latest_observed_worktree_record(paths: OmhPaths, worktree_path: str | Path) 
         ):
             return record
     return {}
-
-
-def _blocked_result(
-    paths: OmhPaths,
-    *,
-    repo_root: Path,
-    task: str,
-    branch: str,
-    worktree_path: str | Path | None,
-    base_dir: str | Path,
-    from_ref: str,
-    reason: str,
-    message: str,
-) -> dict[str, Any]:
-    resolved_branch = _branch_name(branch, task)
-    resolved_path = _worktree_path(repo_root, resolved_branch, worktree_path=worktree_path, base_dir=base_dir)
-    record = {
-        "schema_version": WORKTREE_PREPARE_SCHEMA_VERSION,
-        "status": "blocked",
-        "observed": False,
-        "created": False,
-        "repo_root": str(repo_root),
-        "branch": resolved_branch,
-        "worktree_path": str(resolved_path),
-        "from_ref": from_ref,
-        "reason": reason,
-        "message": message,
-        "evidence_refs": [],
-        "recorded_at": utc_now(),
-        "claim_boundary": WORKTREE_CLAIM_BOUNDARY,
-        "runtime_observation_followup": RUNTIME_OBSERVATION_FOLLOWUP,
-        "next_action": "resolve_blocker_before_opening_executor",
-    }
-    _append_worktree_record(paths, _observation_record(record))
-    update_state(paths, {"last_worktree_prepare": record})
-    return record
 
 
 def _observation_record(result: dict[str, Any]) -> dict[str, Any]:
@@ -204,42 +70,3 @@ def _append_worktree_record(paths: OmhPaths, record: dict[str, Any]) -> None:
     ensure_file(paths.runtime_worktrees_path, private=True)
     with paths.runtime_worktrees_path.open("a", encoding="utf-8") as handle:
         handle.write(json.dumps(record, sort_keys=True) + "\n")
-
-
-def _repo_root(repo: str | Path) -> Path:
-    repo_path = expand_path(repo)
-    completed = _git(repo_path, "rev-parse", "--show-toplevel", check=False)
-    if completed.returncode != 0:
-        raise ValueError(f"not a Git worktree: {repo_path}")
-    return expand_path(completed.stdout.strip())
-
-
-def _branch_name(branch: str, task: str) -> str:
-    if branch.strip():
-        return branch.strip()
-    slug = re.sub(r"[^a-z0-9]+", "-", task.lower()).strip("-")[:42].strip("-")
-    stamp = utc_now().replace(":", "").replace("-", "").lower()
-    return f"omh/{slug or 'worktree'}-{stamp}"
-
-
-def _worktree_path(repo_root: Path, branch: str, *, worktree_path: str | Path | None, base_dir: str | Path) -> Path:
-    if worktree_path:
-        return expand_path(worktree_path)
-    base = Path(base_dir)
-    if not base.is_absolute():
-        base = repo_root / base
-    safe_branch = re.sub(r"[^a-zA-Z0-9._-]+", "-", branch).strip("-") or "worktree"
-    return expand_path(base / safe_branch)
-
-
-def _git(cwd: Path, *args: str, check: bool) -> subprocess.CompletedProcess[str]:
-    completed = subprocess.run(
-        ["git", "-C", str(cwd), *args],
-        check=False,
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
-    if check and completed.returncode != 0:
-        raise ValueError(completed.stderr.strip() or completed.stdout.strip() or "git command failed")
-    return completed

--- a/src/commands/main.py
+++ b/src/commands/main.py
@@ -175,7 +175,7 @@ from .visual import _add_visual_commands, cmd_visual_observe, cmd_visual_prompt_
 from .adapter_quality import _add_adapter_quality_commands
 from .quality_evidence import _add_quality_evidence_commands
 from .web_qa import _add_web_qa_commands, cmd_web_qa_observe_capture, cmd_web_qa_package, cmd_web_qa_record_verdict
-from .worktree import cmd_worktree_bind, cmd_worktree_list, cmd_worktree_prepare, _add_worktree_commands
+from .worktree import cmd_worktree_bind, cmd_worktree_list, _add_worktree_commands
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -221,7 +221,7 @@ def build_parser() -> argparse.ArgumentParser:
             "  omh materials list\n"
             "  omh img-summary prompt-card --kind github_pr --visual-format auto --section summary:What_changed:Safer_setup_copy\n"
             "  omh img-summary prompt-card --kind report --aspect-ratio long_scroll --section summary:Executive_summary:Weekly_metrics_changed\n"
-            "  omh worktree prepare --repo . --task \"risky refactor\" --dry-run\n"
+            "  omh worktree list\n"
             "  omh worktree bind --path .worktrees/risky-refactor --executor codex --session <session-id>\n"
             "  omh runtime status\n"
             "  omh runtime team-readiness\n\n"
@@ -340,7 +340,7 @@ Useful operator commands:
   omh ops list           List local operations artifacts
   omh materials list     List material-processing artifacts
   omh img-summary prompt-card Prepare image-generation-ready summary cards
-  omh worktree prepare --repo . --task "risky refactor" --dry-run
+  omh worktree list      List observed worktree isolation records
   omh worktree bind --path .worktrees/risky-refactor --executor codex --session <session-id>
   omh runtime status     Show local evidence artifacts
 

--- a/src/commands/worktree.py
+++ b/src/commands/worktree.py
@@ -4,28 +4,9 @@ import argparse
 
 from ..executors import CODING_EXECUTOR_TARGETS
 from ..installer import OmhError
-from ..worktree_creator import list_worktree_records, prepare_git_worktree
+from ..worktree_creator import list_worktree_records
 from ..wrapper.worktree_binding import build_worktree_executor_binding
 from .common import _paths, _print_json
-
-
-def cmd_worktree_prepare(args: argparse.Namespace) -> int:
-    try:
-        payload = prepare_git_worktree(
-            _paths(args),
-            repo=args.repo,
-            task=args.task or "",
-            branch=args.branch or "",
-            worktree_path=args.path,
-            base_dir=args.base_dir,
-            from_ref=args.from_ref,
-            dry_run=args.dry_run,
-            allow_dirty_source=args.allow_dirty_source,
-        )
-    except ValueError as exc:
-        raise OmhError(str(exc)) from exc
-    _print_json({"worktree": payload})
-    return 1 if payload["status"] == "blocked" else 0
 
 
 def cmd_worktree_list(args: argparse.Namespace) -> int:
@@ -64,28 +45,13 @@ def cmd_worktree_bind(args: argparse.Namespace) -> int:
 
 
 def _add_worktree_commands(sub) -> None:
-    worktree = sub.add_parser("worktree", help="Prepare opt-in Git worktrees for isolated coding handoffs.")
+    worktree = sub.add_parser(
+        "worktree",
+        help="Observe worktree isolation evidence and bind coding handoffs (creation is deferred to native Hermes/Git tooling).",
+    )
     worktree_sub = worktree.add_subparsers(dest="worktree_command", required=True)
 
-    prepare = worktree_sub.add_parser(
-        "prepare",
-        help="Create an explicit Git worktree and record local workspace-isolation evidence.",
-    )
-    prepare.add_argument("--repo", required=True, help="Existing Git repository/worktree to isolate from.")
-    prepare.add_argument("--task", default="", help="Short task label used for the default branch name.")
-    prepare.add_argument("--branch", default="", help="Branch name for the new worktree. Defaults to omh/<task>-<timestamp>.")
-    prepare.add_argument("--path", default=None, help="Absolute or relative destination path for the new worktree.")
-    prepare.add_argument("--base-dir", default=".worktrees", help="Default worktree parent when --path is omitted.")
-    prepare.add_argument("--from-ref", default="HEAD", help="Starting ref for git worktree add.")
-    prepare.add_argument("--dry-run", action="store_true", help="Show the git worktree command without writing files.")
-    prepare.add_argument(
-        "--allow-dirty-source",
-        action="store_true",
-        help="Allow creating from a source worktree with uncommitted changes; dirty changes are not copied.",
-    )
-    prepare.set_defaults(func=cmd_worktree_prepare)
-
-    listing = worktree_sub.add_parser("list", help="List recent OMH worktree preparation records.")
+    listing = worktree_sub.add_parser("list", help="List recent observed OMH worktree records.")
     listing.add_argument("--limit", type=int, default=20)
     listing.set_defaults(func=cmd_worktree_list)
 

--- a/src/maintenance/probe.py
+++ b/src/maintenance/probe.py
@@ -152,11 +152,11 @@ def _worktree_creator_capability() -> Capability:
     return Capability(
         "worktree_creator",
         "available",
-        "omh worktree prepare; omh worktree list; omh worktree bind",
+        "omh worktree list; omh worktree bind",
         (
-            "OMH can explicitly create local Git worktrees, record omh_worktree_observation/v1 "
-            "workspace-isolation evidence, and return wrapper binding recipes for opening or attaching "
-            "the selected coding agent without launching it"
+            "OMH observes worktree isolation, records omh_worktree_observation/v1 workspace-isolation "
+            "evidence, and returns wrapper binding recipes for opening or attaching the selected coding "
+            "agent without launching it; worktree creation is deferred to native Hermes/Git tooling"
         ),
     )
 

--- a/src/quality/parity.py
+++ b/src/quality/parity.py
@@ -102,11 +102,11 @@ PARITY_CAPABILITIES: tuple[ParityCapability, ...] = (
         id="worktree_isolation",
         title="Worktree and project-session isolation",
         common_pattern="Use isolated workspaces so parallel agents can work without stepping on each other's files.",
-        omh_surface="`worktree_session_isolation/v1` plans inside coding handoffs, wrapper Prepare worktree actions, `omh worktree prepare/list/bind`, executor-session status cards, loop queue metadata, and runtime observations for worktree creation.",
+        omh_surface="`worktree_session_isolation/v1` plans inside coding handoffs, wrapper Prepare worktree actions, `omh worktree list/bind`, executor-session status cards, loop queue metadata, and runtime observations for worktree creation.",
         status="available",
         evidence=("src/coding/isolation.py", "src/coding/worktree_creator.py", "src/commands/worktree.py", "src/wrapper/executor_sessions.py", "tests/test_worktree_creator.py"),
-        missing_piece="OMH can explicitly create a local Git worktree and return binding recipes, but it does not auto-launch executors or claim host agent sessions without wrapper/runtime evidence.",
-        v1_decision="Make worktree mutation explicit and opt-in: the wrapper may show Prepare worktree, create it through the backend, then bind the selected coding agent with a recipe.",
+        missing_piece="OMH observes worktree isolation and returns binding recipes, but it defers worktree creation to native Hermes/Git tooling and does not auto-launch executors or claim host agent sessions without wrapper/runtime evidence.",
+        v1_decision="Defer worktree creation to Hermes-native tooling (Kanban worktree-per-task, Desktop Projects) or git: the wrapper may show Prepare worktree guidance, then bind the selected coding agent to the resulting worktree with a recipe.",
         user_value="Teams see when same workspace is acceptable, when an isolated worktree is recommended, and how to open or attach the chosen coding agent from that worktree.",
         claim_boundary=(
             "A worktree plan is not a created worktree; an OMH-created worktree is "

--- a/src/workflows/hermes_readiness_catalog.py
+++ b/src/workflows/hermes_readiness_catalog.py
@@ -306,7 +306,7 @@ def omh_reinforcement() -> list[ReinforcementSurface]:
                 "isolated subagents, branch sessions, coding executor handoffs, delegate_task background "
                 "subagents, kanban.db durable multi-agent board (worktree-per-task, per-task model overrides)"
             ),
-            "omh_commands": ["omh runtime team-readiness", "omh coding delegate", "omh worktree prepare"],
+            "omh_commands": ["omh runtime team-readiness", "omh coding delegate", "omh worktree bind"],
             "mapping_state": "mapped",
             "claim_boundary": boundary,
         },

--- a/src/wrapper/worktree_binding.py
+++ b/src/wrapper/worktree_binding.py
@@ -202,7 +202,8 @@ def _binding_actions(
     preferred_command_template_id: str,
 ) -> list[dict[str, Any]]:
     disabled_reason = (
-        "Worktree path is missing; run omh worktree prepare first."
+        "Worktree path is missing; prepare it with your native tooling "
+        "(Hermes Kanban worktree-per-task, Desktop Projects, or `git worktree add`) first."
         if status == "blocked_missing_worktree"
         else ""
     )

--- a/tests/test_worktree_creator.py
+++ b/tests/test_worktree_creator.py
@@ -1,144 +1,97 @@
 from __future__ import annotations
 
 import json
-import subprocess
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from _cli_harness import run_cli
 
+from omh.commands.main import build_parser
+from omh.paths import expand_path, resolve_paths
+from omh.coding.worktree_creator import _append_worktree_record, _observation_record
 
-class WorktreeCreatorTests(unittest.TestCase):
-    def test_worktree_prepare_dry_run_does_not_create_path(self) -> None:
+
+def _seed_observed_worktree(home: Path, target: Path, *, branch: str = "omh/seeded") -> None:
+    """Record an observed worktree in the local ledger without OMH creating it.
+
+    Worktree creation is deferred to native Hermes/Git tooling; tests seed the
+    observation ledger directly through the retained observation helpers so the
+    binding and listing surfaces have observed evidence to read.
+    """
+
+    target.mkdir(parents=True, exist_ok=True)
+    resolved = str(expand_path(target))
+    record = _observation_record(
+        {
+            "status": "created",
+            "observed": True,
+            "created": True,
+            "repo_root": str(expand_path(home)),
+            "branch": branch,
+            "worktree_path": resolved,
+            "from_ref": "HEAD",
+            "evidence_refs": [f"git-worktree:{resolved}", f"git-branch:{branch}"],
+        }
+    )
+    _append_worktree_record(resolve_paths(str(home)), record)
+
+
+class WorktreeParserTests(unittest.TestCase):
+    def test_worktree_prepare_subcommand_is_absent(self) -> None:
+        parser = build_parser()
+        with self.assertRaises(SystemExit):
+            parser.parse_args(["worktree", "prepare", "--repo", "."])
+
+    def test_worktree_list_and_bind_subcommands_remain(self) -> None:
+        parser = build_parser()
+        list_args = parser.parse_args(["worktree", "list"])
+        self.assertEqual(list_args.worktree_command, "list")
+        bind_args = parser.parse_args(
+            ["worktree", "bind", "--path", ".worktrees/x", "--executor", "codex"]
+        )
+        self.assertEqual(bind_args.worktree_command, "bind")
+
+    def test_prepare_git_worktree_is_not_importable(self) -> None:
+        import omh.worktree_creator as worktree_creator
+
+        self.assertFalse(hasattr(worktree_creator, "prepare_git_worktree"))
+
+    def test_no_source_module_imports_prepare_git_worktree(self) -> None:
+        src_root = Path(__file__).resolve().parents[1] / "src"
+        offenders = [
+            str(path.relative_to(src_root))
+            for path in src_root.rglob("*.py")
+            if "prepare_git_worktree" in path.read_text(encoding="utf-8")
+        ]
+        self.assertEqual(offenders, [])
+
+
+class WorktreeObservationTests(unittest.TestCase):
+    def test_worktree_list_returns_observed_records(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)
-            repo = _init_repo(root / "repo")
-            target = root / "worktrees" / "dry"
-
-            status, stdout, stderr = run_cli(
-                [
-                    "--omh-home",
-                    str(root / ".omh"),
-                    "worktree",
-                    "prepare",
-                    "--repo",
-                    str(repo),
-                    "--task",
-                    "risky refactor",
-                    "--path",
-                    str(target),
-                    "--dry-run",
-                ]
-            )
-
-            self.assertEqual(stderr, "")
-            self.assertEqual(status, 0)
-            payload = json.loads(stdout)["worktree"]
-            self.assertEqual(payload["schema_version"], "omh_worktree_prepare/v1")
-            self.assertEqual(payload["status"], "dry_run")
-            self.assertFalse(payload["observed"])
-            self.assertFalse(target.exists())
-            self.assertIn("git", payload["command"][0])
-            self.assertEqual(payload["runtime_observation_followup"]["event_type"], "worktree_creation")
-
-    def test_worktree_prepare_creates_git_worktree_and_records_ledger(self) -> None:
-        with TemporaryDirectory() as tmp:
-            root = Path(tmp)
-            repo = _init_repo(root / "repo")
-            target = root / "worktrees" / "risky"
             home = root / ".omh"
-
-            status, stdout, stderr = run_cli(
-                [
-                    "--omh-home",
-                    str(home),
-                    "worktree",
-                    "prepare",
-                    "--repo",
-                    str(repo),
-                    "--task",
-                    "risky refactor",
-                    "--branch",
-                    "omh/risky-refactor-test",
-                    "--path",
-                    str(target),
-                ]
-            )
-
-            self.assertEqual(stderr, "")
-            self.assertEqual(status, 0, stdout)
-            payload = json.loads(stdout)["worktree"]
-            self.assertEqual(payload["status"], "created")
-            self.assertTrue(payload["observed"])
-            self.assertTrue(payload["created"])
-            self.assertTrue((target / ".git").exists() or (target / ".git").is_file())
-            self.assertIn(f"git-worktree:{target.resolve()}", payload["evidence_refs"])
-            self.assertIn("not executor dispatch", payload["claim_boundary"])
-            self.assertIn("omh runtime observe", payload["runtime_observation_followup"]["record_with"])
-            worktree_list = _git(repo, "worktree", "list", "--porcelain")
-            self.assertIn(str(target), worktree_list.stdout)
+            target = root / "worktrees" / "listed"
+            _seed_observed_worktree(home, target)
 
             status, stdout, stderr = run_cli(["--omh-home", str(home), "worktree", "list", "--limit", "1"])
+
             self.assertEqual(stderr, "")
             self.assertEqual(status, 0)
-            records = json.loads(stdout)["records"]
+            payload = json.loads(stdout)
+            self.assertEqual(payload["schema_version"], "omh_worktree_observations/v1")
+            records = payload["records"]
             self.assertEqual(records[0]["schema_version"], "omh_worktree_observation/v1")
             self.assertTrue(records[0]["created"])
-
-    def test_worktree_prepare_blocks_dirty_source_by_default(self) -> None:
-        with TemporaryDirectory() as tmp:
-            root = Path(tmp)
-            repo = _init_repo(root / "repo")
-            (repo / "dirty.txt").write_text("dirty\n", encoding="utf-8")
-
-            status, stdout, stderr = run_cli(
-                [
-                    "--omh-home",
-                    str(root / ".omh"),
-                    "worktree",
-                    "prepare",
-                    "--repo",
-                    str(repo),
-                    "--task",
-                    "risky refactor",
-                    "--path",
-                    str(root / "worktrees" / "blocked"),
-                ]
-            )
-
-            self.assertEqual(stderr, "")
-            self.assertEqual(status, 1)
-            payload = json.loads(stdout)["worktree"]
-            self.assertEqual(payload["status"], "blocked")
-            self.assertEqual(payload["reason"], "source_dirty")
-            self.assertFalse(payload["created"])
+            self.assertEqual(records[0]["worktree_path"], str(target.resolve()))
 
     def test_worktree_bind_builds_codex_launch_recipe_for_observed_worktree(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)
-            repo = _init_repo(root / "repo")
-            target = root / "worktrees" / "codex-bind"
             home = root / ".omh"
-
-            prepare_status, _, prepare_stderr = run_cli(
-                [
-                    "--omh-home",
-                    str(home),
-                    "worktree",
-                    "prepare",
-                    "--repo",
-                    str(repo),
-                    "--task",
-                    "codex binding",
-                    "--branch",
-                    "omh/codex-binding-test",
-                    "--path",
-                    str(target),
-                ]
-            )
-            self.assertEqual(prepare_stderr, "")
-            self.assertEqual(prepare_status, 0)
+            target = root / "worktrees" / "codex-bind"
+            _seed_observed_worktree(home, target, branch="omh/codex-binding-test")
 
             status, stdout, stderr = run_cli(
                 [
@@ -207,33 +160,15 @@ class WorktreeCreatorTests(unittest.TestCase):
             self.assertFalse(payload["worktree"]["exists"])
             self.assertFalse(payload["wrapper_actions"][0]["enabled"])
             self.assertEqual(payload["next_action"], "prepare_worktree_before_opening_executor")
+            self.assertIn("git worktree add", payload["wrapper_actions"][0]["disabled_reason"])
             self.assertIn("not proof of execution", payload["launch"]["claim_boundary"])
 
     def test_worktree_bind_runtime_profile_adds_runtime_observation_recipe(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)
-            repo = _init_repo(root / "repo")
-            target = root / "worktrees" / "runtime-bind"
             home = root / ".omh"
-
-            prepare_status, _, prepare_stderr = run_cli(
-                [
-                    "--omh-home",
-                    str(home),
-                    "worktree",
-                    "prepare",
-                    "--repo",
-                    str(repo),
-                    "--task",
-                    "runtime binding",
-                    "--branch",
-                    "omh/runtime-binding-test",
-                    "--path",
-                    str(target),
-                ]
-            )
-            self.assertEqual(prepare_stderr, "")
-            self.assertEqual(prepare_status, 0)
+            target = root / "worktrees" / "runtime-bind"
+            _seed_observed_worktree(home, target, branch="omh/runtime-binding-test")
 
             status, stdout, stderr = run_cli(
                 [
@@ -261,28 +196,6 @@ class WorktreeCreatorTests(unittest.TestCase):
             self.assertIn("omh runtime observe --session session-3", actions["record_worktree_runtime_observation"]["backend_command"])
             self.assertIn("--event worktree_creation", actions["record_worktree_runtime_observation"]["backend_command"])
             self.assertIn("prompt_only", str(payload["launch"]["resolved_command_templates"]))
-
-
-def _init_repo(path: Path) -> Path:
-    path.mkdir(parents=True)
-    _git(path, "init")
-    (path / "README.md").write_text("# temp\n", encoding="utf-8")
-    _git(path, "add", "README.md")
-    _git(path, "-c", "user.name=OMH Test", "-c", "user.email=omh@example.com", "commit", "-m", "init")
-    return path
-
-
-def _git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
-    completed = subprocess.run(
-        ["git", "-C", str(cwd), *args],
-        check=False,
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
-    if completed.returncode != 0:
-        raise AssertionError(completed.stderr or completed.stdout)
-    return completed
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What & Why

Upstream Hermes now manages git worktrees natively — Kanban worktree-per-task (v0.15.0) and Desktop Projects git-worktree management (v0.18.0) — and OMH's own docs already conceded the collision risk ("it can collide with a worktree Hermes's own Kanban manages"). OMH's worktree **creation** layer could only ever reach `prepared_not_observed`: it advised but could not detect or prevent anything, while duplicating upstream-owned behavior.

This PR surgically retires creation while keeping everything that still earns its place: worktree **observation** reads, session **binding** (`worktree_session_isolation/v1`, which coding handoffs depend on per DIRECTION Rule 4), and the `prepare_worktree` **action vocabulary** (hard-required by the records validator and executor-session status cards — its retirement is a coordinated P2 follow-up recorded in the commit body).

## What changed (13 files, +140 / −421)

- **Deleted** from `src/coding/worktree_creator.py`: `prepare_git_worktree` + creation-only helpers (`_blocked_result`, `_repo_root`, `_branch_name`, `_worktree_path`, `_git`), dead constants and imports. The module is now observation-only (docstring updated).
- **Retained in place**: `list_worktree_records`, `latest_observed_worktree_record`, and the observation writers — live consumers in `src/commands/worktree.py` and `src/wrapper/worktree_binding.py` keep their import paths (module intentionally not renamed: a rename would force facade-shim and architecture-layout test churn for zero functional gain).
- **CLI**: `omh worktree prepare` removed (parser now rejects it); `omh worktree bind` / `list` retained. Help/epilog examples scrubbed.
- **Action vocabulary preserved everywhere**: `records.py` validator, `contract.py`, `roles.py`, `executor_sessions`, `skills/catalog.py`, `isolation.py` insertion — all untouched; `tests/test_wrapper_sessions.py` green and unmodified.
- **Guidance strings** that literally said "run omh worktree prepare" now point to native tooling (Hermes Kanban/Desktop Projects or `git worktree add`) while keeping the action token identical.
- **Docs** state the defer-to-native posture: ARCHITECTURE, CAPABILITIES, INSTALLATION, MULTI_AGENT_OPERATIONS, PARITY.
- **Tests**: creation tests removed; bind/list re-seeded through observation helpers; new guards assert `prepare` is absent from the parser and `prepare_git_worktree` is unimportable with zero remaining imports.

## Verification (observed)

- Full suite: 1446 tests OK (1 pre-existing skip); `tests/test_wrapper_sessions.py` green unmodified
- `compileall` clean; `omh.cli docs workflows --check` ok; `git diff --check` clean

## Risks / Follow-ups

- `omh worktree prepare` is a user-facing CLI removal — intentional capability boundary, documented rather than shimmed (DIRECTION treats removal as an exceptional maintenance path).
- `prepare_worktree` action-vocabulary retirement remains a coordinated P2 follow-up across ~8 executor-session sites + roles + catalog + the locking test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLULEvSNhQg48Ay49dEoaT
