### PR TITLE
fix: classify plugin package-call failure separately from missing-package fallback

### DIFF
--- a/src/plugin_bundle/omh/tools/context_tool.py
+++ b/src/plugin_bundle/omh/tools/context_tool.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import hashlib
 import json
+import re
 from typing import Any
 
 from ..context_brief import bounded_context_hint_limit, build_context_brief as build_plugin_context_brief
@@ -68,7 +70,7 @@ def _context_brief(
 ) -> tuple[dict[str, object], str]:
     try:
         from omh.context import build_context_brief as build_package_context_brief
-    except Exception:
+    except (ImportError, ModuleNotFoundError):
         return build_plugin_context_brief(
             message,
             source=source,
@@ -82,10 +84,36 @@ def _context_brief(
             max_hints=max_hints,
             include_prompt_context=include_prompt_context,
         ), "package_context"
-    except Exception:
-        return build_plugin_context_brief(
-            message,
-            source=source,
-            max_hints=max_hints,
-            include_prompt_context=include_prompt_context,
-        ), "standalone_plugin_bundle_fallback"
+    except Exception as exc:
+        # The package imported successfully but the delegated call raised. This is a
+        # package runtime failure, not a genuine missing-package fallback, so it must
+        # not be mislabeled as `standalone_plugin_bundle_fallback`.
+        return _package_context_error(message, source=source, error_type=type(exc).__name__), "package_context_error"
+
+
+def _package_context_error(message: str, *, source: str, error_type: str) -> dict[str, object]:
+    text = str(message or "")
+    return {
+        "schema_version": "omh_context_brief_error/v1",
+        "status": "error",
+        "error": "package_backend_error",
+        "error_type": _safe_error_type(error_type),
+        "source": source,
+        "message": {
+            "sha256": hashlib.sha256(text.encode("utf-8")).hexdigest() if text else "",
+            "length": len(text),
+            "raw_prompt_stored": False,
+            "raw_prompt_echoed": False,
+        },
+        "degraded": True,
+        "claim_boundary": (
+            "The installed OMH package raised while building this context brief. This response carries no "
+            "lanes, route hints, or capability context; it is neither a normal package-backed brief nor a "
+            "genuine missing-package standalone fallback."
+        ),
+    }
+
+
+def _safe_error_type(error_type: str) -> str:
+    text = re.sub(r"[^A-Za-z0-9_.-]", "", str(error_type or ""))
+    return text[:80] or "Exception"

--- a/src/plugin_bundle/omh/tools/recommend_tool.py
+++ b/src/plugin_bundle/omh/tools/recommend_tool.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 from typing import Any
 
 from ..awareness import awareness_primer_payload, awareness_route_hint
@@ -81,10 +82,10 @@ def omh_recommend_handler(args: dict, **kwargs) -> str:
         }
         return json.dumps(attach_public_observation(payload, observation), sort_keys=True)
 
-    recommendations, source = _recommendations(message, limit)
+    recommendations, source, error_type = _recommendations(message, limit)
     payload = {
         "schema_version": "omh_recommend_result/v1",
-        "status": "recommended" if recommendations else "no_match",
+        "status": "error" if error_type else ("recommended" if recommendations else "no_match"),
         "source": source,
         "message": {
             "sha256": hashlib.sha256(message.encode("utf-8")).hexdigest(),
@@ -99,18 +100,30 @@ def omh_recommend_handler(args: dict, **kwargs) -> str:
         ),
         "claim_boundary": _claim_boundary(),
     }
+    if error_type:
+        payload["error"] = "package_backend_error"
+        payload["error_type"] = error_type
+        payload["degraded"] = True
     return json.dumps(attach_public_observation(payload, observation), sort_keys=True)
 
 
-def _recommendations(message: str, limit: int) -> tuple[list[dict[str, Any]], str]:
+def _recommendations(message: str, limit: int) -> tuple[list[dict[str, Any]], str, str | None]:
     try:
         from omh.routing.recommend import recommend_skills
-    except Exception:
-        return _fallback_recommendations(message, limit), "standalone_plugin_bundle_fallback"
+    except (ImportError, ModuleNotFoundError):
+        return _fallback_recommendations(message, limit), "standalone_plugin_bundle_fallback", None
     try:
-        return [_redacted_recommendation(item) for item in recommend_skills(message, limit=limit)], "package_recommend"
-    except Exception:
-        return _fallback_recommendations(message, limit), "standalone_plugin_bundle_fallback"
+        return [_redacted_recommendation(item) for item in recommend_skills(message, limit=limit)], "package_recommend", None
+    except Exception as exc:
+        # The package imported successfully but the delegated call raised. This is a
+        # package runtime failure, not a genuine missing-package fallback, so it must
+        # not be mislabeled as `standalone_plugin_bundle_fallback`.
+        return [], "package_recommend_error", _safe_error_type(type(exc).__name__)
+
+
+def _safe_error_type(error_type: str) -> str:
+    text = re.sub(r"[^A-Za-z0-9_.-]", "", str(error_type or ""))
+    return text[:80] or "Exception"
 
 
 def _redacted_recommendation(item: dict[str, Any]) -> dict[str, Any]:

--- a/tests/test_plugin_distribution.py
+++ b/tests/test_plugin_distribution.py
@@ -156,6 +156,62 @@ print(json.dumps(observed, ensure_ascii=False))
                 with self.assertRaises(ModuleNotFoundError):
                     probe_tool.omh_probe_handler(args)
 
+    def test_context_tool_distinguishes_missing_package_from_package_call_failure(self) -> None:
+        from omh.plugin_bundle.omh.tools import context_tool
+
+        args = {"message": "plan a risky refactor with secret-token-123", "limit": 2}
+
+        # Case (a): the package genuinely cannot be imported. This is the true
+        # standalone fallback and must keep working.
+        with mock.patch.dict(sys.modules, {"omh.context": None}):
+            fallback_payload = json.loads(context_tool.omh_context_handler(dict(args)))
+        self.assertEqual(fallback_payload["source_backend"], "standalone_plugin_bundle_fallback")
+        self.assertEqual(fallback_payload["schema_version"], "omh_context_brief/v1")
+        self.assertFalse(fallback_payload["message"]["raw_prompt_echoed"])
+
+        # Case (b): the package imports fine but the delegated call raises. This must
+        # not be mislabeled as the same normal standalone fallback.
+        with mock.patch("omh.context.build_context_brief", side_effect=RuntimeError("package-context-boom")):
+            error_payload = json.loads(context_tool.omh_context_handler(dict(args)))
+        self.assertEqual(error_payload["source_backend"], "package_context_error")
+        self.assertNotEqual(error_payload["source_backend"], "standalone_plugin_bundle_fallback")
+        self.assertEqual(error_payload["status"], "error")
+        self.assertEqual(error_payload["error"], "package_backend_error")
+        self.assertEqual(error_payload["error_type"], "RuntimeError")
+        self.assertTrue(error_payload["degraded"])
+        self.assertFalse(error_payload["message"]["raw_prompt_echoed"])
+        serialized = json.dumps(error_payload, sort_keys=True)
+        self.assertNotIn("package-context-boom", serialized)
+        self.assertNotIn("secret-token-123", serialized)
+
+    def test_recommend_tool_distinguishes_missing_package_from_package_call_failure(self) -> None:
+        from omh.plugin_bundle.omh.tools import recommend_tool
+
+        args = {"message": "plan a risky refactor with secret-token-123", "limit": 2}
+
+        # Case (a): the package genuinely cannot be imported. This is the true
+        # standalone fallback and must keep working.
+        with mock.patch.dict(sys.modules, {"omh.routing.recommend": None}):
+            fallback_payload = json.loads(recommend_tool.omh_recommend_handler(dict(args)))
+        self.assertEqual(fallback_payload["source"], "standalone_plugin_bundle_fallback")
+        self.assertIn(fallback_payload["status"], {"recommended", "no_match"})
+        self.assertNotIn("error", fallback_payload)
+
+        # Case (b): the package imports fine but the delegated call raises. This must
+        # not be mislabeled as the same normal standalone fallback.
+        with mock.patch("omh.routing.recommend.recommend_skills", side_effect=RuntimeError("package-recommend-boom")):
+            error_payload = json.loads(recommend_tool.omh_recommend_handler(dict(args)))
+        self.assertEqual(error_payload["source"], "package_recommend_error")
+        self.assertNotEqual(error_payload["source"], "standalone_plugin_bundle_fallback")
+        self.assertEqual(error_payload["status"], "error")
+        self.assertEqual(error_payload["error"], "package_backend_error")
+        self.assertEqual(error_payload["error_type"], "RuntimeError")
+        self.assertTrue(error_payload["degraded"])
+        self.assertEqual(error_payload["recommendations"], [])
+        serialized = json.dumps(error_payload, sort_keys=True)
+        self.assertNotIn("package-recommend-boom", serialized)
+        self.assertNotIn("secret-token-123", serialized)
+
     def test_setup_default_installs_plugin(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## Feature Report

### What Changed

- `src/plugin_bundle/omh/tools/context_tool.py::_context_brief` and
  `src/plugin_bundle/omh/tools/recommend_tool.py::_recommendations` /
  `omh_recommend_handler` now split two previously-conflated failure states:
  - **Genuine missing/unimportable OMH package** (`ImportError`,
    `ModuleNotFoundError` on the `from omh.context import ...` /
    `from omh.routing.recommend import ...` line) — unchanged behavior,
    still returns the normal `standalone_plugin_bundle_fallback` result.
  - **Installed, importable package whose delegated call raised** (any
    other exception from `build_context_brief(...)` /
    `recommend_skills(...)`) — now returns a distinct, stable
    degraded/error result instead of masquerading as the fallback above.
- New context-tool error shape: `source_backend: "package_context_error"`,
  `schema_version: "omh_context_brief_error/v1"`, `status: "error"`,
  `error: "package_backend_error"`, `error_type: <bounded exception class
  name>`, `degraded: true`. No route hints/lanes/capability content, no
  raw exception text, no echoed request text (message hash/length only).
- New recommend-tool error shape: same `omh_recommend_result/v1` schema as
  before, with `source: "package_recommend_error"`, `status: "error"`,
  `error: "package_backend_error"`, `error_type: <bounded exception class
  name>`, `degraded: true`, and `recommendations: []`.
- `error_type` is sanitized with a whitelist regex
  (`[^A-Za-z0-9_.-]` stripped) and capped at 80 characters — it is a
  diagnostic code (the exception's class name), never the exception
  message or the user's request text.

### Why This Exists

Both tools caught `except Exception` around the delegated
`omh.context.build_context_brief` / `omh.routing.recommend.recommend_skills`
calls and returned the same `standalone_plugin_bundle_fallback` payload used
for a genuinely absent package. An installed package that imports fine but
raises at call time was silently relabeled as a normal fallback, with no
diagnostic field, which can hide package regressions from the operator and
let behavior silently diverge from the installed package (issue #637).

### User / Operator Impact

- A Hermes host (or anyone inspecting `omh_context` / `omh_recommend`
  tool output) can now tell "package genuinely unavailable in this
  standalone install" apart from "package is installed but broke on this
  call" by checking `source_backend`/`source` plus the new `status`,
  `error`, and `degraded` fields — without any raw exception text or
  request content ever appearing in the response.
- Standalone Hermes plugin installs (package genuinely absent) are
  unaffected; that fallback path and its payload shape are unchanged.

### How It Works

- `context_tool.py::_context_brief` keeps the existing two-stage
  `try/except`: the outer `except (ImportError, ModuleNotFoundError)`
  around the import statement returns the true standalone fallback; the
  inner `except Exception as exc` around the delegated call now builds a
  compact `_package_context_error(...)` payload instead of re-running the
  standalone builder under the same fallback label.
- `recommend_tool.py::_recommendations` now returns a 3-tuple
  `(recommendations, source, error_type)`; `omh_recommend_handler` sets
  `status`/`error`/`error_type`/`degraded` only when `error_type` is set,
  keeping the normal `omh_recommend_result/v1` schema stable for the
  success and true-fallback paths.
- Both tools follow the distinction already established in
  `src/plugin_bundle/omh/tools/chat_tool.py::omh_interact_handler`
  (`_backend_error_interaction` / `_safe_error_type`), which already
  separates package-call failure from import failure and only echoes a
  bounded exception-type diagnostic. That existing code was used as the
  template for this change rather than inventing a new convention.

### Files And Contracts Touched

- `src/plugin_bundle/omh/tools/context_tool.py` — new
  `_package_context_error` / `_safe_error_type` helpers; `_context_brief`
  now distinguishes import vs. call failure.
- `src/plugin_bundle/omh/tools/recommend_tool.py` — new `_safe_error_type`
  helper; `_recommendations` returns error diagnostics; handler adds
  `error`/`error_type`/`degraded` fields on package-call failure.
- `tests/test_plugin_distribution.py` — two new tests:
  `test_context_tool_distinguishes_missing_package_from_package_call_failure`
  and
  `test_recommend_tool_distinguishes_missing_package_from_package_call_failure`,
  each covering both failure classes plus a no-raw-text guard assertion.

### Audit Of Other Plugin Bridges (per issue #637's explicit ask)

Reviewed every broad `except Exception` under `src/plugin_bundle/omh/`:

- `tools/chat_tool.py` — **already correct**; this is the existing
  pattern this PR extends to the other two tools. No change.
- `host_observation.py::_record_observation` — **already correct**;
  `(ImportError, ModuleNotFoundError)` is handled separately from the
  broad `except Exception`, and the broad-exception path already returns
  a distinct `status: "not_recorded"` result (schema
  `omh_plugin_host_observation_error/v1`), never the normal fallback
  label. No change.
- `tools/capability_tool.py::_load_package_registry` and
  `tools/probe_tool.py::omh_probe_handler` — only catch
  `ModuleNotFoundError` around the import itself (already tested by
  `test_probe_tool_falls_back_only_when_package_is_absent`, which asserts
  a non-`omh`-named `ModuleNotFoundError` re-raises rather than falling
  back). A failure from the delegated call itself is not caught at all
  and propagates uncaught. That is a different failure shape (an
  unhandled crash, not a silent mislabel) and pre-existing; left
  untouched to keep this change scoped to the mislabeling defect the
  issue reports.
- `tools/hud_tool.py`, `tools/status_tool.py`, `tools/evidence_tool.py`,
  `tools/role_tool.py`, `tools/capability_impact.py`,
  `hooks/llm_hooks.py::pre_llm_call` — no delegated `omh.*` package call
  behind their `except` blocks (local file reads, subprocess calls, or no
  `omh` package import at all), so this class of bug does not apply.
- `context_brief.py::_capability_family_cards` /
  `_is_catalog_question` — internal per-field degradation helpers used
  *inside* the standalone fallback builder itself; they don't make or
  mislabel a top-level `source`/`source_backend` claim, so they're a
  different (already-safe) shape.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests` — 1570 passed, 1 skipped
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [x] `git diff --check`
- [ ] `python3 -m omh.cli harness validate` — not run (no harness/runtime contract touched)
- [ ] `python3 -m omh.cli release checklist --json` / `release hermes-smoke` — not run (not a release-prep change)
- [ ] `omh --help` — not run (no CLI surface changed)
- [ ] Manual Hermes/TUI check — not run; no live Hermes host available in this environment. Verified via targeted unit tests that monkeypatch the delegated package calls (`omh.context.build_context_brief`, `omh.routing.recommend.recommend_skills`) and simulate genuine import absence via `sys.modules[...] = None`, matching the issue's own reproduction recipe.

## Risk

- Narrow: only two tool modules changed, both plugin-bundle-local. No
  changes to CLI commands, generated docs/skills, catalog data, or
  runtime state contracts.
- Response shape changes are additive for the error case only
  (`error`/`error_type`/`degraded` fields, and a new `source_backend` /
  `source` value on package-call failure). The success path and the
  genuine-missing-package fallback path are byte-for-byte unchanged.
- A caller that pattern-matched on `source_backend`/`source` for exactly
  `"standalone_plugin_bundle_fallback"` to detect "the package isn't
  installed" would now also need to check for
  `"package_context_error"`/`"package_recommend_error"` if it wants to
  detect package-call failures too — but before this change it had no way
  to detect that case at all, so this is a strict improvement, not a
  behavior removal.

## Compatibility / Rollout

- Standalone Hermes plugin installs (package genuinely absent) keep
  working identically; that is the primary compatibility constraint from
  `CLAUDE.md`/`AGENTS.md` and is covered by a dedicated test assertion in
  both new tests.
- No new dependencies, no network calls, no Hermes core patching.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`) — plugin-bundle-local observability fix, no release-channel-specific behavior
- [x] Runtime/native capability claims are backed by evidence or marked as not observed — new fields are metadata-only diagnostics, not execution/review/CI/merge claims
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap — no live Hermes host round-trip was performed; only monkeypatched unit-level verification (see Validation)

## Follow-Up

- Optional, deliberately not done here: give `capability_tool.py` /
  `probe_tool.py` the same explicit degraded/error handling for a
  delegated-call failure (today it propagates as an unhandled exception
  rather than a graceful degraded result). That is a different failure
  shape from the mislabeling defect this issue targets, so it was left
  out to keep this PR scoped to #637's evidence.

Closes #637