### PR TITLE
fix: bound meta-router catalog escalation to rephrased recommend queries

### DIFF
--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -133,20 +133,20 @@ These surfaces are generated command references, not installed Hermes workflow s
   - If wrapper metadata is unavailable, keep the recommendation advisory and avoid runtime claims.
 - Required inputs:
   - leading /omh or ./omh command with an imperative remainder
-  - live OMH catalog via `omh recommend`/`omh docs workflows`
+  - live OMH catalog via bounded `omh recommend --json` queries
   - available shell/CLI or plugin tool surface
 - Expected outputs:
   - selected workflow or chain with rationale
-  - consulted catalog evidence from the recommend/docs output
+  - consulted catalog evidence from the bounded recommend output
   - observed-vs-prepared evidence boundary for the routing decision
 - Artifact expectations:
   - runtime run record when a wrapper can observe the meta-routing decision
 - Safety rules:
   - Trigger only on a leading `/omh` or `./omh` command token with a task remainder; bare `/omh`, `./omh`, or `omh` without a slash is a picker/other-lane signal, not meta-routing.
-  - Consult the live catalog with `omh recommend "<remainder>" --json`; escalate to `omh docs workflows --json` when the remainder spans multiple stages or the top recommendation is low-confidence. Never rely on a memorized or embedded skill list — the catalog changes after `omh update`.
+  - Consult the live catalog with `omh recommend "<remainder>" --json --limit 3`; when the remainder spans multiple stages or the top recommendation is low-confidence, re-query `omh recommend` once per stage with a rephrased stage description instead of dumping the full catalog. Never run `omh docs workflows --json` or `omh list --json` in chat context — their full-catalog output does not fit a chat budget — and never rely on a memorized or embedded skill list; the catalog changes after `omh update`.
   - Never select `meta-router` itself from the recommendation output; exclude it and route to the next best concrete workflow or chain.
   - Report the selected workflow(s), why, and the observed-vs-prepared evidence boundary; a routing decision is not execution, review, CI, or merge evidence.
-  - If no shell/CLI surface is available, ask the wrapper to run `omh recommend`/`omh docs workflows` or use the plugin tool surface; never guess the catalog from memory — say the catalog is unavailable and offer the workflow picker instead.
+  - If no shell/CLI surface is available, ask the wrapper to run the bounded `omh recommend` queries or use the plugin tool surface; never guess the catalog from memory — say the catalog is unavailable and offer the workflow picker instead.
 
 ### ralph
 

--- a/skills/meta-router/SKILL.md
+++ b/skills/meta-router/SKILL.md
@@ -87,13 +87,13 @@ Reason over the /omh remainder, select or chain concrete workflows from the live
 Required inputs:
 
 - leading /omh or ./omh command with an imperative remainder
-- live OMH catalog via `omh recommend`/`omh docs workflows`
+- live OMH catalog via bounded `omh recommend --json` queries
 - available shell/CLI or plugin tool surface
 
 Expected outputs:
 
 - selected workflow or chain with rationale
-- consulted catalog evidence from the recommend/docs output
+- consulted catalog evidence from the bounded recommend output
 - observed-vs-prepared evidence boundary for the routing decision
 
 Artifact expectations:
@@ -103,10 +103,10 @@ Artifact expectations:
 Safety rules:
 
 - Trigger only on a leading `/omh` or `./omh` command token with a task remainder; bare `/omh`, `./omh`, or `omh` without a slash is a picker/other-lane signal, not meta-routing.
-- Consult the live catalog with `omh recommend "<remainder>" --json`; escalate to `omh docs workflows --json` when the remainder spans multiple stages or the top recommendation is low-confidence. Never rely on a memorized or embedded skill list — the catalog changes after `omh update`.
+- Consult the live catalog with `omh recommend "<remainder>" --json --limit 3`; when the remainder spans multiple stages or the top recommendation is low-confidence, re-query `omh recommend` once per stage with a rephrased stage description instead of dumping the full catalog. Never run `omh docs workflows --json` or `omh list --json` in chat context — their full-catalog output does not fit a chat budget — and never rely on a memorized or embedded skill list; the catalog changes after `omh update`.
 - Never select `meta-router` itself from the recommendation output; exclude it and route to the next best concrete workflow or chain.
 - Report the selected workflow(s), why, and the observed-vs-prepared evidence boundary; a routing decision is not execution, review, CI, or merge evidence.
-- If no shell/CLI surface is available, ask the wrapper to run `omh recommend`/`omh docs workflows` or use the plugin tool surface; never guess the catalog from memory — say the catalog is unavailable and offer the workflow picker instead.
+- If no shell/CLI surface is available, ask the wrapper to run the bounded `omh recommend` queries or use the plugin tool surface; never guess the catalog from memory — say the catalog is unavailable and offer the workflow picker instead.
 
 ## Harness Discipline
 

--- a/src/skills/catalog.py
+++ b/src/skills/catalog.py
@@ -888,21 +888,21 @@ _DEFINITIONS = [
         handoff_policy="Reason over the /omh remainder, select or chain concrete workflows from the live catalog, and prepare a selected executor/runtime handoff only when the chosen chain requires code edits; do not execute code.",
         required_inputs=(
             "leading /omh or ./omh command with an imperative remainder",
-            "live OMH catalog via `omh recommend`/`omh docs workflows`",
+            "live OMH catalog via bounded `omh recommend --json` queries",
             "available shell/CLI or plugin tool surface",
         ),
         expected_outputs=(
             "selected workflow or chain with rationale",
-            "consulted catalog evidence from the recommend/docs output",
+            "consulted catalog evidence from the bounded recommend output",
             "observed-vs-prepared evidence boundary for the routing decision",
         ),
         artifact_expectations=("runtime run record when a wrapper can observe the meta-routing decision",),
         safety_rules=(
             "Trigger only on a leading `/omh` or `./omh` command token with a task remainder; bare `/omh`, `./omh`, or `omh` without a slash is a picker/other-lane signal, not meta-routing.",
-            "Consult the live catalog with `omh recommend \"<remainder>\" --json`; escalate to `omh docs workflows --json` when the remainder spans multiple stages or the top recommendation is low-confidence. Never rely on a memorized or embedded skill list — the catalog changes after `omh update`.",
+            "Consult the live catalog with `omh recommend \"<remainder>\" --json --limit 3`; when the remainder spans multiple stages or the top recommendation is low-confidence, re-query `omh recommend` once per stage with a rephrased stage description instead of dumping the full catalog. Never run `omh docs workflows --json` or `omh list --json` in chat context — their full-catalog output does not fit a chat budget — and never rely on a memorized or embedded skill list; the catalog changes after `omh update`.",
             "Never select `meta-router` itself from the recommendation output; exclude it and route to the next best concrete workflow or chain.",
             "Report the selected workflow(s), why, and the observed-vs-prepared evidence boundary; a routing decision is not execution, review, CI, or merge evidence.",
-            "If no shell/CLI surface is available, ask the wrapper to run `omh recommend`/`omh docs workflows` or use the plugin tool surface; never guess the catalog from memory — say the catalog is unavailable and offer the workflow picker instead.",
+            "If no shell/CLI surface is available, ask the wrapper to run the bounded `omh recommend` queries or use the plugin tool surface; never guess the catalog from memory — say the catalog is unavailable and offer the workflow picker instead.",
         ),
         quality_tier="routing-gated",
         quality_bar=(

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -1033,7 +1033,7 @@ _META_ROUTER_CHAT_CARDS: dict[str, dict[str, object]] = {
         "headline": "I can read the task and pick the right workflow(s) from the live catalog.",
         "body": (
             "I will reason over the /omh task, consult the live OMH catalog with `omh recommend --json` "
-            "(escalating to `omh docs workflows --json` when the shortlist is unclear), and select or chain the "
+            "(re-querying with rephrased stage descriptions when the shortlist is unclear), and select or chain the "
             "workflow(s) that fit — excluding meta-router itself. The routing decision names the workflow(s) to run "
             "and reports its evidence boundary; it is not execution, review, CI, or merge evidence."
         ),


### PR DESCRIPTION
## Feature Report

### What Changed

- The meta-router escalation path no longer points Hermes at `omh docs workflows --json`. When a `/omh` remainder spans multiple stages or the top recommendation is low-confidence, the generated SKILL.md now instructs one bounded `omh recommend --json --limit 3` re-query per stage with a rephrased stage description, and explicitly forbids `omh docs workflows --json` / `omh list --json` in chat context.

### Why This Exists

Follow-up to #618 from a token-cost review. Measured payloads: `omh docs workflows --json` is ~839KB (~210k tokens) and grows with every skill; `omh list --json` is ~158KB; a rephrased `recommend --limit 3` re-query is 4–6KB. An instruction the LLM may actually follow must not point at an unbounded payload — one followed escalation would blow the chat context budget in a single call.

### User / Operator Impact

- Worst-case per-`/omh` catalog consultation cost drops from ~210k tokens to a few bounded 4–6KB queries; the ceiling no longer grows with catalog size.
- Live-catalog freshness is unchanged: `omh recommend` reads the installed catalog on every call, so new skills still surface after `omh update` with no regeneration.

### Files And Contracts Touched

- `src/skills/catalog.py` (meta-router safety rules, required inputs, expected outputs) + regenerated `skills/meta-router/SKILL.md`, `docs/WORKFLOWS.md`
- `src/wrapper/contract.py` (`meta_route` card body aligned to the same contract)

## Validation

- [x] `python3 -m unittest discover -s tests` (via `PYTHONPATH=tests uv run …`: 1530 tests OK, 1 pre-existing skip)
- [x] `python3 -m compileall src`
- [x] `python3 -m omh.cli docs workflows --check` (and `docs roles --check`)
- [x] Payload measurements observed: recommend --limit 3 ≈ 4–6KB; docs workflows --json ≈ 839KB; list --json ≈ 158KB
- [ ] Manual Hermes/TUI check: not run — live adherence to the revised guidance stays `prepared_not_observed`

## Risk

- Low: wording-only change in catalog source and one card body; deterministic routing untouched. Deep multi-stage ambiguity now resolves through several small queries instead of one exhaustive dump — if that ever proves insufficient, the documented follow-up is a bounded `omh docs workflows --skill <name>` filter (new surface, deliberately deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JvsmGtdeiRrAVNgKXm7vYY