### PR TITLE
Default omh setup to a 9-skill core profile; make the full 83-skill install an explicit, warned opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ hermes skills tap add rlaope/oh-my-hermes
 hermes skills install rlaope/oh-my-hermes/skills/oh-my-hermes --yes
 ```
 
+`omh setup` installs a **core** skill profile by default: the doctor health
+floor plus the chat/plan/status/handoff essentials, not every packaged skill.
+Pass `omh setup --full` to install the complete catalog instead; see
+[Skill Profiles: Core vs Full](docs/INSTALLATION.md#skill-profiles-core-vs-full)
+for the context-cost rationale.
+
 Most people only need three direct OMH commands:
 
 - `omh setup` to connect or repair OMH.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -43,6 +43,12 @@ First-run expectation:
 3. You restart or reload Hermes Agent.
 4. You ask Hermes normally, for example: `I want to safely add a feature to this repo.`
 
+By default, `omh setup` installs the **core** skill profile: the doctor health
+floor plus the chat/plan/status/handoff essentials a messenger-first user needs
+for a first session, not every packaged skill. Pass `--full` to install every
+skill in the catalog; see [Skill Profiles: Core vs Full](#skill-profiles-core-vs-full)
+for why the smaller default exists and how to opt in.
+
 You do not need to know or name a workflow. The quickstart card offers
 representative natural-language starters from the locally tested request corpus
 and tells the wrapper which workflow and next action each starter should expose.
@@ -1099,6 +1105,55 @@ omh doctor
 Then restart Hermes Agent.
 
 ## Install Options
+
+### Skill Profiles: Core vs Full
+
+`omh setup`, `omh install`, and `omh update` install one of two skill
+profiles:
+
+- **`core` (default).** Installs the doctor health floor (the router plus the
+  `doctor`, `skill`, `cancel`, and `agent-ops-review` operator skills OMH needs
+  to describe, diagnose, manage, and stop itself) plus the workflow skills a
+  messenger-first user needs for a first chat/plan/status/handoff session
+  (`plan` for planning and coding handoff, `gateway-intent-card` for chat
+  delivery/status-update policy, `executor-runtime-readiness` for handoff
+  readiness, and `ops-observability-card` for status questions). Everything
+  else in the catalog stays opt-in.
+- **`full`.** Installs every packaged skill (~89 skills, growing over time).
+  Pass `--full` to opt in:
+
+```sh
+omh setup --full
+omh install --full
+omh update --full
+```
+
+Every skill OMH installs is skill guidance that Hermes carries into its
+routing context on every turn, not just when that workflow is used. A `core`
+install keeps that per-turn context weight bounded to the essentials; a `full`
+install trades that weight for having every workflow's guidance available
+immediately, with no `full` -> `core` skill left unpresented. Choose `full`
+when a workspace already knows it will use the wider catalog (specialist
+review, research, or ops workflows beyond the messenger-first core); otherwise
+`core` is the smaller, faster default.
+
+Machine-readable install output makes this checkable: `install_skill_pack`
+always records `skill_profile` (`"core"` or `"full"`) in the install/setup
+result and in `~/.omh/manifest.json`, and a `full` install additionally
+includes a `context_cost_warning` (`omh_skill_profile_context_cost_warning/v1`)
+with the installed skill count, the core-profile skill count, and the extra
+skill count so a wrapper or CI check can flag an unintentional `full` install
+without parsing prose:
+
+```sh
+omh install --full --json | python3 -c 'import json,sys; print(json.load(sys.stdin)["context_cost_warning"])'
+```
+
+A `core` install still passes `omh doctor` because the core profile installs
+a superset of the doctor health-floor skills; `--full` never removes skills
+that a later `--force` reinstall does not also write, so switching from
+`full` back to a default `core` install does not delete previously installed
+skill files on disk.
 
 Record the optional MCP bridge preference during setup:
 

--- a/src/commands/setup.py
+++ b/src/commands/setup.py
@@ -99,7 +99,15 @@ def _install_result(args: argparse.Namespace) -> dict[str, object]:
     source = str(source_dir) if source_dir else "builtin"
     source_ref = _release_source_ref(args, release)
     previous_release = _previous_release_update_state(paths)
-    result = install_skill_pack(paths, source=source, source_dir=source_dir, force=args.force, dry_run=args.dry_run)
+    skill_profile = "full" if getattr(args, "full", False) else "core"
+    result = install_skill_pack(
+        paths,
+        source=source,
+        source_dir=source_dir,
+        force=args.force,
+        dry_run=args.dry_run,
+        profile=skill_profile,
+    )
     result.update(
         {
             "operation": operation,
@@ -2722,6 +2730,16 @@ def _add_common_install_options(p: argparse.ArgumentParser) -> None:
     p.add_argument("--language", default=None, help=f"Human output language for setup/install/update ({', '.join(LANGUAGE_CODES)}).")
     p.add_argument("--force", action="store_true")
     p.add_argument("--dry-run", action="store_true")
+    p.add_argument(
+        "--full",
+        action="store_true",
+        help=(
+            "Install every packaged skill instead of the smaller core default "
+            "(chat/plan/status/handoff essentials plus the doctor health floor); "
+            "the result records a context-cost warning because every extra skill "
+            "adds per-turn context weight."
+        ),
+    )
 
 
 def _add_top_level_commands(sub) -> None:

--- a/src/install/installer.py
+++ b/src/install/installer.py
@@ -11,7 +11,17 @@ from ..local_store import atomic_write_text, read_json_object_result
 from ..manifest import local_modifications, new_manifest, read_manifest, skill_records, write_manifest
 from ..paths import OmhPaths
 from ..profiles.team import TEAM_PROFILE_SCHEMA_VERSION
-from ..skill_pack import SkillReferenceTemplate, SkillTemplate, builtin_skill_reference_templates, builtin_skill_templates
+from ..skill_pack import (
+    CORE_PROFILE_SKILLS,
+    SkillReferenceTemplate,
+    SkillTemplate,
+    builtin_skill_reference_templates,
+    builtin_skill_templates,
+)
+
+SKILL_PROFILES = ("core", "full")
+DEFAULT_SKILL_PROFILE = "core"
+CONTEXT_COST_WARNING_SCHEMA_VERSION = "omh_skill_profile_context_cost_warning/v1"
 
 
 def _write_skill(skills_dir: Path, template: SkillTemplate, force: bool = False, managed: bool = False) -> None:
@@ -45,20 +55,42 @@ def install_skill_pack(
     source_dir: Path | None = None,
     force: bool = False,
     dry_run: bool = False,
+    profile: str = DEFAULT_SKILL_PROFILE,
 ) -> dict:
-    templates = convert_from_dir(source_dir) if source_dir else builtin_skill_templates()
+    if profile not in SKILL_PROFILES:
+        raise OmhError(f"unknown skill profile {profile!r}; choose one of {', '.join(SKILL_PROFILES)}")
+    all_templates = convert_from_dir(source_dir) if source_dir else builtin_skill_templates()
     reference_templates = [] if source_dir else builtin_skill_reference_templates()
+    # Profile filtering only applies to the packaged builtin catalog: an explicit
+    # `source_dir` is a caller-scoped skill set, not the curated core/full catalog,
+    # so every skill it names is installed regardless of `profile`.
+    if source_dir or profile == "full":
+        templates = all_templates
+    else:
+        templates = [template for template in all_templates if template.name in CORE_PROFILE_SKILLS]
+        reference_templates = [
+            template for template in reference_templates if template.skill_name in CORE_PROFILE_SKILLS
+        ]
     manifest = read_manifest(paths.manifest_path)
     modified = local_modifications(manifest, paths.skills_dir)
     if modified and not force:
         raise OmhError("local modifications detected; rerun with --force or resolve: " + ", ".join(modified))
+    context_cost_warning = (
+        _context_cost_warning(core_count=len(CORE_PROFILE_SKILLS), full_count=len(builtin_skill_templates()))
+        if profile == "full"
+        else None
+    )
     if dry_run:
-        return {
+        result = {
             "dry_run": True,
             "skills_dir": str(paths.skills_dir),
             "skills": [template.name for template in templates],
             "source": source,
+            "skill_profile": profile,
         }
+        if context_cost_warning is not None:
+            result["context_cost_warning"] = context_cost_warning
+        return result
     paths.skills_dir.mkdir(parents=True, exist_ok=True)
     managed = manifest is not None
     for template in templates:
@@ -67,8 +99,27 @@ def install_skill_pack(
         _write_skill_reference(paths.skills_dir, template, force=force, managed=managed)
     records = skill_records(paths.skills_dir, source)
     manifest_data = new_manifest(source, paths.skills_dir, records)
+    manifest_data["skill_profile"] = profile
+    if context_cost_warning is not None:
+        manifest_data["context_cost_warning"] = context_cost_warning
     write_manifest(paths.manifest_path, manifest_data)
     return manifest_data
+
+
+def _context_cost_warning(*, core_count: int, full_count: int) -> dict:
+    extra_count = max(full_count - core_count, 0)
+    return {
+        "schema_version": CONTEXT_COST_WARNING_SCHEMA_VERSION,
+        "profile": "full",
+        "installed_skill_count": full_count,
+        "core_profile_skill_count": core_count,
+        "extra_skill_count": extra_count,
+        "message": (
+            f"full profile installs all {full_count} packaged skills, {extra_count} more than the "
+            f"{core_count}-skill core default; every installed skill adds per-turn context weight to "
+            "every Hermes request, so prefer core unless this workspace genuinely needs the complete catalog."
+        ),
+    }
 
 
 def uninstall_skill_pack(

--- a/src/omh/skill_pack.py
+++ b/src/omh/skill_pack.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from .skills import (
+    CORE_PROFILE_SKILLS,
     CORE_SKILLS,
     DESCRIPTIONS,
     HarnessDefinition,
@@ -29,6 +30,7 @@ from .skills import (
 )
 
 __all__ = [
+    "CORE_PROFILE_SKILLS",
     "CORE_SKILLS",
     "DESCRIPTIONS",
     "HarnessDefinition",

--- a/src/skills/__init__.py
+++ b/src/skills/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from .catalog import (
+    CORE_PROFILE_SKILLS,
     CORE_SKILLS,
     DESCRIPTIONS,
     HarnessDefinition,
@@ -24,6 +25,7 @@ from .packaging import builtin_skill_reference_templates, builtin_skill_template
 from .render import SkillReferenceTemplate, SkillTemplate, router_skill, workflow_reference_payload, workflow_skill
 
 __all__ = [
+    "CORE_PROFILE_SKILLS",
     "CORE_SKILLS",
     "DESCRIPTIONS",
     "HarnessDefinition",

--- a/src/skills/catalog.py
+++ b/src/skills/catalog.py
@@ -10142,5 +10142,34 @@ def explicit_memory_context_skill_names() -> tuple[str, ...]:
     return _EXPLICIT_MEMORY_CONTEXT_SKILLS
 
 
-CORE_SKILLS = list(installable_skill_names())
+# The doctor health floor: skills OMH needs on disk to describe, diagnose, manage,
+# and stop itself. This is intentionally small and independent of
+# `installable_skill_names()` (the full catalog) so a health check does not force
+# every packaged skill onto disk just to pass `omh doctor`.
+CORE_SKILLS = (
+    "oh-my-hermes",
+    "doctor",
+    "skill",
+    "cancel",
+    "agent-ops-review",
+)
+
+# The default install profile: the doctor health floor above, plus the workflow
+# skills a messenger-first user needs for the chat/plan/status/handoff flows that
+# make up a first session (planning with a coding handoff, gateway status-update
+# and delivery policy for chat channels, executor runtime readiness before a
+# handoff, and an ops observability card for status questions). Everything else
+# in the catalog is opt-in via a `full` install so a default install does not add
+# every packaged skill's context weight to every turn.
+CORE_PROFILE_SKILLS = tuple(
+    dict.fromkeys(
+        CORE_SKILLS
+        + (
+            "plan",
+            "gateway-intent-card",
+            "executor-runtime-readiness",
+            "ops-observability-card",
+        )
+    )
+)
 DESCRIPTIONS = {definition.name: definition.description for definition in _DEFINITIONS}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,7 +21,7 @@ from omh.config_adapter import ensure_external_dir, external_dirs
 from omh.maintenance.doctor import _skill_shadowing_check
 from omh.paths import resolve_paths
 from omh.routing.intent import classify_omh_quality_intent
-from omh.skill_pack import builtin_skill_reference_templates, builtin_skill_templates
+from omh.skill_pack import CORE_PROFILE_SKILLS, builtin_skill_reference_templates, builtin_skill_templates
 from omh.skills.catalog import builtin_harnesses, installable_skill_names
 from omh.wrapper.localized_copy import detect_copy_locale
 from omh.wrapper_sessions import (
@@ -2087,7 +2087,7 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
             root = Path(tmp)
             base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
 
-            status, stdout, stderr = run_cli(base + ["install"], output_json=False)
+            status, stdout, stderr = run_cli(base + ["install", "--full"], output_json=False)
             self.assertEqual(status, 0, stderr)
 
             status, stdout, stderr = run_cli(base + ["list"], output_json=False)
@@ -2120,7 +2120,7 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
             root = Path(tmp)
             base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
 
-            status, _, stderr = run_cli(base + ["setup", "--with-plugin"], output_json=False)
+            status, _, stderr = run_cli(base + ["setup", "--with-plugin", "--full"], output_json=False)
             self.assertEqual(status, 0, stderr)
 
             status, stdout, stderr = run_cli(base + ["probe", "--parity", "--json"], output_json=False)
@@ -2187,7 +2187,7 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
             self.assertIn("runtime_observation/v1", payload["claim_boundary"])
             self.assertIn("omh setup", " ".join(payload["next_actions"]))
 
-            status, _, stderr = run_cli(base + ["setup", "--with-plugin"], output_json=False)
+            status, _, stderr = run_cli(base + ["setup", "--with-plugin", "--full"], output_json=False)
             self.assertEqual(status, 0, stderr)
 
             status, stdout, stderr = run_cli(base + ["runtime", "team-readiness"], output_json=False)
@@ -2610,7 +2610,7 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
             self.assertEqual(status, 0, stderr)
             self.assertEqual(stderr, "")
             self.assertIn("刷新 OMH 工作流包", stdout)
-            self.assertIn(f"已准备 {len(builtin_skill_templates())} 个工作流", stdout)
+            self.assertIn(f"已准备 {len(CORE_PROFILE_SKILLS)} 个工作流", stdout)
             self.assertIn("OMH install 已完成。", stdout)
 
     def test_setup_reports_status_helper_conflict_in_plain_language(self) -> None:
@@ -2660,7 +2660,7 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
             self.assertEqual(stderr, "")
             self.assertIn("Installing OMH workflows", stdout)
             self.assertIn("OMH install complete.", stdout)
-            self.assertIn(f"OMH workflows: {len(builtin_skill_templates())} ready", stdout)
+            self.assertIn(f"OMH workflows: {len(CORE_PROFILE_SKILLS)} ready", stdout)
             self.assertIn("Run `omh setup`", stdout)
             with self.assertRaises(json.JSONDecodeError):
                 json.loads(stdout)
@@ -2711,7 +2711,7 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
             self.assertEqual(state["last_update"]["operation"], "update")
             self.assertEqual(state["last_update"]["command_package"]["status"], "not_updated")
             self.assertEqual(state["last_update"]["release_update"]["status"], "refreshed")
-            self.assertEqual(state["last_update"]["managed_skills"]["count"], len(builtin_skill_templates()))
+            self.assertEqual(state["last_update"]["managed_skills"]["count"], len(CORE_PROFILE_SKILLS))
 
     def test_update_self_update_reenters_with_command_package_marker(self) -> None:
         args = Namespace(json=True)
@@ -9617,8 +9617,8 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
             manifest = json.loads((omh_home / "manifest.json").read_text(encoding="utf-8"))
             names = {skill["name"] for skill in manifest["skills"]}
             self.assertIn("oh-my-hermes", names)
-            self.assertIn("ralph", names)
-            self.assertIn("ultragoal", names)
+            self.assertIn("plan", names)
+            self.assertIn("doctor", names)
             self.assertIn(str(omh_home / "skills"), (hermes_home / "config.yaml").read_text(encoding="utf-8"))
             state = json.loads((omh_home / "runtime" / "state.json").read_text(encoding="utf-8"))
             self.assertEqual(state["installed_skills"], len(manifest["skills"]))
@@ -10352,12 +10352,12 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
             omh_home = root / ".omh"
             hermes_home = root / ".hermes"
 
-            self.assertEqual(run_cli(["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "install"])[0], 0)
-            self.assertEqual(run_cli(["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "install"])[0], 0)
+            self.assertEqual(run_cli(["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "install", "--full"])[0], 0)
+            self.assertEqual(run_cli(["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "install", "--full"])[0], 0)
             skill_file = omh_home / "skills" / "ralph" / "SKILL.md"
             skill_file.write_text(skill_file.read_text(encoding="utf-8") + "\nlocal edit\n", encoding="utf-8")
 
-            status, _, stderr = run_cli(["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "install"])
+            status, _, stderr = run_cli(["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "install", "--full"])
             self.assertEqual(status, 2)
             self.assertIn("local modifications detected", stderr)
 
@@ -10368,7 +10368,7 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
             self.assertEqual(checks["local_modifications"]["severity"], "blocking")
             self.assertIn("omh install --force", checks["local_modifications"]["next_action"])
             self.assertIn("ralph/SKILL.md", checks["local_modifications"]["message"])
-            self.assertEqual(run_cli(["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "install", "--force"])[0], 0)
+            self.assertEqual(run_cli(["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "install", "--full", "--force"])[0], 0)
 
     def test_doctor_reports_wrong_runtime_home(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_installer_skill_profile.py
+++ b/tests/test_installer_skill_profile.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+from unittest.mock import patch
+
+from _local_package import load_local_package
+
+load_local_package()
+
+from _cli_harness import run_cli
+from omh.installer import install_skill_pack
+from omh.maintenance.doctor import run_doctor
+from omh.paths import resolve_paths
+from omh.skill_pack import CORE_PROFILE_SKILLS, CORE_SKILLS, builtin_skill_templates
+
+
+class InstallerSkillProfileTests(unittest.TestCase):
+    def test_core_profile_is_a_strict_subset_of_full_and_covers_doctor_core_skills(self) -> None:
+        full_names = {template.name for template in builtin_skill_templates()}
+
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            result = install_skill_pack(paths, dry_run=True)
+
+        self.assertEqual(result["skill_profile"], "core")
+        installed_names = set(result["skills"])
+        self.assertLess(len(installed_names), len(full_names))
+        self.assertTrue(installed_names.issubset(full_names))
+        self.assertTrue(set(CORE_SKILLS).issubset(installed_names))
+        self.assertEqual(installed_names, set(CORE_PROFILE_SKILLS))
+        self.assertNotIn("context_cost_warning", result)
+
+    def test_full_profile_installs_everything_and_emits_context_cost_warning(self) -> None:
+        full_names = {template.name for template in builtin_skill_templates()}
+
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            result = install_skill_pack(paths, profile="full", dry_run=True)
+
+        self.assertEqual(result["skill_profile"], "full")
+        self.assertEqual(set(result["skills"]), full_names)
+        warning = result["context_cost_warning"]
+        self.assertEqual(warning["schema_version"], "omh_skill_profile_context_cost_warning/v1")
+        self.assertEqual(warning["profile"], "full")
+        self.assertEqual(warning["installed_skill_count"], len(full_names))
+        self.assertEqual(warning["core_profile_skill_count"], len(CORE_PROFILE_SKILLS))
+        self.assertEqual(warning["extra_skill_count"], len(full_names) - len(CORE_PROFILE_SKILLS))
+        self.assertIn("context weight", warning["message"])
+
+    def test_manifest_records_the_installed_profile(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+
+            core_manifest = install_skill_pack(paths)
+            self.assertEqual(core_manifest["skill_profile"], "core")
+            on_disk = json.loads(paths.manifest_path.read_text(encoding="utf-8"))
+            self.assertEqual(on_disk["skill_profile"], "core")
+            self.assertNotIn("context_cost_warning", on_disk)
+
+            full_manifest = install_skill_pack(paths, profile="full", force=True)
+            self.assertEqual(full_manifest["skill_profile"], "full")
+            self.assertIn("context_cost_warning", full_manifest)
+            on_disk = json.loads(paths.manifest_path.read_text(encoding="utf-8"))
+            self.assertEqual(on_disk["skill_profile"], "full")
+            self.assertIn("context_cost_warning", on_disk)
+
+    def test_unknown_profile_is_rejected(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            with self.assertRaises(Exception):
+                install_skill_pack(paths, profile="everything", dry_run=True)
+
+    def test_core_install_passes_doctors_skill_checks(self) -> None:
+        # Mirrors the CLI setup/doctor harness pattern used in test_cli.py: run a
+        # real `omh setup` (now defaulting to the core profile) and confirm
+        # `omh doctor` still reports every managed skill check as healthy.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            base = ["--omh-home", str(paths.omh_home), "--hermes-home", str(paths.hermes_home)]
+
+            with patch("omh.command_path.shutil.which", return_value="/usr/local/bin/omh"):
+                status, _stdout, stderr = run_cli(base + ["setup", "--no-interactive"], output_json=False)
+            self.assertEqual(status, 0, stderr)
+
+            checks = run_doctor(paths)
+            skill_checks = [check for check in checks if check.name.startswith("skill:")]
+            # Doctor only requires the small health-floor set (CORE_SKILLS); the
+            # core install profile installs a superset of it for messenger flows.
+            self.assertEqual(len(skill_checks), len(CORE_SKILLS))
+            self.assertTrue(all(check.ok for check in skill_checks), skill_checks)
+
+            with patch("omh.command_path.shutil.which", return_value="/usr/local/bin/omh"):
+                status, stdout, stderr = run_cli(base + ["doctor", "--json"], output_json=False)
+            self.assertEqual(status, 0, stderr)
+            payload = json.loads(stdout)
+            self.assertTrue(payload["ok"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What & Why

`omh setup` force-installed every builtin skill (~83) into Hermes. Every installed SKILL.md header adds per-turn context weight to every Hermes message and worsens skill routing — the harness itself was causing the "all skills loaded all the time" footgun that the audit flagged (and that the new `omh doctor` advisory lane reports on). Users had no leaner option and no cost signal.

This PR makes the default install a deliberate **core profile** and turns the full catalog into an explicit, warned opt-in.

## What changed

- **`CORE_SKILLS` was a pre-existing naming bug** — it was defined as `list(installable_skill_names())`, i.e. the entire catalog, which made "core" meaningless. It is now the genuine doctor health floor (5 skills: `oh-my-hermes` router, `doctor`, `skill`, `cancel`, `agent-ops-review`); full-catalog consumers were audited and left on `installable_skill_names()` untouched.
- **`CORE_PROFILE_SKILLS` (9 skills)** = doctor floor + the messenger-first chat/plan/status/handoff essentials (`plan`, `gateway-intent-card`, `executor-runtime-readiness`, `ops-observability-card`). Selection rationale documented in docs/INSTALLATION.md and the commit body.
- **`install_skill_pack(profile="core")`** is the new default; `profile="full"` (CLI: `--full` on `setup`/`install`/`update`) installs all 83 and the result carries a machine-checkable `context_cost_warning` (`omh_skill_profile_context_cost_warning/v1`: installed/core/extra counts + message). The manifest records which profile was installed.
- Docs: "Skill Profiles: Core vs Full" section in INSTALLATION.md + README Quick Start pointer.
- Tests: new `tests/test_installer_skill_profile.py` (default < full and ⊇ doctor floor; full = everything + warning; manifest profile; doctor passes on a core install); 8 existing `test_cli.py` assertions updated to the new default (tests needing non-core skills now pass `--full` explicitly).

## Verification (observed)

- Full suite: 1449 tests OK (1 pre-existing skip)
- `compileall` clean; `omh.cli docs workflows --check` ok (89 tap skills unaffected); `git diff --check` clean

## Risks / Follow-ups

- Existing installs are unaffected until the next `omh update`; a core-profile update prunes nothing by itself (installer writes the selected set — full-state reconciliation semantics follow existing installer behavior, recorded in the manifest).
- The core set is a product decision surface — easy to adjust by editing `CORE_PROFILE_SKILLS`; the doctor floor is test-locked so core can never drop below diagnosability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLULEvSNhQg48Ay49dEoaT
