### PR TITLE
fix: grant claude-code fanout units the git add/commit tools they need

### DIFF
--- a/docs/FANOUT.md
+++ b/docs/FANOUT.md
@@ -54,12 +54,14 @@ goal to Hermes in chat; these commands are the backend surface.
   `run_ref` run, then re-run `dispatch --unit <dependent>`; completed units
   satisfy dependencies even when not re-selected. Blocked entries carry a
   `blocked_on` list naming the offending units.
-- **First-use validation note.** `codex exec` has in-repo precedent; the
-  `claude -p ... --permission-mode acceptEdits` template does not — validate
-  it interactively on first real use before relying on it in bulk fanouts.
-  Template drift in either CLI surfaces as a clean readiness or exit-code
-  failure recorded as observed evidence, and the fix is a one-line data edit
-  in `DISPATCH_COMMAND_TEMPLATES`.
+- **First-use validation note.** `codex exec` has in-repo precedent. The
+  claude template was validated in a live dispatch (2026-07): `acceptEdits`
+  alone let the agent create files but blocked the requested `git commit`,
+  so the template additionally grants `--allowedTools
+  "Bash(git add:*),Bash(git commit:*)"` — exactly those two git verbs,
+  nothing broader. Template drift in either CLI surfaces as a clean
+  readiness or exit-code failure recorded as observed evidence, and the fix
+  is a one-line data edit in `DISPATCH_COMMAND_TEMPLATES`.
 - **Resume.** Re-running dispatch skips units whose runs already carry an
   observed successful result. `--unit <id>` selects subsets.
 - **Never**: auto-merge, default-on execution, network calls by omh itself,

--- a/src/coding/fanout_dispatch.py
+++ b/src/coding/fanout_dispatch.py
@@ -21,7 +21,18 @@ DISPATCH_CLAIM_BOUNDARY = (
 # unassigned) gets a prepared-prompt fallback and is never spawned.
 DISPATCH_COMMAND_TEMPLATES: dict[str, tuple[str, ...]] = {
     "codex": ("codex", "exec", "{prompt}"),
-    "claude-code": ("claude", "-p", "{prompt}", "--permission-mode", "acceptEdits"),
+    # acceptEdits alone lets Claude edit files but blocks the `git add/commit`
+    # the unit prompt asks for (observed in the first live dispatch);
+    # allowedTools grants exactly those two git verbs, nothing broader.
+    "claude-code": (
+        "claude",
+        "-p",
+        "{prompt}",
+        "--permission-mode",
+        "acceptEdits",
+        "--allowedTools",
+        "Bash(git add:*),Bash(git commit:*)",
+    ),
 }
 
 

--- a/tests/test_fanout_dispatch.py
+++ b/tests/test_fanout_dispatch.py
@@ -241,7 +241,10 @@ class FanoutDispatchEngineTests(unittest.TestCase):
             self.assertIn(("codex", "exec"), heads)
             claude_argv = next(argv for argv in runner.spawned if argv[0] == "claude")
             self.assertEqual(claude_argv[1], "-p")
-            self.assertEqual(claude_argv[3:], ["--permission-mode", "acceptEdits"])
+            self.assertEqual(
+                claude_argv[3:],
+                ["--permission-mode", "acceptEdits", "--allowedTools", "Bash(git add:*),Bash(git commit:*)"],
+            )
             self.assertIn("Work unit:", claude_argv[2])
 
     def test_missing_cli_maps_to_exit_127(self) -> None:


### PR DESCRIPTION
## Capability

Claude-owned fanout units can now complete their own `git add`/`git commit`, making them fully autonomous end to end like codex units.

## Motivation

The first live dispatch validated the bridge end to end (both units completed, observed evidence recorded, merge_order merge + integration check passed) and surfaced exactly one gap, anticipated by docs/FANOUT.md's first-use validation note: with `--permission-mode acceptEdits` alone, the spawned claude agent created its unit file perfectly but could not run the commit the unit prompt asks for — the operator had to finalize. That made claude units second-class against the executor-neutral contract.

## Implementation

One data-table edit: the `claude-code` template in `DISPATCH_COMMAND_TEMPLATES` adds `--allowedTools "Bash(git add:*),Bash(git commit:*)"` — exactly the two git verbs the unit prompt requires, nothing broader (`bypassPermissions` was rejected as violating least-privilege for a spawned agent). The argv-template test pins the new shape; docs/FANOUT.md now records the live validation outcome.

## Verification (observed)

Full suite 1568 OK; all three `docs --check` byte gates, compileall, `git diff --check` clean. The gap itself was observed in a real dispatch (fanout-065b6db3fe71): claude produced a correct `mul.py` but left it uncommitted; codex committed autonomously.

## Risks

Scoped permission widening only, inside the unit's own isolated worktree. A second live claude dispatch validates the widened template on next real use; drift surfaces as observed exit-code evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)