### PR TITLE
feat: show the degradation signal to chat users instead of dropping it at the wrapper

### DIFF
--- a/src/plugin_bundle/omh/degradation.py
+++ b/src/plugin_bundle/omh/degradation.py
@@ -47,6 +47,17 @@ DEGRADATION_CLAIM_BOUNDARY = (
     "CI, merge-readiness, or merge evidence."
 )
 
+# The one line a chat surface renders. Deliberately label-free: the component
+# names are engineer-facing and mean nothing to a Discord or Slack reader, so
+# they stay in the structured block and never reach rendered text. English
+# only; localized output is explicit opt-in via `--language`/`OMH_LANG`, and
+# nothing here may auto-detect a locale.
+DEGRADATION_CHAT_NOTE = (
+    "Heads-up: part of this answer came from a reduced local fallback because an "
+    "OMH-local step failed, so it may be less accurate than usual. Ask again if it "
+    "looks wrong."
+)
+
 
 def safe_error_type(error_type: str) -> str:
     """Return a bounded, character-safe exception class name."""
@@ -60,6 +71,18 @@ def degradation_component(component: str, error_type: str) -> dict[str, str]:
     if label not in DEGRADATION_COMPONENTS:
         label = UNKNOWN_COMPONENT
     return {"component": label, "error_type": safe_error_type(error_type)}
+
+
+def degradation_chat_note(degradation: object) -> str:
+    """Return the chat-surface note for a degradation block, or `""`.
+
+    The empty string is the happy path and must stay empty: a caller appends
+    the result unconditionally, so a non-empty default would put permanent
+    degradation text in front of every healthy chat user.
+    """
+    if not isinstance(degradation, dict) or not degradation.get("degraded"):
+        return ""
+    return DEGRADATION_CHAT_NOTE
 
 
 def degradation_payload(components: Iterable[tuple[str, str]]) -> dict[str, object]:

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -30,6 +30,7 @@ from ..memory import memory_recall_pack_for_handoff
 from ..operator_productivity import build_agent_operator_productivity_card
 from ..paths import OmhPaths, resolve_paths
 from ..plugin_bundle.omh.awareness import workflow_context_card_for_workflow, workflow_context_cards
+from ..plugin_bundle.omh.degradation import degradation_chat_note
 from ..probe import probe_capabilities
 from ..quickstart import build_quickstart_card
 from ..skills.catalog import installable_skill_definitions, primary_harness_for_skill, retained_delegation_skill_names
@@ -5784,6 +5785,8 @@ def build_chat_response_from_omh_context_brief(
     thread_key: str = "",
 ) -> dict[str, object]:
     brief = build_context_brief(message, source=source, max_hints=2, include_prompt_context=False)
+    degradation = brief.get("degradation")
+    degradation_note = degradation_chat_note(degradation)
     lanes = brief.get("lanes", [])
     lane_summaries: list[str] = []
     if isinstance(lanes, list):
@@ -5805,6 +5808,9 @@ def build_chat_response_from_omh_context_brief(
         "- Open the workflow picker with ./omh when you want to choose manually.",
         "- Ask what to do next after setup when you want the first-use path.",
         "",
+        # Empty on the happy path, so a healthy brief renders exactly the lines
+        # it rendered before.
+        *([degradation_note, ""] if degradation_note else []),
         "Boundary: this context explains routing and workflow choices; it is not execution, delivery, verification, review, CI, or merge evidence.",
     ]
     return _chat_response(

--- a/src/wrapper/route_hints.py
+++ b/src/wrapper/route_hints.py
@@ -5,6 +5,7 @@ from ..plugin_bundle.omh.awareness import (
     awareness_route_hint,
     awareness_route_hint_context_from_payload,
 )
+from ..plugin_bundle.omh.degradation import degradation_chat_note
 from ..routing.catalog_questions import is_skill_catalog_question
 from ..routing.action_copy import next_action_label
 
@@ -217,6 +218,31 @@ def _response_for_hint(
             },
         ]
         render_kind = "no_route_hint"
+    # Appended after both branches so the note is always the last sentence a
+    # chat reader sees, whichever branch built the body.
+    degradation = route_hint.get("degradation") if isinstance(route_hint, dict) else None
+    degradation_note = degradation_chat_note(degradation)
+    if degradation_note:
+        body = f"{body} {degradation_note}"
+    state_route_hint: dict[str, object] = {
+        "schema_version": "omh_route_hint/v1",
+        "primary_workflow": workflow,
+        "primary_next_action": next_action,
+        "primary_next_action_label": next_action_label_text,
+        "intent_class": str(route_hint.get("intent_class") or ""),
+        "selected_workflow": str(route_hint.get("selected_workflow") or workflow),
+        "mentioned_workflows": list(route_hint.get("mentioned_workflows", [])),
+        "mentioned_runtime_terms": list(route_hint.get("mentioned_runtime_terms", [])),
+        "adjacent_workflows": list(route_hint.get("adjacent_workflows", [])),
+        "not_executed": list(route_hint.get("not_executed", [])),
+        "hints": hints,
+        "catalog_question": bool(route_hint.get("catalog_question", False)),
+    }
+    # This rebuild is an explicit key whitelist, so a key added upstream is
+    # dropped here by default. `degradation` is set conditionally: a healthy
+    # request must keep exactly today's key set.
+    if isinstance(degradation, dict) and degradation:
+        state_route_hint["degradation"] = degradation
     return {
         "schema_version": CHAT_ROUTE_HINT_RESPONSE_SCHEMA_VERSION,
         "kind": render_kind,
@@ -240,20 +266,7 @@ def _response_for_hint(
             "next_action": next_action,
             "next_action_label": next_action_label_text,
             "route_hint_count": len(hints),
-            "route_hint": {
-                "schema_version": "omh_route_hint/v1",
-                "primary_workflow": workflow,
-                "primary_next_action": next_action,
-                "primary_next_action_label": next_action_label_text,
-                "intent_class": str(route_hint.get("intent_class") or ""),
-                "selected_workflow": str(route_hint.get("selected_workflow") or workflow),
-                "mentioned_workflows": list(route_hint.get("mentioned_workflows", [])),
-                "mentioned_runtime_terms": list(route_hint.get("mentioned_runtime_terms", [])),
-                "adjacent_workflows": list(route_hint.get("adjacent_workflows", [])),
-                "not_executed": list(route_hint.get("not_executed", [])),
-                "hints": hints,
-                "catalog_question": bool(route_hint.get("catalog_question", False)),
-            },
+            "route_hint": state_route_hint,
         },
         "claim_boundary": (
             "This response is a preview hint only. It is not workflow selection, execution, generated output, "

--- a/tests/test_degradation_signal.py
+++ b/tests/test_degradation_signal.py
@@ -30,15 +30,20 @@ from omh.plugin_bundle.omh.degradation import (
     COMPONENT_LOCALIZED_ROUTING_TEXT,
     COMPONENT_LOOP_ROUTE_HINT_ASSESSMENT,
     COMPONENT_RUNTIME_STATUS_READ,
+    DEGRADATION_CHAT_NOTE,
     MAX_DEGRADATION_COMPONENTS,
     OMH_DEGRADATION_SCHEMA_VERSION,
     UNKNOWN_COMPONENT,
+    degradation_chat_note,
     degradation_component,
     degradation_payload,
     safe_error_type,
 )
 from omh.plugin_bundle.omh.hooks import llm_hooks as llm_hooks_module
 from omh.plugin_bundle.omh.hooks.llm_hooks import pre_llm_call
+from omh.wrapper import contract as contract_module
+from omh.wrapper.contract import build_chat_interaction_payload
+from omh.wrapper.route_hints import build_chat_route_hint_payload
 
 # `AGENTS.md` evidence-boundary phrasing, carried verbatim into every degraded
 # surface. A degradation marker observes a local call failure and nothing more.
@@ -442,6 +447,118 @@ class MultiLevelMergeTests(DegradationSignalTestCase):
         self.assertTrue(second["degradation"]["degraded"])
         self.assertEqual(component_labels(second["degradation"]), [COMPONENT_LOCALIZED_ROUTING_TEXT])
         self.assertEqual(second["degradation"]["privacy"]["mode"], "metadata_only")
+
+
+class WrapperSurfaceDegradationTests(DegradationSignalTestCase):
+    """The Discord/Slack-facing surfaces must show the signal, not swallow it.
+
+    `_response_for_hint` rebuilds `omh_route_hint/v1` from an explicit key
+    whitelist, so a key added upstream is dropped unless it is listed. These
+    cases pin both directions: healthy renders exactly as before, degraded
+    renders a reader-actionable line plus the structured block.
+    """
+
+    ROUTE_HINT_MESSAGE = "Users report a wrapper-surface checkout bug"
+    INTRO_MESSAGE = "What is OMH and how should I use it?"
+
+    def setUp(self) -> None:
+        super().setUp()
+        contract_module._build_chat_interaction_payload_cached.cache_clear()
+
+    def test_a_healthy_route_hint_renders_exactly_todays_key_set_and_text(self) -> None:
+        payload = build_chat_route_hint_payload(self.ROUTE_HINT_MESSAGE, source="discord")
+
+        state_route_hint = payload["chat_response"]["state"]["route_hint"]
+        # Non-emptiness first: without it every assertion below passes on an
+        # empty payload and proves nothing.
+        self.assertTrue(state_route_hint)
+        self.assertTrue(payload["chat_response"]["body"].strip())
+        self.assertEqual(state_route_hint["primary_workflow"], "feedback-triage")
+
+        self.assertNotIn("degradation", payload["route_hint"])
+        self.assertNotIn("degradation", state_route_hint)
+        serialized = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+        self.assertNotIn(DEGRADATION_CHAT_NOTE, serialized)
+        self.assertNotIn("omh_degradation/v1", serialized)
+
+    def test_a_degraded_route_hint_renders_the_note_and_the_whitelisted_block(self) -> None:
+        with self.locale_failure():
+            payload = build_chat_route_hint_payload(self.ROUTE_HINT_MESSAGE, source="discord")
+
+        response = payload["chat_response"]
+        block = payload["route_hint"]["degradation"]
+        self.assertEqual(component_labels(block), [COMPONENT_LOCALIZED_ROUTING_TEXT])
+        self.assert_block_is_well_formed(block)
+
+        # The whitelist rebuild must carry the block through unchanged.
+        self.assertEqual(
+            json.dumps(response["state"]["route_hint"]["degradation"], sort_keys=True),
+            json.dumps(block, sort_keys=True),
+        )
+        # The routing answer itself is unchanged; only the signal is added.
+        self.assertEqual(response["state"]["route_hint"]["primary_workflow"], "feedback-triage")
+
+        body = response["body"]
+        self.assertTrue(body.strip())
+        self.assertIn(DEGRADATION_CHAT_NOTE, body)
+        self.assertTrue(body.endswith(DEGRADATION_CHAT_NOTE))
+        self.assertIn(DEGRADATION_CHAT_NOTE, response["messenger_rendering"]["body_text"])
+
+    def test_a_degraded_route_hint_never_renders_request_or_exception_message_text(self) -> None:
+        with self.locale_failure():
+            payload = build_chat_route_hint_payload(self.ROUTE_HINT_MESSAGE, source="discord")
+
+        serialized = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+        self.assertIn(DEGRADATION_CHAT_NOTE, serialized)
+        self.assertNotIn(self.ROUTE_HINT_MESSAGE, serialized)
+        self.assertNotIn(LOCALE_BOOM, serialized)
+        # Component labels are engineer-facing, so they stay in the structured
+        # block and never reach the rendered chat text.
+        self.assertNotIn(COMPONENT_LOCALIZED_ROUTING_TEXT, payload["chat_response"]["body"])
+
+    def test_a_healthy_context_brief_interaction_renders_exactly_todays_text(self) -> None:
+        payload = build_chat_interaction_payload(self.INTRO_MESSAGE, source="discord")
+
+        response = payload["chat_response"]
+        self.assertEqual(response["kind"], "context_brief")
+        brief = response["state"]["context_brief"]
+        self.assertTrue(brief)
+        self.assertTrue(response["body"].strip())
+
+        self.assertNotIn("degradation", brief)
+        serialized = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+        self.assertNotIn(DEGRADATION_CHAT_NOTE, serialized)
+        self.assertNotIn("omh_degradation/v1", serialized)
+
+    def test_a_degraded_context_brief_interaction_renders_the_note_and_the_block(self) -> None:
+        with self.locale_failure():
+            payload = build_chat_interaction_payload(self.INTRO_MESSAGE, source="discord")
+
+        response = payload["chat_response"]
+        self.assertEqual(response["kind"], "context_brief")
+        block = response["state"]["context_brief"]["degradation"]
+        self.assertEqual(component_labels(block), [COMPONENT_LOCALIZED_ROUTING_TEXT])
+        self.assert_block_is_well_formed(block)
+
+        body = response["body"]
+        self.assertTrue(body.strip())
+        self.assertIn(DEGRADATION_CHAT_NOTE, body)
+        # Placed before the boundary line, so the reader sees the caveat and
+        # the evidence boundary in the same block of text.
+        self.assertLess(body.index(DEGRADATION_CHAT_NOTE), body.index("Boundary:"))
+
+        serialized = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+        self.assertNotIn(LOCALE_BOOM, serialized)
+        self.assertNotIn(COMPONENT_LOCALIZED_ROUTING_TEXT, body)
+
+    def test_the_chat_note_is_empty_for_every_non_degraded_input(self) -> None:
+        for value in ({}, None, "", [], {"degraded": False}, {"components": []}):
+            with self.subTest(repr(value)):
+                self.assertEqual(degradation_chat_note(value), "")
+        self.assertEqual(
+            degradation_chat_note(degradation_payload([(COMPONENT_LOCALIZED_ROUTING_TEXT, "RuntimeError")])),
+            DEGRADATION_CHAT_NOTE,
+        )
 
 
 class DegradationPayloadUnitTests(unittest.TestCase):


### PR DESCRIPTION
## Feature Report

### What Changed

- A chat user who receives a degraded answer now gets told so. When an OMH-local delegated call fails and a reduced local fallback answers instead, the wrapper renders one short English line at the end of the reply, and the structured `omh_degradation/v1` block now reaches the wrapper-declared state path instead of being dropped.
- `src/wrapper/route_hints.py`: the `chat_response.state.route_hint` rebuild is an explicit key whitelist; `degradation` is now on it (conditionally), and the note is appended to `body`.
- `src/wrapper/contract.py`: `build_chat_response_from_omh_context_brief` renders the same note as its own paragraph, immediately before the existing `Boundary:` line.
- `src/plugin_bundle/omh/degradation.py`: new `DEGRADATION_CHAT_NOTE` constant and `degradation_chat_note()` helper, so both surfaces render one identical, single-sourced string.
- `tests/test_degradation_signal.py`: new `WrapperSurfaceDegradationTests` with 6 cases.

### Why This Exists

PR #654 introduced `omh_degradation/v1`. It records which component failed and a sanitized exception *class name* — never raw request text, never exception message text — so a broad `except` around a delegated call surfaces the failure instead of relabeling it as a normal result.

That signal stopped at the plugin and hook surface. `_response_for_hint` in `src/wrapper/route_hints.py` rebuilds `omh_route_hint/v1` from an explicit key whitelist, and `degradation` was not one of the twelve listed keys. The consequence at the product boundary: a Discord or Slack user asked a question, an OMH-local call raised, a reduced fallback answered, and the user saw a confident-looking reply with no indication that anything had gone wrong. The failure was recorded in the plugin payload and thrown away on the way to the person reading it.

The repo owner decided this belongs in front of chat users. This PR implements that decision and picks the shape.

### User / Operator Impact

Before: a degraded Discord/Slack answer was indistinguishable from a healthy one.

After, on a degraded turn only, the reply ends with:

> Heads-up: part of this answer came from a reduced local fallback because an OMH-local step failed, so it may be less accurate than usual. Ask again if it looks wrong.

Three deliberate choices about that shape:

- **No component labels in chat text.** `localized_routing_text` and `loop_route_hint_assessment` are internal names. A chat reader cannot act on them; an operator reads them from `state.route_hint.degradation` / `state.context_brief.degradation`, where they still live in full alongside the sanitized error type. Engineer-facing detail stays in the structured block.
- **Actionable, not diagnostic.** The line says what happened in outcome terms (reduced path, may be less accurate) and gives one recovery action (ask again). That is the whole of what a chat user can do about it.
- **English by default.** The note is a plain constant with no locale lookup and nothing that inspects the OS locale. Localized output remains explicit opt-in through `--language` / `OMH_LANG`.

Operators additionally get the block at `chat_response.state.route_hint.degradation`, which is the `state_path` the route-hint wrapper contract already declares, so no wrapper needs a new read path.

### How It Works

`degradation_chat_note()` returns `""` for anything that is not a degraded block, and both call sites append its result unconditionally. That inversion is the whole happy-path guarantee: nothing degraded means empty string means byte-identical output.

In `route_hints.py` the note is appended after both the hint and no-hint branches have built `body`, so it is the final sentence in either. It then reaches `messenger_rendering.body_text` and the `omh chat route-hint --summary` printer for free, because both already read `body` — no printer or renderer changed. The inline `state.route_hint` dict literal was lifted to a named `state_route_hint` so `degradation` can be set conditionally rather than always present.

In `contract.py` the note is placed as its own paragraph immediately before the `Boundary:` line, so the caveat and the evidence boundary read as one block rather than the caveat trailing after the boundary.

**Projections audited.** Beyond the two changed, the following were checked and found not to drop the block:

- `_copy_chat_response_state`, `_clone_static_dict` / `_clone_static_payload`, `_copy_chat_interaction_payload` (`contract.py`) — key-preserving recursive clones, so the block survives the interaction `lru_cache` copy path.
- `_copy_awareness_route_hint_payload` (`awareness.py`) — already given an explicit `degradation` branch by #654.
- `build_context_brief` embeds the brief whole under `state.context_brief`, so the block already travelled; only the rendered text was missing.

One whitelist was found and deliberately **not** changed: `_evaluate_context_brief_case` in `src/quality/context_brief_coverage.py` projects the brief through an explicit observed-key dict. It is a coverage/demo report surface rather than a chat surface, so widening it is outside this goal. Flagged under Follow-Up.

### Files And Contracts Touched

| File | Change |
| --- | --- |
| `src/plugin_bundle/omh/degradation.py` | `DEGRADATION_CHAT_NOTE`, `degradation_chat_note()` |
| `src/wrapper/route_hints.py` | whitelist entry + body note in `_response_for_hint` |
| `src/wrapper/contract.py` | body note in `build_chat_response_from_omh_context_brief` |
| `tests/test_degradation_signal.py` | `WrapperSurfaceDegradationTests` (6 cases) |

Contracts: `omh_degradation/v1` unchanged. `omh_route_hint/v1` as rebuilt at `chat_response.state.route_hint` gains one optional key, present only on a degraded turn. `chat_route_hint_response/v1` and `omh_chat_response/v1` gain no keys; only `body` text differs, and only when degraded.

**No fixture changed.** `examples/wrapper-golden/route-hints.json` and the other wrapper-golden fixtures assert healthy requests only, and healthy output is byte-identical, so `tests/test_wrapper_golden_examples.py` and `tests/test_wrapper_contract.py` pass unmodified. No exact-count assertion moved: no routing case, skill, or demo card was added. No generated artifact was hand-edited; all four `--check` byte gates pass unchanged.

**Claim boundary.** A degradation marker is an observation of an OMH-local call failure and nothing more: it is not execution, review, CI, merge-readiness, or merge evidence. The block's own `claim_boundary` carries that AGENTS.md phrasing verbatim and travels unchanged; no response-level claim boundary was broadened, and no new "not evidence" claim was invented. Nothing new is persisted — this is render-time only.

## Validation

Observed on this branch:

- [x] `uv run --group lint ruff check src tests` → `All checks passed!`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests` → `Ran 1697 tests in 49.628s / OK (skipped=1)` (the skip pre-exists this branch)
- [x] `uv run python -m compileall -q src tests` → exit 0, no output
- [x] `uv run python -m omh.cli docs workflows --check` → `"ok":true`, tap_skills `checked:97 expected:97`, no missing/stale/extra
- [x] `uv run python -m omh.cli docs roles --check` → `"ok":true`
- [x] `uv run python -m omh.cli docs capability-families --check` → `"ok":true`
- [x] `uv run --group lint ruff check --select BLE001 src` → `Found 11 errors.` (unchanged; this PR adds no `except` and relocates none)
- [x] `git diff --check` → exit 0, clean
- [x] `PYTHONPATH=tests uv run python -m unittest tests.test_degradation_signal` → `Ran 31 tests / OK`

New coverage, 6 cases in `WrapperSurfaceDegradationTests`. Every case asserts non-emptiness before asserting shape, so none of them can pass against an empty payload:

1. Healthy route hint: `state.route_hint` non-empty and `primary_workflow == "feedback-triage"` first, then no `degradation` key anywhere and neither the note nor `omh_degradation/v1` in the serialized payload.
2. Degraded route hint: block is well-formed, the whitelisted copy is byte-equal to the source block, the routing answer is unchanged, and the note is present and last in both `body` and `messenger_rendering.body_text`.
3. Degraded route hint privacy: the request text and the exception *message* (`locale-boom`) appear nowhere in the serialized payload, and the component label appears nowhere in the rendered body.
4. Healthy context-brief interaction: same both-directions check on `build_chat_interaction_payload`.
5. Degraded context-brief interaction: block well-formed, note present and positioned before `Boundary:`, no exception message text.
6. `degradation_chat_note()` unit: returns `""` for `{}`, `None`, `""`, `[]`, `{"degraded": False}`, `{"components": []}`, and the note for a real block.

Mutation checks — each new assertion was proven to fail when its wiring is removed:

| Mutation | Result |
| --- | --- |
| Drop `state_route_hint["degradation"] = degradation` | `KeyError: 'degradation'`, 1 error |
| Drop the `route_hints.py` body append | 2 failures |
| Drop the `contract.py` note line | 1 failure |
| Make `degradation_chat_note()` unconditional | 8 failures (both happy-path cases included) |

Restored and re-verified green after each.

Not run / not observed: no live Hermes host, Discord client, or Slack client rendered the degraded body — the wrapper-level shape is proven by contract tests only. Degradation was induced with `mock.patch` on `_prepare_routing_text`, not by a real locale-pack fault. `omh release hermes-smoke`, `omh harness validate`, and `omh release checklist` were not run: this change touches no harness, release, or skill-catalog surface, and the four byte gates plus the full suite cover the artifacts it could have moved.

## Risk

Low, and bounded to turns where a guarded delegated call actually raised.

- The only behavioural change on a healthy turn is none: `degradation_chat_note()` returns `""`, both call sites append nothing, and two tests assert byte-level parity of the key set and the absence of the note.
- The degraded reply gets ~160 characters longer. On a messenger surface with a length cap that is a real, if small, cost — accepted, because the alternative is the user acting on a silently degraded answer.
- The wrapper interaction `lru_cache` can cache a degraded response for a repeated message, exactly as the upstream awareness `lru_cache` already does. Consistent with the existing design rather than new behaviour.
- No new dependency, no network call, no new persisted state, no `except` added or moved.

## Compatibility / Rollout

Additive and backward compatible. A wrapper that does not read `degradation` behaves exactly as before; the only difference it sees is longer body text on a degraded turn. No schema version bumped. No migration. Genuine "package absent" standalone hosts still emit no block and therefore no note, so that legitimate path is byte-identical — the distinction #654 established between absence and failure is preserved end to end.

## Release / Claims

- [x] Release-channel impact considered — render-time only, no packaging, harness, or setup surface touched; safe on `stable`.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed — every verification line above is pasted from an observed run on this branch; the live Hermes/Discord/Slack rendering gap is stated explicitly rather than implied.
- [x] Known manual Hermes checks are listed — `omh release hermes-smoke --live` was not run; no live host exercised the degraded body.

Introduced by #654, which added the signal this PR makes visible. No issue is associated with this work.

## Follow-Up

- `_evaluate_context_brief_case` in `src/quality/context_brief_coverage.py` still projects the brief through an explicit key whitelist and drops `degradation`. It is a coverage report, not a chat surface, so it was out of scope here; adding a `degraded` observation there would make the coverage demo self-reporting.
- No Discord or Slack client has rendered the degraded body. A live check would confirm the note survives each platform's formatting and length handling.
