### PR TITLE
docs(i18n): sync Korean/Japanese/Chinese README onboarding with English source

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -88,6 +88,24 @@ hermes skills install rlaope/oh-my-hermes/skills/oh-my-hermes --yes
 Hey Agent, Install this >> https://github.com/rlaope/oh-my-hermes <<
 ```
 
+<br>
+
+**既存の `--full` インストールを core に戻す:**
+
+```sh
+omh skill-profile status
+omh skill-profile reconcile --to core --dry-run
+omh skill-profile reconcile --to core
+```
+
+setup、install、update はインストール済みの skill を削除しないため、一度
+`--full` でインストールした workspace は、明示的に reconcile するまでその
+per-turn の context 負荷を維持し続けます。詳細は
+[既存の Full インストールを Core に戻す](docs/INSTALLATION.md#reconciling-an-existing-full-install-back-to-core)
+を参照してください。
+
+<br>
+
 ## OMH が追加するもの
 
 OMH は **88 個**のインストール可能な workflow skill を、理解しやすい6つの

--- a/README.ja.md
+++ b/README.ja.md
@@ -34,24 +34,23 @@
   <em>計画、調査、制作、コーディング handoff、運用、プロジェクト記憶を明確な証拠境界とともに提供します。</em>
 </p>
 
+<p align="center">
+  <img src="assets/oh-my-hermes-agent-poster.png" alt="Oh My Hermes Agent poster" width="720">
+</p>
+
 **oh-my-hermes**（OMH）は、
 [Hermes Agent](https://github.com/NousResearch/hermes-agent) への通常の依頼を、
 適切な機能、有用な次の行動、そして実際に起きたこと・まだ起きていないことの
 正直な状態へ変換します。Hermes を置き換えたり、コーディング executor を
 隠したりせず、既存の Hermes ワークフローを強化します。
 
-```text
-通常の依頼
-  -> 6つの機能ファミリーから選択
-  -> 計画、ソース brief、成果物 contract、コーディング handoff を準備
-  -> runtime、provider、review、CI、merge の証拠は観測時のみ記録
-```
-
 [Website](https://rlaope.github.io/oh-my-hermes/) ·
 [Documentation](docs/README.md) ·
 [Installation](docs/INSTALLATION.md) ·
 [Capabilities](docs/CAPABILITIES.md) ·
-[Capability Impact](docs/CAPABILITY_IMPACT.md)
+[Capability Impact](docs/CAPABILITY_IMPACT.md) ·
+[Agent Install](INSTALL_FOR_AGENTS.md) ·
+[GitHub Pages site](site/index.html)
 
 > [!NOTE]
 > OMH は Hermes を自然言語の窓口として維持し、明確な証拠境界を持つプロ向け
@@ -83,16 +82,6 @@ hermes skills tap add rlaope/oh-my-hermes
 hermes skills install rlaope/oh-my-hermes/skills/oh-my-hermes --yes
 ```
 
-<br>
-
-**その後は Hermes にいつも通り依頼します:**
-
-```text
-このリポジトリに安全に機能を追加したいです。
-```
-
-<br>
-
 **または Your AI Agent に依頼します:**
 
 ```text
@@ -116,21 +105,67 @@ OMH は **88 個**のインストール可能な workflow skill を、理解し�
 完全な catalog、trigger、harness、証拠ルールは
 [Workflow Reference](docs/WORKFLOWS.md) にあります。
 
+**ハイライト**
+
+| 機能 | 使い方 | 内容 |
+| --- | --- | --- |
+| 🧭 **明確化と計画** | `$deep-interview` · `$ralplan` · `$strategy-brief` | 曖昧な依頼を、明確な目標・制約・トレードオフ・受け入れ基準、そしてそのまま引き渡せる計画に変えます。 |
+| ⚡ **レバレッジを効かせた実行** | `$ultrawork` · `$ultragoal` · `$team` · `$loop` | 高速な並列作業から持続的な複数ステップの実行までスケールしながら、所有権・チェックポイント・検証を常に可視化します。 |
+| 🔬 **調査と学習** | `$best-practice-research` · `$web-research` · `$research-brief` | 鮮度・情報源の質・未解決の不確実性の境界を示しながら、根拠に基づく証拠を収集・統合します。 |
+| 🛠️ **安全なコーディングと出荷** | `$request-to-handoff` · `$code-review` · `$ultraqa` | executor に依存しないコーディング作業を準備し、review・QA・CI・merge に関する主張は観測された証拠にのみ基づかせます。 |
+| 🎨 **洗練された成果物の制作** | `$design-quality-gate` · `$materials-package` · `$deliverable-package` · `$img-summary` | コンテンツ・完成度・アクセシビリティ・レンダリング品質ゲートを軸に、Web サイト、ビジュアル、レポート、スライド、ドキュメント、PDF、ポスター、パッケージを制作します。 |
+| 🧠 **記憶と運用** | `$memory` · `$ops-observability-card` · `$doctor` | プロジェクト記憶をレビュー優先で保ち、運用の準備状況を可視化し、provider やシステム状態を作り話にせず次の修復アクションを示します。 |
+| 🔌 **境界を隠さない接続** | `omh mcp` · `omh plugin` · `$agent-board` | Hermes および互換 host 向けにローカルな metadata 専用 contract を公開しつつ、host のロード・ツール利用・外部 provider アクセスを個別に観測可能な状態に保ちます。 |
+
 ## 実務向けの設計
 
-**コマンド一覧ではなくルーター。** 英語、韓国語、日本語、中国語、
-スペイン語、フランス語、ドイツ語、ヒンディー語の依頼を翻訳 API なしで
-ローカル分類し、推奨ファミリー、skill、owner、次の行動、未観測の項目を返します。
+<p align="center">
+  <img src="assets/built-for-real-work-orchestration.png" alt="OMH orchestrating coding agents and creative tools" width="900">
+</p>
 
-**より良いコーディング handoff。** リポジトリ制約、合意済み scope、
-worktree ガイド、ローカル skill、受け入れ条件、review、verification gate を
-選択した executor に渡します。Codex、Claude Code、Hermes、generic executor
-のどれも暗黙のデフォルトにはしません。
+> **OMH (Oh-My-Hermes)** — 誰でも hermes-agent をプロフェッショナルに使えるようにします。<br>
+> あなたの AI エージェントのための強力なインテリジェンスハーネスです。
 
-**品質を理解する制作と provider-neutral な運用。** Web、accessibility、
-画像、report、slide、document は専用の制作・QA ガイダンスを使います。
-metric、wiki、browser、image、video、connector は明示的な外部 provider
-contract の背後に置き、接続・呼び出しをしていない provider を使ったとは主張しません。
+**🧭 コマンド一覧ではなく、より賢いルーター。** 英語、韓国語、日本語、中国語、
+スペイン語、フランス語、ドイツ語、ヒンディー語の依頼を、翻訳 API なしで
+ローカルに分類します。OMH は推奨ファミリー、skill、owner、次の行動、そして
+まだ証拠になっていない部分をあわせて返します。
+
+**🤝 より良いコーディング handoff。** リポジトリの制約、合意済み scope、
+worktree と session-isolation の指針、ローカルで利用可能な skill、受け入れ
+基準、review の期待値、verification gate を含められます。Codex、Claude
+Code、Hermes、generic executor はいずれも隠れたデフォルトにはならず、明示的
+な owner のままです。
+
+**🎨 品質を意識した制作。** Frontend、アクセシビリティ、画像、レポート、
+スライド、ドキュメント、スプレッドシート、PDF、ポスター、共有パッケージの
+依頼は専用の制作・QA ガイダンスを経由します。準備済みのブリーフを、生成済み
+や視覚的に検証済みの成果物であるかのようには扱いません。
+
+**🔍 主張より先に証拠。** OMH は準備された意図、観測された runtime イベント、
+検証済みの結果を区別します。executor が実行した、review が通った、CI が
+成功した、デプロイが完了した、PR が merge されたと主張しなくても、handoff
+は準備完了になり得ます。
+
+**🧠 レビュー優先のプロジェクト記憶。** OMH はプロジェクト記憶の候補を
+承認済みの記録と分けて管理し、レビュー済みで準備された文脈だけを以降の
+handoff に呼び戻します。不透明な Hermes 内部の記憶を読んだり書き換えたりし
+たとは主張しません。
+
+**🔌 provider-neutral な運用。** metric、wiki、browser、image、video、
+connector の各システムは、明示的な外部 provider contract の背後にありま
+す。実際に接続・呼び出しをしていない provider を使ったと主張することなく、
+提供されたデータを検証・分析できます。
+
+**🏛️ Hermes-native かつ executor-neutral なアーキテクチャ。** Hermes は
+引き続きチャット、明確化、計画、調査、状態表示の窓口です。選択された
+executor が実装を担い、OMH はその作業を取り巻くローカル contract、ルー
+ティング、記憶、品質ゲート、証拠境界を提供します。
+
+**🧱 local-first な control plane。** OMH のコアとなるルーティング、
+catalog、manifest、主張ルールは決定的なローカル表面です。外部呼び出しや
+provider アクセスは、コア内部に隠された挙動ではなく、明示的な統合であり続
+けます。
 
 ## 主張より証拠
 
@@ -151,6 +186,8 @@ deployment、merge readiness、merge ではありません。
 - [アーキテクチャ](docs/ARCHITECTURE.md)
 - [機能 manifest](docs/CAPABILITIES.md)
 - [Workflow reference](docs/WORKFLOWS.md)
+- [ロール](docs/ROLES.md)
+- [活用事例](docs/APPLICATION_CASES.md)
 - [リリースと開発](docs/RELEASE.md)
 
 ## 開発

--- a/README.ko.md
+++ b/README.ko.md
@@ -88,6 +88,24 @@ hermes skills install rlaope/oh-my-hermes/skills/oh-my-hermes --yes
 Hey Agent, Install this >> https://github.com/rlaope/oh-my-hermes <<
 ```
 
+<br>
+
+**기존 `--full` 설치를 core로 되돌리기:**
+
+```sh
+omh skill-profile status
+omh skill-profile reconcile --to core --dry-run
+omh skill-profile reconcile --to core
+```
+
+setup, install, update는 설치된 skill을 삭제하지 않으므로, 한 번 `--full`로
+설치한 workspace는 명시적으로 reconcile하기 전까지 매 턴 context 부담을
+그대로 유지합니다. 자세한 내용은
+[기존 Full 설치를 Core로 되돌리기](docs/INSTALLATION.md#reconciling-an-existing-full-install-back-to-core)에서
+확인하세요.
+
+<br>
+
 ## OMH가 더하는 것
 
 OMH는 **88개**의 설치형 workflow skill을 사람이 이해하기 쉬운 6개 기능군으로

--- a/README.ko.md
+++ b/README.ko.md
@@ -34,24 +34,23 @@
   <em>계획, 조사, 제작, 코딩 handoff, 운영, 프로젝트 기억을 명확한 증거 경계와 함께 제공합니다.</em>
 </p>
 
+<p align="center">
+  <img src="assets/oh-my-hermes-agent-poster.png" alt="Oh My Hermes Agent poster" width="720">
+</p>
+
 **oh-my-hermes**(OMH)는
 [Hermes Agent](https://github.com/NousResearch/hermes-agent)의 평범한 요청을
 알맞은 기능, 유용한 다음 단계, 그리고 실제로 일어난 일과 아직 일어나지 않은
 일에 대한 정직한 상태로 바꿉니다. Hermes를 대체하거나 코딩 executor를 숨기지
 않고, 이미 사용 중인 Hermes 작업 흐름을 강화합니다.
 
-```text
-일반 요청
-  -> 6개 기능군 중 하나를 선택
-  -> 계획, 출처 브리프, 산출물 계약, 코딩 handoff를 준비
-  -> runtime, provider, review, CI, merge 증거는 관측된 경우에만 기록
-```
-
 [Website](https://rlaope.github.io/oh-my-hermes/) ·
 [Documentation](docs/README.md) ·
 [Installation](docs/INSTALLATION.md) ·
 [Capabilities](docs/CAPABILITIES.md) ·
-[Capability Impact](docs/CAPABILITY_IMPACT.md)
+[Capability Impact](docs/CAPABILITY_IMPACT.md) ·
+[Agent Install](INSTALL_FOR_AGENTS.md) ·
+[GitHub Pages site](site/index.html)
 
 > [!NOTE]
 > OMH는 Hermes를 자연어 표면으로 유지하고 명확한 증거 경계를 갖춘 전문 운영층을
@@ -83,16 +82,6 @@ hermes skills tap add rlaope/oh-my-hermes
 hermes skills install rlaope/oh-my-hermes/skills/oh-my-hermes --yes
 ```
 
-<br>
-
-**그런 다음 Hermes에 평소처럼 요청합니다:**
-
-```text
-이 저장소에 안전하게 기능을 추가하고 싶습니다.
-```
-
-<br>
-
 **또는 Your AI Agent에게 요청합니다:**
 
 ```text
@@ -116,20 +105,63 @@ OMH는 **88개**의 설치형 workflow skill을 사람이 이해하기 쉬운 6�
 전체 목록과 trigger, harness, 증거 규칙은
 [Workflow Reference](docs/WORKFLOWS.md)에 있습니다.
 
+**하이라이트**
+
+| 기능 | 사용 방법 | 동작 |
+| --- | --- | --- |
+| 🧭 **명확화와 계획** | `$deep-interview` · `$ralplan` · `$strategy-brief` | 모호한 요청을 명확한 목표, 제약, trade-off, 완료 기준, 그리고 그대로 전달할 수 있는 계획으로 바꿉니다. |
+| ⚡ **레버리지를 활용한 실행** | `$ultrawork` · `$ultragoal` · `$team` · `$loop` | 빠른 병렬 작업부터 지속적인 다단계 실행까지 확장하면서도 소유권, 체크포인트, 검증을 계속 볼 수 있게 유지합니다. |
+| 🔬 **조사와 학습** | `$best-practice-research` · `$web-research` · `$research-brief` | 최신성, 출처 품질, 아직 해소되지 않은 불확실성 경계를 함께 표시하며 근거 기반 증거를 찾고 종합합니다. |
+| 🛠️ **안전한 코딩과 배포** | `$request-to-handoff` · `$code-review` · `$ultraqa` | executor에 종속되지 않는 코딩 작업을 준비하고, review·QA·CI·merge에 대한 주장은 관측된 증거에만 근거하게 만듭니다. |
+| 🎨 **완성도 높은 산출물 제작** | `$design-quality-gate` · `$materials-package` · `$deliverable-package` · `$img-summary` | 콘텐츠, 완성도, 접근성, 렌더링 품질 게이트를 기준으로 웹사이트, 시각 자료, 보고서, 발표 자료, 문서, PDF, 포스터, 패키지를 만듭니다. |
+| 🧠 **기억과 운영** | `$memory` · `$ops-observability-card` · `$doctor` | 프로젝트 기억을 검토 우선으로 유지하고, 운영 준비 상태를 보여주며, provider나 시스템 상태를 지어내지 않고 다음 복구 행동을 제시합니다. |
+| 🔌 **경계를 숨기지 않는 연결** | `omh mcp` · `omh plugin` · `$agent-board` | Hermes와 호환 host를 위한 로컬 metadata 전용 계약을 제공하면서, host 로드·도구 사용·외부 provider 접근을 각각 별도로 관측할 수 있게 유지합니다. |
+
 ## 실제 업무를 위한 설계
 
-**명령어 목록이 아닌 라우터.** 영어, 한국어, 일본어, 중국어, 스페인어,
-프랑스어, 독일어, 힌디어 요청을 번역 API 없이 로컬에서 분류하고, 추천 기능군,
-skill, 담당자, 다음 행동, 아직 증거가 아닌 항목을 함께 보여줍니다.
+<p align="center">
+  <img src="assets/built-for-real-work-orchestration.png" alt="OMH orchestrating coding agents and creative tools" width="900">
+</p>
 
-**더 나은 코딩 handoff.** 저장소 제약, 합의된 범위, worktree 지침, 로컬 skill,
-완료 기준, 리뷰 기대치, 검증 게이트를 선택된 executor에 전달합니다. Codex,
-Claude Code, Hermes, generic executor 중 누구도 숨은 기본값이 되지 않습니다.
+> **OMH (Oh-My-Hermes)** — 누구나 hermes-agent를 전문가처럼 쓸 수 있게 합니다.<br>
+> AI 에이전트를 위한 강력한 지능 하네스입니다.
 
-**품질을 아는 제작과 provider-neutral 운영.** 웹, 접근성, 이미지, 보고서,
-발표 자료, 문서 요청은 전용 제작·QA 지침을 사용합니다. metric, wiki, browser,
-image, video, connector는 명시적인 외부 provider 계약 뒤에 두며, 연결하거나
-호출하지 않은 provider를 사용했다고 주장하지 않습니다.
+**🧭 명령어 목록이 아닌, 더 똑똑한 라우터.** 영어, 한국어, 일본어, 중국어,
+스페인어, 프랑스어, 독일어, 힌디어 요청을 번역 API 없이 로컬에서 분류합니다.
+OMH는 추천 기능군, skill, 담당자, 다음 행동, 그리고 아직 증거가 아닌 부분을
+함께 돌려줍니다.
+
+**🤝 더 나은 코딩 handoff.** 저장소 제약, 합의된 범위, worktree 및
+session-isolation 지침, 로컬에서 사용 가능한 skill, 완료 기준, review
+기대치, verification gate를 담을 수 있습니다. Codex, Claude Code, Hermes,
+generic executor는 모두 숨은 기본값이 아니라 명시적인 담당자로 남습니다.
+
+**🎨 품질을 아는 제작.** Frontend, 접근성, 이미지, 보고서, 발표 자료, 문서,
+스프레드시트, PDF, 포스터, 공유 패키지 요청은 전용 제작·QA 지침을 거칩니다.
+준비된 브리프를 생성되었거나 시각적으로 검증된 산출물처럼 보여주지 않습니다.
+
+**🔍 주장보다 증거.** OMH는 준비된 의도, 관측된 runtime 이벤트, 검증된
+결과를 구분합니다. handoff는 executor가 실행했다거나 review가 통과했다거나
+CI가 성공했다거나 배포가 끝났다거나 PR이 merge됐다는 주장 없이도 준비될 수
+있습니다.
+
+**🧠 검토 우선 프로젝트 기억.** OMH는 프로젝트 기억 후보를 승인된 기록과
+분리해서 관리하고, 검토를 거쳐 준비된 맥락만 이후 handoff에 다시 불러옵니다.
+불투명한 Hermes 내부 기억을 읽거나 바꿨다고 주장하지 않습니다.
+
+**🔌 provider-neutral 운영.** metric, wiki, browser, image, video, connector
+시스템은 명시적인 외부 provider 계약 뒤에 있습니다. 실제로 연결하거나
+호출하지 않은 provider를 사용했다고 주장하지 않으면서 제공된 데이터를
+검증하고 분석할 수 있습니다.
+
+**🏛️ Hermes-native, executor-neutral 아키텍처.** Hermes는 여전히 채팅,
+명확화, 계획, 조사, 상태 표면을 담당합니다. 선택된 executor가 구현을 맡고,
+OMH는 그 작업을 둘러싼 로컬 계약, 라우팅, 기억, 품질 게이트, 증거 경계를
+제공합니다.
+
+**🧱 local-first 제어면.** OMH의 핵심 라우팅, catalog, manifest, 주장
+규칙은 결정적인 로컬 표면입니다. 외부 호출과 provider 접근은 코어 내부에
+숨겨진 동작이 아니라 명시적인 통합으로 남습니다.
 
 ## 주장보다 증거
 
@@ -150,6 +182,8 @@ merge readiness 또는 merge가 아닙니다.
 - [아키텍처](docs/ARCHITECTURE.md)
 - [기능 manifest](docs/CAPABILITIES.md)
 - [Workflow reference](docs/WORKFLOWS.md)
+- [역할](docs/ROLES.md)
+- [활용 사례](docs/APPLICATION_CASES.md)
 - [릴리스와 개발](docs/RELEASE.md)
 
 ## 개발

--- a/README.zh.md
+++ b/README.zh.md
@@ -34,23 +34,22 @@
   <em>以清晰的证据边界提供规划、研究、内容制作、编码 handoff、运维和项目记忆。</em>
 </p>
 
+<p align="center">
+  <img src="assets/oh-my-hermes-agent-poster.png" alt="Oh My Hermes Agent poster" width="720">
+</p>
+
 **oh-my-hermes**（OMH）把
 [Hermes Agent](https://github.com/NousResearch/hermes-agent) 中的普通请求，
 转化为合适的能力、明确的下一步，以及对“已经发生”和“尚未发生”的诚实状态。
 它不会取代 Hermes，也不会隐藏编码 executor，而是增强现有 Hermes 工作流。
 
-```text
-普通请求
-  -> 从6个能力族中选择
-  -> 准备计划、来源 brief、产物 contract 或编码 handoff
-  -> 仅在实际观测后记录 runtime、provider、review、CI、merge 证据
-```
-
 [Website](https://rlaope.github.io/oh-my-hermes/) ·
 [Documentation](docs/README.md) ·
 [Installation](docs/INSTALLATION.md) ·
 [Capabilities](docs/CAPABILITIES.md) ·
-[Capability Impact](docs/CAPABILITY_IMPACT.md)
+[Capability Impact](docs/CAPABILITY_IMPACT.md) ·
+[Agent Install](INSTALL_FOR_AGENTS.md) ·
+[GitHub Pages site](site/index.html)
 
 > [!NOTE]
 > OMH 保留 Hermes 作为自然语言入口，并增加具有明确证据边界的专业工作层。
@@ -81,16 +80,6 @@ hermes skills tap add rlaope/oh-my-hermes
 hermes skills install rlaope/oh-my-hermes/skills/oh-my-hermes --yes
 ```
 
-<br>
-
-**然后像往常一样向 Hermes 提出请求：**
-
-```text
-我想安全地为这个仓库添加一个功能。
-```
-
-<br>
-
 **或者向 Your AI Agent 提出请求：**
 
 ```text
@@ -113,20 +102,59 @@ OMH 将 **88 个**可安装的 workflow skill 组织为6个容易理解的能力
 完整 catalog、trigger、harness 和证据规则位于
 [Workflow Reference](docs/WORKFLOWS.md)。
 
+**亮点**
+
+| 能力 | 使用方式 | 作用 |
+| --- | --- | --- |
+| 🧭 **澄清与规划** | `$deep-interview` · `$ralplan` · `$strategy-brief` | 把模糊的请求转化为明确的目标、约束、权衡、验收标准，以及可以直接交接的计划。 |
+| ⚡ **借助杠杆推进工作** | `$ultrawork` · `$ultragoal` · `$team` · `$loop` | 从快速并行工作扩展到持久的多步骤执行，同时保持所有权、检查点和验证始终可见。 |
+| 🔬 **研究与学习** | `$best-practice-research` · `$web-research` · `$research-brief` | 在标明时效性、来源质量和尚未解决的不确定性边界的同时，查找并综合有依据的证据。 |
+| 🛠️ **安全地编码与交付** | `$request-to-handoff` · `$code-review` · `$ultraqa` | 准备不依赖特定 executor 的编码工作，并让 review、QA、CI 和 merge 的相关声明只依据实际观测到的证据。 |
+| 🎨 **打造精致的交付物** | `$design-quality-gate` · `$materials-package` · `$deliverable-package` · `$img-summary` | 围绕内容、审美、无障碍性和渲染质量 gate，制作网站、视觉素材、报告、演示文稿、文档、PDF、海报和交付包。 |
+| 🧠 **记忆与运维** | `$memory` · `$ops-observability-card` · `$doctor` | 让项目记忆保持“先审查后使用”，呈现运维就绪状态，并在不臆造 provider 或系统状态的前提下给出下一步修复动作。 |
+| 🔌 **在不隐藏边界的前提下连接** | `omh mcp` · `omh plugin` · `$agent-board` | 为 Hermes 及兼容的 host 提供仅含元数据的本地 contract，同时让 host 加载、工具使用和外部 provider 访问都能被分别观测。 |
+
 ## 面向真实工作的设计
 
-**不是命令列表，而是路由器。** 英语、韩语、日语、中文、西班牙语、法语、
-德语和印地语请求可在本地分类，无需翻译 API。OMH 会返回推荐能力族、skill、
-owner、下一步以及仍未形成证据的部分。
+<p align="center">
+  <img src="assets/built-for-real-work-orchestration.png" alt="OMH orchestrating coding agents and creative tools" width="900">
+</p>
 
-**更好的编码 handoff。** 将仓库约束、已接受 scope、worktree 指南、本地
-skill、验收标准、review 期望和 verification gate 交给选定 executor。
-Codex、Claude Code、Hermes 和 generic executor 都不会成为隐藏默认值。
+> **OMH (Oh-My-Hermes)** — 让任何人都能像专业人士一样使用 hermes-agent。<br>
+> 为你的 AI Agent 打造的强大智能工作层（harness）。
 
-**理解质量的制作与 provider-neutral 运维。** 网站、accessibility、图像、
-report、slide 和 document 请求使用专门的制作与 QA 指南。metric、wiki、
-browser、image、video 和 connector 位于明确的外部 provider contract 之后；
-OMH 不会声称连接或调用了实际未使用的 provider。
+**🧭 不是命令列表，而是更聪明的路由器。** 英语、韩语、日语、中文、西班牙语、
+法语、德语和印地语请求都可以在本地分类，无需翻译 API。OMH 会返回推荐能力
+族、skill、owner、下一步，以及尚未形成证据的部分。
+
+**🤝 更好的编码 handoff。** 可以包含仓库约束、已达成一致的 scope、worktree
+与 session-isolation 指南、本地可用的 skill、验收标准、review 期望和
+verification gate。Codex、Claude Code、Hermes 和 generic executor 都不会
+成为隐藏的默认值，而是保持明确的 owner 身份。
+
+**🎨 懂质量的制作。** Frontend、无障碍、图像、报告、演示文稿、文档、表格、
+PDF、海报和共享交付包请求都会走专门的制作与 QA 流程。准备好的 brief 不会
+被当作已生成或已通过视觉验证的产物来呈现。
+
+**🔍 证据先于声明。** OMH 会区分已准备的意图、已观测的 runtime 事件和已
+验证的结果。即便没有声称 executor 已执行、review 已通过、CI 已成功、部署
+已完成或 PR 已 merge，handoff 依然可以处于就绪状态。
+
+**🧠 以审查为先的项目记忆。** OMH 把项目记忆候选与已批准的记录分开管理，
+只把经过审查、已准备好的上下文重新带入后续 handoff，不会声称读取或修改了
+不透明的 Hermes 内部记忆。
+
+**🔌 provider-neutral 的运维。** metric、wiki、browser、image、video 和
+connector 系统都位于明确的外部 provider contract 之后。OMH 可以在不声称
+连接或调用未实际使用的 provider 的情况下，验证并分析已提供的数据。
+
+**🏛️ Hermes-native、executor-neutral 的架构。** Hermes 仍然是聊天、澄清、
+规划、研究和状态展示的入口。被选定的 executor 负责具体实现，而 OMH 为这项
+工作提供本地 contract、路由、记忆、质量 gate 和证据边界。
+
+**🧱 local-first 的控制面。** OMH 的核心路由、catalog、manifest 和声明规则
+都是确定性的本地表面。外部调用与 provider 访问始终是显式集成，而不是核心
+内部隐藏的行为。
 
 ## 证据先于声明
 
@@ -147,6 +175,8 @@ deployment、merge readiness 或 merge。
 - [架构](docs/ARCHITECTURE.md)
 - [能力 manifest](docs/CAPABILITIES.md)
 - [Workflow reference](docs/WORKFLOWS.md)
+- [角色](docs/ROLES.md)
+- [应用案例](docs/APPLICATION_CASES.md)
 - [发布与开发](docs/RELEASE.md)
 
 ## 开发

--- a/README.zh.md
+++ b/README.zh.md
@@ -86,6 +86,23 @@ hermes skills install rlaope/oh-my-hermes/skills/oh-my-hermes --yes
 Hey Agent, Install this >> https://github.com/rlaope/oh-my-hermes <<
 ```
 
+<br>
+
+**把已经 `--full` 安装的环境收敛回 core：**
+
+```sh
+omh skill-profile status
+omh skill-profile reconcile --to core --dry-run
+omh skill-profile reconcile --to core
+```
+
+setup、install 和 update 都不会删除已安装的 skill，因此曾经以 `--full`
+安装过的 workspace，在被显式 reconcile 之前会一直保留那部分逐轮 context
+负担。详见
+[把已有的 Full 安装收敛回 Core](docs/INSTALLATION.md#reconciling-an-existing-full-install-back-to-core)。
+
+<br>
+
 ## OMH 提供什么
 
 OMH 将 **88 个**可安装的 workflow skill 组织为6个容易理解的能力族。

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -2555,7 +2555,7 @@ class RouterContentTests(unittest.TestCase):
         self.assertIn("**88 個**", localized_readmes["ja"])
         self.assertIn("**88 个**", localized_readmes["zh"])
         for localized_readme in localized_readmes.values():
-            self.assertLess(len(localized_readme.splitlines()), 220)
+            self.assertLess(len(localized_readme.splitlines()), 240)
             self.assertIn("prepared_not_observed", localized_readme)
             self.assertIn("omh setup", localized_readme)
             self.assertNotIn("omh doctor", localized_readme)

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -2555,7 +2555,7 @@ class RouterContentTests(unittest.TestCase):
         self.assertIn("**88 個**", localized_readmes["ja"])
         self.assertIn("**88 个**", localized_readmes["zh"])
         for localized_readme in localized_readmes.values():
-            self.assertLess(len(localized_readme.splitlines()), 170)
+            self.assertLess(len(localized_readme.splitlines()), 220)
             self.assertIn("prepared_not_observed", localized_readme)
             self.assertIn("omh setup", localized_readme)
             self.assertNotIn("omh doctor", localized_readme)
@@ -3052,6 +3052,77 @@ class RouterContentTests(unittest.TestCase):
         self.assertIn(".image-format-grid", site_css)
         self.assertIn(".feature-flow", site_css)
         self.assertIn("grid-template-columns: repeat(2, minmax(0, 1fr));", site_css)
+
+    def test_localized_readmes_stay_structurally_synced_with_english_source(self) -> None:
+        # README.md is the explicit onboarding source structure (issue #639).
+        # Each entry maps an English top-level (`## `) heading to its natural
+        # translation in each localized README. When README.md gains, drops,
+        # or reorders a top-level section, this table (and the localized
+        # README files) must be updated in the same commit, or the assertions
+        # below fail with a message pointing at the drift. This test asserts
+        # structure (heading set and order) and a few historical stale-copy
+        # regressions only; it intentionally does not assert prose wording,
+        # so natural, non-mechanical per-language translation is allowed.
+        readme_section_translations = (
+            ("## Quick Start", {"ko": "## 빠른 시작", "ja": "## クイックスタート", "zh": "## 快速开始"}),
+            (
+                "## What OMH Adds",
+                {"ko": "## OMH가 더하는 것", "ja": "## OMH が追加するもの", "zh": "## OMH 提供什么"},
+            ),
+            (
+                "## Built For Real Work",
+                {"ko": "## 실제 업무를 위한 설계", "ja": "## 実務向けの設計", "zh": "## 面向真实工作的设计"},
+            ),
+            (
+                "## Evidence Before Claims",
+                {"ko": "## 주장보다 증거", "ja": "## 主張より証拠", "zh": "## 证据先于声明"},
+            ),
+            ("## Documentation", {"ko": "## 문서", "ja": "## ドキュメント", "zh": "## 文档"}),
+            ("## Development", {"ko": "## 개발", "ja": "## 開発", "zh": "## 开发"}),
+        )
+
+        readme = Path("README.md").read_text(encoding="utf-8")
+        localized_readmes = {
+            "ko": Path("README.ko.md").read_text(encoding="utf-8"),
+            "ja": Path("README.ja.md").read_text(encoding="utf-8"),
+            "zh": Path("README.zh.md").read_text(encoding="utf-8"),
+        }
+
+        english_headings = re.findall(r"^## .+$", readme, flags=re.MULTILINE)
+        expected_english_headings = [heading for heading, _ in readme_section_translations]
+        self.assertEqual(
+            english_headings,
+            expected_english_headings,
+            "README.md top-level sections changed. Update "
+            "readme_section_translations in this test (and sync README.ko.md, "
+            "README.ja.md, README.zh.md) for the new section set/order.",
+        )
+
+        for locale, localized_readme in localized_readmes.items():
+            localized_headings = re.findall(r"^## .+$", localized_readme, flags=re.MULTILINE)
+            expected_localized_headings = [
+                translations[locale] for _, translations in readme_section_translations
+            ]
+            self.assertEqual(
+                localized_headings,
+                expected_localized_headings,
+                f"README.{locale}.md top-level sections are out of sync with "
+                "README.md; a section was added, dropped, or reordered in "
+                "English without updating this locale.",
+            )
+
+        # Regression guards for the exact stale onboarding copy identified in
+        # issue #639: a four-line request-pipeline block, and a "then ask
+        # Hermes normally" example that no longer matches the English Quick
+        # Start flow. These must never silently come back to a locale file.
+        self.assertNotIn("plain request", readme)
+        self.assertNotIn("Then ask Hermes normally", readme)
+        self.assertNotIn("6개 기능군 중 하나를 선택", localized_readmes["ko"])
+        self.assertNotIn("그런 다음 Hermes에 평소처럼 요청합니다", localized_readmes["ko"])
+        self.assertNotIn("6つの機能ファミリーから選択", localized_readmes["ja"])
+        self.assertNotIn("その後は Hermes にいつも通り依頼します", localized_readmes["ja"])
+        self.assertNotIn("从6个能力族中选择", localized_readmes["zh"])
+        self.assertNotIn("然后像往常一样向 Hermes 提出请求", localized_readmes["zh"])
 
     def test_direction_and_agent_contract_lock_product_boundary(self) -> None:
         direction = Path("docs/DIRECTION.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Feature Report

### What Changed

- Resynced `README.ko.md`, `README.ja.md`, and `README.zh.md` to the current
  `README.md` onboarding structure: added the second hero (poster) image,
  the two extra top-of-file links (`Agent Install`, `GitHub Pages site`), the
  new `Highlights` capability table, the expanded `Built For Real Work`
  section (image + tagline blockquote + 8 emoji-labeled points), and the
  `Roles` / `Application cases` documentation links.
- Removed stale locale-only onboarding copy that no longer exists in
  `README.md`: the four-line `plain request -> ...` pipeline block in all
  three locales, and the `그런 다음 Hermes에 평소처럼 요청합니다` /
  `その後は Hermes にいつも通り依頼します` / `然后像往常一样向 Hermes 提出请求`
  "then ask Hermes normally" safe-feature example that used to sit ahead of
  the "or ask Your AI Agent" call-to-action.
- Added a new test,
  `test_localized_readmes_stay_structurally_synced_with_english_source` in
  `tests/test_router_content.py`, that asserts the ordered set of top-level
  (`## `) headings in `README.md` matches an explicit translation table, and
  that each locale README's headings match the translated set in the same
  order. It also regression-guards the two specific stale-copy blocks removed
  in this PR so they cannot silently return to a locale file.
- Raised the existing localized-README line budget in
  `test_first_release_trust_surfaces_are_present` from `170` to `220` lines
  to make room for the synced content (Korean 200, Japanese 204, Chinese 192
  lines after this change, vs. English's 228).

### Why This Exists

Closes #639. The localized READMEs had drifted from the English source:
`README.md` had already moved on to a hero/callout positioning statement and
an "or ask Your AI Agent" call-to-action, dropping the old four-line pipeline
diagram and the "ask Hermes normally" example, but `README.ko.md`,
`README.ja.md`, and `README.zh.md` still carried both. That made the public
onboarding story differ by language, and nothing caught the drift except
manual review.

### User / Operator Impact

Korean, Japanese, and Chinese readers now see the same onboarding sequence,
CTA choices, hero/callout placement, capability-family content, and
evidence-boundary claims as English readers, in natural (not mechanically
mirrored) prose. Future edits to `README.md`'s top-level section structure
will now fail a fast, targeted unit test instead of silently drifting until
someone notices by eye.

### How It Works

- The parity test extracts English's `## ` headings with a regex, compares
  them against an explicit `readme_section_translations` tuple of
  `(english_heading, {locale: translated_heading})` pairs, and asserts each
  locale README's headings equal the translated set in the same order. This
  enforces structure (which sections exist, and their order) without
  constraining translated wording, so natural, idiomatic Korean/Japanese/
  Chinese prose stays fully allowed — only the section skeleton is locked.
- If a future PR adds, removes, or reorders a `## ` section in `README.md`
  without updating `readme_section_translations` and the locale files, the
  first assertion (`english_headings == expected_english_headings`) fails
  with a message pointing at the drift; if English is updated but a locale
  isn't, the per-locale heading comparison fails with a locale-specific
  message.
- Existing localized-README assertions in
  `test_first_release_trust_surfaces_are_present` (file existence, line
  budget, `prepared_not_observed`/`omh setup` presence, `omh doctor` absence,
  required/forbidden image references) are kept and still pass; only the line
  budget constant changed, since it is a byte-count ceiling that the added
  structural content pushed past.

### Files And Contracts Touched

- `README.ko.md`, `README.ja.md`, `README.zh.md` (content only; no generated
  files touched)
- `tests/test_router_content.py` (new test + one line-budget constant update)

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests` -> `Ran 1569 tests ... OK (skipped=1)`
- [x] `uv run python -m compileall -q src tests` -> clean, no output
- [x] `uv run python -m omh.cli docs workflows --check` -> `"ok": true` (tap_skills 95/95, no missing/stale/extra)
- [x] `uv run python -m omh.cli docs roles --check` -> `"ok": true`
- [x] `uv run python -m omh.cli docs capability-families --check` -> `"ok": true`
- [x] `git diff --check` -> clean
- [ ] Manual Hermes/TUI check: not run — this is a documentation-only change; no runtime behavior changed.

## Risk

Low. Documentation-only change to three locale README files and one test
file; no `src/omh` behavior touched, no generated artifacts hand-edited.

## Compatibility / Rollout

No compatibility impact. No CLI, schema, or generated-artifact contract
changed.

## Release / Claims

- [x] Release-channel impact considered (docs-only, no runtime/CLI change)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed (no runtime claims changed)
- [x] Known manual Hermes checks are listed: none required for a docs-only change; not run.

## Follow-Up

- None identified. Out of scope per the issue: translating the rest of the
  docs tree, or adding a runtime translation service.

Closes #639
