### PR TITLE
Reframe no-run HUD/menu-bar status around request-led routing

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -174,11 +174,44 @@ recommendation, metadata-only HUD/status/role support, and a bounded evidence
 probe.
 `omh hud` prints the same compact status line a Hermes TUI or plugin surface can
 render. It shows only operationally useful status: OMH version, plugin
-readiness, target topology, current or default coding agent, and evidence
-state. Skill counts, setup inventory, token metadata, and deep diagnostics are
-left to `omh doctor`, `omh_status`, and machine-readable HUD JSON. A quiet idle
-line looks like
-`[omh] v1.0.2 | plugin:ready | target:single | coding-agent:idle(ask)`.
+readiness, target topology, the coding-agent segment described below, and
+evidence state. Skill counts, setup inventory, token metadata, and deep
+diagnostics are left to `omh doctor`, `omh_status`, and machine-readable HUD
+JSON.
+
+#### Status model: no-run, prepared-handoff, observed-run
+
+`omh setup` deliberately records a safety-first `choose` preference and asks
+no upfront coding-owner question, so Hermes asks which coding agent to use at
+the first coding request instead of at install time. The HUD line and the
+`menubar_status/v1` payload follow the same three-state model so that an
+unselected coding agent never reads as an idle external agent named
+`choose`/`ask`:
+
+1. **No-run.** No coding request has been routed yet.
+   - No preference recorded (the normal safety-first default): the HUD
+     `coding-agent` segment is executor-neutral,
+     `coding-agent:not-selected`, and the menu bar's `settings.coding_handoff`
+     reads `Coding agent: Not selected` with `source: "none"`. The Coding
+     Agent card shows `Status: ready` with the detail "Hermes routes the next
+     request to a coding agent" instead of an idle-agent row.
+   - A real preference was recorded (for example `omh setup
+     --default-executor codex`): the executor name is shown because it is a
+     genuine user choice, not a placeholder — `coding-agent:idle(codex)` on
+     the HUD line, and `Coding agent: Codex` with `source: "user_preference"`
+     and `Status: preferred` (detail "no request routed yet") in the menu bar.
+2. **Prepared handoff.** `omh coding delegate --record` prepared a handoff for
+   a run but execution has not been observed: `coding-agent:prepared(codex)`
+   on the HUD line, and the menu bar shows `source: "prepared_handoff"` with
+   the executor's prepared status.
+3. **Observed run.** A run recorded observed evidence (dispatch, execution,
+   verification, review, CI, or merge): the HUD line shows the run's actual
+   phase, for example `coding-agent:runtime(codex)`, and the menu bar shows
+   `source: "observed_runtime"`. The `evidence` HUD segment and the menu bar's
+   Evidence card carry the same prepared-versus-observed boundary as before.
+
+A quiet no-run line looks like
+`[omh] v1.0.2 | plugin:ready | target:single | coding-agent:not-selected`.
 The plugin also exposes `omh_context` for a compact OMH mental model plus
 generic-tool checkpoint, `omh_interact` for shell-free chat responses and
 metadata-only wrapper session records, `omh_recommend` for route hints without
@@ -212,8 +245,12 @@ omh menubar status --json
 
 The `menubar_status/v1` JSON has separate `hermes_agents` and
 `external_coding_executors` sections, friendly labels such as `OMH connection:
-Ready`, `Hermes targets: 2`, `Coding agent: Codex`, and `Open mode: Ask before
-opening Codex`, plus source/model icon IDs with tooltip text. It also includes
+Ready`, `Hermes targets: 2`, `Coding agent: Codex` (or `Coding agent: Not
+selected` in the no-run/no-preference state), and `Open mode: Ask before
+opening Codex`, plus source/model icon IDs with tooltip text. The
+`settings.coding_handoff.source` field distinguishes why an executor name is
+or is not shown — `"none"`, `"user_preference"`, `"prepared_handoff"`, or
+`"observed_runtime"` — per the status model above. It also includes
 `display.menu_cards`, a compact Agent Status/Coding Agent/Evidence card model
 for native menu bar surfaces. The Agent Status card is a small `Agent | PID |
 Status` list. Codex and other coding tools are external executors, not Hermes

--- a/src/plugin_bundle/omh/runtime_reader.py
+++ b/src/plugin_bundle/omh/runtime_reader.py
@@ -675,15 +675,27 @@ def _evidence_display_status(state: str) -> str:
 
 
 def _coding_agent_segment(runtime: dict[str, Any], executor: dict[str, Any]) -> str:
-    agent = _coding_agent_label(runtime.get("executor_target") or executor.get("default"))
-    state = _coding_agent_state(runtime)
-    return f"coding-agent:{state}({agent})"
+    # Three-state model (see docs/INSTALLATION.md "Status model: no-run,
+    # prepared-handoff, observed-run"):
+    #   1. no-run, no preference -> executor-neutral "not-selected" (no
+    #      executor name; nothing to imply is idle).
+    #   2. no-run, real preference recorded at setup -> the preference is
+    #      shown, labeled by its idle state, because it is a genuine user
+    #      choice rather than a placeholder.
+    #   3. a run exists with an executor_target -> a prepared handoff or
+    #      observed runtime fact, shown with its actual phase.
+    executor_target = str(runtime.get("executor_target", "") or "").strip()
+    if executor_target:
+        return f"coding-agent:{_coding_agent_state(runtime)}({_coding_agent_label(executor_target)})"
+    preference = str(executor.get("default", "") or "").strip()
+    if preference and preference != "choose":
+        return f"coding-agent:idle({_coding_agent_label(preference)})"
+    return "coding-agent:not-selected"
 
 
 def _coding_agent_label(value: Any) -> str:
-    default = str(value or "choose").strip() or "choose"
+    normalized = str(value or "").strip()
     labels = {
-        "choose": "ask",
         "generic": "prompt",
         "hermes": "hermes",
         "codex": "codex",
@@ -692,7 +704,7 @@ def _coding_agent_label(value: Any) -> str:
         "omo-runtime": "omo-runtime",
         "omc-runtime": "omc-runtime",
     }
-    return labels.get(default, default)
+    return labels.get(normalized, normalized)
 
 
 def _activity_label(runtime: dict[str, Any]) -> str:

--- a/src/surfaces/menubar_status.py
+++ b/src/surfaces/menubar_status.py
@@ -386,6 +386,12 @@ def _settings(
         if current_executor_row
         else str(executor.get("dispatch_policy", "") or "ask_before_dispatch")
     )
+    coding_handoff = _setting(
+        value=current_executor,
+        label=f"Coding agent: {_executor_setting_label(current_executor)}",
+        raw=f"coding_agent:{current_executor}",
+    )
+    coding_handoff["source"] = _coding_handoff_source(current_executor_row, current_executor)
     return {
         "omh_connection": _setting(
             value=str(plugin.get("status", "") or "unknown"),
@@ -397,17 +403,27 @@ def _settings(
             label=_target_label(topology, hermes_agents),
             raw=f"target:{_target_value(topology, hermes_agents)}",
         ),
-        "coding_handoff": _setting(
-            value=current_executor,
-            label=f"Coding agent: {_executor_setting_label(current_executor)}",
-            raw=f"coding_agent:{current_executor}",
-        ),
+        "coding_handoff": coding_handoff,
         "send_mode": _setting(
             value=dispatch_policy,
             label=_dispatch_policy_label(dispatch_policy, current_executor),
             raw=f"dispatch_policy:{dispatch_policy}",
         ),
     }
+
+
+def _coding_handoff_source(current_executor_row: dict[str, Any], current_executor: str) -> str:
+    # Distinguishes WHY an executor name is (or is not) shown, per the
+    # three-state model in docs/INSTALLATION.md: a route result/observed
+    # runtime fact from a run, a prepared handoff recorded but not yet
+    # executed, a standing user preference recorded at setup, or none of
+    # the above (the safety-first no-run state).
+    if current_executor_row:
+        evidence = _dict(current_executor_row.get("evidence"))
+        return "observed_runtime" if bool(evidence.get("execution_observed")) else "prepared_handoff"
+    if current_executor != "choose":
+        return "user_preference"
+    return "none"
 
 
 def _versions(hud: dict[str, Any]) -> dict[str, Any]:
@@ -435,8 +451,10 @@ def _display(
     pieces = [f"{len(hermes_agents)} Hermes target(s)"]
     if current_executor_row:
         pieces.append(f"{current_executor_row['name']} {current_executor_row['status_label'].lower()}")
+    elif str(settings["coding_handoff"]["value"]) != "choose":
+        pieces.append(f"{_executor_setting_label(str(settings['coding_handoff']['value']))} preferred, no request routed yet")
     else:
-        pieces.append("coding agent idle")
+        pieces.append("ready for the next request")
     return {
         "menu_title": "omh",
         "headline": headline,
@@ -533,11 +551,20 @@ def _coding_menu_rows(settings: dict[str, Any], current_executor_row: dict[str, 
         if next_action:
             rows.append(_menu_row("Next", _human_next_action(next_action)))
         return rows
+    # No-run state: nothing has been routed yet, so this card is led by
+    # Hermes/OMH readiness rather than an idle coding-agent concept. See
+    # docs/INSTALLATION.md "Status model: no-run, prepared-handoff,
+    # observed-run".
     dispatch = _setting_value(settings, "send_mode", default="ask_before_dispatch")
+    coding_value = _setting_value(settings, "coding_handoff", default="choose")
+    if coding_value == "choose":
+        status_row = _menu_row("Status", "ready", detail="Hermes routes the next request to a coding agent")
+    else:
+        status_row = _menu_row("Status", "preferred", detail="no request routed yet")
     return [
         _menu_row("Agent", _coding_agent_menu_value(settings, current_executor_row)),
-        _menu_row("Status", "idle", detail="no coding agent selected"),
-        _menu_row("Open mode", _dispatch_policy_menu_value(dispatch, _setting_value(settings, "coding_handoff"))),
+        status_row,
+        _menu_row("Open mode", _dispatch_policy_menu_value(dispatch, coding_value)),
     ]
 
 
@@ -927,7 +954,7 @@ def _target_label(topology: dict[str, Any], hermes_agents: list[dict[str, Any]])
 
 def _executor_setting_label(executor_profile: str) -> str:
     if executor_profile == "choose":
-        return "Ask each time"
+        return "Not selected"
     return executor_label(executor_profile)
 
 

--- a/tests/test_hud.py
+++ b/tests/test_hud.py
@@ -35,10 +35,49 @@ class HudCliTests(unittest.TestCase):
             self.assertEqual(status, 0)
             self.assertIn("[omh] v1.0.2", stdout)
             self.assertIn("plugin:not-installed", stdout)
-            self.assertIn("coding-agent:idle(ask)", stdout)
+            # No run and no recorded coding-agent preference: the segment is
+            # executor-neutral, not an idle agent named "ask". See
+            # docs/INSTALLATION.md "Status model: no-run, prepared-handoff,
+            # observed-run".
+            self.assertIn("coding-agent:not-selected", stdout)
+            self.assertNotIn("coding-agent:idle(ask)", stdout)
             self.assertNotIn("tokens:unobserved", stdout)
             self.assertNotIn("executor:", stdout)
             self.assertNotIn("handoff:", stdout)
+
+    def test_hud_shows_recorded_executor_preference_without_a_run(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / ".omh"
+            hermes_home = root / ".hermes"
+            self.assertEqual(
+                run_cli(
+                    [
+                        "--omh-home",
+                        str(omh_home),
+                        "--hermes-home",
+                        str(hermes_home),
+                        "setup",
+                        "--default-executor",
+                        "codex",
+                    ]
+                )[0],
+                0,
+            )
+
+            status, stdout, stderr = run_cli(
+                ["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "hud", "--json"]
+            )
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            payload = json.loads(stdout)
+            self.assertEqual(payload["runtime"]["latest_run_id"], "")
+            # A real, explicitly recorded preference is a legitimate reason to
+            # name the executor even with no run yet; it is distinct from the
+            # neutral "not-selected" no-preference state.
+            self.assertIn("coding-agent:idle(codex)", payload["display"]["line"])
+            self.assertNotIn("coding-agent:not-selected", payload["display"]["line"])
 
     def test_hud_reports_setup_plugin_target_and_prepared_runtime_boundary(self) -> None:
         with TemporaryDirectory() as tmp:
@@ -149,8 +188,13 @@ class HudCliTests(unittest.TestCase):
             payload = json.loads(stdout)
             self.assertEqual(payload["runtime"]["workflow"], "loop")
             self.assertEqual(payload["runtime"]["evidence_state"], "execution_observed")
-            self.assertIn("coding-agent:idle(ask)", payload["display"]["line"])
+            # A non-coding runtime run (loop) never recorded a coding
+            # executor_target, and no preference is configured, so the
+            # coding-agent segment stays executor-neutral rather than
+            # reporting a busy or idle coding agent.
+            self.assertIn("coding-agent:not-selected", payload["display"]["line"])
             self.assertIn("evidence:executed", payload["display"]["line"])
+            self.assertNotIn("coding-agent:idle(ask)", payload["display"]["line"])
             self.assertNotIn("coding-agent:runtime(ask)", payload["display"]["line"])
 
     def test_hud_marks_older_plugin_bundle_as_stale(self) -> None:

--- a/tests/test_menubar_status.py
+++ b/tests/test_menubar_status.py
@@ -117,6 +117,71 @@ class MenubarStatusTests(unittest.TestCase):
             self.assertEqual(current["row_id"], executors[0]["id"])
             self.assertEqual(current["run_id"], executors[0]["evidence"]["run_id"])
 
+    def test_menubar_status_no_run_state_is_executor_neutral(self) -> None:
+        # Safety-first setup deliberately records "choose" (no upfront
+        # coding-owner question). The no-run status must be led by Hermes/OMH
+        # readiness and the next request route, not by an idle coding agent
+        # named "choose"/"ask". See docs/INSTALLATION.md "Status model:
+        # no-run, prepared-handoff, observed-run".
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / ".omh"
+            hermes_home = root / ".hermes"
+            self.assertEqual(run_cli(["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "setup"])[0], 0)
+
+            status, stdout, stderr = run_cli(
+                ["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "menubar", "status"]
+            )
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            payload = json.loads(stdout)
+            self.assertEqual(payload["settings"]["coding_handoff"]["label"], "Coding agent: Not selected")
+            self.assertEqual(payload["settings"]["coding_handoff"]["source"], "none")
+            self.assertFalse(payload["current_external_coding_executor"]["selected"])
+            self.assertEqual(payload["display"]["summary_line"], "1 Hermes target(s) · ready for the next request")
+            coding_card = next(card for card in payload["display"]["menu_cards"] if card["title"] == "Coding Agent")
+            rows = {row["label"]: row for row in coding_card["rows"]}
+            self.assertEqual(rows["Agent"]["value"], "Not selected")
+            self.assertEqual(rows["Status"]["value"], "ready")
+            self.assertIn("Hermes routes the next request", rows["Status"]["detail"])
+
+    def test_menubar_status_shows_recorded_preference_without_a_run(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / ".omh"
+            hermes_home = root / ".hermes"
+            self.assertEqual(
+                run_cli(
+                    [
+                        "--omh-home",
+                        str(omh_home),
+                        "--hermes-home",
+                        str(hermes_home),
+                        "setup",
+                        "--default-executor",
+                        "codex",
+                    ]
+                )[0],
+                0,
+            )
+
+            status, stdout, stderr = run_cli(
+                ["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "menubar", "status"]
+            )
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            payload = json.loads(stdout)
+            self.assertEqual(payload["settings"]["coding_handoff"]["label"], "Coding agent: Codex")
+            self.assertEqual(payload["settings"]["coding_handoff"]["source"], "user_preference")
+            self.assertFalse(payload["current_external_coding_executor"]["selected"])
+            coding_card = next(card for card in payload["display"]["menu_cards"] if card["title"] == "Coding Agent")
+            rows = {row["label"]: row for row in coding_card["rows"]}
+            self.assertEqual(rows["Agent"]["value"], "Codex")
+            self.assertEqual(rows["Status"]["value"], "preferred")
+            self.assertIn("no request routed yet", rows["Status"]["detail"])
+
     def test_menubar_status_defaults_to_human_readable_output(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## Feature Report

### What Changed

- The no-run HUD line segment and `menubar_status/v1` payload no longer render an unselected coding-agent preference as `coding-agent:idle(ask)` / `Coding agent: Ask each time`. A three-state model now governs both surfaces:
  - **No-run, no preference** (the normal safety-first default from `omh setup`): `coding-agent:not-selected` on the HUD line; `Coding agent: Not selected` with `source: "none"` in the menu bar; the Coding Agent card shows `Status: ready` / "Hermes routes the next request to a coding agent" instead of an idle-agent row.
  - **No-run, real preference** (e.g. `omh setup --default-executor codex`): the executor name is still shown (`coding-agent:idle(codex)`, `source: "user_preference"`) because it is a genuine user choice, not a placeholder.
  - **Prepared handoff / observed run**: unchanged rendering, now labeled `source: "prepared_handoff"` / `"observed_runtime"` so the JSON payload makes the reason an executor name appears explicit and distinguishable from the no-run states.
- Added a new "Status model: no-run, prepared-handoff, observed-run" section to `docs/INSTALLATION.md` documenting all three states for both the HUD line and `menubar_status/v1`.
- Updated `_executor_setting_label`, `_settings`, `_display`, and `_coding_menu_rows` in `src/surfaces/menubar_status.py`, and `_coding_agent_segment`/`_coding_agent_label` in `src/plugin_bundle/omh/runtime_reader.py` (the single canonical HUD generator — `src/surfaces/hud.py` just re-exports `read_omh_hud` from it, so no duplicate edit was needed).

### Why This Exists

`omh setup` deliberately avoids an upfront coding-owner question: `src/commands/setup.py::_run_setup_wizard` records the safety-first `choose` preference so Hermes asks which coding agent to use at the first coding request instead of at install time (issue #631, evidence from `docs/DIRECTION.md` and `src/commands/setup.py`). The status surfaces did not follow that direction — they fell back to `executor.default` / `choose`, rendered `Coding agent: Ask each time`, and showed a `Coding Agent` idle row even with zero runs. That taught users OMH needs a preselected coding agent before it can route anything, which contradicts the request-led, executor-neutral install path.

### User / Operator Impact

- A user who ran plain `omh setup` (the default, no coding-owner question) now sees an honest, executor-neutral no-run status in `omh hud` and `omh menubar status` instead of a status line that reads as if a coding agent named "ask" is sitting idle.
- A user who did record an explicit executor preference (`--default-executor codex`) still sees that preference surfaced, now with a machine-readable `source: "user_preference"` field distinguishing it from a prepared handoff or an observed runtime fact.
- No behavior change for prepared-handoff or observed-run states beyond the additive `source` field.

### How It Works

- `src/plugin_bundle/omh/runtime_reader.py::_coding_agent_segment`: if a run recorded an `executor_target` (prepared handoff or observed run), render `coding-agent:<phase>(<executor>)` as before. Otherwise, only render an executor name if `executor.default` is a real, non-`"choose"` preference (`coding-agent:idle(<executor>)`); otherwise render the executor-neutral `coding-agent:not-selected`. The now-unreachable `"choose": "ask"` label mapping was removed from `_coding_agent_label`.
- `src/surfaces/menubar_status.py::_settings`: `coding_handoff` gained a `source` field (`"none" | "user_preference" | "prepared_handoff" | "observed_runtime"`) computed by the new `_coding_handoff_source` helper, so the JSON payload always makes explicit *why* an executor name is (or is not) shown. `_executor_setting_label("choose")` now returns `"Not selected"` instead of `"Ask each time"`.
- `_display`: the `summary_line` no longer says `"coding agent idle"`; it says `"ready for the next request"` when there is no preference, or `"<Executor> preferred, no request routed yet"` when there is one.
- `_coding_menu_rows`: the no-run branch of the `Coding Agent` menu card now shows `Status: ready` (detail "Hermes routes the next request to a coding agent") when there is no preference, or `Status: preferred` (detail "no request routed yet") when there is a real preference, instead of a generic `Status: idle` row.
- `docs/INSTALLATION.md` documents the three states and updates the example HUD line and the `Coding agent: Codex` / `settings.coding_handoff.source` description.

### Files And Contracts Touched

- `src/plugin_bundle/omh/runtime_reader.py` (`omh_hud/v1` — the canonical HUD generator; `src/surfaces/hud.py` re-exports it unchanged)
- `src/surfaces/menubar_status.py` (`menubar_status/v1`)
- `docs/INSTALLATION.md`
- `tests/test_hud.py`, `tests/test_menubar_status.py`

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests` → 1571 tests, 1 skipped, OK
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [x] `git diff --check`
- [x] Manual before/after HUD and `omh menubar status --json` runs against scratch `--omh-home`/`--hermes-home` under `/tmp` for all three states (no-run/no-preference, no-run/preference, prepared handoff)
- [ ] `python3 -m omh.cli harness validate` — not run (not in this repo's documented gate set for a status-surface change; scoped to `CLAUDE.md`/`AGENTS.md` gates listed above)
- [ ] `python3 -m omh.cli release checklist --json` / `release hermes-smoke` — not run; no release-channel or install-flow behavior changed
- Manual Hermes/TUI check: not run — no live Hermes runtime available in this environment; verified via deterministic CLI/JSON output only

## Risk

- Low. The change only affects the *content* of a display string and one additive JSON field; no schema version bump, no field removal, no change to evidence/observation semantics (`prepared_not_observed` boundaries untouched).
- Any external consumer that string-matches the literal text `coding-agent:idle(ask)` (a Hermes plugin prompt, a wrapper fixture, or an external dashboard) needs to switch to matching `coding-agent:not-selected` for the no-preference no-run case. Grepped this repo's own consumers (`tests/`, `docs/`, `src/routing/`) and found none that depend on the exact idle-agent string beyond the two test assertions updated in this PR.

## Compatibility / Rollout

- `menubar_status/v1` and `omh_hud/v1` schema versions are unchanged — the payload shape is additive only (`settings.coding_handoff.source` is new; all other keys keep their existing types).
- No new dependencies, no network calls, no change to `omh setup`'s recorded profile data.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`) — none; local deterministic status surfaces only
- [x] Runtime/native capability claims are backed by evidence or marked as not observed — the native macOS SwiftUI menu-bar app (`menubar_app.py`) and live Hermes plugin consumption were not exercised end-to-end; only the deterministic Python payload/CLI output was verified (see Not-tested in the commit trailer)
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap — not run in this environment; listed as Not-tested

## Follow-Up

- None required by this change. If a future PR wants the same request-led framing in `src/wrapper/briefing.py`'s `_coding_agent_label`/`_headline` (chat_interaction briefing text), that is a separate surface not named in issue #631's acceptance criteria and was left untouched to keep this PR scoped.

Closes #631
