### PR TITLE
Surface the four relabeled broad-exception failures instead of hiding them

### DIFF
--- a/src/capabilities/hooks.py
+++ b/src/capabilities/hooks.py
@@ -91,7 +91,14 @@ def _cli_backend_surface(name: str) -> str:
 
 def _hook_payload_fields(name: str) -> list[str]:
     if name == "pre_llm_call":
-        return ["omh_awareness_primer", "omh_context_brief", "omh_route_hint", "bounded_status_context", "redacted"]
+        return [
+            "omh_awareness_primer",
+            "omh_context_brief",
+            "omh_route_hint",
+            "omh_degradation",
+            "bounded_status_context",
+            "redacted",
+        ]
     if name == "pre_tool_call":
         return ["tool_name", "tool_family_hint", "omh_generic_tool_checkpoint", "claim_boundary", "redacted"]
     if name == "on_session_end":

--- a/src/plugin_bundle/omh/awareness.py
+++ b/src/plugin_bundle/omh/awareness.py
@@ -5,6 +5,13 @@ import hashlib
 import re
 import unicodedata
 
+from .degradation import (
+    COMPONENT_LOCALIZED_ROUTING_TEXT,
+    COMPONENT_LOOP_ROUTE_HINT_ASSESSMENT,
+    degradation_payload,
+    safe_error_type,
+)
+
 _DIAGNOSTIC_STATUS_MARKERS = (
     "[omh awareness]",
     "[omh route hint]",
@@ -4365,20 +4372,50 @@ def workflow_context_card_for_workflow(workflow: str) -> dict[str, object]:
 
 def awareness_context_matches_message(message: str) -> bool:
     """Return true when a non-first-turn message should refresh OMH context."""
-    return _awareness_context_matches_message_cached(message)
+    return _awareness_context_matches_message_cached(message)[0]
+
+
+def awareness_context_match_degradation(message: str) -> str:
+    """Return the sanitized error type when the match's delegated call failed."""
+    # Reads the same cache entry as `awareness_context_matches_message`, so it
+    # costs a cache hit and never a miss.
+    return _awareness_context_matches_message_cached(message)[1]
 
 
 @lru_cache(maxsize=512)
-def _awareness_context_matches_message_cached(message: str) -> bool:
+def _awareness_context_matches_message_cached(message: str) -> tuple[bool, str]:
+    # This is the one function in the degradation design whose return type
+    # changed. Every other helper takes a `degraded` accumulator parameter and
+    # keeps its return type, deliberately: turning a `-> bool` / `-> dict`
+    # helper into a tuple silently inverts every enclosing `if`/`not`, and a
+    # non-empty tuple is always truthy, so neither `compileall` nor Pyflakes
+    # sees it. Do not reintroduce a courier tuple on the other helpers. Both
+    # references here destructure explicitly: `[0]` above and `[1]` in
+    # `awareness_context_match_degradation`.
+    #
+    # `lru_cache` is why the signal has to live in the returned value rather
+    # than in ambient state: ambient state is recorded on the first call and
+    # silently lost on every cache hit.
+    degraded: list[tuple[str, str]] = []
     raw_text = unicodedata.normalize("NFKC", message).casefold()
     if not raw_text.strip():
-        return False
-    localized_text = unicodedata.normalize("NFKC", _localized_routing_text(message)).casefold()
+        # Above the accumulator's only writer, so nothing can have degraded
+        # yet. This return must stay a tuple: bare `False` would make the
+        # `[0]` accessor raise `TypeError` on every empty message, and the
+        # `llm_hooks.pre_llm_call` call site is unguarded.
+        return (False, "")
+    localized_text = unicodedata.normalize("NFKC", _localized_routing_text(message, degraded)).casefold()
     text = f"{raw_text} {localized_text}"
     tokens = set(re.findall(r"[a-z0-9][a-z0-9_-]*", text))
-    return bool(tokens & _AWARENESS_TOKEN_MARKERS) or any(
+    result = bool(tokens & _AWARENESS_TOKEN_MARKERS) or any(
         marker in text for marker in _AWARENESS_MESSAGE_MARKERS
     )
+    # `degraded[0][1]` is lossless here because the `_localized_routing_text`
+    # call above is the sole guarded call in this function body, so the
+    # accumulator holds at most one row. If a second guarded call is ever added
+    # here, widen this accessor (and `awareness_context_match_degradation`) to
+    # carry the whole list instead of the first error type.
+    return (result, degraded[0][1] if degraded else "")
 
 
 def awareness_route_hint(message: str, *, max_hints: int = 2) -> dict[str, object]:
@@ -4407,6 +4444,20 @@ def _copy_awareness_route_hint_payload(payload: dict[str, object]) -> dict[str, 
             list(stored_fields) if isinstance(stored_fields, list | tuple) else []
         )
         copied["privacy"] = copied_privacy
+
+    degradation = payload.get("degradation")
+    if isinstance(degradation, dict):
+        # This function deliberately avoids generic deepcopy, so the nested
+        # degradation block needs an explicit branch: without it a caller
+        # mutating the block corrupts the lru_cached entry for every later
+        # caller.
+        copied["degradation"] = {
+            **degradation,
+            "components": [
+                dict(row) for row in degradation.get("components", []) if isinstance(row, dict)
+            ],
+            "privacy": dict(degradation.get("privacy", {})),
+        }
 
     decision = payload.get("primary_coding_route_decision")
     if isinstance(decision, dict):
@@ -4457,8 +4508,9 @@ def _route_hint_with_action_labels(hint: dict[str, object]) -> dict[str, object]
 
 @lru_cache(maxsize=512)
 def _awareness_route_hint_cached(message: str, max_hints: int) -> dict[str, object]:
+    degraded: list[tuple[str, str]] = []
     normalized = unicodedata.normalize("NFKC", message).casefold()
-    routing_text = _localized_routing_text(message)
+    routing_text = _localized_routing_text(message, degraded)
     localized_normalized = unicodedata.normalize("NFKC", routing_text).casefold()
     diagnostic_status = _diagnostic_status_context(normalized)
     diagnostic_eval = _prefers_diagnostic_workflow_learning_hint(message, classify_workflow_intent(message))
@@ -4486,7 +4538,7 @@ def _awareness_route_hint_cached(message: str, max_hints: int) -> dict[str, obje
     if normalized.strip() and hint_limit:
         if omh_quality_intent.applies and not diagnostic_learning_first:
             hints.append(_omh_quality_improvement_hint(omh_quality_intent))
-        direct_hint = _direct_workflow_invocation_hint(intent, routing_normalized, message)
+        direct_hint = _direct_workflow_invocation_hint(intent, routing_normalized, message, degraded)
         if len(hints) < hint_limit and direct_hint and not any(
             isinstance(hint, dict) and hint.get("workflow") == direct_hint.get("workflow") for hint in hints
         ):
@@ -4556,7 +4608,7 @@ def _awareness_route_hint_cached(message: str, max_hints: int) -> dict[str, obje
             context_card = workflow_context_card_for_workflow(workflow)
             next_action = str(rule["next_action"])
             if workflow == "loop":
-                next_action = _loop_route_hint_next_action(message, next_action)
+                next_action = _loop_route_hint_next_action(message, next_action, degraded)
             if rule["id"] == "coding_delivery":
                 next_action = _coding_delivery_route_hint_next_action(message, next_action)
             hints.append(
@@ -4588,7 +4640,7 @@ def _awareness_route_hint_cached(message: str, max_hints: int) -> dict[str, obje
         if isinstance(hint, dict)
         for item in hint.get("adjacent_workflows", [])
     )
-    return {
+    payload: dict[str, object] = {
         "schema_version": OMH_ROUTE_HINT_SCHEMA_VERSION,
         "status": "hinted" if hints else "no_hint",
         "message_sha256": hashlib.sha256(message.encode("utf-8")).hexdigest() if message else "",
@@ -4614,6 +4666,10 @@ def _awareness_route_hint_cached(message: str, max_hints: int) -> dict[str, obje
             "tool invocation, generated output, verification, review, CI, merge, or proof that routing was correct."
         ),
     }
+    degradation = degradation_payload(degraded)
+    if degradation:
+        payload["degradation"] = degradation
+    return payload
 
 
 def _route_hint_with_coding_route_decision(hint: dict[str, object], routing_normalized: str) -> dict[str, object]:
@@ -4824,12 +4880,18 @@ def _contains_phrase(haystack: str, phrase: str) -> bool:
     return phrase in haystack
 
 
-def _localized_routing_text(message: str) -> str:
+def _localized_routing_text(message: str, degraded: list[tuple[str, str]]) -> str:
     if _prepare_routing_text is None:
+        # Genuine absence: a standalone host without the locale pack. Not a
+        # degradation, so nothing is appended.
         return message
     try:
         return str(_prepare_routing_text(message).scoring_text or message)
-    except Exception:  # pragma: no cover - defensive for standalone plugin hosts.
+    except Exception as exc:
+        # The locale pack is present but the delegated call raised. Record the
+        # classified failure so the caller can tell it apart from the absence
+        # branch above, which returns the same value.
+        degraded.append((COMPONENT_LOCALIZED_ROUTING_TEXT, safe_error_type(type(exc).__name__)))
         return message
 
 
@@ -5305,12 +5367,17 @@ _DIRECT_WORKFLOW_NEXT_ACTIONS = {
 }
 
 
-def _loop_route_hint_next_action(message: str, default_action: str) -> str:
+def _loop_route_hint_next_action(message: str, default_action: str, degraded: list[tuple[str, str]]) -> str:
     if _assess_loopability is None:
+        # Genuine absence: the loopability assessor is not installed. Not a
+        # degradation, so nothing is appended.
         return default_action
     try:
         assessment = _assess_loopability(message or "loop", expose_goal=False)
-    except Exception:  # pragma: no cover - route hints should not break standalone hosts.
+    except Exception as exc:
+        # The assessor is present but the delegated call raised. Record it so a
+        # failed assessment is not readable as no assessment being available.
+        degraded.append((COMPONENT_LOOP_ROUTE_HINT_ASSESSMENT, safe_error_type(type(exc).__name__)))
         return default_action
     next_action = str(assessment.get("recommended_next_action") or "").strip()
     normalized = unicodedata.normalize("NFKC", message).casefold().strip()
@@ -5340,7 +5407,12 @@ def _coding_delivery_route_hint_next_action(message: str, default_action: str) -
     return default_action
 
 
-def _direct_workflow_invocation_hint(intent: object, routing_normalized: str, message: str) -> dict[str, object]:
+def _direct_workflow_invocation_hint(
+    intent: object,
+    routing_normalized: str,
+    message: str,
+    degraded: list[tuple[str, str]],
+) -> dict[str, object]:
     mentioned = [str(item) for item in getattr(intent, "mentioned_workflows", ()) if str(item)]
     direct_prefix_workflow = _direct_workflow_prefix(routing_normalized)
     if not mentioned and not direct_prefix_workflow:
@@ -5354,7 +5426,7 @@ def _direct_workflow_invocation_hint(intent: object, routing_normalized: str, me
     lane = str(context_card.get("id") or _WORKFLOW_CONTEXT_CARD_BY_WORKFLOW.get(workflow.casefold(), "intent_to_plan"))
     next_action = _DIRECT_WORKFLOW_NEXT_ACTIONS.get(workflow, "route_to_downstream_workflow")
     if workflow == "loop":
-        next_action = _loop_route_hint_next_action(message, next_action)
+        next_action = _loop_route_hint_next_action(message, next_action, degraded)
     return {
         "id": "direct_workflow_invocation",
         "workflow": workflow,

--- a/src/plugin_bundle/omh/context_brief.py
+++ b/src/plugin_bundle/omh/context_brief.py
@@ -9,6 +9,11 @@ from .awareness import (
     awareness_route_hint,
     awareness_route_hint_context_from_payload,
 )
+from .degradation import (
+    COMPONENT_CATALOG_QUESTION_CLASSIFIER,
+    degradation_payload,
+    safe_error_type,
+)
 
 OMH_CONTEXT_BRIEF_SCHEMA_VERSION = "omh_context_brief/v1"
 
@@ -23,6 +28,7 @@ def build_context_brief(
     achievements_profile: dict[str, object] | None = None,
 ) -> dict[str, object]:
     """Build bounded Hermes-facing OMH operating context."""
+    degraded: list[tuple[str, str]] = []
     text = str(message or "")
     limit = bounded_context_hint_limit(max_hints, default=2)
     primer = awareness_primer_payload()
@@ -90,9 +96,20 @@ def build_context_brief(
         )
     if isinstance(achievements_profile, dict) and achievements_profile.get("observed"):
         payload["achievements_profile"] = achievements_profile
-    catalog_hint = _catalog_question_hint(text)
+    catalog_hint = _catalog_question_hint(text, degraded)
     if catalog_hint:
         payload["catalog_question"] = catalog_hint
+    # Merge the embedded route hint's block upward without stripping it: the
+    # nested `payload["route_hint"]["degradation"]` stays byte-identical
+    # whether the route hint is read standalone or embedded here.
+    route_hint_degradation = route_hint.get("degradation") if isinstance(route_hint, dict) else None
+    if isinstance(route_hint_degradation, dict):
+        for row in route_hint_degradation.get("components", []):
+            if isinstance(row, dict):
+                degraded.append((str(row.get("component", "")), str(row.get("error_type", ""))))
+    degradation = degradation_payload(degraded)
+    if degradation:
+        payload["degradation"] = degradation
     return payload
 
 
@@ -114,8 +131,11 @@ def bounded_context_hint_limit(value: object, *, default: int) -> int:
     return max(0, min(parsed, 10))
 
 
-def _catalog_question_hint(message: str) -> dict[str, object]:
-    if not _is_catalog_question(message):
+def _catalog_question_hint(message: str, degraded: list[tuple[str, str]]) -> dict[str, object]:
+    # `degraded` is a parameter rather than part of the return value on
+    # purpose: this `if not ...` guard cannot invert, because the helper's
+    # return type is unchanged.
+    if not _is_catalog_question(message, degraded):
         return {}
     return {
         "schema_version": "omh_catalog_question_hint/v1",
@@ -136,17 +156,25 @@ def _catalog_question_hint(message: str) -> dict[str, object]:
     }
 
 
-def _is_catalog_question(message: str) -> bool:
+def _is_catalog_question(message: str, degraded: list[tuple[str, str]]) -> bool:
     text = message.strip()
     if not text:
         return False
     try:
         from omh.routing.catalog_questions import is_skill_catalog_question
     except Exception:
+        # Genuine absence: a module that raises at import really is unusable,
+        # so the standalone answer is the accurate label and no degradation is
+        # emitted. A host where `omh` is absent must stay indistinguishable
+        # from today.
         return _standalone_catalog_question(text)
     try:
         return bool(is_skill_catalog_question(text))
-    except Exception:
+    except Exception as exc:
+        # The package imported but the delegated call raised. Record it so the
+        # failure is not relabeled as the standalone-fallback path above, which
+        # returns the same value.
+        degraded.append((COMPONENT_CATALOG_QUESTION_CLASSIFIER, safe_error_type(type(exc).__name__)))
         return _standalone_catalog_question(text)
 
 

--- a/src/plugin_bundle/omh/degradation.py
+++ b/src/plugin_bundle/omh/degradation.py
@@ -1,0 +1,89 @@
+"""Bounded, metadata-only degradation signalling for OMH-local call failures.
+
+A broad `except` around a delegated call is acceptable when the failure is
+classified and surfaced; it is a defect when the failure is relabeled as a
+normal result (`tests/test_broad_exception_policy.py`). This module owns the
+vocabulary those handlers use to surface a failure: a closed set of component
+labels, a sanitized exception *class name*, and a bounded payload block.
+
+Nothing here raises. Every producer calls into it from inside an `except`
+body, so a helper that could raise there would recreate exactly the class of
+defect it exists to fix.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+
+OMH_DEGRADATION_SCHEMA_VERSION = "omh_degradation/v1"
+
+# Named label constants. Every producer imports and uses these, never a bare
+# string literal: a typo in a literal is silently coerced to
+# `UNKNOWN_COMPONENT` below and yields a well-formed payload that names
+# nothing useful, while a typo in an imported name is an ImportError at load.
+COMPONENT_LOCALIZED_ROUTING_TEXT = "localized_routing_text"
+COMPONENT_LOOP_ROUTE_HINT_ASSESSMENT = "loop_route_hint_assessment"
+COMPONENT_CATALOG_QUESTION_CLASSIFIER = "catalog_question_classifier"
+COMPONENT_RUNTIME_STATUS_READ = "runtime_status_read"
+
+DEGRADATION_COMPONENTS = frozenset(
+    {
+        COMPONENT_LOCALIZED_ROUTING_TEXT,
+        COMPONENT_LOOP_ROUTE_HINT_ASSESSMENT,
+        COMPONENT_CATALOG_QUESTION_CLASSIFIER,
+        COMPONENT_RUNTIME_STATUS_READ,
+    }
+)
+UNKNOWN_COMPONENT = "unknown_component"
+# The closed component set (4) times two distinct error types. Exceeding it
+# indicates a duplication bug, which `components_truncated` makes visible.
+MAX_DEGRADATION_COMPONENTS = 8
+
+DEGRADATION_CLAIM_BOUNDARY = (
+    "An OMH-local delegated call failed and a reduced local fallback answered. "
+    "This is a local call failure, not a genuine standalone host. It is an "
+    "observation of that failure and nothing else: it is not execution, review, "
+    "CI, merge-readiness, or merge evidence."
+)
+
+
+def safe_error_type(error_type: str) -> str:
+    """Return a bounded, character-safe exception class name."""
+    text = re.sub(r"[^A-Za-z0-9_.-]", "", str(error_type or ""))
+    return text[:80] or "Exception"
+
+
+def degradation_component(component: str, error_type: str) -> dict[str, str]:
+    """Return one bounded degradation row, coercing contract violations."""
+    label = str(component or "")
+    if label not in DEGRADATION_COMPONENTS:
+        label = UNKNOWN_COMPONENT
+    return {"component": label, "error_type": safe_error_type(error_type)}
+
+
+def degradation_payload(components: Iterable[tuple[str, str]]) -> dict[str, object]:
+    """Return a bounded degradation block, or `{}` when nothing degraded."""
+    rows = sorted(
+        {
+            (row["component"], row["error_type"])
+            for row in (degradation_component(component, error_type) for component, error_type in components)
+        }
+    )
+    if not rows:
+        return {}
+    capped = rows[:MAX_DEGRADATION_COMPONENTS]
+    return {
+        "schema_version": OMH_DEGRADATION_SCHEMA_VERSION,
+        "degraded": True,
+        "components": [{"component": component, "error_type": error_type} for component, error_type in capped],
+        "component_count": len(rows),
+        "components_truncated": len(capped) < len(rows),
+        "privacy": {
+            "mode": "metadata_only",
+            "raw_prompt_stored": False,
+            "raw_prompt_echoed": False,
+            "error_message_stored": False,
+        },
+        "claim_boundary": DEGRADATION_CLAIM_BOUNDARY,
+    }

--- a/src/plugin_bundle/omh/hooks/llm_hooks.py
+++ b/src/plugin_bundle/omh/hooks/llm_hooks.py
@@ -1,12 +1,19 @@
 from __future__ import annotations
 
 from ..awareness import (
+    awareness_context_match_degradation,
     awareness_context_matches_message,
     awareness_primer_context,
     awareness_route_hint,
     awareness_route_hint_context_from_payload,
 )
 from ..context_brief import build_context_brief
+from ..degradation import (
+    COMPONENT_LOCALIZED_ROUTING_TEXT,
+    COMPONENT_RUNTIME_STATUS_READ,
+    degradation_payload,
+    safe_error_type,
+)
 from ..host_observation import observe_plugin_hook_call
 from ..omh_roles import extract_role_marker, role_context_payload
 from ..runtime_reader import read_omh_hud, read_omh_status
@@ -34,8 +41,19 @@ def pre_llm_call(**kwargs) -> dict[str, object] | None:
     route_hint_context = ""
     route_hint_payload: dict[str, object] | None = None
     message_matches_awareness = False
+    degraded: list[tuple[str, str]] = []
     if include_awareness:
-        message_matches_awareness = is_first_turn or awareness_context_matches_message(user_message)
+        if is_first_turn:
+            message_matches_awareness = True
+        else:
+            # The matcher is called exactly when it is called today; the
+            # `is_first_turn` short circuit is preserved because the cache-count
+            # tests depend on it. The accessor reads the same cache entry the
+            # matcher just populated, so it costs a hit and never a miss.
+            message_matches_awareness = awareness_context_matches_message(user_message)
+            match_error = awareness_context_match_degradation(user_message)
+            if match_error:
+                degraded.append((COMPONENT_LOCALIZED_ROUTING_TEXT, match_error))
         if message_matches_awareness:
             route_hint_payload = awareness_route_hint(user_message)
             route_hint_context = awareness_route_hint_context_from_payload(route_hint_payload)
@@ -54,6 +72,11 @@ def pre_llm_call(**kwargs) -> dict[str, object] | None:
         )
         if route_hint_context:
             context_parts.append(route_hint_context)
+        brief = payload.get("omh_context_brief")
+        if isinstance(brief, dict):
+            for row in brief.get("degradation", {}).get("components", []):
+                if isinstance(row, dict):
+                    degraded.append((str(row.get("component", "")), str(row.get("error_type", ""))))
 
     marker = extract_role_marker(user_message)
     if marker:
@@ -85,11 +108,21 @@ def pre_llm_call(**kwargs) -> dict[str, object] | None:
             limit=3,
             token_metadata=_token_metadata_from_kwargs(kwargs),
         )
-    except Exception:
+    except Exception as exc:
+        # The read raised. Without this the next branch reads the empty status
+        # as `runtime_state_present` being false, so a failed status read looks
+        # exactly like a host with nothing to report.
         status = {}
         hud = {}
+        degraded.append((COMPONENT_RUNTIME_STATUS_READ, safe_error_type(type(exc).__name__)))
 
-    if not context_parts and not status.get("runtime_state_present") and not status.get("runs"):
+    degradation = degradation_payload(degraded)
+    if (
+        not context_parts
+        and not degradation
+        and not status.get("runtime_state_present")
+        and not status.get("runs")
+    ):
         return None
 
     if status.get("runtime_state_present") or status.get("runs"):
@@ -116,5 +149,16 @@ def pre_llm_call(**kwargs) -> dict[str, object] | None:
             )
         lines.append("Use omh_hud for the compact status line, omh_role for role context, or omh_status for full metadata-only status.")
         context_parts.append("\n".join(lines))
+    if degradation:
+        payload["omh_degradation"] = degradation
+        # Component labels only: error types stay in the structured payload, so
+        # the model-facing text is minimal and stable.
+        context_parts.append(
+            "[OMH Degraded] components="
+            + ",".join(str(row["component"]) for row in degradation["components"])
+            + ". An OMH-local delegated call failed and a reduced local fallback answered. "
+            "This is a local call failure, not a genuine standalone host. It is an observation of "
+            "that failure only: not execution, review, CI, merge-readiness, or merge evidence."
+        )
     payload["context"] = "\n\n".join(context_parts)
     return payload

--- a/src/plugin_bundle/omh/tools/capability_tool.py
+++ b/src/plugin_bundle/omh/tools/capability_tool.py
@@ -680,7 +680,14 @@ def _standalone_matches(wanted: str, item: dict[str, object]) -> bool:
 
 def _standalone_hook_payload_fields(name: str) -> list[str]:
     if name == "pre_llm_call":
-        return ["omh_awareness_primer", "omh_context_brief", "omh_route_hint", "bounded_status_context", "redacted"]
+        return [
+            "omh_awareness_primer",
+            "omh_context_brief",
+            "omh_route_hint",
+            "omh_degradation",
+            "bounded_status_context",
+            "redacted",
+        ]
     if name == "pre_tool_call":
         return ["tool_name", "tool_family_hint", "omh_generic_tool_checkpoint", "claim_boundary", "redacted"]
     if name == "on_session_end":

--- a/src/plugin_bundle/omh/tools/chat_tool.py
+++ b/src/plugin_bundle/omh/tools/chat_tool.py
@@ -6,6 +6,7 @@ import re
 from typing import Any
 
 from ..awareness import awareness_route_hint
+from ..degradation import safe_error_type as _safe_error_type
 from ..host_observation import OBSERVATION_SCHEMA, attach_public_observation, observe_plugin_tool_call
 
 OMH_INTERACT_SCHEMA = {
@@ -330,11 +331,6 @@ def _thread_key(source: str, metadata: dict[str, str], message_hash: str) -> str
     channel = metadata.get("channel_ref") or "channel"
     event = metadata.get("source_event_id") or message_hash[:12]
     return f"{source}:{channel}:{event}"
-
-
-def _safe_error_type(error_type: str) -> str:
-    text = re.sub(r"[^A-Za-z0-9_.-]", "", str(error_type or ""))
-    return text[:80] or "Exception"
 
 
 def _safe_metadata_text(value: object) -> str:

--- a/src/plugin_bundle/omh/tools/context_tool.py
+++ b/src/plugin_bundle/omh/tools/context_tool.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import hashlib
 import json
-import re
 
 from ..context_brief import bounded_context_hint_limit, build_context_brief as build_plugin_context_brief
+from ..degradation import safe_error_type as _safe_error_type
 from ..host_observation import OBSERVATION_SCHEMA, attach_public_observation, observe_plugin_tool_call
 
 OMH_CONTEXT_SCHEMA = {
@@ -111,8 +111,3 @@ def _package_context_error(message: str, *, source: str, error_type: str) -> dic
             "genuine missing-package standalone fallback."
         ),
     }
-
-
-def _safe_error_type(error_type: str) -> str:
-    text = re.sub(r"[^A-Za-z0-9_.-]", "", str(error_type or ""))
-    return text[:80] or "Exception"

--- a/src/plugin_bundle/omh/tools/recommend_tool.py
+++ b/src/plugin_bundle/omh/tools/recommend_tool.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import hashlib
 import json
-import re
 from typing import Any
 
 from ..awareness import awareness_primer_payload, awareness_route_hint
+from ..degradation import safe_error_type as _safe_error_type
 from ..host_observation import OBSERVATION_SCHEMA, attach_public_observation, observe_plugin_tool_call
 
 OMH_RECOMMEND_SCHEMA = {
@@ -119,11 +119,6 @@ def _recommendations(message: str, limit: int) -> tuple[list[dict[str, Any]], st
         # package runtime failure, not a genuine missing-package fallback, so it must
         # not be mislabeled as `standalone_plugin_bundle_fallback`.
         return [], "package_recommend_error", _safe_error_type(type(exc).__name__)
-
-
-def _safe_error_type(error_type: str) -> str:
-    text = re.sub(r"[^A-Za-z0-9_.-]", "", str(error_type or ""))
-    return text[:80] or "Exception"
 
 
 def _redacted_recommendation(item: dict[str, Any]) -> dict[str, Any]:

--- a/tests/test_broad_exception_policy.py
+++ b/tests/test_broad_exception_policy.py
@@ -84,34 +84,43 @@ CLASSIFIED_SITES: tuple[ClassifiedSite, ...] = (
     ClassifiedSite(
         "src/plugin_bundle/omh/awareness.py",
         "_localized_routing_text",
-        NEEDS_637_TREATMENT,
-        "Returns the raw message, the exact value of the `_prepare_routing_text is None` branch "
-        "above it, so a failure inside the delegated call is indistinguishable from the helper "
-        "being absent.",
+        INTENTIONAL,
+        "Still returns the raw message, but appends `localized_routing_text` plus a sanitized "
+        "error type to the `degraded` accumulator its caller passes in, which the "
+        "`_prepare_routing_text is None` branch above deliberately does not. The signal reaches "
+        "`omh_route_hint/v1.degradation`, `omh_context_brief/v1.degradation`, and the "
+        "`pre_llm_call` return's `omh_degradation`.",
     ),
     ClassifiedSite(
         "src/plugin_bundle/omh/awareness.py",
         "_loop_route_hint_next_action",
-        NEEDS_637_TREATMENT,
-        "Returns `default_action`, the exact value of the `_assess_loopability is None` branch, "
-        "so a failed loopability assessment reads as no assessment being available.",
+        INTENTIONAL,
+        "Still returns `default_action`, but appends `loop_route_hint_assessment` plus a "
+        "sanitized error type to the caller's `degraded` accumulator, which the "
+        "`_assess_loopability is None` branch does not. The signal surfaces at "
+        "`omh_route_hint/v1.degradation` and merges upward to `omh_degradation`.",
     ),
     ClassifiedSite(
         "src/plugin_bundle/omh/context_brief.py",
         "_is_catalog_question",
-        NEEDS_637_TREATMENT,
-        "Two handlers in one function. The import guard is accurate -- an import that raises "
-        "means the package path really is unusable, so the standalone answer is the right label. "
-        "The second wraps the delegated `is_skill_catalog_question()` call and returns the same "
-        "standalone answer, which is the mislabeling #637 fixed elsewhere.",
+        INTENTIONAL,
+        "Two handlers in one function, treated differently on purpose. The import guard stays "
+        "broad and deliberately emits nothing: a module that raises at import really is "
+        "unusable, so `_standalone_catalog_question` is the accurate label and a host where "
+        "`omh` is genuinely absent must stay indistinguishable from before. The second wraps "
+        "the delegated `is_skill_catalog_question()` call and now appends "
+        "`catalog_question_classifier` plus a sanitized error type to the caller's `degraded` "
+        "accumulator, so the call failure is told apart from that absence path even on a "
+        "non-catalog message that produces no `catalog_question` key.",
     ),
     ClassifiedSite(
         "src/plugin_bundle/omh/hooks/llm_hooks.py",
         "pre_llm_call",
-        NEEDS_637_TREATMENT,
-        "Sets status={} and hud={} on failure; the next branch reads empty status as "
-        "`runtime_state_present` being false and injects no context, so a failed status read "
-        "looks like a host with nothing to report.",
+        INTENTIONAL,
+        "Still sets status={} and hud={}, but appends `runtime_status_read` plus a sanitized "
+        "error type, so the return carries `omh_degradation` and one bounded `[OMH Degraded]` "
+        "context line where a genuinely idle host still returns None. A failed status read is "
+        "no longer readable as a host with nothing to report.",
     ),
     ClassifiedSite(
         "src/plugin_bundle/omh/host_observation.py",
@@ -221,6 +230,22 @@ class BroadExceptionPolicyTests(unittest.TestCase):
                     40,
                     "Each verdict needs a rationale a reviewer can check against the source.",
                 )
+
+    def test_no_site_is_left_needing_the_637_treatment(self) -> None:
+        outstanding = sorted(
+            (site.path, site.function) for site in CLASSIFIED_SITES if site.verdict == NEEDS_637_TREATMENT
+        )
+
+        self.assertEqual(
+            outstanding,
+            [],
+            "Every broad-exception site in `src/` was moved to the classified-and-surfaced "
+            "verdict; this ratchet keeps it that way. If you are recording a genuine new defect "
+            f"rather than regressing an existing one, that is a deliberate decision -- see {POLICY_TEST_PATH} "
+            f"and policy owner {POLICY_OWNER_ISSUE}, then remove this test in the same commit "
+            "with the reason in the commit body. Outstanding: "
+            f"{outstanding}.",
+        )
 
     def test_ble001_stays_unselected_under_the_pyflakes_baseline(self) -> None:
         config = tomllib.loads(_pyproject_text())

--- a/tests/test_capability_impact.py
+++ b/tests/test_capability_impact.py
@@ -161,6 +161,20 @@ class PreVerifyHookTests(unittest.TestCase):
         self.assertIn("src/plugin_bundle/omh/hooks/verify_hooks.py", manifest["source_refs"])
         self.assertEqual(hook["payload_fields"], capability_tool._standalone_hook_payload_fields("pre_verify"))
 
+    def test_core_and_standalone_hook_payload_fields_agree_on_every_hook(self) -> None:
+        # The two bodies are character-identical by convention and nothing else
+        # asserts it beyond `pre_verify`, so editing one and not the other
+        # would ship a bundle advertising different payload fields than the core.
+        hooks = hook_manifest()["plugin_hooks"]
+        self.assertTrue(hooks)
+
+        for hook in hooks:
+            with self.subTest(hook=hook["name"]):
+                self.assertEqual(
+                    hook["payload_fields"],
+                    capability_tool._standalone_hook_payload_fields(hook["name"]),
+                )
+
     def test_pre_verify_registration_is_skipped_when_the_host_does_not_support_it(self) -> None:
         context = FakeHermesContext()
 

--- a/tests/test_degradation_signal.py
+++ b/tests/test_degradation_signal.py
@@ -1,0 +1,534 @@
+"""Distinguishability proofs for the four `#637 treatment` broad-exception sites.
+
+Each of the four sites used to relabel a delegated-call failure as a normal
+result. `tests/test_broad_exception_policy.py` records the verdict; this module
+proves it against behaviour: per site, genuine absence and call failure must
+produce payloads a caller can tell apart.
+
+Harness rule: both awareness `lru_cache`s are cleared in `setUp` and every case
+uses a unique message. Without both, a failure case can be served a payload
+cached by a healthy case and pass for the wrong reason.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from tempfile import TemporaryDirectory
+import unittest
+from unittest import mock
+
+from _local_package import load_local_package
+
+load_local_package()
+
+from omh.plugin_bundle.omh import awareness as awareness_module
+from omh.plugin_bundle.omh.awareness import awareness_route_hint
+from omh.plugin_bundle.omh.context_brief import build_context_brief
+from omh.plugin_bundle.omh.degradation import (
+    COMPONENT_CATALOG_QUESTION_CLASSIFIER,
+    COMPONENT_LOCALIZED_ROUTING_TEXT,
+    COMPONENT_LOOP_ROUTE_HINT_ASSESSMENT,
+    COMPONENT_RUNTIME_STATUS_READ,
+    MAX_DEGRADATION_COMPONENTS,
+    OMH_DEGRADATION_SCHEMA_VERSION,
+    UNKNOWN_COMPONENT,
+    degradation_component,
+    degradation_payload,
+    safe_error_type,
+)
+from omh.plugin_bundle.omh.hooks import llm_hooks as llm_hooks_module
+from omh.plugin_bundle.omh.hooks.llm_hooks import pre_llm_call
+
+# `AGENTS.md` evidence-boundary phrasing, carried verbatim into every degraded
+# surface. A degradation marker observes a local call failure and nothing more.
+CLAIM_BOUNDARY_PHRASE = "not execution, review, CI, merge-readiness, or merge evidence"
+
+LOCALE_BOOM = "locale-boom"
+LOOP_BOOM = "loop-boom"
+CATALOG_BOOM = "catalog-boom"
+STATUS_BOOM = "status-boom"
+
+
+def component_labels(block: object) -> list[str]:
+    """Return the component labels of a degradation block, or []."""
+    if not isinstance(block, dict):
+        return []
+    return [str(row["component"]) for row in block.get("components", [])]
+
+
+def nested_degradation_blocks(payload: object) -> list[dict]:
+    """Return every nested `degradation` block reachable inside `payload`."""
+    found: list[dict] = []
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            if key == "degradation" and isinstance(value, dict):
+                found.append(value)
+            else:
+                found.extend(nested_degradation_blocks(value))
+    elif isinstance(payload, list):
+        for item in payload:
+            found.extend(nested_degradation_blocks(item))
+    return found
+
+
+class DegradationSignalTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        awareness_module._awareness_context_matches_message_cached.cache_clear()
+        awareness_module._awareness_route_hint_cached.cache_clear()
+
+    def locale_failure(self) -> mock._patch:
+        return mock.patch.object(
+            awareness_module,
+            "_prepare_routing_text",
+            mock.Mock(side_effect=RuntimeError(LOCALE_BOOM)),
+        )
+
+    def locale_absent(self) -> mock._patch:
+        return mock.patch.object(awareness_module, "_prepare_routing_text", None)
+
+    def loop_failure(self) -> mock._patch:
+        return mock.patch.object(
+            awareness_module,
+            "_assess_loopability",
+            mock.Mock(side_effect=RuntimeError(LOOP_BOOM)),
+        )
+
+    def loop_absent(self) -> mock._patch:
+        return mock.patch.object(awareness_module, "_assess_loopability", None)
+
+    def catalog_failure(self) -> mock._patch:
+        return mock.patch(
+            "omh.routing.catalog_questions.is_skill_catalog_question",
+            side_effect=RuntimeError(CATALOG_BOOM),
+        )
+
+    def catalog_absent(self) -> mock._patch:
+        return mock.patch.dict(sys.modules, {"omh.routing.catalog_questions": None})
+
+    def status_failure(self) -> mock._patch:
+        return mock.patch.object(
+            llm_hooks_module, "read_omh_status", side_effect=RuntimeError(STATUS_BOOM)
+        )
+
+    def call_pre_llm(self, message: str, **kwargs: object) -> dict | None:
+        with TemporaryDirectory() as temp_dir:
+            return pre_llm_call(
+                omh_home=temp_dir,
+                hermes_home=temp_dir,
+                user_message=message,
+                is_first_turn=False,
+                **kwargs,
+            )
+
+    def assert_block_is_well_formed(self, block: dict) -> None:
+        self.assertEqual(block["schema_version"], OMH_DEGRADATION_SCHEMA_VERSION)
+        self.assertTrue(block["degraded"])
+        self.assertFalse(block["privacy"]["error_message_stored"])
+        self.assertFalse(block["privacy"]["raw_prompt_stored"])
+        self.assertFalse(block["privacy"]["raw_prompt_echoed"])
+        self.assertIn(CLAIM_BOUNDARY_PHRASE, block["claim_boundary"])
+
+
+class SiteDistinguishabilityTests(DegradationSignalTestCase):
+    def test_site_1_localized_routing_text_absence_differs_from_call_failure(self) -> None:
+        message = "show token cost latency run history for this site-one automation loop"
+
+        with self.locale_absent():
+            absent = awareness_route_hint(message)
+        self.setUp()
+        with self.locale_failure():
+            failed = awareness_route_hint(message)
+
+        # Genuine absence: a standalone host without the locale pack looks
+        # exactly like it does today.
+        self.assertNotIn("degradation", absent)
+        # Call failure: same routing answer, but now classified and surfaced.
+        self.assertEqual(failed["primary_workflow"], absent["primary_workflow"])
+        block = failed["degradation"]
+        self.assertEqual(component_labels(block), [COMPONENT_LOCALIZED_ROUTING_TEXT])
+        self.assertEqual(block["components"][0]["error_type"], "RuntimeError")
+        self.assert_block_is_well_formed(block)
+
+        serialized = json.dumps(failed, ensure_ascii=False, sort_keys=True)
+        self.assertNotIn(LOCALE_BOOM, serialized)
+        self.assertNotIn(message, serialized)
+
+    def test_site_2_loop_assessment_absence_differs_from_call_failure(self) -> None:
+        message = "/loop fix the flaky site-two integration test"
+
+        with self.loop_absent():
+            absent = awareness_route_hint(message)
+        self.setUp()
+        with self.loop_failure():
+            failed = awareness_route_hint(message)
+
+        self.assertNotIn("degradation", absent)
+        self.assertEqual(failed["primary_workflow"], "loop")
+        self.assertEqual(failed["primary_next_action"], absent["primary_next_action"])
+        block = failed["degradation"]
+        self.assertEqual(component_labels(block), [COMPONENT_LOOP_ROUTE_HINT_ASSESSMENT])
+        self.assertEqual(block["components"][0]["error_type"], "RuntimeError")
+        self.assert_block_is_well_formed(block)
+
+        serialized = json.dumps(failed, ensure_ascii=False, sort_keys=True)
+        self.assertNotIn(LOOP_BOOM, serialized)
+        self.assertNotIn(message, serialized)
+
+    def test_site_3_catalog_classifier_import_absence_emits_nothing(self) -> None:
+        message = "what workflows are available in omh for site three"
+
+        with self.catalog_absent():
+            absent = build_context_brief(message)
+
+        # Principle 2: a host where the package is genuinely absent produces
+        # the same output as today. The import guard emits no degradation.
+        self.assertNotIn("degradation", absent)
+        self.assertIn("catalog_question", absent)
+
+    def test_site_3_catalog_classifier_call_failure_is_surfaced(self) -> None:
+        message = "what workflows are available in omh for site three call failure"
+
+        with self.catalog_failure():
+            failed = build_context_brief(message)
+
+        self.assertIn("catalog_question", failed)
+        block = failed["degradation"]
+        self.assertEqual(component_labels(block), [COMPONENT_CATALOG_QUESTION_CLASSIFIER])
+        self.assertEqual(block["components"][0]["error_type"], "RuntimeError")
+        self.assert_block_is_well_formed(block)
+
+        serialized = json.dumps(failed, ensure_ascii=False, sort_keys=True)
+        self.assertNotIn(CATALOG_BOOM, serialized)
+        self.assertNotIn(message, serialized)
+
+    def test_site_3_call_failure_on_a_non_catalog_message_is_visible(self) -> None:
+        # The sharpest consequence: today this failure produces no key at all,
+        # so it is completely invisible. The classifier answered "no" either
+        # way, and only the degradation block tells the two apart.
+        message = "tell me a short joke about site-three penguins"
+
+        healthy = build_context_brief(message)
+        self.setUp()
+        with self.catalog_failure():
+            failed = build_context_brief(message)
+
+        self.assertNotIn("catalog_question", healthy)
+        self.assertNotIn("degradation", healthy)
+        self.assertNotIn("catalog_question", failed)
+        self.assertEqual(component_labels(failed["degradation"]), [COMPONENT_CATALOG_QUESTION_CLASSIFIER])
+
+    def test_site_4_runtime_status_read_absence_differs_from_call_failure(self) -> None:
+        # Genuine absence: a real empty runtime home has nothing to report.
+        healthy = self.call_pre_llm("tell me a short joke about site-four otters")
+        self.assertIsNone(healthy)
+
+        self.setUp()
+        with self.status_failure():
+            failed = self.call_pre_llm("tell me a short joke about site-four badgers")
+
+        self.assertIsNotNone(failed)
+        assert failed is not None
+        block = failed["omh_degradation"]
+        self.assertEqual(component_labels(block), [COMPONENT_RUNTIME_STATUS_READ])
+        self.assertEqual(block["components"][0]["error_type"], "RuntimeError")
+        self.assert_block_is_well_formed(block)
+        # PM-1: no status panel is implied. The status block stays gated on the
+        # runtime fields, which are still absent.
+        self.assertNotIn("runs", failed)
+        self.assertNotIn("[OMH] Native bridge status context.", failed["context"])
+
+        serialized = json.dumps(failed, ensure_ascii=False, sort_keys=True)
+        self.assertNotIn(STATUS_BOOM, serialized)
+
+
+class PreLlmCallDegradationTests(DegradationSignalTestCase):
+    def test_happy_path_carries_no_degradation_key_anywhere(self) -> None:
+        payload = self.call_pre_llm("show token cost latency run history for this healthy automation loop")
+
+        self.assertIsNotNone(payload)
+        assert payload is not None
+        self.assertNotIn("omh_degradation", payload)
+        self.assertNotIn("[OMH Degraded]", payload["context"])
+        self.assertNotIn("degradation", json.dumps(payload, sort_keys=True))
+
+    def test_empty_and_whitespace_messages_do_not_raise(self) -> None:
+        # Pins the tuple conversion of the empty/whitespace guard inside
+        # `_awareness_context_matches_message_cached`. A bare `False` there
+        # makes the `[0]` accessor raise `TypeError: 'bool' object is not
+        # subscriptable`, and this call site in `pre_llm_call` has no enclosing
+        # try/except, so the exception would escape into the Hermes host.
+        for message in ("", "   "):
+            with self.subTest(message=message):
+                self.setUp()
+                try:
+                    payload = self.call_pre_llm(message)
+                except TypeError as exc:  # pragma: no cover - the regression itself
+                    self.fail(f"pre_llm_call raised TypeError on an empty message: {exc}")
+                self.assertIsNone(payload)
+
+    def test_site_1_failure_flips_a_non_matching_message_from_none_to_a_payload(self) -> None:
+        # The B1 headline case. Today this message produces `None`; with the
+        # locale-pack call failing, the failure is the only thing in the
+        # payload, and it reaches the top level with no nested block at all.
+        message = "raconte-moi une blague vraiment courte s'il te plait"
+
+        healthy = self.call_pre_llm(message)
+        self.assertIsNone(healthy)
+
+        self.setUp()
+        with self.locale_failure():
+            failed = self.call_pre_llm(message)
+
+        self.assertIsNotNone(failed)
+        assert failed is not None
+        self.assertEqual(component_labels(failed["omh_degradation"]), [COMPONENT_LOCALIZED_ROUTING_TEXT])
+        # `awareness_route_hint` was never called on this turn, so there is no
+        # nested producer. This is why the invariant is containment, not equality.
+        self.assertNotIn("omh_context_brief", failed)
+        self.assertEqual(nested_degradation_blocks(failed), [])
+
+    def test_suppressed_awareness_stays_none_even_when_site_1_fails(self) -> None:
+        with self.locale_failure():
+            payload = self.call_pre_llm(
+                "raconte-moi une autre blague courte", include_omh_awareness=False
+            )
+
+        self.assertIsNone(payload)
+
+    def test_degraded_context_line_is_bounded_and_last_on_an_otherwise_normal_turn(self) -> None:
+        # PM-4: site 1 fails on a message that *does* match awareness, so the
+        # payload is non-`None` for the pre-existing reason and the model
+        # simply receives one extra line.
+        message = "이 자동화 루프의 토큰 비용 기록을 보여줘"
+
+        with self.locale_failure():
+            payload = self.call_pre_llm(message)
+
+        self.assertIsNotNone(payload)
+        assert payload is not None
+        context = payload["context"]
+        parts = context.split("\n\n")
+        self.assertEqual(context.count("[OMH Degraded]"), 1)
+        self.assertTrue(parts[-1].startswith("[OMH Degraded] components="))
+        self.assertIn(COMPONENT_LOCALIZED_ROUTING_TEXT, parts[-1])
+        self.assertIn(CLAIM_BOUNDARY_PHRASE, parts[-1])
+        # Component labels only; error types stay in the structured payload.
+        self.assertNotIn("RuntimeError", parts[-1])
+        self.assertNotIn(LOCALE_BOOM, parts[-1])
+        self.assertNotIn(message, parts[-1])
+        # The awareness primer is still present, so the payload did not appear
+        # only because of the degradation.
+        self.assertIn("omh_context_brief", payload)
+
+    def test_two_sites_degrading_in_one_request_are_both_reported(self) -> None:
+        message = "raconte-moi une blague courte sur deux pannes"
+
+        with self.locale_failure(), self.status_failure():
+            payload = self.call_pre_llm(message)
+
+        self.assertIsNotNone(payload)
+        assert payload is not None
+        block = payload["omh_degradation"]
+        self.assertEqual(
+            component_labels(block),
+            sorted([COMPONENT_LOCALIZED_ROUTING_TEXT, COMPONENT_RUNTIME_STATUS_READ]),
+        )
+        self.assertEqual(block["component_count"], 2)
+        self.assertFalse(block["components_truncated"])
+
+    def test_runtime_status_read_is_top_level_only(self) -> None:
+        # Case (b) for the containment invariant: this component has no nested
+        # producer by construction, so equality is unsatisfiable.
+        message = "show token cost latency run history for this top-level-only loop"
+
+        with self.status_failure():
+            payload = self.call_pre_llm(message)
+
+        self.assertIsNotNone(payload)
+        assert payload is not None
+        self.assertIn(COMPONENT_RUNTIME_STATUS_READ, component_labels(payload["omh_degradation"]))
+        for block in nested_degradation_blocks(payload):
+            self.assertNotIn(COMPONENT_RUNTIME_STATUS_READ, component_labels(block))
+
+
+class MultiLevelMergeTests(DegradationSignalTestCase):
+    MATCHING_MESSAGE = "이 자동화 루프의 토큰 비용과 지연 기록을 보여줘"
+
+    def test_nested_route_hint_block_is_non_empty_on_a_matching_message(self) -> None:
+        # Non-vacuity, asserted first and at its specific nesting level. This
+        # is the only assertion that proves the route-hint producer was wired;
+        # without it the containment check below is satisfied by an entirely
+        # unimplemented change.
+        with self.locale_failure():
+            payload = self.call_pre_llm(self.MATCHING_MESSAGE)
+
+        self.assertIsNotNone(payload)
+        assert payload is not None
+        nested = payload["omh_context_brief"]["route_hint"]["degradation"]
+        self.assertIn(COMPONENT_LOCALIZED_ROUTING_TEXT, component_labels(nested))
+        self.assertTrue(component_labels(nested))
+
+        brief_level = payload["omh_context_brief"]["degradation"]
+        self.assertIn(COMPONENT_LOCALIZED_ROUTING_TEXT, component_labels(brief_level))
+
+        top_level = payload["omh_degradation"]
+        self.assertIn(COMPONENT_LOCALIZED_ROUTING_TEXT, component_labels(top_level))
+
+    def test_every_nested_block_is_contained_in_the_top_level_union(self) -> None:
+        # Containment, never equality: the top level is a union superset, and
+        # the converse does not hold.
+        with self.locale_failure(), self.status_failure():
+            payload = self.call_pre_llm(self.MATCHING_MESSAGE + " 두 번째")
+
+        self.assertIsNotNone(payload)
+        assert payload is not None
+        top = set(component_labels(payload["omh_degradation"]))
+        blocks = nested_degradation_blocks(payload)
+        self.assertTrue(blocks, "Expected at least one nested degradation block.")
+        for block in blocks:
+            labels = set(component_labels(block))
+            self.assertTrue(labels, "A nested degradation block must not be empty.")
+            self.assertLessEqual(labels, top)
+
+    def test_the_nested_route_hint_block_is_not_stripped_when_embedded(self) -> None:
+        # `omh_route_hint/v1` must stay byte-identical read standalone or
+        # embedded inside `omh_context_brief/v1`.
+        message = "show token cost latency run history for this embedded loop"
+
+        with self.locale_failure():
+            standalone = awareness_route_hint(message)
+        self.setUp()
+        with self.locale_failure():
+            brief = build_context_brief(message)
+
+        self.assertEqual(
+            json.dumps(brief["route_hint"]["degradation"], sort_keys=True),
+            json.dumps(standalone["degradation"], sort_keys=True),
+        )
+
+    def test_repeated_identical_calls_produce_byte_equal_degraded_payloads(self) -> None:
+        # Cache-hit determinism: the assertion an ambient collector would fail.
+        message = "show token cost latency run history for this deterministic loop"
+
+        with self.locale_failure():
+            first = self.call_pre_llm(message)
+            second = self.call_pre_llm(message)
+
+        self.assertIsNotNone(first)
+        assert first is not None and second is not None
+        self.assertEqual(
+            json.dumps(first["omh_degradation"], sort_keys=True),
+            json.dumps(second["omh_degradation"], sort_keys=True),
+        )
+        self.assertEqual(
+            json.dumps(first["omh_context_brief"]["route_hint"]["degradation"], sort_keys=True),
+            json.dumps(second["omh_context_brief"]["route_hint"]["degradation"], sort_keys=True),
+        )
+
+    def test_cached_degradation_block_survives_caller_mutation(self) -> None:
+        # `_copy_awareness_route_hint_payload` avoids generic deepcopy, so the
+        # nested block needs its own branch or a caller poisons the cache.
+        message = "show token cost latency run history for this poisoned loop"
+
+        with self.locale_failure():
+            first = awareness_route_hint(message)
+            first["degradation"]["degraded"] = "mutated"
+            first["degradation"]["components"][0]["component"] = "mutated"
+            first["degradation"]["privacy"]["mode"] = "mutated"
+
+            second = awareness_route_hint(message)
+
+        self.assertTrue(second["degradation"]["degraded"])
+        self.assertEqual(component_labels(second["degradation"]), [COMPONENT_LOCALIZED_ROUTING_TEXT])
+        self.assertEqual(second["degradation"]["privacy"]["mode"], "metadata_only")
+
+
+class DegradationPayloadUnitTests(unittest.TestCase):
+    def test_empty_input_produces_no_block(self) -> None:
+        self.assertEqual(degradation_payload([]), {})
+
+    def test_identical_pairs_are_deduped(self) -> None:
+        block = degradation_payload(
+            [
+                (COMPONENT_LOCALIZED_ROUTING_TEXT, "RuntimeError"),
+                (COMPONENT_LOCALIZED_ROUTING_TEXT, "RuntimeError"),
+            ]
+        )
+
+        self.assertEqual(block["component_count"], 1)
+        self.assertEqual(len(block["components"]), 1)
+
+    def test_distinct_error_types_on_one_component_are_kept(self) -> None:
+        block = degradation_payload(
+            [
+                (COMPONENT_LOCALIZED_ROUTING_TEXT, "ValueError"),
+                (COMPONENT_LOCALIZED_ROUTING_TEXT, "RuntimeError"),
+            ]
+        )
+
+        self.assertEqual(block["component_count"], 2)
+        self.assertEqual(
+            [row["error_type"] for row in block["components"]],
+            ["RuntimeError", "ValueError"],
+        )
+
+    def test_ordering_is_deterministic_regardless_of_input_order(self) -> None:
+        pairs = [
+            (COMPONENT_RUNTIME_STATUS_READ, "OSError"),
+            (COMPONENT_CATALOG_QUESTION_CLASSIFIER, "RuntimeError"),
+            (COMPONENT_LOCALIZED_ROUTING_TEXT, "ValueError"),
+        ]
+
+        forward = degradation_payload(pairs)
+        backward = degradation_payload(list(reversed(pairs)))
+
+        self.assertEqual(
+            json.dumps(forward, sort_keys=True), json.dumps(backward, sort_keys=True)
+        )
+        self.assertEqual(
+            component_labels(forward),
+            [
+                COMPONENT_CATALOG_QUESTION_CLASSIFIER,
+                COMPONENT_LOCALIZED_ROUTING_TEXT,
+                COMPONENT_RUNTIME_STATUS_READ,
+            ],
+        )
+
+    def test_the_cap_truncates_the_tail_and_reports_the_pre_cap_total(self) -> None:
+        pairs = [
+            (component, f"Error{index}")
+            for index in range(3)
+            for component in (
+                COMPONENT_LOCALIZED_ROUTING_TEXT,
+                COMPONENT_LOOP_ROUTE_HINT_ASSESSMENT,
+                COMPONENT_CATALOG_QUESTION_CLASSIFIER,
+                COMPONENT_RUNTIME_STATUS_READ,
+            )
+        ]
+
+        block = degradation_payload(pairs)
+
+        self.assertEqual(block["component_count"], 12)
+        self.assertEqual(len(block["components"]), MAX_DEGRADATION_COMPONENTS)
+        self.assertTrue(block["components_truncated"])
+
+    def test_an_out_of_set_label_is_coerced_without_raising(self) -> None:
+        row = degradation_component("typo_component", "RuntimeError")
+        self.assertEqual(row["component"], UNKNOWN_COMPONENT)
+
+        block = degradation_payload([("typo_component", "RuntimeError")])
+        self.assertEqual(component_labels(block), [UNKNOWN_COMPONENT])
+
+    def test_safe_error_type_is_bounded_and_falls_back(self) -> None:
+        self.assertEqual(safe_error_type(""), "Exception")
+        self.assertEqual(safe_error_type(None), "Exception")
+        self.assertEqual(safe_error_type("RuntimeError"), "RuntimeError")
+        # Whitespace, colons, and punctuation are stripped, so an exception
+        # *message* accidentally passed here cannot survive as readable text.
+        self.assertEqual(safe_error_type("Runtime Error: secret token 123!"), "RuntimeErrorsecrettoken123")
+        self.assertEqual(len(safe_error_type("E" * 200)), 80)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_plugin_distribution.py
+++ b/tests/test_plugin_distribution.py
@@ -212,6 +212,51 @@ print(json.dumps(observed, ensure_ascii=False))
         self.assertNotIn("package-recommend-boom", serialized)
         self.assertNotIn("secret-token-123", serialized)
 
+    def test_pre_llm_call_distinguishes_an_idle_host_from_a_failed_status_read(self) -> None:
+        # This is the bundle surface that ships to third-party hosts, so the
+        # degraded path is exercised here as an installed host would hit it.
+        from omh.plugin_bundle.omh import awareness as awareness_module
+        from omh.plugin_bundle.omh.hooks import llm_hooks
+
+        awareness_module._awareness_context_matches_message_cached.cache_clear()
+        awareness_module._awareness_route_hint_cached.cache_clear()
+
+        message = "tell me a short joke about secret-token-123"
+
+        # Case (a): a genuinely idle host with an empty runtime home. Nothing
+        # to report, so the hook keeps returning None exactly as today.
+        with TemporaryDirectory() as tmp:
+            idle_payload = llm_hooks.pre_llm_call(
+                omh_home=tmp, hermes_home=tmp, user_message=message, is_first_turn=False
+            )
+        self.assertIsNone(idle_payload)
+
+        # Case (b): the status read raises. This must not be mislabeled as the
+        # same idle host.
+        awareness_module._awareness_context_matches_message_cached.cache_clear()
+        awareness_module._awareness_route_hint_cached.cache_clear()
+        with TemporaryDirectory() as tmp:
+            with mock.patch.object(llm_hooks, "read_omh_status", side_effect=RuntimeError("status-boom")):
+                error_payload = llm_hooks.pre_llm_call(
+                    omh_home=tmp, hermes_home=tmp, user_message=message, is_first_turn=False
+                )
+
+        self.assertIsNotNone(error_payload)
+        assert error_payload is not None
+        degradation = error_payload["omh_degradation"]
+        self.assertEqual(degradation["schema_version"], "omh_degradation/v1")
+        self.assertTrue(degradation["degraded"])
+        self.assertEqual([row["component"] for row in degradation["components"]], ["runtime_status_read"])
+        self.assertEqual(degradation["components"][0]["error_type"], "RuntimeError")
+        self.assertFalse(degradation["privacy"]["error_message_stored"])
+        self.assertIn("[OMH Degraded]", error_payload["context"])
+        # PM-1: no status panel is implied, because the status fields are still absent.
+        self.assertNotIn("runs", error_payload)
+        self.assertNotIn("[OMH] Native bridge status context.", error_payload["context"])
+        serialized = json.dumps(error_payload, sort_keys=True)
+        self.assertNotIn("status-boom", serialized)
+        self.assertNotIn("secret-token-123", serialized)
+
     def test_setup_default_installs_plugin(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## Feature Report

### What Changed

The four broad-`except` sites that `tests/test_broad_exception_policy.py` classified
`needs_637_treatment` now classify `intentional_classified_failure`. Each one used to
return the exact value of its own "optional dependency absent" branch, so a runtime
error inside a delegated call was indistinguishable from a healthy fallback. Each now
records a bounded, metadata-only degradation marker that reaches a payload boundary.

- `awareness._localized_routing_text` -> `localized_routing_text`
- `awareness._loop_route_hint_next_action` -> `loop_route_hint_assessment`
- `context_brief._is_catalog_question` (the delegated-call handler only) -> `catalog_question_classifier`
- `hooks/llm_hooks.pre_llm_call` (the runtime status read) -> `runtime_status_read`

Follow-up to #652, the live owner of the broad-exception policy ledger. #637 is the
precedent that established the classified-versus-relabeled distinction; it is cited as
the pattern, not as the tracking owner. There is no tracking issue for this change.

### Why This Exists

`CLAUDE.md` states the policy as a gate, not a comment: a broad `except` around a
delegated call is acceptable when the failure is classified and surfaced, and a defect
when the failure is relabeled as a normal result. The ledger recorded four sites as
defects but nothing fixed them, so the verdict was durable documentation of a known gap
rather than a closed one.

The sharpest case is the catalog classifier on a **non-catalog** message: the delegated
call raising and the classifier honestly answering "no" produce byte-identical output
today. There is no key to inspect, no error channel, and no log. That failure is
completely invisible. The same is true of a failed locale-pack call, which silently
degrades non-English routing to raw-text matching.

### User / Operator Impact

An operator or host can now tell "OMH is running standalone without the optional package"
apart from "the package is installed and its call just failed". Before, both produced the
same answer.

- A Hermes host reading the `pre_llm_call` return gets a top-level `omh_degradation`
  block with a `schema_version` it can branch on.
- A host reading `omh_context_brief` / `omh_route_hint` structurally gets the same signal
  nested at the level that produced it.
- The model gets one bounded `[OMH Degraded]` line naming component labels only.

Nothing appears on the happy path. A genuinely standalone host produces exactly today's
output, by construction and by test: genuine-absence branches append nothing, and the
`_is_catalog_question` *import* guard deliberately emits no degradation, because a module
that raises at import really is unusable and the standalone answer is the accurate label.

### How It Works

New `src/plugin_bundle/omh/degradation.py` owns the closed component-label set as named
constants, `degradation_component`, and `degradation_payload`. Nothing in it raises,
because every caller invokes it from inside an `except` body; an out-of-set label is
coerced to `unknown_component` rather than raising. Emitted content is a bounded label
plus a sanitized exception *class name* -- never raw request text, never exception
message text.

The five private helpers that swallowed a delegated-call failure take a required
positional `degraded: list[tuple[str, str]]` accumulator and keep their existing return
types. The accumulator is a parameter rather than part of the return value on purpose:
converting these `-> bool` / `-> dict` helpers into tuples would silently invert every
enclosing `if`/`not`, verified live at the catalog guard in `context_brief.py` and the
`direct_hint` guard in `awareness.py`.

`lru_cache` sits on both awareness entry points, so a signal held in ambient state would
be recorded on the first call and silently lost on every cache hit. Both cached
boundaries therefore fold the accumulator into the value they return.
`_awareness_route_hint_cached` emits it under `"degradation"`.
`_awareness_context_matches_message_cached` is the single return-type change in the diff
(`-> tuple[bool, str]`); **both** of its returns are converted and **both** of its
references destructure explicitly. The empty/whitespace guard is load-bearing: left as a
bare `False`, the `[0]` accessor raises `TypeError: 'bool' object is not subscriptable`
on every empty message, and that call site in `pre_llm_call` has no enclosing
`try`/`except`, so it would escape into the Hermes host. A regression test pins exactly
that, and the mutation check below reproduces the crash.

Merge semantics across the three nesting levels: the route hint is the producer,
`build_context_brief` merges upward **without stripping** the nested block, and
`pre_llm_call` publishes the request-level union at `payload["omh_degradation"]`. The
invariant is containment (nested is a subset of top-level), never equality -- top-level
is a union superset. Two cases make equality unsatisfiable: a site-1 failure on a message
that does not end up matching produces a top-level component with no nested block at all,
and `runtime_status_read` is top-level-only by construction. Every degradation test
asserts non-emptiness at its specific nesting level *before* any containment check, so
containment cannot pass vacuously.

Three duplicated `_safe_error_type` bodies (character-identical, verified) collapse into
the module's single `safe_error_type`, imported under the same local alias so no call
site changed. Exactly one such body now exists in the tree.

### Files And Contracts Touched

- `src/plugin_bundle/omh/degradation.py` (new) -- `omh_degradation/v1`. Auto-collected
  into the plugin bundle by the existing resource walk; no registration step needed.
- `src/plugin_bundle/omh/awareness.py` -- the two producers, the two cached boundaries, a
  new additive public accessor `awareness_context_match_degradation` (reads the same
  cache entry, so it costs a hit and never a miss), and an explicit copy branch in
  `_copy_awareness_route_hint_payload`, which avoids generic `deepcopy` and would
  otherwise share the nested block so a caller could poison the cache.
- `src/plugin_bundle/omh/context_brief.py` -- classifier accumulator and upward merge.
- `src/plugin_bundle/omh/hooks/llm_hooks.py` -- status-read classification, the
  request-level union, and the `[OMH Degraded]` context line.
- `src/capabilities/hooks.py` and `src/plugin_bundle/omh/tools/capability_tool.py` --
  `"omh_degradation"` added to the `pre_llm_call` payload-field manifest in **both**
  copies. These have character-identical bodies and the only parity assertion covered
  `pre_verify` alone, so a four-hook parity loop was added.
- `src/plugin_bundle/omh/tools/{context,chat,recommend}_tool.py` -- `safe_error_type`
  consolidation. `import re` dropped from context_tool and recommend_tool; kept in
  chat_tool, which still compiles `_SENSITIVE_VALUE_PATTERN`.
- `tests/test_broad_exception_policy.py` -- four verdicts moved, rationales rewritten to
  be source-checkable, plus a ratchet test asserting no site carries
  `NEEDS_637_TREATMENT`. `EXPECTED_HANDLER_COUNT` / `EXPECTED_ANCHOR_COUNT` stay 11 / 10.
- `tests/test_degradation_signal.py` (new, 25 tests), plus one test each in
  `tests/test_capability_impact.py` and `tests/test_plugin_distribution.py`.

`select = ["F"]` in `pyproject.toml` is untouched; `BLE001` stays unselected and
`test_ble001_stays_unselected_under_the_pyflakes_baseline` is green unmodified.

## Validation

- [x] `uv run --group lint ruff check src tests` -- `All checks passed!`
- [x] `python3 -m unittest discover -s tests` -- `Ran 1691 tests ... OK (skipped=1)`
- [x] `python3 -m compileall src` -- exit 0 (run over `src tests`)
- [x] `python3 -m omh.cli docs workflows --check` -- `ok:true`, tap_skills 97/97
- [x] `python3 -m omh.cli harness validate` -- `ok:true`, 69 harnesses / 90 skills
- [x] `python3 -m omh.cli release checklist --json` -- `ok:true` (plan mode,
      `observed:false`; a deterministic plan, not execution evidence)
- [x] `python3 -m omh.cli release hermes-smoke` -- plan rendered, plan-only boundary
- [ ] `omh --help` -- not run; no console-script or packaging surface changed
- [ ] `omh ... release hermes-smoke --install-path setup --include-command-smoke` -- not run
- [ ] Workflow-learning review queue smoke -- not applicable; no learning contract changed
- [x] Relevant dry-run or smoke command: `docs roles --check` and
      `docs capability-families --check` both `ok:true`; `git diff --check` clean
- [ ] Manual Hermes/TUI check -- **not run.** No live Hermes host exercised the installed
      bundle. The degraded path is covered at the vendored-bundle level in
      `tests/test_plugin_distribution.py` only.

Additional observed evidence beyond the template:

- `uv run --group lint ruff check --select BLE001 src` -> **exactly 11**, unchanged from
  base. This change adds no `except` and relocates none, so the recorded counts did not
  move.
- **Mutation checks.** Ten mutations were applied one at a time to a committed tree and
  reverted; each had to make a named test fail. All ten were killed, so none of the new
  assertions is vacuous. They cover: the empty-message tuple guard (reproduces
  `TypeError: 'bool' object is not subscriptable`), the route-hint producer wiring, the
  upward merge, the `pre_llm_call` accessor wiring, the cache-copy branch, a regressed
  policy verdict, core/standalone manifest drift, removing the `[0]` destructure, the
  site-3 delegated-call handler, and wrongly making the site-3 *import* guard emit a
  component.
- **Arity sweep** over all five helpers that gained a parameter: every call site passes
  the accumulator (`awareness.py` x5, `context_brief.py` x2). Reported as a **manual
  completeness sweep**, not a gate -- see Risk.
- **Truthiness sweep** over the one function whose return type changed: exactly two call
  references exist and both destructure (`[0]` and `[1]`); every other reference is
  `.cache_clear()` / `.cache_info()` attribute access.
- **Return-site completeness** re-derived from the AST rather than trusted: the converted
  function has exactly two returns and both are tuples.
- Existing genuine-absence and cache-count tests are **unmodified and green**, including
  the three `assertIsNone` cases and the two `pre_llm_call` cache-count tests, which
  confirm the new accessor adds a cache hit and not a miss.

## Risk

- **`pre_llm_call` can now return a payload where it returned `None`.** This is the one
  behavioural change, accepted deliberately and bounded to turns where a guarded
  delegated call actually raised. Without it, the single failure path the locale pack
  exists for stays permanently invisible. A genuinely idle host still returns `None`. A
  host that branches on `payload is not None` rather than on the status fields could
  render an empty panel; the status block is still gated on `runtime_state_present` /
  `runs` and is unchanged, and a test asserts the degraded payload carries no `runs` and
  no status line.
- **A new model-facing line on a superset of those turns.** When a site fails on a
  message that *does* match awareness, no `None` flip occurs but the model still receives
  one extra line it did not receive before. It is asserted to appear exactly once, to be
  last in `context_parts`, to carry component labels but no error types and no substring
  of the user message, and to carry the `AGENTS.md` evidence-boundary phrasing verbatim.
  The wording deliberately frames it as an observation of a local call failure rather
  than as "not evidence", which is the phrasing most likely to be misread by a model
  reading its own prompt.
- **No static gate catches a missed call site.** Neither `ruff --select F` nor
  `compileall` has a call-arity rule, in either the defaulted or the required form. The
  parameter is a *required* positional precisely so a missed site raises a loud
  `TypeError` under the per-site tests instead of silently returning a healthy-shaped
  payload with the signal dropped. The grep sweep above is a manual completeness check
  and is reported as such, not as a gate.
- **Installed hosts diverge until `omh update`.** The bundle manifest is sha-pinned, so a
  host on the old bundle will not produce the block. `omh doctor` already surfaces
  `plugin_bundle_stale`, and `omh_degradation` carries a `schema_version` a host can
  detect.
- **Unrelated pre-existing flake observed, not caused by this change.**
  `tests/test_fanout_dispatch.py` intermittently fails under full-suite load -- observed
  on three *different* tests across runs, including `test_timeout_records_failed_unit`,
  which is overtly timing-based. That module dispatches through a `ThreadPoolExecutor`
  and shells out to real `git`. It imports **none** of the modules this PR touches
  (verified), and the flake still reproduces with this PR's new test file removed and the
  source changes in place. Flagging it as an existing issue worth a separate fix; I am
  not claiming it is fixed or fully characterised here.

## Compatibility / Rollout

Additive and absent on the happy path. No key appears unless something actually degraded,
so no consumer sees a new field on a healthy request. No test asserts an exact key set,
full-dict equality, or a byte budget on the affected schemas. Nested blocks are never
stripped, so `omh_route_hint/v1` stays byte-identical whether read standalone or embedded
(asserted). Repeated identical calls produce byte-equal degraded payloads across cache
hits (asserted). No new dependency, no network call, no generated artifact hand-edited;
all three byte gates re-run clean.

## Release / Claims

- [x] Release-channel impact considered -- `local`; no version bump, no packaging change
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Known manual Hermes checks are listed, including the `omh release hermes-smoke --live` gap

Claim boundary, stated plainly: a degradation marker is an observation of a local
delegated-call failure and nothing more. It does not touch `prepared_not_observed`, and
it is not execution, review, CI, merge-readiness, or merge evidence. Everything reported
above is local deterministic evidence; no live Hermes runtime use was observed.

**Please do not merge on my behalf** -- submitted for review.

## Follow-Up

1. Whether `NEEDS_637_TREATMENT` stays a permitted verdict in `VERDICTS` now that the
   ratchet exists. Recommendation: keep both, with the ratchet's failure message pointing
   at the decision, so a contributor recording a genuine *new* defect gets a readable
   instruction rather than a mystery.
2. **Wrapper chat responses drop the `omh_degradation` signal.**
   `src/wrapper/route_hints.py` rebuilds `omh_route_hint/v1` from an explicit key
   whitelist, so a Discord or Slack user sees nothing when a local call failed and a
   reduced fallback answered them. Deliberately out of scope: that file contains no broad
   `except` and is not among the 11 derived sites, so this is a user-facing visibility
   goal rather than a handler-relabeling defect. Worth deciding whether an end user
   benefits from seeing it at all, or whether it belongs in `omh doctor` output instead.
3. Whether the unguarded `.resolve()` / `.glob()` calls in `runtime_reader.py` should get
   narrow `OSError` handling, which would make site 4's broad handler nearly unreachable.
4. The `tests/test_fanout_dispatch.py` flake noted under Risk.
