### PR TITLE
fix: default all setup output to English; localization is explicit opt-in

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,10 @@ Rules:
   (`case_count == 51`, `intervention_case_count == 105`, etc.). When you add a
   routing case, skill, or demo card, update the exact-count assertions in the
   same commit — they are the point, not noise.
-- English for code, docs, commits, and PR text.
+- English for code, docs, commits, and PR text — and for all user-facing CLI
+  output by default. Localized output (ko/ja/zh) is explicit opt-in via
+  `--language` or `OMH_LANG` only; never auto-detect the OS locale. Korean-only
+  surfaces shrink the audience to Korean users.
 
 ## Workflow Rules
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -120,8 +120,8 @@ command package and `omh` executable only. `omh setup` is the explicit,
 repairable step that installs generated managed skills and registers them with
 Hermes through `skills.external_dirs`.
 When `omh setup` is run in a real terminal, it asks exactly one question —
-install scope (user or project). The setup language is auto-detected from the
-OS locale (`--language` or `OMH_LANG` override it), Hermes registration
+install scope (user or project). Output is English by default (`--language`
+or `OMH_LANG` opt into ko/ja/zh), Hermes registration
 defaults to on (`--skip-apply` opts out), and there is no upfront coding-agent
 question: Hermes asks who should own coding work at the first coding request,
 in natural language. Optional surfaces stay behind flags — `--with-mcp` for

--- a/src/commands/language.py
+++ b/src/commands/language.py
@@ -797,28 +797,6 @@ def language_from_env(default: str = "en") -> str:
     return normalize_language(os.environ.get("OMH_LANG") or os.environ.get("OMH_LANGUAGE") or default)
 
 
-def detect_locale_language(default: str = "en") -> str:
-    """Best-effort OS-locale language detection from env strings.
-
-    Reads `LC_ALL` > `LC_MESSAGES` > `LANG` as plain strings (never calls
-    `locale.setlocale`, which can raise on CI runners without generated
-    locales), then falls back to `locale.getlocale()`; unknown or unset
-    locales resolve to `default`.
-    """
-    candidates = [os.environ.get(name, "") for name in ("LC_ALL", "LC_MESSAGES", "LANG")]
-    try:
-        import locale
-
-        candidates.append((locale.getlocale()[0] or ""))
-    except Exception:
-        pass
-    for raw in candidates:
-        prefix = raw.split(".", 1)[0].split("_", 1)[0].split("-", 1)[0].strip().lower()
-        if prefix in LANGUAGE_CODES:
-            return prefix
-    return default
-
-
 def language_options() -> list[dict[str, str]]:
     return [
         {"choice": str(index), "value": code, "label": LANGUAGE_NAMES[code], "description": ""}

--- a/src/commands/setup.py
+++ b/src/commands/setup.py
@@ -55,7 +55,7 @@ from ..team_profiles import (
     operating_model_ids,
 )
 from .common import _action_label, _paths, _print_json, _wants_json
-from .language import LANGUAGE_CODES, detect_locale_language, language_from_env, normalize_language, tr
+from .language import LANGUAGE_CODES, language_from_env, normalize_language, tr
 
 INSTALLER_COMMAND = "curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes/main/install.sh | sh"
 COMMAND_PACKAGE_STATUS_SCHEMA_VERSION = "command_package_status/v1"
@@ -1129,9 +1129,11 @@ def _resolve_language(args: argparse.Namespace) -> str:
 
 
 def _setup_language(args: argparse.Namespace) -> str:
+    # English-first product surface: localized output is explicit opt-in via
+    # --language or OMH_LANG, never inferred from the OS locale.
     if _language_was_explicit(args):
         return _resolve_language(args)
-    return detect_locale_language()
+    return "en"
 
 
 def _language_was_explicit(args: argparse.Namespace) -> bool:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2354,22 +2354,19 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
             star.assert_called_once_with()
             self.assertIn("Thanks!", stdout)
 
-    def test_setup_locale_language_detection_precedence(self) -> None:
-        from omh.commands.language import detect_locale_language
-
-        cleared = {name: "" for name in ("OMH_LANG", "OMH_LANGUAGE", "LC_ALL", "LC_MESSAGES", "LANG")}
-        with patch.dict(os.environ, {**cleared, "LANG": "ko_KR.UTF-8"}):
-            self.assertEqual(detect_locale_language(), "ko")
-        with patch.dict(os.environ, {**cleared, "LC_ALL": "ja_JP.UTF-8", "LANG": "ko_KR.UTF-8"}):
-            self.assertEqual(detect_locale_language(), "ja")
-        with patch.dict(os.environ, {**cleared, "LANG": "fr_FR.UTF-8"}):
-            self.assertEqual(detect_locale_language(), "en")
+    def test_setup_output_defaults_to_english_regardless_of_os_locale(self) -> None:
+        cleared = {name: "" for name in ("OMH_LANG", "OMH_LANGUAGE", "LC_ALL", "LC_MESSAGES")}
         with TemporaryDirectory() as tmp:
             root = Path(tmp)
             omh_home = root / ".omh"
             hermes_home = root / ".hermes"
             base = ["--omh-home", str(omh_home), "--hermes-home", str(hermes_home)]
             with patch.dict(os.environ, {**cleared, "LANG": "ko_KR.UTF-8"}):
+                status, stdout, stderr = run_cli(base + ["setup", "--dry-run"], output_json=False)
+            self.assertEqual(status, 0, stderr)
+            self.assertIn("Coding requests:", stdout)
+            self.assertNotIn("코딩 요청", stdout)
+            with patch.dict(os.environ, {**cleared, "OMH_LANG": "ko"}):
                 status, stdout, stderr = run_cli(base + ["setup", "--dry-run"], output_json=False)
             self.assertEqual(status, 0, stderr)
             self.assertIn("코딩 요청", stdout)


### PR DESCRIPTION
## Capability

`omh setup` output is English by default on every machine, regardless of OS locale. Localized output (ko/ja/zh) remains fully supported but is now explicit opt-in via `--language` or `OMH_LANG`.

## Motivation

PR #624's locale auto-detection meant a `LANG=ko_KR` machine got a Korean install summary out of the box. User direction after live use: the project is managed in English and Korean-only surfaces shrink the audience — English-first is the product posture, localization is a choice.

## Implementation

- `_setup_language` defaults to `en` unless `--language`/`OMH_LANG`/`OMH_LANGUAGE` is set; `detect_locale_language` removed (dead code). Message catalogs untouched.
- The rule is codified in CLAUDE.md (English for all user-facing CLI output by default; never auto-detect the OS locale) and docs/INSTALLATION.md.

## Verification (observed)

Full suite 1539 OK — includes a new pin: under `LANG=ko_KR.UTF-8` setup renders English; with `OMH_LANG=ko` it renders Korean. All three `docs --check` byte gates, compileall, `git diff --check` clean.

## Risks

None beyond reverting one #624 sub-decision at the user's direction; opt-in paths behave exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)