### PR TITLE
feat: deterministic parallel fan-out merge contract for split coding work

### DIFF
--- a/src/coding/fanout.py
+++ b/src/coding/fanout.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+from hashlib import sha256
+import re
+from typing import Mapping, Sequence
+
+from ..ingress import compact_source_metadata
+from .fanout_contracts import (
+    FANOUT_CLAIM_BOUNDARY,
+    FANOUT_CONTRACT_SCHEMA_VERSION,
+    FANOUT_FINAL_INTEGRATION_GATE,
+    FANOUT_UNIT_OWNERS,
+    FanoutContractError,
+    PREPARED_NOT_OBSERVED,
+)
+
+_UNIT_ID_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}$")
+
+
+def build_fanout_contract(
+    goal: str,
+    units: Sequence[Mapping[str, object]],
+    *,
+    source: str = "generic",
+    source_metadata: Mapping[str, object] | None = None,
+) -> dict[str, object]:
+    normalized_goal = " ".join(goal.split())
+    if not normalized_goal:
+        raise FanoutContractError("fanout goal is required")
+    normalized_units = [_normalized_unit(unit, index) for index, unit in enumerate(units)]
+    validate_fanout_units(normalized_units)
+    conflict_notes = detect_boundary_overlaps(normalized_units)
+    order = merge_order(normalized_units)
+    digest = sha256(normalized_goal.encode("utf-8")).hexdigest()
+    fanout_id = f"fanout-{digest[:12]}"
+    unit_ids = [str(unit["unit_id"]) for unit in normalized_units]
+    contract_units = [
+        _contract_unit(unit, sibling_scopes=_sibling_scopes(normalized_units, str(unit["unit_id"])), fanout_id=fanout_id)
+        for unit in normalized_units
+    ]
+    return {
+        "schema_version": FANOUT_CONTRACT_SCHEMA_VERSION,
+        "fanout_id": fanout_id,
+        "status": PREPARED_NOT_OBSERVED,
+        "source": source,
+        "source_metadata": compact_source_metadata(source_metadata),
+        "goal": {
+            "summary": f"Fanout request ({len(normalized_goal)} chars, sha256:{digest[:12]})",
+            "summary_kind": "digest_reference",
+            "input_chars": len(normalized_goal),
+            "sha256": digest,
+            "raw_prompt_stored": False,
+        },
+        "units": contract_units,
+        "merge_plan": {
+            "merge_order": order,
+            "final_integration_gate": list(FANOUT_FINAL_INTEGRATION_GATE),
+            "conflict_risk_notes": conflict_notes,
+        },
+        "board_projection": {
+            "schema_version": "agent_board_card/v1",
+            "unit_ids": unit_ids,
+            "status_by_unit": {unit_id: "prepared" for unit_id in unit_ids},
+        },
+        "observed_evidence_required": [
+            "per-unit run records for dispatch, worker result, verification, review, CI, merge-readiness, and merge",
+        ],
+        "claim_boundary": FANOUT_CLAIM_BOUNDARY,
+    }
+
+
+def validate_fanout_units(units: Sequence[Mapping[str, object]]) -> None:
+    if len(units) < 2:
+        raise FanoutContractError(
+            "fanout requires at least two units; route a single unit through `omh coding delegate` instead"
+        )
+    seen: set[str] = set()
+    known = {str(unit.get("unit_id", "")) for unit in units}
+    for unit in units:
+        unit_id = str(unit.get("unit_id", ""))
+        if not _UNIT_ID_RE.match(unit_id):
+            raise FanoutContractError(f"unit_id must be a lowercase slug: {unit_id!r}")
+        if unit_id in seen:
+            raise FanoutContractError(f"duplicate unit_id: {unit_id}")
+        seen.add(unit_id)
+        owner = unit.get("owner")
+        if owner is not None and str(owner) not in FANOUT_UNIT_OWNERS:
+            raise FanoutContractError(
+                f"unit {unit_id} owner {owner!r} is not one of {', '.join(FANOUT_UNIT_OWNERS)} (or null for unassigned)"
+            )
+        file_scope = unit.get("file_scope", [])
+        if not isinstance(file_scope, (list, tuple)) or not [str(path) for path in file_scope if str(path).strip()]:
+            raise FanoutContractError(f"unit {unit_id} requires a non-empty file_scope boundary")
+        for dependency in unit.get("depends_on", []) or []:
+            if str(dependency) not in known:
+                raise FanoutContractError(f"unit {unit_id} depends on unknown unit {dependency!r}")
+            if str(dependency) == unit_id:
+                raise FanoutContractError(f"unit {unit_id} cannot depend on itself")
+
+
+def detect_boundary_overlaps(units: Sequence[Mapping[str, object]]) -> list[dict[str, object]]:
+    notes: list[dict[str, object]] = []
+    indexed = [(str(unit["unit_id"]), {str(path) for path in unit.get("file_scope", [])}) for unit in units]
+    edges = {
+        (str(unit["unit_id"]), str(dependency))
+        for unit in units
+        for dependency in unit.get("depends_on", []) or []
+    }
+    for position, (first_id, first_scope) in enumerate(indexed):
+        for second_id, second_scope in indexed[position + 1 :]:
+            shared = sorted(first_scope & second_scope)
+            if not shared:
+                continue
+            if (first_id, second_id) not in edges and (second_id, first_id) not in edges:
+                raise FanoutContractError(
+                    f"units {first_id} and {second_id} share files {shared} without a depends_on edge; "
+                    "make one depend on the other or split the boundary"
+                )
+            notes.append(
+                {
+                    "units": sorted((first_id, second_id)),
+                    "shared_files": shared,
+                    "resolution": "ordered by depends_on edge; merge strictly in merge_order",
+                }
+            )
+    return notes
+
+
+def merge_order(units: Sequence[Mapping[str, object]]) -> list[str]:
+    remaining = {
+        str(unit["unit_id"]): {str(dependency) for dependency in unit.get("depends_on", []) or []}
+        for unit in units
+    }
+    order: list[str] = []
+    while remaining:
+        ready = sorted(unit_id for unit_id, deps in remaining.items() if not deps)
+        if not ready:
+            cycle = ", ".join(sorted(remaining))
+            raise FanoutContractError(f"depends_on contains a cycle among units: {cycle}")
+        for unit_id in ready:
+            order.append(unit_id)
+            del remaining[unit_id]
+        for deps in remaining.values():
+            deps.difference_update(ready)
+    return order
+
+
+def is_degenerate_single_unit(units: Sequence[Mapping[str, object]]) -> bool:
+    return len(units) == 1
+
+
+def single_unit_redirect(units: Sequence[Mapping[str, object]]) -> dict[str, object]:
+    unit = dict(units[0]) if units else {}
+    return {
+        "schema_version": "fanout_redirect/v1",
+        "status": "redirect_to_delegate",
+        "reason": "A single work unit does not need a fanout contract.",
+        "next_command": "omh coding delegate",
+        "unit_id": str(unit.get("unit_id", "")),
+    }
+
+
+def _normalized_unit(unit: Mapping[str, object], index: int) -> dict[str, object]:
+    if not isinstance(unit, Mapping):
+        raise FanoutContractError(f"unit at index {index} must be an object")
+    file_scope = [str(path).strip() for path in unit.get("file_scope", []) or [] if str(path).strip()]
+    depends_on = [str(dependency).strip() for dependency in unit.get("depends_on", []) or [] if str(dependency).strip()]
+    owner = unit.get("owner")
+    return {
+        "unit_id": str(unit.get("unit_id", "")).strip(),
+        "title": " ".join(str(unit.get("title", "")).split()),
+        "owner": str(owner) if owner is not None and str(owner).strip() else None,
+        "file_scope": sorted(set(file_scope)),
+        "depends_on": sorted(set(depends_on)),
+    }
+
+
+def _sibling_scopes(units: Sequence[Mapping[str, object]], unit_id: str) -> list[str]:
+    scopes: set[str] = set()
+    for unit in units:
+        if str(unit["unit_id"]) == unit_id:
+            continue
+        scopes.update(str(path) for path in unit.get("file_scope", []))
+    return sorted(scopes)
+
+
+def _contract_unit(unit: Mapping[str, object], *, sibling_scopes: list[str], fanout_id: str) -> dict[str, object]:
+    unit_id = str(unit["unit_id"])
+    own_scope = set(str(path) for path in unit.get("file_scope", []))
+    return {
+        "unit_id": unit_id,
+        "title": str(unit.get("title") or unit_id),
+        "owner": unit.get("owner"),
+        "boundary": {
+            "file_scope": sorted(own_scope),
+            "do_not_touch": [path for path in sibling_scopes if path not in own_scope],
+        },
+        "branch_suggestion": f"agent/{unit_id}",
+        "depends_on": list(unit.get("depends_on", [])),
+        "run_ref": f"{fanout_id}-{unit_id}",
+        "handoff": {
+            "schema_version": "fanout_unit_handoff/v1",
+            "executor_target": str(unit.get("owner")) if unit.get("owner") else "choose",
+            "dispatch_policy": "prepare_only",
+            "status": PREPARED_NOT_OBSERVED,
+            "claim_boundary": (
+                "This per-unit handoff is prepared guidance only; record observed evidence on a run named by "
+                "run_ref before any dispatch, verification, review, CI, or merge claim."
+            ),
+        },
+        "integration_checks": [
+            "unit tests covering the unit's file_scope pass",
+            "no edits outside boundary.file_scope",
+        ],
+        "status": "prepared",
+    }

--- a/src/coding/fanout_artifacts.py
+++ b/src/coding/fanout_artifacts.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+import re
+
+from ..system.local_store import atomic_write_json
+from ..system.local_store import ensure_dir
+from ..system.paths import OmhPaths
+from .fanout_contracts import FANOUT_ID_PATTERN
+
+_FANOUT_ID_RE = re.compile(FANOUT_ID_PATTERN)
+
+
+def write_fanout_contract(paths: OmhPaths, contract: dict[str, object]) -> dict[str, object]:
+    fanout_id = _validated_fanout_id(contract.get("fanout_id"))
+    contract_dir = _managed_fanout_dir(paths, fanout_id)
+    contract_path = contract_dir / "fanout_contract.json"
+    ensure_dir(paths.fanout_contracts_dir, private=True)
+    ensure_dir(contract_dir, private=True)
+
+    payload = deepcopy(contract)
+    payload["artifacts"] = {"contract_path": str(contract_path), "privacy": "metadata_only"}
+    atomic_write_json(contract_path, payload, private=True)
+    return payload
+
+
+def read_fanout_contract(paths: OmhPaths, fanout_id: str) -> dict[str, object]:
+    import json
+
+    contract_path = _managed_fanout_dir(paths, _validated_fanout_id(fanout_id)) / "fanout_contract.json"
+    return json.loads(contract_path.read_text(encoding="utf-8"))
+
+
+def _validated_fanout_id(value: object) -> str:
+    fanout_id = str(value or "")
+    if not _FANOUT_ID_RE.match(fanout_id):
+        raise ValueError(f"invalid fanout_id: {fanout_id!r}")
+    return fanout_id
+
+
+def _managed_fanout_dir(paths: OmhPaths, fanout_id: str) -> Path:
+    root = paths.fanout_contracts_dir
+    if root.is_symlink():
+        raise ValueError("fanout contract storage must not be a symlink")
+    root_resolved = root.resolve(strict=False)
+    if not root_resolved.is_relative_to(paths.omh_home.resolve(strict=False)):
+        raise ValueError("fanout contract storage must resolve under OMH home")
+
+    contract_dir = root / fanout_id
+    if contract_dir.is_symlink():
+        raise ValueError("fanout contract directory must not be a symlink")
+    if contract_dir.resolve(strict=False).parent != root_resolved:
+        raise ValueError("fanout_id must resolve under the fanout contracts directory")
+    return contract_dir

--- a/src/coding/fanout_contracts.py
+++ b/src/coding/fanout_contracts.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from .executors import EXECUTOR_PROFILES, HERMES_CODING_TEAM_STATUS_LADDER
+
+
+FANOUT_CONTRACT_SCHEMA_VERSION = "fanout_contract/v1"
+FANOUT_ID_PATTERN = r"^fanout-[0-9a-f]{12}$"
+FANOUT_UNIT_STATUSES = ("prepared", *HERMES_CODING_TEAM_STATUS_LADDER)
+FANOUT_UNIT_OWNERS = EXECUTOR_PROFILES
+PREPARED_NOT_OBSERVED = "prepared_not_observed"
+FANOUT_CLAIM_BOUNDARY = (
+    "A fanout contract freezes a proposed parallel work split into prepared per-unit handoffs and a merge plan. "
+    "It is not dispatch, execution, implementation, verification, review, CI, merge-readiness, or merge evidence; "
+    "unit status advances only on observed per-unit run records."
+)
+FANOUT_FINAL_INTEGRATION_GATE = (
+    "PYTHONPATH=tests uv run python -m unittest discover -s tests",
+    "uv run python -m omh.cli docs workflows --check",
+    "uv run python -m omh.cli docs roles --check",
+    "uv run python -m omh.cli docs capability-families --check",
+    "git diff --check",
+)
+
+
+class FanoutContractError(ValueError):
+    """Raised when a proposed fanout unit list cannot be frozen into a contract."""

--- a/src/commands/coding.py
+++ b/src/commands/coding.py
@@ -574,9 +574,124 @@ def cmd_coding_quality_harness_show(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_coding_fanout_prepare(args: argparse.Namespace) -> int:
+    from ..coding.fanout import build_fanout_contract, is_degenerate_single_unit, single_unit_redirect
+    from ..coding.fanout_artifacts import write_fanout_contract
+    from ..coding.fanout_contracts import FanoutContractError
+
+    units = _read_fanout_units(args.units)
+    if is_degenerate_single_unit(units):
+        _print_json(single_unit_redirect(units))
+        return 0
+    try:
+        contract = build_fanout_contract(
+            " ".join(args.goal).strip(),
+            units,
+            source=args.source,
+            source_metadata=_explicit_source_metadata(args),
+        )
+    except FanoutContractError as exc:
+        raise OmhError(str(exc)) from exc
+    if args.record:
+        contract = write_fanout_contract(_paths(args), contract)
+    _print_json(contract)
+    return 0
+
+
+def cmd_coding_fanout_validate(args: argparse.Namespace) -> int:
+    from ..coding.fanout import detect_boundary_overlaps, merge_order, validate_fanout_units, _normalized_unit
+    from ..coding.fanout_contracts import FanoutContractError
+
+    units = [_normalized_unit(unit, index) for index, unit in enumerate(_read_fanout_units(args.units))]
+    try:
+        validate_fanout_units(units)
+        notes = detect_boundary_overlaps(units)
+        order = merge_order(units)
+    except FanoutContractError as exc:
+        _print_json({"schema_version": "fanout_validation/v1", "ok": False, "error": str(exc)})
+        return 1
+    _print_json(
+        {
+            "schema_version": "fanout_validation/v1",
+            "ok": True,
+            "unit_count": len(units),
+            "merge_order": order,
+            "conflict_risk_notes": notes,
+        }
+    )
+    return 0
+
+
+def cmd_coding_fanout_show(args: argparse.Namespace) -> int:
+    from ..coding.fanout_artifacts import read_fanout_contract
+    from ..runtime.artifacts import read_state_result
+
+    paths = _paths(args)
+    try:
+        contract = read_fanout_contract(paths, args.fanout_id)
+    except (OSError, ValueError) as exc:
+        raise OmhError(f"fanout contract not found: {exc}") from exc
+
+    state = read_state_result(paths)
+    runs = state.get("runs", {}) if isinstance(state, dict) else {}
+    units = contract.get("units", [])
+    status_by_unit: dict[str, object] = {}
+    for unit in units:
+        if not isinstance(unit, dict):
+            continue
+        run_ref = str(unit.get("run_ref", ""))
+        run = runs.get(run_ref) if isinstance(runs, dict) else None
+        observed = run.get("status") if isinstance(run, dict) else None
+        status_by_unit[str(unit.get("unit_id"))] = {
+            "prepared_status": unit.get("status", "prepared"),
+            "observed_run_status": observed or "not_observed",
+            "run_ref": run_ref,
+        }
+    _print_json(
+        {
+            "schema_version": "fanout_board/v1",
+            "fanout_id": contract.get("fanout_id"),
+            "merge_order": contract.get("merge_plan", {}).get("merge_order", []),
+            "units": status_by_unit,
+            "claim_boundary": contract.get("claim_boundary", ""),
+        }
+    )
+    return 0
+
+
+def _read_fanout_units(units_arg: str) -> list[dict[str, object]]:
+    raw = sys.stdin.read() if units_arg == "-" else Path(units_arg).expanduser().read_text(encoding="utf-8")
+    payload = json.loads(raw)
+    units = payload.get("units") if isinstance(payload, dict) else payload
+    if not isinstance(units, list):
+        raise OmhError("fanout units input must be a JSON list (or an object with a 'units' list)")
+    return units
+
+
 def _add_coding_commands(sub) -> None:
     coding = sub.add_parser("coding", help="Prepare executor-neutral or tracked coding handoff artifacts.")
     coding_sub = coding.add_subparsers(dest="coding_command", required=True)
+
+    fanout = coding_sub.add_parser(
+        "fanout",
+        help="Validate and freeze a proposed parallel work split into a fanout contract (agent/backend surface).",
+    )
+    fanout_sub = fanout.add_subparsers(dest="fanout_command", required=True)
+
+    fanout_prepare = fanout_sub.add_parser("prepare")
+    fanout_prepare.add_argument("--goal", nargs="+", required=True, help="Accepted user goal being split.")
+    fanout_prepare.add_argument("--units", required=True, help="JSON unit list path, or '-' for stdin.")
+    fanout_prepare.add_argument("--source", choices=CHAT_SOURCES, default="generic")
+    fanout_prepare.add_argument("--record", action="store_true", help="Persist the contract under ~/.omh/coding/fanout/.")
+    fanout_prepare.set_defaults(func=cmd_coding_fanout_prepare)
+
+    fanout_validate = fanout_sub.add_parser("validate")
+    fanout_validate.add_argument("--units", required=True, help="JSON unit list path, or '-' for stdin.")
+    fanout_validate.set_defaults(func=cmd_coding_fanout_validate)
+
+    fanout_show = fanout_sub.add_parser("show")
+    fanout_show.add_argument("fanout_id")
+    fanout_show.set_defaults(func=cmd_coding_fanout_show)
 
     delegate = coding_sub.add_parser("delegate")
     delegate.add_argument("message", nargs="*", help="Coding task description to prepare for executor delegation.")

--- a/src/system/paths.py
+++ b/src/system/paths.py
@@ -171,6 +171,10 @@ class OmhPaths:
         return self.omh_home / "coding" / "dynamic-workflows"
 
     @property
+    def fanout_contracts_dir(self) -> Path:
+        return self.omh_home / "coding" / "fanout"
+
+    @property
     def target_registry_path(self) -> Path:
         return self.omh_home / "targets.json"
 

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -1518,8 +1518,9 @@ _WORKFLOW_OPERATIONS_CHAT_CARDS: dict[str, dict[str, object]] = {
         "headline": "I can prepare a board for multiple Hermes agents.",
         "body": (
             "I will prepare the agent board: targets, roles, tasks, handoff lanes, heartbeat expectations, blocker "
-            "states, and completion rules. Other agents accepting, working, heartbeat-ing, or completing work remains "
-            "unobserved until target-specific evidence exists."
+            "states, and completion rules. For parallel coding splits, `omh coding fanout` freezes the unit split "
+            "into a merge contract and `omh coding fanout show` is the live evidence view. Other agents accepting, "
+            "working, heartbeat-ing, or completing work remains unobserved until target-specific evidence exists."
         ),
         "phase": "agent_board_prepared",
         "next_action": "prepare_agent_board_card",

--- a/tests/test_fanout_contract.py
+++ b/tests/test_fanout_contract.py
@@ -1,0 +1,267 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+
+from _local_package import load_local_package
+
+load_local_package()
+
+from _cli_harness import run_cli  # noqa: E402
+
+from omh.coding.fanout import (  # noqa: E402
+    build_fanout_contract,
+    detect_boundary_overlaps,
+    is_degenerate_single_unit,
+    merge_order,
+    single_unit_redirect,
+)
+from omh.coding.fanout_artifacts import read_fanout_contract, write_fanout_contract  # noqa: E402
+from omh.coding.fanout_contracts import FanoutContractError  # noqa: E402
+from omh.system.paths import OmhPaths  # noqa: E402
+
+
+_UNITS = [
+    {"unit_id": "core", "title": "Refactor core", "owner": "codex", "file_scope": ["src/auth/"], "depends_on": []},
+    {"unit_id": "tests", "title": "Add tests", "owner": "claude-code", "file_scope": ["tests/auth/"], "depends_on": ["core"]},
+    {"unit_id": "docs", "title": "Update docs", "owner": None, "file_scope": ["docs/auth.md"], "depends_on": []},
+]
+
+
+class FanoutEngineTests(unittest.TestCase):
+    def test_contract_is_deterministic_and_prepared_only(self) -> None:
+        first = build_fanout_contract("refactor auth and cover it", _UNITS, source="discord")
+        second = build_fanout_contract("refactor auth and cover it", _UNITS, source="discord")
+
+        self.assertEqual(first, second)
+        self.assertEqual(first["schema_version"], "fanout_contract/v1")
+        self.assertEqual(first["status"], "prepared_not_observed")
+        self.assertEqual(first["merge_plan"]["merge_order"], ["core", "docs", "tests"])
+        self.assertNotIn("refactor auth and cover it", json.dumps(first))
+        self.assertFalse(first["goal"]["raw_prompt_stored"])
+        self.assertIn("not dispatch", first["claim_boundary"])
+
+    def test_unit_boundaries_derive_do_not_touch_and_neutral_handoff(self) -> None:
+        contract = build_fanout_contract("split work", _UNITS)
+        units = {unit["unit_id"]: unit for unit in contract["units"]}
+
+        self.assertEqual(units["core"]["boundary"]["do_not_touch"], ["docs/auth.md", "tests/auth/"])
+        self.assertEqual(units["core"]["branch_suggestion"], "agent/core")
+        self.assertEqual(units["core"]["handoff"]["executor_target"], "codex")
+        self.assertEqual(units["docs"]["handoff"]["executor_target"], "choose")
+        self.assertIsNone(units["docs"]["owner"])
+        for unit in contract["units"]:
+            self.assertEqual(unit["handoff"]["dispatch_policy"], "prepare_only")
+            self.assertEqual(unit["handoff"]["status"], "prepared_not_observed")
+            self.assertEqual(unit["status"], "prepared")
+
+    def test_overlap_without_dependency_is_rejected(self) -> None:
+        with self.assertRaises(FanoutContractError):
+            build_fanout_contract(
+                "x",
+                [
+                    {"unit_id": "a", "file_scope": ["src/shared.py"]},
+                    {"unit_id": "b", "file_scope": ["src/shared.py"]},
+                ],
+            )
+
+    def test_overlap_with_dependency_is_noted_and_ordered(self) -> None:
+        contract = build_fanout_contract(
+            "x",
+            [
+                {"unit_id": "a", "file_scope": ["src/shared.py"]},
+                {"unit_id": "b", "file_scope": ["src/shared.py", "src/b.py"], "depends_on": ["a"]},
+            ],
+        )
+        notes = contract["merge_plan"]["conflict_risk_notes"]
+
+        self.assertEqual(len(notes), 1)
+        self.assertEqual(notes[0]["units"], ["a", "b"])
+        self.assertEqual(notes[0]["shared_files"], ["src/shared.py"])
+        self.assertEqual(contract["merge_plan"]["merge_order"], ["a", "b"])
+
+    def test_dependency_cycle_is_rejected(self) -> None:
+        with self.assertRaises(FanoutContractError):
+            merge_order(
+                [
+                    {"unit_id": "a", "file_scope": ["1"], "depends_on": ["b"]},
+                    {"unit_id": "b", "file_scope": ["2"], "depends_on": ["a"]},
+                ]
+            )
+
+    def test_empty_boundary_unknown_owner_and_unknown_dependency_are_rejected(self) -> None:
+        with self.assertRaises(FanoutContractError):
+            build_fanout_contract("x", [{"unit_id": "a", "file_scope": []}, {"unit_id": "b", "file_scope": ["f"]}])
+        with self.assertRaises(FanoutContractError):
+            build_fanout_contract(
+                "x",
+                [
+                    {"unit_id": "a", "owner": "skynet", "file_scope": ["f1"]},
+                    {"unit_id": "b", "file_scope": ["f2"]},
+                ],
+            )
+        with self.assertRaises(FanoutContractError):
+            build_fanout_contract(
+                "x",
+                [
+                    {"unit_id": "a", "file_scope": ["f1"], "depends_on": ["ghost"]},
+                    {"unit_id": "b", "file_scope": ["f2"]},
+                ],
+            )
+
+    def test_single_unit_is_degenerate_redirect(self) -> None:
+        units = [_UNITS[0]]
+
+        self.assertTrue(is_degenerate_single_unit(units))
+        redirect = single_unit_redirect(units)
+        self.assertEqual(redirect["schema_version"], "fanout_redirect/v1")
+        self.assertEqual(redirect["next_command"], "omh coding delegate")
+
+    def test_merge_order_tie_break_is_deterministic(self) -> None:
+        units = [
+            {"unit_id": "zeta", "file_scope": ["z"]},
+            {"unit_id": "alpha", "file_scope": ["a"]},
+            {"unit_id": "mid", "file_scope": ["m"], "depends_on": ["zeta", "alpha"]},
+        ]
+
+        self.assertEqual(merge_order(units), ["alpha", "zeta", "mid"])
+
+    def test_overlap_detector_returns_no_notes_for_disjoint_units(self) -> None:
+        self.assertEqual(detect_boundary_overlaps(_UNITS), [])
+
+
+class FanoutArtifactTests(unittest.TestCase):
+    def test_writer_persists_metadata_only_contract_under_omh_home(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = OmhPaths(omh_home=Path(tmp) / ".omh", hermes_home=Path(tmp) / ".hermes")
+            contract = build_fanout_contract("persist me", _UNITS)
+
+            written = write_fanout_contract(paths, contract)
+            contract_path = Path(written["artifacts"]["contract_path"])
+
+            self.assertTrue(contract_path.is_file())
+            self.assertTrue(contract_path.is_relative_to(paths.fanout_contracts_dir))
+            self.assertEqual(written["artifacts"]["privacy"], "metadata_only")
+            self.assertEqual(read_fanout_contract(paths, contract["fanout_id"])["fanout_id"], contract["fanout_id"])
+
+    def test_writer_rejects_invalid_id_and_symlinked_storage(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = OmhPaths(omh_home=Path(tmp) / ".omh", hermes_home=Path(tmp) / ".hermes")
+
+            with self.assertRaises(ValueError):
+                write_fanout_contract(paths, {"fanout_id": "../escape"})
+
+            outside = Path(tmp) / "outside"
+            outside.mkdir()
+            paths.fanout_contracts_dir.parent.mkdir(parents=True)
+            paths.fanout_contracts_dir.symlink_to(outside)
+            contract = build_fanout_contract("symlink guard", _UNITS)
+            with self.assertRaises(ValueError):
+                write_fanout_contract(paths, contract)
+
+
+class FanoutCliTests(unittest.TestCase):
+    def _units_file(self, root: Path) -> Path:
+        units_path = root / "units.json"
+        units_path.write_text(json.dumps(_UNITS), encoding="utf-8")
+        return units_path
+
+    def test_fanout_prepare_records_contract_and_never_dispatches(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+
+            status, stdout, stderr = run_cli(
+                base
+                + [
+                    "coding",
+                    "fanout",
+                    "prepare",
+                    "--goal",
+                    "refactor",
+                    "auth",
+                    "safely",
+                    "--units",
+                    str(self._units_file(root)),
+                    "--record",
+                ]
+            )
+
+            self.assertEqual(status, 0, stderr)
+            payload = json.loads(stdout)
+            self.assertEqual(payload["schema_version"], "fanout_contract/v1")
+            self.assertEqual(payload["status"], "prepared_not_observed")
+            for unit in payload["units"]:
+                self.assertEqual(unit["handoff"]["dispatch_policy"], "prepare_only")
+            # Negative guards: freezing a contract is not dispatch and creates
+            # no run records; unit evidence lands on runs the operator starts.
+            for forbidden in ("worker_dispatch", "start_team", "start_swarm"):
+                self.assertNotIn(forbidden, stdout)
+            self.assertFalse((root / ".omh" / "runtime" / "runs").exists())
+            self.assertNotIn('"executor_profile": "codex"', stdout)
+            self.assertTrue((root / ".omh" / "coding" / "fanout" / payload["fanout_id"] / "fanout_contract.json").is_file())
+
+    def test_fanout_validate_reports_errors_without_writing(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            bad = root / "bad.json"
+            bad.write_text(
+                json.dumps(
+                    [
+                        {"unit_id": "a", "file_scope": ["src/f.py"]},
+                        {"unit_id": "b", "file_scope": ["src/f.py"]},
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+
+            status, stdout, stderr = run_cli(base + ["coding", "fanout", "validate", "--units", str(bad)])
+
+            self.assertEqual(status, 1)
+            payload = json.loads(stdout)
+            self.assertFalse(payload["ok"])
+            self.assertIn("depends_on edge", payload["error"])
+            self.assertFalse((root / ".omh" / "coding").exists())
+
+    def test_fanout_show_projects_not_observed_units(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+            status, stdout, _ = run_cli(
+                base
+                + ["coding", "fanout", "prepare", "--goal", "g", "--units", str(self._units_file(root)), "--record"]
+            )
+            self.assertEqual(status, 0)
+            fanout_id = json.loads(stdout)["fanout_id"]
+
+            status, stdout, stderr = run_cli(base + ["coding", "fanout", "show", fanout_id])
+
+            self.assertEqual(status, 0, stderr)
+            board = json.loads(stdout)
+            self.assertEqual(board["schema_version"], "fanout_board/v1")
+            self.assertEqual(board["merge_order"], ["core", "docs", "tests"])
+            for unit in board["units"].values():
+                self.assertEqual(unit["observed_run_status"], "not_observed")
+
+    def test_fanout_single_unit_redirects_to_delegate(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            single = root / "single.json"
+            single.write_text(json.dumps([_UNITS[0]]), encoding="utf-8")
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+
+            status, stdout, stderr = run_cli(
+                base + ["coding", "fanout", "prepare", "--goal", "g", "--units", str(single)]
+            )
+
+            self.assertEqual(status, 0, stderr)
+            payload = json.loads(stdout)
+            self.assertEqual(payload["schema_version"], "fanout_redirect/v1")
+            self.assertEqual(payload["next_command"], "omh coding delegate")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Capability

`omh coding fanout {prepare|validate|show}`: Hermes proposes a parallel work split in chat; omh deterministically **validates and freezes** it into `fanout_contract/v1` — per-unit file boundaries (allowlist + sibling-derived do-not-touch), executor-neutral owners (or unassigned), branch suggestions, dependency-aware **topological merge order** with cycle rejection, conflict-risk notes for overlapping-but-ordered units, and the repo's own final integration gate. `fanout show` is the live evidence view, joining the frozen contract with runtime run records by `run_ref` (everything `not_observed` until real evidence exists).

## Motivation

PR #624 made "Split across agents" a first-class delegation choice, but it routed to a prose-only board card — nothing checked that a proposed split was actually parallelizable (no shared files without ordering, no dependency cycles) or planned how the pieces merge back. This is the deferred engine at the user-approved "plan + merge contract" scope: the deterministic substrate for multi-agent split-and-merge, with real execution orchestration still explicitly deferred.

## Implementation (boundary level)

- **Pure engine** (`src/coding/fanout.py`, `fanout_contracts.py`): normalization/validation (slug ids, owner ∈ EXECUTOR_PROFILES or null — never defaulted), overlap detection (shared files without a `depends_on` edge = hard error; with an edge = ordered conflict note), Kahn topo merge order with deterministic tie-breaks, single-unit degenerate redirect to `omh coding delegate`. Goals stored as digest metadata only.
- **Artifact writer** (`fanout_artifacts.py` + `OmhPaths.fanout_contracts_dir`): private metadata-only JSON at `~/.omh/coding/fanout/<id>/`, id-regex + symlink/under-home guards (dynamic-workflow pattern).
- **CLI** (agent/backend surface): `--units` takes a JSON path or `-` (the `--event-json` convention). Per Critic-binding decisions: **no standalone chat preview card** (would move the 59/179 coverage counts for a static duplicate of `fanout show`), and **fanout never creates run records or touches Codex lifecycle recorders** — unit evidence lands on operator-started runs named by `run_ref`. One static discoverability sentence added to the agent-board card body; the wrapper renderer stays pure (no filesystem reads at render time — the Architect-verified constraint that moved the live view to the CLI).

## Verification (observed)

- Full suite **1554 OK** (+15: contract determinism, overlap/cycle/empty-boundary/unknown-owner/unknown-dep rejects, tie-break ordering, symlink + id guards, CLI prepare/validate/show contracts, single-unit redirect, and negative guards — no dispatch tokens in output, no run records created, no codex executor_profile leakage).
- Routing untouched: 55/118/173 and 59/179 verbatim; card kind/next_action/artifact_schema frozen; demo-cards JSON parse-identical; all three `docs --check` byte gates + compileall + `git diff --check` clean.
- Consensus: ralplan Planner → Architect (SOUND-WITH-AMENDMENTS; discovered the pure-renderer constraint and the Codex evidence gap) → Critic (ITERATE with binding resolutions, all folded: preview card dropped, unit-as-run constrained to prepared-only, cycle/overlap negative tests added).

## Risks / evidence boundaries

- A frozen contract is never dispatch/execution/merge evidence (claim boundary embedded per unit and per contract); live multi-agent execution against a contract is the named deferred follow-up.
- Live Hermes rendering of the one-sentence card change is `prepared_not_observed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)