### PR TITLE
feat: make prepared runtime run validation registry-scoped and matrix-explicit

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -706,6 +706,46 @@ status means a handoff was prepared; the companion run envelope is also marked
 Executor-choice, runtime-handoff, clarify, fallback, and prompt-only handoffs
 return `runtime.recorded=false` and should stay in wrapper/session state.
 
+### Prepared Runtime Run Executor Matrix
+
+A `prepared_coding_delegation` run is not the generic shape of every coding
+handoff. It is the run-backed lifecycle for one work-owner mode. Every executor
+profile OMH models belongs to exactly one lane, and the lane decides whether a
+runtime run exists at all:
+
+| `work_owner_mode` | Executor profiles | Prepared handoff contract | `prepared_coding_delegation` run | Wrapper `current_run_id` link |
+| --- | --- | --- | --- | --- |
+| `external_executor` | `codex` | `coding_executor_handoff/v1` | required | required |
+| `prompt_only_handoff` | `claude-code`, `generic` | `coding_prompt_handoff/v1` | forbidden | forbidden |
+| `runtime_handoff` | `hermes`, `omx-runtime`, `omo-runtime`, `omc-runtime` | `coding_runtime_handoff/v1` | forbidden | forbidden |
+| pending choice (`choose`) | none selected yet | executor-choice contract | forbidden | forbidden |
+
+`external_executor` is the only run-backed lane today because
+`coding_executor_handoff/v1` is the only handoff contract that carries the
+dispatch, result, verification, review, CI, and merge ledger a run directory
+validates. Its supported profile set is the `CODING_EXECUTOR_HANDOFF_TARGETS`
+registry in `src/coding/executors.py`, currently `codex` alone. That is a
+documented capability boundary, not an executor default: adding a second
+run-backed profile is a capability decision that must extend the registry and
+the profile-specific handoff validation together, not a special case inside the
+validator.
+
+`src/runtime/artifacts.py` validates against that registry rather than a
+hard-coded profile name, and `PREPARED_RUNTIME_RUN_EXECUTOR_MATRIX` is the
+single rejection sentence appended to every mismatch. A rejected record is told
+which lane it belongs to, which profiles are run-backed, and which field made it
+fail — a `claude-code` record stored as a runtime run is rejected both as a
+prompt-only handoff and because its `work_owner_mode` is not
+`external_executor`, while a record that reaches `external_executor` with an
+unsupported or missing profile is rejected on `selected_executor_profile` or on
+the absent `executor_handoff`. The same registry gates the wrapper-session link, so
+a session cannot point `current_run_id` at a run whose
+`executor_handoff.executor_target` is outside the run-backed set.
+
+None of this changes evidence semantics. Accepting a run-backed profile keeps
+`observation_status: prepared_not_observed`; rejecting a non-run-backed profile
+is a schema error, never a downgrade or upgrade of observed evidence.
+
 Bot wrappers can still call `omh runtime delegate` after the response if
 delegation metadata is available. If not, they should record `not_observed`
 rather than guessing.

--- a/src/runtime/artifacts.py
+++ b/src/runtime/artifacts.py
@@ -10,6 +10,12 @@ from typing import Any
 
 from ..context_safety import build_coding_progress_reporting_policy
 from ..executor_progress import validate_progress_binding, validate_progress_event, validate_progress_report
+from ..executors import (
+    CODING_EXECUTOR_HANDOFF_TARGETS,
+    CODING_RUNTIME_HANDOFF_TARGETS,
+    EXECUTOR_HANDOFF_SCHEMA_VERSION,
+    PROMPT_ONLY_EXECUTOR_PROFILES,
+)
 from ..harness_quality import build_harness_progress
 from ..local_store import (
     atomic_write_json,
@@ -67,6 +73,15 @@ from .records import (
     validate_runtime_observation_record,
     validate_wrapper_record,
     validate_wrapper_session_record,
+)
+
+
+PREPARED_RUNTIME_RUN_EXECUTOR_MATRIX = (
+    "prepared_coding_delegation runs are run-backed only for work_owner_mode=external_executor with "
+    f"selected_executor_profile in ({', '.join(CODING_EXECUTOR_HANDOFF_TARGETS)}) and a "
+    f"{EXECUTOR_HANDOFF_SCHEMA_VERSION} executor_handoff; prompt-only profiles "
+    f"({', '.join(PROMPT_ONLY_EXECUTOR_PROFILES)}) and runtime profiles "
+    f"({', '.join(CODING_RUNTIME_HANDOFF_TARGETS)}) are prepared in wrapper session state without a runtime run"
 )
 
 
@@ -1491,6 +1506,20 @@ def _delegated_status_integrity_warnings(
     return warnings
 
 
+def _prepared_runtime_run_executor_rejection(coding: dict[str, Any]) -> str:
+    work_owner_mode = coding.get("work_owner_mode")
+    selected = coding.get("selected_executor_profile")
+    if work_owner_mode != "external_executor":
+        reason = f"work_owner_mode {work_owner_mode!r} is not external_executor"
+    elif selected not in CODING_EXECUTOR_HANDOFF_TARGETS:
+        reason = f"selected_executor_profile {selected!r} has no run-backed executor handoff lifecycle"
+    elif not isinstance(coding.get("executor_handoff"), dict):
+        reason = f"executor_handoff is missing for selected_executor_profile {selected!r}"
+    else:
+        return ""
+    return f"prepared runtime run rejected because {reason}; {PREPARED_RUNTIME_RUN_EXECUTOR_MATRIX}"
+
+
 def validate_run_dir(run_dir: Path) -> dict[str, Any]:
     errors: list[str] = []
     coding_for_observation: dict[str, Any] | None = None
@@ -1518,17 +1547,23 @@ def validate_run_dir(run_dir: Path) -> dict[str, Any]:
                 selection = coding.get("executor_selection")
                 choice_required = isinstance(selection, dict) and selection.get("choice_required") is True
                 if choice_required:
-                    errors.append(f"{coding_delegation_path}: executor choice must not be stored as a prepared runtime run")
+                    errors.append(
+                        f"{coding_delegation_path}: executor choice must not be stored as a prepared runtime run; "
+                        f"{PREPARED_RUNTIME_RUN_EXECUTOR_MATRIX}"
+                    )
                 if coding.get("work_owner_mode") == "prompt_only_handoff":
-                    errors.append(f"{coding_delegation_path}: prompt-only handoff must not be stored as a prepared runtime run")
+                    errors.append(
+                        f"{coding_delegation_path}: prompt-only handoff must not be stored as a prepared runtime run; "
+                        f"{PREPARED_RUNTIME_RUN_EXECUTOR_MATRIX}"
+                    )
                 if coding.get("work_owner_mode") == "runtime_handoff":
-                    errors.append(f"{coding_delegation_path}: runtime handoff must not be stored as a prepared runtime run")
-                if (
-                    coding.get("work_owner_mode") != "external_executor"
-                    or coding.get("selected_executor_profile") != "codex"
-                    or not isinstance(coding.get("executor_handoff"), dict)
-                ):
-                    errors.append(f"{coding_delegation_path}: prepared runtime run requires a Codex executor_handoff")
+                    errors.append(
+                        f"{coding_delegation_path}: runtime handoff must not be stored as a prepared runtime run; "
+                        f"{PREPARED_RUNTIME_RUN_EXECUTOR_MATRIX}"
+                    )
+                rejection = _prepared_runtime_run_executor_rejection(coding)
+                if rejection:
+                    errors.append(f"{coding_delegation_path}: {rejection}")
     events_path = run_dir / "events.jsonl"
     if events_path.exists():
         events, event_errors = read_jsonl_objects(events_path)
@@ -1888,8 +1923,17 @@ def _validate_wrapper_session_run_link(session_dir: Path, session: dict[str, Any
     else:
         errors.extend(f"{coding_path}: {error}" for error in validate_coding_delegation_record(coding))
         handoff = coding.get("executor_handoff") if isinstance(coding, dict) else None
-        if not isinstance(handoff, dict) or handoff.get("executor_target") != "codex":
-            errors.append(f"{session_path}: linked run must include a Codex executor handoff")
+        if not isinstance(handoff, dict):
+            errors.append(
+                f"{session_path}: linked run must include an executor_handoff for a run-backed executor profile; "
+                f"{PREPARED_RUNTIME_RUN_EXECUTOR_MATRIX}"
+            )
+        elif handoff.get("executor_target") not in CODING_EXECUTOR_HANDOFF_TARGETS:
+            errors.append(
+                f"{session_path}: linked run executor_handoff.executor_target "
+                f"{handoff.get('executor_target')!r} has no run-backed executor handoff lifecycle; "
+                f"{PREPARED_RUNTIME_RUN_EXECUTOR_MATRIX}"
+            )
         if isinstance(coding, dict) and coding.get("status") != "prepared_not_observed":
             errors.append(f"{session_path}: linked coding delegation must be prepared_not_observed")
     has_link_event = any(

--- a/src/runtime/records.py
+++ b/src/runtime/records.py
@@ -3201,7 +3201,12 @@ def validate_coding_handoff_combination(delegation: dict[str, Any], label: str) 
             _require(selected is None, errors, f"{label} executor_choice_required must not select an executor")
             _require(dispatchable is False, errors, f"{label} executor_choice_required must not be dispatchable")
         else:
-            _require(selected == "codex", errors, f"{label} external_executor is Codex-only in phase 1")
+            _require(
+                selected in CODING_EXECUTOR_TARGETS,
+                errors,
+                f"{label} external_executor selected executor {selected!r} is not run-backed: "
+                f"supported profiles are ({', '.join(CODING_EXECUTOR_TARGETS)})",
+            )
             _require(has_executor, errors, f"{label} external_executor requires executor_handoff")
             _require(not has_runtime, errors, f"{label} external_executor must not include runtime_handoff")
             _require(not has_prompt, errors, f"{label} external_executor must not include prompt_handoff")

--- a/tests/test_prepared_runtime_run_executor_matrix.py
+++ b/tests/test_prepared_runtime_run_executor_matrix.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.coding_delegation import build_coding_delegation_payload, coding_delegation_record_payload
+from omh.executors import (
+    CODING_EXECUTOR_HANDOFF_TARGETS,
+    CODING_RUNTIME_HANDOFF_TARGETS,
+    EXECUTOR_PROFILES,
+    PROMPT_ONLY_EXECUTOR_PROFILES,
+)
+from omh.paths import resolve_paths
+from omh.runtime_artifacts import (
+    PREPARED_RUNTIME_RUN_EXECUTOR_MATRIX,
+    create_prepared_coding_delegation_run,
+    validate_runtime,
+    write_coding_delegation,
+)
+from omh.wrapper_sessions import (
+    create_or_resume_wrapper_session,
+    prepare_wrapper_session_handoff,
+    record_plan_decision,
+    select_wrapper_session_executor,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ARCHITECTURE_DOC = REPO_ROOT / "docs" / "ARCHITECTURE.md"
+MESSAGE = "risky refactor"
+
+
+def _run_errors(paths, run_id: str) -> str:
+    return json.dumps(validate_runtime(paths, run_id))
+
+
+def _store_delegation_as_prepared_run(paths, executor_target: str) -> str:
+    run = create_prepared_coding_delegation_run(paths, {"skill": "ai-slop-cleaner", "harness": "coding-handling"})
+    run_dir = paths.runtime_runs_dir / run["run_id"]
+    payload = build_coding_delegation_payload(MESSAGE, source="discord", executor_target=executor_target)
+    write_coding_delegation(run_dir, coding_delegation_record_payload(payload, MESSAGE))
+    return str(run["run_id"])
+
+
+class PreparedRuntimeRunExecutorMatrixTests(unittest.TestCase):
+    def test_executor_profiles_partition_into_exactly_one_handoff_lane(self) -> None:
+        lanes = (CODING_EXECUTOR_HANDOFF_TARGETS, PROMPT_ONLY_EXECUTOR_PROFILES, CODING_RUNTIME_HANDOFF_TARGETS)
+        for profile in EXECUTOR_PROFILES:
+            with self.subTest(profile=profile):
+                self.assertEqual(sum(profile in lane for lane in lanes), 1)
+        self.assertEqual(
+            sorted(EXECUTOR_PROFILES),
+            sorted([*CODING_EXECUTOR_HANDOFF_TARGETS, *PROMPT_ONLY_EXECUTOR_PROFILES, *CODING_RUNTIME_HANDOFF_TARGETS]),
+        )
+
+    def test_matrix_message_names_every_executor_profile(self) -> None:
+        for profile in EXECUTOR_PROFILES:
+            with self.subTest(profile=profile):
+                self.assertIn(profile, PREPARED_RUNTIME_RUN_EXECUTOR_MATRIX)
+        self.assertIn("external_executor", PREPARED_RUNTIME_RUN_EXECUTOR_MATRIX)
+
+    def test_architecture_doc_states_the_supported_executor_matrix(self) -> None:
+        doc = ARCHITECTURE_DOC.read_text(encoding="utf-8")
+        self.assertIn("Prepared Runtime Run Executor Matrix", doc)
+        for profile in EXECUTOR_PROFILES:
+            with self.subTest(profile=profile):
+                self.assertIn(f"`{profile}`", doc)
+        for mode in ("external_executor", "prompt_only_handoff", "runtime_handoff"):
+            with self.subTest(mode=mode):
+                self.assertIn(f"`{mode}`", doc)
+
+    def test_prepared_run_accepts_every_run_backed_executor_profile(self) -> None:
+        for profile in CODING_EXECUTOR_HANDOFF_TARGETS:
+            with self.subTest(profile=profile), TemporaryDirectory() as tmp:
+                paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+                run_id = _store_delegation_as_prepared_run(paths, profile)
+
+                result = validate_runtime(paths, run_id)
+
+                self.assertTrue(result["ok"], result)
+                run = json.loads((paths.runtime_runs_dir / run_id / "run.json").read_text(encoding="utf-8"))
+                self.assertEqual(run["observation_status"], "prepared_not_observed")
+
+    def test_prepared_run_rejects_every_non_run_backed_executor_profile(self) -> None:
+        rejected = [profile for profile in EXECUTOR_PROFILES if profile not in CODING_EXECUTOR_HANDOFF_TARGETS]
+        self.assertTrue(rejected)
+        for profile in rejected:
+            with self.subTest(profile=profile), TemporaryDirectory() as tmp:
+                paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+                run_id = _store_delegation_as_prepared_run(paths, profile)
+
+                result = validate_runtime(paths, run_id)
+                errors = "\n".join(result["runs"][0]["errors"])
+
+                self.assertFalse(result["ok"])
+                self.assertIn(PREPARED_RUNTIME_RUN_EXECUTOR_MATRIX, errors)
+                for supported in CODING_EXECUTOR_HANDOFF_TARGETS:
+                    self.assertIn(supported, errors)
+
+    def test_prepared_run_rejects_pending_executor_choice_with_matrix_reason(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            run_id = _store_delegation_as_prepared_run(paths, "choose")
+
+            result = validate_runtime(paths, run_id)
+            errors = "\n".join(result["runs"][0]["errors"])
+
+            self.assertFalse(result["ok"])
+            self.assertIn("executor choice must not be stored as a prepared runtime run", errors)
+            self.assertIn(
+                "prepared runtime run rejected because selected_executor_profile None "
+                "has no run-backed executor handoff lifecycle",
+                errors,
+            )
+            self.assertIn(PREPARED_RUNTIME_RUN_EXECUTOR_MATRIX, errors)
+
+    def test_prompt_only_and_runtime_profiles_report_their_own_lane_in_the_rejection(self) -> None:
+        expectations = {
+            **{
+                profile: ("prompt-only handoff must not be stored as a prepared runtime run", "prompt_only_handoff")
+                for profile in PROMPT_ONLY_EXECUTOR_PROFILES
+            },
+            **{
+                profile: ("runtime handoff must not be stored as a prepared runtime run", "runtime_handoff")
+                for profile in CODING_RUNTIME_HANDOFF_TARGETS
+            },
+        }
+        for profile, (lane_message, mode) in expectations.items():
+            with self.subTest(profile=profile), TemporaryDirectory() as tmp:
+                paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+                run_id = _store_delegation_as_prepared_run(paths, profile)
+
+                errors = "\n".join(validate_runtime(paths, run_id)["runs"][0]["errors"])
+
+                self.assertIn(lane_message, errors)
+                self.assertIn(f"prepared runtime run rejected because work_owner_mode '{mode}' is not external_executor", errors)
+
+    def test_wrapper_session_handoff_creates_a_run_only_for_run_backed_profiles(self) -> None:
+        for profile in EXECUTOR_PROFILES:
+            with self.subTest(profile=profile), TemporaryDirectory() as tmp:
+                paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+                started = create_or_resume_wrapper_session(paths, MESSAGE, source="discord")
+                session_id = str(started["session"]["session_id"])
+                record_plan_decision(paths, session_id, "accept")
+                select_wrapper_session_executor(paths, session_id, profile)
+
+                prepared = prepare_wrapper_session_handoff(paths, session_id, MESSAGE)
+
+                run_created = bool(prepared["session"]["current_run_id"])
+                self.assertEqual(run_created, profile in CODING_EXECUTOR_HANDOFF_TARGETS)
+                self.assertTrue(validate_runtime(paths)["ok"], validate_runtime(paths))
+                if run_created:
+                    run_id = str(prepared["session"]["current_run_id"])
+                    run = json.loads((paths.runtime_runs_dir / run_id / "run.json").read_text(encoding="utf-8"))
+                    self.assertEqual(run["observation_status"], "prepared_not_observed")
+                    self.assertEqual(run["artifact_kind"], "prepared_coding_delegation")
+
+    def test_linked_session_rejects_a_non_run_backed_executor_target(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            session_id, run_id = _prepare_linked_codex_session(paths)
+            coding_path = paths.runtime_runs_dir / run_id / "coding_delegation.json"
+            coding = json.loads(coding_path.read_text(encoding="utf-8"))
+            coding["executor_handoff"]["executor_target"] = "claude-code"
+            coding_path.write_text(json.dumps(coding, indent=2, sort_keys=True), encoding="utf-8")
+
+            report = _run_errors(paths, run_id)
+
+            self.assertIn("has no run-backed executor handoff lifecycle", report)
+            self.assertIn(PREPARED_RUNTIME_RUN_EXECUTOR_MATRIX, report)
+            self.assertIn(session_id, report)
+
+    def test_linked_session_rejects_a_missing_executor_handoff(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            _, run_id = _prepare_linked_codex_session(paths)
+            coding_path = paths.runtime_runs_dir / run_id / "coding_delegation.json"
+            coding = json.loads(coding_path.read_text(encoding="utf-8"))
+            del coding["executor_handoff"]
+            coding_path.write_text(json.dumps(coding, indent=2, sort_keys=True), encoding="utf-8")
+
+            report = _run_errors(paths, run_id)
+
+            self.assertIn("linked run must include an executor_handoff for a run-backed executor profile", report)
+            self.assertIn(PREPARED_RUNTIME_RUN_EXECUTOR_MATRIX, report)
+
+    def test_accepted_run_backed_handoff_stays_prepared_not_observed(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            _, run_id = _prepare_linked_codex_session(paths)
+            run_dir = paths.runtime_runs_dir / run_id
+
+            self.assertTrue(validate_runtime(paths, run_id)["ok"])
+            run = json.loads((run_dir / "run.json").read_text(encoding="utf-8"))
+            coding = json.loads((run_dir / "coding_delegation.json").read_text(encoding="utf-8"))
+            self.assertEqual(run["observation_status"], "prepared_not_observed")
+            self.assertEqual(coding["status"], "prepared_not_observed")
+            self.assertEqual(coding["executor_handoff"]["status"], "prepared_not_observed")
+            self.assertFalse((run_dir / "delegation.json").exists())
+            self.assertFalse((run_dir / "wrapper.json").exists())
+
+
+def _prepare_linked_codex_session(paths) -> tuple[str, str]:
+    started = create_or_resume_wrapper_session(paths, MESSAGE, source="discord")
+    session_id = str(started["session"]["session_id"])
+    record_plan_decision(paths, session_id, "accept")
+    select_wrapper_session_executor(paths, session_id, "codex")
+    prepared = prepare_wrapper_session_handoff(paths, session_id, MESSAGE)
+    return session_id, str(prepared["session"]["current_run_id"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_runtime_artifacts.py
+++ b/tests/test_runtime_artifacts.py
@@ -989,7 +989,12 @@ class RuntimeArtifactTests(unittest.TestCase):
             self.assertFalse(result["ok"])
             errors = "\n".join(result["runs"][0]["errors"])
             self.assertIn("executor choice must not be stored as a prepared runtime run", errors)
-            self.assertIn("prepared runtime run requires a Codex executor_handoff", errors)
+            self.assertIn(
+                "prepared runtime run rejected because selected_executor_profile None "
+                "has no run-backed executor handoff lifecycle",
+                errors,
+            )
+            self.assertIn("selected_executor_profile in (codex)", errors)
 
     def test_validate_runtime_rejects_raw_top_level_coding_delegation_key(self) -> None:
         with TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Feature Report

Closes #632.

### What Changed

- `validate_run_dir` no longer decides whether a `prepared_coding_delegation` run is valid by comparing `selected_executor_profile` to the literal `"codex"`. It consults the `CODING_EXECUTOR_HANDOFF_TARGETS` registry, then reports the first concrete reason the record cannot back a runtime run: the `work_owner_mode` is not `external_executor`, the `selected_executor_profile` has no run-backed executor handoff lifecycle, or the `executor_handoff` is missing.
- `_validate_wrapper_session_run_link` no longer requires `executor_handoff.executor_target == "codex"`. It checks the same registry and distinguishes "handoff missing" from "handoff targets a profile outside the run-backed set", naming the offending target.
- Every rejection from both validators now appends one shared sentence, `PREPARED_RUNTIME_RUN_EXECUTOR_MATRIX`, which states the run-backed profiles, the required `coding_executor_handoff/v1` contract, the prompt-only profiles, and the runtime profiles. A caller reading a single error line learns which profiles are supported and why this record failed.
- `src/runtime/records.py` `external_executor` selection validation reads the same registry instead of a literal `"codex"`, matching the `CODING_RUNTIME_TARGETS` pattern already used by the `runtime_handoff` branch one line above, so the run-level and record-level validators cannot drift apart if the registry grows.
- `docs/ARCHITECTURE.md` gains a **Prepared Runtime Run Executor Matrix** section: a table mapping all seven modeled executor profiles plus the pending-choice state to their `work_owner_mode`, prepared handoff contract, whether a `prepared_coding_delegation` run may exist, and whether a wrapper `current_run_id` link may exist.
- New contract test file `tests/test_prepared_runtime_run_executor_matrix.py` (11 tests).

### Why This Exists

`docs/DIRECTION.md` and `AGENTS.md` both treat prepared coding handoffs as executor-neutral — Codex, Claude Code, Hermes runtime, and generic executor profiles are all first-class owners, and Codex must not be the implicit default in schemas or reports. But the runtime artifact validator encoded the opposite in two hard-coded string comparisons, under an artifact kind (`prepared_coding_delegation`) whose name promises nothing Codex-specific.

That created two failure directions the issue names. A reader of the generic validation path could reasonably conclude the run format is the generic OMH contract for any executor, or could be blocked by a rejection reading only `prepared runtime run requires a Codex executor_handoff` — a message that names neither the supported set nor the field that actually failed. Neither the code nor the docs stated the boundary anywhere a caller would look.

#### Which boundary was chosen, and why

The issue offered two boundaries. **This PR takes option 1's contract shape while preserving the current capability scope**, and that hybrid is the honest reading of the surrounding lifecycle rather than a compromise.

Reading the lifecycle first: `WORK_OWNER_MODES` partitions the seven values of `EXECUTOR_PROFILES` into three lanes with no overlap and no gap — `external_executor` → `codex`; `prompt_only_handoff` → `claude-code`, `generic`; `runtime_handoff` → `hermes`, `omx-runtime`, `omo-runtime`, `omc-runtime`. The prompt-only and runtime lanes deliberately never create a runtime run at all (`tests/test_runtime_lifecycle_invariants.py::test_prompt_only_and_runtime_handoff_paths_do_not_create_lifecycle_runs`, and `validate_run_dir` explicitly rejects both if one is written into a run directory). So a "generic prepared runtime run that accepts any profile" does not describe anything the codebase models — the run-backed lane is one lane of three.

Option 1 is still the right answer, because what was actually wrong was the *shape* of the check, not the scope. `external_executor` is the run-backed lane because `coding_executor_handoff/v1` is the only handoff contract carrying the dispatch → result → verification → review → CI → merge ledger that a run directory validates. Its supported profile set is a registry, and the validator should accept whatever that registry supports and explain profile-specific handoff requirements when it does not. That set is `("codex",)` today. That is a documented capability boundary, not an executor default.

Option 2 was rejected. Renaming `artifact_kind: prepared_coding_delegation` would churn every run fixture, wrapper contract, and status projection in the repo, and it would still leave the generic validation path scope-blind — the rename alone does not make a rejection explain itself. It also cuts against the direction docs, which describe prepared coding handoffs as executor-neutral; isolating the whole lifecycle as "the Codex one" hardens exactly the implicit-default framing `AGENTS.md` warns about.

Expanding the run-backed set to a second profile was explicitly out of scope per the issue, and remains so: it would require inventing run-backed lifecycle semantics (dispatch/result/verification recording) for a profile that has none today. That is a capability decision, not a validator change. The commit records a `Directive:` trailer to that effect.

### User / Operator Impact

- An operator or wrapper that writes a non-run-backed handoff into a runtime run now gets a rejection that names the run-backed profiles, its own lane, and the specific field that failed, instead of a bare `requires a Codex executor_handoff`.
- The supported executor matrix is stated in `docs/ARCHITECTURE.md`, so integrators can determine which profiles produce a runtime run before they write one, rather than inferring it from a validator error.
- No accepted record changes shape and no previously accepted record becomes invalid. Codex run-backed handoffs validate exactly as before.

### How It Works

The run-backed executor set has one source of truth, `CODING_EXECUTOR_HANDOFF_TARGETS` in `src/coding/executors.py`. Three consumers now read it:

1. `_prepared_runtime_run_executor_rejection()` in `src/runtime/artifacts.py` — a small ordered check returning either `""` (record may back a runtime run) or one specific reason string. The ordering matters for message quality: mode is checked before profile, so a `claude-code` record is told it is a prompt-only handoff in the wrong lane rather than being told its profile is unsupported in a lane it never claimed.
2. `_validate_wrapper_session_run_link()` in `src/runtime/artifacts.py` — the session-side gate, split into a missing-handoff branch and an unsupported-target branch.
3. The `external_executor` selection check in `src/runtime/records.py`.

`PREPARED_RUNTIME_RUN_EXECUTOR_MATRIX` is a module-level constant in `src/runtime/artifacts.py` built by joining the three profile registries at import time, so the sentence cannot drift from the constants it describes. `tests/test_prepared_runtime_run_executor_matrix.py` asserts the three registries partition `EXECUTOR_PROFILES` exactly, that the sentence names every profile, and that `docs/ARCHITECTURE.md` names every profile and every work-owner mode — a cheap drift gate tying the docs to the code.

The Codex-scoped lifecycle capability is scoped, not deleted. `validate_coding_executor_handoff` in `src/runtime/records.py` still requires `codex_skill`, `codex_invocation.syntax == "$skill"`, and the Codex session observation contract. Those are genuinely Codex-specific fields of `coding_executor_handoff/v1` and are untouched.

`prepared_not_observed` is untouched in both directions. Accepting a run-backed profile leaves `observation_status: prepared_not_observed`, `coding_delegation.status`, and `executor_handoff.status` exactly as they were; rejecting a non-run-backed profile produces a schema error and never a dispatch, execution, review, CI, or merge claim. A dedicated test asserts the accepted path stays prepared-only with no `delegation.json` or `wrapper.json` present. No executor dispatch was added, and Hermes ownership of intake and planning is unchanged.

### Files And Contracts Touched

| File | Change |
| --- | --- |
| `src/runtime/artifacts.py` | New `PREPARED_RUNTIME_RUN_EXECUTOR_MATRIX` constant and `_prepared_runtime_run_executor_rejection()` helper; registry-driven checks in `validate_run_dir` and `_validate_wrapper_session_run_link` |
| `src/runtime/records.py` | `external_executor` selection reads `CODING_EXECUTOR_TARGETS` (the run-backed registry) instead of a literal profile name |
| `docs/ARCHITECTURE.md` | New **Prepared Runtime Run Executor Matrix** section under Runtime Artifacts |
| `tests/test_prepared_runtime_run_executor_matrix.py` | New, 11 contract tests |
| `tests/test_runtime_artifacts.py` | Updated the one assertion that pinned the old Codex-specific rejection string |

No schema version was bumped: no record shape, field, or accepted-value set changed. `coding_executor_handoff/v1`, `coding_prompt_handoff/v1`, `coding_runtime_handoff/v1`, and `prepared_coding_delegation` all keep their names and contents.

The diff is deliberately confined to the validation functions. Another branch is concurrently editing `show_run` / `_apply_limit` in the same file; no shared helper was refactored and neither of those functions is touched.

New contract tests:

- `test_executor_profiles_partition_into_exactly_one_handoff_lane` — every `EXECUTOR_PROFILES` value is in exactly one lane, and the three lanes cover the set.
- `test_matrix_message_names_every_executor_profile`
- `test_architecture_doc_states_the_supported_executor_matrix` — docs/code drift gate.
- `test_prepared_run_accepts_every_run_backed_executor_profile` — parameterized over `CODING_EXECUTOR_HANDOFF_TARGETS`; validates and asserts `prepared_not_observed`.
- `test_prepared_run_rejects_every_non_run_backed_executor_profile` — parameterized over the other six profiles; asserts the matrix and the supported set appear in the errors.
- `test_prepared_run_rejects_pending_executor_choice_with_matrix_reason` — the `choose` boundary.
- `test_prompt_only_and_runtime_profiles_report_their_own_lane_in_the_rejection` — each of the six non-run-backed profiles gets both its lane message and its mode-specific reason.
- `test_wrapper_session_handoff_creates_a_run_only_for_run_backed_profiles` — end-to-end over all seven profiles through `select_wrapper_session_executor` + `prepare_wrapper_session_handoff`.
- `test_linked_session_rejects_a_non_run_backed_executor_target`
- `test_linked_session_rejects_a_missing_executor_handoff`
- `test_accepted_run_backed_handoff_stays_prepared_not_observed`

## Validation

Observed locally on this branch (`uv run` in place of bare `python3`; this repo's documented invocation):

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests` — `Ran 1579 tests in 53.934s / OK (skipped=1)`
- [x] `uv run python -m compileall -q src tests` — clean
- [x] `uv run python -m omh.cli docs workflows --check` — `"ok": true`, tap skills `checked: 95, expected: 95`, no missing/stale/extra
- [x] `uv run python -m omh.cli docs roles --check` — `"ok": true`
- [x] `uv run python -m omh.cli docs capability-families --check` — `"ok": true`
- [x] `uv run python -m omh.cli harness validate` — `catalog_validation/v1`, no warnings
- [x] `uv run python -m omh.cli release checklist --json` — `required_item_count: 34`, version `1.0.2`
- [x] `uv run python -m omh.cli release hermes-smoke` — plan mode completed; explicitly not observed Hermes evidence
- [x] `uv run python -m omh.cli --help`
- [x] `git diff --check` — clean
- [x] Targeted before/after: `tests/test_prepared_runtime_run_executor_matrix.py tests/test_runtime_artifacts.py tests/test_runtime_lifecycle_invariants.py` — 63 tests, OK
- [ ] Workflow-learning review queue smoke — not run; learning contracts unchanged
- [ ] `omh release hermes-smoke --live --target-confirmed` — not run; requires a target Hermes profile
- [ ] Manual Hermes/TUI check — not run. This change is a local validator and docs change with no chat, wrapper, or TUI surface; the wrapper-session path it gates is covered by the end-to-end test over all seven profiles.

No CI evidence is claimed in this description; CI results on this PR are the observed record.

## Risk

- **Low, and bounded to rejection messages.** No accepted record changes. Every previously valid run and linked session remains valid; only the text and granularity of failures changed.
- Any external tooling string-matching the old messages `prepared runtime run requires a Codex executor_handoff` or `linked run must include a Codex executor handoff` will stop matching. A repo-wide grep found the only consumer was `tests/test_runtime_artifacts.py`, updated here. The three lane messages (`executor choice must not be stored...`, `prompt-only handoff must not be stored...`, `runtime handoff must not be stored...`) kept their leading clauses precisely so existing matchers keep working.
- `records.py` now rejects an `external_executor` record whose profile is outside the registry with a different message than before; since the registry is `("codex",)`, the accepted/rejected partition is byte-for-byte the same as the previous literal comparison.
- Error strings are longer. Every rejection now carries the full matrix sentence, which is verbose in aggregated validator output. This was a deliberate trade for the issue's requirement that a rejection state which profiles are supported and why the record failed.

## Compatibility / Rollout

- No schema version bumps, no migration, no state rewrite. `.omh/runtime/` artifacts written by an older OMH validate identically.
- No new dependencies. No network calls. Core `omh` still makes none.
- Rollout is immediate on merge with no operator action.

## Release / Claims

- [x] Release-channel impact considered — `local`; validator and docs only, no user-facing command or chat surface changes.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed — `prepared_not_observed` semantics are unchanged and asserted by test; `release hermes-smoke` was run in plan mode only and is explicitly not observed Hermes evidence; no live Hermes run was performed.
- [x] Known manual Hermes checks are listed, including the `omh release hermes-smoke --live` gap (see Validation).

## Follow-Up

- If a second run-backed executor profile is ever wanted, it is now a single explicit decision: extend `CODING_EXECUTOR_HANDOFF_TARGETS` and add the profile-specific `executor_handoff` validation together. The parameterized tests will exercise the new profile on both the prepared-run and wrapper-session paths automatically, and the docs drift gate will fail until the matrix table is updated. That remains a capability decision and is intentionally not made here.
- `records.py` `prompt_only_handoff` validation asserts only `selected != "codex"` rather than `selected in PROMPT_ONLY_EXECUTOR_PROFILES`, so a `hermes` profile in the prompt-only lane would pass. Symmetric with the `runtime_handoff` branch it is not; it is a different lane than the one this issue audits and was left alone deliberately rather than widened into this PR.
