### PR TITLE
feat: opt-in local dispatch bridge executes fanout contracts in parallel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,10 @@ executor. If support differs, document the difference as a capability boundary
 instead of silently optimizing for Codex.
 
 Do not turn OMH into a hidden Hermes runtime patch, transport bot, network
-service, LLM router, or secret coding executor.
+service, LLM router, or secret coding executor. The one sanctioned execution
+surface is the explicit opt-in fanout dispatch bridge described under
+Implementation Boundaries — operator-invoked, local-only, fully observed,
+never hidden and never a default.
 
 ## Command Audience
 
@@ -97,6 +100,16 @@ PR without the chat history.
 
 - No LLM, API, Discord, Slack, GitHub, or network calls inside core `omh`
   features unless the user explicitly approves a scoped integration.
+- The approved scoped integration under that clause is the fanout dispatch
+  bridge (`omh coding fanout dispatch`, 2026-07 owner approval): an explicit
+  operator command that spawns LOCAL agent CLIs (the CLIs make their own
+  network calls; omh still makes none) in per-unit worktrees against a frozen
+  `fanout_contract/v1`, recording every spawn and exit as observed journal
+  evidence. It never runs by default, never merges branches, never persists
+  raw prompts under `.omh`, and never executes anything outside an explicit
+  `dispatch` invocation. Bridge dispatch is a separate axis from chat
+  prompt-handoff semantics: chat-prepared handoffs remain prompt-only for
+  prompt-only profiles.
 - No Hermes core patching.
 - Runtime artifacts are local, deterministic, schema-versioned, and
   metadata-only by default.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,10 @@ repeat them.
 oh-my-hermes (OMH) is a Hermes-native wrapper orchestration layer: a
 deterministic skill catalog, router, and prepared-handoff generator installed
 next to Hermes Agent. Core `omh` code makes no LLM, API, or network calls and
-never patches Hermes. Pure Python 3.11+, zero runtime dependencies.
+never patches Hermes. Pure Python 3.11+, zero runtime dependencies. One scoped
+exception: `omh coding fanout dispatch` (explicit opt-in) spawns local agent
+CLIs as subprocesses — those CLIs make their own network calls; omh itself
+still makes none, and nothing executes without that explicit command.
 
 ## Build & Test
 

--- a/docs/DIRECTION.md
+++ b/docs/DIRECTION.md
@@ -129,7 +129,10 @@ OMH is not:
 - a Hermes core patch
 - a Discord or Slack bot implementation
 - an LLM router or network service
-- a hidden coding runtime
+- a hidden coding runtime (the fanout dispatch bridge is the explicit,
+  observed, opt-in exception: an operator command that spawns local agent
+  CLIs against a frozen fanout contract and records everything as observed
+  evidence — the opposite of hidden)
 - a claim that Hermes executed work that only a handoff prepared
 
 ## Ownership Boundary

--- a/docs/FANOUT.md
+++ b/docs/FANOUT.md
@@ -1,0 +1,81 @@
+# Fanout: Parallel Split, Dispatch Bridge, and Merge Contract
+
+Audience: operators, wrappers, and coding agents. Normal users describe the
+goal to Hermes in chat; these commands are the backend surface.
+
+## Lifecycle
+
+1. **Propose** — Hermes (the LLM) proposes the unit split in chat: unit ids,
+   titles, owners, file boundaries, dependencies.
+2. **Freeze** — `omh coding fanout prepare --goal <words> --units units.json
+   --record` validates the split deterministically (boundary overlaps without
+   a `depends_on` edge are hard errors; dependency cycles are hard errors) and
+   freezes it as `fanout_contract/v1` under `~/.omh/coding/fanout/<id>/`. The
+   goal is stored as a digest only.
+3. **Dispatch (opt-in bridge)** — `omh coding fanout dispatch <id>
+   --goal-file goal.txt` spawns each spawnable unit's local agent CLI in an
+   isolated per-unit worktree, dependency-aware, with bounded concurrency.
+4. **Observe** — `omh coding fanout show <id>` joins the frozen contract with
+   per-unit run records; unit status is `not_observed` until real evidence
+   exists.
+5. **Merge (human/agent-gated)** — dispatch never merges. The summary lists
+   merge-ready units in the contract's `merge_order`; merging and the final
+   integration gate remain the operator's or reviewing agent's job.
+
+## Dispatch bridge semantics
+
+- **Spawnability is data.** `DISPATCH_COMMAND_TEMPLATES` in
+  `src/coding/fanout_dispatch.py` maps profiles with a local headless CLI to
+  fixed argv templates. Profiles without a template (hermes, omx/omo/omc
+  runtimes, generic, unassigned) are reported
+  `unsupported_for_local_dispatch` with the unit handoff as a prepared-prompt
+  fallback — no profile is privileged.
+- **Bridge dispatch is a separate axis from chat prompt-handoff.** Chat
+  surfaces keep their prompt-only semantics for prompt-only profiles; the
+  bridge is an operator-invoked command on a different surface.
+- **Goal integrity.** `--goal-file` must hash to the digest frozen in the
+  contract; a diverged goal is refused.
+- **Worktrees.** One per unit at `<repo>-fanout-<unit>` on branch
+  `agent/<unit>`, all branched from one SHA resolved at dispatch start
+  (`--base-ref`, default HEAD). Pre-existing paths or branches are errors,
+  never silently reused. Worktrees are never auto-deleted; reconcile with
+  `git worktree list`.
+- **Evidence.** Each dispatched unit gets a run named by its `run_ref`;
+  spawn and exit are recorded as journal observations
+  (`worker_dispatch`/`worker_result`, canonicalized to
+  `executor_dispatch_observed`/`executor_result_observed`).
+- **Dependency bar.** A satisfied dependency means only that the owner agent
+  process exited 0. It is not verified, reviewed, or correct work. Failed
+  units block their dependents, never their independents.
+- **Blocked-by-design cascades.** An `unsupported_for_local_dispatch` or
+  `executor_not_ready` dependency also blocks its dependents — dependents must
+  never build on an unstarted base. Recovery: complete that unit manually (or
+  via its owner's own tooling), record its observed result on the unit's
+  `run_ref` run, then re-run `dispatch --unit <dependent>`; completed units
+  satisfy dependencies even when not re-selected. Blocked entries carry a
+  `blocked_on` list naming the offending units.
+- **First-use validation note.** `codex exec` has in-repo precedent; the
+  `claude -p ... --permission-mode acceptEdits` template does not — validate
+  it interactively on first real use before relying on it in bulk fanouts.
+  Template drift in either CLI surfaces as a clean readiness or exit-code
+  failure recorded as observed evidence, and the fix is a one-line data edit
+  in `DISPATCH_COMMAND_TEMPLATES`.
+- **Resume.** Re-running dispatch skips units whose runs already carry an
+  observed successful result. `--unit <id>` selects subsets.
+- **Never**: auto-merge, default-on execution, network calls by omh itself,
+  raw-prompt persistence under `.omh`.
+
+## Command reference
+
+```sh
+omh coding fanout prepare --goal <words...> --units units.json [--record] [--source discord]
+omh coding fanout validate --units units.json
+omh coding fanout show <fanout-id>
+omh coding fanout dispatch <fanout-id> --goal-file goal.txt \
+  [--repo-root .] [--base-ref HEAD] [--concurrency 2] [--timeout 1800] \
+  [--unit <id> ...] [--dry-run]
+```
+
+`--units` and `--goal-file` accept `-` for stdin. `--dry-run` resolves
+readiness, planned argv, and worktree paths without spawning anything or
+creating any runs.

--- a/src/coding/executors.py
+++ b/src/coding/executors.py
@@ -367,7 +367,10 @@ def prompt_invocation_for_profile(profile: str) -> dict[str, str]:
         "tool_label": labels[profile],
         "dispatch_text_template": templates[profile],
         "message_placeholder": "{message}",
-        "wrapper_note": "Copy or pass this prompt only when the user chooses that executor; OMH does not dispatch it.",
+        "wrapper_note": (
+            "Copy or pass this prompt only when the user chooses that executor; this chat prompt handoff does not "
+            "dispatch it. Only the explicit opt-in `omh coding fanout dispatch` bridge may spawn a local agent CLI."
+        ),
     }
 
 

--- a/src/coding/fanout_dispatch.py
+++ b/src/coding/fanout_dispatch.py
@@ -1,0 +1,356 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+import subprocess
+from typing import Any, Callable, Mapping, Sequence
+
+from ..runtime.artifacts import append_journal_observation, create_run, show_run
+from ..system.paths import OmhPaths
+from .executor_readiness import probe_executor_readiness
+from .fanout_contracts import FANOUT_CLAIM_BOUNDARY
+
+FANOUT_DISPATCH_SCHEMA_VERSION = "fanout_dispatch_summary/v1"
+DISPATCH_CLAIM_BOUNDARY = (
+    "A dispatch summary records observed local subprocess activity only. It is not verification, review, CI, "
+    "merge-readiness, or merge evidence, and omh never merges unit branches itself."
+)
+
+# Spawnability is a data property: profiles listed here have a local headless
+# CLI template. Every other profile (hermes, omx/omo/omc runtimes, generic,
+# unassigned) gets a prepared-prompt fallback and is never spawned.
+DISPATCH_COMMAND_TEMPLATES: dict[str, tuple[str, ...]] = {
+    "codex": ("codex", "exec", "{prompt}"),
+    "claude-code": ("claude", "-p", "{prompt}", "--permission-mode", "acceptEdits"),
+}
+
+
+def build_unit_prompt(unit: Mapping[str, Any], goal_text: str) -> str:
+    boundary = unit.get("boundary", {}) if isinstance(unit.get("boundary"), Mapping) else {}
+    file_scope = ", ".join(str(path) for path in boundary.get("file_scope", []))
+    do_not_touch = ", ".join(str(path) for path in boundary.get("do_not_touch", []))
+    checks = "; ".join(str(check) for check in unit.get("integration_checks", []))
+    lines = [
+        f"Work unit: {unit.get('title', unit.get('unit_id'))}",
+        f"Overall goal: {goal_text.strip()}",
+        f"Stay strictly inside these paths: {file_scope}.",
+    ]
+    if do_not_touch:
+        lines.append(f"Do not touch: {do_not_touch} (owned by sibling units).")
+    lines.append(f"Work on branch {unit.get('branch_suggestion', '')} in the current worktree.")
+    if checks:
+        lines.append(f"Before finishing: {checks}.")
+    lines.append("Commit your work; do not merge or push other branches.")
+    return "\n".join(lines)
+
+
+def verify_goal_matches_contract(contract: Mapping[str, Any], goal_text: str) -> None:
+    """Refuse dispatch when the supplied goal diverges from the frozen contract.
+
+    The contract stores the goal as a digest only (privacy); the operator
+    re-supplies the text at dispatch time, so integrity must be re-proven.
+    """
+    from hashlib import sha256
+
+    normalized = " ".join(goal_text.split())
+    digest = sha256(normalized.encode("utf-8")).hexdigest()
+    expected = str(contract.get("goal", {}).get("sha256", ""))
+    if digest != expected:
+        raise ValueError(
+            "goal text does not match the digest frozen in the fanout contract; "
+            "dispatch refuses to run a diverged goal (re-run fanout prepare for a new goal)"
+        )
+
+
+def dispatch_fanout(
+    paths: OmhPaths,
+    contract: Mapping[str, Any],
+    *,
+    goal_text: str,
+    repo_root: Path,
+    base_sha: str,
+    concurrency: int = 2,
+    timeout: int = 1800,
+    only_units: Sequence[str] | None = None,
+    dry_run: bool = False,
+    runner: Callable[..., Any] = subprocess.run,
+    readiness: Callable[..., dict[str, object]] = probe_executor_readiness,
+) -> dict[str, Any]:
+    verify_goal_matches_contract(contract, goal_text)
+    units = {str(unit["unit_id"]): unit for unit in contract.get("units", []) if isinstance(unit, Mapping)}
+    order = [str(unit_id) for unit_id in contract.get("merge_plan", {}).get("merge_order", [])]
+    selected = set(only_units) if only_units else set(order)
+    results: dict[str, dict[str, Any]] = {}
+
+    for unit_id in order:
+        unit = units[unit_id]
+        if _already_completed(paths, unit):
+            # Completed units satisfy dependencies whether or not they are in
+            # the current selection, so partial re-dispatch of downstream
+            # units works after an earlier run (or manual recovery) finished
+            # their prerequisites.
+            results[unit_id] = _skipped(unit, "already_completed", merge_ready=True)
+        elif unit_id not in selected:
+            results[unit_id] = _skipped(unit, "not_selected")
+
+    pending = [unit_id for unit_id in order if unit_id not in results]
+    with ThreadPoolExecutor(max_workers=max(1, concurrency)) as pool:
+        while pending:
+            ready = [
+                unit_id
+                for unit_id in pending
+                if all(_dependency_satisfied(results.get(dep)) for dep in units[unit_id].get("depends_on", []))
+            ]
+            blocked = [
+                unit_id
+                for unit_id in pending
+                if any(_dependency_failed(results.get(dep)) for dep in units[unit_id].get("depends_on", []))
+            ]
+            for unit_id in blocked:
+                results[unit_id] = _blocked(units[unit_id], results)
+                pending.remove(unit_id)
+            ready = [unit_id for unit_id in ready if unit_id in pending]
+            if not ready:
+                if pending and not blocked:
+                    for unit_id in list(pending):
+                        results[unit_id] = _blocked(units[unit_id], results)
+                        pending.remove(unit_id)
+                continue
+            futures = {
+                unit_id: pool.submit(
+                    _dispatch_unit,
+                    paths,
+                    units[unit_id],
+                    goal_text=goal_text,
+                    repo_root=repo_root,
+                    base_sha=base_sha,
+                    timeout=timeout,
+                    dry_run=dry_run,
+                    runner=runner,
+                    readiness=readiness,
+                )
+                for unit_id in ready
+            }
+            for unit_id, future in futures.items():
+                results[unit_id] = future.result()
+                pending.remove(unit_id)
+
+    summary_units = [results[unit_id] for unit_id in order]
+    return {
+        "schema_version": FANOUT_DISPATCH_SCHEMA_VERSION,
+        "fanout_id": contract.get("fanout_id", ""),
+        "dry_run": dry_run,
+        "merge_order": order,
+        "units": summary_units,
+        "merge_ready_units": [entry["unit_id"] for entry in summary_units if entry.get("merge_ready")],
+        "auto_merge": False,
+        "dependency_bar": (
+            "A satisfied dependency means only that the owner agent process exited 0. "
+            "It is not verified, reviewed, or correct work."
+        ),
+        "base_sha": base_sha,
+        "claim_boundary": f"{DISPATCH_CLAIM_BOUNDARY} {FANOUT_CLAIM_BOUNDARY}",
+    }
+
+
+def _dispatch_unit(
+    paths: OmhPaths,
+    unit: Mapping[str, Any],
+    *,
+    goal_text: str,
+    repo_root: Path,
+    base_sha: str,
+    timeout: int,
+    dry_run: bool,
+    runner: Callable[..., Any],
+    readiness: Callable[..., dict[str, object]],
+) -> dict[str, Any]:
+    unit_id = str(unit["unit_id"])
+    run_ref = str(unit.get("run_ref", unit_id))
+    owner = str(unit.get("handoff", {}).get("executor_target", "choose"))
+    template = DISPATCH_COMMAND_TEMPLATES.get(owner)
+    if template is None:
+        return {
+            "unit_id": unit_id,
+            "run_ref": run_ref,
+            "owner": owner,
+            "status": "unsupported_for_local_dispatch",
+            "merge_ready": False,
+            "fallback": "use the unit handoff as a prepared prompt for this owner",
+        }
+    probe = readiness(paths, owner)
+    if str(probe.get("status", "")) != "ready":
+        return {
+            "unit_id": unit_id,
+            "run_ref": run_ref,
+            "owner": owner,
+            "status": "executor_not_ready",
+            "readiness_status": str(probe.get("status", "unknown")),
+            "merge_ready": False,
+        }
+    prompt = build_unit_prompt(unit, goal_text)
+    argv = [part.replace("{prompt}", prompt) for part in template]
+    worktree = _worktree_path(repo_root, unit_id)
+    if dry_run:
+        return {
+            "unit_id": unit_id,
+            "run_ref": run_ref,
+            "owner": owner,
+            "status": "dry_run_planned",
+            "planned_argv": [part if part != prompt else "<unit prompt>" for part in argv],
+            "worktree_path": str(worktree),
+            "merge_ready": False,
+        }
+    from .worktree_creator import ensure_fanout_unit_worktree
+
+    worktree_record = ensure_fanout_unit_worktree(
+        paths,
+        repo_root=repo_root,
+        unit_id=unit_id,
+        branch=str(unit.get("branch_suggestion", f"agent/{unit_id}")),
+        base_sha=base_sha,
+        runner=runner,
+    )
+    if not worktree_record.get("created"):
+        return {
+            "unit_id": unit_id,
+            "run_ref": run_ref,
+            "owner": owner,
+            "status": "worktree_failed",
+            "reason": str(worktree_record.get("reason", "")),
+            "merge_ready": False,
+        }
+    worktree = Path(str(worktree_record["worktree_path"]))
+    _ensure_unit_run(paths, unit, owner)
+    append_journal_observation(
+        paths,
+        {
+            "target_type": "run",
+            "target_id": run_ref,
+            "run_id": run_ref,
+            "event": "worker_dispatch",
+            "status": "observed",
+            "summary": f"local dispatch of unit {unit_id} to {owner}",
+            "worker_ref": unit_id,
+            "worktree_ref": str(worktree),
+        },
+    )
+    try:
+        completed = runner(argv, cwd=str(worktree), text=True, capture_output=True, timeout=timeout)
+        exit_code = int(getattr(completed, "returncode", 1))
+        output_tail = str(getattr(completed, "stdout", "") or "")[-2000:]
+    except FileNotFoundError:
+        exit_code, output_tail = 127, f"{argv[0]} not found on PATH"
+    except subprocess.TimeoutExpired:
+        exit_code, output_tail = 124, f"unit timed out after {timeout}s"
+    except OSError as exc:
+        exit_code, output_tail = 1, f"spawn failed: {exc}"
+    status = "observed" if exit_code == 0 else "failed"
+    append_journal_observation(
+        paths,
+        {
+            "target_type": "run",
+            "target_id": run_ref,
+            "run_id": run_ref,
+            "event": "worker_result",
+            "status": status,
+            "summary": f"unit {unit_id} exit {exit_code}: {output_tail[-300:]}",
+            "worker_ref": unit_id,
+            "worktree_ref": str(worktree),
+        },
+    )
+    return {
+        "unit_id": unit_id,
+        "run_ref": run_ref,
+        "owner": owner,
+        "status": "completed" if exit_code == 0 else "failed",
+        "exit_code": exit_code,
+        "worktree_path": str(worktree),
+        "merge_ready": exit_code == 0,
+    }
+
+
+def _ensure_unit_run(paths: OmhPaths, unit: Mapping[str, Any], owner: str) -> None:
+    run_ref = str(unit.get("run_ref", unit.get("unit_id", "")))
+    run_path = paths.runtime_runs_dir / run_ref / "run.json"
+    if run_path.exists():
+        return
+    create_run(
+        paths,
+        {
+            "run_id": run_ref,
+            "skill": "fanout-unit",
+            "harness": "coding-handling",
+            "trigger": f"fanout:dispatch:{unit.get('unit_id')}",
+            "privacy": "metadata_only",
+            "inputs_summary": f"fanout unit {unit.get('unit_id')} owned by {owner}",
+            "outputs_summary": "local dispatch bridge run",
+            "verification_summary": "observed via journal worker_dispatch/worker_result events",
+        },
+    )
+
+
+def _already_completed(paths: OmhPaths, unit: Mapping[str, Any]) -> bool:
+    run_ref = str(unit.get("run_ref", ""))
+    try:
+        shown = show_run(paths, run_ref)
+    except (OSError, ValueError, KeyError):
+        return False
+    if not isinstance(shown, dict):
+        return False
+    for event in shown.get("journal_events", []) or []:
+        if (
+            isinstance(event, dict)
+            and str(event.get("event", "")) in {"worker_result", "executor_result_observed"}
+            and str(event.get("status", "")) == "observed"
+        ):
+            return True
+    return False
+
+
+def _dependency_satisfied(result: dict[str, Any] | None) -> bool:
+    if result is None:
+        return False
+    # dry_run_planned satisfies dependencies so a --dry-run renders the full
+    # plan; live dispatch only advances on an observed exit-0 result.
+    return (
+        result.get("status") in {"completed", "already_completed", "dry_run_planned"}
+        or bool(result.get("merge_ready"))
+    )
+
+
+def _dependency_failed(result: dict[str, Any] | None) -> bool:
+    if result is None:
+        return False
+    return result.get("status") in {
+        "failed",
+        "blocked_by_dependency",
+        "executor_not_ready",
+        "unsupported_for_local_dispatch",
+        "worktree_failed",
+        "not_selected",
+    } and not result.get("merge_ready")
+
+
+def _blocked(unit: Mapping[str, Any], results: Mapping[str, dict[str, Any]]) -> dict[str, Any]:
+    entry = _skipped(unit, "blocked_by_dependency")
+    entry["blocked_on"] = [
+        str(dep)
+        for dep in unit.get("depends_on", []) or []
+        if _dependency_failed(results.get(str(dep)))
+    ]
+    return entry
+
+
+def _skipped(unit: Mapping[str, Any], status: str, *, merge_ready: bool = False) -> dict[str, Any]:
+    return {
+        "unit_id": str(unit["unit_id"]),
+        "run_ref": str(unit.get("run_ref", "")),
+        "owner": str(unit.get("handoff", {}).get("executor_target", "choose")),
+        "status": status,
+        "merge_ready": merge_ready,
+    }
+
+
+def _worktree_path(repo_root: Path, unit_id: str) -> Path:
+    return repo_root.parent / f"{repo_root.name}-fanout-{unit_id}"

--- a/src/coding/worktree_creator.py
+++ b/src/coding/worktree_creator.py
@@ -1,22 +1,25 @@
 """Worktree observation ledger helpers.
 
-OMH no longer *creates* Git worktrees. Upstream Hermes Agent manages worktrees
-natively (Kanban worktree-per-task since v0.15.0, Desktop Projects since
-v0.18.0), so an OMH-owned creation path is redundant and can collide with the
-worktree Hermes is already managing for the same task. This module retains only
-the observation-side helpers: reading the local worktree ledger and recording
-observed worktree evidence when a wrapper or runtime reports it. Worktree
-preparation is deferred to the operator's native tooling (Hermes Kanban /
-Desktop Projects, or a manual `git worktree add`).
+OMH does not create Git worktrees for chat-prepared handoffs. Upstream Hermes
+Agent manages worktrees natively (Kanban worktree-per-task since v0.15.0,
+Desktop Projects since v0.18.0), so a chat-side creation path is redundant and
+can collide with the worktree Hermes is already managing for the same task.
+This module retains the observation-side helpers (reading the local worktree
+ledger, recording observed worktree evidence) plus one scoped exception:
+`ensure_fanout_unit_worktree`, used only by the explicit opt-in
+`omh coding fanout dispatch` bridge, which needs one isolated worktree per
+fanout unit before spawning a local agent CLI. Worktrees are never
+auto-deleted.
 """
 
 from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any
+import subprocess
+from typing import Any, Callable
 
-from ..local_store import ensure_dir, ensure_file, read_jsonl_objects, utc_now
+from ..local_store import ensure_dir, ensure_file, file_lock, read_jsonl_objects, utc_now
 from ..paths import OmhPaths, expand_path
 
 WORKTREE_OBSERVATION_SCHEMA_VERSION = "omh_worktree_observation/v1"
@@ -68,5 +71,60 @@ def _observation_record(result: dict[str, Any]) -> dict[str, Any]:
 def _append_worktree_record(paths: OmhPaths, record: dict[str, Any]) -> None:
     ensure_dir(paths.runtime_dir, private=True)
     ensure_file(paths.runtime_worktrees_path, private=True)
-    with paths.runtime_worktrees_path.open("a", encoding="utf-8") as handle:
-        handle.write(json.dumps(record, sort_keys=True) + "\n")
+    # Dispatch appends from concurrent unit threads; lock the shared ledger.
+    with file_lock(paths.runtime_worktrees_path, private=True):
+        with paths.runtime_worktrees_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(record, sort_keys=True) + "\n")
+
+
+def ensure_fanout_unit_worktree(
+    paths: OmhPaths,
+    *,
+    repo_root: Path,
+    unit_id: str,
+    branch: str,
+    base_sha: str,
+    runner: Callable[..., Any] = subprocess.run,
+) -> dict[str, Any]:
+    """Create the per-unit worktree for the opt-in fanout dispatch bridge.
+
+    A pre-existing branch or worktree path is an error, never silently reused:
+    building on divergent state defeats the contract's isolation guarantee.
+    Completed units are skipped by dispatch before this helper is called.
+    """
+    worktree_path = repo_root.parent / f"{repo_root.name}-fanout-{unit_id}"
+    result: dict[str, Any] = {
+        "status": "failed",
+        "observed": False,
+        "created": False,
+        "repo_root": str(repo_root),
+        "branch": branch,
+        "worktree_path": str(worktree_path),
+        "from_ref": base_sha,
+        "evidence_refs": [],
+        "recorded_at": utc_now(),
+    }
+    if worktree_path.exists():
+        result["reason"] = f"worktree path already exists: {worktree_path}; remove it or dispatch --unit selectively"
+        _append_worktree_record(paths, _observation_record(result))
+        return result
+    try:
+        completed = runner(
+            ["git", "worktree", "add", str(worktree_path), "-b", branch, base_sha],
+            cwd=str(repo_root),
+            text=True,
+            capture_output=True,
+            timeout=120,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        result["reason"] = f"git worktree add failed to run: {exc}"
+        _append_worktree_record(paths, _observation_record(result))
+        return result
+    if int(getattr(completed, "returncode", 1)) != 0:
+        stderr_tail = str(getattr(completed, "stderr", "") or "")[-300:]
+        result["reason"] = f"git worktree add exited nonzero: {stderr_tail}"
+        _append_worktree_record(paths, _observation_record(result))
+        return result
+    result.update({"status": "created", "observed": True, "created": True, "evidence_refs": [f"git-worktree:{branch}"]})
+    _append_worktree_record(paths, _observation_record(result))
+    return result

--- a/src/commands/coding.py
+++ b/src/commands/coding.py
@@ -624,7 +624,7 @@ def cmd_coding_fanout_validate(args: argparse.Namespace) -> int:
 
 def cmd_coding_fanout_show(args: argparse.Namespace) -> int:
     from ..coding.fanout_artifacts import read_fanout_contract
-    from ..runtime.artifacts import read_state_result
+    from ..runtime.artifacts import show_run
 
     paths = _paths(args)
     try:
@@ -632,19 +632,31 @@ def cmd_coding_fanout_show(args: argparse.Namespace) -> int:
     except (OSError, ValueError) as exc:
         raise OmhError(f"fanout contract not found: {exc}") from exc
 
-    state = read_state_result(paths)
-    runs = state.get("runs", {}) if isinstance(state, dict) else {}
     units = contract.get("units", [])
     status_by_unit: dict[str, object] = {}
     for unit in units:
         if not isinstance(unit, dict):
             continue
         run_ref = str(unit.get("run_ref", ""))
-        run = runs.get(run_ref) if isinstance(runs, dict) else None
-        observed = run.get("status") if isinstance(run, dict) else None
+        observed = "not_observed"
+        latest_event = ""
+        if run_ref and (paths.runtime_runs_dir / run_ref / "run.json").exists():
+            try:
+                shown = show_run(paths, run_ref)
+            except (OSError, ValueError, KeyError):
+                shown = None
+            if isinstance(shown, dict):
+                events = [event for event in shown.get("journal_events", []) or [] if isinstance(event, dict)]
+                if events:
+                    latest = events[-1]
+                    latest_event = str(latest.get("event", ""))
+                    observed = str(latest.get("status", "not_observed"))
+                else:
+                    observed = "run_recorded_no_observations"
         status_by_unit[str(unit.get("unit_id"))] = {
             "prepared_status": unit.get("status", "prepared"),
-            "observed_run_status": observed or "not_observed",
+            "observed_run_status": observed,
+            "latest_observed_event": latest_event,
             "run_ref": run_ref,
         }
     _print_json(
@@ -656,6 +668,46 @@ def cmd_coding_fanout_show(args: argparse.Namespace) -> int:
             "claim_boundary": contract.get("claim_boundary", ""),
         }
     )
+    return 0
+
+
+def cmd_coding_fanout_dispatch(args: argparse.Namespace) -> int:
+    import subprocess as _subprocess
+
+    from ..coding.fanout_artifacts import read_fanout_contract
+    from ..coding.fanout_dispatch import dispatch_fanout
+
+    paths = _paths(args)
+    try:
+        contract = read_fanout_contract(paths, args.fanout_id)
+    except (OSError, ValueError) as exc:
+        raise OmhError(f"fanout contract not found: {exc}") from exc
+    goal_text = sys.stdin.read() if args.goal_file == "-" else Path(args.goal_file).expanduser().read_text(encoding="utf-8")
+    repo_root = Path(args.repo_root).expanduser().resolve()
+    resolved = _subprocess.run(
+        ["git", "rev-parse", args.base_ref],
+        cwd=str(repo_root),
+        text=True,
+        capture_output=True,
+        timeout=30,
+    )
+    if resolved.returncode != 0:
+        raise OmhError(f"could not resolve --base-ref {args.base_ref!r} in {repo_root}: {resolved.stderr.strip()}")
+    try:
+        summary = dispatch_fanout(
+            paths,
+            contract,
+            goal_text=goal_text,
+            repo_root=repo_root,
+            base_sha=resolved.stdout.strip(),
+            concurrency=args.concurrency,
+            timeout=args.timeout,
+            only_units=args.unit,
+            dry_run=bool(args.dry_run),
+        )
+    except ValueError as exc:
+        raise OmhError(str(exc)) from exc
+    _print_json(summary)
     return 0
 
 
@@ -692,6 +744,20 @@ def _add_coding_commands(sub) -> None:
     fanout_show = fanout_sub.add_parser("show")
     fanout_show.add_argument("fanout_id")
     fanout_show.set_defaults(func=cmd_coding_fanout_show)
+
+    fanout_dispatch = fanout_sub.add_parser(
+        "dispatch",
+        help="Opt-in local bridge: spawn each unit's local agent CLI in an isolated worktree (never merges).",
+    )
+    fanout_dispatch.add_argument("fanout_id")
+    fanout_dispatch.add_argument("--goal-file", required=True, help="File with the goal text frozen at prepare time ('-' for stdin).")
+    fanout_dispatch.add_argument("--repo-root", default=".", help="Repository the unit worktrees branch from.")
+    fanout_dispatch.add_argument("--base-ref", default="HEAD", help="Ref resolved once to a SHA all unit branches start from.")
+    fanout_dispatch.add_argument("--concurrency", type=int, default=2)
+    fanout_dispatch.add_argument("--timeout", type=int, default=1800, help="Per-unit subprocess timeout in seconds.")
+    fanout_dispatch.add_argument("--unit", action="append", default=None, help="Dispatch only these unit ids (repeatable).")
+    fanout_dispatch.add_argument("--dry-run", action="store_true", help="Resolve readiness, argv, and worktree paths; spawn nothing.")
+    fanout_dispatch.set_defaults(func=cmd_coding_fanout_dispatch)
 
     delegate = coding_sub.add_parser("delegate")
     delegate.add_argument("message", nargs="*", help="Coding task description to prepare for executor delegation.")

--- a/tests/test_fanout_dispatch.py
+++ b/tests/test_fanout_dispatch.py
@@ -1,0 +1,444 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+from tempfile import TemporaryDirectory
+import unittest
+
+from _local_package import load_local_package
+
+load_local_package()
+
+from _cli_harness import run_cli  # noqa: E402
+
+from omh.coding.fanout import build_fanout_contract  # noqa: E402
+from omh.coding.fanout_artifacts import write_fanout_contract  # noqa: E402
+from omh.coding.fanout_dispatch import dispatch_fanout, verify_goal_matches_contract  # noqa: E402
+from omh.runtime.artifacts import show_run  # noqa: E402
+from omh.system.paths import OmhPaths  # noqa: E402
+
+_GOAL = "split the sample feature across agents"
+_UNITS = [
+    {"unit_id": "core", "title": "Core work", "owner": "codex", "file_scope": ["src/core/"]},
+    {"unit_id": "docs", "title": "Docs work", "owner": "claude-code", "file_scope": ["docs/"]},
+    {"unit_id": "tests", "title": "Test work", "owner": "codex", "file_scope": ["tests/"], "depends_on": ["core"]},
+]
+
+
+def _git(repo: Path, *argv: str) -> None:
+    subprocess.run(["git", *argv], cwd=str(repo), check=True, capture_output=True, text=True)
+
+
+def _make_repo(root: Path) -> tuple[Path, str]:
+    repo = root / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "--allow-empty", "-q", "-m", "init")
+    sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=str(repo), capture_output=True, text=True, check=True
+    ).stdout.strip()
+    return repo, sha
+
+
+class _FakeCompleted:
+    def __init__(self, returncode: int, stdout: str = "") -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = ""
+
+
+def _agent_runner(*, fail_units: set[str] | None = None, timeout_units: set[str] | None = None):
+    """Route git commands to the real subprocess; fake agent CLI spawns."""
+
+    spawned: list[list[str]] = []
+
+    def runner(argv, **kwargs):
+        if argv[0] == "git":
+            return subprocess.run(argv, **kwargs)
+        spawned.append(list(argv))
+        prompt = " ".join(argv)
+        for unit_id in timeout_units or set():
+            if f"Work unit:" in prompt and unit_id in prompt:
+                raise subprocess.TimeoutExpired(argv, kwargs.get("timeout", 0))
+        for unit_id in fail_units or set():
+            if unit_id in prompt:
+                return _FakeCompleted(1, f"unit {unit_id} failed")
+        return _FakeCompleted(0, "done")
+
+    runner.spawned = spawned
+    return runner
+
+
+def _ready(paths, profile, **kwargs):
+    return {"status": "ready", "profile": profile}
+
+
+class FanoutDispatchEngineTests(unittest.TestCase):
+    def _setup(self, tmp: str):
+        root = Path(tmp)
+        paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+        repo, sha = _make_repo(root)
+        contract = write_fanout_contract(paths, build_fanout_contract(_GOAL, _UNITS))
+        return paths, repo, sha, contract
+
+    def test_happy_path_dispatches_units_and_records_observed_evidence(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            runner = _agent_runner()
+
+            summary = dispatch_fanout(
+                paths,
+                contract,
+                goal_text=_GOAL,
+                repo_root=repo,
+                base_sha=sha,
+                runner=runner,
+                readiness=_ready,
+            )
+
+            by_unit = {entry["unit_id"]: entry for entry in summary["units"]}
+            self.assertEqual(by_unit["core"]["status"], "completed")
+            self.assertEqual(by_unit["docs"]["status"], "completed")
+            self.assertEqual(by_unit["tests"]["status"], "completed")
+            self.assertEqual(summary["merge_ready_units"], ["core", "docs", "tests"])
+            self.assertFalse(summary["auto_merge"])
+            self.assertIn("exited 0", summary["dependency_bar"])
+            # observed evidence per unit run
+            shown = show_run(paths, by_unit["core"]["run_ref"])
+            events = [e["event"] for e in shown["journal_events"]]
+            self.assertIn("executor_dispatch_observed", events)
+            self.assertIn("executor_result_observed", events)
+            # worktrees created per unit, never merged
+            self.assertTrue((repo.parent / "repo-fanout-core").exists())
+            self.assertNotIn(["git", "merge"], runner.spawned)
+
+    def test_dependent_unit_waits_and_failure_blocks_only_dependents(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+
+            summary = dispatch_fanout(
+                paths,
+                contract,
+                goal_text=_GOAL,
+                repo_root=repo,
+                base_sha=sha,
+                runner=_agent_runner(fail_units={"Core"}),
+                readiness=_ready,
+            )
+
+            by_unit = {entry["unit_id"]: entry for entry in summary["units"]}
+            self.assertEqual(by_unit["core"]["status"], "failed")
+            self.assertEqual(by_unit["tests"]["status"], "blocked_by_dependency")
+            self.assertEqual(by_unit["docs"]["status"], "completed")
+            self.assertEqual(summary["merge_ready_units"], ["docs"])
+
+    def test_timeout_records_failed_unit(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+
+            summary = dispatch_fanout(
+                paths,
+                contract,
+                goal_text=_GOAL,
+                repo_root=repo,
+                base_sha=sha,
+                timeout=5,
+                runner=_agent_runner(timeout_units={"Docs"}),
+                readiness=_ready,
+            )
+
+            by_unit = {entry["unit_id"]: entry for entry in summary["units"]}
+            self.assertEqual(by_unit["docs"]["status"], "failed")
+            self.assertEqual(by_unit["docs"]["exit_code"], 124)
+
+    def test_readiness_refusal_skips_unit_without_fabricating_a_run(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+
+            def not_ready(paths_, profile, **kwargs):
+                return {"status": "missing", "profile": profile}
+
+            summary = dispatch_fanout(
+                paths,
+                contract,
+                goal_text=_GOAL,
+                repo_root=repo,
+                base_sha=sha,
+                runner=_agent_runner(),
+                readiness=not_ready,
+            )
+
+            by_unit = {entry["unit_id"]: entry for entry in summary["units"]}
+            self.assertEqual(by_unit["core"]["status"], "executor_not_ready")
+            self.assertFalse((paths.runtime_runs_dir / by_unit["core"]["run_ref"]).exists())
+
+    def test_dry_run_plans_without_spawning_or_creating_runs(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            runner = _agent_runner()
+
+            summary = dispatch_fanout(
+                paths,
+                contract,
+                goal_text=_GOAL,
+                repo_root=repo,
+                base_sha=sha,
+                dry_run=True,
+                runner=runner,
+                readiness=_ready,
+            )
+
+            self.assertTrue(all(entry["status"] == "dry_run_planned" for entry in summary["units"]))
+            self.assertEqual(runner.spawned, [])
+            self.assertFalse(paths.runtime_runs_dir.exists())
+            self.assertFalse((repo.parent / "repo-fanout-core").exists())
+
+    def test_resume_skips_completed_units(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            first = dispatch_fanout(
+                paths,
+                contract,
+                goal_text=_GOAL,
+                repo_root=repo,
+                base_sha=sha,
+                runner=_agent_runner(),
+                readiness=_ready,
+            )
+            self.assertEqual(len({e["unit_id"] for e in first["units"] if e["status"] == "completed"}), 3)
+
+            rerun_runner = _agent_runner()
+            second = dispatch_fanout(
+                paths,
+                contract,
+                goal_text=_GOAL,
+                repo_root=repo,
+                base_sha=sha,
+                runner=rerun_runner,
+                readiness=_ready,
+            )
+
+            self.assertTrue(all(entry["status"] == "already_completed" for entry in second["units"]))
+            self.assertEqual(rerun_runner.spawned, [])
+
+    def test_argv_templates_for_both_spawnable_profiles(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            runner = _agent_runner()
+
+            dispatch_fanout(
+                paths,
+                contract,
+                goal_text=_GOAL,
+                repo_root=repo,
+                base_sha=sha,
+                runner=runner,
+                readiness=_ready,
+            )
+
+            heads = {tuple(argv[:2]) for argv in runner.spawned}
+            self.assertIn(("codex", "exec"), heads)
+            claude_argv = next(argv for argv in runner.spawned if argv[0] == "claude")
+            self.assertEqual(claude_argv[1], "-p")
+            self.assertEqual(claude_argv[3:], ["--permission-mode", "acceptEdits"])
+            self.assertIn("Work unit:", claude_argv[2])
+
+    def test_missing_cli_maps_to_exit_127(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+
+            def runner(argv, **kwargs):
+                if argv[0] == "git":
+                    return subprocess.run(argv, **kwargs)
+                raise FileNotFoundError(argv[0])
+
+            summary = dispatch_fanout(
+                paths,
+                contract,
+                goal_text=_GOAL,
+                repo_root=repo,
+                base_sha=sha,
+                runner=runner,
+                readiness=_ready,
+            )
+
+            by_unit = {entry["unit_id"]: entry for entry in summary["units"]}
+            self.assertEqual(by_unit["core"]["status"], "failed")
+            self.assertEqual(by_unit["core"]["exit_code"], 127)
+
+    def test_unsupported_profile_falls_back_and_blocks_dependents_with_pointer(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+            repo, sha = _make_repo(root)
+            units = [
+                {"unit_id": "manual", "owner": "hermes", "file_scope": ["notes/"]},
+                {"unit_id": "auto", "owner": "codex", "file_scope": ["src/"], "depends_on": ["manual"]},
+            ]
+            contract = write_fanout_contract(paths, build_fanout_contract(_GOAL, units))
+
+            summary = dispatch_fanout(
+                paths,
+                contract,
+                goal_text=_GOAL,
+                repo_root=repo,
+                base_sha=sha,
+                runner=_agent_runner(),
+                readiness=_ready,
+            )
+
+            by_unit = {entry["unit_id"]: entry for entry in summary["units"]}
+            self.assertEqual(by_unit["manual"]["status"], "unsupported_for_local_dispatch")
+            self.assertIn("prepared prompt", by_unit["manual"]["fallback"])
+            self.assertEqual(by_unit["auto"]["status"], "blocked_by_dependency")
+            self.assertEqual(by_unit["auto"]["blocked_on"], ["manual"])
+
+    def test_partial_redispatch_consumes_previously_completed_dependency(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            dispatch_fanout(
+                paths,
+                contract,
+                goal_text=_GOAL,
+                repo_root=repo,
+                base_sha=sha,
+                only_units=["core"],
+                runner=_agent_runner(),
+                readiness=_ready,
+            )
+
+            (repo.parent / "repo-fanout-tests").exists()
+            second = dispatch_fanout(
+                paths,
+                contract,
+                goal_text=_GOAL,
+                repo_root=repo,
+                base_sha=sha,
+                only_units=["tests"],
+                runner=_agent_runner(),
+                readiness=_ready,
+            )
+
+            by_unit = {entry["unit_id"]: entry for entry in second["units"]}
+            self.assertEqual(by_unit["core"]["status"], "already_completed")
+            self.assertEqual(by_unit["tests"]["status"], "completed")
+            self.assertEqual(by_unit["docs"]["status"], "not_selected")
+
+    def test_goal_divergence_is_refused(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+
+            with self.assertRaises(ValueError):
+                verify_goal_matches_contract(contract, "a different goal entirely")
+            with self.assertRaises(ValueError):
+                dispatch_fanout(
+                    paths,
+                    contract,
+                    goal_text="a different goal entirely",
+                    repo_root=repo,
+                    base_sha=sha,
+                    runner=_agent_runner(),
+                    readiness=_ready,
+                )
+
+    def test_existing_worktree_path_errors_instead_of_reuse(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            (repo.parent / "repo-fanout-core").mkdir()
+
+            summary = dispatch_fanout(
+                paths,
+                contract,
+                goal_text=_GOAL,
+                repo_root=repo,
+                base_sha=sha,
+                runner=_agent_runner(),
+                readiness=_ready,
+            )
+
+            by_unit = {entry["unit_id"]: entry for entry in summary["units"]}
+            self.assertEqual(by_unit["core"]["status"], "worktree_failed")
+            self.assertIn("already exists", by_unit["core"]["reason"])
+
+
+class FanoutDispatchCliTests(unittest.TestCase):
+    def test_cli_dry_run_and_show_join(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo, _sha = _make_repo(root)
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+            units_path = root / "units.json"
+            units_path.write_text(json.dumps(_UNITS), encoding="utf-8")
+            goal_path = root / "goal.txt"
+            goal_path.write_text(_GOAL, encoding="utf-8")
+
+            status, stdout, stderr = run_cli(
+                base + ["coding", "fanout", "prepare", "--goal", *_GOAL.split(), "--units", str(units_path), "--record"]
+            )
+            self.assertEqual(status, 0, stderr)
+            fanout_id = json.loads(stdout)["fanout_id"]
+
+            status, stdout, stderr = run_cli(
+                base
+                + [
+                    "coding",
+                    "fanout",
+                    "dispatch",
+                    fanout_id,
+                    "--goal-file",
+                    str(goal_path),
+                    "--repo-root",
+                    str(repo),
+                    "--dry-run",
+                ]
+            )
+            self.assertEqual(status, 0, stderr)
+            summary = json.loads(stdout)
+            self.assertEqual(summary["schema_version"], "fanout_dispatch_summary/v1")
+            self.assertTrue(summary["dry_run"])
+            self.assertFalse(summary["auto_merge"])
+            for entry in summary["units"]:
+                self.assertIn(entry["status"], {"dry_run_planned", "executor_not_ready", "unsupported_for_local_dispatch"})
+
+            status, stdout, stderr = run_cli(base + ["coding", "fanout", "show", fanout_id])
+            self.assertEqual(status, 0, stderr)
+            board = json.loads(stdout)
+            for unit in board["units"].values():
+                self.assertEqual(unit["observed_run_status"], "not_observed")
+
+    def test_cli_refuses_diverged_goal_file(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo, _sha = _make_repo(root)
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+            units_path = root / "units.json"
+            units_path.write_text(json.dumps(_UNITS), encoding="utf-8")
+            wrong_goal = root / "wrong.txt"
+            wrong_goal.write_text("not the frozen goal", encoding="utf-8")
+
+            status, stdout, _ = run_cli(
+                base + ["coding", "fanout", "prepare", "--goal", *_GOAL.split(), "--units", str(units_path), "--record"]
+            )
+            fanout_id = json.loads(stdout)["fanout_id"]
+
+            status, stdout, stderr = run_cli(
+                base
+                + [
+                    "coding",
+                    "fanout",
+                    "dispatch",
+                    fanout_id,
+                    "--goal-file",
+                    str(wrong_goal),
+                    "--repo-root",
+                    str(repo),
+                    "--dry-run",
+                ]
+            )
+            self.assertNotEqual(status, 0)
+            self.assertIn("does not match the digest", stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_fanout_dispatch.py
+++ b/tests/test_fanout_dispatch.py
@@ -398,8 +398,20 @@ class FanoutDispatchCliTests(unittest.TestCase):
             self.assertEqual(summary["schema_version"], "fanout_dispatch_summary/v1")
             self.assertTrue(summary["dry_run"])
             self.assertFalse(summary["auto_merge"])
+            # Readiness is probed for real here, so statuses depend on which
+            # agent CLIs exist on the host; the invariant is that nothing
+            # spawns or completes under --dry-run.
             for entry in summary["units"]:
-                self.assertIn(entry["status"], {"dry_run_planned", "executor_not_ready", "unsupported_for_local_dispatch"})
+                self.assertIn(
+                    entry["status"],
+                    {
+                        "dry_run_planned",
+                        "executor_not_ready",
+                        "unsupported_for_local_dispatch",
+                        "blocked_by_dependency",
+                    },
+                )
+                self.assertNotIn(entry["status"], {"completed", "failed"})
 
             status, stdout, stderr = run_cli(base + ["coding", "fanout", "show", fanout_id])
             self.assertEqual(status, 0, stderr)


### PR DESCRIPTION
## Capability

`omh coding fanout dispatch <fanout-id> --goal-file goal.txt` — the execution orchestration layer for frozen `fanout_contract/v1` splits. For each unit it probes the owner CLI's readiness, creates an isolated worktree (`<repo>-fanout-<unit>` on `agent/<unit>`, all branched from one SHA), spawns the owner's **local** headless agent CLI (`codex exec` / `claude -p ... --permission-mode acceptEdits` — fixed data templates), and records every spawn and exit as **observed** journal evidence on the unit's `run_ref` run. Scheduling is dependency-aware with bounded concurrency (`--concurrency`, default 2) and per-unit timeouts; failures block dependents (with `blocked_on` pointers) but never independents; completed units satisfy dependencies even when unselected, so partial re-dispatch and resume work; `--dry-run` plans everything and touches nothing. **Dispatch never merges** — the summary reports merge-ready units in the contract's `merge_order`, with an explicit dependency-bar claim boundary (exit 0 ≠ verified work).

## Motivation

PR #625 delivered the deterministic plan+merge-contract substrate; this is the user-approved follow-up that actually runs the units in parallel ("omh 로컬 브리지" scope selection). It is the first omh surface that spawns processes, so the PR treats the product boundary as a first-class deliverable, not a footnote.

## Product boundary (handled honestly, same PR)

- AGENTS.md names the bridge as the concrete instance of the existing "scoped integration with explicit user approval" clause, and the "secret coding executor" prohibition now points at it as the one sanctioned, non-hidden execution surface. DIRECTION.md's "not a hidden coding runtime" and CLAUDE.md's "no LLM/API/network calls" are qualified the same way: omh spawns local CLIs only on the explicit command; **the CLIs make their own network calls, omh still makes none**; no auto-merge, no default-on, no raw-prompt persistence (`--goal-file` must hash to the digest frozen at prepare time — divergence is refused).
- Two-axis taxonomy (Critic-arbitrated): chat prompt-handoff surfaces stay prompt-only (`claude-code` chat cards unchanged; the wrapper_note is now scoped — "this chat prompt handoff does not dispatch it"), while the operator bridge is a distinct surface that may spawn any templated profile. This keeps all three of the owner's executors (Hermes-fallback / Codex / Claude Code) usable without contradicting the chat contract.

## Implementation (boundary level)

- `src/coding/fanout_dispatch.py` — scheduler + templates + digest verification + evidence recording (injectable `runner`/`readiness` seams for CI).
- `src/coding/worktree_creator.py` — scoped `ensure_fanout_unit_worktree` (pre-existing path/branch = error, never reuse; never auto-delete) + the shared worktree ledger append now takes a file lock (fixes a latent concurrent-append race).
- `src/commands/coding.py` — dispatch CLI + a real bugfix to `fanout show`: the old join read `read_state_result` as a dict (it returns a tuple) against a `state["runs"]` registry nothing writes — status was unconditionally `not_observed`. It now resolves per-unit run dirs and reports the latest observed journal event.
- `docs/FANOUT.md` — full lifecycle, blocked-by-design cascade recovery, and a first-use validation note for the `claude -p` template (codex has in-repo precedent; claude does not).

## Verification (observed)

- Full suite **1568 OK** (+14 dispatch tests): happy path with journal-evidence assertions, dependency wait, failure/unsupported/unready blocking with `blocked_on`, timeout→124 and missing-CLI→127 mapping, both argv templates, goal-digest refusal (engine + CLI), dry-run zero-side-effects, resume, **partial re-dispatch across runs** (the Critic-found gap, fixed), existing-worktree error, show join.
- Routing untouched (55/118/173, 59/179 verbatim); prepare/validate byte-unchanged and still create no runs; all three `docs --check` byte gates + compileall + `git diff --check` clean.
- Consensus: deliberate-mode ralplan — Planner v1 → Architect SOUND-WITH-AMENDMENTS (9/9 claims verified; found the show bug and the ledger race) → Critic ITERATE with 5 binding amendments, all landed.

## Risks / evidence boundaries

- Real `codex`/`claude` spawns are exercised through the injected-runner seam only; first real use is operator-validated per docs/FANOUT.md. Template drift surfaces as clean readiness/exit-code failures recorded as observed evidence.
- Merging unit branches and the final integration gate remain human/agent-gated by design; a dispatch summary is never merge evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
