### PR TITLE
Surface goal-quality coaching in chat when a goal has no success criteria

### DIFF
--- a/examples/wrapper-golden/goal-quality-coaching.json
+++ b/examples/wrapper-golden/goal-quality-coaching.json
@@ -1,0 +1,36 @@
+{
+  "schema_version": "goal_quality_coaching_golden_examples/v1",
+  "description": "Plain-language coaching card shown when a goal-classified chat message has no stated success/acceptance criteria. Kept in a dedicated file (not status-ladder.json) because status-ladder.json's test asserts an exact scenario set.",
+  "scenarios": [
+    {
+      "scenario": "goal_without_success_criteria",
+      "source": "slack",
+      "message": "improve the onboarding experience",
+      "expected_goal_quality_coaching_card": {
+        "schema_version": "goal_quality_coaching_card/v1",
+        "kind": "goal_quality_coaching",
+        "headline": "This goal does not have a finish line yet.",
+        "next_action": "state_goal_success_criteria"
+      },
+      "claim_boundary": "This is coaching copy about stating success criteria; it is not a goal ledger, completion gate, or execution evidence.",
+      "not_evidence": [
+        "goal ledger",
+        "completion gate",
+        "acceptance criteria satisfied",
+        "goal completion"
+      ]
+    },
+    {
+      "scenario": "goal_with_success_criteria_has_no_coaching_card",
+      "source": "slack",
+      "message": "improve the onboarding experience. done when new users complete signup in under 2 minutes.",
+      "expected_goal_quality_coaching_card": null
+    },
+    {
+      "scenario": "non_goal_chat_has_no_coaching_card",
+      "source": "slack",
+      "message": "please fix the typo in README",
+      "expected_goal_quality_coaching_card": null
+    }
+  ]
+}

--- a/src/workflows/goal_ledger.py
+++ b/src/workflows/goal_ledger.py
@@ -111,6 +111,50 @@ def _criteria_objects(criteria: Iterable[str | dict[str, Any]]) -> list[dict[str
     return result
 
 
+_STATED_CRITERIA_MARKER_RE = re.compile(
+    r"(?:done when|success (?:is|means)|complete when|completion means|"
+    r"acceptance criteria|success criteria|completion criteria|definition of done|"
+    r"완료\s*조건|성공\s*기준|완료\s*기준|끝나는\s*조건)"
+    r"\s*(?:is|means|[:\-])?\s*(.+)",
+    re.IGNORECASE,
+)
+
+
+def extract_stated_acceptance_criteria(text: str) -> list[str]:
+    """Pull user-stated success/acceptance-criteria phrases out of free chat text.
+
+    This only recognizes explicit "done when ...", "success is/means ...",
+    "acceptance criteria: ...", "완료 조건: ..." style markers. Other surfaces
+    (chat coaching, etc.) should call this -- or `goal_message_states_acceptance_criteria`
+    below -- instead of re-implementing what counts as a stated criterion.
+    """
+    candidates: list[str] = []
+    for line in re.split(r"[\r\n]+|(?<=[.!?])\s+", str(text)):
+        match = _STATED_CRITERIA_MARKER_RE.search(line)
+        if not match:
+            continue
+        candidate = match.group(1).strip(" .,:;-")
+        if candidate:
+            candidates.append(candidate)
+    return candidates
+
+
+def goal_message_states_acceptance_criteria(text: str) -> bool:
+    """True when free chat text already states at least one valid acceptance criterion.
+
+    Reuses `_criteria_objects` -- the same validation goal ledgers rely on --
+    so "what counts as a criterion" has exactly one definition in this codebase.
+    """
+    candidates = extract_stated_acceptance_criteria(text)
+    if not candidates:
+        return False
+    try:
+        _criteria_objects(candidates)
+    except ValueError:
+        return False
+    return True
+
+
 def _evidence_refs(values: Iterable[str] | None) -> list[str]:
     return [_safe_summary(str(value), limit=320) for value in values or [] if str(value).strip()]
 

--- a/src/workflows/goal_quality_coaching.py
+++ b/src/workflows/goal_quality_coaching.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from .loopability import assess_loopability
+
+
+GOAL_QUALITY_COACHING_CARD_SCHEMA = "goal_quality_coaching_card/v1"
+_UPSTREAM_GOAL_DEFAULT_MAX_TURNS = 20
+_GOAL_CLASSIFIED_MIN_UNCLEAR_LENGTH = 12
+
+
+def is_goal_classified_message(message: str) -> bool:
+    """True when this message reads as an open-ended goal rather than a bounded
+    direct task or a pure external-wait request.
+
+    Reuses `workflows.loopability.assess_loopability` -- the same classifier
+    OMH's own /loop routing already relies on to decide whether a chat message
+    is goal-shaped -- instead of re-implementing goal detection here. The
+    ambiguous "no signal at all" bucket (loopability needs_reframe with
+    goal_kind project) is intentionally excluded to avoid flagging ordinary
+    short questions as goals.
+    """
+    text = str(message).strip()
+    if not text:
+        return False
+    try:
+        assessment = assess_loopability(text, expose_goal=False)
+    except ValueError:
+        return False
+    loopability = str(assessment.get("loopability", ""))
+    goal_kind = str(assessment.get("goal_kind", ""))
+    if loopability == "loopable":
+        return True
+    if loopability == "needs_reframe" and goal_kind == "ambition":
+        return True
+    if loopability == "needs_clarification" and goal_kind == "unclear":
+        return len(text) >= _GOAL_CLASSIFIED_MIN_UNCLEAR_LENGTH
+    return False

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -34,6 +34,8 @@ from ..skills.catalog import installable_skill_definitions, primary_harness_for_
 from ..setup_profiles import read_setup_profile
 from ..surfaces.evidence_copy import not_evidence_action_suffix, not_evidence_reply_suffix
 from ..visual_summary import image_generation_setup_fallback
+from ..workflows.goal_ledger import goal_message_states_acceptance_criteria
+from ..workflows.goal_quality_coaching import is_goal_classified_message
 from ..workflows.web_visual_qa_projection import build_prepared_web_visual_qa_chat_state
 from .hermes_runtime import (
     hermes_coding_team_body,
@@ -62,6 +64,7 @@ MESSENGER_RENDERING_SCHEMA_VERSION = "omh_messenger_rendering/v1"
 DELIVERY_OBLIGATION_SCHEMA_VERSION = "wrapper_delivery_obligation/v1"
 DELIVERY_OBLIGATION_TRIGGERS = ("handoff_ci_pass", "loop_iteration_complete")
 DELIVERY_OBLIGATION_STATE = "prepared_not_delivered"
+GOAL_QUALITY_COACHING_CARD_SCHEMA_VERSION = "goal_quality_coaching_card/v1"
 RENDER_PROFILE_LIMITED_MARKDOWN = "limited_markdown"
 RENDER_PROFILE_RICH_MARKDOWN = "rich_markdown"
 RENDER_PROFILES = (RENDER_PROFILE_LIMITED_MARKDOWN, RENDER_PROFILE_RICH_MARKDOWN)
@@ -107,6 +110,7 @@ VISIBLE_ACTIONS = (
     "assess_loopability",
     "convert_to_loop_goal",
     "route_direct_task",
+    "state_goal_success_criteria",
     "start_ultraprocess",
     "start_loop",
     "run_loop_tick",
@@ -3250,6 +3254,9 @@ def _build_chat_interaction_payload_uncached(
     if learning_candidate_card:
         base["learning_candidate_card"] = learning_candidate_card
         route_payload["learning_candidate_card"] = learning_candidate_card
+    goal_quality_coaching_card = build_goal_quality_coaching_card(message)
+    if goal_quality_coaching_card:
+        base["goal_quality_coaching_card"] = goal_quality_coaching_card
 
     if _is_omh_intro_question(message) and resolved_mode in {"route", "plan", "clarify"}:
         base["mode"] = "route"
@@ -5644,6 +5651,54 @@ def _base_interaction(
     return payload
 
 
+def build_goal_quality_coaching_card(message: str, *, locale: str | None = None) -> dict[str, object] | None:
+    """Build a plain-language coaching card for a goal-classified chat message that
+    has no stated success/acceptance criteria, or return None when coaching does
+    not apply.
+
+    Classification reuses `workflows.goal_quality_coaching.is_goal_classified_message`
+    (itself built on the same loopability classifier OMH's /loop routing uses) and
+    criteria detection reuses `workflows.goal_ledger.goal_message_states_acceptance_criteria`
+    (the same criteria validation goal ledgers rely on). Neither is re-implemented here.
+    """
+    if not is_goal_classified_message(message):
+        return None
+    if goal_message_states_acceptance_criteria(message):
+        return None
+    copy = chat_copy("goal_quality_coaching", locale=locale or detect_copy_locale(message))
+    return {
+        "schema_version": GOAL_QUALITY_COACHING_CARD_SCHEMA_VERSION,
+        "kind": "goal_quality_coaching",
+        "headline": copy.headline,
+        "body": copy.body,
+        "next_action": "state_goal_success_criteria",
+        "claim_boundary": (
+            "This is coaching copy about stating success criteria; it is not a goal ledger, "
+            "completion gate, or execution evidence."
+        ),
+    }
+
+
+def _chat_response_with_goal_quality_coaching(
+    response: dict[str, object], card: dict[str, object]
+) -> dict[str, object]:
+    updated = dict(response)
+    state = dict(_nested(updated, "state"))
+    state["goal_quality_coaching_card"] = card
+    updated["state"] = state
+    body = str(updated.get("body", ""))
+    coaching_body = str(card.get("body", ""))
+    if coaching_body and coaching_body not in body:
+        updated["body"] = f"{body} {coaching_body}".strip()
+    raw_actions = updated.get("actions", [])
+    actions = [action for action in raw_actions if isinstance(action, dict)] if isinstance(raw_actions, list) else []
+    action_ids = {str(action.get("id", "")) for action in actions}
+    if "state_goal_success_criteria" not in action_ids:
+        actions.append(_action("state_goal_success_criteria", "State success criteria", "secondary"))
+    updated["actions"] = actions
+    return updated
+
+
 def _finish_interaction(payload: dict[str, object], target_notice: dict[str, object] | None) -> dict[str, object]:
     if target_notice:
         payload["target_notice"] = target_notice
@@ -5655,6 +5710,9 @@ def _finish_interaction(payload: dict[str, object], target_notice: dict[str, obj
         response = _chat_response_with_route_explanation(response, _nested(payload, "route"))
         if target_notice:
             response = _chat_response_with_target_notice(response, target_notice)
+        goal_quality_coaching_card = payload.get("goal_quality_coaching_card")
+        if isinstance(goal_quality_coaching_card, dict):
+            response = _chat_response_with_goal_quality_coaching(response, goal_quality_coaching_card)
         agentic_playbook = payload.get("agentic_playbook")
         if isinstance(agentic_playbook, dict):
             response = chat_response_with_agentic_playbook(response, agentic_playbook)

--- a/src/wrapper/localized_copy.py
+++ b/src/wrapper/localized_copy.py
@@ -448,6 +448,27 @@ _CARD_COPY: dict[str, dict[str, ChatCopy]] = {
         "fr": ChatCopy(headline="Je dois comprendre l'objectif avant la route.", body="Dites en une phrase le résultat voulu et je choisirai le bon workflow."),
         "de": ChatCopy(headline="Vor dem Routing muss ich das Ziel verstehen.", body="Sag mir das gewünschte Ergebnis in einem Satz; ich wähle den passenden workflow."),
     },
+    "goal_quality_coaching": {
+        "en": ChatCopy(
+            headline="This goal does not have a finish line yet.",
+            body=(
+                "An open-ended goal like this has no completion test, so an automated completion "
+                "judge can keep going until it hits its turn ceiling (the default is 20 turns) "
+                "without ever confirming it is actually done. Tell me what \"done\" means -- for "
+                "example \"done when the tests pass\" or \"done when new users can sign up in under "
+                "a minute\" -- and I will use that as the success criteria."
+            ),
+        ),
+        "ko": ChatCopy(
+            headline="이 목표에는 아직 끝나는 기준이 없습니다.",
+            body=(
+                "이렇게 열린 목표는 완료를 판단할 기준이 없어서, 완료 여부를 자동으로 판단하는 "
+                "심사가 정해진 턴 수(기본값 20턴)까지 계속 반복될 수 있습니다. "
+                "\"테스트가 통과하면 완료\"처럼 \"완료\"가 무엇을 뜻하는지 알려주시면 "
+                "그것을 성공 기준으로 쓰겠습니다."
+            ),
+        ),
+    },
 }
 
 

--- a/tests/test_goal_coaching_chat.py
+++ b/tests/test_goal_coaching_chat.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+import unittest
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.wrapper.contract import build_chat_interaction_payload, build_goal_quality_coaching_card
+from omh.workflows import goal_quality_coaching
+from omh.workflows.goal_ledger import goal_message_states_acceptance_criteria
+
+
+GOAL_WITHOUT_CRITERIA = "improve the onboarding experience"
+GOAL_WITH_CRITERIA = (
+    "improve the onboarding experience. done when new users complete signup in under 2 minutes."
+)
+NON_GOAL_MESSAGE = "please fix the typo in README"
+KOREAN_GOAL_WITHOUT_CRITERIA = "온보딩을 개선해줘"
+
+GOLDEN_PATH = Path("examples/wrapper-golden/goal-quality-coaching.json")
+
+
+class GoalQualityCoachingChatTests(unittest.TestCase):
+    def test_criteria_absent_goal_message_shows_coaching_card(self) -> None:
+        payload = build_chat_interaction_payload(GOAL_WITHOUT_CRITERIA, source="slack")
+
+        card = payload.get("goal_quality_coaching_card")
+        self.assertIsInstance(card, dict)
+        self.assertEqual(card["schema_version"], "goal_quality_coaching_card/v1")
+        self.assertEqual(card["kind"], "goal_quality_coaching")
+        self.assertEqual(card["next_action"], "state_goal_success_criteria")
+        self.assertTrue(card["headline"])
+        self.assertTrue(card["body"])
+
+        state = payload["chat_response"]["state"]
+        self.assertEqual(state.get("goal_quality_coaching_card"), card)
+        self.assertIn(card["body"], payload["chat_response"]["body"])
+        action_ids = {action["id"] for action in payload["chat_response"]["actions"]}
+        self.assertIn("state_goal_success_criteria", action_ids)
+
+    def test_criteria_present_goal_has_no_coaching_card(self) -> None:
+        payload = build_chat_interaction_payload(GOAL_WITH_CRITERIA, source="slack")
+
+        self.assertNotIn("goal_quality_coaching_card", payload)
+        state = payload["chat_response"]["state"]
+        self.assertNotIn("goal_quality_coaching_card", state)
+
+    def test_non_goal_chat_has_no_coaching_card(self) -> None:
+        payload = build_chat_interaction_payload(NON_GOAL_MESSAGE, source="slack")
+
+        self.assertNotIn("goal_quality_coaching_card", payload)
+        state = payload["chat_response"]["state"]
+        self.assertNotIn("goal_quality_coaching_card", state)
+
+    def test_non_goal_question_has_no_coaching_card(self) -> None:
+        payload = build_chat_interaction_payload("what does OMH do?", source="slack")
+
+        self.assertNotIn("goal_quality_coaching_card", payload)
+
+    def test_korean_goal_without_criteria_shows_localized_coaching_card(self) -> None:
+        card = build_goal_quality_coaching_card(KOREAN_GOAL_WITHOUT_CRITERIA)
+
+        self.assertIsInstance(card, dict)
+        self.assertIn("목표", card["headline"])
+        self.assertIn("완료", card["body"])
+
+    def test_coaching_path_reuses_goal_ledger_criteria_validation_single_source(self) -> None:
+        # The coaching module must call into goal_ledger's shared criteria validation
+        # instead of re-implementing "what counts as a stated criterion".
+        source = Path("src/wrapper/contract.py").read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        imported_names = {
+            alias.asname or alias.name
+            for node in ast.walk(tree)
+            if isinstance(node, ast.ImportFrom)
+            for alias in node.names
+        }
+        self.assertIn("goal_message_states_acceptance_criteria", imported_names)
+
+        coaching_source = Path("src/workflows/goal_quality_coaching.py").read_text(encoding="utf-8")
+        # The classification module must not define its own criteria-list validator;
+        # it only decides whether a message is goal-classified.
+        self.assertNotIn("acceptance criterion", coaching_source)
+
+        ledger_source = Path("src/workflows/goal_ledger.py").read_text(encoding="utf-8")
+        self.assertIn("def goal_message_states_acceptance_criteria", ledger_source)
+        self.assertIn("_criteria_objects(candidates)", ledger_source)
+
+        # Sanity: the shared helper actually works the way both callers expect.
+        self.assertTrue(goal_message_states_acceptance_criteria("done when the tests pass"))
+        self.assertFalse(goal_message_states_acceptance_criteria("no criteria mentioned here"))
+
+    def test_coaching_card_body_is_plain_language_not_raw_json(self) -> None:
+        card = build_goal_quality_coaching_card(GOAL_WITHOUT_CRITERIA)
+        self.assertIsInstance(card, dict)
+        for field_name in ("headline", "body"):
+            text = card[field_name]
+            self.assertNotIn("{", text)
+            self.assertNotIn("}", text)
+            self.assertNotIn('"schema_version"', text)
+
+        payload = build_chat_interaction_payload(GOAL_WITHOUT_CRITERIA, source="slack")
+        body = payload["chat_response"]["body"]
+        self.assertNotIn("{", body)
+        self.assertNotIn("}", body)
+
+    def test_is_goal_classified_message_excludes_direct_tasks_and_external_wait(self) -> None:
+        self.assertFalse(goal_quality_coaching.is_goal_classified_message(NON_GOAL_MESSAGE))
+        self.assertFalse(goal_quality_coaching.is_goal_classified_message(""))
+        self.assertTrue(goal_quality_coaching.is_goal_classified_message(GOAL_WITHOUT_CRITERIA))
+
+    def test_golden_goal_quality_coaching_examples(self) -> None:
+        payload = json.loads(GOLDEN_PATH.read_text(encoding="utf-8"))
+        self.assertEqual(payload["schema_version"], "goal_quality_coaching_golden_examples/v1")
+
+        for item in payload["scenarios"]:
+            with self.subTest(item["scenario"]):
+                live = build_chat_interaction_payload(item["message"], source=item["source"])
+                expected_card = item["expected_goal_quality_coaching_card"]
+                live_card = live.get("goal_quality_coaching_card")
+                if expected_card is None:
+                    self.assertIsNone(live_card)
+                    continue
+                self.assertIsInstance(live_card, dict)
+                self.assertEqual(live_card["schema_version"], expected_card["schema_version"])
+                self.assertEqual(live_card["kind"], expected_card["kind"])
+                self.assertEqual(live_card["headline"], expected_card["headline"])
+                self.assertEqual(live_card["next_action"], expected_card["next_action"])
+                self.assertEqual(live_card["claim_boundary"], item["claim_boundary"])
+                serialized = json.dumps(item).lower()
+                for phrase in item.get("not_evidence", []):
+                    self.assertNotIn(phrase.lower(), live_card["body"].lower())
+                self.assertNotIn("token", serialized)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What & Why

Vague goals loop forever: upstream Hermes /goal runs until an LLM judge deems it done (goals.max_turns default 20), so a goal with no completion test never converges — one of the most common real-user failure modes. OMH already has strong success-criteria machinery in `src/workflows/goal_ledger.py`, but it was only reachable through `omh goal` JSON output — an agent surface the messenger user never sees.

This PR promotes that machinery to the chat surface: when a goal-shaped chat message states no acceptance criteria, the chat response includes a plain-language **goal-quality coaching card** asking the user to define "done".

## What changed

- `src/workflows/goal_ledger.py`: `extract_stated_acceptance_criteria()` / `goal_message_states_acceptance_criteria()` — detects "done when…", "success means…", "acceptance criteria:", Korean "완료 조건"/"성공 기준" phrasing in free text, validated through the existing `_criteria_objects()` helper (single source of truth; no duplicated criteria logic — locked by an AST-based test).
- `src/workflows/goal_quality_coaching.py` (new): goal classification reuses the existing `/loop` loopability classifier (`assess_loopability`), restricted to the loopable / ambition / long-unclear buckets and deliberately excluding the no-signal catch-all — so plain questions and direct tasks never trigger the card.
- `src/wrapper/contract.py`: `goal_quality_coaching` card (schema-versioned) built once per message, merged additively into `chat_response.state` and body, with a `state_goal_success_criteria` action registered in `VISIBLE_ACTIONS`.
- `src/wrapper/localized_copy.py`: English + Korean copy (other locales fall back to English per existing convention). The copy names the concrete risk — an automated completion judge can run to its turn ceiling (default 20) without ever confirming done — and asks for a "done means X" statement, no JSON in the user-facing text.
- `examples/wrapper-golden/goal-quality-coaching.json`: dedicated golden file (adding to status-ladder.json would break its exact-set test).
- `tests/test_goal_coaching_chat.py`: 9 tests — criteria-absent triggers, criteria-present suppresses, non-goal chat suppresses (2 variants), Korean localization, single-source reuse, plain-language assertion, classifier boundaries, golden scenarios.

## Verification (observed)

- Full suite: 1453 tests OK (1 pre-existing skip)
- `compileall` clean; `omh.cli docs workflows --check` ok; diff check clean

## Risks / Follow-ups

- Trigger precision depends on the loopability classifier; the conservative bucket selection favors false negatives over false positives by design. Card copy is additive to the response body — no existing chat kind was replaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLULEvSNhQg48Ay49dEoaT
