### PR TITLE
feat: measure and cut repeated common-rail context in generated skills

### DIFF
--- a/docs/ADDING-A-SKILL.md
+++ b/docs/ADDING-A-SKILL.md
@@ -49,6 +49,15 @@ uv run python -m omh.cli cases demo --all --json > examples/use-cases/g1-g10-dem
 
 ## 5. Verify
 
+Every added skill grows the always-loaded prompt body of a `full` install.
+Check what it cost, and keep shared policy in
+`skills/oh-my-hermes/references/skill-common-rail.md` instead of a new
+repeated section in `workflow_skill`:
+
+```sh
+uv run python -m omh.cli docs skill-context-cost
+```
+
 ```sh
 uv run python -m compileall -q src tests
 uv run python -m omh.cli docs workflows --check

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1153,6 +1153,25 @@ without parsing prose:
 omh install --full --json | python3 -c 'import json,sys; print(json.load(sys.stdin)["context_cost_warning"])'
 ```
 
+The warning reports skill *counts*. To see the actual bytes behind them, run
+the context-cost report, which measures the always-loaded `SKILL.md` body for
+both profiles and shows how much of it is text repeated verbatim across skills
+rather than guidance specific to one workflow:
+
+```sh
+omh docs skill-context-cost          # human-readable table
+omh docs skill-context-cost --json   # omh_skill_context_cost/v1
+```
+
+Repetition is derived, not hand-classified: for each `##` heading the report
+counts occurrences, distinct bodies, and the duplicate bytes an install pays
+for the second and later copies. Policy shared by every generated workflow
+skill lives once in `skills/oh-my-hermes/references/skill-common-rail.md`
+(progressive disclosure, loaded on demand) rather than inside each body; that
+reference ships with the always-installed `oh-my-hermes` skill, so both
+profiles resolve it. Reference bytes are reported separately from the
+always-loaded total because they are not carried on every turn.
+
 A `core` install still passes `omh doctor` because the core profile installs
 a superset of the doctor health-floor skills; `--full` never removes skills
 that a later `--force` reinstall does not also write, so switching from

--- a/skills/accessibility-audit/SKILL.md
+++ b/skills/accessibility-audit/SKILL.md
@@ -132,43 +132,20 @@ Safety rules:
 - For destructive or credentialed flows, require staging-safe or read-only paths before browser/accessibility walks.
 - Do not call external scanners, browsers, screen readers, LLMs, or platform services from OMH core.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `accessibility-audit`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill accessibility-audit --harness accessibility-audit --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/achievements/SKILL.md
+++ b/skills/achievements/SKILL.md
@@ -107,43 +107,20 @@ Safety rules:
 - An achievements card reflects only locally observed hermes-achievements plugin artifacts; it is not a session-history rescan, badge recomputation, unlock proof beyond those artifacts, or productivity evidence.
 - Do not claim connector, gateway, runtime, file generation, memory mutation, or host automation evidence from prepared guidance.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `coding-handling`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill achievements --harness coding-handling --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/agent-board/SKILL.md
+++ b/skills/agent-board/SKILL.md
@@ -106,43 +106,20 @@ Safety rules:
 - An agent board card is not proof that another Hermes agent accepted, executed, heartbeat-ed, or completed work unless target-specific evidence exists.
 - Do not claim connector, gateway, runtime, file generation, memory mutation, or host automation evidence from prepared guidance.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `agent-board`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill agent-board --harness agent-board --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/agent-debug/SKILL.md
+++ b/skills/agent-debug/SKILL.md
@@ -110,43 +110,20 @@ Safety rules:
 - An agent debug report is not executor reset, hidden state mutation, tool repair, implementation, verification, CI, merge-readiness, merge, or proof that future loops are fixed. Record only observed failure evidence, diagnosis hypotheses, contained recovery actions, and remaining blockers.
 - Do not claim connector, gateway, runtime, file generation, memory mutation, or host automation evidence from prepared guidance.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `agent-debug`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill agent-debug --harness agent-debug --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/agent-evaluation/SKILL.md
+++ b/skills/agent-evaluation/SKILL.md
@@ -114,43 +114,20 @@ Safety rules:
 - Do not send secrets, credentials, private data, or production tasks into evaluation without explicit authority.
 - Keep benchmark design, observed run evidence, scoring, and executor selection separate.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `agent-evaluation`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill agent-evaluation --harness agent-evaluation --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/agent-ops-review/SKILL.md
+++ b/skills/agent-ops-review/SKILL.md
@@ -106,43 +106,20 @@ Safety rules:
 - An agent ops review card is not source retrieval, executor dispatch, coding progress, implementation, review, verification, CI, merge, platform delivery, provider billing, or live runtime telemetry evidence. If Hermes is the coding owner, summarize `hermes_coding_harness/v1` stage, lane owner, next action, and missing evidence.
 - Do not claim connector, gateway, runtime, file generation, memory mutation, or host automation evidence from prepared guidance.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `agent-ops-review`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill agent-ops-review --harness agent-ops-review --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/ai-slop-cleaner/SKILL.md
+++ b/skills/ai-slop-cleaner/SKILL.md
@@ -113,43 +113,20 @@ Safety rules:
 - Prefer deletion and existing utilities over new layers.
 - Do not add dependencies for cleanup unless explicitly requested.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `coding-handling`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill ai-slop-cleaner --harness coding-handling --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/ask/SKILL.md
+++ b/skills/ask/SKILL.md
@@ -104,43 +104,20 @@ Safety rules:
 - Treat advisor output as evidence to evaluate, not authority.
 - Do not send secrets or private prompts without explicit opt-in.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `critic`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill ask --harness critic --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/automation-blueprint/SKILL.md
+++ b/skills/automation-blueprint/SKILL.md
@@ -108,43 +108,20 @@ Safety rules:
 - Keep scheduled operations as projection metadata until the host runtime supplies observed evidence.
 - Route later coding, material generation, or report delivery into separate accepted handoffs when needed.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `scheduled-ops-blueprint`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill automation-blueprint --harness scheduled-ops-blueprint --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/autoresearch-goal/SKILL.md
+++ b/skills/autoresearch-goal/SKILL.md
@@ -104,43 +104,20 @@ Safety rules:
 - Do not imply hidden Hermes runtime behavior.
 - Use the smallest verification that can prove the claim.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `research`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill autoresearch-goal --harness research --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/best-practice-research/SKILL.md
+++ b/skills/best-practice-research/SKILL.md
@@ -104,43 +104,20 @@ Safety rules:
 - Do not imply hidden Hermes runtime behavior.
 - Use the smallest verification that can prove the claim.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `research`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill best-practice-research --harness research --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/browser-operator/SKILL.md
+++ b/skills/browser-operator/SKILL.md
@@ -114,43 +114,20 @@ Safety rules:
 - A browser operator card is not browser launch, login, credential validation, page mutation, form submission, purchase/payment/destructive action, screenshot, scraping, or successful interaction evidence unless an observed browser trace records it.
 - Do not claim connector, gateway, runtime, file generation, memory mutation, or host automation evidence from prepared guidance.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `browser-operator`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill browser-operator --harness browser-operator --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/build-failure-triage/SKILL.md
+++ b/skills/build-failure-triage/SKILL.md
@@ -127,43 +127,20 @@ Safety rules:
 - Separate flaky or environment failures from product-code failures before recommending a fix.
 - Keep remediation, reruns, review, CI, DCO, merge-readiness, and merge evidence separate.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `build-failure-triage`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill build-failure-triage --harness build-failure-triage --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/cancel/SKILL.md
+++ b/skills/cancel/SKILL.md
@@ -101,43 +101,20 @@ Safety rules:
 - Do not imply hidden Hermes runtime behavior.
 - Use the smallest verification that can prove the claim.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `goal-execution`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill cancel --harness goal-execution --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -109,43 +109,20 @@ Safety rules:
 - Cite concrete evidence for every finding.
 - Say clearly when no issue is found.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `critic`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill code-review --harness critic --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/codebase-onboarding/SKILL.md
+++ b/skills/codebase-onboarding/SKILL.md
@@ -116,43 +116,20 @@ Safety rules:
 - Keep onboarding findings, inferred risks, first-task suggestions, and implementation handoffs separate.
 - Never expose secrets from config or environment files; record only redacted paths and risk categories.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `codebase-onboarding`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill codebase-onboarding --harness codebase-onboarding --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/codegraph-refresh/SKILL.md
+++ b/skills/codegraph-refresh/SKILL.md
@@ -117,43 +117,20 @@ Safety rules:
 - Keep command planning, observed command output, generated artifacts, inferred focus files, and executor dispatch separate.
 - Never expose secret values from codegraph inputs or config files; record redacted paths and warning categories only.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `codegraph-refresh`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill codegraph-refresh --harness codegraph-refresh --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/command-operator/SKILL.md
+++ b/skills/command-operator/SKILL.md
@@ -113,43 +113,20 @@ Safety rules:
 - A command operator card is not terminal launch, shell execution, package-manager action, test run, stdout/stderr capture, exit-code success, filesystem mutation, network access, or destructive command evidence unless observed command-result evidence records it.
 - Do not claim connector, gateway, runtime, file generation, memory mutation, or host automation evidence from prepared guidance.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `command-operator`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill command-operator --harness command-operator --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/connector-operator/SKILL.md
+++ b/skills/connector-operator/SKILL.md
@@ -115,43 +115,20 @@ Safety rules:
 - A connector operator card is not connector availability, credential validation, API call, message send, ticket creation, ticket update, database/CRM mutation, external write, webhook delivery, or provider success evidence unless observed connector-result evidence records it.
 - Do not claim connector, gateway, runtime, file generation, memory mutation, or host automation evidence from prepared guidance.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `connector-operator`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill connector-operator --harness connector-operator --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/content-operator/SKILL.md
+++ b/skills/content-operator/SKILL.md
@@ -116,43 +116,20 @@ Safety rules:
 - A content operator card is not source retrieval, fact verification, hallucination-free copy, stakeholder approval, publishing, email/message sending, file export, delivery, or proof that final copy was accepted unless observed content output evidence records it.
 - Do not claim connector, gateway, runtime, file generation, memory mutation, or host automation evidence from prepared guidance.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `content-operator`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill content-operator --harness content-operator --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/context-budget-review/SKILL.md
+++ b/skills/context-budget-review/SKILL.md
@@ -115,43 +115,20 @@ Safety rules:
 - Keep estimated budget risk, observed usage, checkpoint summaries, and completion evidence separate.
 - Do not use budget pressure as a reason to shrink the user's requested end state.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `context-budget-review`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill context-budget-review --harness context-budget-review --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/cto-loop/SKILL.md
+++ b/skills/cto-loop/SKILL.md
@@ -109,43 +109,20 @@ Safety rules:
 - Do not imply CTO, PM, QA, Security, or Ops runtime agents exist without observed wrapper evidence.
 - Separate strategy decisions from implementation handoffs and release evidence.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `app-delivery-loop`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill cto-loop --harness app-delivery-loop --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/data-analysis/SKILL.md
+++ b/skills/data-analysis/SKILL.md
@@ -118,43 +118,20 @@ Safety rules:
 - A data analysis card is not file extraction, query execution, chart generation, statistical proof, data correctness, hallucination-safe numeric evidence, association, or causality unless observed data and method evidence records it.
 - Do not claim connector, gateway, runtime, file generation, memory mutation, or host automation evidence from prepared guidance.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `data-analysis`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill data-analysis --harness data-analysis --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/deep-interview/SKILL.md
+++ b/skills/deep-interview/SKILL.md
@@ -106,43 +106,20 @@ Safety rules:
 - Gather discoverable repo facts before asking the user.
 - Stop interviewing once ambiguity is low enough to plan.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `deep-interview`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill deep-interview --harness deep-interview --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/deliverable-package/SKILL.md
+++ b/skills/deliverable-package/SKILL.md
@@ -106,43 +106,20 @@ Safety rules:
 - A deliverable package card is not binary generation, render QA, formula recalculation, approval, upload, attachment, or delivery evidence.
 - Do not claim connector, gateway, runtime, file generation, memory mutation, or host automation evidence from prepared guidance.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `deliverable-package`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill deliverable-package --harness deliverable-package --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/deploy-and-monitor/SKILL.md
+++ b/skills/deploy-and-monitor/SKILL.md
@@ -109,43 +109,20 @@ Safety rules:
 - Keep release readiness, deploy decision, monitor signals, and rollback as separate evidence steps.
 - Route code fixes discovered during monitoring as later executor handoffs.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `app-delivery-loop`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill deploy-and-monitor --harness app-delivery-loop --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/design-orchestration/SKILL.md
+++ b/skills/design-orchestration/SKILL.md
@@ -114,43 +114,20 @@ Safety rules:
 - Keep free-form briefs in Hermes conversation context; persist only closed vocabulary and opaque reference metadata in the deterministic artifact.
 - Do not call Claude Design, Figma, Open Design, an image provider, browser, network service, daemon, or executor from OMH core.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `design-orchestration`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill design-orchestration --harness design-orchestration --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/design-quality-gate/SKILL.md
+++ b/skills/design-quality-gate/SKILL.md
@@ -128,43 +128,20 @@ Safety rules:
 - For Korean/CJK text, awkward breaks, clipped glyphs, orphan particles, or tiny copy block visual QA.
 - Do not call a result high-quality unless it is compared against a named ordinary-output baseline or references.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `design-quality-gate`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill design-quality-gate --harness design-quality-gate --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/doctor/SKILL.md
+++ b/skills/doctor/SKILL.md
@@ -107,43 +107,20 @@ Safety rules:
 - Do not imply hidden Hermes runtime behavior.
 - Use the smallest verification that can prove the claim.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `qa-specialist`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill doctor --harness qa-specialist --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/executor-runtime-readiness/SKILL.md
+++ b/skills/executor-runtime-readiness/SKILL.md
@@ -114,43 +114,20 @@ Safety rules:
 - Runtime readiness is not executor dispatch, plugin load, tool invocation, repository mutation, review, CI, or merge evidence.
 - Do not claim connector, gateway, runtime, file generation, memory mutation, or host automation evidence from prepared guidance.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `executor-runtime-readiness`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill executor-runtime-readiness --harness executor-runtime-readiness --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/external-connector-readiness/SKILL.md
+++ b/skills/external-connector-readiness/SKILL.md
@@ -119,43 +119,20 @@ Safety rules:
 - An external connector readiness card is not connector installation, credential validation, provider access, API invocation, multimodal capture, live-data retrieval, external mutation, cost authorization, or successful trial evidence unless observed connector-trial evidence records it.
 - Do not claim connector, gateway, runtime, file generation, memory mutation, or host automation evidence from prepared guidance.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `external-connector-readiness`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill external-connector-readiness --harness external-connector-readiness --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/failure-signal-audit/SKILL.md
+++ b/skills/failure-signal-audit/SKILL.md
@@ -116,43 +116,20 @@ Safety rules:
 - A failure signal audit is not remediation, code modification, runtime repair, console/network pass, incident closure, verification, review, CI, merge-readiness, merge, or proof that hidden failures no longer exist.
 - Do not claim connector, gateway, runtime, file generation, memory mutation, or host automation evidence from prepared guidance.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `failure-signal-audit`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill failure-signal-audit --harness failure-signal-audit --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/feedback-triage/SKILL.md
+++ b/skills/feedback-triage/SKILL.md
@@ -108,43 +108,20 @@ Safety rules:
 - Route code changes only after explicit user intent or accepted planning evidence.
 - product_evidence_loop/v1 is prepared-only opaque references, not observed evidence or execution.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `customer-insight-triage`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill feedback-triage --harness customer-insight-triage --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/frontend/SKILL.md
+++ b/skills/frontend/SKILL.md
@@ -141,43 +141,20 @@ Safety rules:
 - For Korean/CJK text, clipped glyphs, awkward line breaks, orphan particles, tiny copy, and overflow block visual QA.
 - Do not call external design, image, browser, LLM, or network services from OMH core.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `frontend`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill frontend --harness frontend --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/gateway-intent-card/SKILL.md
+++ b/skills/gateway-intent-card/SKILL.md
@@ -106,43 +106,20 @@ Safety rules:
 - A gateway intent card is not platform login, message send, thread mutation, attachment upload, or delivery evidence.
 - Do not claim connector, gateway, runtime, file generation, memory mutation, or host automation evidence from prepared guidance.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `gateway-intent-card`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill gateway-intent-card --harness gateway-intent-card --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/github-event-ops/SKILL.md
+++ b/skills/github-event-ops/SKILL.md
@@ -106,43 +106,20 @@ Safety rules:
 - A GitHub event ops card is not webhook delivery, GitHub API mutation, review completion, label application, CI rerun, or fix execution evidence. When a fix is owned by Hermes coding, read `hermes_coding_harness/v1` before reporting build, review, CI, PR, or merge state.
 - Do not claim connector, gateway, runtime, file generation, memory mutation, or host automation evidence from prepared guidance.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `github-event-ops`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill github-event-ops --harness github-event-ops --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/harness-session-inventory/SKILL.md
+++ b/skills/harness-session-inventory/SKILL.md
@@ -113,43 +113,20 @@ Safety rules:
 - A harness session inventory is not host load, MCP tool-call, connector availability, executor dispatch, worktree cleanup, merge-conflict resolution, or session progress evidence.
 - Do not claim connector, gateway, runtime, file generation, memory mutation, or host automation evidence from prepared guidance.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `harness-session-inventory`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill harness-session-inventory --harness harness-session-inventory --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/idea-to-deploy/SKILL.md
+++ b/skills/idea-to-deploy/SKILL.md
@@ -108,43 +108,20 @@ Safety rules:
 - Keep coding, release, and monitoring observations as separate evidence gates.
 - Ask for missing success metric, release scope, or executor choice before preparing a handoff.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `app-delivery-loop`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill idea-to-deploy --harness app-delivery-loop --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/img-summary/SKILL.md
+++ b/skills/img-summary/SKILL.md
@@ -138,43 +138,20 @@ Safety rules:
 - When image_generation_capability/v1 is unknown or prompt_only, ask which image tool to use and route to image_generation_setup/v1 instead of pretending generation can start.
 - For image edits, require a supplied image reference and state preserve, remove, replace, crop, and output constraints without claiming the source image was loaded.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `img-summary`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill img-summary --harness img-summary --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/instinct-ledger/SKILL.md
+++ b/skills/instinct-ledger/SKILL.md
@@ -112,43 +112,20 @@ Safety rules:
 - An instinct ledger is not hook installation, automatic observation, model training, hidden memory mutation, skill mutation, prompt mutation, global rule promotion, import, export, or proof that future behavior changed. Record only reviewed candidate instincts, confidence, scope, promotion state, and evidence gaps.
 - Do not claim connector, gateway, runtime, file generation, memory mutation, or host automation evidence from prepared guidance.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `instinct-ledger`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill instinct-ledger --harness instinct-ledger --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/live-info-operator/SKILL.md
+++ b/skills/live-info-operator/SKILL.md
@@ -113,43 +113,20 @@ Safety rules:
 - A live information card is not provider availability, API access, live data retrieval, weather, market price, sports score, exchange-rate, time-zone, map, or place-result evidence unless observed live-info result evidence records it.
 - Do not claim connector, gateway, runtime, file generation, memory mutation, or host automation evidence from prepared guidance.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `live-info-operator`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill live-info-operator --harness live-info-operator --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/loop/SKILL.md
+++ b/skills/loop/SKILL.md
@@ -147,43 +147,20 @@ Safety rules:
 - Do not let unattended loop progress bypass verification; missing or failed verification returns to plan/research or waits for evidence.
 - Do not let comprehension debt or cognitive surrender hide behind green-looking loop status.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `goal-loop`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill loop --harness goal-loop --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/materials-package/SKILL.md
+++ b/skills/materials-package/SKILL.md
@@ -109,43 +109,20 @@ Safety rules:
 - Do not claim render QA, formula recalculation, approval, or delivery from a prepared material plan.
 - Keep source facts, assumptions, missing inputs, and generated output evidence separate.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `materials-package`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill materials-package --harness materials-package --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/media-input-operator/SKILL.md
+++ b/skills/media-input-operator/SKILL.md
@@ -115,43 +115,20 @@ Safety rules:
 - A media input card is not media access, file upload, download, transcript extraction, OCR output, screenshot text extraction, receipt fields, speech-to-text output, timestamp accuracy, copyright clearance, source retrieval, or summary correctness evidence unless observed media-result evidence records it.
 - Do not claim connector, gateway, runtime, file generation, memory mutation, or host automation evidence from prepared guidance.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `media-input-operator`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill media-input-operator --harness media-input-operator --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/meeting-brief/SKILL.md
+++ b/skills/meeting-brief/SKILL.md
@@ -108,43 +108,20 @@ Safety rules:
 - Separate proposed action items from observed decisions.
 - Use a later status or decision record for actual meeting outcomes.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `meeting-facilitation`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill meeting-brief --harness meeting-facilitation --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/memory-sync/SKILL.md
+++ b/skills/memory-sync/SKILL.md
@@ -124,43 +124,20 @@ Safety rules:
 - 각 클레임은 원문 그대로 인용한다; 세션에 실제 근거가 있을 때만 출처를 언급한다.
 - 승인 전에는 어떤 파일도 수정하지 않는다; 승인 후 1회 일괄 쓰기로만 반영한다.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `memory-sync`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill memory-sync --harness memory-sync --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/meta-router/SKILL.md
+++ b/skills/meta-router/SKILL.md
@@ -108,43 +108,20 @@ Safety rules:
 - Report the selected workflow(s), why, and the observed-vs-prepared evidence boundary; a routing decision is not execution, review, CI, or merge evidence.
 - If no shell/CLI surface is available, ask the wrapper to run the bounded `omh recommend` queries or use the plugin tool surface; never guess the catalog from memory — say the catalog is unavailable and offer the workflow picker instead.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `coding-handling`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill meta-router --harness coding-handling --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/model-setup/SKILL.md
+++ b/skills/model-setup/SKILL.md
@@ -109,43 +109,20 @@ Safety rules:
 - Do not name or assume a specific model, provider tier, or price; ask the user which provider and role slot they want and read the current assignment instead of guessing.
 - Keep prerequisite check, diagnosis, guidance, apply, and verify as separate, explicit steps.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `coding-handling`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill model-setup --harness coding-handling --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/morning-brief/SKILL.md
+++ b/skills/morning-brief/SKILL.md
@@ -108,43 +108,20 @@ Safety rules:
 - OAuth tokens or app passwords are pasted by the user directly in chat and are never stored, logged, or persisted beyond the immediate diff confirmation.
 - Do not treat a prepared connection as an observed brief; only report a brief after the connection is verified.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `coding-handling`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill morning-brief --harness coding-handling --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/oh-my-hermes/references/skill-common-rail.md
+++ b/skills/oh-my-hermes/references/skill-common-rail.md
@@ -1,0 +1,56 @@
+# OMH Skill Common Rail
+
+Every generated OMH workflow skill shares this policy. It is kept here once instead of
+inside each `SKILL.md` so an install does not pay the same bytes 88 times per turn.
+Each workflow skill still states its own harness, its own runtime-record command, its
+own evidence boundary, and a pointer to this file.
+
+Load this reference when harness selection, a missing Hermes runtime capability,
+multi-agent target topology, or the generic execution checklist is in play.
+
+## Harness Discipline
+
+- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
+- Prefer richer evidence and clearer stop conditions over adding more workflow names.
+- Use specialist lanes only when they change the quality of the answer or verification.
+
+## Runtime Mechanism Translation
+
+When a runtime-specific mechanism appears in imported instructions, translate it to a
+Hermes-native artifact:
+
+- goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
+- question renderers -> one concise question in the current Hermes interface,
+- native subagents -> Hermes delegation when available, otherwise sequential lanes,
+- shell bridge commands -> optional bridge mode only.
+
+## Delegation Records
+
+Skills record their own start with `omh runtime record --skill <name> --harness <harness> --status started`.
+The delegation result is generic:
+
+```sh
+omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
+```
+
+Record observed delegation results when Hermes or the wrapper exposes them. If delegation is
+unavailable, keep the result explicit as `not_available` or `not_observed`. A recorded run is
+preparation, not execution, review, CI, merge-readiness, or merge evidence.
+
+## Multi-Agent Target Awareness
+
+Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
+
+When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+
+## Memory Context
+
+When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
+
+## Execution Rules
+
+1. Load supporting context with `skills_list` / `skill_view` when needed.
+2. State the workflow target, constraints, validation evidence, and stop condition.
+3. Keep progress evidence-backed.
+4. Verify with the smallest relevant test or inspection before claiming completion.
+5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.

--- a/skills/operating-rhythm/SKILL.md
+++ b/skills/operating-rhythm/SKILL.md
@@ -108,43 +108,20 @@ Safety rules:
 - Do not mark decisions or action items accepted without supplied notes or owner acknowledgement.
 - Keep implementation follow-ups separate from operating history.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `operating-rhythm`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill operating-rhythm --harness operating-rhythm --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/ops-observability-card/SKILL.md
+++ b/skills/ops-observability-card/SKILL.md
@@ -113,43 +113,20 @@ Safety rules:
 - An ops observability card is not billing truth, provider quota truth, live metric-provider access, complete tracing, SLO pass, incident closure, root-cause proof, remediation completion, performance proof, or successful workflow completion evidence.
 - Do not claim connector, gateway, runtime, file generation, memory mutation, or host automation evidence from prepared guidance.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `ops-observability-card`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill ops-observability-card --harness ops-observability-card --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/ops-review/SKILL.md
+++ b/skills/ops-review/SKILL.md
@@ -108,43 +108,20 @@ Safety rules:
 - Separate observed facts, risks, blockers, decisions, and follow-up actions.
 - Do not report review, CI, release, or merge readiness from an ops summary alone.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `ops-review`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill ops-review --harness ops-review --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/paper-learning/SKILL.md
+++ b/skills/paper-learning/SKILL.md
@@ -120,43 +120,20 @@ Safety rules:
 - Level changes may change scaffolding, vocabulary, analogies, and critique depth, but must not drop substantive content.
 - End each chunk with covered / next / missing rather than done unless the coverage ledger is complete.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `paper-learning`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill paper-learning --harness paper-learning --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/parallel-tools/SKILL.md
+++ b/skills/parallel-tools/SKILL.md
@@ -107,43 +107,20 @@ Safety rules:
 - Do not name a specific version number, release date, or product tier; read and report the installed version instead of assuming one.
 - Report the update command for the user to run themselves rather than claiming Hermes restarted or reloaded on its own.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `coding-handling`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill parallel-tools --harness coding-handling --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/performance-goal/SKILL.md
+++ b/skills/performance-goal/SKILL.md
@@ -105,43 +105,20 @@ Safety rules:
 - Do not imply hidden Hermes runtime behavior.
 - Use the smallest verification that can prove the claim.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `goal-execution`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill performance-goal --harness goal-execution --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/physical-device-readiness/SKILL.md
+++ b/skills/physical-device-readiness/SKILL.md
@@ -122,43 +122,20 @@ Safety rules:
 - A physical device readiness card is not device discovery, network pairing, credential validation, slicer output, G-code safety, camera inspection, sensor reading, relay actuation, robot movement, heat command, print start, emergency stop test, or successful hardware trial evidence unless observed device-trial evidence records it.
 - Do not claim connector, gateway, runtime, file generation, memory mutation, or host automation evidence from prepared guidance.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `physical-device-readiness`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill physical-device-readiness --harness physical-device-readiness --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -105,43 +105,20 @@ Safety rules:
 - Do not imply hidden Hermes runtime behavior.
 - Use the smallest verification that can prove the claim.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `planning`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill plan --harness planning --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/production-audit/SKILL.md
+++ b/skills/production-audit/SKILL.md
@@ -113,43 +113,20 @@ Safety rules:
 - Do not perform deploy, infra, credential, production, or external-platform actions from the audit lane.
 - Keep readiness verdict separate from implementation, CI, incident closure, or merge evidence.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `production-audit`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill production-audit --harness production-audit --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/prompt-import-readiness/SKILL.md
+++ b/skills/prompt-import-readiness/SKILL.md
@@ -120,43 +120,20 @@ Safety rules:
 - A prompt import readiness card is not prompt file access, prompt parsing success, slash command registration, prompt mutation, command activation, imported prompt trust, or successful dry-run evidence unless observed prompt-import evidence records it.
 - Do not claim connector, gateway, runtime, file generation, memory mutation, or host automation evidence from prepared guidance.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `prompt-import-readiness`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill prompt-import-readiness --harness prompt-import-readiness --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/ralph/SKILL.md
+++ b/skills/ralph/SKILL.md
@@ -113,43 +113,20 @@ Safety rules:
 - Do not imply hidden Hermes runtime behavior.
 - Use the smallest verification that can prove the claim.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `goal-execution`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill ralph --harness goal-execution --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/ralplan/SKILL.md
+++ b/skills/ralplan/SKILL.md
@@ -118,43 +118,20 @@ Safety rules:
 - Record unresolved tradeoffs explicitly.
 - Keep rejected options and handoff readiness separate from accepted execution evidence.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `planning`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill ralplan --harness planning --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/reliability-review/SKILL.md
+++ b/skills/reliability-review/SKILL.md
@@ -107,43 +107,20 @@ Safety rules:
 - Do not treat a reliability narrative as verification, review, CI, merge, or deploy evidence.
 - Route code remediation through a separate accepted plan or executor handoff.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `reliability-review`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill reliability-review --harness reliability-review --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/report-package/SKILL.md
+++ b/skills/report-package/SKILL.md
@@ -108,43 +108,20 @@ Safety rules:
 - Do not claim stakeholder approval or presentation delivery without observed evidence.
 - Do not couple report packages to SLO, incident, or error-budget evidence by default.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `report-package`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill report-package --harness report-package --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/research-brief/SKILL.md
+++ b/skills/research-brief/SKILL.md
@@ -105,43 +105,20 @@ Safety rules:
 - Separate evidence, inference, confidence, source diversity, and missing-source gaps.
 - Route later implementation separately through an accepted plan and coding handoff.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `business-research`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill research-brief --harness business-research --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/research-department/SKILL.md
+++ b/skills/research-department/SKILL.md
@@ -112,43 +112,20 @@ Safety rules:
 - Keep raw findings, processed notes, briefs, conflicts, and verification needs in separate source inbox buckets.
 - Treat vendor-specific tool names as optional aliases for synthesis-tool and knowledge-store readiness unless observed evidence exists.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `research-department`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill research-department --harness research-department --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/rules-distill/SKILL.md
+++ b/skills/rules-distill/SKILL.md
@@ -113,43 +113,20 @@ Safety rules:
 - Do not promote one-off preferences, weak anecdotes, or stale traces into global rules.
 - Keep observed sources, inferred principles, candidate wording, review state, and implementation patches separate.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `rules-distill`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill rules-distill --harness rules-distill --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/security-safety-review/SKILL.md
+++ b/skills/security-safety-review/SKILL.md
@@ -116,43 +116,20 @@ Safety rules:
 - Do not claim vulnerability absence, sandbox safety, credential validity, or dependency safety without observed tool or source evidence.
 - Treat untrusted prompts, downloaded files, generated commands, and external config as untrusted until reviewed.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `security-safety-review`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill security-safety-review --harness security-safety-review --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/skill-health/SKILL.md
+++ b/skills/skill-health/SKILL.md
@@ -109,43 +109,20 @@ Safety rules:
 - A skill health dashboard is not install/setup health, live skill execution success, automatic skill mutation, model training, verification, review, CI, or proof that future routing is fixed.
 - Do not claim connector, gateway, runtime, file generation, memory mutation, or host automation evidence from prepared guidance.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `skill-health`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill skill-health --harness skill-health --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/skill-scout/SKILL.md
+++ b/skills/skill-scout/SKILL.md
@@ -113,43 +113,20 @@ Safety rules:
 - A skill scout report is not skill installation, external source trust, marketplace mutation, file copy, network retrieval, credential use, implementation, review, CI, or proof that a candidate is safe to adopt.
 - Do not claim connector, gateway, runtime, file generation, memory mutation, or host automation evidence from prepared guidance.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `skill-scout`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill skill-scout --harness skill-scout --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/skill/SKILL.md
+++ b/skills/skill/SKILL.md
@@ -101,43 +101,20 @@ Safety rules:
 - Do not imply hidden Hermes runtime behavior.
 - Use the smallest verification that can prove the claim.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `docs-specialist`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill skill --harness docs-specialist --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/source-finder/SKILL.md
+++ b/skills/source-finder/SKILL.md
@@ -117,43 +117,20 @@ Safety rules:
 - Do not redefine research-department's source_inbox/v1; source-finder owns source_candidate_set/v1 and source_acquisition_status/v1 only.
 - Route current citations and source-backed synthesis to `web-research`, supplied-paper explanation to `paper-learning`, recurring monitoring to `research-department`, file export to `materials-package`, and image cards to `img-summary`.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `source-finder`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill source-finder --harness source-finder --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/strategy-brief/SKILL.md
+++ b/skills/strategy-brief/SKILL.md
@@ -107,43 +107,20 @@ Safety rules:
 - Keep unresolved assumptions visible.
 - Separate strategy from implementation planning unless the user asks for execution.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `strategy-synthesis`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill strategy-brief --harness strategy-synthesis --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -113,43 +113,20 @@ Safety rules:
 - Keep shared-file edits under one owner.
 - Record unobserved delegation as not_observed.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `goal-execution`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill team --harness goal-execution --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/toolbelt-readiness/SKILL.md
+++ b/skills/toolbelt-readiness/SKILL.md
@@ -106,43 +106,20 @@ Safety rules:
 - A toolbelt readiness card is not MCP server installation, credential validation, API access, connector invocation, or successful workflow execution evidence.
 - Do not claim connector, gateway, runtime, file generation, memory mutation, or host automation evidence from prepared guidance.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `toolbelt-readiness`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill toolbelt-readiness --harness toolbelt-readiness --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/ultragoal/SKILL.md
+++ b/skills/ultragoal/SKILL.md
@@ -121,43 +121,20 @@ Safety rules:
 - Do not imply hidden Hermes runtime behavior.
 - Use the smallest verification that can prove the claim.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `goal-execution`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill ultragoal --harness goal-execution --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/ultraprocess/SKILL.md
+++ b/skills/ultraprocess/SKILL.md
@@ -126,43 +126,20 @@ Safety rules:
 - Keep web research source-backed and permission-aware; do not run hidden network or LLM calls from OMH core.
 - Run docs sync only when behavior, setup, commands, or public claims changed.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `goal-execution`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill ultraprocess --harness goal-execution --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/ultraqa/SKILL.md
+++ b/skills/ultraqa/SKILL.md
@@ -106,43 +106,20 @@ Safety rules:
 - Do not imply hidden Hermes runtime behavior.
 - Use the smallest verification that can prove the claim.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `qa-specialist`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill ultraqa --harness qa-specialist --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/ultrawork/SKILL.md
+++ b/skills/ultrawork/SKILL.md
@@ -116,43 +116,20 @@ Safety rules:
 - Keep Hermes responsible for orchestration/status; when Hermes itself is selected for coding, still preserve runtime evidence boundaries.
 - Record unobserved executor work as prepared_not_observed or not_observed.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `goal-execution`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill ultrawork --harness goal-execution --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/verification-gate/SKILL.md
+++ b/skills/verification-gate/SKILL.md
@@ -113,43 +113,20 @@ Safety rules:
 - Do not collapse build, lint, tests, security, generated docs, review, CI, DCO, merge-readiness, or merge into one claim.
 - Failed or unavailable checks must produce HOLD/BLOCK with a rerun or remediation path.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `verification-gate`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill verification-gate --harness verification-gate --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/visual-qa/SKILL.md
+++ b/skills/visual-qa/SKILL.md
@@ -161,43 +161,20 @@ Safety rules:
 - CJK clipping, broken wrapping, overlapping UI, invisible text, unusable controls, or offscreen critical content block PASS.
 - Do not call browsers, image tools, LLMs, or external services from OMH core.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `visual-qa`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill visual-qa --harness visual-qa --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/voice-operator/SKILL.md
+++ b/skills/voice-operator/SKILL.md
@@ -106,43 +106,20 @@ Safety rules:
 - A voice operator card is not speech recognition, mobile notification delivery, platform action, or accepted execution evidence.
 - Do not claim connector, gateway, runtime, file generation, memory mutation, or host automation evidence from prepared guidance.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `voice-operator`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill voice-operator --harness voice-operator --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/web-research/SKILL.md
+++ b/skills/web-research/SKILL.md
@@ -115,43 +115,20 @@ Safety rules:
 - State retrieval limits, dates, and missing-source gaps for unstable facts.
 - product_evidence_loop/v1 is prepared-only opaque references, not observed evidence or execution.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `research`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill web-research --harness research --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/websearch-setup/SKILL.md
+++ b/skills/websearch-setup/SKILL.md
@@ -108,43 +108,20 @@ Safety rules:
 - Never combine the scraper API key `.env` write and the auxiliary web-extract model routing write into a single apply step; each gets its own diff and its own approval.
 - Do not name a specific scraper product, extract-model provider, or price; ask the user which provider they hold an account with and read the current config instead of assuming one.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `coding-handling`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill websearch-setup --harness coding-handling --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/wiki/SKILL.md
+++ b/skills/wiki/SKILL.md
@@ -110,43 +110,20 @@ Safety rules:
 - Do not imply hidden Hermes runtime behavior.
 - Use the smallest verification that can prove the claim.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `docs-specialist`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill wiki --harness docs-specialist --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/workflow-learning/SKILL.md
+++ b/skills/workflow-learning/SKILL.md
@@ -106,43 +106,20 @@ Safety rules:
 - A workflow learning trace, self-improvement store route, patch proposal, or export is process evidence for review. It is not automatic model training, memory mutation, skill mutation, wiki write, automation creation, execution, verification, CI, or merge evidence.
 - Do not claim connector, gateway, runtime, file generation, memory mutation, or host automation evidence from prepared guidance.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `workflow-learning`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill workflow-learning --harness workflow-learning --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/workspace-audit/SKILL.md
+++ b/skills/workspace-audit/SKILL.md
@@ -115,43 +115,20 @@ Safety rules:
 - Do not claim a surface exists, is loaded, or is reachable unless file, CLI, wrapper, or supplied evidence was observed.
 - Keep audit findings separate from implementation, setup repair, security remediation, or skill mutation.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `workspace-audit`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill workspace-audit --harness workspace-audit --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/skills/workspace-file-operator/SKILL.md
+++ b/skills/workspace-file-operator/SKILL.md
@@ -113,43 +113,20 @@ Safety rules:
 - A workspace file operator card is not file read, file write, copy, move, rename, delete, archive, upload, download, permission change, or destructive filesystem evidence unless observed file-operation output records it.
 - Do not claim connector, gateway, runtime, file generation, memory mutation, or host automation evidence from prepared guidance.
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
 ## Runtime Evidence
 
 Preferred harness for this skill: `workspace-file-operator`.
 
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
 ```sh
 omh runtime record --skill workspace-file-operator --harness workspace-file-operator --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
 ```
 
 Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
 
 ## Hermes Compatibility Contract
 
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, adapt only the parts of this workflow that benefit from multiple Hermes agents, and fall back to single-target behavior when `active_agent_count` is one.
-- When target topology changes from one to many or many to one, give a concise setup-change comment or use the wrapper's apply action before treating the new topology as persistent.
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+- Respect `omh_target_topology/v1` when a wrapper reports it: bind state to the current target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one concise setup-change comment before treating a one-to-many or many-to-one change as persistent.
 - Treat wrapper-supplied memory/context summaries as advisory local context, not proof that opaque Hermes memory was read or changed.
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+- Shared rail: `oh-my-hermes/references/skill-common-rail.md` carries harness discipline, the runtime-mechanism translation table, the delegation-record command, and the execution-rule checklist. Load it when one of those applies; if it is not installed, name the unavailable capability instead of assuming it.

--- a/src/commands/docs.py
+++ b/src/commands/docs.py
@@ -7,6 +7,7 @@ from ..catalogs.roles import roles_reference_markdown
 from ..installer import OmhError
 from ..local_store import atomic_write_text
 from ..skill_pack import builtin_harnesses, builtin_skill_reference_templates, builtin_skill_templates
+from ..skills.context_cost import skill_context_cost_markdown, skill_context_cost_payload
 from ..skills.render import workflow_reference_markdown, workflow_reference_payload
 from ..skills.validation import harness_inspection_payload, harness_summary_payload, validate_catalog_contract
 from .common import _print_json
@@ -83,6 +84,14 @@ def cmd_docs_capability_families(args: argparse.Namespace) -> int:
         return 0
     atomic_write_text(output, content)
     _print_json({"written": str(output)})
+    return 0
+
+
+def cmd_docs_skill_context_cost(args: argparse.Namespace) -> int:
+    if args.json:
+        _print_json(skill_context_cost_payload())
+        return 0
+    print(skill_context_cost_markdown().rstrip())
     return 0
 
 
@@ -163,6 +172,17 @@ def _add_docs_commands(sub) -> None:
     docs_capability_families.add_argument("--output", default=None)
     docs_capability_families.add_argument("--check", action="store_true")
     docs_capability_families.set_defaults(func=cmd_docs_capability_families)
+
+    docs_skill_context_cost = docs_sub.add_parser(
+        "skill-context-cost",
+        help="Report always-loaded skill-body size and cross-skill repetition for the core and full profiles.",
+    )
+    docs_skill_context_cost.add_argument(
+        "--json",
+        action="store_true",
+        help="Print the machine-readable omh_skill_context_cost/v1 payload.",
+    )
+    docs_skill_context_cost.set_defaults(func=cmd_docs_skill_context_cost)
 
 
 def _add_harness_commands(sub) -> None:

--- a/src/skills/context_cost.py
+++ b/src/skills/context_cost.py
@@ -1,0 +1,214 @@
+"""Deterministic prompt-context accounting for the generated skill pack.
+
+`omh docs skill-context-cost` renders this payload. It answers one question:
+how many bytes of always-loaded `SKILL.md` body does an install carry, and how
+much of that body is text repeated verbatim across skills rather than guidance
+specific to one workflow?
+
+Two cost classes are tracked separately because they load differently:
+
+- ``skill_body``: `skills/<name>/SKILL.md`. Loaded whenever Hermes puts the
+  skill in context, once per installed skill. This is the per-turn cost the
+  installer's context-cost warning is about.
+- ``reference``: `skills/<name>/references/*.md`. Progressive disclosure --
+  loaded only when a skill or the router explicitly points at it. Moving an
+  invariant section from a body into a reference removes it from every
+  installed skill's always-loaded weight and keeps exactly one copy on disk.
+
+Repetition is derived, never hand-classified: for each `##` heading, sections
+whose body text is byte-identical across skills are duplicates, and
+``duplicate_bytes`` is what an install pays for the second and later copies.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .catalog import CORE_PROFILE_SKILLS
+from .packaging import builtin_skill_reference_templates, builtin_skill_templates
+
+SKILL_CONTEXT_COST_SCHEMA_VERSION = "omh_skill_context_cost/v1"
+
+# Deterministic, dependency-free token estimate. Four characters per token is
+# the usual English-prose approximation; it is a comparison unit for before/after
+# work in this repo, not a tokenizer result.
+CHARS_PER_TOKEN_ESTIMATE = 4
+
+
+@dataclass(frozen=True)
+class SectionSlice:
+    skill: str
+    heading: str
+    body: str
+
+
+def _split_sections(content: str) -> list[tuple[str, str]]:
+    """Split rendered markdown into `(heading, body)` pairs.
+
+    The `## ` line stays at the head of its own body, and frontmatter plus any
+    preamble before the first heading is returned under the synthetic heading
+    ``"(preamble)"``. Both rules exist so the section bytes of a skill sum to
+    exactly ``len(content)`` -- a repeated heading line is repeated cost too.
+    """
+    sections: list[tuple[str, str]] = []
+    heading = "(preamble)"
+    buffer: list[str] = []
+    for line in content.splitlines(keepends=True):
+        if line.startswith("## "):
+            sections.append((heading, "".join(buffer)))
+            heading = line[3:].strip()
+            buffer = [line]
+            continue
+        buffer.append(line)
+    sections.append((heading, "".join(buffer)))
+    return sections
+
+
+def _estimated_tokens(chars: int) -> int:
+    return -(-chars // CHARS_PER_TOKEN_ESTIMATE)
+
+
+def _size_payload(text_chars: int, line_count: int) -> dict[str, int]:
+    return {
+        "bytes": text_chars,
+        "lines": line_count,
+        "estimated_tokens": _estimated_tokens(text_chars),
+    }
+
+
+def _profile_skill_names(profile: str) -> set[str]:
+    names = {template.name for template in builtin_skill_templates()}
+    if profile == "full":
+        return names
+    return {name for name in names if name in CORE_PROFILE_SKILLS}
+
+
+def _section_slices(names: set[str]) -> list[SectionSlice]:
+    slices: list[SectionSlice] = []
+    for template in builtin_skill_templates():
+        if template.name not in names:
+            continue
+        for heading, body in _split_sections(template.content):
+            slices.append(SectionSlice(template.name, heading, body))
+    return slices
+
+
+def _heading_repetition(slices: list[SectionSlice]) -> list[dict[str, object]]:
+    grouped: dict[str, list[str]] = {}
+    for section in slices:
+        grouped.setdefault(section.heading, []).append(section.body)
+    rows: list[dict[str, object]] = []
+    for heading, bodies in grouped.items():
+        total_bytes = sum(len(body) for body in bodies)
+        distinct = set(bodies)
+        unique_bytes = sum(len(body) for body in distinct)
+        rows.append(
+            {
+                "heading": heading,
+                "occurrences": len(bodies),
+                "distinct_bodies": len(distinct),
+                "bytes": total_bytes,
+                "unique_bytes": unique_bytes,
+                "duplicate_bytes": total_bytes - unique_bytes,
+                "estimated_duplicate_tokens": _estimated_tokens(total_bytes - unique_bytes),
+            }
+        )
+    rows.sort(key=lambda row: (-int(row["duplicate_bytes"]), str(row["heading"])))
+    return rows
+
+
+def _reference_payload(names: set[str]) -> dict[str, object]:
+    templates = [
+        template for template in builtin_skill_reference_templates() if template.skill_name in names
+    ]
+    total_chars = sum(len(template.content) for template in templates)
+    total_lines = sum(len(template.content.splitlines()) for template in templates)
+    return {
+        "file_count": len(templates),
+        **_size_payload(total_chars, total_lines),
+        "files": sorted(f"{template.skill_name}/{template.relative_path}" for template in templates),
+    }
+
+
+def _percent(part: int, whole: int) -> float:
+    if whole <= 0:
+        return 0.0
+    return round(part * 100 / whole, 2)
+
+
+def skill_context_cost_profile(profile: str) -> dict[str, object]:
+    names = _profile_skill_names(profile)
+    slices = _section_slices(names)
+    headings = _heading_repetition(slices)
+    total_chars = sum(len(section.body) for section in slices)
+    total_lines = sum(len(section.body.splitlines()) for section in slices)
+    duplicate_bytes = sum(int(row["duplicate_bytes"]) for row in headings)
+    return {
+        "profile": profile,
+        "skill_count": len(names),
+        "skill_body": _size_payload(total_chars, total_lines),
+        "repeated": {
+            **_size_payload(duplicate_bytes, 0),
+            "share_percent": _percent(duplicate_bytes, total_chars),
+        },
+        "skill_specific": {
+            **_size_payload(total_chars - duplicate_bytes, 0),
+            "share_percent": _percent(total_chars - duplicate_bytes, total_chars),
+        },
+        "references": _reference_payload(names),
+        "headings": headings,
+    }
+
+
+def skill_context_cost_payload() -> dict[str, object]:
+    return {
+        "schema_version": SKILL_CONTEXT_COST_SCHEMA_VERSION,
+        "description": (
+            "Deterministic prompt-context accounting for generated skill bodies. Byte counts are exact; "
+            "token counts are a chars/4 estimate for before/after comparison, not tokenizer output. "
+            "Reference files are progressive-disclosure surfaces and are reported outside the "
+            "always-loaded skill-body total."
+        ),
+        "chars_per_token_estimate": CHARS_PER_TOKEN_ESTIMATE,
+        "profiles": [skill_context_cost_profile(profile) for profile in ("core", "full")],
+    }
+
+
+def skill_context_cost_markdown() -> str:
+    payload = skill_context_cost_payload()
+    lines = [
+        "# Generated Skill Context Cost",
+        "",
+        str(payload["description"]),
+        "",
+    ]
+    for profile in payload["profiles"]:
+        body = profile["skill_body"]
+        repeated = profile["repeated"]
+        specific = profile["skill_specific"]
+        references = profile["references"]
+        lines.extend(
+            [
+                f"## {profile['profile']} profile",
+                "",
+                f"- Installed skills: {profile['skill_count']}",
+                f"- Always-loaded skill body: {body['bytes']} bytes, {body['lines']} lines, "
+                f"~{body['estimated_tokens']} tokens",
+                f"- Repeated across skills: {repeated['bytes']} bytes "
+                f"(~{repeated['estimated_tokens']} tokens, {repeated['share_percent']}%)",
+                f"- Skill-specific: {specific['bytes']} bytes "
+                f"(~{specific['estimated_tokens']} tokens, {specific['share_percent']}%)",
+                f"- On-demand references: {references['file_count']} files, {references['bytes']} bytes "
+                f"(~{references['estimated_tokens']} tokens)",
+                "",
+                "| Heading | Occurrences | Distinct bodies | Bytes | Duplicate bytes |",
+                "| --- | --- | --- | --- | --- |",
+            ]
+        )
+        for row in profile["headings"]:
+            lines.append(
+                f"| {row['heading']} | {row['occurrences']} | {row['distinct_bodies']} | "
+                f"{row['bytes']} | {row['duplicate_bytes']} |"
+            )
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"

--- a/src/skills/render.py
+++ b/src/skills/render.py
@@ -90,21 +90,51 @@ GOAL_STATUS_REFERENCE_CONTEXT = (
     "from generic `status_card/v1`; they must name the next action instead of merely summarizing work."
 )
 
+# The common rail: policy that used to be repeated verbatim inside every generated
+# workflow skill body. It now lives in one progressive-disclosure reference shipped
+# with the always-installed `oh-my-hermes` skill (see `CORE_SKILLS`), so both the
+# core and full install profiles resolve it. Each workflow skill keeps a compact
+# inline restatement of the safety-critical duties plus the pointer below; the
+# verbatim policy text below is the single maintained copy.
+SHARED_RAIL_REFERENCE_PATH = "oh-my-hermes/references/skill-common-rail.md"
+
+HARNESS_DISCIPLINE_RULES = (
+    "Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, "
+    "research, planning, goal execution, architecture, critique, QA, or documentation lanes.",
+    "Prefer richer evidence and clearer stop conditions over adding more workflow names.",
+    "Use specialist lanes only when they change the quality of the answer or verification.",
+)
+
+RUNTIME_MECHANISM_TRANSLATIONS = (
+    "goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, "
+    "`goal_continuation/v1`, or explicit checklists with named next actions",
+    "question renderers -> one concise question in the current Hermes interface",
+    "native subagents -> Hermes delegation when available, otherwise sequential lanes",
+    "shell bridge commands -> optional bridge mode only",
+)
+
+EXECUTION_RULES = (
+    "Load supporting context with `skills_list` / `skill_view` when needed.",
+    "State the workflow target, constraints, validation evidence, and stop condition.",
+    "Keep progress evidence-backed.",
+    "Verify with the smallest relevant test or inspection before claiming completion.",
+    "If Hermes cannot provide a required runtime capability, say so and use the fallback above.",
+)
+
+DELEGATION_RECORD_COMMAND = "omh runtime delegate --run <run-id> --requested --not-observed --result not_observed"
+
+SHARED_RAIL_POINTER = (
+    f"Shared rail: `{SHARED_RAIL_REFERENCE_PATH}` carries harness discipline, the runtime-mechanism "
+    "translation table, the delegation-record command, and the execution-rule checklist. Load it when "
+    "one of those applies; if it is not installed, name the unavailable capability instead of assuming it."
+)
+
 def _target_topology_router_section() -> str:
     return "\n\n".join(
         [
             "## Multi-Agent Target Awareness",
             TARGET_TOPOLOGY_ROUTER_CONTEXT,
             TARGET_TOPOLOGY_CHANGE_CONTEXT,
-        ]
-    )
-
-
-def _target_topology_skill_contract_bullets() -> str:
-    return "\n".join(
-        [
-            f"- {TARGET_TOPOLOGY_SKILL_CONTRACT}",
-            f"- {TARGET_TOPOLOGY_SKILL_CHANGE_CONTRACT}",
         ]
     )
 
@@ -117,6 +147,43 @@ def _memory_context_skill_contract_bullets(definition: SkillDefinition) -> str:
 
 def _needs_explicit_memory_context(definition: SkillDefinition) -> bool:
     return memory_context_policy_for_skill(definition.name) == "explicit"
+
+
+def _target_topology_skill_contract_bullet() -> str:
+    return (
+        f"- Respect `{TARGET_TOPOLOGY_SCHEMA}` when a wrapper reports it: bind state to the current "
+        "target/thread, fall back to single-target behavior when `active_agent_count` is one, and give one "
+        "concise setup-change comment before treating a one-to-many or many-to-one change as persistent."
+    )
+
+
+def _common_rail_sections(definition: SkillDefinition, primary_harness: str) -> str:
+    """Render the compact per-skill tail that replaced the repeated common rail.
+
+    What stays inline is the self-containment floor a standalone Hermes tap needs: this
+    skill's harness and record command, the observed-vs-unavailable delegation result rule,
+    the Hermes-native tool contract with its native-subagent fallback, target topology, the
+    skill's memory-context policy, and the pointer to `references/skill-common-rail.md`.
+    `tests/test_router_content.py::test_all_tap_skills_include_subagent_fallback_contract`
+    is the gate on that floor. Everything else moved to the shared rail verbatim.
+    """
+    return f"""## Runtime Evidence
+
+Preferred harness for this skill: `{primary_harness}`.
+
+```sh
+omh runtime record --skill {definition.name} --harness {primary_harness} --status started
+```
+
+Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
+
+## Hermes Compatibility Contract
+
+- Preserve the workflow intent, stop conditions, and verification discipline; verify with the smallest relevant test or inspection before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available, and do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose. If Hermes cannot provide a required runtime capability, say so and fall back: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+{_target_topology_skill_contract_bullet()}
+{_memory_context_skill_contract_bullets(definition)}
+- {SHARED_RAIL_POINTER}"""
 
 
 @lru_cache(maxsize=1)
@@ -347,7 +414,67 @@ def _router_reference_templates_cached() -> tuple[SkillReferenceTemplate, ...]:
             "references/evidence-boundaries.md",
             _router_evidence_boundaries_reference(),
         ),
+        SkillReferenceTemplate(
+            "oh-my-hermes",
+            "references/skill-common-rail.md",
+            _router_skill_common_rail_reference(),
+        ),
     )
+
+
+def _router_skill_common_rail_reference() -> str:
+    harness_rules = "\n".join(f"- {rule}" for rule in HARNESS_DISCIPLINE_RULES)
+    translations = "\n".join(f"- {item}," for item in RUNTIME_MECHANISM_TRANSLATIONS[:-1])
+    translations = f"{translations}\n- {RUNTIME_MECHANISM_TRANSLATIONS[-1]}."
+    execution_rules = "\n".join(f"{index}. {rule}" for index, rule in enumerate(EXECUTION_RULES, start=1))
+    return f"""# OMH Skill Common Rail
+
+Every generated OMH workflow skill shares this policy. It is kept here once instead of
+inside each `SKILL.md` so an install does not pay the same bytes 88 times per turn.
+Each workflow skill still states its own harness, its own runtime-record command, its
+own evidence boundary, and a pointer to this file.
+
+Load this reference when harness selection, a missing Hermes runtime capability,
+multi-agent target topology, or the generic execution checklist is in play.
+
+## Harness Discipline
+
+{harness_rules}
+
+## Runtime Mechanism Translation
+
+When a runtime-specific mechanism appears in imported instructions, translate it to a
+Hermes-native artifact:
+
+{translations}
+
+## Delegation Records
+
+Skills record their own start with `omh runtime record --skill <name> --harness <harness> --status started`.
+The delegation result is generic:
+
+```sh
+{DELEGATION_RECORD_COMMAND}
+```
+
+Record observed delegation results when Hermes or the wrapper exposes them. If delegation is
+unavailable, keep the result explicit as `not_available` or `not_observed`. A recorded run is
+preparation, not execution, review, CI, merge-readiness, or merge evidence.
+
+## Multi-Agent Target Awareness
+
+{TARGET_TOPOLOGY_SKILL_CONTRACT}
+
+{TARGET_TOPOLOGY_SKILL_CHANGE_CONTRACT}
+
+## Memory Context
+
+{MEMORY_CONTEXT_SKILL_CONTRACT}
+
+## Execution Rules
+
+{execution_rules}
+""".rstrip() + "\n"
 
 
 def _router_catalog_index_reference() -> str:
@@ -770,45 +897,7 @@ A memory-sync review is not MEMORY.md or USER.md modification evidence until an 
 
 {_skill_metadata_block(definition)}
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
-## Runtime Evidence
-
-Preferred harness for this skill: `{primary_harness}`.
-
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
-```sh
-omh runtime record --skill {name} --harness {primary_harness} --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
-```
-
-Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-{_target_topology_skill_contract_bullets()}
-{_memory_context_skill_contract_bullets(definition)}
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+{_common_rail_sections(definition, primary_harness)}
 """
     return SkillTemplate(name, _frontmatter(name, definition.description) + "\n" + body)
 
@@ -836,45 +925,7 @@ This is a Hermes-native `{name}` workflow skill.
 
 {_skill_metadata_block(definition)}
 
-## Harness Discipline
-
-- Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.
-- Prefer richer evidence and clearer stop conditions over adding more workflow names.
-- Use specialist lanes only when they change the quality of the answer or verification.
-
-## Runtime Evidence
-
-Preferred harness for this skill: `{primary_harness}`.
-
-When local shell access or a bot wrapper is available, record metadata-only evidence:
-
-```sh
-omh runtime record --skill {name} --harness {primary_harness} --status started
-omh runtime delegate --run <run-id> --requested --not-observed --result not_observed
-```
-
-Record observed delegation results when Hermes or the wrapper exposes them. If delegation is unavailable, keep the result explicit as `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve the workflow intent, stop conditions, and verification discipline.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available.
-- Do not require runtime tools, role prompts, or overlays that Hermes Agent does not expose.
-{_target_topology_skill_contract_bullets()}
-{_memory_context_skill_contract_bullets(definition)}
-- When a runtime-specific mechanism appears in imported instructions, translate it to a Hermes-native artifact:
-  - goal tools -> `.omh/goals/` ledgers, `goal_completion_gate/v1`, `goal_status_card/v1`, `goal_continuation/v1`, or explicit checklists with named next actions,
-  - question renderers -> one concise question in the current Hermes interface,
-  - native subagents -> Hermes delegation when available, otherwise sequential lanes,
-  - shell bridge commands -> optional bridge mode only.
-
-## Execution Rules
-
-1. Load supporting context with `skills_list` / `skill_view` when needed.
-2. State the workflow target, constraints, validation evidence, and stop condition.
-3. Keep progress evidence-backed.
-4. Verify with the smallest relevant test or inspection before claiming completion.
-5. If Hermes cannot provide a required runtime capability, say so and use the fallback above.
+{_common_rail_sections(definition, primary_harness)}
 """
     return SkillTemplate(name, _frontmatter(name, definition.description) + "\n" + body)
 

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -53,7 +53,9 @@ from omh.plugin_bundle.omh.awareness import (
     awareness_workflow_context_markdown,
     workflow_context_card_for_workflow,
 )
+from omh.skill_pack import builtin_skill_reference_templates
 from omh.skills.catalog import (
+    CORE_PROFILE_SKILLS,
     builtin_harnesses,
     catalog_intent_delegation_skill_names,
     coding_skills_for_intent,
@@ -131,6 +133,111 @@ class EfficiencyContractTests(unittest.TestCase):
         self.assertLessEqual(combined.count("memory_review_card/v1"), explicit_budget)
         self.assertLessEqual(combined.count("handoff_context_pack/v1"), explicit_budget)
         self.assertLessEqual(combined.count("advisory local context"), compact_budget)
+
+    def test_skill_context_cost_report_is_reproducible_and_bounded(self) -> None:
+        """Standing gate for issue #634: the generated pack's always-loaded prompt cost.
+
+        `omh docs skill-context-cost` renders the same payload. The ceilings below are the
+        post-#634 measurements plus a small margin, so a section that creeps back into every
+        skill body fails here with the byte number instead of growing silently.
+        """
+        from omh.skills.context_cost import (
+            SKILL_CONTEXT_COST_SCHEMA_VERSION,
+            skill_context_cost_markdown,
+            skill_context_cost_payload,
+        )
+
+        payload = skill_context_cost_payload()
+        self.assertEqual(payload["schema_version"], SKILL_CONTEXT_COST_SCHEMA_VERSION)
+        profiles = {profile["profile"]: profile for profile in payload["profiles"]}
+        self.assertEqual(set(profiles), {"core", "full"})
+
+        core = profiles["core"]
+        full = profiles["full"]
+        self.assertEqual(core["skill_count"], len(CORE_PROFILE_SKILLS))
+        self.assertEqual(full["skill_count"], len(builtin_skill_templates()))
+
+        # Every byte of every skill body is accounted for exactly once.
+        for profile in (core, full):
+            with self.subTest(profile=profile["profile"]):
+                expected_bytes = sum(
+                    len(template.content)
+                    for template in builtin_skill_templates()
+                    if profile["profile"] == "full" or template.name in CORE_PROFILE_SKILLS
+                )
+                self.assertEqual(profile["skill_body"]["bytes"], expected_bytes)
+                self.assertEqual(
+                    profile["repeated"]["bytes"] + profile["skill_specific"]["bytes"],
+                    profile["skill_body"]["bytes"],
+                )
+                self.assertEqual(
+                    profile["repeated"]["bytes"],
+                    sum(int(row["duplicate_bytes"]) for row in profile["headings"]),
+                )
+
+        # Post-#634 ceilings. Baseline on main was 72,878 (core) / 759,969 (full) bytes
+        # with 41.70% of the full-profile body repeated verbatim across skills.
+        self.assertLess(core["skill_body"]["bytes"], 68_000)
+        self.assertLess(full["skill_body"]["bytes"], 700_000)
+        self.assertLess(full["repeated"]["share_percent"], 38.0)
+
+        # References are progressive disclosure, counted outside the always-loaded body.
+        self.assertEqual(full["references"]["file_count"], len(builtin_skill_reference_templates()))
+        self.assertIn(
+            "oh-my-hermes/references/skill-common-rail.md",
+            full["references"]["files"],
+        )
+
+        report = skill_context_cost_markdown()
+        self.assertIn("## core profile", report)
+        self.assertIn("## full profile", report)
+        self.assertIn("Hermes Compatibility Contract", report)
+
+    def test_skill_triggers_and_evidence_boundaries_survive_common_rail_move(self) -> None:
+        """Differential gate for issue #634 on the three surfaces it must not change.
+
+        Routing is deterministic Python that never reads `SKILL.md`, so the router is
+        asserted directly; triggers, safety rules, and the prepared-vs-observed fallback
+        are asserted against each rendered body for representative core and full skills.
+        """
+        from omh.routing.chat import route_chat_message
+        from omh.skills.render import SHARED_RAIL_REFERENCE_PATH
+
+        templates = {template.name: template.content for template in builtin_skill_templates()}
+        definitions = {definition.name: definition for definition in builtin_definitions()}
+
+        representative = {
+            "plan": "plan",  # core profile
+            "ops-observability-card": "ops-observability-card",  # core profile
+            "code-review": "code-review",  # full profile only
+            "ultragoal": "ultragoal",  # full profile only
+        }
+        for name, expected_skill in representative.items():
+            with self.subTest(skill=name):
+                definition = definitions[name]
+                content = templates[name]
+
+                # Deterministic routing still selects the skill from its own trigger.
+                routed = route_chat_message(definition.triggers[0], source="discord")
+                self.assertEqual(routed["selected_skill"], expected_skill)
+
+                # Task-specific triggers stay listed in full.
+                for trigger in definition.triggers:
+                    self.assertIn(f"`{trigger}`", content)
+
+                # Evidence boundaries stay inline.
+                for rule in definition.safety_rules:
+                    self.assertIn(rule, content)
+                self.assertIn("Prepared OMH routing", content)
+                self.assertIn("prepared", content.lower())
+
+                # Fallback behavior stays inline, plus the pointer to the moved policy.
+                self.assertIn("`not_available` or `not_observed`", content)
+                self.assertIn(
+                    "native subagents -> Hermes delegation when available, otherwise sequential lanes",
+                    content,
+                )
+                self.assertIn(SHARED_RAIL_REFERENCE_PATH, content)
 
     def test_omh_awareness_context_is_strong_but_bounded(self) -> None:
         workflow_skill_names = {template.name for template in builtin_skill_templates()} - {"oh-my-hermes"}

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -661,6 +661,63 @@ class RouterContentTests(unittest.TestCase):
                 missing = {name: fragments for name, fragments in missing.items() if fragments}
                 self.assertEqual(missing, {})
 
+    def test_shared_common_rail_reference_carries_moved_policy(self) -> None:
+        """Replacement gate for the policy issue #634 moved out of every SKILL.md body.
+
+        Nothing may leave a skill body without landing verbatim in the shared rail, and the
+        rail only resolves if it ships with a skill both install profiles write to disk.
+        """
+        from omh.skills.catalog import CORE_PROFILE_SKILLS
+        from omh.skills.render import (
+            DELEGATION_RECORD_COMMAND,
+            EXECUTION_RULES,
+            HARNESS_DISCIPLINE_RULES,
+            RUNTIME_MECHANISM_TRANSLATIONS,
+            SHARED_RAIL_REFERENCE_PATH,
+            TARGET_TOPOLOGY_SKILL_CHANGE_CONTRACT,
+            TARGET_TOPOLOGY_SKILL_CONTRACT,
+        )
+
+        rail_skill, _, rail_relative = SHARED_RAIL_REFERENCE_PATH.partition("/")
+        rail = next(
+            template
+            for template in builtin_skill_reference_templates()
+            if template.skill_name == rail_skill and template.relative_path == rail_relative
+        )
+
+        # The rail lives on a skill the core profile installs, so both profiles resolve it.
+        self.assertIn(rail_skill, CORE_PROFILE_SKILLS)
+        self.assertEqual(
+            Path("skills") / SHARED_RAIL_REFERENCE_PATH,
+            Path("skills") / rail.skill_name / rail.relative_path,
+        )
+        self.assertEqual(
+            (Path("skills") / SHARED_RAIL_REFERENCE_PATH).read_text(encoding="utf-8"),
+            rail.content,
+        )
+
+        moved = (
+            *HARNESS_DISCIPLINE_RULES,
+            *RUNTIME_MECHANISM_TRANSLATIONS,
+            *EXECUTION_RULES,
+            DELEGATION_RECORD_COMMAND,
+            TARGET_TOPOLOGY_SKILL_CONTRACT,
+            TARGET_TOPOLOGY_SKILL_CHANGE_CONTRACT,
+        )
+        for fragment in moved:
+            with self.subTest(fragment=fragment[:48]):
+                self.assertIn(fragment, rail.content)
+
+        for template in builtin_skill_templates():
+            if template.name == rail_skill:
+                continue
+            with self.subTest(skill=template.name):
+                self.assertIn(SHARED_RAIL_REFERENCE_PATH, template.content)
+                # The moved bodies must not silently reappear in a skill body.
+                self.assertNotIn(HARNESS_DISCIPLINE_RULES[1], template.content)
+                self.assertNotIn(EXECUTION_RULES[0], template.content)
+                self.assertNotIn(DELEGATION_RECORD_COMMAND, template.content)
+
     def test_hermes_setup_skills_share_five_step_contract_and_skip_semantics(self) -> None:
         hermes_setup_skill_names = (
             "model-setup",
@@ -2183,7 +2240,10 @@ class RouterContentTests(unittest.TestCase):
     def test_workflow_skills_refer_to_harness_discipline(self) -> None:
         skills = {skill.name: skill for skill in builtin_skill_templates()}
 
-        self.assertIn("Harness Discipline", skills["ultragoal"].content)
+        # Harness discipline moved to the shared rail reference (issue #634); each skill
+        # keeps the pointer instead of its own verbatim copy. The rail's own content is
+        # gated by test_shared_common_rail_reference_carries_moved_policy below.
+        self.assertIn("oh-my-hermes/references/skill-common-rail.md", skills["ultragoal"].content)
         self.assertIn("Catalog Metadata", skills["ultragoal"].content)
         self.assertIn("Category: `execution`", skills["ultragoal"].content)
         self.assertIn("Phase: `durable-goals`", skills["ultragoal"].content)
@@ -2238,7 +2298,6 @@ class RouterContentTests(unittest.TestCase):
         self.assertIn("one delivery cycle", skills["ultraprocess"].content)
         self.assertIn("lane owner, next action, and missing evidence", skills["ultraprocess"].content)
         self.assertIn("PR readiness", skills["ultraprocess"].content)
-        self.assertIn("Prefer richer evidence and clearer stop conditions", skills["code-review"].content)
         self.assertIn("Findings come first", skills["code-review"].content)
         self.assertIn("independent review evidence", skills["code-review"].content)
         self.assertIn("hermes_coding_harness/v1", skills["code-review"].content)


### PR DESCRIPTION
## Feature Report

### What Changed

- Added `omh docs skill-context-cost` (`omh_skill_context_cost/v1`), a reproducible report that measures the always-loaded `SKILL.md` body of the core and full install profiles and derives how much of it is repeated verbatim across skills.
- Moved four invariant sections out of every generated workflow skill body into one shared progressive-disclosure reference, `skills/oh-my-hermes/references/skill-common-rail.md`: Harness Discipline, the runtime-mechanism translation table, the generic delegation-record command, and the Execution Rules checklist.
- Kept the tap self-containment floor inline in every skill: its own harness and record command, the observed-vs-unavailable delegation rule, the Hermes-native tool contract with its native-subagent fallback, target topology, its memory-context policy, and the pointer to the shared rail.
- Added two standing gates: a measurement/ceiling test and a differential test on triggers, evidence boundaries, and fallback behavior.
- Regenerated all 87 affected `skills/*/SKILL.md` from `render.py`. `docs/WORKFLOWS.md`, `docs/ROLES.md`, the capability-families sidecar, and the demo cards regenerate byte-identical (the moved sections are skill-body only), so they carry no diff.

Closes #634.

### Why This Exists

The issue is aggregate per-turn prompt cost and maintenance drift, not any one oversized skill. Measured on `main`, the full profile's always-loaded skill body was **781,084 bytes (~195,271 estimated tokens) across 88 skills, of which 327,007 bytes (41.87%) were byte-identical duplicates** of another skill's same-heading section. `src/install/installer.py:_context_cost_warning` already warned operators about this in skill *counts*; there was no way to see the bytes, and no gate to stop the rail from growing.

### User / Operator Impact

Measured with identical accounting on both trees:

| Surface | Before (`main`) | After | Delta |
| --- | --- | --- | --- |
| Full profile, always-loaded skill body | 781,084 B | 689,908 B | **-91,176 B (-11.67%)** |
| Full profile, estimated tokens | ~195,271 | ~172,477 | **-22,794** |
| Full profile, repeated share | 41.87% | 36.49% | -5.38 pp |
| Core profile, always-loaded skill body | 75,157 B | 66,773 B | **-8,384 B (-11.16%)** |
| Core profile, estimated tokens | ~18,790 | ~16,694 | -2,096 |
| On-demand references | 7 files / 68,438 B | 8 files / 71,521 B | +3,083 B (never per-turn) |

Net on disk: -88,093 bytes. Operators get `omh docs skill-context-cost` to check this themselves, documented in `docs/INSTALLATION.md` next to the existing context-cost warning and in `docs/ADDING-A-SKILL.md` as a step when adding a skill.

**The reduction is more modest than the raw duplicate figure suggests, and that is deliberate.** See Risk for the largest block I chose not to touch and why.

### How It Works

**Measurement (`src/skills/context_cost.py`).** Two cost classes are tracked separately because they load differently: `skill_body` (`skills/<name>/SKILL.md`, carried whenever Hermes has the skill in context) and `reference` (`references/*.md`, loaded only when something points at it). Repetition is derived, never hand-classified: each body is split on `## ` headings, and for each heading the report counts occurrences, distinct bodies, and `duplicate_bytes` — what an install pays for the second and later copies. The `## ` line stays at the head of its own section so a skill's section bytes sum to exactly `len(content)`; a repeated heading line is repeated cost too, and nothing hides in the gaps. Token figures are a documented `chars/4` estimate for before/after comparison, not tokenizer output.

**Classification.** The report drove the split rather than the reverse:

| Section | Full-profile duplicate bytes | Decision |
| --- | --- | --- |
| Hermes Compatibility Contract | 115,720 | **Split.** Translation table + execution rules moved; intent/stop-conditions, Hermes-native tool contract, native-subagent fallback, target topology, and memory-context policy stay inline. |
| OMH Context Rail | 110,694 | **Kept inline.** See Risk. |
| Execution Rules | 31,906 | **Moved.** Generic procedure; its one safety duty (say so and fall back when a capability is missing) is folded into the inline compatibility bullet. |
| Harness Discipline | 31,218 | **Moved.** Already only a pointer at the `oh-my-hermes` harness registry. |
| Runtime Evidence | 0 (all 88 distinct) | **Kept inline**, trimmed: the skill-specific `omh runtime record` line and the `not_available`/`not_observed` rule stay; the invariant `omh runtime delegate` recipe moved. |
| Do Not Use When / Completion Checklist / Recovery Notes | 27,403 combined | **Untouched.** Duplication here comes from catalog data reused across skills; deduping it means catalog surgery, which is out of scope for this issue. |

**Resolution path.** The rail ships with `oh-my-hermes`, which is in `CORE_SKILLS` and therefore in `CORE_PROFILE_SKILLS`, so both profiles write it to disk. Verified by running `install_skill_pack` into a temp dir for each profile:

```
core: skills=9  refs=8 rail_on_disk=True rail_bytes=3083  plan points at rail: True -> resolves: True
full: skills=88 refs=8 rail_on_disk=True rail_bytes=3083  plan points at rail: True -> resolves: True
```

`docs workflows --check` tap-skills staleness reports `96/96 checked, missing/stale/extra all empty`. (The install manifest records `SKILL.md` files only, never reference files — pre-existing behavior shared by all seven existing references, unchanged here.)

**Demonstrating routing and evidence behavior is unchanged.** Routing in this repo is deterministic Python that never reads `SKILL.md`, so `test_skill_triggers_and_evidence_boundaries_survive_common_rail_move` asserts the router directly *and* asserts the rendered bodies, for two core-profile skills (`plan`, `ops-observability-card`) and two full-profile-only skills (`code-review`, `ultragoal`): `route_chat_message` still selects the skill from its own first trigger; every catalog trigger is still listed in the body; every catalog `safety_rule` is still inline; and the `Prepared OMH routing` boundary, the `not_available`/`not_observed` fallback, and the native-subagent fallback are all still inline.

The strongest evidence is a test I did **not** write. An earlier, more aggressive version of this patch moved the delegation-record prose and the native-subagent fallback into the reference; the repo's existing `test_all_tap_skills_include_subagent_fallback_contract` failed for all 88 skills. That contract is left completely unchanged and now gates the inline floor.

### Files And Contracts Touched

- `src/skills/context_cost.py` (new) — `omh_skill_context_cost/v1` accounting.
- `src/commands/docs.py` — `docs skill-context-cost` subcommand (report only; no `--check`, it is not a generated artifact).
- `src/skills/render.py` — shared-rail constants, `_router_skill_common_rail_reference()`, `_common_rail_sections()` shared by `workflow_skill` and `memory_sync_skill` (removing a duplicated tail inside `render.py` itself), compacted target-topology bullet, dead `_target_topology_skill_contract_bullets` removed.
- `skills/oh-my-hermes/references/skill-common-rail.md` (new, generated, 3,083 B) + 87 regenerated `skills/*/SKILL.md`.
- `tests/test_router_content.py` — new `test_shared_common_rail_reference_carries_moved_policy`; two assertions in `test_workflow_skills_refer_to_harness_discipline` retargeted from the removed inline copy to the rail pointer.
- `tests/test_efficiency.py` — new measurement/ceiling test and differential test.
- `docs/INSTALLATION.md`, `docs/ADDING-A-SKILL.md`.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests` — **Ran 1571 tests, OK (skipped=1)**
- [x] `uv run python -m compileall -q src tests` — clean
- [x] `uv run python -m omh.cli docs workflows --check` — `ok: true`, `tap_skills: {expected: 96, checked: 96, missing: [], stale: [], extra: []}`
- [x] `uv run python -m omh.cli docs roles --check` — `ok: true`
- [x] `uv run python -m omh.cli docs capability-families --check` — `ok: true`
- [x] `uv run python -m omh.cli harness validate` — `ok: true`, `errors: []`, `warnings: []`
- [x] `uv run python -m omh.cli release checklist --json` — exit 0, `required_item_count: 34`
- [x] `uv run python -m omh.cli release hermes-smoke` — exit 0 (plan mode; not live)
- [x] `omh --help`
- [x] `git diff --check` — clean
- [x] Dry-run / smoke: `install_skill_pack` into a temp dir for `core` and `full`, confirming the shared reference lands on disk and the inline pointer resolves in both profiles (output above)
- [x] New measurement report before/after, computed by running the committed accounting code against `main`'s and `HEAD`'s `skills/` trees
- [ ] Manual Hermes/TUI check — **not run.** No live Hermes Agent available in this environment; the tap path is covered by the `docs workflows --check` staleness gate and the temp-dir install above, not by an observed Hermes load.

## Risk

**The largest remaining repeated block was deliberately left in place.** `## OMH Context Rail` is now the single biggest duplicate contributor at **110,694 bytes (16.0% of the current full-profile body)** — 87 occurrences with only 6 distinct bodies, since the only skill-specific line is the lane. Compacting it would roughly double this PR's savings. I did not, for three reasons:

1. `tests/test_router_content.py` contracts `Product context:`, `Cross-skill context:`, and `Coverage:` inline for **every** skill; `src/maintenance/release.py:WORKFLOW_CONTEXT_MARKERS` and `tests/test_memory_sync_skill.py` add more. The repo has explicitly decided this text is per-skill.
2. Its `Generic-tool checkpoint:` bullet is cross-lane routing guidance (`image->img-summary; frontend->...`). The issue explicitly scopes out removing routing triggers.
3. It renders from `src/plugin_bundle/omh/awareness.py`, a vendored bundle also consumed by the plugin runtime with its own char budgets. Changing it reaches well past `render.py`.

That is a separate change with separate risk, and the new report now quantifies it precisely for whoever takes it on. Reporting an honest 11.67% with a durable gate beats stripping test-contracted routing and safety text to hit a rounder number.

Second risk: **the shared rail is a new resolution dependency.** A workflow skill tapped standalone without `oh-my-hermes` would see a pointer to a file it does not have. Mitigated by keeping the self-containment floor inline (gated by the untouched `test_all_tap_skills_include_subagent_fallback_contract`), by the pointer itself instructing the model to name the unavailable capability rather than assume it, and by `oh-my-hermes` being in `CORE_SKILLS` so every documented install path ships it.

Third: the new reference could **not** be added to the router's Progressive Disclosure list. The `oh-my-hermes` body is 11,969 bytes against a 12,000-byte gate — 31 bytes of headroom. Per that gate's own comment, a ceiling is raised deliberately or not at all, and this did not justify raising it. The rail is discovered from each workflow skill's inline pointer, which is where it is needed.

## Compatibility / Rollout

No schema, CLI, or contract removals. `omh_skill_context_cost/v1` is additive and read-only. Existing installs converge on the next `omh setup` / `omh update`, which rewrites managed skills and writes the new reference; a stale install keeps working because the inline floor is self-sufficient and the pointer degrades to a named missing capability. `git diff --stat`: 95 files, +972 / -2438.

## Release / Claims

- [x] Release-channel impact considered — no channel impact; generated-artifact and report change only
- [x] Runtime/native capability claims are backed by evidence or marked as not observed — byte and token figures come from the committed accounting code run against both trees; token figures are labeled a `chars/4` estimate, not tokenizer output; the install-path check is a temp-dir `install_skill_pack`, not an observed Hermes tap
- [x] Known manual Hermes checks are listed — no live Hermes Agent was available, so `omh release hermes-smoke --live` and a real tap install remain unobserved

## Follow-Up

- Compacting `## OMH Context Rail` is the next measured lever, worth ~110,694 duplicate bytes. It needs `src/plugin_bundle/omh/awareness.py`, the per-skill rail assertions in `test_router_content.py`, `WORKFLOW_CONTEXT_MARKERS`, and the awareness char budgets moved together.
- `Do Not Use When` / `Completion Checklist` / `Recovery Notes` carry 27,403 duplicate bytes from catalog entries reusing identical wording across skills — a catalog-authoring cleanup, now visible per-heading in the report.
