### PR TITLE
feat: one-question setup with usage-time coding-owner delegation

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -119,15 +119,17 @@ The curl installer intentionally stops before setup. It installs the isolated
 command package and `omh` executable only. `omh setup` is the explicit,
 repairable step that installs generated managed skills and registers them with
 Hermes through `skills.external_dirs`.
-When `omh setup` is run in a real terminal, it opens a small colored wizard that
-chooses the setup language, connects OMH to the target Hermes profile, asks for
-one simple default coding agent suggestion (`Codex`, `Claude Code`, or
-`Hermes`), installs the OMH status helper, and then prints a human-readable
-summary. For a first install, pressing Enter through the recommended choices is
-the intended path. Advanced setup only asks about optional tool bridge
-preferences. Team/profile packs and operating models stay available as explicit
-commands or flags, but setup does not make a user lock the whole organization
-shape during first install. In non-interactive shells it uses safe defaults and
+When `omh setup` is run in a real terminal, it asks exactly one question —
+install scope (user or project). The setup language is auto-detected from the
+OS locale (`--language` or `OMH_LANG` override it), Hermes registration
+defaults to on (`--skip-apply` opts out), and there is no upfront coding-agent
+question: Hermes asks who should own coding work at the first coding request,
+in natural language. Optional surfaces stay behind flags — `--with-mcp` for
+the tool bridge, `--with-menubar`/`--no-menubar` for the menu bar, `--star`
+to star the GitHub repo. Team/profile packs and operating models stay
+available as explicit commands or flags, but setup does not make a user lock
+the whole organization shape during first install. In non-interactive shells
+it uses the same safe defaults and
 prints a concise step-by-step summary. Use
 `omh setup --json` or `OMH_OUTPUT=json omh setup` for the full
 machine-readable payload.
@@ -1204,17 +1206,17 @@ The `cto-loop` pack is an optional CTO, PM, Dev, QA, Security, and Ops
 team-shaped preset. It is not installed by default; use it only when the target
 Hermes workspace benefits from visible role files.
 
-Record a default coding agent during setup:
+Pin a durable coding-owner preference (optional — interactive setup never
+asks; by default Hermes asks at the first coding request):
 
 ```sh
 omh setup --default-executor claude-code
 ```
 
 Supported values are `choose`, `hermes`, `codex`, `claude-code`, `generic`,
-`omx-runtime`, `omo-runtime`, and `omc-runtime`. The interactive wizard
-intentionally shows only `Codex`, `Claude Code`, and `Hermes` so first setup
-stays understandable. Use the wider flag values only for wrappers, scripts, or
-advanced runtime profiles. Legacy `OMH_SETUP_PROFILES=1,3` still maps to setup
+`omx-runtime`, `omo-runtime`, and `omc-runtime`. This flag exists for
+wrappers, scripts, and users who want a standing default instead of the
+per-request question. Legacy `OMH_SETUP_PROFILES=1,3` still maps to setup
 profile categories for automation that already uses it, but new scripts should
 prefer `OMH_DEFAULT_EXECUTOR`.
 

--- a/src/commands/language.py
+++ b/src/commands/language.py
@@ -38,8 +38,6 @@ LANGUAGE_NAMES = {
 
 MESSAGES = {
     "en": {
-        "language_title": "Setup language",
-        "language_intro": "Choose the language OMH should use for this terminal setup.",
         "menu_hint": "Use ↑/↓, Space/Enter, or a number. Colors are not required.",
         "recommended": "recommended",
         "select": "Select",
@@ -59,27 +57,8 @@ MESSAGES = {
         "status_already_registered": "already registered",
         "status_will_register": "will connect OMH workflows",
         "status_will_create": "will create",
-        "register_question": "Connect OMH workflows to this Hermes profile?",
-        "register_note": "This lets Hermes find the OMH workflows installed on this machine.",
-        "executor_title": "Default coding agent",
-        "executor_intro_1": "Choose who Hermes should suggest for coding work.",
-        "executor_intro_2": "This only saves the first suggestion; Hermes can still switch per request.",
-        "executor_choose_label": "Ask every time",
-        "executor_choose_desc": "Recommended. Hermes asks before using Codex, Claude Code, Hermes, or another coding agent.",
-        "executor_codex_label": "Codex",
-        "executor_codex_desc": "Use Codex for repo implementation, tests, and PR-shaped work.",
-        "executor_claude_label": "Claude Code",
-        "executor_claude_desc": "Use Claude Code when your team codes through Claude Code.",
-        "executor_generic_label": "Other coding agent",
-        "executor_generic_desc": "Prepare a portable prompt for another coding agent.",
-        "executor_hermes_label": "Hermes",
-        "executor_hermes_desc": "Keep coding work inside Hermes with OMH workflow guidance.",
-        "executor_runtime_label": "Oh-my runtime",
-        "executor_runtime_desc": "Use an oh-my runtime profile when the user has one.",
         "invalid_executor": "Invalid default executor: {error}",
         "plugin_note": "The plugin exposes local status context to Hermes without changing workflow behavior by itself.",
-        "mcp_question": "Prepare optional MCP bridge settings?",
-        "mcp_note": "This only records the bridge preference; OMH does not claim MCP host load until a host reports it.",
         "mcp_host_title": "MCP host",
         "mcp_host_intro": "Choose where OMH should write the local stdio MCP bridge config.",
         "mcp_host_generic_desc": "Only show the portable recipe; do not write a host config file.",
@@ -100,11 +79,6 @@ MESSAGES = {
         "team_none_label": "No extra team role preset now",
         "team_none_desc": "Recommended for first install. Core skills stay installed; other surfaces remain available through Hermes routing.",
         "advanced_title": "Advanced options",
-        "advanced_question": "Show advanced tool bridge options?",
-        "advanced_note": "Skip this on a first install. Team/profile packs stay available with explicit setup flags or `omh profile`.",
-        "github_star_question": "Would you like to star oh-my-hermes on GitHub?",
-        "github_star_note": "Yes uses your authenticated GitHub account. Setup continues either way.",
-        "github_star_declined": "🥲 No worries — continuing setup.",
         "github_star_thanks": "Thanks!",
         "github_star_dry_run": "Dry run only — GitHub star would be recorded here.",
         "github_star_failed": "Could not record the GitHub star: {reason}",
@@ -157,6 +131,7 @@ MESSAGES = {
         "registration_unknown": "Hermes connection: {status}",
         "apply_line": "Hermes connection detail: {message}",
         "default_handoff": "Coding requests: {summary}",
+        "default_handoff_pin_hint": "Tip: pin a durable owner anytime with `omh setup --default-executor <name>`.",
         "setup_profile": "Advanced routing detail: {selected}",
         "target_topology": "Hermes profile check: {count} profile(s) detected.",
         "plugin_bridge": "OMH status helper: {status}",
@@ -249,8 +224,6 @@ MESSAGES = {
         "kept": "Kept",
     },
     "ko": {
-        "language_title": "설치 언어",
-        "language_intro": "이 터미널 설치에서 OMH가 사용할 언어를 선택합니다.",
         "menu_hint": "↑/↓, Space/Enter, 숫자로 선택할 수 있습니다. 색상 없이도 동작합니다.",
         "recommended": "추천",
         "select": "선택",
@@ -270,27 +243,8 @@ MESSAGES = {
         "status_already_registered": "이미 등록됨",
         "status_will_register": "OMH 워크플로 연결 예정",
         "status_will_create": "생성 예정",
-        "register_question": "이 Hermes 프로필에 OMH 워크플로를 연결할까요?",
-        "register_note": "Hermes가 이 기기에 설치된 OMH 워크플로를 찾을 수 있게 합니다.",
-        "executor_title": "기본 코딩 에이전트",
-        "executor_intro_1": "Hermes가 코딩 작업에 먼저 제안할 대상을 고릅니다.",
-        "executor_intro_2": "이 값은 첫 제안만 저장합니다. 요청마다 Hermes가 다시 바꿀 수 있습니다.",
-        "executor_choose_label": "매번 물어보기",
-        "executor_choose_desc": "추천. Codex, Claude Code, Hermes, 기타 코딩 에이전트 중 무엇을 쓸지 먼저 묻습니다.",
-        "executor_codex_label": "Codex",
-        "executor_codex_desc": "저장소 구현, 테스트, PR 형태 작업에 Codex를 사용합니다.",
-        "executor_claude_label": "Claude Code",
-        "executor_claude_desc": "팀이 Claude Code로 코딩할 때 Claude Code를 사용합니다.",
-        "executor_generic_label": "기타 코딩 에이전트",
-        "executor_generic_desc": "다른 코딩 에이전트에도 줄 수 있는 프롬프트를 준비합니다.",
-        "executor_hermes_label": "Hermes",
-        "executor_hermes_desc": "OMH 워크플로 안내와 함께 Hermes 안에서 코딩 작업을 다룹니다.",
-        "executor_runtime_label": "Oh-my 런타임",
-        "executor_runtime_desc": "사용자가 oh-my 런타임을 쓰는 경우 그 프로필을 기본값으로 둡니다.",
         "invalid_executor": "기본 실행자 값이 올바르지 않습니다: {error}",
         "plugin_note": "플러그인은 워크플로 동작 자체를 바꾸지 않고 Hermes에 로컬 상태 맥락을 제공합니다.",
-        "mcp_question": "선택형 MCP 브리지 설정을 준비할까요?",
-        "mcp_note": "브리지 선호만 기록합니다. MCP 호스트가 보고하기 전까지 OMH는 로드됐다고 말하지 않습니다.",
         "mcp_host_title": "MCP 호스트",
         "mcp_host_intro": "OMH가 로컬 stdio MCP 브리지 설정을 어디에 쓸지 고릅니다.",
         "mcp_host_generic_desc": "이식 가능한 recipe만 보여주고 호스트 설정 파일은 쓰지 않습니다.",
@@ -311,11 +265,6 @@ MESSAGES = {
         "team_none_label": "지금은 추가 팀 역할 프리셋 없음",
         "team_none_desc": "첫 설치에 추천합니다. 핵심 스킬은 설치되고, 나머지 surface는 Hermes 라우팅으로 사용할 수 있습니다.",
         "advanced_title": "고급 옵션",
-        "advanced_question": "고급 도구 브리지 옵션을 볼까요?",
-        "advanced_note": "첫 설치라면 건너뛰어도 됩니다. 팀/프로필 팩은 명시적 setup 옵션이나 `omh profile`로 계속 사용할 수 있습니다.",
-        "github_star_question": "GitHub에서 oh-my-hermes에 star를 눌러줄까요?",
-        "github_star_note": "Yes를 누르면 인증된 GitHub 계정으로 star를 시도합니다. setup은 어떤 답을 골라도 계속 진행됩니다.",
-        "github_star_declined": "🥲 괜찮아요 — setup을 계속 진행합니다.",
         "github_star_thanks": "고마워요!",
         "github_star_dry_run": "dry-run입니다 — 여기서는 GitHub star를 기록하지 않습니다.",
         "github_star_failed": "GitHub star를 기록하지 못했습니다: {reason}",
@@ -368,6 +317,7 @@ MESSAGES = {
         "registration_unknown": "Hermes 연결: {status}",
         "apply_line": "Hermes 연결 상세: {message}",
         "default_handoff": "코딩 요청: {summary}",
+        "default_handoff_pin_hint": "팁: `omh setup --default-executor <이름>` 으로 언제든 기본 코딩 에이전트를 고정할 수 있습니다.",
         "setup_profile": "고급 라우팅 상세: {selected}",
         "target_topology": "Hermes 프로필 확인: {count}개 프로필 감지.",
         "plugin_bridge": "OMH 상태 도우미: {status}",
@@ -460,8 +410,6 @@ MESSAGES = {
         "kept": "유지됨",
     },
     "ja": {
-        "language_title": "セットアップ言語",
-        "language_intro": "このターミナルセットアップで OMH が使う言語を選びます。",
         "menu_hint": "↑/↓、Space/Enter、または数字で選択できます。色なしでも動作します。",
         "recommended": "推奨",
         "select": "選択",
@@ -481,27 +429,8 @@ MESSAGES = {
         "status_already_registered": "登録済み",
         "status_will_register": "OMH ワークフローを接続予定",
         "status_will_create": "作成予定",
-        "register_question": "この Hermes プロファイルに OMH ワークフローを接続しますか?",
-        "register_note": "Hermes がこのマシンにインストールされた OMH ワークフローを見つけられるようにします。",
-        "executor_title": "既定のコーディングエージェント",
-        "executor_intro_1": "Hermes がコーディング作業で最初に提案する相手を選びます。",
-        "executor_intro_2": "保存されるのは最初の提案だけです。リクエストごとに Hermes は切り替えられます。",
-        "executor_choose_label": "毎回確認",
-        "executor_choose_desc": "推奨。Codex、Claude Code、Hermes、その他のコーディングエージェントのどれを使うか確認します。",
-        "executor_codex_label": "Codex",
-        "executor_codex_desc": "リポジトリ実装、テスト、PR 形の作業に Codex を使います。",
-        "executor_claude_label": "Claude Code",
-        "executor_claude_desc": "チームが Claude Code でコーディングする場合に使います。",
-        "executor_generic_label": "その他のコーディングエージェント",
-        "executor_generic_desc": "別のコーディングエージェントに渡せるプロンプトを準備します。",
-        "executor_hermes_label": "Hermes",
-        "executor_hermes_desc": "OMH ワークフロー案内とともに Hermes 内でコーディング作業を扱います。",
-        "executor_runtime_label": "Oh-my ランタイム",
-        "executor_runtime_desc": "oh-my ランタイムを使う場合、そのプロファイルを既定にします。",
         "invalid_executor": "既定実行者が無効です: {error}",
         "plugin_note": "プラグインはワークフロー動作自体を変えずに、Hermes にローカル状態の文脈を渡します。",
-        "mcp_question": "任意の MCP ブリッジ設定を準備しますか?",
-        "mcp_note": "ブリッジ設定の希望だけを記録します。MCP ホストが報告するまで、OMH はロード済みとは主張しません。",
         "mcp_host_title": "MCP ホスト",
         "mcp_host_intro": "OMH がローカル stdio MCP ブリッジ設定を書き込む先を選びます。",
         "mcp_host_generic_desc": "ポータブルなレシピだけを表示し、ホスト設定ファイルは書き込みません。",
@@ -522,11 +451,6 @@ MESSAGES = {
         "team_none_label": "今は追加チームペルソナなし",
         "team_none_desc": "初回インストールに推奨。主要スキルは入り、他の surface は Hermes ルーティングで利用できます。",
         "advanced_title": "詳細オプション",
-        "advanced_question": "詳細なツールブリッジオプションを表示しますか?",
-        "advanced_note": "初回インストールではスキップして問題ありません。チーム/プロファイルパックは明示的な setup フラグや `omh profile` で利用できます。",
-        "github_star_question": "GitHub で oh-my-hermes に star を付けますか?",
-        "github_star_note": "Yes を選ぶと、認証済みの GitHub アカウントで star を試みます。どちらを選んでもセットアップは続行します。",
-        "github_star_declined": "🥲 大丈夫です — セットアップを続行します。",
         "github_star_thanks": "ありがとうございます!",
         "github_star_dry_run": "dry-run のため、ここでは GitHub star を記録しません。",
         "github_star_failed": "GitHub star を記録できませんでした: {reason}",
@@ -579,6 +503,7 @@ MESSAGES = {
         "registration_unknown": "Hermes 接続: {status}",
         "apply_line": "Hermes 接続詳細: {message}",
         "default_handoff": "コーディングリクエスト: {summary}",
+        "default_handoff_pin_hint": "ヒント: `omh setup --default-executor <name>` でいつでも既定のコーディングエージェントを固定できます。",
         "setup_profile": "詳細ルーティング: {selected}",
         "target_topology": "Hermes プロファイル確認: {count} 個のプロファイルを検出。",
         "plugin_bridge": "OMH ステータスヘルパー: {status}",
@@ -671,8 +596,6 @@ MESSAGES = {
         "kept": "保持",
     },
     "zh": {
-        "language_title": "设置语言",
-        "language_intro": "选择 OMH 在本次终端设置中使用的语言。",
         "menu_hint": "可用 ↑/↓、Space/Enter 或数字选择。无颜色也可使用。",
         "recommended": "推荐",
         "select": "选择",
@@ -692,27 +615,8 @@ MESSAGES = {
         "status_already_registered": "已注册",
         "status_will_register": "将连接 OMH 工作流",
         "status_will_create": "将创建",
-        "register_question": "是否将 OMH 工作流连接到此 Hermes 配置?",
-        "register_note": "这会让 Hermes 找到此机器上安装的 OMH 工作流。",
-        "executor_title": "默认编码代理",
-        "executor_intro_1": "选择 Hermes 在编码工作中优先建议的对象。",
-        "executor_intro_2": "这里只保存首次建议；每次请求 Hermes 仍可切换。",
-        "executor_choose_label": "每次询问",
-        "executor_choose_desc": "推荐。先询问使用 Codex、Claude Code、Hermes，还是其他编码代理。",
-        "executor_codex_label": "Codex",
-        "executor_codex_desc": "将 Codex 用于仓库实现、测试和 PR 型工作。",
-        "executor_claude_label": "Claude Code",
-        "executor_claude_desc": "当团队通过 Claude Code 编码时使用 Claude Code。",
-        "executor_generic_label": "其他编码代理",
-        "executor_generic_desc": "准备可交给其他编码代理的通用提示词。",
-        "executor_hermes_label": "Hermes",
-        "executor_hermes_desc": "在 OMH 工作流指导下把编码工作留在 Hermes 内处理。",
-        "executor_runtime_label": "Oh-my 运行时",
-        "executor_runtime_desc": "用户使用 oh-my 运行时时，将该配置作为默认值。",
         "invalid_executor": "默认执行器无效: {error}",
         "plugin_note": "插件向 Hermes 提供本地状态上下文，但本身不会改变工作流行为。",
-        "mcp_question": "是否准备可选 MCP 桥设置?",
-        "mcp_note": "这里只记录桥接偏好；在 MCP host 报告前，OMH 不会声称已加载。",
         "mcp_host_title": "MCP host",
         "mcp_host_intro": "选择 OMH 应写入本地 stdio MCP 桥配置的位置。",
         "mcp_host_generic_desc": "只显示可移植 recipe，不写入 host 配置文件。",
@@ -733,11 +637,6 @@ MESSAGES = {
         "team_none_label": "现在不添加团队角色预设",
         "team_none_desc": "首次安装推荐。核心技能会安装，其他 surface 仍可通过 Hermes 路由使用。",
         "advanced_title": "高级选项",
-        "advanced_question": "显示高级工具桥选项吗?",
-        "advanced_note": "首次安装可以跳过。团队/配置包仍可通过显式 setup 标志或 `omh profile` 使用。",
-        "github_star_question": "要在 GitHub 上给 oh-my-hermes 加星吗?",
-        "github_star_note": "选择 Yes 会使用已认证的 GitHub 账户尝试加星。无论选择什么，setup 都会继续。",
-        "github_star_declined": "🥲 没关系 — 继续 setup。",
         "github_star_thanks": "谢谢!",
         "github_star_dry_run": "dry-run 模式 — 此处不会记录 GitHub star。",
         "github_star_failed": "未能记录 GitHub star: {reason}",
@@ -790,6 +689,7 @@ MESSAGES = {
         "registration_unknown": "Hermes 连接: {status}",
         "apply_line": "Hermes 连接详情: {message}",
         "default_handoff": "编码请求: {summary}",
+        "default_handoff_pin_hint": "提示: 随时可用 `omh setup --default-executor <name>` 固定默认编码代理。",
         "setup_profile": "高级路由详情: {selected}",
         "target_topology": "Hermes 配置检查: 检测到 {count} 个配置。",
         "plugin_bridge": "OMH 状态助手: {status}",
@@ -895,6 +795,28 @@ def normalize_language(value: str | None) -> str:
 
 def language_from_env(default: str = "en") -> str:
     return normalize_language(os.environ.get("OMH_LANG") or os.environ.get("OMH_LANGUAGE") or default)
+
+
+def detect_locale_language(default: str = "en") -> str:
+    """Best-effort OS-locale language detection from env strings.
+
+    Reads `LC_ALL` > `LC_MESSAGES` > `LANG` as plain strings (never calls
+    `locale.setlocale`, which can raise on CI runners without generated
+    locales), then falls back to `locale.getlocale()`; unknown or unset
+    locales resolve to `default`.
+    """
+    candidates = [os.environ.get(name, "") for name in ("LC_ALL", "LC_MESSAGES", "LANG")]
+    try:
+        import locale
+
+        candidates.append((locale.getlocale()[0] or ""))
+    except Exception:
+        pass
+    for raw in candidates:
+        prefix = raw.split(".", 1)[0].split("_", 1)[0].split("-", 1)[0].strip().lower()
+        if prefix in LANGUAGE_CODES:
+            return prefix
+    return default
 
 
 def language_options() -> list[dict[str, str]]:

--- a/src/commands/setup.py
+++ b/src/commands/setup.py
@@ -42,7 +42,6 @@ from ..runtime.artifacts import read_state_result, update_state
 from ..setup_profiles import (
     PROJECT_MEMORY_MODES,
     build_setup_profile,
-    setup_profile_categories_for_executor,
     write_setup_profile,
 )
 from ..snippet import WORKSPACE_SNIPPET
@@ -56,7 +55,7 @@ from ..team_profiles import (
     operating_model_ids,
 )
 from .common import _action_label, _paths, _print_json, _wants_json
-from .language import LANGUAGE_CODES, language_from_env, language_options, normalize_language, tr
+from .language import LANGUAGE_CODES, detect_locale_language, language_from_env, normalize_language, tr
 
 INSTALLER_COMMAND = "curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes/main/install.sh | sh"
 COMMAND_PACKAGE_STATUS_SCHEMA_VERSION = "command_package_status/v1"
@@ -895,14 +894,12 @@ def cmd_setup(args: argparse.Namespace) -> int:
     language = _setup_language(args)
     paths = _paths(args)
     if _setup_should_interact(args):
-        if not _language_was_explicit(args):
-            language = _ask_setup_language(use_color=_use_color())
-            args.language = language
         if not _setup_paths_were_explicit(args) and not getattr(args, "scope", None):
             args.scope = _ask_setup_scope(use_color=_use_color(), language=language)
             paths = _paths(args)
         _run_setup_wizard(args, paths, language)
-        _offer_github_star_before_setup(language=language, use_color=_use_color(), dry_run=bool(args.dry_run))
+    if getattr(args, "star", False):
+        _star_github_repo(language=language, use_color=_use_color(), dry_run=bool(args.dry_run))
     if not args.with_mcp and (
         str(getattr(args, "mcp_host", "generic") or "generic") != "generic"
         or getattr(args, "mcp_config_path", None)
@@ -1134,7 +1131,7 @@ def _resolve_language(args: argparse.Namespace) -> str:
 def _setup_language(args: argparse.Namespace) -> str:
     if _language_was_explicit(args):
         return _resolve_language(args)
-    return "en"
+    return detect_locale_language()
 
 
 def _language_was_explicit(args: argparse.Namespace) -> bool:
@@ -1143,17 +1140,6 @@ def _language_was_explicit(args: argparse.Namespace) -> bool:
 
 def _setup_paths_were_explicit(args: argparse.Namespace) -> bool:
     return bool(getattr(args, "omh_home", None) or getattr(args, "hermes_home", None))
-
-
-def _ask_setup_language(*, use_color: bool) -> str:
-    return _ask_single_choice(
-        tr("en", "language_title"),
-        [tr("en", "language_intro")],
-        language_options(),
-        default_choice="1",
-        use_color=use_color,
-        language="en",
-    )
 
 
 def _ask_setup_scope(*, use_color: bool, language: str) -> str:
@@ -1198,54 +1184,21 @@ def _run_setup_wizard(args: argparse.Namespace, paths, language: str) -> None:
         print(f"{tr(language, 'hermes_config')}: {_color(str(paths.hermes_config_path), '36', use_color)} ({tr(language, 'status_will_create')})")
     print(f"{tr(language, 'managed_skills')}: {_color(str(paths.skills_dir), '36', use_color)}")
 
-    args.skip_apply = not _ask_yes_no(
-        tr(language, "register_question"),
-        default=True,
-        use_color=use_color,
-        note=tr(language, "register_note"),
-        language=language,
-    )
-    args.default_executor = _ask_default_executor(use_color=use_color, language=language)
-    args.profile = setup_profile_categories_for_executor(str(args.default_executor))
-    show_advanced = _ask_yes_no(
-        tr(language, "advanced_question"),
-        default=False,
-        use_color=use_color,
-        note=tr(language, "advanced_note"),
-        language=language,
-    )
-    if show_advanced:
-        args.with_mcp = _ask_yes_no(
-            tr(language, "mcp_question"),
-            default=False,
+    if not args.profile and not getattr(args, "default_executor", None):
+        # No upfront coding-owner question: safety-first records "choose" so
+        # Hermes asks at the first coding request instead of setup time.
+        args.profile = ["safety-first"]
+    if args.with_mcp and str(getattr(args, "mcp_host", "generic") or "generic") == "generic":
+        args.mcp_host = _ask_mcp_host(
             use_color=use_color,
-            note=tr(language, "mcp_note"),
             language=language,
+            default_host=_default_mcp_host_for_executor(str(getattr(args, "default_executor", "") or "")),
         )
-        if args.with_mcp:
-            args.mcp_host = _ask_mcp_host(
-                use_color=use_color,
-                language=language,
-                default_host=_default_mcp_host_for_executor(str(getattr(args, "default_executor", "") or "")),
-            )
-    else:
-        args.with_mcp = False
     args.profile_pack = explicit_profile_packs
     print("")
 
 
-def _offer_github_star_before_setup(*, language: str, use_color: bool, dry_run: bool = False) -> None:
-    wants_star = _ask_yes_no(
-        tr(language, "github_star_question"),
-        default=True,
-        use_color=use_color,
-        note=tr(language, "github_star_note"),
-        language=language,
-    )
-    if not wants_star:
-        print(tr(language, "github_star_declined"))
-        print("")
-        return
+def _star_github_repo(*, language: str, use_color: bool, dry_run: bool = False) -> None:
     if dry_run:
         print(_color(tr(language, "github_star_dry_run"), "33", use_color))
         print("")
@@ -1274,46 +1227,6 @@ def _try_star_github_repo() -> dict[str, object]:
         return {"ok": True, "reason": "starred_or_already_starred"}
     detail = (completed.stderr or completed.stdout or "gh repo star failed").strip()
     return {"ok": False, "reason": detail}
-
-
-def _ask_default_executor(*, use_color: bool, language: str) -> str:
-    options = [
-        {
-            "choice": "1",
-            "value": "codex",
-            "label": tr(language, "executor_codex_label"),
-            "description": tr(language, "executor_codex_desc"),
-        },
-        {
-            "choice": "2",
-            "value": "claude-code",
-            "label": tr(language, "executor_claude_label"),
-            "description": tr(language, "executor_claude_desc"),
-        },
-        {
-            "choice": "3",
-            "value": "hermes",
-            "label": tr(language, "executor_hermes_label"),
-            "description": tr(language, "executor_hermes_desc"),
-        },
-    ]
-    value = _ask_single_choice(
-        tr(language, "executor_title"),
-        [
-            tr(language, "executor_intro_1"),
-            tr(language, "executor_intro_2"),
-        ],
-        options,
-        default_choice="1",
-        use_color=use_color,
-        language=language,
-    )
-    try:
-        build_setup_profile(default_executor=value)
-    except ValueError as exc:
-        print(_color(tr(language, "invalid_executor", error=exc), "31", use_color))
-        return "choose"
-    return value
 
 
 def _ask_mcp_host(*, use_color: bool, language: str, default_host: str = "generic") -> str:
@@ -1663,6 +1576,8 @@ def _print_setup_summary(payload: dict[str, object], *, language: str = "en") ->
         executor = str(profile.get("default_executor", ""))
         if executor:
             print(f"  {tr(language, 'default_handoff', summary=_executor_summary(language, executor))}")
+            if executor == "choose":
+                print(f"  {tr(language, 'default_handoff_pin_hint')}")
 
     if isinstance(topology, dict):
         print(
@@ -2789,6 +2704,7 @@ def _add_top_level_commands(sub) -> None:
     setup.add_argument("--interactive", action="store_true", help="Force the interactive setup wizard.")
     setup.add_argument("--no-interactive", action="store_true", help="Disable the interactive setup wizard.")
     setup.add_argument("--skip-apply", action="store_true", help="Install skills without registering them in Hermes config.")
+    setup.add_argument("--star", action="store_true", help="Star the oh-my-hermes GitHub repo via gh after setup (opt-in; never prompted).")
     setup.add_argument(
         "--profile",
         action="append",
@@ -2799,7 +2715,7 @@ def _add_top_level_commands(sub) -> None:
         "--default-executor",
         choices=CODING_EXECUTOR_TARGETS,
         default=None,
-        help="Default coding agent suggestion. Interactive setup only shows Codex, Claude Code, and Hermes.",
+        help="Durable coding-owner preference for automation and scripted installs. Interactive setup never asks; by default Hermes asks at the first coding request.",
     )
     setup.add_argument(
         "--operating-model",

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -5304,11 +5304,15 @@ def build_chat_response_from_delegation(delegation_payload: dict[str, object], *
         return _chat_response(
             kind="handoff",
             headline="Choose the coding agent.",
-            body="Pick Codex, Claude Code, Hermes, or an oh-my runtime path before this becomes a prepared coding handoff.",
+            body="Keep this in Hermes, hand it to Claude Code, hand it to Codex or an oh-my runtime path, or split it across several agents in parallel before this becomes a prepared coding handoff.",
             phase="executor_choice_required",
             next_action="choose_executor",
             thread_key=thread_key,
-            actions=[_action("choose_executor", "Choose coding agent", "primary"), _action("show_status", "Show status", "secondary")],
+            actions=[
+                _action("choose_executor", "Choose coding agent", "primary"),
+                _action("prepare_agent_board_card", "Split across agents", "secondary"),
+                _action("show_status", "Show status", "secondary"),
+            ],
             claim_boundary="Coding-agent choice is not dispatch or implementation evidence.",
             extra_state={
                 "delegation_action": action,

--- a/src/wrapper/sessions.py
+++ b/src/wrapper/sessions.py
@@ -973,11 +973,15 @@ def _session_chat_response(session: dict[str, Any]) -> dict[str, object]:
         return response(
             kind="handoff",
             headline="Choose the coding agent.",
-            body="Pick Codex, Claude Code, Hermes, or a runtime path before this becomes a prepared coding handoff.",
+            body="Keep this in Hermes, hand it to Claude Code, hand it to Codex or an oh-my runtime path, or split it across several agents in parallel before this becomes a prepared coding handoff.",
             phase="executor_choice_required",
             next_action="choose_executor",
             thread_key=thread_key,
-            actions=[_action("choose_executor", "Choose coding agent", "primary"), _action("cancel", "Cancel", "secondary")],
+            actions=[
+                _action("choose_executor", "Choose coding agent", "primary"),
+                _action("prepare_agent_board_card", "Split across agents", "secondary"),
+                _action("cancel", "Cancel", "secondary"),
+            ],
             claim_boundary="Choosing a coding agent is not dispatch or implementation evidence.",
         )
     if status == "executor_selected":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2262,47 +2262,32 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
             omh_home = root / ".omh"
             hermes_home = root / ".hermes"
             base = ["--omh-home", str(omh_home), "--hermes-home", str(hermes_home)]
-            answers = "\n".join(
-                [
-                    "1",
-                    "y",
-                    "1",
-                    "y",
-                    "y",
-                    "n",
-                ]
-            ) + "\n"
 
-            status, stdout, stderr = run_cli(base + ["setup", "--interactive"], output_json=False, stdin_text=answers)
+            status, stdout, stderr = run_cli(base + ["setup", "--interactive"], output_json=False, stdin_text="")
 
             self.assertEqual(status, 0, stderr)
             self.assertEqual(stderr, "")
             self.assertIn("OMH setup", stdout)
-            self.assertIn("Default coding agent", stdout)
-            self.assertIn("Choose who Hermes should suggest for coding work", stdout)
-            self.assertIn("1) Codex", stdout)
-            self.assertIn("2) Claude Code", stdout)
-            self.assertIn("3) Hermes", stdout)
-            self.assertIn("Show advanced tool bridge options", stdout)
-            self.assertNotIn("Ask every time", stdout)
-            self.assertNotIn("Other coding agent", stdout)
-            self.assertNotIn("Oh-my runtime", stdout)
+            self.assertNotIn("Default coding agent", stdout)
+            self.assertNotIn("Choose who Hermes should suggest for coding work", stdout)
+            self.assertNotIn("Register OMH workflows", stdout)
+            self.assertNotIn("Show advanced tool bridge options", stdout)
+            self.assertNotIn("GitHub star", stdout)
             self.assertNotIn("Add an optional visible team role preset", stdout)
-            self.assertNotIn("every OMH workflow is still installed", stdout)
             self.assertIn("OMH setup complete.", stdout)
             self.assertIn("OMH status helper:", stdout)
-            self.assertNotIn("Install optional plugin bridge", stdout)
-            self.assertIn("Advanced tool bridge: preference recorded", stdout)
+            self.assertIn("coding preference saved: Ask every time", stdout)
+            self.assertIn("omh setup --default-executor", stdout)
             self.assertIn(str(omh_home / "skills"), (hermes_home / "config.yaml").read_text(encoding="utf-8"))
             profile = json.loads((omh_home / "setup-profile.json").read_text(encoding="utf-8"))
-            self.assertEqual(profile["selected_categories"], ["codex-lifecycle"])
-            self.assertEqual(profile["default_executor"], "codex")
+            self.assertEqual(profile["selected_categories"], ["safety-first"])
+            self.assertEqual(profile["default_executor"], "choose")
+            self.assertEqual(profile["dispatch_policy"], "ask_before_dispatch")
             self.assertTrue((hermes_home / "plugins" / "omh" / "plugin.yaml").exists())
             self.assertFalse((hermes_home / "agents" / "omh-cto-loop-cto.md").exists())
             self.assertFalse((omh_home / "team-profile-packs" / "cto-loop.json").exists())
             state = json.loads((omh_home / "runtime" / "state.json").read_text(encoding="utf-8"))
-            self.assertEqual(state["last_setup"]["mcp_setup"]["mode"], "bridge_requested")
-            self.assertFalse(state["last_setup"]["mcp_setup"]["observed"])
+            self.assertEqual(state["last_setup"]["mcp_setup"]["mode"], "none")
 
     def test_setup_interactive_wizard_uses_defaults_on_eof(self) -> None:
         with TemporaryDirectory() as tmp:
@@ -2314,18 +2299,80 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
             with patch(
                 "omh.commands.setup._try_star_github_repo",
                 return_value={"ok": True, "reason": "starred_or_already_starred"},
-            ) as star:
+            ) as star, patch("omh.commands.setup._ask_single_choice") as single_choice, patch(
+                "omh.commands.setup._ask_yes_no"
+            ) as yes_no:
                 status, stdout, stderr = run_cli(base + ["setup", "--interactive"], output_json=False)
 
             self.assertEqual(status, 0, stderr)
             self.assertEqual(stderr, "")
             self.assertIn("OMH setup", stdout)
             self.assertIn("OMH setup complete.", stdout)
-            star.assert_called_once_with()
+            # Explicit --omh-home/--hermes-home skips the scope question, so a
+            # fully-flagged interactive run asks ZERO questions; star is opt-in
+            # via --star and never fires on its own.
+            self.assertEqual(single_choice.call_count, 0)
+            self.assertEqual(yes_no.call_count, 0)
+            star.assert_not_called()
             profile = json.loads((omh_home / "setup-profile.json").read_text(encoding="utf-8"))
-            self.assertEqual(profile["selected_categories"], ["codex-lifecycle"])
-            self.assertEqual(profile["default_executor"], "codex")
+            self.assertEqual(profile["selected_categories"], ["safety-first"])
+            self.assertEqual(profile["default_executor"], "choose")
             self.assertTrue((hermes_home / "plugins" / "omh" / "plugin.yaml").exists())
+
+    def test_setup_interactive_asks_exactly_one_scope_question(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+
+            with patch("omh.paths.Path.cwd", return_value=root), patch(
+                "omh.commands.setup._ask_single_choice", return_value="project"
+            ) as single_choice, patch("omh.commands.setup._ask_yes_no") as yes_no, patch(
+                "omh.commands.setup._try_star_github_repo"
+            ) as star:
+                status, stdout, stderr = run_cli(["setup", "--interactive"], output_json=False)
+
+            self.assertEqual(status, 0, stderr)
+            self.assertEqual(single_choice.call_count, 1)
+            title = single_choice.call_args.args[0]
+            self.assertIn("scope", title.lower())
+            self.assertEqual(yes_no.call_count, 0)
+            star.assert_not_called()
+
+    def test_setup_star_flag_records_star_headless(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / ".omh"
+            hermes_home = root / ".hermes"
+            base = ["--omh-home", str(omh_home), "--hermes-home", str(hermes_home)]
+
+            with patch(
+                "omh.commands.setup._try_star_github_repo",
+                return_value={"ok": True, "reason": "starred_or_already_starred"},
+            ) as star:
+                status, stdout, stderr = run_cli(base + ["setup", "--star"], output_json=False)
+
+            self.assertEqual(status, 0, stderr)
+            star.assert_called_once_with()
+            self.assertIn("Thanks!", stdout)
+
+    def test_setup_locale_language_detection_precedence(self) -> None:
+        from omh.commands.language import detect_locale_language
+
+        cleared = {name: "" for name in ("OMH_LANG", "OMH_LANGUAGE", "LC_ALL", "LC_MESSAGES", "LANG")}
+        with patch.dict(os.environ, {**cleared, "LANG": "ko_KR.UTF-8"}):
+            self.assertEqual(detect_locale_language(), "ko")
+        with patch.dict(os.environ, {**cleared, "LC_ALL": "ja_JP.UTF-8", "LANG": "ko_KR.UTF-8"}):
+            self.assertEqual(detect_locale_language(), "ja")
+        with patch.dict(os.environ, {**cleared, "LANG": "fr_FR.UTF-8"}):
+            self.assertEqual(detect_locale_language(), "en")
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / ".omh"
+            hermes_home = root / ".hermes"
+            base = ["--omh-home", str(omh_home), "--hermes-home", str(hermes_home)]
+            with patch.dict(os.environ, {**cleared, "LANG": "ko_KR.UTF-8"}):
+                status, stdout, stderr = run_cli(base + ["setup", "--dry-run"], output_json=False)
+            self.assertEqual(status, 0, stderr)
+            self.assertIn("코딩 요청", stdout)
 
     def test_setup_project_scope_uses_project_local_paths(self) -> None:
         with TemporaryDirectory() as tmp:
@@ -10104,43 +10151,43 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
         self.assertFalse(result["ok"])
         self.assertIn("could not run", result["reason"])
 
-    def test_setup_github_star_prompt_uses_localized_copy(self) -> None:
-        output = io.StringIO()
-        with patch("omh.commands.setup._ask_yes_no", return_value=False) as ask, patch("sys.stdout", output):
-            setup_commands._offer_github_star_before_setup(language="ko", use_color=False)
-
-        ask.assert_called_once()
-        self.assertTrue(ask.call_args.kwargs["default"])
-        self.assertEqual(
-            ask.call_args.kwargs["note"],
-            "Yes를 누르면 인증된 GitHub 계정으로 star를 시도합니다. setup은 어떤 답을 골라도 계속 진행됩니다.",
-        )
-        self.assertIn("GitHub에서 oh-my-hermes에 star를 눌러줄까요?", ask.call_args.args[0])
-        self.assertIn("🥲 괜찮아요", output.getvalue())
-
-    def test_setup_github_star_prompt_yes_records_star(self) -> None:
+    def test_setup_star_flag_flow_records_star_without_prompting(self) -> None:
         output = io.StringIO()
         with (
-            patch("omh.commands.setup._ask_yes_no", return_value=True),
             patch(
                 "omh.commands.setup._try_star_github_repo",
                 return_value={"ok": True, "reason": "starred_or_already_starred"},
             ) as star,
+            patch("omh.commands.setup._ask_yes_no") as ask,
             patch("sys.stdout", output),
         ):
-            setup_commands._offer_github_star_before_setup(language="en", use_color=False)
+            setup_commands._star_github_repo(language="en", use_color=False)
 
         star.assert_called_once_with()
+        ask.assert_not_called()
         self.assertIn("Thanks!", output.getvalue())
 
-    def test_setup_github_star_prompt_dry_run_does_not_call_github(self) -> None:
+    def test_setup_star_flag_flow_reports_failure_and_continues(self) -> None:
         output = io.StringIO()
         with (
-            patch("omh.commands.setup._ask_yes_no", return_value=True),
+            patch(
+                "omh.commands.setup._try_star_github_repo",
+                return_value={"ok": False, "reason": "GitHub CLI is not installed"},
+            ),
+            patch("sys.stdout", output),
+        ):
+            setup_commands._star_github_repo(language="en", use_color=False)
+
+        self.assertIn("Could not record the GitHub star", output.getvalue())
+        self.assertIn("Continuing setup.", output.getvalue())
+
+    def test_setup_star_flag_dry_run_does_not_call_github(self) -> None:
+        output = io.StringIO()
+        with (
             patch("omh.commands.setup._try_star_github_repo") as star,
             patch("sys.stdout", output),
         ):
-            setup_commands._offer_github_star_before_setup(language="en", use_color=False, dry_run=True)
+            setup_commands._star_github_repo(language="en", use_color=False, dry_run=True)
 
         star.assert_not_called()
         self.assertIn("Dry run only", output.getvalue())
@@ -10223,30 +10270,12 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
         self.assertNotIn(f"\033[{full_rows}F\033[J", rendered)
         self.assertEqual(rendered.count("Default coding agent"), 1)
 
-    def test_setup_executor_copy_uses_simple_coding_agent_names(self) -> None:
-        from omh.commands.language import tr
+    def test_setup_executor_summary_uses_simple_coding_agent_names(self) -> None:
         from omh.commands.setup import _executor_summary
 
-        self.assertEqual(tr("en", "executor_title"), "Default coding agent")
-        self.assertEqual(tr("en", "executor_intro_1"), "Choose who Hermes should suggest for coding work.")
-        self.assertEqual(tr("en", "executor_codex_label"), "Codex")
-        self.assertEqual(tr("en", "executor_claude_label"), "Claude Code")
-        self.assertEqual(tr("ko", "executor_codex_label"), "Codex")
         self.assertEqual(_executor_summary("en", "codex"), "Codex")
+        self.assertEqual(_executor_summary("en", "claude-code"), "Claude Code")
         self.assertEqual(_executor_summary("ko", "choose"), "매번 물어보기")
-        setup_copy = " ".join(
-            [
-                tr("en", "executor_intro_1"),
-                tr("en", "executor_codex_label"),
-                tr("en", "executor_claude_label"),
-                tr("ko", "executor_intro_1"),
-                tr("ko", "executor_codex_label"),
-                tr("ko", "executor_claude_label"),
-            ]
-        ).lower()
-        self.assertNotIn("handoff", setup_copy)
-        self.assertNotIn("other coding agent", setup_copy)
-        self.assertNotIn("runtime", setup_copy)
 
     def test_optional_team_profile_packs_are_listed_and_installed_on_request(self) -> None:
         status, stdout, stderr = run_cli(["profile", "list"])

--- a/tests/test_wrapper_contract.py
+++ b/tests/test_wrapper_contract.py
@@ -454,6 +454,33 @@ class WrapperContractTests(unittest.TestCase):
         self.assertIn("choose_executor", actions)
         self.assertIn("not dispatch", payload["chat_response"]["claim_boundary"])
 
+    def test_executor_choice_card_offers_neutral_split_across_agents(self) -> None:
+        payload = build_chat_interaction_payload(
+            "research the repo, plan, implement, code-review, sync docs, and prepare a PR",
+            source="discord",
+        )
+        response = payload["chat_response"]
+        actions = {action["id"]: action for action in response["actions"]}
+
+        # POSITIVE: the split option routes to the prepare-only agent-board
+        # surface — a routing choice, never dispatch.
+        self.assertIn("prepare_agent_board_card", actions)
+        self.assertEqual(actions["prepare_agent_board_card"]["label"], "Split across agents")
+        self.assertEqual(actions["prepare_agent_board_card"]["style"], "secondary")
+        self.assertFalse(response["state"]["dispatchable"])
+
+        # Executor-neutral body: Hermes named first, no owner presented as a
+        # numbered default.
+        body = response["body"]
+        self.assertLess(body.index("Hermes"), body.index("Claude Code"))
+        self.assertLess(body.index("Claude Code"), body.index("Codex"))
+        self.assertIn("split it across several agents", body)
+
+        # NEGATIVE: splitting must not surface team/dispatch-style actions or
+        # an executor-specific alias from this card.
+        for forbidden in ("start_team", "start_swarm", "dispatch", "prepare_handoff", "open_codex", "open_claude_code"):
+            self.assertNotIn(forbidden, actions)
+
     def test_clarify_mode_has_no_handoff_actions(self) -> None:
         payload = build_chat_interaction_payload("fix maybe", mode="delegate")
 


### PR DESCRIPTION
## Capability

Interactive `omh setup` now asks **exactly one question — install scope (user vs project)**. Everything else resolves automatically: language auto-detects from the OS locale (`--language`/`OMH_LANG` override), Hermes registration defaults to on (`--skip-apply` opts out), and the coding-agent question is gone from setup entirely. Instead, when the first coding-shaped request arrives with no resolvable owner, Hermes asks **in context, executor-neutrally**: keep it in Hermes, hand it to Claude Code, hand it to Codex or a runtime path — or **split it across several agents in parallel** (a new card action routing to the existing prepare-only agent-board surface).

## Motivation

The old wizard asked 5+ questions and presented **Codex as numbered default choice "1"** in the coding-agent picker — a live violation of the AGENTS.md executor-neutrality contract. The user's direction: don't fix a coding-agent default at install time; ask at use time, in natural language, and treat multi-agent split-and-merge as a first-class option. The runtime already had the right machinery (explicit > message-mention > setup-default > choose/ask-at-dispatch resolution chain); setup was front-loading a decision the chain handles better in context.

## Implementation (boundary level)

- **`src/commands/setup.py`**: language question, register question, executor picker (`_ask_default_executor`), advanced/MCP prompts, and the GitHub-star prompt all removed from the interactive flow; scope remains the sole prompt. Interactive default profile → `safety-first` (`default_executor: choose`, `ask_before_dispatch`). Completion summary gains one line surfacing `omh setup --default-executor <name>` as the opt-in durable-preference escape hatch (never prompted). New opt-in `--star` flag replaces the star prompt — this also kills the previous **silent auto-star on headless/EOF installs**. `--default-executor` help reworded (was factually tied to the removed menu and Codex-first).
- **`src/commands/language.py`**: new `detect_locale_language()` — string-based env parsing only (`LC_ALL` > `LC_MESSAGES` > `LANG` > guarded `locale.getlocale()`, never `setlocale` — CI-safe), mapped through the existing language codes. Precedence: `OMH_LANG`/`OMH_LANGUAGE` > `--language` > OS locale > `en`. 104 orphaned prompt entries removed symmetrically across all four locales; `default_handoff_pin_hint` added in four locales; key parity holds.
- **`src/wrapper/contract.py` + `sessions.py`**: the `executor_choice_required` card bodies are now identical and executor-neutral (Hermes → Claude Code → Codex/runtime order) and gain `Split across agents` → `prepare_agent_board_card` (already-registered action; prepare-only boundary). No new executor profile; `CODING_EXECUTOR_TARGETS`/`executor_selection.options` untouched.
- **Deferred by design** (named per delivery grain): the parallel fan-out + result-merge orchestration engine, and a card-level "remember this choice" affordance.

## Verification (observed)

- Full suite **1539 OK** (+4 net new guards): exactly-one-scope-question test (mock call-count mechanism), headless `--star` positive + star-never-fires-by-default negative, locale-precedence tests incl. a `ko_KR.UTF-8` end-to-end dry-run rendering Korean output with zero prompts, and split-card **positive** (prepare-only agent-board routing, `dispatchable: false`) + **negative** (no team/dispatch/executor-alias actions) guards.
- **Zero routing-fixture churn**: 55/118/173 and 59/179 exact-count contracts confirmed unchanged; README/site capability-table pins untouched (enumeration ≠ default menu).
- `docs workflows/roles/capability-families --check`, `compileall`, `git diff --check` clean; interactive smoke: one prompt, safety-first summary + pin hint.
- Consensus: ralplan Planner v2 → Architect (2 rounds, incl. two newly-found breaks fixed: `github_star_continue` retained for the kept failure path; explicit-path EOF asserts zero prompts with a separate one-prompt test) → Critic **APPROVE** with 7 binding amendments, all honored.

## Risks / evidence boundaries

- Headless installs no longer auto-star the repo (intended fix of a consent issue). Users wanting a standing default use the flag; per-request asking is the user-approved default posture.
- Live Hermes rendering of the reworded card and real-tty wizard behavior beyond the mocked prompt-count tests remain `prepared_not_observed`.
- Locale detection is deliberately scoped to setup; `doctor`/`status` keep their pre-existing English default (documented limitation, candidate follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)