### PR TITLE
docs: give the BLE001 policy a live owner and a self-checking site inventory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,14 @@ git diff --check
   Pyflakes (`F`) only, scoped narrow to stay actionable on a ~135k LOC repo;
   see the `[tool.ruff]` block in `pyproject.toml` for the per-file re-export
   exclusions and the deliberately-not-yet-enforced broad-exception
-  (`BLE001`) policy tracked under issue #637.
+  (`BLE001`) policy, owned by issue #652.
+- That broad-exception policy is a gate, not a comment.
+  `tests/test_broad_exception_policy.py` re-derives every broad `except` site
+  in `src/` from source and fails when one is not classified as either
+  intentional (the failure is classified and surfaced) or needing the #637
+  treatment (the failure is relabeled as a normal result). Add the verdict in
+  that file when you add a broad `except`; do not record hit counts or line
+  numbers in prose, they drift.
 
 ## Generated Artifacts Map
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,11 +100,20 @@ lint = [
 # style-driven ruleset would demand a repo-wide reformat out of scope for a
 # baseline gate. Broaden the ruleset in follow-up work, not this issue.
 #
-# BLE001 (flake8-blind-except: bare `except Exception`) was evaluated and
-# found 13 hits. It is deliberately NOT selected here: broad-exception
-# handling is a real, tracked defect class (see issue #637) but fixing it is
-# out of scope for this gate. Recorded here so the omission reads as a
-# decision, not an oversight.
+# BLE001 (flake8-blind-except: bare `except Exception`) is deliberately NOT
+# selected here. Re-derive the current sites at any time with:
+#
+#     uv run --group lint ruff check --select BLE001 src
+#
+# A broad `except` is not itself the defect. Around a delegated call it is
+# acceptable when the failure is classified and surfaced, and it is a defect
+# when the failure is relabeled as a normal result — the mislabeling PR #641
+# (issue #637) removed from the `omh_context` and `omh_recommend` plugin
+# tools, which still catch broadly on purpose. Every current site carries that
+# verdict in `tests/test_broad_exception_policy.py`, which re-derives the site
+# list from source and fails when an unclassified one appears, so turning the
+# rule on later is bounded work rather than an open-ended audit. Policy owner:
+# issue #652.
 [tool.ruff]
 target-version = "py311"
 

--- a/tests/test_broad_exception_policy.py
+++ b/tests/test_broad_exception_policy.py
@@ -1,0 +1,246 @@
+"""Gate for the broad-exception (`BLE001`) policy recorded in `pyproject.toml`.
+
+Ruff's `BLE001` (flake8-blind-except) is deliberately not in `select`. That
+omission is a decision, not an oversight, and this module is where the decision
+is kept honest.
+
+The policy, as established by issue #637 / PR #641:
+
+    A broad `except` is not itself the defect. Around a delegated call it is
+    acceptable when the failure is classified and surfaced -- the handler
+    produces a result the caller can tell apart from success and from the
+    "optional dependency absent" path, or reports it on an error channel. It
+    is a defect when the failure is relabeled as a normal result, so a runtime
+    error inside a delegated call becomes indistinguishable from a healthy
+    fallback.
+
+`CLASSIFIED_SITES` below records that verdict for every broad `except` site in
+`src/`, anchored by file plus enclosing function -- never by line number, which
+drifts on unrelated edits. The tests re-derive the live site list from source
+and fail when it stops matching, so a new broad `except` cannot land
+unclassified and enabling `BLE001` later stays bounded work rather than an
+open-ended audit.
+
+Re-derive the same list with Ruff:
+
+    uv run --group lint ruff check --select BLE001 src
+
+`_broad_except_sites()` is intentionally at least as broad as `BLE001`: it
+flags every handler catching `Exception` or `BaseException`, including one
+carrying a `# noqa: BLE001`, because silencing the rule is exactly the case
+that most needs a recorded verdict.
+
+Policy owner: issue #652.
+"""
+
+from __future__ import annotations
+
+import ast
+import tomllib
+import unittest
+from pathlib import Path
+from typing import NamedTuple
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SOURCE_ROOT = REPO_ROOT / "src"
+POLICY_TEST_PATH = "tests/test_broad_exception_policy.py"
+REDERIVE_COMMAND = "uv run --group lint ruff check --select BLE001 src"
+POLICY_OWNER_ISSUE = "#652"
+
+BLIND_EXCEPTION_NAMES = frozenset({"Exception", "BaseException"})
+
+# The failure is classified and surfaced: the caller can tell it apart from
+# both success and the "optional dependency absent" path.
+INTENTIONAL = "intentional_classified_failure"
+# The failure is relabeled as a normal result. Same shape as the defect #637
+# fixed; needs that treatment before `BLE001` can be enforced.
+NEEDS_637_TREATMENT = "needs_637_treatment"
+
+VERDICTS = frozenset({INTENTIONAL, NEEDS_637_TREATMENT})
+
+
+class ClassifiedSite(NamedTuple):
+    path: str
+    function: str
+    verdict: str
+    rationale: str
+
+
+CLASSIFIED_SITES: tuple[ClassifiedSite, ...] = (
+    ClassifiedSite(
+        "src/install/plugin_pack.py",
+        "_register_smoke",
+        INTENTIONAL,
+        "Returns import_smoke=False, register_smoke=False and an `error` string carrying the "
+        "exception text, so a failed smoke run is never readable as a passing one.",
+    ),
+    ClassifiedSite(
+        "src/mcp/bridge.py",
+        "run_stdio_mcp_server",
+        INTENTIONAL,
+        "Defensive stdio transport boundary: prints the exception to stderr and answers the "
+        "JSON-RPC peer with -32603 Internal error instead of a result.",
+    ),
+    ClassifiedSite(
+        "src/plugin_bundle/omh/awareness.py",
+        "_localized_routing_text",
+        NEEDS_637_TREATMENT,
+        "Returns the raw message, the exact value of the `_prepare_routing_text is None` branch "
+        "above it, so a failure inside the delegated call is indistinguishable from the helper "
+        "being absent.",
+    ),
+    ClassifiedSite(
+        "src/plugin_bundle/omh/awareness.py",
+        "_loop_route_hint_next_action",
+        NEEDS_637_TREATMENT,
+        "Returns `default_action`, the exact value of the `_assess_loopability is None` branch, "
+        "so a failed loopability assessment reads as no assessment being available.",
+    ),
+    ClassifiedSite(
+        "src/plugin_bundle/omh/context_brief.py",
+        "_is_catalog_question",
+        NEEDS_637_TREATMENT,
+        "Two handlers in one function. The import guard is accurate -- an import that raises "
+        "means the package path really is unusable, so the standalone answer is the right label. "
+        "The second wraps the delegated `is_skill_catalog_question()` call and returns the same "
+        "standalone answer, which is the mislabeling #637 fixed elsewhere.",
+    ),
+    ClassifiedSite(
+        "src/plugin_bundle/omh/hooks/llm_hooks.py",
+        "pre_llm_call",
+        NEEDS_637_TREATMENT,
+        "Sets status={} and hud={} on failure; the next branch reads empty status as "
+        "`runtime_state_present` being false and injects no context, so a failed status read "
+        "looks like a host with nothing to report.",
+    ),
+    ClassifiedSite(
+        "src/plugin_bundle/omh/host_observation.py",
+        "_record_observation",
+        INTENTIONAL,
+        "Already carries the #637 split: ImportError/ModuleNotFoundError takes the standalone "
+        "path, any other exception returns `_observation_error(...)` with the error text.",
+    ),
+    ClassifiedSite(
+        "src/plugin_bundle/omh/tools/chat_tool.py",
+        "omh_interact_handler",
+        INTENTIONAL,
+        "Already carries the #637 split: ImportError/ModuleNotFoundError takes "
+        "`_fallback_interaction`, any other exception takes `_backend_error_interaction` with the "
+        "error type.",
+    ),
+    ClassifiedSite(
+        "src/plugin_bundle/omh/tools/context_tool.py",
+        "_context_brief",
+        INTENTIONAL,
+        "Fixed by #637: returns `_package_context_error(...)` under the distinct "
+        "`package_context_error` source instead of `standalone_plugin_bundle_fallback`.",
+    ),
+    ClassifiedSite(
+        "src/plugin_bundle/omh/tools/recommend_tool.py",
+        "_recommendations",
+        INTENTIONAL,
+        "Fixed by #637: returns the distinct `package_recommend_error` source plus a sanitized "
+        "error type instead of `standalone_plugin_bundle_fallback`.",
+    ),
+)
+
+# Ruff reports one hit per handler; the inventory is keyed per enclosing
+# function, and `_is_catalog_question` holds two handlers, so the two totals
+# differ by exactly one.
+EXPECTED_HANDLER_COUNT = 11
+EXPECTED_ANCHOR_COUNT = 10
+
+
+class DerivedSite(NamedTuple):
+    path: str
+    function: str
+
+
+def _catches_blind_exception(handler: ast.ExceptHandler) -> bool:
+    caught = handler.type
+    if caught is None:
+        return False
+    parts = caught.elts if isinstance(caught, ast.Tuple) else [caught]
+    return any(isinstance(part, ast.Name) and part.id in BLIND_EXCEPTION_NAMES for part in parts)
+
+
+def _enclosing_function(tree: ast.Module, lineno: int) -> str:
+    innermost = ""
+    innermost_start = -1
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        end = node.end_lineno or node.lineno
+        if node.lineno <= lineno <= end and node.lineno > innermost_start:
+            innermost = node.name
+            innermost_start = node.lineno
+    return innermost or "<module>"
+
+
+def _broad_except_sites() -> list[DerivedSite]:
+    sites: list[DerivedSite] = []
+    for path in sorted(SOURCE_ROOT.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ExceptHandler) and _catches_blind_exception(node):
+                relative = path.relative_to(REPO_ROOT).as_posix()
+                sites.append(DerivedSite(relative, _enclosing_function(tree, node.lineno)))
+    return sites
+
+
+def _pyproject_text() -> str:
+    return (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+
+
+class BroadExceptionPolicyTests(unittest.TestCase):
+    def test_classified_inventory_covers_every_broad_except_site(self) -> None:
+        derived = set(_broad_except_sites())
+        classified = {DerivedSite(site.path, site.function) for site in CLASSIFIED_SITES}
+
+        unclassified = sorted(derived - classified)
+        stale = sorted(classified - derived)
+        self.assertEqual(
+            (unclassified, stale),
+            ([], []),
+            "Broad-exception inventory drifted from source. Re-derive with "
+            f"`{REDERIVE_COMMAND}`, then update CLASSIFIED_SITES in {POLICY_TEST_PATH}: "
+            f"add a verdict for {unclassified or 'nothing'}; drop the stale entries "
+            f"{stale or 'nothing'}.",
+        )
+
+    def test_site_totals_match_the_recorded_counts(self) -> None:
+        self.assertEqual(len(_broad_except_sites()), EXPECTED_HANDLER_COUNT)
+        self.assertEqual(len(CLASSIFIED_SITES), EXPECTED_ANCHOR_COUNT)
+
+    def test_every_site_carries_a_known_verdict_and_a_rationale(self) -> None:
+        for site in CLASSIFIED_SITES:
+            with self.subTest(path=site.path, function=site.function):
+                self.assertIn(site.verdict, VERDICTS)
+                self.assertGreater(
+                    len(site.rationale.strip()),
+                    40,
+                    "Each verdict needs a rationale a reviewer can check against the source.",
+                )
+
+    def test_ble001_stays_unselected_under_the_pyflakes_baseline(self) -> None:
+        config = tomllib.loads(_pyproject_text())
+        select = config["tool"]["ruff"]["lint"]["select"]
+
+        self.assertEqual(select, ["F"], "The baseline gate is Pyflakes-only; broadening it is separate work.")
+        self.assertNotIn("BLE001", select)
+
+    def test_recorded_policy_names_a_live_owner_and_the_rederive_command(self) -> None:
+        # Issue #637 may still be cited as the precedent that established the
+        # classified-versus-relabeled distinction, but it is closed and must not
+        # be the tracking owner. The durable link is this module's path.
+        for relative in ("pyproject.toml", "CLAUDE.md"):
+            text = (REPO_ROOT / relative).read_text(encoding="utf-8")
+            with self.subTest(path=relative):
+                self.assertIn(POLICY_OWNER_ISSUE, text)
+                self.assertIn(POLICY_TEST_PATH, text)
+
+        self.assertIn(REDERIVE_COMMAND, _pyproject_text())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- The `BLE001` (broad `except`) policy now has a live owner (issue #652) instead of pointing at closed issue #637, in both places it is recorded: the comment above `[tool.ruff]` in `pyproject.toml` and the static-analysis bullet in `CLAUDE.md`.
- The hard-coded hit count ("found 13 hits", actually 11 today) is gone from prose entirely, replaced by the reproducible command `uv run --group lint ruff check --select BLE001 src`.
- Both records now state the distinction PR #641 (issue #637) established: **a broad `except` is not itself the defect.** It is acceptable around a delegated call when the failure is classified and surfaced; it is a defect when the failure is relabeled as a normal result.
- New `tests/test_broad_exception_policy.py` records a verdict for every broad-`except` site in `src/` and turns the policy into a CI gate that fails when an unclassified site appears.
- `select = ["F"]` is unchanged, `BLE001` is still not enabled, and no exception handler was refactored.

### Why This Exists

Both recorded copies of the policy had rotted in the two ways a comment rots. The tracking owner (#637) is closed — it fixed exactly two call sites and never claimed to own the rule — so the next contributor reading `pyproject.toml` followed a dead link. And the recorded count was stale by exactly #637's two fixes: 13 written down, 11 reported.

The drift is not hypothetical or one-off. While preparing this change the site list was re-derived twice in one day, and two `awareness.py` line numbers had already moved (4728 -> 4832, 5210 -> 5313) because PR #650 merged in between. Anything line-pinned written into the repo would have been stale before the PR opened.

The decision the comment records is correct and unchanged: a Pyflakes-only baseline gate on a ~135k LOC repo is the right scope, and `BLE001` staying out of `select` is deliberate. Only the bookkeeping around it was wrong.

### User / Operator Impact

For a maintainer this is the difference between an open-ended audit and bounded work. Before: "there are 13-ish broad excepts somewhere, tracked by a closed issue" — enabling `BLE001` meant reading every hit from scratch and re-deriving which ones are fine.

After: every site already carries a verdict and a rationale a reviewer can check against the source, split into two buckets. Turning the rule on is now "fix the 4 sites in the `needs_637_treatment` bucket, then flip `select`". And a contributor who adds a new broad `except` gets a failing test with paste-ready instructions rather than silently growing the backlog.

### How It Works

`tests/test_broad_exception_policy.py` holds `CLASSIFIED_SITES`, one entry per enclosing function, each with a verdict and a rationale. Two verdicts exist, mirroring the #637 distinction:

- `intentional_classified_failure` — the caller can tell the failure apart from success *and* from the "optional dependency absent" path.
- `needs_637_treatment` — the failure is relabeled as a normal result.

Five tests run against it:

1. Re-derive every handler catching `Exception`/`BaseException` under `src/` and assert the derived set equals the classified set. Failure prints the exact anchors to add or drop.
2. Assert the totals: 11 handlers, 10 anchors (`_is_catalog_question` holds two handlers). The count is now a gated assertion rather than a sentence that can drift.
3. Assert every entry has a known verdict and a non-trivial rationale.
4. Assert `select == ["F"]` and that `BLE001` is not in it — the "do not enable this by accident" guard.
5. Assert both `pyproject.toml` and `CLAUDE.md` name the live owner and the test path, and that `pyproject.toml` carries the re-derive command.

Two implementation choices worth flagging for review:

- **Anchored by file + enclosing function, never by line number.** Given the PR #650 drift above, a line-pinned list is stale on arrival.
- **Derivation uses stdlib `ast`, not a `uv run ruff` subprocess.** Shelling out would tie the unittest suite to the `lint` dependency group and a possibly-cold `uv` cache; `ast` runs offline with no new dependency. It reproduces Ruff's 11 hits exactly on this tree (verified against `ruff check --select BLE001 src`), and is documented as intentionally *at least as broad* as `BLE001` — a `# noqa: BLE001` does not exempt a site, since silencing the rule is the case that most needs a recorded verdict.

### Files And Contracts Touched

- `pyproject.toml` — comment above `[tool.ruff]` rewritten. No config keys changed; `select = ["F"]` and the per-file-ignores are byte-identical.
- `CLAUDE.md` — static-analysis bullet repointed at #652, plus a new bullet describing the gate.
- `tests/test_broad_exception_policy.py` — new, no production code touched.

Per-site verdicts, read from source rather than inferred from filenames:

| Site (file + function) | Verdict | Anchor |
| --- | --- | --- |
| `install/plugin_pack.py` `_register_smoke` | intentional | returns `import_smoke=False, register_smoke=False` plus an `error` string |
| `mcp/bridge.py` `run_stdio_mcp_server` | intentional | stderr print + JSON-RPC `-32603 Internal error` instead of a result |
| `plugin_bundle/omh/awareness.py` `_localized_routing_text` | **needs #637** | returns the raw message, identical to the `_prepare_routing_text is None` branch |
| `plugin_bundle/omh/awareness.py` `_loop_route_hint_next_action` | **needs #637** | returns `default_action`, identical to the `_assess_loopability is None` branch |
| `plugin_bundle/omh/context_brief.py` `_is_catalog_question` (import guard) | intentional | an import that raises really does mean the package path is unusable |
| `plugin_bundle/omh/context_brief.py` `_is_catalog_question` (delegated call) | **needs #637** | delegated `is_skill_catalog_question()` failure returns the standalone answer |
| `plugin_bundle/omh/hooks/llm_hooks.py` `pre_llm_call` | **needs #637** | `status={}` reads downstream as `runtime_state_present` false |
| `plugin_bundle/omh/host_observation.py` `_record_observation` | intentional | already splits ImportError from `_observation_error(...)` |
| `plugin_bundle/omh/tools/chat_tool.py` `omh_interact_handler` | intentional | already splits `_fallback_interaction` from `_backend_error_interaction` |
| `plugin_bundle/omh/tools/context_tool.py` `_context_brief` | intentional | fixed by #637: distinct `package_context_error` source |
| `plugin_bundle/omh/tools/recommend_tool.py` `_recommendations` | intentional | fixed by #637: distinct `package_recommend_error` source |

The three tool sites that #637 already fixed still appear in the `BLE001` output, and that is the point of the distinction: they keep a broad `except` on purpose and now classify what they caught.

Both `_is_catalog_question` handlers share one inventory anchor whose verdict is `needs_637_treatment`; the rationale names which of the two is the accurate one, so the entry is not read as condemning both.

## Validation

- [x] `uv run --group lint ruff check src tests` — `All checks passed!`
- [x] `python3 -m unittest discover -s tests` — run as `PYTHONPATH=tests uv run python -m unittest discover -s tests`: `Ran 1663 tests in 45.840s / OK (skipped=1)`
- [x] `python3 -m compileall src` — run as `uv run python -m compileall -q src tests`, clean
- [x] `python3 -m omh.cli docs workflows --check` — `"ok":true`, tap_skills 97/97, no missing/stale/extra
- [x] `python3 -m omh.cli harness validate` — `"ok":true`, 69 harnesses / 90 skills, no errors or warnings
- [x] `python3 -m omh.cli release checklist --json` — emitted
- [x] `python3 -m omh.cli release hermes-smoke` — `Status: ok` (plan mode; observed evidence: no)
- [x] `omh --help` — usage emitted
- [ ] `omh ... release hermes-smoke --install-path setup --include-command-smoke` — not run; this change touches no install or release surface
- [ ] Workflow-learning review queue smoke — not applicable, no learning contract changed
- [x] Additional gates: `omh.cli docs roles --check` `"ok":true`, `omh.cli docs capability-families --check` `"ok":true`, `git diff --check` clean
- [x] **Negative probe** — a temporary broad `except` was appended to `src/mcp/bridge.py`; the gate failed with `add a verdict for [DerivedSite(path='src/mcp/bridge.py', function='_gate_probe')]` and `12 != 11`, then the file was reverted. The gate is verified to fire, not just to pass.
- [ ] Manual Hermes/TUI check — not run. The change reaches no runtime surface: a lint-config comment, a `CLAUDE.md` paragraph, and a new test module.

No generated artifact was hand-edited; no catalog data changed, so no regeneration was required.

## Risk

Low. No production code path is touched and no lint rule was enabled, so runtime behavior is unchanged by construction.

The one maintenance risk worth naming: the `ast` derivation and Ruff's `BLE001` are two implementations that agree today but are not the same code. They are verified equal on this tree (11/11, same files, same functions). If they ever diverge, the failure mode is the safe direction — the `ast` rule is deliberately broader, so it over-reports and demands a classification Ruff would not, rather than letting a site through unclassified. The docstring states this explicitly.

Renaming a function containing a broad `except` will fail the gate until `CLASSIFIED_SITES` is updated. That is intended, and the failure message names the old and new anchors.

## Compatibility / Rollout

No compatibility surface. Nothing is installed, generated, persisted, or exported by this change; no schema version moves. CI picks the new test up automatically through `unittest discover`.

## Release / Claims

- [x] Release-channel impact considered — none; no packaged artifact, CLI surface, or skill content changed
- [x] Runtime/native capability claims are backed by evidence or marked as not observed — every check above is either real pasted output or explicitly marked not run with a reason
- [x] Known manual Hermes checks listed — the `--live` hermes-smoke gap and the manual TUI check are both listed above as not run, with the reason

## Follow-Up

The four `needs_637_treatment` sites are now a bounded, named work item rather than an audit. A follow-up issue can apply the #637 split to `_localized_routing_text`, `_loop_route_hint_next_action`, the delegated-call handler in `_is_catalog_question`, and `pre_llm_call`, flip their verdicts to `intentional_classified_failure`, and only then is enabling `BLE001` in `select` a small mechanical change. Deliberately not attempted here — issue #652 scopes this to the tracking defect and explicitly puts refactoring out of scope.

Closes #652
