### PR TITLE
refactor: cut new-skill marginal cost to catalog fields, gates, and regen

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@ Source of truth → generated file → regen command → drift gate:
 | Same catalog data | `docs/WORKFLOWS.md` | `uv run python -m omh.cli docs workflows --output docs/WORKFLOWS.md` | `uv run python -m omh.cli docs workflows --check` |
 | Same catalog data | `docs/ROLES.md` | `uv run python -m omh.cli docs roles --output docs/ROLES.md` | `uv run python -m omh.cli docs roles --check` |
 | Demo case engine | `examples/use-cases/g1-g10-demo-cards.json` | `uv run python -m omh.cli cases demo --all --json` output | parse-equality in `tests/test_application_cases.py` |
+| `capability_family_projection()` in `src/capabilities/families.py` | `src/plugin_bundle/omh/tools/capability_families.json` | `uv run python -m omh.cli docs capability-families` | `uv run python -m omh.cli docs capability-families --check`; dict-parity in `tests/test_plugin_capabilities.py` |
 
 Rules:
 
@@ -79,6 +80,10 @@ Rules:
 
 ## Common Pitfalls
 
+- Adding a new installable skill involves more than `catalog.py` — awareness
+  lane + context card, ack/label/card coverage, and the generated
+  capability-family sidecar. Follow `docs/ADDING-A-SKILL.md`; the coverage
+  gates fail with paste-ready instructions when a surface is missed.
 - Hand-editing a generated `skills/*/SKILL.md` — the change is silently lost on
   regeneration and fails the byte gates. Edit `src/skills/catalog.py` /
   `render.py` instead.

--- a/docs/ADDING-A-SKILL.md
+++ b/docs/ADDING-A-SKILL.md
@@ -1,0 +1,59 @@
+# Adding a New Installable Skill
+
+Checklist for adding a skill to the OMH catalog. Every surface below is
+enforced by a test; skipping one fails CI with an actionable message naming
+the file and structure to edit.
+
+## 1. Define the skill (single registration point)
+
+- Add the `SkillDefinition` to `src/skills/catalog.py`.
+- Set `capability_family` **only** when the skill's user-facing family differs
+  from its awareness-lane default (rare — 5 of 88 skills today). Leave it
+  empty otherwise; the lane default governs.
+- If the skill needs a recommendation policy, add its `_SKILL_POLICIES` entry
+  in `src/routing/recommend.py`.
+
+## 2. Hand-authored surfaces (curated order and UX copy)
+
+These cannot be derived from the catalog; each has a gate that fails with
+paste-ready guidance:
+
+| Surface | File / structure | Gate |
+| --- | --- | --- |
+| Awareness lane membership | `awareness_primer_payload()` lane `skills` lists in `src/plugin_bundle/omh/awareness.py` | `tests/test_capabilities.py` (lane coverage) |
+| Workflow context card lane | `_WORKFLOW_CONTEXT_CARD_BY_WORKFLOW` in the same file | `tests/test_capabilities.py` (context-card coverage) |
+| Visible/ack wrapper actions | `VISIBLE_ACTIONS` + `_ACK_PRIMARY_ACTIONS_BY_NEXT_ACTION` in `src/wrapper/contract.py` | `tests/test_wrapper_contract.py` (visible-ack) |
+| Next-action label | `NEXT_ACTION_LABELS` in `src/routing/action_copy.py` | `tests/test_wrapper_contract.py` (curated-label gate) |
+| Dedicated non-ack chat card | a `*_CHAT_CARDS` entry or bespoke renderer in `src/wrapper/contract.py` | intervention harness + coverage-case gate |
+| Coverage case | `ChatCardCoverageCase` in `src/quality/chat_card_coverage.py` or `RoutingInterventionCase` in `src/quality/routing_precision.py` | `tests/test_wrapper_contract.py` (coverage-case gate) |
+
+The curated-label and coverage-case gates carry frozen legacy allowlists; do
+not extend the allowlists for a new skill — register the skill instead.
+
+## 3. Exact-count fixtures (contracts, updated in the same commit)
+
+Adding a routing/intervention case moves exact-count assertions in
+`tests/test_routing_precision.py`, `tests/test_cli.py`,
+`tests/test_hermes_ux_quality.py`, and `tests/test_release_smoke.py`. Grep
+those four for the old count.
+
+## 4. Regenerate every generated artifact family
+
+```sh
+# skills/*/SKILL.md + references (short template-write loop; see CLAUDE.md)
+uv run python -m omh.cli docs workflows --output docs/WORKFLOWS.md
+uv run python -m omh.cli docs roles --output docs/ROLES.md
+uv run python -m omh.cli docs capability-families
+uv run python -m omh.cli cases demo --all --json > examples/use-cases/g1-g10-demo-cards.json
+```
+
+## 5. Verify
+
+```sh
+uv run python -m compileall -q src tests
+uv run python -m omh.cli docs workflows --check
+uv run python -m omh.cli docs roles --check
+uv run python -m omh.cli docs capability-families --check
+git diff --check
+PYTHONPATH=tests uv run python -m unittest discover -s tests
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,3 +86,4 @@ packages = [
 "omh.catalogs" = ["*.json"]
 "omh.plugin_bundle.omh" = ["plugin.yaml", "config.yaml"]
 "omh.plugin_bundle.omh.references" = ["*.md"]
+"omh.plugin_bundle.omh.tools" = ["capability_families.json"]

--- a/src/capabilities/families.py
+++ b/src/capabilities/families.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+import json
 from functools import lru_cache
 from typing import Iterable, cast
 
 from ..plugin_bundle.omh.awareness import awareness_lane_examples, awareness_primer_payload
-from ..skills.catalog import installable_skill_names
+from ..skills.catalog import builtin_definitions, installable_skill_names
 
 CAPABILITY_FAMILY_SCHEMA_VERSION = "omh_capability_families/v1"
 
@@ -158,97 +159,35 @@ _FAMILY_DEFINITIONS = (
     },
 )
 
-_WORKFLOW_FAMILY_OVERRIDES = {
-    "oh-my-hermes": "plan_and_decide",
-    "meta-router": "plan_and_decide",
-    "deep-interview": "plan_and_decide",
-    "plan": "plan_and_decide",
-    "ralplan": "plan_and_decide",
-    "ralph": "plan_and_decide",
-    "ultragoal": "plan_and_decide",
-    "loop": "plan_and_decide",
-    "performance-goal": "plan_and_decide",
-    "strategy-brief": "plan_and_decide",
-    "codebase-onboarding": "plan_and_decide",
-    "codegraph-refresh": "plan_and_decide",
-    "source-finder": "learn_and_gather",
-    "data-analysis": "learn_and_gather",
-    "command-operator": "operate_and_observe",
-    "connector-operator": "operate_and_observe",
-    "live-info-operator": "operate_and_observe",
-    "workspace-audit": "operate_and_observe",
-    "production-audit": "operate_and_observe",
-    "agent-evaluation": "operate_and_observe",
-    "rules-distill": "operate_and_observe",
-    "context-budget-review": "operate_and_observe",
-    "agent-debug": "operate_and_observe",
-    "failure-signal-audit": "operate_and_observe",
-    "instinct-ledger": "operate_and_observe",
-    "skill-scout": "operate_and_observe",
-    "skill-health": "operate_and_observe",
-    "web-research": "learn_and_gather",
-    "best-practice-research": "learn_and_gather",
-    "autoresearch-goal": "learn_and_gather",
-    "research-brief": "learn_and_gather",
-    "research-department": "learn_and_gather",
-    "paper-learning": "learn_and_gather",
-    "feedback-triage": "learn_and_gather",
-    "meeting-brief": "learn_and_gather",
-    "wiki": "retain_knowledge",
-    "materials-package": "create_materials_and_visuals",
-    "report-package": "create_materials_and_visuals",
-    "deliverable-package": "create_materials_and_visuals",
-    "content-operator": "create_materials_and_visuals",
-    "media-input-operator": "create_materials_and_visuals",
-    "img-summary": "create_materials_and_visuals",
-    "design-orchestration": "create_materials_and_visuals",
-    "frontend": "create_materials_and_visuals",
-    "accessibility-audit": "create_materials_and_visuals",
-    "visual-qa": "create_materials_and_visuals",
-    "idea-to-deploy": "delegate_coding_and_ship",
-    "ultraprocess": "delegate_coding_and_ship",
-    "code-review": "delegate_coding_and_ship",
-    "build-failure-triage": "delegate_coding_and_ship",
-    "verification-gate": "delegate_coding_and_ship",
-    "security-safety-review": "delegate_coding_and_ship",
-    "team": "delegate_coding_and_ship",
-    "ultrawork": "delegate_coding_and_ship",
-    "ultraqa": "delegate_coding_and_ship",
-    "ai-slop-cleaner": "delegate_coding_and_ship",
-    "executor-runtime-readiness": "delegate_coding_and_ship",
-    "dynamic-workflow": "delegate_coding_and_ship",
-    "request-to-handoff": "delegate_coding_and_ship",
-    "executor selection": "delegate_coding_and_ship",
-    "coding runtime handoff": "delegate_coding_and_ship",
-    "cto-loop": "delegate_coding_and_ship",
-    "deploy-and-monitor": "delegate_coding_and_ship",
-    "github-event-ops": "operate_and_observe",
-    "automation-blueprint": "operate_and_observe",
-    "agent-board": "operate_and_observe",
-    "gateway-intent-card": "operate_and_observe",
-    "voice-operator": "operate_and_observe",
-    "browser-operator": "operate_and_observe",
-    "workspace-file-operator": "operate_and_observe",
-    "command-operator": "operate_and_observe",
-    "connector-operator": "operate_and_observe",
-    "live-info-operator": "operate_and_observe",
-    "external-connector-readiness": "operate_and_observe",
-    "prompt-import-readiness": "operate_and_observe",
-    "physical-device-readiness": "operate_and_observe",
-    "toolbelt-readiness": "operate_and_observe",
-    "harness-session-inventory": "operate_and_observe",
-    "ops-observability-card": "operate_and_observe",
-    "agent-ops-review": "operate_and_observe",
-    "memory-sync": "operate_and_observe",
-    "workflow-learning": "operate_and_observe",
-    "doctor": "operate_and_observe",
-    "skill": "operate_and_observe",
-    "ask": "operate_and_observe",
-    "cancel": "operate_and_observe",
-    "operating-rhythm": "operate_and_observe",
-    "ops-review": "operate_and_observe",
-    "reliability-review": "operate_and_observe",
-}
+
+@lru_cache(maxsize=1)
+def _workflow_family_overrides() -> dict[str, str]:
+    """Cross-lane family overrides derived from the skill catalog.
+
+    A skill inherits its family from its awareness-lane default; a
+    `SkillDefinition.capability_family` value is needed only when the skill
+    belongs to a different family than its lane. `dynamic-workflow` is a
+    conceptual CLI surface with no SkillDefinition and no awareness lane, so
+    its assignment lives here directly.
+    """
+    overrides = {
+        definition.name: definition.capability_family
+        for definition in builtin_definitions()
+        if definition.capability_family
+    }
+    overrides["dynamic-workflow"] = "delegate_coding_and_ship"
+    return overrides
+
+
+def standalone_capability_families_json() -> str:
+    """Serialize the canonical families for the vendored plugin-bundle sidecar.
+
+    The standalone bundle cannot import this module, so it loads this
+    generated JSON instead; `omh docs capability-families --check` keeps the
+    file byte-identical to this projection.
+    """
+    families = capability_family_projection()["families"]
+    return json.dumps(families, ensure_ascii=False, indent=1, sort_keys=True) + "\n"
 
 
 def capability_family_projection(available_workflows: Iterable[str] | None = None) -> dict[str, object]:
@@ -418,7 +357,7 @@ def _workflow_to_family(
 ) -> dict[str, str]:
     mapping: dict[str, str] = {}
     family_ids = {str(family["id"]) for family in families}
-    for workflow, family_id in sorted(_WORKFLOW_FAMILY_OVERRIDES.items()):
+    for workflow, family_id in sorted(_workflow_family_overrides().items()):
         if workflow in available and family_id in family_ids:
             mapping[workflow] = family_id
             mapping[workflow.casefold()] = family_id
@@ -440,7 +379,7 @@ def _workflow_to_family(
 
 
 def _workflow_belongs_to_family(workflow: str, family_id: str, source_lanes: tuple[str, ...]) -> bool:
-    override = _WORKFLOW_FAMILY_OVERRIDES.get(workflow)
+    override = _workflow_family_overrides().get(workflow)
     if override:
         return override == family_id
     return any(_default_family_for_source_lane(lane_id) == family_id for lane_id in source_lanes)

--- a/src/commands/docs.py
+++ b/src/commands/docs.py
@@ -63,6 +63,35 @@ def cmd_docs_roles(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_docs_capability_families(args: argparse.Namespace) -> int:
+    from ..capabilities.families import standalone_capability_families_json
+
+    content = standalone_capability_families_json()
+    output = (
+        Path(args.output).expanduser().resolve()
+        if args.output
+        else _default_capability_families_path()
+    )
+    if args.check:
+        try:
+            current = output.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise OmhError(f"capability families sidecar check failed: {exc}") from exc
+        if current != content:
+            raise OmhError(f"capability families sidecar is stale: {output}")
+        _print_json({"ok": True, "checked": str(output)})
+        return 0
+    atomic_write_text(output, content)
+    _print_json({"written": str(output)})
+    return 0
+
+
+def _default_capability_families_path() -> Path:
+    from ..plugin_bundle.omh import tools as plugin_tools
+
+    return (Path(plugin_tools.__file__).resolve().parent / "capability_families.json").resolve()
+
+
 def _tap_skills_check_payload(skills_root: Path) -> dict[str, object]:
     templates = {template.name: template for template in builtin_skill_templates()}
     reference_templates = {
@@ -126,6 +155,14 @@ def _add_docs_commands(sub) -> None:
     docs_roles.add_argument("--output", default=None)
     docs_roles.add_argument("--check", action="store_true")
     docs_roles.set_defaults(func=cmd_docs_roles)
+
+    docs_capability_families = docs_sub.add_parser(
+        "capability-families",
+        help="Write or check the generated plugin-bundle capability-family sidecar JSON.",
+    )
+    docs_capability_families.add_argument("--output", default=None)
+    docs_capability_families.add_argument("--check", action="store_true")
+    docs_capability_families.set_defaults(func=cmd_docs_capability_families)
 
 
 def _add_harness_commands(sub) -> None:

--- a/src/plugin_bundle/omh/tools/capability_families.json
+++ b/src/plugin_bundle/omh/tools/capability_families.json
@@ -1,0 +1,252 @@
+[
+ {
+  "example_prompt": "Make onboarding feel smoother.",
+  "id": "plan_and_decide",
+  "label": "Plan and decide",
+  "next_action": "clarify_or_prepare_plan",
+  "not_evidence_until_observed": [
+   "plan acceptance",
+   "executor dispatch",
+   "verification"
+  ],
+  "owner_role": "planner",
+  "primary_workflows": [
+   "deep-interview",
+   "ralplan",
+   "codebase-onboarding",
+   "codegraph-refresh",
+   "ultragoal",
+   "loop",
+   "strategy-brief",
+   "oh-my-hermes",
+   "meta-router",
+   "plan",
+   "ralph",
+   "performance-goal"
+  ],
+  "route_summary": "Clarify the goal, choose the planning depth, and show the next concrete action.",
+  "source_examples": [
+   "ambitious goal -> loopability check -> loop or ultraprocess -> verification status",
+   "new repo -> codebase-onboarding -> reading path -> first-task runway",
+   "stale code index -> codegraph-refresh -> summary or task-scoped handoff",
+   "fuzzy feature request -> deep-interview -> ralplan -> accepted plan"
+  ],
+  "source_lanes": [
+   "intent_to_plan"
+  ],
+  "use_for": "Ambiguous goals, planning, decisions, and loopable work before execution."
+ },
+ {
+  "example_prompt": "Find papers, datasets, and repos for this topic.",
+  "id": "learn_and_gather",
+  "label": "Learn and gather",
+  "next_action": "gather_source_backed_evidence",
+  "not_evidence_until_observed": [
+   "source retrieval",
+   "source verification",
+   "decision approval"
+  ],
+  "owner_role": "researcher",
+  "primary_workflows": [
+   "source-finder",
+   "web-research",
+   "paper-learning",
+   "data-analysis",
+   "research-department",
+   "feedback-triage",
+   "best-practice-research",
+   "autoresearch-goal",
+   "research-brief",
+   "meeting-brief"
+  ],
+  "route_summary": "Name the source/synthesis split before summarizing or planning from the material.",
+  "source_examples": [
+   "customer signal -> feedback-triage -> investigation plan -> coding handoff -> status",
+   "source discovery -> source-finder -> candidate set -> downstream workflow",
+   "supplied CSV/logs -> data-analysis -> scope, schema, method, and evidence-limited findings",
+   "supplied paper -> paper-learning -> level choice -> coverage ledger -> section walkthrough"
+  ],
+  "source_lanes": [
+   "research_and_ops"
+  ],
+  "use_for": "Source finding, web research, papers, customer signals, and briefings."
+ },
+ {
+  "example_prompt": "Capture this decision.",
+  "id": "retain_knowledge",
+  "label": "Retain knowledge",
+  "next_action": "prepare_retained_knowledge_guidance",
+  "not_evidence_until_observed": [
+   "external write",
+   "memory mutation",
+   "connector I/O",
+   "source verification"
+  ],
+  "owner_role": "memory-keeper",
+  "primary_workflows": [
+   "wiki"
+  ],
+  "route_summary": "Prepare notes and hints without claiming writes.",
+  "source_examples": [
+   "decision -> wiki -> write boundary",
+   "external store -> wiki -> retrieval hints"
+  ],
+  "source_lanes": [
+   "retained_knowledge"
+  ],
+  "use_for": "Project wiki notes and external connection hints."
+ },
+ {
+  "example_prompt": "Make a PR summary card for reviewers.",
+  "id": "create_materials_and_visuals",
+  "label": "Create materials and visuals",
+  "next_action": "prepare_material_or_visual_card",
+  "not_evidence_until_observed": [
+   "frontend implementation",
+   "accessibility PASS",
+   "file export",
+   "image generation",
+   "visual QA",
+   "delivery"
+  ],
+  "owner_role": "operator",
+  "primary_workflows": [
+   "design-quality-gate",
+   "frontend",
+   "accessibility-audit",
+   "visual-qa",
+   "materials-package",
+   "report-package",
+   "deliverable-package",
+   "img-summary",
+   "content-operator",
+   "media-input-operator",
+   "design-orchestration"
+  ],
+  "route_summary": "Prepare the copy, prompt, package, or QA contract before claiming generated output.",
+  "source_examples": [
+   "meeting notes -> meeting-brief -> report-package -> img-summary -> delivery evidence",
+   "broad design request -> design-orchestration -> named specialist lanes -> executor selection -> observed visual evidence",
+   "release notes or customer copy -> content-operator -> source, audience, tone, review, and output slots",
+   "frontend request -> frontend -> visual-qa -> observed render evidence"
+  ],
+  "source_lanes": [
+   "materials_and_visuals"
+  ],
+  "use_for": "Decks, PDFs, spreadsheets, reports, websites, frontend surfaces, accessibility audits, posters, image cards, visual QA, and shareable packages."
+ },
+ {
+  "example_prompt": "Turn this issue into a PR-ready plan and hand it to implementation.",
+  "executor_choices": [
+   "Codex",
+   "Claude Code",
+   "Hermes",
+   "generic runtime"
+  ],
+  "id": "delegate_coding_and_ship",
+  "label": "Delegate coding and ship",
+  "next_action": "prepare_scoped_coding_handoff",
+  "not_evidence_until_observed": [
+   "executor dispatch",
+   "implementation",
+   "review",
+   "CI",
+   "merge"
+  ],
+  "owner_role": "handoff-guide",
+  "primary_workflows": [
+   "idea-to-deploy",
+   "ultraprocess",
+   "executor-runtime-readiness",
+   "dynamic-workflow",
+   "code-review",
+   "build-failure-triage",
+   "verification-gate",
+   "security-safety-review",
+   "team",
+   "ultrawork",
+   "ultraqa",
+   "cto-loop",
+   "deploy-and-monitor",
+   "ai-slop-cleaner",
+   "request-to-handoff",
+   "executor selection",
+   "coding runtime handoff"
+  ],
+  "route_summary": "Choose model, runtime, and coding-owner targets only after scope is concrete, then track observed evidence separately.",
+  "source_examples": [
+   "accepted plan -> ultraprocess -> coding handoff -> review and CI evidence",
+   "failed checks -> build-failure-triage -> minimal fix handoff -> verification-gate",
+   "agentic action risk -> security-safety-review -> safe action policy -> remediation handoff",
+   "risky change -> ralplan -> executor selection -> observed coding-agent status"
+  ],
+  "source_lanes": [
+   "coding_handoff"
+  ],
+  "use_for": "Scoped coding handoffs, dynamic typed target choice across model, runtime, wrapper, tool, and agent surfaces, review, QA, CI, and merge readiness."
+ },
+ {
+  "example_prompt": "Why did this route to plan? Make it a regression.",
+  "id": "operate_and_observe",
+  "label": "Operate and observe",
+  "next_action": "show_status_or_prepare_operating_card",
+  "not_evidence_until_observed": [
+   "schedule creation",
+   "connector I/O",
+   "runtime load",
+   "skill patch approval"
+  ],
+  "owner_role": "tracker",
+  "primary_workflows": [
+   "doctor",
+   "workspace-audit",
+   "production-audit",
+   "automation-blueprint",
+   "github-event-ops",
+   "agent-board",
+   "gateway-intent-card",
+   "voice-operator",
+   "browser-operator",
+   "workspace-file-operator",
+   "command-operator",
+   "connector-operator",
+   "live-info-operator",
+   "agent-ops-review",
+   "agent-debug",
+   "failure-signal-audit",
+   "instinct-ledger",
+   "agent-evaluation",
+   "rules-distill",
+   "context-budget-review",
+   "toolbelt-readiness",
+   "external-connector-readiness",
+   "prompt-import-readiness",
+   "physical-device-readiness",
+   "skill-scout",
+   "skill-health",
+   "workflow-learning",
+   "memory-sync",
+   "achievements",
+   "harness-session-inventory",
+   "ops-observability-card",
+   "model-setup",
+   "parallel-tools",
+   "websearch-setup",
+   "morning-brief",
+   "skill",
+   "ask",
+   "cancel"
+  ],
+  "route_summary": "Show status, repair, schedule, or learning shape without claiming runtime actions happened.",
+  "source_examples": [
+   "daily digest request -> automation-blueprint -> confirmation card -> observed schedule evidence",
+   "long agent run -> context-budget-review -> must-keep pack -> checkpoint plan",
+   "stuck agent run -> agent-debug -> failure capture, diagnosis, and contained recovery",
+   "hidden failure -> failure-signal-audit -> fallback and false-green review"
+  ],
+  "source_lanes": [
+   "automation_and_status"
+  ],
+  "use_for": "Setup repair, status, automation, workflow learning, memory review, and ops cards."
+ }
+]

--- a/src/plugin_bundle/omh/tools/capability_tool.py
+++ b/src/plugin_bundle/omh/tools/capability_tool.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from typing import Protocol, TypedDict
 
 from ..awareness import awareness_lane_examples, awareness_primer_payload
@@ -71,180 +72,26 @@ LANE_OWNER_ROLES = {
     "automation_and_status": "tracker",
     "coding_handoff": "handoff-guide",
 }
-STANDALONE_CAPABILITY_FAMILIES = (
-    {
-        "id": "plan_and_decide",
-        "label": "Plan and decide",
-        "owner_role": "planner",
-        "source_lanes": ("intent_to_plan",),
-        "use_for": "Ambiguous goals, planning, decisions, and loopable work before execution.",
-        "primary_workflows": (
-            "deep-interview",
-            "ralplan",
-            "codebase-onboarding",
-            "codegraph-refresh",
-            "ultragoal",
-            "loop",
-            "strategy-brief",
-            "oh-my-hermes",
-            "meta-router",
-            "plan",
-            "ralph",
-            "performance-goal",
-        ),
-        "next_action": "clarify_or_prepare_plan",
-        "example_prompt": "Make onboarding feel smoother.",
-        "route_summary": "Clarify the goal, choose the planning depth, and show the next concrete action.",
-        "not_evidence_until_observed": ("plan acceptance", "executor dispatch", "verification"),
-    },
-    {
-        "id": "learn_and_gather",
-        "label": "Learn and gather",
-        "owner_role": "researcher",
-        "source_lanes": ("research_and_ops",),
-        "use_for": "Source finding, web research, papers, customer signals, and briefings.",
-        "primary_workflows": (
-            "source-finder",
-            "web-research",
-            "paper-learning",
-            "data-analysis",
-            "research-department",
-            "feedback-triage",
-            "best-practice-research",
-            "autoresearch-goal",
-            "research-brief",
-            "meeting-brief",
-        ),
-        "next_action": "gather_source_backed_evidence",
-        "example_prompt": "Find papers, datasets, and repos for this topic.",
-        "route_summary": "Name the source/synthesis split before summarizing or planning from the material.",
-        "not_evidence_until_observed": ("source retrieval", "source verification", "decision approval"),
-    },
-    {
-        "id": "retain_knowledge",
-        "label": "Retain knowledge",
-        "owner_role": "memory-keeper",
-        "source_lanes": ("retained_knowledge",),
-        "use_for": "Project wiki notes and external connection hints.",
-        "primary_workflows": ("wiki",),
-        "next_action": "prepare_retained_knowledge_guidance",
-        "example_prompt": "Capture this decision.",
-        "route_summary": "Prepare notes and hints without claiming writes.",
-        "not_evidence_until_observed": ("external write", "memory mutation", "connector I/O", "source verification"),
-    },
-    {
-        "id": "create_materials_and_visuals",
-        "label": "Create materials and visuals",
-        "owner_role": "operator",
-        "source_lanes": ("materials_and_visuals",),
-        "use_for": "Decks, PDFs, spreadsheets, reports, websites, frontend surfaces, accessibility audits, posters, image cards, visual QA, and shareable packages.",
-        "primary_workflows": (
-            "design-quality-gate",
-            "frontend",
-            "accessibility-audit",
-            "visual-qa",
-            "materials-package",
-            "report-package",
-            "deliverable-package",
-            "img-summary",
-            "content-operator",
-            "media-input-operator",
-            "design-orchestration",
-        ),
-        "next_action": "prepare_material_or_visual_card",
-        "example_prompt": "Make a PR summary card for reviewers.",
-        "route_summary": "Prepare the copy, prompt, package, or QA contract before claiming generated output.",
-        "not_evidence_until_observed": ("frontend implementation", "accessibility PASS", "file export", "image generation", "visual QA", "delivery"),
-    },
-    {
-        "id": "delegate_coding_and_ship",
-        "label": "Delegate coding and ship",
-        "owner_role": "handoff-guide",
-        "source_lanes": ("coding_handoff",),
-        "use_for": (
-            "Scoped coding handoffs, dynamic typed target choice across model, runtime, wrapper, tool, and agent "
-            "surfaces, review, QA, CI, and merge readiness."
-        ),
-        "primary_workflows": (
-            "idea-to-deploy",
-            "ultraprocess",
-            "executor-runtime-readiness",
-            "dynamic-workflow",
-            "code-review",
-            "build-failure-triage",
-            "verification-gate",
-            "security-safety-review",
-            "team",
-            "ultrawork",
-            "ultraqa",
-            "cto-loop",
-            "deploy-and-monitor",
-            "ai-slop-cleaner",
-            "request-to-handoff",
-            "executor selection",
-            "coding runtime handoff",
-        ),
-        "executor_choices": ("Codex", "Claude Code", "Hermes", "generic runtime"),
-        "next_action": "prepare_scoped_coding_handoff",
-        "example_prompt": "Turn this issue into a PR-ready plan and hand it to implementation.",
-        "route_summary": (
-            "Choose model, runtime, and coding-owner targets only after scope is concrete, then track observed "
-            "evidence separately."
-        ),
-        "not_evidence_until_observed": ("executor dispatch", "implementation", "review", "CI", "merge"),
-    },
-    {
-        "id": "operate_and_observe",
-        "label": "Operate and observe",
-        "owner_role": "tracker",
-        "source_lanes": ("automation_and_status",),
-        "use_for": "Setup repair, status, automation, workflow learning, memory review, and ops cards.",
-        "primary_workflows": (
-            "doctor",
-            "workspace-audit",
-            "production-audit",
-            "automation-blueprint",
-            "github-event-ops",
-            "agent-board",
-            "gateway-intent-card",
-            "voice-operator",
-            "browser-operator",
-            "workspace-file-operator",
-            "command-operator",
-            "connector-operator",
-            "live-info-operator",
-            "agent-ops-review",
-            "agent-debug",
-            "failure-signal-audit",
-            "instinct-ledger",
-            "agent-evaluation",
-            "rules-distill",
-            "context-budget-review",
-            "toolbelt-readiness",
-            "external-connector-readiness",
-            "prompt-import-readiness",
-            "physical-device-readiness",
-            "skill-scout",
-            "skill-health",
-            "workflow-learning",
-            "memory-sync",
-            "achievements",
-            "harness-session-inventory",
-            "ops-observability-card",
-            "model-setup",
-            "parallel-tools",
-            "websearch-setup",
-            "morning-brief",
-            "skill",
-            "ask",
-            "cancel",
-        ),
-        "next_action": "show_status_or_prepare_operating_card",
-        "example_prompt": "Why did this route to plan? Make it a regression.",
-        "route_summary": "Show status, repair, schedule, or learning shape without claiming runtime actions happened.",
-        "not_evidence_until_observed": ("schedule creation", "connector I/O", "runtime load", "skill patch approval"),
-    },
-)
+def _load_standalone_capability_families() -> tuple[dict[str, object], ...]:
+    """Load the generated family sidecar written by `omh docs capability-families`.
+
+    The standalone bundle cannot import omh core, so the canonical
+    capability-family projection is vendored as `capability_families.json`
+    next to this module and kept in sync by the
+    `omh docs capability-families --check` drift gate. A missing or invalid
+    sidecar degrades to an empty tuple instead of breaking bundle import.
+    """
+    path = Path(__file__).resolve().with_name("capability_families.json")
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return ()
+    if not isinstance(payload, list):
+        return ()
+    return tuple(item for item in payload if isinstance(item, dict))
+
+
+STANDALONE_CAPABILITY_FAMILIES = _load_standalone_capability_families()
 STANDALONE_LANE_PLAYBOOK_IDS = {
     "intent_to_plan": ("request-to-handoff", "safe-feature-change"),
     "research_and_ops": ("source-finder", "research-department", "source-backed-research", "feedback-triage"),

--- a/src/skills/catalog.py
+++ b/src/skills/catalog.py
@@ -357,6 +357,10 @@ class SkillDefinition:
     bad_example: SkillExample | None = None
     final_checklist: tuple[str, ...] = ()
     recovery_notes: tuple[str, ...] = ()
+    # Render-invisible routing metadata: only consumed by the capability-family
+    # projection. Set it only when the skill's family differs from its
+    # awareness-lane default; leave empty to inherit the lane default.
+    capability_family: str = ""
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "description", omh_description(self.description))
@@ -1156,6 +1160,7 @@ _DEFINITIONS = [
         "Use when the user asks Hermes to take a concrete task through one full delivery cycle: research/codebase context, reviewed plan, selected implementation handoff, code review, docs sync when needed, and PR preparation.",
         category="process",
         phase="single-cycle-plan-to-pr",
+        capability_family="delegate_coding_and_ship",
         hermes_role="retained-cognition",
         delegation_boundary="retained-catalog-intent",
         handoff_policy="Keep the one-cycle process orchestration, source/codebase research, planning, review framing, docs-sync checks, PR narration, and evidence boundaries in Hermes; convert implementation into a selected executor/runtime handoff such as Codex, Claude Code, OMX/OMO/OMC, another coding agent, or explicit Hermes coding runtime only when the user accepts that owner.",
@@ -1813,6 +1818,7 @@ _DEFINITIONS = [
         "Use when Hermes should turn goals and evidence into options, tradeoffs, recommendations, and a decision-ready brief.",
         category="strategy",
         phase="brief",
+        capability_family="plan_and_decide",
         hermes_role="retained-cognition",
         delegation_boundary="retained-catalog-intent",
         handoff_policy="Keep strategy synthesis in Hermes; do not create implementation handoff until a decision is accepted and code work is explicit.",
@@ -1984,6 +1990,7 @@ _DEFINITIONS = [
         "Use when Hermes should summarize observed status, risks, blockers, priorities, and follow-up actions for recurring operating work.",
         category="operations",
         phase="status-review",
+        capability_family="operate_and_observe",
         hermes_role="retained-cognition",
         delegation_boundary="retained-catalog-intent",
         handoff_policy="Keep operating review and status narration in Hermes; delegate code fixes only from explicit accepted follow-up items.",
@@ -2028,6 +2035,7 @@ _DEFINITIONS = [
         "Use when Hermes should prepare or maintain recurring operating records such as meetings, scrums, sprint plans, retrospectives, decisions, and follow-ups.",
         category="operations",
         phase="rhythm-history",
+        capability_family="operate_and_observe",
         hermes_role="retained-cognition",
         delegation_boundary="retained-catalog-intent",
         handoff_policy="Keep cadence records, minutes scaffolds, decisions, and follow-up history in Hermes; delegate implementation only from separately accepted action items.",
@@ -4078,6 +4086,7 @@ _DEFINITIONS = [
         "Use when Hermes should review incident notes, SLOs, error budgets, or service reliability evidence while keeping remediation and closure claims observed.",
         category="reliability",
         phase="incident-and-slo-review",
+        capability_family="operate_and_observe",
         hermes_role="retained-cognition",
         delegation_boundary="retained-catalog-intent",
         handoff_policy="Keep incident/SLO/error-budget review in Hermes; prepare remediation handoffs only after an accepted fix direction exists and record closure only from observed evidence.",

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -70,8 +70,34 @@ class CapabilityManifestTests(unittest.TestCase):
         catalog_surfaces = {definition.name for definition in builtin_definitions()}
         conceptual_surfaces = {"request-to-handoff", "executor selection", "coding runtime handoff", "dynamic-workflow"}
 
-        self.assertFalse(generated_skills - lane_skills)
+        uncovered = sorted(generated_skills - lane_skills)
+        self.assertFalse(
+            uncovered,
+            "Installable skill(s) missing from awareness lanes: "
+            f"{uncovered}. For each, add the skill name to the matching lane "
+            "'skills' list inside awareness_primer_payload() in "
+            "src/plugin_bundle/omh/awareness.py, keeping the curated lane order.",
+        )
         self.assertLessEqual(lane_skills - catalog_surfaces, conceptual_surfaces)
+
+        from omh.plugin_bundle.omh.awareness import _WORKFLOW_CONTEXT_CARD_BY_WORKFLOW
+
+        # The router itself and the cancel control surface intentionally have
+        # no workflow context card.
+        context_card_exempt = {"oh-my-hermes", "cancel"}
+        missing_context_cards = sorted(
+            skill
+            for skill in lane_skills & generated_skills
+            if skill not in _WORKFLOW_CONTEXT_CARD_BY_WORKFLOW and skill not in context_card_exempt
+        )
+        self.assertFalse(
+            missing_context_cards,
+            "Lane skill(s) missing a workflow context card lane: "
+            f"{missing_context_cards}. Add '<skill>': '<lane_id>' to "
+            "_WORKFLOW_CONTEXT_CARD_BY_WORKFLOW in "
+            "src/plugin_bundle/omh/awareness.py (use the lane the skill "
+            "belongs to in awareness_primer_payload()).",
+        )
 
     def test_capability_families_are_user_facing_front_door_projection(self) -> None:
         projection = capability_family_projection()

--- a/tests/test_plugin_distribution.py
+++ b/tests/test_plugin_distribution.py
@@ -72,6 +72,11 @@ class PluginDistributionTests(unittest.TestCase):
             "*.md",
             pyproject["tool"]["setuptools"]["package-data"]["omh.plugin_bundle.omh.references"],
         )
+        self.assertTrue(root.joinpath("tools", "capability_families.json").is_file())
+        self.assertIn(
+            "capability_families.json",
+            pyproject["tool"]["setuptools"]["package-data"]["omh.plugin_bundle.omh.tools"],
+        )
 
     def test_plugin_yaml_advertises_metadata_tools_and_hooks(self) -> None:
         root = resources.files("omh.plugin_bundle.omh")

--- a/tests/test_wrapper_contract.py
+++ b/tests/test_wrapper_contract.py
@@ -2679,11 +2679,159 @@ class WrapperContractTests(unittest.TestCase):
             if not next_action or next_action in control_actions:
                 continue
             if next_action not in contract.VISIBLE_ACTIONS:
-                missing.append(f"{name}:{next_action}:not-visible")
+                missing.append(
+                    f"{name}: add \"{next_action}\" to VISIBLE_ACTIONS in src/wrapper/contract.py"
+                )
             if next_action not in contract._ACK_PRIMARY_ACTIONS_BY_NEXT_ACTION:
-                missing.append(f"{name}:{next_action}:no-ack-primary")
+                missing.append(
+                    f"{name}: add \"{next_action}\": (\"{next_action}\", \"<Short label>\") to "
+                    "_ACK_PRIMARY_ACTIONS_BY_NEXT_ACTION in src/wrapper/contract.py, and give the "
+                    "skill a dedicated non-ack chat card or the intervention harness will fail it "
+                    "as a generic ack"
+                )
 
         self.assertEqual(missing, [])
+
+    # Frozen legacy sets for the two new-skill coverage gates below. Do NOT
+    # add new entries when a gate fails for a new skill — register the skill
+    # instead (a curated label / a coverage case). Removing entries as legacy
+    # skills gain coverage is welcome.
+    _UNCURATED_LEGACY_NEXT_ACTIONS = frozenset(
+        {
+            # Inline payload-level actions that render via the
+            # `.replace("_", " ")` fallback today. Adding labels for them
+            # would change rendered chat text, which is pinned behavior.
+            "accept_or_revise_plan",
+            "route_coding_request",
+            "state_goal_success_criteria",
+        }
+    )
+    _CARD_COVERAGE_LEGACY_SKILLS = frozenset(
+        {
+            "accessibility-audit",
+            "agent-debug",
+            "agent-evaluation",
+            "browser-operator",
+            "build-failure-triage",
+            "cancel",
+            "codebase-onboarding",
+            "codegraph-refresh",
+            "command-operator",
+            "connector-operator",
+            "content-operator",
+            "context-budget-review",
+            "data-analysis",
+            "design-orchestration",
+            "design-quality-gate",
+            "external-connector-readiness",
+            "failure-signal-audit",
+            "frontend",
+            "harness-session-inventory",
+            "instinct-ledger",
+            "live-info-operator",
+            "media-input-operator",
+            "performance-goal",
+            "physical-device-readiness",
+            "production-audit",
+            "prompt-import-readiness",
+            "rules-distill",
+            "security-safety-review",
+            "skill-health",
+            "skill-scout",
+            "ultraqa",
+            "verification-gate",
+            "visual-qa",
+            "workspace-audit",
+            "workspace-file-operator",
+        }
+    )
+
+    @staticmethod
+    def _uncurated_next_actions(
+        next_actions: set[str], labels: dict[str, str], grandfathered: frozenset[str]
+    ) -> list[str]:
+        return sorted(
+            action
+            for action in next_actions
+            if action and action not in labels and action not in grandfathered
+        )
+
+    @staticmethod
+    def _policy_skills_without_coverage_case(
+        policy_skills: set[str], covered_skills: set[str], grandfathered: frozenset[str]
+    ) -> list[str]:
+        return sorted(
+            skill
+            for skill in policy_skills
+            if skill not in covered_skills and skill not in grandfathered
+        )
+
+    def test_new_policy_and_card_next_actions_have_curated_labels(self) -> None:
+        from omh.routing import recommend
+        from omh.routing.action_copy import NEXT_ACTION_LABELS
+        from omh.wrapper import contract
+
+        policies = {
+            **recommend._SKILL_POLICIES,
+            **recommend._CATEGORY_POLICIES,
+            **recommend._HERMES_ROLE_POLICIES,
+        }
+        card_dicts = (
+            contract._OPERATING_BRIEF_CHAT_CARDS,
+            contract._META_ROUTER_CHAT_CARDS,
+            contract._REVIEW_QUALITY_CHAT_CARDS,
+            contract._DELIVERY_RUNTIME_CHAT_CARDS,
+            contract._WORKFLOW_OPERATIONS_CHAT_CARDS,
+        )
+        next_actions = {policy.next_action for policy in policies.values()}
+        next_actions |= {
+            str(card.get("next_action", "")) for cards in card_dicts for card in cards.values()
+        }
+
+        missing = self._uncurated_next_actions(
+            next_actions, NEXT_ACTION_LABELS, self._UNCURATED_LEGACY_NEXT_ACTIONS
+        )
+        self.assertEqual(
+            missing,
+            [],
+            "next_action(s) without a curated label: add "
+            "'<next_action>': '<gerund phrase>' to NEXT_ACTION_LABELS in "
+            "src/routing/action_copy.py (do not rely on the '_'->' ' fallback "
+            "for new actions).",
+        )
+
+    def test_curated_label_gate_detects_new_uncurated_action(self) -> None:
+        detected = self._uncurated_next_actions(
+            {"prepare_brand_new_surface"}, {}, self._UNCURATED_LEGACY_NEXT_ACTIONS
+        )
+        self.assertEqual(detected, ["prepare_brand_new_surface"])
+
+    def test_new_policy_skills_register_a_chat_card_coverage_case(self) -> None:
+        from omh.quality.chat_card_coverage import CHAT_CARD_COVERAGE_CASES
+        from omh.quality.routing_precision import ROUTING_INTERVENTION_CASES
+        from omh.routing import recommend
+
+        covered = {case.expected_skill for case in CHAT_CARD_COVERAGE_CASES}
+        covered |= {case.expected_workflow for case in ROUTING_INTERVENTION_CASES}
+        missing = self._policy_skills_without_coverage_case(
+            set(recommend._SKILL_POLICIES), covered, self._CARD_COVERAGE_LEGACY_SKILLS
+        )
+        self.assertEqual(
+            missing,
+            [],
+            "Skill(s) with a _SKILL_POLICIES entry but no coverage case: add a "
+            "ChatCardCoverageCase in src/quality/chat_card_coverage.py or a "
+            "RoutingInterventionCase in src/quality/routing_precision.py so the "
+            "harness proves the skill renders a dedicated card, not a generic "
+            "ack. Remember: intervention cases move the exact-count fixtures "
+            "in 4 test files.",
+        )
+
+    def test_card_coverage_gate_detects_new_unregistered_skill(self) -> None:
+        detected = self._policy_skills_without_coverage_case(
+            {"brand-new-skill"}, set(), self._CARD_COVERAGE_LEGACY_SKILLS
+        )
+        self.assertEqual(detected, ["brand-new-skill"])
 
     def test_cancel_routes_to_control_action_without_plan_ui(self) -> None:
         payload = build_chat_interaction_payload("cancel", source="discord")


### PR DESCRIPTION
## Capability

Adding a new installable skill no longer requires blind edits across five hidden registries. After this PR, a skill author touches: the `SkillDefinition` in `src/skills/catalog.py` (with an optional `capability_family` field for the rare cross-lane case), the documented exact-count fixtures, one regen command set — and the genuinely hand-authored surfaces (awareness lane order, UX labels, chat cards), each of which now fails CI with a **paste-ready message naming the exact file, structure, and entry to add** instead of a bare `assertFalse`.

## Motivation

Shipping `meta-router` (PR #618) required discovering, one undocumented test failure at a time: awareness lanes, `_WORKFLOW_CONTEXT_CARD_BY_WORKFLOW`, `_WORKFLOW_FAMILY_OVERRIDES`, the vendored `STANDALONE_CAPABILITY_FAMILIES` byte-copy, `VISIBLE_ACTIONS`/`_ACK_PRIMARY_ACTIONS_BY_NEXT_ACTION`, and `NEXT_ACTION_LABELS`. None of that was in CLAUDE.md. This PR is the consensus-planned (Planner → Architect → Critic, APPROVE with 7 binding amendments) fix for that marginal cost.

## Implementation (boundary level)

- **Derivation where it is provably safe (core-side):** `SkillDefinition.capability_family` (render-invisible) replaces the 86-entry `_WORKFLOW_FAMILY_OVERRIDES` dict — 80 entries were redundant with awareness-lane defaults; the 5 real cross-lane skills carry the field and the conceptual `dynamic-workflow` surface is assigned directly in `_workflow_family_overrides()`.
- **Codegen where the standalone boundary forbids imports:** the plugin bundle's vendored family tuple becomes a generated `capability_families.json` sidecar — written by the new `omh docs capability-families` command from `capability_family_projection()[\"families\"]`, loaded `__file__`-relative via stdlib `json` with graceful degradation, shipped through a new `[tool.setuptools.package-data]` entry, and gated by `--check` byte-parity plus the existing dict-equality test. The bundle still imports nothing from omh core.
- **Actionable gates where humans must author:** awareness-lane/context-card coverage, visible/ack registration, curated `NEXT_ACTION_LABELS`, and chat-card coverage-case registration. The label and coverage gates freeze today's legacy sets (3 fallback next_actions; 35 pre-existing uncovered skills) and fail **only for new unregistered skills** — adding labels for the legacy trio was explicitly rejected because it would change rendered chat text. Each gate ships with a negative test proving it goes red on a synthetic violation (per repo guard-pattern rules).
- **Docs:** `docs/ADDING-A-SKILL.md` checklist; CLAUDE.md Generated Artifacts Map row for the sidecar + a pitfalls pointer.

## Verification (observed)

- Zero behavior change proven: `awareness_primer_payload()` and `capability_family_projection()` JSON dumps **byte-identical** to pre-refactor baselines captured on clean main; `git diff` **empty** on `skills/`, `docs/WORKFLOWS.md`, `docs/ROLES.md`, demo cards (no regeneration needed — the new field is render-invisible by construction).
- `PYTHONPATH=tests uv run python -m unittest discover -s tests`: **1535 tests OK** (baseline 1531 + 4 new gate/negative tests; 1 pre-existing skip). Exact-count fixtures untouched.
- `omh docs workflows --check` (tap-skills 95/95), `docs roles --check`, new `docs capability-families --check`, `compileall`, `git diff --check`: all clean.
- Packaging: `test_plugin_distribution` extended to assert the sidecar ships (`importlib.resources` file check + package-data map entry) — this was the Architect-caught silent prod-only break.

## Risks / evidence boundaries

- The sidecar is the one deploy-visible surface: a stale file fails `--check` in CI, a missing file degrades the standalone tool to an empty family list rather than an import crash. Installed-wheel runtime load on a real Hermes host remains `prepared_not_observed`.
- The frozen legacy allowlists intentionally document debt (3 uncurated next_actions, 35 uncovered skills); shrinking them is welcome follow-up, extending them is a review smell called out in the test comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)