### PR TITLE
fix: tell an unreadable runtime directory apart from an empty one

### DIFF
--- a/src/plugin_bundle/omh/runtime_reader.py
+++ b/src/plugin_bundle/omh/runtime_reader.py
@@ -107,6 +107,31 @@ def _read_jsonl(path: Path) -> list[dict[str, Any]]:
     return records
 
 
+def _child_files(directory: Path, *relative: str) -> list[Path]:
+    """Return every existing `directory/<child>/*relative` file.
+
+    `Path.glob` is tolerant by design: it swallows the `OSError` `os.scandir`
+    raises on an unreadable directory and yields nothing, so a directory the
+    process cannot read produces the same empty result as one that is
+    genuinely empty. That is the failure-relabeled-as-a-normal-result shape
+    `tests/test_broad_exception_policy.py` exists to keep out, so this reads
+    the directory with an API that propagates instead.
+
+    A directory that was never created is the routine case and really is
+    empty, so `FileNotFoundError` and `NotADirectoryError` return `[]`. Any
+    other `OSError` is a real fault and is left to reach the caller that
+    classifies it, which records a `runtime_status_read` degradation rather
+    than reporting a host with nothing to report.
+    """
+    try:
+        with os.scandir(directory) as entries:
+            names = [entry.name for entry in entries]
+    except (FileNotFoundError, NotADirectoryError):
+        return []
+    candidates = [directory.joinpath(name, *relative) for name in names]
+    return [candidate for candidate in candidates if candidate.is_file()]
+
+
 def _bool_from_record(record: dict[str, Any], key: str = "observed") -> bool:
     return bool(record.get(key, False)) if record else False
 
@@ -767,9 +792,8 @@ def read_omh_status(omh_home: str | Path | None = None, limit: int = 5) -> dict[
     runs_dir = runtime_dir / "runs"
     state = _read_json(runtime_dir / "state.json")
     runs: list[dict[str, Any]] = []
-    if runs_dir.exists():
-        for run_json in sorted(runs_dir.glob("*/run.json"), reverse=True)[:safe_limit]:
-            runs.append(_summarize_run(run_json.parent))
+    for run_json in sorted(_child_files(runs_dir, "run.json"), reverse=True)[:safe_limit]:
+        runs.append(_summarize_run(run_json.parent))
     progress = _executor_progress_projection(runtime_dir, limit=max(safe_limit * 10, safe_limit))
     return {
         "schema_version": STATUS_SCHEMA_VERSION,
@@ -839,9 +863,7 @@ def _progress_bindings(runtime_dir: Path, *, limit: int) -> list[dict[str, Any]]
         (runtime_dir / "wrapper_sessions", "wrapper_session"),
     )
     for root, target_type in roots:
-        if not root.exists():
-            continue
-        for binding_path in sorted(root.glob("*/executor_progress/binding.json"), reverse=True):
+        for binding_path in sorted(_child_files(root, "executor_progress", "binding.json"), reverse=True):
             binding = _read_json(binding_path)
             if not _valid_progress_binding(binding, target_type):
                 continue

--- a/tests/test_runtime_reader_filesystem_faults.py
+++ b/tests/test_runtime_reader_filesystem_faults.py
@@ -1,0 +1,263 @@
+"""Filesystem-fault behaviour of `plugin_bundle/omh/runtime_reader.py`.
+
+PR #654 stopped `pre_llm_call` from reading a failed status read as a host with
+nothing to report: the broad handler now records a `runtime_status_read`
+degradation. That handler only helps if the reader below it does not quietly
+turn a fault into an empty result first, so this module pins the reader's
+behaviour per filesystem call site, forcing the real condition rather than
+mocking it.
+
+Two shapes are proved here, and the difference between them is the point:
+
+* Directory enumeration (`read_omh_status` runs, executor-progress bindings)
+  must tell "nothing has been written yet" apart from "cannot be read". The
+  first is a routine empty state and returns `[]`. The second propagates, so
+  the classifying handler sees it. `Path.glob` cannot express that split --
+  it swallows the `os.scandir` `OSError` and yields nothing either way --
+  which is why `_child_files` reads with an API that propagates.
+
+* `_expand_path` and the plugin role-catalog probe are deliberately left
+  unguarded. Their tests are here to prove those decisions still hold, not to
+  record a gap; each explains why below.
+
+Skipped rather than faked where the mechanism is not reproducible: POSIX
+permission bits do not restrict root, and neither `chmod` nor symlink loops
+behave the same off POSIX.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import unittest
+from contextlib import contextmanager
+from collections.abc import Iterator
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from _local_package import load_local_package
+
+load_local_package()
+
+from omh.plugin_bundle.omh.degradation import COMPONENT_RUNTIME_STATUS_READ
+from omh.plugin_bundle.omh.hooks.llm_hooks import pre_llm_call
+from omh.plugin_bundle.omh.runtime_reader import read_omh_hud, read_omh_status
+
+BINDING_SCHEMA_VERSION = "omh_executor_progress_binding/v1"
+
+requires_posix_permissions = unittest.skipUnless(
+    os.name == "posix" and hasattr(os, "geteuid") and os.geteuid() != 0,
+    "POSIX permission bits do not restrict root and do not exist off POSIX",
+)
+requires_symlinks = unittest.skipUnless(
+    os.name == "posix",
+    "symlink-loop resolution differs off POSIX",
+)
+
+
+@contextmanager
+def unreadable(directory: Path) -> Iterator[Path]:
+    """Make `directory` unreadable, restoring the mode so cleanup can run."""
+    original = directory.stat().st_mode
+    os.chmod(directory, 0o000)
+    try:
+        yield directory
+    finally:
+        os.chmod(directory, original)
+
+
+def write_run(runs_dir: Path, run_id: str) -> None:
+    run_dir = runs_dir / run_id
+    run_dir.mkdir(parents=True)
+    (run_dir / "run.json").write_text(json.dumps({"run_id": run_id, "phase": "planned"}), encoding="utf-8")
+
+
+def write_binding(root: Path, target_id: str, target_type: str) -> None:
+    progress_dir = root / target_id / "executor_progress"
+    progress_dir.mkdir(parents=True)
+    (progress_dir / "binding.json").write_text(
+        json.dumps(
+            {
+                "schema_version": BINDING_SCHEMA_VERSION,
+                "binding_id": f"{target_type}:{target_id}:codex",
+                "instance_id": "instance-1",
+                "target_type": target_type,
+                "target_id": target_id,
+                "executor_profile": "codex",
+                "correlation_root": "correlation-1",
+                "state": "active",
+                "claim_boundary": "progress signal, not result evidence",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+class RunEnumerationFaultTests(unittest.TestCase):
+    """`read_omh_status` runs: absence is empty, unreadable is a fault."""
+
+    def test_missing_runs_directory_is_a_routine_empty_state(self) -> None:
+        with TemporaryDirectory() as tmp:
+            status = read_omh_status(Path(tmp) / ".omh")
+
+            self.assertEqual(status["runs"], [])
+            self.assertFalse(status["runtime_state_present"])
+
+    def test_readable_runs_directory_still_summarizes_its_runs(self) -> None:
+        with TemporaryDirectory() as tmp:
+            runs_dir = Path(tmp) / ".omh" / "runtime" / "runs"
+            write_run(runs_dir, "run-a")
+            write_run(runs_dir, "run-b")
+
+            status = read_omh_status(Path(tmp) / ".omh")
+
+            self.assertEqual([run["run_id"] for run in status["runs"]], ["run-b", "run-a"])
+
+    @requires_posix_permissions
+    def test_unreadable_runs_directory_propagates_instead_of_reporting_no_runs(self) -> None:
+        with TemporaryDirectory() as tmp:
+            runs_dir = Path(tmp) / ".omh" / "runtime" / "runs"
+            write_run(runs_dir, "run-a")
+
+            with unreadable(runs_dir):
+                with self.assertRaises(PermissionError):
+                    read_omh_status(Path(tmp) / ".omh")
+
+    @requires_posix_permissions
+    def test_unreadable_runs_directory_is_not_reported_as_an_empty_one(self) -> None:
+        # The regression this guards: the fault and the routine empty state
+        # used to produce byte-identical payloads, so a caller reading `runs`
+        # could not tell them apart.
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp) / ".omh"
+            empty_runs = home / "runtime" / "runs"
+            empty_runs.mkdir(parents=True)
+            empty_status = read_omh_status(home)
+
+            with unreadable(empty_runs):
+                with self.assertRaises(PermissionError):
+                    read_omh_status(home)
+
+            self.assertEqual(empty_status["runs"], [])
+
+
+class ProgressBindingEnumerationFaultTests(unittest.TestCase):
+    """Executor-progress roots carry the same split as the runs directory."""
+
+    def test_missing_wrapper_sessions_directory_is_a_routine_empty_state(self) -> None:
+        with TemporaryDirectory() as tmp:
+            status = read_omh_status(Path(tmp) / ".omh")
+
+            self.assertEqual(status["active_executors"], [])
+            self.assertEqual(status["stale_executors"], [])
+
+    @requires_posix_permissions
+    def test_unreadable_wrapper_sessions_directory_propagates(self) -> None:
+        with TemporaryDirectory() as tmp:
+            runtime_dir = Path(tmp) / ".omh" / "runtime"
+            sessions_dir = runtime_dir / "wrapper_sessions"
+            write_binding(sessions_dir, "session-a", "wrapper_session")
+
+            with unreadable(sessions_dir):
+                with self.assertRaises(PermissionError):
+                    read_omh_status(Path(tmp) / ".omh")
+
+    @requires_posix_permissions
+    def test_unreadable_progress_root_is_not_reported_as_no_active_executors(self) -> None:
+        # An executor mid-flight must never read as "nothing is running"
+        # because the directory holding its binding could not be opened.
+        with TemporaryDirectory() as tmp:
+            runtime_dir = Path(tmp) / ".omh" / "runtime"
+            sessions_dir = runtime_dir / "wrapper_sessions"
+            sessions_dir.mkdir(parents=True)
+            empty_status = read_omh_status(Path(tmp) / ".omh")
+
+            with unreadable(sessions_dir):
+                with self.assertRaises(PermissionError):
+                    read_omh_status(Path(tmp) / ".omh")
+
+            self.assertEqual(empty_status["active_executors"], [])
+
+
+class ClassifyingHandlerReachTests(unittest.TestCase):
+    """Every propagated fault must land in `pre_llm_call`'s classifier."""
+
+    def call_pre_llm(self, omh_home: Path, hermes_home: Path) -> dict | None:
+        return pre_llm_call(
+            omh_home=str(omh_home),
+            hermes_home=str(hermes_home),
+            user_message="unrelated message",
+            is_first_turn=False,
+            include_omh_awareness=False,
+        )
+
+    def assert_status_read_degradation(self, payload: dict | None, error_type: str) -> None:
+        self.assertIsNotNone(payload)
+        assert payload is not None
+        block = payload["omh_degradation"]
+        self.assertEqual(
+            block["components"],
+            [{"component": COMPONENT_RUNTIME_STATUS_READ, "error_type": error_type}],
+        )
+        self.assertIn("[OMH Degraded] components=", str(payload["context"]))
+
+    def test_idle_host_still_returns_none(self) -> None:
+        with TemporaryDirectory() as tmp:
+            self.assertIsNone(self.call_pre_llm(Path(tmp) / ".omh", Path(tmp) / ".hermes"))
+
+    @requires_posix_permissions
+    def test_unreadable_runs_directory_is_classified_not_read_as_idle(self) -> None:
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp) / ".omh"
+            runs_dir = home / "runtime" / "runs"
+            write_run(runs_dir, "run-a")
+
+            with unreadable(runs_dir):
+                payload = self.call_pre_llm(home, Path(tmp) / ".hermes")
+
+            self.assert_status_read_degradation(payload, "PermissionError")
+
+    @requires_symlinks
+    def test_symlink_loop_home_is_classified_not_read_as_idle(self) -> None:
+        # Deliberately not narrowed at `_expand_path`. That function must
+        # return a `Path`, and every fallback path it could invent would send
+        # the reads below it somewhere else -- where they all find nothing and
+        # report a healthy idle host. Propagating is the only answer that
+        # keeps the fault visible.
+        with TemporaryDirectory() as tmp:
+            loop = Path(tmp) / "loop"
+            loop.symlink_to(loop)
+
+            with self.assertRaises((OSError, RuntimeError)):
+                read_omh_status(loop)
+
+            payload = self.call_pre_llm(loop, Path(tmp) / ".hermes")
+
+            self.assert_status_read_degradation(payload, "RuntimeError")
+
+
+class RoleCatalogProbeTests(unittest.TestCase):
+    """The role-catalog probe is deliberately left tolerant."""
+
+    @requires_posix_permissions
+    def test_unreadable_role_catalog_reports_the_capability_as_unavailable(self) -> None:
+        # Unlike the enumeration sites, the tolerant answer here is the
+        # accurate one: a role catalog the process cannot read really does
+        # make the role-dependent tools unusable, and the HUD says so. The
+        # defect shape would be a false `ready`, not this. Raising instead
+        # would take down the whole HUD read over one degraded sub-capability.
+        with TemporaryDirectory() as tmp:
+            hermes_home = Path(tmp) / ".hermes"
+            references = hermes_home / "plugins" / "omh" / "references"
+            references.mkdir(parents=True)
+            (references / "role-executor.md").write_text("role", encoding="utf-8")
+
+            with unreadable(references):
+                payload = read_omh_hud(Path(tmp) / ".omh", hermes_home)
+
+            self.assertFalse(payload["plugin"]["capabilities"]["files"]["role_catalog"])
+            self.assertNotEqual(payload["plugin"]["status"], "ready")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- `read_omh_status()` now tells an unreadable runtime directory apart from an empty one. An unreadable `~/.omh/runtime/runs` or `~/.omh/runtime/wrapper_sessions` propagates the `OSError` instead of returning `runs: []` / `active_executors: []`.
- A directory that was never created stays a routine empty state and still returns `[]` — that case is unchanged and pinned by tests.
- New `_child_files()` helper in `src/plugin_bundle/omh/runtime_reader.py` replaces two `Path.glob()` enumerations and their now-redundant `.exists()` guards.
- New `tests/test_runtime_reader_filesystem_faults.py` (11 cases) forces the real filesystem conditions — actual `chmod 000` directories and actual symlink loops, no mocking of the failure.
- Two other swept sites are deliberately left unguarded. Both decisions are argued below and pinned by tests so a later sweep does not "fix" them.

### Why This Exists

Follow-up to #654 (merged). That PR made `pre_llm_call`'s broad handler classify its failure — it records a `runtime_status_read` degradation instead of silently returning an empty status. The handler only helps if the reader beneath it lets the failure escape.

It did not. `pathlib.Path.glob` is tolerant by design: it catches the `OSError` that `os.scandir` raises and yields nothing. Verified on CPython 3.12/darwin:

```
glob on chmod-000 dir:          NO RAISE -> []
glob when child dir unreadable: NO RAISE -> []
iterdir on chmod-000:           RAISED PermissionError: [Errno 13] Permission denied
exists() on chmod-000 dir:      NO RAISE -> True
```

So an unreadable `runs/` produced `runs: []`, byte-identical to a fresh install. `read_omh_status` then reported `runtime_state_present: False` with no runs, `pre_llm_call` hit its `not context_parts and not degradation and not runs` branch, and returned `None` — a genuinely idle host. The `.exists()` guard did not catch it either: `exists()` returns `True` for a `chmod 000` directory, because stat on the directory itself still succeeds.

That is the exact failure-relabeled-as-a-normal-result shape `tests/test_broad_exception_policy.py` exists to keep out, sitting one layer below the handler #654 fixed. No `except` around `glob` could have addressed it, because nothing ever escaped `glob`.

The `wrapper_sessions/` case is the sharper one: an unreadable progress root made an executor that is mid-flight read as "nothing is running".

### User / Operator Impact

An operator whose `~/.omh` is unreadable — wrong ownership after a `sudo` install, a restrictive `umask`, a partially-restored backup — previously saw OMH report a clean idle state. The status read now surfaces:

- Through `pre_llm_call`: an `omh_degradation` block naming `runtime_status_read` with error type `PermissionError`, plus one bounded `[OMH Degraded]` context line. Previously that call returned `None`.
- Through `omh_status` / `omh_hud` / `omh probe`: the `OSError` reaches the host, which reports a tool error rather than an empty-but-well-formed payload.

The routine paths are untouched: a fresh install with no `runtime/` directory, an empty `runs/`, and every populated case behave exactly as before.

### How It Works

`_child_files(directory, *relative)` enumerates one directory level with `os.scandir` — an API that propagates — and returns the existing `directory/<child>/*relative` files. The split it encodes is the whole point of the change:

- `FileNotFoundError` / `NotADirectoryError` → `[]`. Nothing has been written yet; the directory really is empty. This is routine, not a fault.
- Any other `OSError` (`PermissionError` and friends) → propagates. This is a real fault, and it reaches `pre_llm_call`'s classifying handler.

Enumeration semantics are unchanged. Verified equivalent to the replaced `glob` calls for ordinary children, dot-directories (both include them), a missing directory, and a non-directory path.

**Sites swept in `runtime_reader.py`, and the decision at each:**

| Site | Can it raise? | Decision |
| --- | --- | --- |
| `_expand_path` — `.expanduser().resolve()` | Yes: `RuntimeError` on symlink loop, `FileNotFoundError` on deleted cwd | **Left alone — propagate** |
| `_read_json` / `_read_jsonl` / `_read_text` — `read_text` | Yes | Already narrow (`OSError`, `json.JSONDecodeError`) — unchanged |
| `_plugin_capabilities` — `references/.glob("role-*.md")` | **No** (verified) | **Left alone — tolerant answer is accurate** |
| `read_omh_status` — `runs_dir.glob("*/run.json")` | **No** (verified) | **Changed** — enumerate with an API that propagates |
| `_progress_bindings` — `root.glob("*/executor_progress/binding.json")` | **No** (verified) | **Changed** — same |
| `is_dir()` / `is_file()` / `exists()` | No — pathlib swallows `OSError`/`ValueError` | Left alone |
| `_seconds_since` — `datetime.fromisoformat` | Yes | Already narrow (`TypeError`, `ValueError`) — unchanged |

**Why `_expand_path` was not narrowed.** It has to return a `Path`. Every fallback it could invent — the unexpanded input, `Path.cwd()`, the literal `~/.omh` — aims every read below it at a *different location*, and all of those reads are already `OSError`-tolerant. The result would be a well-formed "nothing here" payload: the #654 defect reintroduced one layer down, and worse, because it would be silent at four call sites instead of one. Propagating is the only answer that keeps the fault visible, and the classifying handler is already there to receive it. `test_symlink_loop_home_is_classified_not_read_as_idle` proves a real symlink loop reaches it as a classified `RuntimeError`.

**Why the role-catalog probe was not narrowed.** Unlike the enumeration sites, its tolerant answer is the *accurate* one. A role catalog the process cannot read genuinely does make the role-dependent tools unusable, and the HUD already says so: `role_catalog: False` flows through `_plugin_tool_capabilities` and the plugin reports a non-`ready` status. The defect shape here would be a false `ready`, not this. Raising instead would take down the entire HUD read over one degraded sub-capability. `test_unreadable_role_catalog_reports_the_capability_as_unavailable` pins that.

A larger uniform change was available and rejected: wrapping all four originally-named sites in `try/except OSError` would have been three pieces of dead code (the `glob` calls cannot raise) plus one wrong fallback (`_expand_path`).

### Files And Contracts Touched

- `src/plugin_bundle/omh/runtime_reader.py` — new `_child_files()`; two call sites converted; two `.exists()` guards removed as redundant (also closing a TOCTOU window between the guard and the enumeration). Stdlib only, no new imports, no new dependencies, no network calls. Standalone plugin hosts unaffected.
- `tests/test_runtime_reader_filesystem_faults.py` — new.
- No schema change. `omh_status/v1`, `omh_hud/v1`, and `omh_degradation/v1` payload shapes are untouched.
- No evidence-boundary change. `prepared_not_observed` is untouched.
- `tests/test_broad_exception_policy.py` — **not modified**. No broad handler was added, removed, or reclassified, and the `pre_llm_call` rationale ("Still sets status={} and hud={}, but appends `runtime_status_read` …") remains accurate. `EXPECTED_HANDLER_COUNT` / `EXPECTED_ANCHOR_COUNT` stay 11/10.
- `pyproject.toml` — untouched; `select = ["F"]` unchanged.
- No generated file touched.

## Validation

Observed on this branch, macOS 15 / CPython 3.12.13:

- [x] `uv run --group lint ruff check --select BLE001 src` → **`Found 11 errors.`** (unchanged: 11 handlers across 10 anchors)
- [x] `uv run --group lint ruff check src tests` → `All checks passed!`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests` → `Ran 1702 tests in 50.077s / OK (skipped=1)`
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_runtime_reader_filesystem_faults.py -v` → `Ran 11 tests / OK`
- [x] `uv run python -m compileall -q src tests` → clean
- [x] `uv run python -m omh.cli docs workflows --check` → `"ok":true`, tap_skills `checked:97 expected:97`
- [x] `uv run python -m omh.cli docs roles --check` → `"ok":true`
- [x] `uv run python -m omh.cli docs capability-families --check` → `"ok":true`
- [x] `git diff --check` → clean

Negative control: with `src/plugin_bundle/omh/runtime_reader.py` stashed to its pre-change state, 5 of the 11 new cases fail (`AssertionError: PermissionError not raised`). The 6 that pass either way are the regression pins for the two deliberately-unchanged sites and the routine empty-state paths.

Not run: `omh.cli harness validate`, `release checklist`, `release hermes-smoke`, and the install smokes — this change touches neither setup, release, nor harness surfaces. No manual Hermes/TUI check was performed, so behaviour of a live Hermes host against a real unreadable `~/.omh` is **not observed**.

## Risk

- **Behaviour change on a failure path.** `read_omh_status` / `read_omh_hud` can now raise `OSError` where they previously returned an empty payload. `pre_llm_call` already handles this (it is the point of the change). The direct callers — `tools/status_tool.py`, `tools/hud_tool.py`, `tools/probe_tool.py`, `surfaces/hud.py` — do not wrap the call, so the error reaches the host as a tool error. This is intended: an explicit "show me status" against an unreadable home should report a failure, not "no runs". It only triggers on a genuinely unreadable directory; it cannot fire on a missing or empty one.
- Enumeration order and contents are unchanged, verified against the replaced `glob` calls including dot-directory and non-directory inputs.
- The permission-based tests skip as root and off POSIX rather than faking the condition, so those paths are unverified in a root CI container.

## Compatibility / Rollout

- No schema version bump; no persisted-artifact format change; no migration.
- Pure Python 3.11+ stdlib, zero new dependencies, no network calls. The plugin bundle stays standalone.
- Safe to roll back on its own — it touches one module plus its new test.

## Release / Claims

- [x] Release-channel impact considered — no release-surface change; behaviour change is confined to a local filesystem failure path.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed — all verification output above was observed locally; the live Hermes host path is explicitly marked not observed.
- [x] Known manual Hermes checks are listed — no `omh release hermes-smoke --live` run; noted as a gap under Validation.

## Follow-Up

- `_read_json` / `_read_jsonl` / `_read_text` still collapse "file unreadable" and "file absent" into the same empty result. Unlike the enumeration sites, changing those has a wide blast radius (they back every run/wrapper/journal record read, and several callers depend on the tolerant behaviour to treat an absent record as "not observed"), so it is deliberately out of scope here rather than overlooked.
- Broad-exception policy owner remains #652; this PR does not move `BLE001` toward `select`.

Reference: follows up #654.
