### PR TITLE
feat: give named coding-agent delivery precedence over advisor and feedback lanes

### DIFF
--- a/src/plugin_bundle/omh/awareness.py
+++ b/src/plugin_bundle/omh/awareness.py
@@ -118,6 +118,73 @@ except ImportError:  # pragma: no cover - exercised by standalone plugin hosts.
         )
 
 try:
+    from ...routing.executor_cues import (
+        CODING_DELIVERY_REQUEST_PHRASES as _CODING_DELIVERY_REQUEST_PHRASES,
+        CODING_DELIVERY_REQUEST_TOKENS as _CODING_DELIVERY_REQUEST_TOKENS,
+        NAMED_CODING_AGENT_PHRASES as _NAMED_CODING_AGENT_PHRASES,
+    )
+except ImportError:  # pragma: no cover - exercised by standalone plugin hosts.
+    _NAMED_CODING_AGENT_PHRASES = (
+        "codex",
+        "코덱스",
+        "claude code",
+        "claude-code",
+        "claudecode",
+        "클로드 코드",
+        "클로드코드",
+        "hermes coding",
+        "헤르메스 코딩",
+        "헤르메스가 코딩",
+        "헤르메스한테 코딩",
+    )
+    _CODING_DELIVERY_REQUEST_PHRASES = (
+        "open a pr",
+        "open the pr",
+        "raise a pr",
+        "send a pr",
+        "write the code",
+        "until tests pass",
+        "해결",
+        "고쳐",
+        "고치",
+        "구현",
+        "수정",
+        "만들어",
+        "작성",
+        "추가",
+        "개선",
+        "테스트",
+        "짜줘",
+        "짜 줘",
+        "처리해",
+        "작업해",
+        "実装",
+        "修正",
+        "解決",
+        "対応",
+        "直して",
+        "テスト",
+        "实现",
+        "修复",
+        "解决",
+        "测试",
+    )
+    _CODING_DELIVERY_REQUEST_TOKENS = frozenset(
+        {
+            "fix",
+            "fixes",
+            "implement",
+            "implementation",
+            "patch",
+            "pr",
+            "resolve",
+            "solve",
+            "test",
+            "tests",
+        }
+    )
+
+try:
     from ...routing.materials_cues import OFFICE_FILE_MATERIAL_PHRASES as _OFFICE_FILE_MATERIAL_PHRASES
 except ImportError:
     _OFFICE_FILE_MATERIAL_PHRASES = (
@@ -4401,10 +4468,13 @@ def _awareness_route_hint_cached(message: str, max_hints: int) -> dict[str, obje
                         else [],
                     }
                 )
+        named_coding_agent_delivery = _named_coding_agent_delivery_signal(routing_normalized, tokens)
         for rule in _ROUTE_HINT_RULES:
             if len(hints) >= hint_limit:
                 break
             if _rule_suppressed_by_omh_quality_intent(rule, omh_quality_intent):
+                continue
+            if _rule_suppressed_by_named_coding_agent_delivery(rule, named_coding_agent_delivery):
                 continue
             if _rule_suppressed_by_reference_intent(rule, intent):
                 continue
@@ -4479,6 +4549,28 @@ def _awareness_route_hint_cached(message: str, max_hints: int) -> dict[str, obje
             "tool invocation, generated output, verification, review, CI, merge, or proof that routing was correct."
         ),
     }
+
+
+def _named_coding_agent_delivery_signal(routing_normalized: str, tokens: set[str]) -> bool:
+    """Explicit coding-agent name plus a coding-delivery request.
+
+    Awareness-side twin of the chat router's
+    `named_coding_agent_delivery_before_advisor_or_feedback` guard: it keeps the request on
+    the coding handoff lane instead of the customer-signal lane. It selects a prepared lane
+    only and never dispatches an executor.
+    """
+    if not any(phrase in routing_normalized for phrase in _NAMED_CODING_AGENT_PHRASES):
+        return False
+    if any(phrase in routing_normalized for phrase in _CODING_DELIVERY_REQUEST_PHRASES):
+        return True
+    return bool(_CODING_DELIVERY_REQUEST_TOKENS & tokens)
+
+
+def _rule_suppressed_by_named_coding_agent_delivery(
+    rule: dict[str, object],
+    named_coding_agent_delivery: bool,
+) -> bool:
+    return named_coding_agent_delivery and rule.get("id") == "customer_signal"
 
 
 def _route_hint_rule_matches(

--- a/src/routing/executor_cues.py
+++ b/src/routing/executor_cues.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+
+# Explicit coding-agent / coding-runtime names.
+#
+# Bare "claude" and bare "gemini" are intentionally absent: they are external-advisor
+# names as often as executor names, and treating them as executor selection would
+# break advisor routing. Only unambiguous executor names belong here. Product names
+# stay in Latin script because ja/zh users write them that way too.
+NAMED_CODING_AGENT_PHRASES: tuple[str, ...] = (
+    "codex",
+    "코덱스",
+    "claude code",
+    "claude-code",
+    "claudecode",
+    "클로드 코드",
+    "클로드코드",
+    "hermes coding",
+    "헤르메스 코딩",
+    "헤르메스가 코딩",
+    "헤르메스한테 코딩",
+)
+
+# Multi-word or non-tokenizable coding-delivery requests.
+#
+# Japanese entries avoid dakuten/handakuten characters because `normalized_phrase`
+# strips combining marks, so only mark-free forms survive on both routing surfaces.
+CODING_DELIVERY_REQUEST_PHRASES: tuple[str, ...] = (
+    "open a pr",
+    "open the pr",
+    "raise a pr",
+    "send a pr",
+    "write the code",
+    "until tests pass",
+    "해결",
+    "고쳐",
+    "고치",
+    "구현",
+    "수정",
+    "만들어",
+    "작성",
+    "추가",
+    "개선",
+    "테스트",
+    "짜줘",
+    "짜 줘",
+    "처리해",
+    "작업해",
+    "実装",
+    "修正",
+    "解決",
+    "対応",
+    "直して",
+    "テスト",
+    "实现",
+    "修复",
+    "解决",
+    "测试",
+)
+
+# Single English tokens that are unambiguous coding-delivery requests once an
+# explicit coding-agent name is already present in the same message.
+CODING_DELIVERY_REQUEST_TOKENS: frozenset[str] = frozenset(
+    {
+        "fix",
+        "fixes",
+        "implement",
+        "implementation",
+        "patch",
+        "pr",
+        "resolve",
+        "solve",
+        "test",
+        "tests",
+    }
+)

--- a/src/routing/policy.py
+++ b/src/routing/policy.py
@@ -3,6 +3,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from functools import lru_cache
 
+from .executor_cues import (
+    CODING_DELIVERY_REQUEST_PHRASES,
+    CODING_DELIVERY_REQUEST_TOKENS,
+    NAMED_CODING_AGENT_PHRASES,
+)
 from .intent import classify_omh_quality_intent
 from .localization import normalized_phrase, routing_tokens
 from .materials_cues import OFFICE_FILE_MATERIAL_PHRASES
@@ -4370,6 +4375,21 @@ DIRECT_CODING_TASK_GUARD = RoutingGuardRule(
     why="Matched explicit code-edit language; prepare one bounded implementation cycle instead of asking which workflow to use.",
     activation_status="active",
 )
+NAMED_CODING_AGENT_DELIVERY_GUARD = RoutingGuardRule(
+    id="named_coding_agent_delivery_before_advisor_or_feedback",
+    rule=(
+        "An explicit coding-agent name plus a coding-delivery request should route to the one-cycle "
+        "delivery lane before external-advisor or customer-feedback lanes."
+    ),
+    matched_label="guard:named_coding_agent_delivery",
+    preferred_skills=("ultraprocess",),
+    score_boost=30,
+    why=(
+        "Matched an explicit coding-agent name with a delivery request; prepare a one-cycle coding handoff "
+        "for the named executor instead of external advice or feedback triage."
+    ),
+    activation_status="active",
+)
 CODING_HANDOFF_STATUS_GUARD = RoutingGuardRule(
     id="coding_handoff_status_before_clarify",
     rule="Executor-named coding handoff plus progress/status tracking should route to Ultraprocess instead of generic clarification.",
@@ -4649,6 +4669,7 @@ ROUTING_GUARD_RULES = (
     DELIVERABLE_PACKAGE_GUARD,
     DELIVERY_CYCLE_GUARD,
     DIRECT_CODING_TASK_GUARD,
+    NAMED_CODING_AGENT_DELIVERY_GUARD,
     CODING_HANDOFF_STATUS_GUARD,
 )
 
@@ -4755,10 +4776,12 @@ def _active_routing_guard_rules_cached(
     )
     if direct_coding_task_applies:
         rules.append(DIRECT_CODING_TASK_GUARD)
+    named_coding_agent_delivery_applies = named_coding_agent_delivery_requested(normalized_query, query_tokens)
     feedback_before_coding_applies = _feedback_before_coding_guard_applies(
         normalized_query,
         query_tokens,
         direct_coding_task_applies=direct_coding_task_applies,
+        named_coding_agent_delivery_applies=named_coding_agent_delivery_applies,
     )
     if feedback_before_coding_applies:
         rules.append(FEEDBACK_BEFORE_CODING_GUARD)
@@ -4946,6 +4969,11 @@ def _active_routing_guard_rules_cached(
         rules.append(CODING_HANDOFF_STATUS_GUARD)
     if delivery_cycle_applies:
         rules.append(DELIVERY_CYCLE_GUARD)
+    # Appended last on purpose: an explicit coding-agent name plus a delivery request
+    # outranks generic advisor and customer-signal routing, but never outranks a more
+    # specific lane that already claimed the message.
+    if named_coding_agent_delivery_applies:
+        rules.append(NAMED_CODING_AGENT_DELIVERY_GUARD)
     return tuple(rules)
 
 
@@ -5165,8 +5193,15 @@ def _feedback_before_coding_guard_applies(
     query_tokens: set[str],
     *,
     direct_coding_task_applies: bool | None = None,
+    named_coding_agent_delivery_applies: bool | None = None,
 ) -> bool:
     if _explicit_executor_delegation_requested(normalized_query, query_tokens):
+        return False
+    if named_coding_agent_delivery_applies is None:
+        named_coding_agent_delivery_applies = named_coding_agent_delivery_requested(normalized_query, query_tokens)
+    # A named coding agent plus a delivery request outranks generic issue/bug wording, but
+    # an explicit customer-report phrase is still real feedback that must be triaged first.
+    if named_coding_agent_delivery_applies and not _contains_phrase(normalized_query, _FEEDBACK_TRIAGE_PHRASES):
         return False
     if _contains_phrase(normalized_query, BROWSER_VISUAL_QA_PHRASES) and not _contains_phrase(
         normalized_query,
@@ -6794,6 +6829,43 @@ def _explicit_executor_delegation_requested(normalized_query: str, query_tokens:
             "let claude",
         ),
     )
+
+
+def named_coding_agent_delivery_requested(normalized_query: str, query_tokens: set[str]) -> bool:
+    """Explicit coding-agent name plus a coding-delivery request.
+
+    This is the precedence signal that keeps a request like "claude code로 이 이슈 해결해줘"
+    on the coding handoff lane instead of the external-advisor (`ask`) or customer-feedback
+    (`feedback-triage`) lanes. It never dispatches anything; it only selects the prepared
+    coding lane.
+    """
+    if not _contains_phrase(normalized_query, NAMED_CODING_AGENT_PHRASES):
+        return False
+    delivery = _contains_phrase(normalized_query, CODING_DELIVERY_REQUEST_PHRASES) or bool(
+        CODING_DELIVERY_REQUEST_TOKENS & query_tokens
+    )
+    if not delivery:
+        return False
+    if _contains_phrase(
+        normalized_query,
+        ("before coding", "before code", "before implementation", "before writing code", "구현 전에", "코딩 전에"),
+    ):
+        return False
+    if _safe_feature_plan_guard_applies(normalized_query, query_tokens):
+        return False
+    if _risky_refactor_guard_applies(normalized_query, query_tokens):
+        return False
+    if _cleanup_refactor_guard_applies(normalized_query, query_tokens):
+        return False
+    if _coding_progress_status_guard_applies(normalized_query, query_tokens):
+        return False
+    if _github_event_ops_guard_applies(normalized_query, query_tokens):
+        return False
+    if _doctor_health_guard_applies(normalized_query, query_tokens):
+        return False
+    if _release_claim_review_guard_applies(normalized_query, query_tokens):
+        return False
+    return True
 
 
 def _executor_runtime_readiness_guard_applies(normalized_query: str, query_tokens: set[str]) -> bool:

--- a/src/routing/recommend.py
+++ b/src/routing/recommend.py
@@ -71,6 +71,7 @@ _GUARDRAIL_CANDIDATE_INJECTION_IDS = frozenset(
         "materials_package_before_report_or_clarify",
         "memory_curation_before_generic_clarification",
         "media_input_operator_before_generic_content_or_direct",
+        "named_coding_agent_delivery_before_advisor_or_feedback",
         "ops_observability_before_generic_loop",
         "release_claim_review_before_file_lookup",
         "safe_feature_change_before_generic_plan",

--- a/tests/test_named_executor_precedence.py
+++ b/tests/test_named_executor_precedence.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import unittest
+
+from _local_package import load_local_package
+
+load_local_package()
+
+from omh.plugin_bundle.omh.awareness import awareness_route_hint
+from omh.routing.chat import route_chat_message
+from omh.routing.localization import normalized_phrase, prepare_routing_text, routing_tokens
+from omh.routing.policy import named_coding_agent_delivery_requested
+from omh.wrapper.contract import build_chat_interaction_payload
+
+
+CODING_HANDOFF_SKILL = "ultraprocess"
+EXECUTOR_READINESS_SKILL = "executor-runtime-readiness"
+CODING_LANES = frozenset({CODING_HANDOFF_SKILL, EXECUTOR_READINESS_SKILL})
+
+# One shared message set for both public routing surfaces. Each entry is
+# (language, message, expected chat skill, expected awareness workflow). The
+# "have codex" row keeps its existing delegation-phrasing owner on the chat side;
+# both surfaces still stay on a coding lane instead of advisor or feedback triage.
+NAMED_EXECUTOR_DELIVERY_MATRIX: tuple[tuple[str, str, str, str], ...] = (
+    ("ko", "claude code로 이 이슈 해결해줘", CODING_HANDOFF_SKILL, CODING_HANDOFF_SKILL),
+    ("ko", "codex로 이 버그 고쳐줘", CODING_HANDOFF_SKILL, CODING_HANDOFF_SKILL),
+    ("ko", "헤르메스 코딩으로 이 이슈 구현해줘", CODING_HANDOFF_SKILL, CODING_HANDOFF_SKILL),
+    ("en", "use claude code to fix this issue", CODING_HANDOFF_SKILL, CODING_HANDOFF_SKILL),
+    ("en", "use codex to fix the login bug", CODING_HANDOFF_SKILL, CODING_HANDOFF_SKILL),
+    ("en", "get codex to open a pr for this fix", CODING_HANDOFF_SKILL, CODING_HANDOFF_SKILL),
+    ("en", "have codex implement this fix", EXECUTOR_READINESS_SKILL, CODING_HANDOFF_SKILL),
+    ("ja", "codexでこの問題を修正して", CODING_HANDOFF_SKILL, CODING_HANDOFF_SKILL),
+    ("ja", "claude codeでこのissueを解決して", CODING_HANDOFF_SKILL, CODING_HANDOFF_SKILL),
+    ("zh", "用 codex 修复这个问题", CODING_HANDOFF_SKILL, CODING_HANDOFF_SKILL),
+    ("zh", "用 claude code 实现这个功能", CODING_HANDOFF_SKILL, CODING_HANDOFF_SKILL),
+)
+
+# Overroute guards: advisor requests that name Claude without any coding-delivery
+# signal. Awareness has no advisor lane, so only the chat router is asserted here.
+BARE_ADVISOR_MESSAGES: tuple[tuple[str, str], ...] = (
+    ("en", "consult claude about this architecture decision"),
+    ("en", "get an external advisor opinion from claude"),
+    ("en", "ask claude for a second opinion on this plan"),
+    ("ko", "claude 의견 좀 들어보자"),
+)
+
+# Overroute guards: issue/bug wording with no named coding agent and no delivery
+# request stays customer-signal work on both surfaces.
+CUSTOMER_SIGNAL_MESSAGES: tuple[tuple[str, str], ...] = (
+    ("en", "this issue keeps happening for our customers"),
+    ("en", "users report a bug in the checkout page"),
+    ("ko", "고객들이 결제 실패 이슈를 계속 제보해요"),
+    ("zh", "用户一直反馈这个 bug"),
+)
+
+
+def _policy_signal(message: str) -> bool:
+    normalized_query = normalized_phrase(prepare_routing_text(message).scoring_text)
+    return named_coding_agent_delivery_requested(normalized_query, routing_tokens(normalized_query))
+
+
+class NamedExecutorPrecedenceTests(unittest.TestCase):
+    def test_named_executor_delivery_selects_coding_lane_on_both_surfaces(self) -> None:
+        for language, message, chat_skill, hint_workflow in NAMED_EXECUTOR_DELIVERY_MATRIX:
+            with self.subTest(language=language, message=message):
+                route = route_chat_message(message)
+                hint = awareness_route_hint(message)
+
+                self.assertEqual(route["selected_skill"], chat_skill)
+                self.assertEqual(route["confidence"], "high")
+                self.assertEqual(hint["selected_workflow"], hint_workflow)
+                self.assertIn(route["selected_skill"], CODING_LANES)
+                self.assertIn(hint["selected_workflow"], CODING_LANES)
+
+    def test_named_executor_delivery_never_selects_advisor_or_feedback_lanes(self) -> None:
+        for language, message, _chat_skill, _hint_workflow in NAMED_EXECUTOR_DELIVERY_MATRIX:
+            with self.subTest(language=language, message=message):
+                self.assertNotIn(route_chat_message(message)["selected_skill"], {"ask", "feedback-triage"})
+                self.assertNotEqual(awareness_route_hint(message)["selected_workflow"], "feedback-triage")
+
+    def test_reproduced_request_selects_the_same_lane_on_both_surfaces(self) -> None:
+        message = "claude code로 이 이슈 해결해줘"
+        route = route_chat_message(message)
+        hint = awareness_route_hint(message)
+
+        self.assertEqual(route["selected_skill"], hint["selected_workflow"])
+        self.assertEqual(route["selected_skill"], CODING_HANDOFF_SKILL)
+        self.assertIn("guard:named_coding_agent_delivery", route["recommendations"][0]["matched"])
+        self.assertEqual(hint["primary_next_action"], "prepare_one_cycle_delivery")
+        self.assertNotEqual(hint["hints"][0]["id"], "customer_signal")
+
+    def test_bare_claude_advisor_requests_still_select_ask(self) -> None:
+        for language, message in BARE_ADVISOR_MESSAGES:
+            with self.subTest(language=language, message=message):
+                self.assertFalse(_policy_signal(message))
+                self.assertEqual(route_chat_message(message)["selected_skill"], "ask")
+
+    def test_issue_and_bug_without_a_named_executor_stay_feedback_triage(self) -> None:
+        for language, message in CUSTOMER_SIGNAL_MESSAGES:
+            with self.subTest(language=language, message=message):
+                self.assertFalse(_policy_signal(message))
+                self.assertEqual(awareness_route_hint(message)["selected_workflow"], "feedback-triage")
+
+    def test_customer_report_language_still_triages_before_named_executor_delivery(self) -> None:
+        message = "결제 실패 이슈가 자주 나와. 재현 계획 세우고 codex로 고쳐서 리뷰까지 추적해줘"
+
+        self.assertTrue(_policy_signal(message))
+        self.assertEqual(route_chat_message(message)["selected_skill"], "feedback-triage")
+
+    def test_executor_runtime_choice_still_wins_over_delivery_precedence(self) -> None:
+        message = "should i use codex or claude code for this?"
+
+        self.assertEqual(route_chat_message(message)["selected_skill"], EXECUTOR_READINESS_SKILL)
+        self.assertEqual(awareness_route_hint(message)["selected_workflow"], EXECUTOR_READINESS_SKILL)
+
+    def test_named_executor_delivery_stays_prepared_and_never_dispatches(self) -> None:
+        for language, message, chat_skill, _hint_workflow in NAMED_EXECUTOR_DELIVERY_MATRIX:
+            with self.subTest(language=language, message=message):
+                hint = awareness_route_hint(message)
+
+                self.assertTrue(hint["hints"][0]["not_evidence_yet"])
+                self.assertIn("not workflow execution", hint["claim_boundary"])
+
+                if chat_skill != CODING_HANDOFF_SKILL:
+                    continue
+                delegation = build_chat_interaction_payload(message, source="discord")["delegation"]
+                # Both statuses are pre-probe states; "ready" would require observed evidence.
+                self.assertIn(delegation["executor_readiness"]["status"], {"not_observed", "choice_required"})
+                self.assertIn(delegation["dispatch_policy"], {"prepare_only", "ask_before_dispatch"})
+
+
+if __name__ == "__main__":  # pragma: no cover - unittest entry point
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- A request that names an explicit coding agent (Codex, Claude Code, Hermes coding) **and** asks for delivery work (implement / fix / PR / test, or the Korean, Japanese, and Chinese equivalents) now selects the coding handoff lane on **both** public routing surfaces: `route_chat_message` in `src/routing/chat.py` and `awareness_route_hint` in `src/plugin_bundle/omh/awareness.py`.
- New shared cue module `src/routing/executor_cues.py` holds the executor-name and coding-delivery vocabulary used by both surfaces, following the existing `visual_qa_cues` / `materials_cues` pattern.
- New routing guard `named_coding_agent_delivery_before_advisor_or_feedback` (`src/routing/policy.py`) and a matching `customer_signal` suppressor in the awareness hint scan.
- New shared multilingual regression matrix `tests/test_named_executor_precedence.py` exercising the same message set through both surfaces, with the two mandatory overroute guards.

Closes #635

### Why This Exists

Reproduced on `main` before the change:

```
$ PYTHONPATH=src python -c "from omh.routing.chat import route_chat_message; r = route_chat_message('claude code로 이 이슈 해결해줘'); print(r['selected_skill'], r['confidence'], r['recommendations'][0]['matched'])"
ask high ['trigger:claude']

$ PYTHONPATH=src python -c "from omh.plugin_bundle.omh.awareness import awareness_route_hint; h = awareness_route_hint('claude code로 이 이슈 해결해줘'); print(h['selected_workflow'], h['primary_next_action'], h['hints'][0]['matched_cues'])"
feedback-triage triage_feedback ['이슈']
```

Two different wrong answers for one request, and the two paths disagreed with each other.

Root causes, one per surface:

- **Chat router.** The `ask` catalog entry (`src/skills/catalog.py:4660`) carries the bare trigger token `claude`. `_score_definition` matches it twice — once through the phrase leg (`_phrase_match` is bidirectional substring containment, +6) and once through the token leg (+3) — so `ask` reaches score 9 and `high` confidence off a single ambiguous word. No coding lane was activated: `_direct_coding_task_guard_applies` needs both an action token and a "concrete surface" token, and neither `해결해줘` nor `이슈` is in those sets, so `active_routing_guard_rules` returned an empty tuple.
- **Awareness hint.** `_ROUTE_HINT_RULES` is scanned in declaration order and the first surviving match wins. `customer_signal` (feedback-triage) is declared at index ~3872 with the bare substring phrases `이슈` and `버그`; `coding_delivery` is the very last rule in the tuple. Any Korean sentence containing 이슈 therefore reached feedback-triage before the coding lane was ever considered.

This matters more after the move to request-led executor routing: naming Claude Code or Codex explicitly must not be read as generic advisor language or as customer feedback merely because the sentence also contains "issue" or "bug".

### User / Operator Impact

After the change, both surfaces agree:

```
$ PYTHONPATH=src python -c "from omh.routing.chat import route_chat_message; r = route_chat_message('claude code로 이 이슈 해결해줘'); print(r['selected_skill'], r['confidence'], r['recommendations'][0]['matched'])"
ultraprocess high ['guard:named_coding_agent_delivery']

$ PYTHONPATH=src python -c "from omh.plugin_bundle.omh.awareness import awareness_route_hint; h = awareness_route_hint('claude code로 이 이슈 해결해줘'); print(h['selected_workflow'], h['primary_next_action'], h['hints'][0]['matched_cues'])"
ultraprocess prepare_one_cycle_delivery ['claude code', 'claude']
```

A user who says "solve this issue with Claude Code" now gets a prepared one-cycle coding handoff instead of an external-advisor prompt or a feedback triage card. Nothing is dispatched: the delegation payload keeps `dispatch_policy` at `prepare_only` / `ask_before_dispatch`, `executor_readiness.status` at `not_observed` / `choice_required`, and the hint keeps its `not_evidence_yet` list and claim boundary.

The `ask` workflow is untouched, and genuine feedback triage is untouched.

### How It Works

**Precedence rule (encoded once, applied on two surfaces):** an explicit coding-agent name plus a coding-delivery request outranks generic advisor and customer-signal triggers, but never outranks a lane that already claimed the message on more specific evidence.

Shared vocabulary — `src/routing/executor_cues.py`:

- `NAMED_CODING_AGENT_PHRASES`: `codex`, `코덱스`, `claude code`, `claude-code`, `claudecode`, `클로드 코드`, `클로드코드`, `hermes coding`, `헤르메스 코딩`, `헤르메스가 코딩`, `헤르메스한테 코딩`. Bare `claude` and bare `gemini` are deliberately **absent** — they are advisor names as often as executor names, and that is exactly what the mandatory advisor negative case protects.
- `CODING_DELIVERY_REQUEST_PHRASES`: multi-word and non-tokenizable delivery requests in en/ko/ja/zh (`open a pr`, `해결`, `고쳐`, `구현`, `修正`, `実装`, `修复`, `实现`, …). Japanese entries avoid dakuten characters because `normalized_phrase` strips combining marks, so only mark-free forms survive on both surfaces.
- `CODING_DELIVERY_REQUEST_TOKENS`: single English tokens that are unambiguous once an executor name is already present (`fix`, `implement`, `patch`, `pr`, `resolve`, `solve`, `test`, …).

Chat router — `src/routing/policy.py`:

- `named_coding_agent_delivery_requested()` matches through the existing `_contains_phrase` helper (normalized phrases, no raw substring checks) and bails out for planning-before-coding language and for the lanes that must keep precedence: safe-feature-plan, risky-refactor, cleanup-refactor, coding-progress-status, github-event-ops, doctor-health, release-claim-review.
- It drives `NAMED_CODING_AGENT_DELIVERY_GUARD` (preferred skill `ultraprocess`, score boost 30), appended **last** in `_active_routing_guard_rules_cached` — `_preferred_guarded_operator_fast_path_guard` returns the first fast guard in list order, so appending last is what keeps `coding_handoff_status_before_clarify` and friends in charge when they also apply.
- The guard id is registered in `_GUARDRAIL_CANDIDATE_INJECTION_IDS` (`src/routing/recommend.py`) so `ultraprocess` becomes a candidate even when catalog scoring never surfaced it. Boost 30 beats the `ask` trigger score of 9 while staying below strong specific catalog matches such as `ai-slop-cleaner` at 48.
- The same predicate suppresses `_feedback_before_coding_guard_applies`, **except** when explicit customer-report language (`_FEEDBACK_TRIAGE_PHRASES`, e.g. `결제 실패 이슈`, `customer feedback`) is present — a real reported failure still triages first even when the sentence later names Codex.

Awareness hint — `src/plugin_bundle/omh/awareness.py`:

- `_named_coding_agent_delivery_signal()` applies the same vocabulary against `routing_normalized` / ASCII tokens, imported from `src/routing/executor_cues.py` with the standard literal fallback for standalone plugin hosts.
- `_rule_suppressed_by_named_coding_agent_delivery()` suppresses only the `customer_signal` rule inside the ordered scan, letting it fall through to `coding_delivery`.
- Suppression was chosen over a pre-loop hint injection on purpose: injection preempted the higher-priority lanes (omh quality intent, direct workflow invocation, workflow-vocabulary reference, verification gate) and broke `ai-slop-cleaner` alignment. Suppression leaves every one of those in charge.

### Files And Contracts Touched

- `src/routing/executor_cues.py` (new) — shared executor-name and coding-delivery cue vocabulary.
- `src/routing/policy.py` — `NAMED_CODING_AGENT_DELIVERY_GUARD`, `named_coding_agent_delivery_requested()`, guard registration in `ROUTING_GUARD_RULES` and `_active_routing_guard_rules_cached`, new keyword argument on `_feedback_before_coding_guard_applies`.
- `src/routing/recommend.py` — one new guardrail candidate injection id.
- `src/plugin_bundle/omh/awareness.py` — shared-cue import with standalone fallback, `_named_coding_agent_delivery_signal()`, `_rule_suppressed_by_named_coding_agent_delivery()`, one suppressor call in the rule scan.
- `tests/test_named_executor_precedence.py` (new) — shared multilingual regression matrix and overroute guards.

No generated artifact changed: `skills/*/SKILL.md`, `docs/WORKFLOWS.md`, `docs/ROLES.md`, the demo-cards JSON, and `capability_families.json` are all byte-identical, and no exact-count fixture assertion moved (no routing corpus case was added).

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests` — `Ran 1576 tests in 46.888s / OK (skipped=1)`. Baseline on the branch point was `Ran 1568 tests / OK (skipped=1)`; the 8 new tests are this PR's matrix.
- [x] `uv run python -m compileall -q src tests` — clean.
- [x] `uv run python -m omh.cli docs workflows --check` — `"ok": true`, tap skills `checked 95 / expected 95`, no missing/stale/extra.
- [x] `uv run python -m omh.cli docs roles --check` — `"ok": true`.
- [x] `uv run python -m omh.cli docs capability-families --check` — `"ok": true`.
- [x] `git diff --check` — clean.
- [x] `uv run python -m omh.cli harness validate` — `catalog_validation/v1`, no warnings.
- [x] `uv run python -m omh.cli release checklist --json` — exit 0, 34 required items.
- [x] `uv run python -m omh.cli release hermes-smoke` — plan mode, exit 0. Explicitly **not** live smoke evidence.
- [x] `omh --help` — exit 0.
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup ... --include-command-smoke` — not run; this change touches routing only, no setup or install path.
- [ ] Workflow-learning review queue smoke — not applicable; no learning contract changed.
- [x] Reproduction commands from #635 re-run before and after; both outputs are quoted above.
- [ ] Manual Hermes/TUI check — **not run.** No Hermes profile is attached to this worktree, and `release hermes-smoke` was executed in plan mode only.

### New regression coverage

`tests/test_named_executor_precedence.py` drives one shared message set through both `route_chat_message` and `awareness_route_hint`:

- Positive matrix, 11 messages across ko/en/ja/zh, e.g. `claude code로 이 이슈 해결해줘`, `use claude code to fix this issue`, `codexでこの問題を修正して`, `用 claude code 实现这个功能` — each asserted against its expected skill and workflow, and asserted to stay inside the coding lanes.
- `test_reproduced_request_selects_the_same_lane_on_both_surfaces` — the exact issue reproduction, asserting the two surfaces now return the same lane and that the primary hint is no longer `customer_signal`.
- Overroute guard 1 (mandatory): `test_bare_claude_advisor_requests_still_select_ask` — `consult claude about this architecture decision`, `get an external advisor opinion from claude`, `ask claude for a second opinion on this plan`, `claude 의견 좀 들어보자` all still select `ask`, and `named_coding_agent_delivery_requested()` returns `False` for each.
- Overroute guard 2 (mandatory): `test_issue_and_bug_without_a_named_executor_stay_feedback_triage` — `this issue keeps happening for our customers`, `users report a bug in the checkout page`, `고객들이 결제 실패 이슈를 계속 제보해요`, `用户一直反馈这个 bug` all stay `feedback-triage`.
- Overroute guard 3: `test_customer_report_language_still_triages_before_named_executor_delivery` — `결제 실패 이슈가 자주 나와. 재현 계획 세우고 codex로 고쳐서 리뷰까지 추적해줘` still triages first even though the named-executor signal is present.
- Overroute guard 4: `test_executor_runtime_choice_still_wins_over_delivery_precedence` — `should i use codex or claude code for this?` stays on `executor-runtime-readiness` on both surfaces.
- Boundary: `test_named_executor_delivery_stays_prepared_and_never_dispatches` asserts `dispatch_policy`, `executor_readiness.status`, `not_evidence_yet`, and the hint claim boundary for every matrix row.

## Risk

- **Moderate blast radius by design.** The predicate participates in the shared guard pipeline, so a bad phrase entry can move routing for unrelated messages. Three iterations during development each surfaced real overroutes — an `ai-slop-cleaner` refactor request, a multi-stage feedback route plan, and a workflow-vocabulary meta message — and each is now a locked test. The final full-suite run is green with no fixture edits, which is the strongest available evidence that nothing else moved.
- **Vocabulary is the fragile part.** Adding a bare vendor word to `NAMED_CODING_AGENT_PHRASES` would immediately collapse the `ask` lane. The tuple carries a comment saying so.
- **Japanese cue fragility.** `normalized_phrase` strips combining marks, so `で` becomes `て` and `バグ` becomes `ハク` on the chat surface while awareness (NFKC casefold) keeps them. Only mark-free Japanese forms are safe in shared tuples; the module documents this.
- **`have codex implement this fix`** keeps its existing owner `executor-runtime-readiness` on the chat side while awareness reports `ultraprocess`. Both are coding lanes, so the acceptance criterion holds, but the two surfaces are not byte-identical for that phrasing. This predates the PR (`_explicit_executor_delegation_requested` owns "have codex") and is encoded honestly in the matrix rather than papered over.

## Compatibility / Rollout

- Pure routing behavior change. No schema version bumped, no persisted artifact format changed, no new dependency, no network or LLM call added.
- The plugin bundle keeps its standalone `ImportError` fallback, so hosts without the installed `omh` package get the same vocabulary; `test_installed_plugin_capabilities_tool_loads_without_installed_omh_package` covers that path.
- Rollback is a plain revert of the commit; nothing persists state.

## Release / Claims

- [x] Release-channel impact considered — routing-only, ships on the normal channel with no migration.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed — precedence selects a prepared lane only; `prepare_only` / `ask_before_dispatch` and `not_observed` / `choice_required` are asserted in the new tests. No auto-dispatch was added.
- [x] Known manual Hermes checks are listed — `omh release hermes-smoke --live` was **not** run; plan-mode output is not observed smoke evidence.

## Follow-Up

- Consider whether the bare `claude` / `gemini` triggers on the `ask` catalog entry should be narrowed to phrase triggers. They violate the repo rule that token triggers are only for unambiguous single tokens, but removing them today regresses advisor requests such as `consult claude about this architecture decision` that reach `ask` only through that trigger. That is a catalog-and-regeneration change and belongs in its own goal.
- The awareness `coding_delivery` rule still carries the bare token `claude`, which is why `ask claude what it thinks about this plan` reports `ultraprocess` on the awareness surface. This is pre-existing (verified against the branch point) and out of scope here; awareness has no advisor lane to route it to.
- Japanese and Chinese feedback-triage cues do not exist in the catalog yet, so the ja/zh coverage in the new matrix is delivery-side only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
