### PR TITLE
Cut delegated-coding observation noise: drift preflight, unchanged-projection suppression, and a quality floor

### DIFF
--- a/skills/oh-my-hermes/references/coding-handoff-progress-reporting.md
+++ b/skills/oh-my-hermes/references/coding-handoff-progress-reporting.md
@@ -11,6 +11,23 @@ process/session id, PID, branch or PR target, and the prepared-vs-observed
 boundary. Do not silently wait for a final result after saying an executor is
 running.
 
+## Narration Ceiling
+
+Active does not mean continuous. Unsolicited narration is capped at roughly one
+status message per meaningful transition, and at most a few per fix/verify
+cycle. Report a transition, not a step.
+
+- If nothing observable changed since the last update, say nothing.
+- If an observe surface returns `unchanged_since_last_emission`, that is the
+  answer; do not restate the previous update in new words.
+- Do not re-list findings that were already reported. Report only what is new,
+  and reference the earlier list instead of repeating it.
+- Do not narrate individual tool calls, file reads, or searches.
+
+This ceiling applies to unsolicited push narration only. When the user asks for
+detail, give the full detail: an explicit request, or an explicit `--full` on an
+observe surface, is never throttled.
+
 ## Progress Cadence
 
 For long-running executor work, use an event-triggered status loop or bounded
@@ -23,6 +40,18 @@ update should separate:
 - changed files or affected area
 - tests/checks started, passed, failed, or still missing
 - commit, push, PR, CI, review, and merge evidence
+
+Separate them within an update; do not send one message per bullet.
+
+## Never Suppressed
+
+The ceiling never applies to these. Report them the first time they occur, even
+if an update was just sent:
+
+- a blocker, failure, or failing verification
+- a claim that the observed state contradicts, such as an edit reported applied
+  while no file changed, or a success report alongside a non-zero exit
+- the first occurrence of any new kind of event
 
 ## Completion Verification
 

--- a/src/coding/codex_progress.py
+++ b/src/coding/codex_progress.py
@@ -96,6 +96,7 @@ def summarize_codex_jsonl_text(
     activity_counts: dict[str, int] = {
         "inspecting": 0,
         "editing": 0,
+        "editing_confirmed": 0,
         "testing": 0,
         "waiting_review": 0,
         "assistant_visible_decisions": 0,
@@ -109,6 +110,8 @@ def summarize_codex_jsonl_text(
             activity_counts["inspecting"] += 1
         if _is_edit_event(lowered):
             activity_counts["editing"] += 1
+        if _is_confirmed_edit_event(lowered):
+            activity_counts["editing_confirmed"] += 1
         if _is_test_event(lowered):
             activity_counts["testing"] += 1
         if _is_waiting_review_event(lowered):
@@ -680,6 +683,23 @@ def _is_edit_event(text: str) -> bool:
     return any(token in text for token in ("apply_patch", "patch", "write", "edit", "modified", "changed file", "diff"))
 
 
+def _is_confirmed_edit_event(text: str) -> bool:
+    """A file change actually happened, as opposed to edit-shaped words.
+
+    `_is_edit_event` is deliberately broad -- it drives the benign
+    `diff_started` label, where over-matching costs nothing. It counts any line
+    containing patch, write, edit, or diff, so "let me run git diff to see the
+    current state" lands in the same bucket as an applied patch.
+
+    Anything that contradicts an executor's own account needs a narrower
+    signal than that, so this requires a token that only appears once a change
+    was made.
+    """
+    if not _is_edit_event(text):
+        return False
+    return any(token in text for token in ("apply_patch", "modified", "changed file"))
+
+
 def _is_test_event(text: str) -> bool:
     if any(token in text for token in ("pytest", "unittest", "compileall", "npm test", "cargo test", "go test", "uv run")):
         return True
@@ -699,6 +719,8 @@ def _observable_activity(activity_counts: dict[str, int]) -> list[str]:
         labels.append("Codex is inspecting files/tests.")
     if activity_counts.get("editing"):
         labels.append("Codex changed files.")
+    if activity_counts.get("editing_confirmed"):
+        labels.append("Codex applied a file change.")
     if activity_counts.get("testing"):
         labels.append("Codex is running tests.")
     if activity_counts.get("waiting_review"):

--- a/src/coding/context_safety.py
+++ b/src/coding/context_safety.py
@@ -46,6 +46,8 @@ CODING_PROGRESS_REPORTABLE_EVENTS = (
     "workflow_started",
     "dispatch_to_executor",
     "blocker_encountered",
+    "reported_change_not_observed",
+    "reported_success_contradicted",
     "targeted_tests_failed",
     "root_cause_identified",
     "fix_strategy_selected",
@@ -77,6 +79,11 @@ _PROGRESS_EVENT_TYPES = {
     "blocker_encountered",
     "workflow_started",
     "workflow_completed",
+    # Claim/observation mismatches. Registered here so `build_progress_event`
+    # does not normalize them down to "status_update", which would erase the one
+    # signal that says the narration and the repository disagree.
+    "reported_change_not_observed",
+    "reported_success_contradicted",
 }
 _PROGRESS_EVENT_STATUSES = {"prepared", "observed", "running", "passed", "failed", "blocked"}
 _PROGRESS_EVENT_SEVERITIES = {"info", "success", "warning", "error", "blocked"}

--- a/src/coding/context_safety.py
+++ b/src/coding/context_safety.py
@@ -47,7 +47,6 @@ CODING_PROGRESS_REPORTABLE_EVENTS = (
     "dispatch_to_executor",
     "blocker_encountered",
     "reported_change_not_observed",
-    "reported_success_contradicted",
     "targeted_tests_failed",
     "root_cause_identified",
     "fix_strategy_selected",
@@ -83,7 +82,6 @@ _PROGRESS_EVENT_TYPES = {
     # does not normalize them down to "status_update", which would erase the one
     # signal that says the narration and the repository disagree.
     "reported_change_not_observed",
-    "reported_success_contradicted",
 }
 _PROGRESS_EVENT_STATUSES = {"prepared", "observed", "running", "passed", "failed", "blocked"}
 _PROGRESS_EVENT_SEVERITIES = {"info", "success", "warning", "error", "blocked"}

--- a/src/coding/executor_progress.py
+++ b/src/coding/executor_progress.py
@@ -342,8 +342,8 @@ def build_safe_progress_signal(
     process_status: str = "",
     codex_progress_summary: dict[str, Any] | None = None,
     profile_progress_summary: dict[str, Any] | None = None,
-    git_status_short: str = "",
-    git_diff_stat: str = "",
+    git_status_short: str | None = None,
+    git_diff_stat: str | None = None,
     explicit_event_type: str = "",
     explicit_summary: str = "",
     evidence_refs: list[str] | tuple[str, ...] | None = None,
@@ -360,8 +360,12 @@ def build_safe_progress_signal(
     signal = {
         "executor_profile": profile,
         "process_status": _compact_text(process_status, 80),
-        "git_status_hash": _hash_if_present(git_status_short),
-        "git_diff_stat_hash": _hash_if_present(git_diff_stat),
+        "git_status_hash": _hash_if_present(git_status_short or ""),
+        "git_diff_stat_hash": _hash_if_present(git_diff_stat or ""),
+        # A missing hash is ambiguous on its own: the caller may have looked at
+        # git and seen nothing, or may never have looked. Only the first case
+        # can contradict a reported change, so record which one it was.
+        "git_observed": git_status_short is not None or git_diff_stat is not None,
         "progress_status": progress.get("status", ""),
         "progress_event_count": progress.get("event_count", 0),
         "latest_progress_event_type": progress.get("latest_progress_event_type", ""),
@@ -378,6 +382,33 @@ def build_safe_progress_signal(
     return _safe_signal(signal)
 
 
+_CHANGE_CLAIM_ACTIVITY = {"Codex changed files.", "Codex is editing files."}
+_CHANGE_CLAIM_EVENT_TYPES = {"diff_started", "file_changed"}
+_SUCCESS_PROCESS_STATUSES = {"completed", "complete", "done", "success", "succeeded", "exited_zero"}
+_FAILURE_LATEST_EVENT_TYPES = {"targeted_tests_failed", "full_tests_failed", "tests_failed", "failure_discovered"}
+
+
+def _change_reported_but_not_observed(signal: dict[str, Any], *, latest: str, activity: set[str]) -> bool:
+    """The executor said it changed files and the working tree disagrees.
+
+    Requires `git_observed`: without it a missing hash only means nobody looked,
+    and reporting a mismatch from that would cry wolf on every caller that does
+    not collect git state.
+    """
+    if not bool(signal.get("git_observed", False)):
+        return False
+    if not (latest in _CHANGE_CLAIM_EVENT_TYPES or activity.intersection(_CHANGE_CLAIM_ACTIVITY)):
+        return False
+    return not signal.get("git_status_hash") and not signal.get("git_diff_stat_hash")
+
+
+def _success_reported_but_contradicted(*, progress_status: str, latest: str, process_status: str) -> bool:
+    """The process exited clean while the observed progress says it failed."""
+    if process_status not in _SUCCESS_PROCESS_STATUSES:
+        return False
+    return progress_status == "failed_or_error_observed" or latest in _FAILURE_LATEST_EVENT_TYPES
+
+
 def infer_progress_event_type(signal: dict[str, Any]) -> str:
     explicit = str(signal.get("explicit_event_type", ""))
     if explicit:
@@ -388,6 +419,10 @@ def infer_progress_event_type(signal: dict[str, Any]) -> str:
     process_status = str(signal.get("process_status", "")).casefold()
     test_activity = bool(activity.intersection({"Codex ran tests.", "Codex is running tests."}))
     inspect_activity = bool(activity.intersection({"Codex inspected the repo.", "Codex is inspecting files/tests."}))
+    if _change_reported_but_not_observed(signal, latest=latest, activity=activity):
+        return "reported_change_not_observed"
+    if _success_reported_but_contradicted(progress_status=progress_status, latest=latest, process_status=process_status):
+        return "reported_success_contradicted"
     if latest == "blocker_encountered" or progress_status == "blocked" or process_status in {"blocked", "blocker"}:
         return "executor_blocked"
     if progress_status == "failed_or_error_observed" or latest in {"targeted_tests_failed", "full_tests_failed", "tests_failed"}:
@@ -954,6 +989,7 @@ def _safe_signal(signal: dict[str, Any]) -> dict[str, Any]:
         "process_status",
         "git_status_hash",
         "git_diff_stat_hash",
+        "git_observed",
         "progress_status",
         "progress_event_count",
         "latest_progress_event_type",

--- a/src/coding/executor_progress.py
+++ b/src/coding/executor_progress.py
@@ -388,7 +388,12 @@ def build_safe_progress_signal(
     return _safe_signal(signal)
 
 
-_CHANGE_CLAIM_ACTIVITY = {"Codex changed files."}
+# Only a confirmed edit counts as a claim worth contradicting. "Codex changed
+# files." comes from a bucket that also matches a line merely mentioning a diff,
+# so it stays out: over-matching is free for the benign `diff_started` label and
+# expensive here.
+_CHANGE_CLAIM_ACTIVITY = {"Codex applied a file change."}
+# An explicit `--event diff_started` is the caller stating the claim outright.
 _CHANGE_CLAIM_EVENT_TYPES = {"diff_started"}
 _SUCCESS_PROCESS_STATUSES = {"completed", "complete", "done", "success", "succeeded", "exited_zero"}
 

--- a/src/coding/executor_progress.py
+++ b/src/coding/executor_progress.py
@@ -30,9 +30,25 @@ PROGRESS_EVENT_TYPES = (
     "executor_completed",
     "executor_blocked",
     "executor_failed",
+    "reported_change_not_observed",
+    "reported_success_contradicted",
     "progress_observed",
 )
-TERMINAL_EVENT_TYPES = {"executor_completed", "executor_blocked", "executor_failed", "tests_failed", "tests_passed"}
+# Never suppressed. The first five are terminal states. The last two are
+# claim/observation mismatches: the executor said it did something and the
+# repository says otherwise. Suppressing those lets a supervising agent keep
+# narrating success past the point where the work stopped landing, which is the
+# failure mode that produced "4 file(s) were NOT modified this turn despite any
+# wording above that may suggest otherwise" only at the end of a long session.
+TERMINAL_EVENT_TYPES = {
+    "executor_completed",
+    "executor_blocked",
+    "executor_failed",
+    "tests_failed",
+    "tests_passed",
+    "reported_change_not_observed",
+    "reported_success_contradicted",
+}
 DEFAULT_FRESHNESS_SECONDS = 900
 DEFAULT_EXPIRY_SECONDS = 86400
 DEFAULT_MINIMUM_REPEAT_INTERVAL_SECONDS = 120
@@ -197,6 +213,7 @@ def build_progress_binding(
         "last_reported_summary_hash": "",
         "last_reported_artifact_sha256": "",
         "report_count": 0,
+        "reported_event_types": [],
         "suppressed_duplicate_count": 0,
         "minimum_repeat_interval_seconds": int(minimum_repeat_interval_seconds),
         "evidence_refs": _compact_strings(evidence_refs or []),
@@ -543,6 +560,30 @@ def latest_progress_report(paths: OmhPaths, binding: dict[str, Any]) -> dict[str
     return valid[-1] if valid else {}
 
 
+def reported_event_types(binding: dict[str, Any]) -> list[str]:
+    recorded = binding.get("reported_event_types")
+    if not isinstance(recorded, list):
+        return []
+    return [str(value) for value in recorded if str(value)]
+
+
+def _is_first_occurrence(binding: dict[str, Any], event_type: str) -> bool:
+    """True when this event type has never been reported for this binding.
+
+    A first occurrence is always worth reporting: the interesting signal is that
+    a new kind of thing happened, and no volume budget should be able to swallow
+    it. Callers that add their own suppression on top of `should_report_event`
+    must preserve this.
+
+    Bindings written before `reported_event_types` existed cannot answer the
+    question. Rather than treat every type as new -- which would un-suppress a
+    live run mid-flight -- fall through to the interval rules for them.
+    """
+    if not isinstance(binding.get("reported_event_types"), list):
+        return int(binding.get("report_count", 0) or 0) == 0
+    return event_type not in reported_event_types(binding)
+
+
 def should_report_event(binding: dict[str, Any], event: dict[str, Any], *, now: str | None = None) -> tuple[bool, str]:
     _require_valid("binding", validate_progress_binding(binding))
     _require_valid("event", validate_progress_event(event))
@@ -552,6 +593,8 @@ def should_report_event(binding: dict[str, Any], event: dict[str, Any], *, now: 
     event_type = str(event.get("event_type", ""))
     if event_type in TERMINAL_EVENT_TYPES:
         return True, "terminal_or_blocker"
+    if _is_first_occurrence(binding, event_type):
+        return True, "first_occurrence"
     last_type = str(binding.get("last_reported_event_type", ""))
     if last_type == event_type and not _minimum_interval_elapsed(
         str(binding.get("last_reported_at", "")),
@@ -584,9 +627,12 @@ def update_binding_reporter_state(
     else:
         updated["state"] = "active"
     if reported:
+        event_type = str(event.get("event_type", ""))
         updated["last_reported_at"] = now
         updated["last_transition_fingerprint"] = str(event.get("transition_fingerprint", ""))
-        updated["last_reported_event_type"] = str(event.get("event_type", ""))
+        updated["last_reported_event_type"] = event_type
+        seen = reported_event_types(binding)
+        updated["reported_event_types"] = seen if event_type in seen else [*seen, event_type]
         updated["last_reported_state"] = str(event.get("status", ""))
         updated["last_reported_summary_hash"] = hashlib.sha256(str(event.get("summary", "")).encode("utf-8")).hexdigest()
         updated["last_reported_artifact_sha256"] = str(signal.get("codex_artifact_sha256", ""))
@@ -1067,6 +1113,12 @@ def _summary_for_event_type(event_type: str) -> str:
         "executor_completed": "The coding executor reported completion, but separate result evidence is still required.",
         "executor_blocked": "The coding executor reported a blocker.",
         "executor_failed": "The coding executor reported a failure.",
+        "reported_change_not_observed": (
+            "The coding executor reported applying a change, but no file change was observed."
+        ),
+        "reported_success_contradicted": (
+            "The coding executor reported success, but the observed exit state contradicts it."
+        ),
         "progress_observed": "The coding executor emitted a safe progress signal.",
     }
     return summaries.get(event_type, "Executor progress was observed.")

--- a/src/coding/executor_progress.py
+++ b/src/coding/executor_progress.py
@@ -31,13 +31,11 @@ PROGRESS_EVENT_TYPES = (
     "executor_blocked",
     "executor_failed",
     "reported_change_not_observed",
-    "reported_success_contradicted",
     "progress_observed",
 )
-# Never suppressed. The first five are terminal states. The last two are
-# claim/observation mismatches: the executor said it did something and the
-# repository says otherwise. Suppressing those lets a supervising agent keep
-# narrating success past the point where the work stopped landing, which is the
+# Exempt from the volume rules -- an exact duplicate transition is still
+# deduplicated. `reported_change_not_observed` belongs here because it only
+# fires on a finished run whose claim the working tree contradicts, which is the
 # failure mode that produced "4 file(s) were NOT modified this turn despite any
 # wording above that may suggest otherwise" only at the end of a long session.
 TERMINAL_EVENT_TYPES = {
@@ -47,7 +45,15 @@ TERMINAL_EVENT_TYPES = {
     "tests_failed",
     "tests_passed",
     "reported_change_not_observed",
-    "reported_success_contradicted",
+}
+# Observations that end a binding's life. Kept as its own name rather than
+# reusing TERMINAL_EVENT_TYPES: `tests_failed` and `tests_passed` are reportable
+# end states but the executor may still be working, so they must not close.
+CLOSING_EVENT_TYPES = {
+    "executor_completed",
+    "executor_blocked",
+    "executor_failed",
+    "reported_change_not_observed",
 }
 DEFAULT_FRESHNESS_SECONDS = 900
 DEFAULT_EXPIRY_SECONDS = 86400
@@ -382,31 +388,43 @@ def build_safe_progress_signal(
     return _safe_signal(signal)
 
 
-_CHANGE_CLAIM_ACTIVITY = {"Codex changed files.", "Codex is editing files."}
-_CHANGE_CLAIM_EVENT_TYPES = {"diff_started", "file_changed"}
+_CHANGE_CLAIM_ACTIVITY = {"Codex changed files."}
+_CHANGE_CLAIM_EVENT_TYPES = {"diff_started"}
 _SUCCESS_PROCESS_STATUSES = {"completed", "complete", "done", "success", "succeeded", "exited_zero"}
-_FAILURE_LATEST_EVENT_TYPES = {"targeted_tests_failed", "full_tests_failed", "tests_failed", "failure_discovered"}
 
 
-def _change_reported_but_not_observed(signal: dict[str, Any], *, latest: str, activity: set[str]) -> bool:
-    """The executor said it changed files and the working tree disagrees.
+def _change_reported_but_not_observed(
+    signal: dict[str, Any],
+    *,
+    latest: str,
+    activity: set[str],
+    process_status: str,
+    progress_status: str,
+) -> bool:
+    """The executor finished claiming it changed files, and the tree disagrees.
 
-    Requires `git_observed`: without it a missing hash only means nobody looked,
-    and reporting a mismatch from that would cry wolf on every caller that does
-    not collect git state.
+    Three guards, each load-bearing:
+
+    `git_observed` -- without it a missing hash only means nobody looked, so a
+    mismatch inferred from it would cry wolf on every caller that does not
+    collect git state.
+
+    A finished run -- the upstream change claim is a coarse bucket. Codex sets
+    it from any log line containing `patch`, `write`, `edit`, or `diff`, so a
+    mid-flight "let me run git diff to see the state" reads as a change claim
+    against a tree that is legitimately still clean. Only a run that has stopped
+    can actually contradict itself.
+
+    An empty tree -- both hashes absent.
     """
     if not bool(signal.get("git_observed", False)):
+        return False
+    finished = process_status in _SUCCESS_PROCESS_STATUSES or progress_status == "completed_or_passed_observed"
+    if not finished:
         return False
     if not (latest in _CHANGE_CLAIM_EVENT_TYPES or activity.intersection(_CHANGE_CLAIM_ACTIVITY)):
         return False
     return not signal.get("git_status_hash") and not signal.get("git_diff_stat_hash")
-
-
-def _success_reported_but_contradicted(*, progress_status: str, latest: str, process_status: str) -> bool:
-    """The process exited clean while the observed progress says it failed."""
-    if process_status not in _SUCCESS_PROCESS_STATUSES:
-        return False
-    return progress_status == "failed_or_error_observed" or latest in _FAILURE_LATEST_EVENT_TYPES
 
 
 def infer_progress_event_type(signal: dict[str, Any]) -> str:
@@ -419,16 +437,24 @@ def infer_progress_event_type(signal: dict[str, Any]) -> str:
     process_status = str(signal.get("process_status", "")).casefold()
     test_activity = bool(activity.intersection({"Codex ran tests.", "Codex is running tests."}))
     inspect_activity = bool(activity.intersection({"Codex inspected the repo.", "Codex is inspecting files/tests."}))
-    if _change_reported_but_not_observed(signal, latest=latest, activity=activity):
-        return "reported_change_not_observed"
-    if _success_reported_but_contradicted(progress_status=progress_status, latest=latest, process_status=process_status):
-        return "reported_success_contradicted"
     if latest == "blocker_encountered" or progress_status == "blocked" or process_status in {"blocked", "blocker"}:
         return "executor_blocked"
     if progress_status == "failed_or_error_observed" or latest in {"targeted_tests_failed", "full_tests_failed", "tests_failed"}:
         return "tests_failed" if test_activity or latest in {"targeted_tests_failed", "full_tests_failed", "tests_failed"} else "executor_failed"
     if latest == "failure_discovered" or process_status in {"failed", "failure", "error", "errored", "exited_nonzero"}:
         return "executor_failed"
+    # After blocked/failed, before completed. A blocker whose text also mentions
+    # a patch is a blocker, not a contradiction, and blocked/failed carry the
+    # more actionable classification. What this preempts is the benign reading:
+    # a run that claims it changed files and is about to be called completed.
+    if _change_reported_but_not_observed(
+        signal,
+        latest=latest,
+        activity=activity,
+        process_status=process_status,
+        progress_status=progress_status,
+    ):
+        return "reported_change_not_observed"
     if progress_status == "completed_or_passed_observed":
         return "tests_passed" if (test_activity or latest in {"targeted_tests_passed", "full_tests_passed", "tests_passed"}) else "executor_completed"
     if latest in {"targeted_tests_passed", "full_tests_passed", "tests_passed"}:
@@ -602,6 +628,21 @@ def reported_event_types(binding: dict[str, Any]) -> list[str]:
     return [str(value) for value in recorded if str(value)]
 
 
+def _legacy_reported_seed(binding: dict[str, Any]) -> list[str]:
+    """Best-known history for a binding written before `reported_event_types`.
+
+    Migrating with an empty list would discard everything the binding already
+    reported, so the next event writes a one-entry list and every other type
+    then looks like a first occurrence -- a burst of un-suppression on a run
+    already in flight. The last reported type is the only history such a binding
+    kept, so seed from it.
+    """
+    last = str(binding.get("last_reported_event_type", ""))
+    if last and int(binding.get("report_count", 0) or 0) > 0:
+        return [last]
+    return []
+
+
 def _is_first_occurrence(binding: dict[str, Any], event_type: str) -> bool:
     """True when this event type has never been reported for this binding.
 
@@ -657,7 +698,7 @@ def update_binding_reporter_state(
     updated["last_observed_signal_hash"] = _signal_fingerprint(signal)
     updated["last_observed_event_count"] = _safe_int(signal.get("progress_event_count"), 0)
     updated["last_observed_artifact_sha256"] = str(signal.get("codex_artifact_sha256", ""))
-    if str(event.get("event_type", "")) in {"executor_completed", "executor_blocked", "executor_failed"}:
+    if str(event.get("event_type", "")) in CLOSING_EVENT_TYPES:
         updated["state"] = "closed"
     else:
         updated["state"] = "active"
@@ -666,7 +707,7 @@ def update_binding_reporter_state(
         updated["last_reported_at"] = now
         updated["last_transition_fingerprint"] = str(event.get("transition_fingerprint", ""))
         updated["last_reported_event_type"] = event_type
-        seen = reported_event_types(binding)
+        seen = reported_event_types(binding) or _legacy_reported_seed(binding)
         updated["reported_event_types"] = seen if event_type in seen else [*seen, event_type]
         updated["last_reported_state"] = str(event.get("status", ""))
         updated["last_reported_summary_hash"] = hashlib.sha256(str(event.get("summary", "")).encode("utf-8")).hexdigest()
@@ -1151,9 +1192,6 @@ def _summary_for_event_type(event_type: str) -> str:
         "executor_failed": "The coding executor reported a failure.",
         "reported_change_not_observed": (
             "The coding executor reported applying a change, but no file change was observed."
-        ),
-        "reported_success_contradicted": (
-            "The coding executor reported success, but the observed exit state contradicts it."
         ),
         "progress_observed": "The coding executor emitted a safe progress signal.",
     }

--- a/src/commands/coding.py
+++ b/src/commands/coding.py
@@ -626,7 +626,7 @@ def cmd_coding_fanout_validate(args: argparse.Namespace) -> int:
 def cmd_coding_fanout_show(args: argparse.Namespace) -> int:
     from ..coding.fanout_artifacts import read_fanout_contract
     from ..runtime.artifacts import show_run
-    from ..runtime.context_budget import run_context_budget
+    from ..runtime.context_budget import payload_fingerprint, run_context_budget
 
     paths = _paths(args)
     try:
@@ -674,27 +674,57 @@ def cmd_coding_fanout_show(args: argparse.Namespace) -> int:
             "run_ref": run_ref,
             "journal_event_counts": history,
         }
-    payload = {
+    board = {
         "schema_version": "fanout_board/v1",
         "fanout_id": contract.get("fanout_id"),
         "merge_order": contract.get("merge_plan", {}).get("merge_order", []),
         "units": status_by_unit,
-        "context_budget": {
-            "history_limit": history_limit,
-            "watched_run_count": len(watched_runs),
-            "budget_exhausted_units": exhausted_units,
-            "policy": "timed_polling_rejected; raw_log_dumping_rejected",
-            "next_action": (
-                "read_full_history_from_artifacts_instead_of_repeating_this_command"
-                if exhausted_units
-                else "wait_for_executor_evidence"
-            ),
-        },
-        "claim_boundary": contract.get("claim_boundary", ""),
     }
+    fingerprint = payload_fingerprint(board)
+    context_budget = {
+        "history_limit": history_limit,
+        "watched_run_count": len(watched_runs),
+        "budget_exhausted_units": exhausted_units,
+        "policy": "timed_polling_rejected; raw_log_dumping_rejected",
+        "next_action": (
+            "read_full_history_from_artifacts_instead_of_repeating_this_command"
+            if exhausted_units
+            else "wait_for_executor_evidence"
+        ),
+    }
+    if not full and _fanout_board_unchanged(paths, watched_runs, fingerprint):
+        payload = {
+            "schema_version": "fanout_board_unchanged/v1",
+            "fanout_id": contract.get("fanout_id"),
+            "unchanged_since_last_emission": True,
+            "delta": {},
+            "context_budget": context_budget,
+            "next_action": "wait_for_new_observed_evidence_instead_of_repeating_this_command",
+            "full_output_command": f"omh coding fanout show {contract.get('fanout_id')} --full",
+            "claim_boundary": contract.get("claim_boundary", ""),
+        }
+    else:
+        payload = {**board, "context_budget": context_budget, "claim_boundary": contract.get("claim_boundary", "")}
     _print_json(payload)
-    _record_fanout_board_emission(paths, watched_runs, payload)
+    _record_fanout_board_emission(paths, watched_runs, payload, fingerprint)
     return 0
+
+
+def _fanout_board_unchanged(paths, watched_runs: list[str], fingerprint: str) -> bool:
+    """True when every watched run already saw exactly this board.
+
+    The ledger is keyed per run while the board spans several, so a board only
+    counts as unchanged if no watched run has newer state than the last
+    emission. A partially-changed board still prints in full.
+    """
+    from ..runtime.context_budget import run_context_budget
+
+    if not watched_runs:
+        return False
+    return all(
+        run_context_budget(paths, run_ref, surface="fanout_show")["last_payload_fingerprint"] == fingerprint
+        for run_ref in watched_runs
+    )
 
 
 def _fanout_history_limit(args: argparse.Namespace) -> int:
@@ -708,14 +738,20 @@ def _fanout_history_limit(args: argparse.Namespace) -> int:
     return int(limit)
 
 
-def _record_fanout_board_emission(paths, watched_runs: list[str], payload: dict) -> None:
+def _record_fanout_board_emission(paths, watched_runs: list[str], payload: dict, fingerprint: str = "") -> None:
     from ..runtime.context_budget import record_context_emission
 
     if not watched_runs:
         return
     per_run = len(json.dumps(payload, sort_keys=True)) // len(watched_runs)
     for run_ref in watched_runs:
-        record_context_emission(paths, run_ref, surface="fanout_show", byte_count=per_run)
+        record_context_emission(
+            paths,
+            run_ref,
+            surface="fanout_show",
+            byte_count=per_run,
+            payload_fingerprint_value=fingerprint,
+        )
 
 
 def cmd_coding_fanout_dispatch(args: argparse.Namespace) -> int:

--- a/src/commands/release.py
+++ b/src/commands/release.py
@@ -160,9 +160,27 @@ def cmd_release_evidence_bundle(args: argparse.Namespace) -> int:
     return 0 if payload["status"] == "ready" else 1
 
 
+def cmd_release_drift(args: argparse.Namespace) -> int:
+    from ..maintenance.drift import drift_report, format_drift_report
+
+    payload = drift_report()
+    if _wants_json(args):
+        _print_json(payload)
+    else:
+        print(format_drift_report(payload))
+    return 0 if payload["ok"] else 1
+
+
 def _add_release_commands(sub) -> None:
     release = sub.add_parser("release", help="Plan or run release smoke checks for real Hermes installation paths.")
     release_sub = release.add_subparsers(dest="release_command", required=True)
+
+    drift = release_sub.add_parser(
+        "drift",
+        help="Report every catalog-driven count, budget, and generated artifact that is out of sync, in one pass.",
+    )
+    drift.add_argument("--json", action="store_true", help="Print the machine-readable drift report payload.")
+    drift.set_defaults(func=cmd_release_drift)
 
     checklist = release_sub.add_parser(
         "checklist",

--- a/src/commands/runtime.py
+++ b/src/commands/runtime.py
@@ -436,6 +436,11 @@ def cmd_runtime_progress_observe(args: argparse.Namespace) -> int:
     try:
         codex_summary = summarize_codex_jsonl_file(args.codex_log_jsonl, evidence_refs=args.evidence_ref or []) if args.codex_log_jsonl else None
         profile_summary = _profile_progress_summary(args)
+        _reject_ignored_progress_inputs(
+            executor_profile=str(binding.get("executor_profile", "")),
+            codex_summary=codex_summary,
+            profile_summary=profile_summary,
+        )
         signal = build_safe_progress_signal(
             executor_profile=str(binding.get("executor_profile", "")),
             process_status=args.process_status or "",
@@ -529,6 +534,35 @@ def _require_progress_target(paths, target_type: str, target_id: str) -> None:
             raise OmhError(f"runtime wrapper_session not found: {target_id}")
         return
     raise OmhError(f"unsupported progress target type: {target_type}")
+
+
+def _reject_ignored_progress_inputs(
+    *,
+    executor_profile: str,
+    codex_summary: dict[str, object] | None,
+    profile_summary: dict[str, object] | None,
+) -> None:
+    """Fail when the caller described progress this binding will not read.
+
+    `build_safe_progress_signal` picks exactly one summary by executor profile:
+    codex bindings read `--codex-log-jsonl`, every other profile reads the
+    `--profile-*` flags. Passing the wrong pair used to be accepted silently,
+    and the observation was then inferred from an empty summary -- so an
+    operator who described a failing test run got a generic status back and no
+    indication that their input had been discarded. That is a failure relabelled
+    as a normal result, which this repo's broad-exception policy exists to keep
+    out.
+    """
+    if executor_profile == "codex" and profile_summary is not None and codex_summary is None:
+        raise OmhError(
+            "codex progress bindings read --codex-log-jsonl; the --profile-* flags would be ignored. "
+            "Pass --codex-log-jsonl, or use --event/--summary to state the observation explicitly."
+        )
+    if executor_profile != "codex" and codex_summary is not None:
+        raise OmhError(
+            f"--codex-log-jsonl only applies to codex bindings; this binding is {executor_profile}. "
+            "Use the --profile-* flags instead."
+        )
 
 
 def _profile_progress_summary(args: argparse.Namespace) -> dict[str, object] | None:

--- a/src/commands/runtime.py
+++ b/src/commands/runtime.py
@@ -46,6 +46,7 @@ from ..runtime.context_budget import (
     public_budget,
     record_context_emission,
     run_context_budget,
+    run_show_surface,
     unchanged_run_payload,
 )
 from ..executors import CODING_RUNTIME_HANDOFF_TARGETS
@@ -118,7 +119,8 @@ def cmd_runtime_show(args: argparse.Namespace) -> int:
         shown = show_run(paths, args.run_id, history_limit=_history_limit(args))
     except FileNotFoundError as exc:
         raise OmhError(f"runtime run not found: {args.run_id}") from exc
-    ledger = run_context_budget(paths, args.run_id, surface="runtime_show")
+    surface = run_show_surface(full=full, history_limit=_history_limit(args))
+    ledger = run_context_budget(paths, args.run_id, surface=surface)
     fingerprint = payload_fingerprint(shown)
     unchanged = fingerprint == ledger["last_payload_fingerprint"]
     budget = public_budget(ledger)
@@ -137,7 +139,7 @@ def cmd_runtime_show(args: argparse.Namespace) -> int:
     record_context_emission(
         paths,
         args.run_id,
-        surface="runtime_show",
+        surface=surface,
         byte_count=len(json.dumps(payload, sort_keys=True)),
         payload_fingerprint_value=fingerprint,
     )

--- a/src/commands/runtime.py
+++ b/src/commands/runtime.py
@@ -421,8 +421,8 @@ def cmd_runtime_progress_observe(args: argparse.Namespace) -> int:
             process_status=args.process_status or "",
             codex_progress_summary=codex_summary,
             profile_progress_summary=profile_summary,
-            git_status_short=args.git_status_short or "",
-            git_diff_stat=args.git_diff_stat or "",
+            git_status_short=args.git_status_short,
+            git_diff_stat=args.git_diff_stat,
             explicit_event_type=args.event or "",
             explicit_summary=args.summary or "",
             evidence_refs=args.evidence_ref or [],
@@ -555,8 +555,11 @@ def _add_progress_bind_args(parser: argparse.ArgumentParser) -> None:
 def _add_progress_observe_args(parser: argparse.ArgumentParser) -> None:
     _add_progress_target_args(parser)
     parser.add_argument("--process-status", default="")
-    parser.add_argument("--git-status-short", default="")
-    parser.add_argument("--git-diff-stat", default="")
+    # Default None, not "": passing the flag with an empty value means "git was
+    # checked and reports nothing changed", which is what contradicts a reported
+    # change. Omitting the flag means nobody looked and contradicts nothing.
+    parser.add_argument("--git-status-short", default=None)
+    parser.add_argument("--git-diff-stat", default=None)
     parser.add_argument("--event", choices=PROGRESS_EVENT_TYPES, default="")
     parser.add_argument("--summary", default="")
     parser.add_argument("--codex-log-jsonl", default=None)

--- a/src/commands/runtime.py
+++ b/src/commands/runtime.py
@@ -40,7 +40,13 @@ from ..runtime.artifacts import (
     write_runtime_observation,
     write_wrapper_contract,
 )
-from ..runtime.context_budget import degrade_run_payload, record_context_emission, run_context_budget
+from ..runtime.context_budget import (
+    degrade_run_payload,
+    payload_fingerprint,
+    record_context_emission,
+    run_context_budget,
+    unchanged_run_payload,
+)
 from ..executors import CODING_RUNTIME_HANDOFF_TARGETS
 from ..local_store import read_json_object
 from ..skill_pack import builtin_harnesses, routable_definitions
@@ -112,8 +118,16 @@ def cmd_runtime_show(args: argparse.Namespace) -> int:
     except FileNotFoundError as exc:
         raise OmhError(f"runtime run not found: {args.run_id}") from exc
     budget = run_context_budget(paths, args.run_id, surface="runtime_show")
-    if budget["exhausted"] and not full:
+    fingerprint = payload_fingerprint(shown)
+    if full:
+        payload = {**shown, "context_budget": budget}
+    elif budget["exhausted"]:
+        # Exhaustion outranks the unchanged check on purpose. Both are stop
+        # signals, but the degraded payload is the one that points at the
+        # artifacts, and its shape is an existing contract.
         payload = degrade_run_payload(shown, budget)
+    elif fingerprint == budget["last_payload_fingerprint"]:
+        payload = unchanged_run_payload(shown, budget)
     else:
         payload = {**shown, "context_budget": budget}
     _print_json(payload)
@@ -122,6 +136,7 @@ def cmd_runtime_show(args: argparse.Namespace) -> int:
         args.run_id,
         surface="runtime_show",
         byte_count=len(json.dumps(payload, sort_keys=True)),
+        payload_fingerprint_value=fingerprint,
     )
     return 0
 

--- a/src/commands/runtime.py
+++ b/src/commands/runtime.py
@@ -43,6 +43,7 @@ from ..runtime.artifacts import (
 from ..runtime.context_budget import (
     degrade_run_payload,
     payload_fingerprint,
+    public_budget,
     record_context_emission,
     run_context_budget,
     unchanged_run_payload,
@@ -117,8 +118,10 @@ def cmd_runtime_show(args: argparse.Namespace) -> int:
         shown = show_run(paths, args.run_id, history_limit=_history_limit(args))
     except FileNotFoundError as exc:
         raise OmhError(f"runtime run not found: {args.run_id}") from exc
-    budget = run_context_budget(paths, args.run_id, surface="runtime_show")
+    ledger = run_context_budget(paths, args.run_id, surface="runtime_show")
     fingerprint = payload_fingerprint(shown)
+    unchanged = fingerprint == ledger["last_payload_fingerprint"]
+    budget = public_budget(ledger)
     if full:
         payload = {**shown, "context_budget": budget}
     elif budget["exhausted"]:
@@ -126,7 +129,7 @@ def cmd_runtime_show(args: argparse.Namespace) -> int:
         # signals, but the degraded payload is the one that points at the
         # artifacts, and its shape is an existing contract.
         payload = degrade_run_payload(shown, budget)
-    elif fingerprint == budget["last_payload_fingerprint"]:
+    elif unchanged:
         payload = unchanged_run_payload(shown, budget)
     else:
         payload = {**shown, "context_budget": budget}

--- a/src/maintenance/drift.py
+++ b/src/maintenance/drift.py
@@ -253,6 +253,36 @@ def _budget_drift(metric: BudgetMetric) -> dict[str, Any] | None:
     }
 
 
+def _tap_skills_drift(repo_root: Path) -> dict[str, Any] | None:
+    """Generated `skills/*/SKILL.md` and `skills/*/references/*.md`.
+
+    These do not fit the one-file-per-artifact shape above -- there are dozens,
+    and a catalog change can make some stale while adding or removing others.
+    Reusing the same check `docs workflows --check` runs keeps one definition of
+    stale.
+    """
+    from ..commands.docs import _tap_skills_check_payload
+
+    payload = _tap_skills_check_payload(repo_root / "skills")
+    if payload["ok"]:
+        return None
+    affected = list(payload["missing"]) + list(payload["stale"]) + list(payload["extra"])
+    return {
+        "name": "tap_skills",
+        "kind": "generated",
+        "describe": f"{len(affected)} generated skill file(s) out of sync",
+        "state": "stale",
+        "missing": payload["missing"],
+        "stale": payload["stale"],
+        "extra": payload["extra"],
+        "sites": [f"skills/{item}" for item in affected],
+        "fix": (
+            "write each template's .content back under skills/ "
+            "(builtin_skill_templates() and builtin_skill_reference_templates())"
+        ),
+    }
+
+
 def _generated_drift(artifact: GeneratedArtifact, repo_root: Path) -> dict[str, Any] | None:
     target = repo_root / artifact.path
     expected = artifact.render()
@@ -294,6 +324,7 @@ def drift_report(
     counts: tuple[CountMetric, ...] | None = None,
     budgets: tuple[BudgetMetric, ...] | None = None,
     artifacts: tuple[GeneratedArtifact, ...] | None = None,
+    include_tap_skills: bool = True,
 ) -> dict[str, Any]:
     """Check every metric and report all findings; never stop at the first.
 
@@ -319,6 +350,11 @@ def drift_report(
     for artifact in artifacts:
         checked.append(artifact.name)
         found = _generated_drift(artifact, root)
+        if found:
+            drift.append(found)
+    if include_tap_skills:
+        checked.append("tap_skills")
+        found = _tap_skills_drift(root)
         if found:
             drift.append(found)
 

--- a/src/maintenance/drift.py
+++ b/src/maintenance/drift.py
@@ -1,0 +1,366 @@
+"""One-shot report of everything a catalog change knocks out of sync.
+
+Adding a single skill invalidates counts, budgets, and generated artifacts at
+once, but the test suite reveals them a few at a time: you fix what the run
+showed, rerun the whole suite, and learn about the next one. An observed
+session spent twelve full-suite cycles that way -- four of them chasing the
+same byte budget down 305 -> 303 -> 299 -> 264, and one hunting a limit that
+lived in `src/maintenance/release.py` rather than in a test.
+
+This module recomputes every drift-prone value from source and reports the
+whole set in one pass, with the sites that hardcode each one.
+
+The expected values here do not replace the assertions in `tests/` -- those are
+deliberate contracts (see `CLAUDE.md`). This is the index that says which ones
+a change just invalidated. `tests/test_drift_registry.py` keeps the index
+honest by checking that every declared site still contains the value it claims.
+
+No source parsing: every live value comes from calling the real producer, and
+every site is declared data. Sites are file paths, never line numbers, because
+line numbers drift.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+DRIFT_REPORT_SCHEMA_VERSION = "omh_drift_report/v1"
+
+
+@dataclass(frozen=True)
+class CountMetric:
+    """A value that must match exactly across every site that hardcodes it."""
+
+    name: str
+    describe: str
+    live: Callable[[], int]
+    expected: int
+    sites: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class BudgetMetric:
+    """A rendered size that must stay under a declared ceiling."""
+
+    name: str
+    describe: str
+    live: Callable[[], int]
+    limit: int
+    limit_site: str
+
+
+@dataclass(frozen=True)
+class GeneratedArtifact:
+    """A committed file that must byte-match what the catalog renders today."""
+
+    name: str
+    path: str
+    render: Callable[[], str]
+    regenerate: str
+
+
+def _chat_card_case_count() -> int:
+    from ..quality.chat_card_coverage import build_chat_card_coverage_demo
+
+    return int(build_chat_card_coverage_demo()["summary"]["case_count"])
+
+
+def _route_hint_case_count() -> int:
+    from ..quality.route_hint_alignment import build_route_hint_alignment_demo
+
+    return int(build_route_hint_alignment_demo()["summary"]["case_count"])
+
+
+def _routing_precision_case_count() -> int:
+    from ..quality.routing_precision import build_routing_precision_demo
+
+    return int(build_routing_precision_demo()["summary"]["case_count"])
+
+
+def _common_request_case_count() -> int:
+    from ..quality.common_request_coverage import build_common_request_coverage_demo
+
+    return int(build_common_request_coverage_demo()["summary"]["case_count"])
+
+
+def _awareness_primer_markdown_chars() -> int:
+    from ..plugin_bundle.omh.awareness import awareness_primer_markdown
+
+    return len(awareness_primer_markdown())
+
+
+def _full_capability_section_chars() -> int:
+    from ..capabilities.skills import skill_capabilities
+
+    return len(json.dumps(skill_capabilities(), sort_keys=True, ensure_ascii=False))
+
+
+def _standalone_capability_section_chars() -> int:
+    from ..plugin_bundle.omh.tools.capability_tool import standalone_skill_capability_items
+
+    return len(json.dumps(standalone_skill_capability_items(), sort_keys=True, ensure_ascii=False))
+
+
+def count_metrics() -> tuple[CountMetric, ...]:
+    return (
+        CountMetric(
+            name="chat_card_case_count",
+            describe="Chat card coverage cases",
+            live=_chat_card_case_count,
+            expected=60,
+            sites=(
+                "tests/test_cli.py",
+                "tests/test_hermes_ux_quality.py",
+                "tests/test_release_smoke.py",
+            ),
+        ),
+        CountMetric(
+            name="route_hint_case_count",
+            describe="Route hint alignment cases",
+            live=_route_hint_case_count,
+            expected=180,
+            sites=(
+                "tests/test_cli.py",
+                "tests/test_hermes_ux_quality.py",
+                "tests/test_release_smoke.py",
+            ),
+        ),
+        CountMetric(
+            name="routing_precision_case_count",
+            describe="Routing precision cases",
+            live=_routing_precision_case_count,
+            expected=55,
+            sites=(
+                "tests/test_cli.py",
+                "tests/test_hermes_ux_quality.py",
+                "tests/test_release_smoke.py",
+                "tests/test_routing_precision.py",
+            ),
+        ),
+        CountMetric(
+            name="common_request_case_count",
+            describe="Common request coverage cases",
+            live=_common_request_case_count,
+            expected=90,
+            sites=(
+                "tests/test_cli.py",
+                "tests/test_hermes_ux_quality.py",
+                "tests/test_release_smoke.py",
+                "tests/test_common_request_coverage.py",
+            ),
+        ),
+    )
+
+
+def budget_metrics() -> tuple[BudgetMetric, ...]:
+    from .release import (
+        AWARENESS_PRIMER_MARKDOWN_CHAR_LIMIT,
+        FULL_CAPABILITY_SKILL_SECTION_CHAR_LIMIT,
+        STANDALONE_CAPABILITY_SKILL_SECTION_CHAR_LIMIT,
+    )
+
+    return (
+        BudgetMetric(
+            name="awareness_primer_markdown_chars",
+            describe="Awareness primer markdown size",
+            live=_awareness_primer_markdown_chars,
+            limit=AWARENESS_PRIMER_MARKDOWN_CHAR_LIMIT,
+            limit_site="src/maintenance/release.py",
+        ),
+        BudgetMetric(
+            name="full_capability_skill_section_chars",
+            describe="Full capability skill section size",
+            live=_full_capability_section_chars,
+            limit=FULL_CAPABILITY_SKILL_SECTION_CHAR_LIMIT,
+            limit_site="src/maintenance/release.py",
+        ),
+        BudgetMetric(
+            name="standalone_capability_skill_section_chars",
+            describe="Standalone capability skill section size",
+            live=_standalone_capability_section_chars,
+            limit=STANDALONE_CAPABILITY_SKILL_SECTION_CHAR_LIMIT,
+            limit_site="src/maintenance/release.py",
+        ),
+    )
+
+
+def generated_artifacts() -> tuple[GeneratedArtifact, ...]:
+    from ..capabilities.families import standalone_capability_families_json
+    from ..catalogs.roles import roles_reference_markdown
+    from ..skills.render import workflow_reference_markdown
+
+    return (
+        GeneratedArtifact(
+            name="workflows_doc",
+            path="docs/WORKFLOWS.md",
+            render=workflow_reference_markdown,
+            regenerate="uv run python -m omh.cli docs workflows --output docs/WORKFLOWS.md",
+        ),
+        GeneratedArtifact(
+            name="roles_doc",
+            path="docs/ROLES.md",
+            render=roles_reference_markdown,
+            regenerate="uv run python -m omh.cli docs roles --output docs/ROLES.md",
+        ),
+        GeneratedArtifact(
+            name="capability_families_sidecar",
+            path="src/plugin_bundle/omh/tools/capability_families.json",
+            render=standalone_capability_families_json,
+            regenerate="uv run python -m omh.cli docs capability-families",
+        ),
+    )
+
+
+def _count_drift(metric: CountMetric) -> dict[str, Any] | None:
+    live = metric.live()
+    if live == metric.expected:
+        return None
+    return {
+        "name": metric.name,
+        "kind": "count",
+        "describe": metric.describe,
+        "expected": metric.expected,
+        "live": live,
+        "sites": list(metric.sites),
+        "fix": (
+            f"replace {metric.expected} with {live} in src/maintenance/drift.py "
+            f"and in every site listed above"
+        ),
+    }
+
+
+def _budget_drift(metric: BudgetMetric) -> dict[str, Any] | None:
+    live = metric.live()
+    if live <= metric.limit:
+        return None
+    return {
+        "name": metric.name,
+        "kind": "budget",
+        "describe": metric.describe,
+        "limit": metric.limit,
+        "live": live,
+        "over_by": live - metric.limit,
+        "sites": [metric.limit_site],
+        "fix": (
+            f"shorten the rendered content by {live - metric.limit} chars, or raise the limit "
+            f"in {metric.limit_site} if the growth is genuinely warranted"
+        ),
+    }
+
+
+def _generated_drift(artifact: GeneratedArtifact, repo_root: Path) -> dict[str, Any] | None:
+    target = repo_root / artifact.path
+    expected = artifact.render()
+    try:
+        current = target.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        state = "missing"
+    except OSError as exc:
+        return {
+            "name": artifact.name,
+            "kind": "generated",
+            "describe": f"{artifact.path} could not be read",
+            "state": "unreadable",
+            "error": str(exc),
+            "sites": [artifact.path],
+            "fix": artifact.regenerate,
+        }
+    else:
+        if current == expected:
+            return None
+        state = "stale"
+    return {
+        "name": artifact.name,
+        "kind": "generated",
+        "describe": f"{artifact.path} is {state}",
+        "state": state,
+        "sites": [artifact.path],
+        "fix": artifact.regenerate,
+    }
+
+
+def repo_root_default() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def drift_report(
+    *,
+    repo_root: Path | None = None,
+    counts: tuple[CountMetric, ...] | None = None,
+    budgets: tuple[BudgetMetric, ...] | None = None,
+    artifacts: tuple[GeneratedArtifact, ...] | None = None,
+) -> dict[str, Any]:
+    """Check every metric and report all findings; never stop at the first.
+
+    Stopping early is the behaviour this command exists to replace.
+    """
+    root = repo_root or repo_root_default()
+    counts = count_metrics() if counts is None else counts
+    budgets = budget_metrics() if budgets is None else budgets
+    artifacts = generated_artifacts() if artifacts is None else artifacts
+
+    drift: list[dict[str, Any]] = []
+    checked: list[str] = []
+    for metric in counts:
+        checked.append(metric.name)
+        found = _count_drift(metric)
+        if found:
+            drift.append(found)
+    for metric in budgets:
+        checked.append(metric.name)
+        found = _budget_drift(metric)
+        if found:
+            drift.append(found)
+    for artifact in artifacts:
+        checked.append(artifact.name)
+        found = _generated_drift(artifact, root)
+        if found:
+            drift.append(found)
+
+    return {
+        "schema_version": DRIFT_REPORT_SCHEMA_VERSION,
+        "ok": not drift,
+        "checked_count": len(checked),
+        "drift_count": len(drift),
+        "checked": checked,
+        "drift": drift,
+        "next_action": (
+            "apply every listed fix in one pass, then rerun this command"
+            if drift
+            else "no drift; run the full suite as the final proof"
+        ),
+        "claim_boundary": (
+            "Drift detection is a preflight over recomputed catalog values. It is not test, "
+            "review, CI, or merge evidence."
+        ),
+    }
+
+
+def format_drift_report(payload: dict[str, Any]) -> str:
+    drift = payload.get("drift") or []
+    lines: list[str] = []
+    if not drift:
+        lines.append(f"No drift. {payload.get('checked_count', 0)} checks passed.")
+        return "\n".join(lines)
+    lines.append(f"DRIFT ({len(drift)} of {payload.get('checked_count', 0)} checks)")
+    lines.append("")
+    for item in drift:
+        kind = item.get("kind")
+        if kind == "count":
+            headline = f"  {item['name']}: {item['expected']} -> {item['live']}"
+        elif kind == "budget":
+            headline = f"  {item['name']}: {item['live']} (over budget {item['limit']} by {item['over_by']})"
+        else:
+            headline = f"  {item['name']}: {item.get('state', 'stale')}"
+        lines.append(headline)
+        for site in item.get("sites", []):
+            lines.append(f"      site: {site}")
+        lines.append(f"      fix:  {item.get('fix', '')}")
+        lines.append("")
+    lines.append(str(payload.get("next_action", "")))
+    return "\n".join(lines)

--- a/src/plugin_bundle/omh/runtime_reader.py
+++ b/src/plugin_bundle/omh/runtime_reader.py
@@ -49,7 +49,6 @@ EXECUTOR_PROGRESS_EVENT_TYPES = {
     "executor_blocked",
     "executor_failed",
     "reported_change_not_observed",
-    "reported_success_contradicted",
     "progress_observed",
 }
 EXECUTOR_PROGRESS_PROFILES = {"codex", "claude_code", "hermes_local"}

--- a/src/plugin_bundle/omh/runtime_reader.py
+++ b/src/plugin_bundle/omh/runtime_reader.py
@@ -48,6 +48,8 @@ EXECUTOR_PROGRESS_EVENT_TYPES = {
     "executor_completed",
     "executor_blocked",
     "executor_failed",
+    "reported_change_not_observed",
+    "reported_success_contradicted",
     "progress_observed",
 }
 EXECUTOR_PROGRESS_PROFILES = {"codex", "claude_code", "hermes_local"}

--- a/src/runtime/context_budget.py
+++ b/src/runtime/context_budget.py
@@ -13,6 +13,8 @@ never blocks an observation surface.
 
 from __future__ import annotations
 
+import hashlib
+import json
 from pathlib import Path
 from typing import Any
 
@@ -22,7 +24,18 @@ from ..paths import OmhPaths
 
 
 RUN_CONTEXT_BUDGET_SCHEMA_VERSION = "omh_run_context_budget/v1"
+RUN_UNCHANGED_SCHEMA_VERSION = "omh_run_show_unchanged/v1"
 CONTEXT_BUDGET_LEDGER_NAME = "context_budget.json"
+
+
+def payload_fingerprint(payload: Any) -> str:
+    """Hash the observable content of a projection.
+
+    Fingerprint the projection itself, never the emitted envelope: the envelope
+    carries the budget, which changes on every call and would make every
+    emission look new.
+    """
+    return hashlib.sha256(json.dumps(payload, sort_keys=True, default=str).encode("utf-8")).hexdigest()
 
 
 def context_budget_ledger_path(paths: OmhPaths) -> Path:
@@ -38,12 +51,16 @@ def _ledger(paths: OmhPaths) -> dict[str, Any]:
 def _entry(ledger: dict[str, Any], run_id: str) -> dict[str, Any]:
     entry = ledger["runs"].get(run_id)
     if not isinstance(entry, dict):
-        return {"emitted_bytes": 0, "call_count": 0, "surfaces": {}}
+        return {"emitted_bytes": 0, "call_count": 0, "surfaces": {}, "payload_fingerprints": {}}
     surfaces = entry.get("surfaces")
+    fingerprints = entry.get("payload_fingerprints")
     return {
         "emitted_bytes": max(0, int(entry.get("emitted_bytes", 0) or 0)),
         "call_count": max(0, int(entry.get("call_count", 0) or 0)),
         "surfaces": {str(key): int(value) for key, value in surfaces.items()} if isinstance(surfaces, dict) else {},
+        "payload_fingerprints": (
+            {str(key): str(value) for key, value in fingerprints.items()} if isinstance(fingerprints, dict) else {}
+        ),
     }
 
 
@@ -61,19 +78,29 @@ def run_context_budget(paths: OmhPaths, run_id: str, *, surface: str = "") -> di
         "remaining_bytes": max(0, RUN_CONTEXT_BUDGET_BYTES - emitted),
         "observe_call_count": entry["call_count"],
         "surfaces": entry["surfaces"],
+        "last_payload_fingerprint": entry["payload_fingerprints"].get(surface, ""),
         "exhausted": exhausted,
         "enforcement": "degrade_to_summary_only_with_artifact_pointers",
         "policy": "timed_polling_rejected; raw_log_dumping_rejected",
     }
 
 
-def record_context_emission(paths: OmhPaths, run_id: str, *, surface: str, byte_count: int) -> dict[str, Any]:
+def record_context_emission(
+    paths: OmhPaths,
+    run_id: str,
+    *,
+    surface: str,
+    byte_count: int,
+    payload_fingerprint_value: str = "",
+) -> dict[str, Any]:
     """Add one observe/show emission to the run's ledger. Best-effort."""
     ledger = _ledger(paths)
     entry = _entry(ledger, run_id)
     entry["emitted_bytes"] += max(0, int(byte_count))
     entry["call_count"] += 1
     entry["surfaces"][surface] = entry["surfaces"].get(surface, 0) + 1
+    if payload_fingerprint_value:
+        entry["payload_fingerprints"][surface] = payload_fingerprint_value
     entry["updated_at"] = utc_now()
     ledger["runs"][run_id] = entry
     payload = {
@@ -87,6 +114,43 @@ def record_context_emission(paths: OmhPaths, run_id: str, *, surface: str, byte_
     except OSError:
         return run_context_budget(paths, run_id, surface=surface)
     return run_context_budget(paths, run_id, surface=surface)
+
+
+def unchanged_run_payload(shown: dict[str, Any], budget: dict[str, Any]) -> dict[str, Any]:
+    """Replacement for a projection identical to the one already emitted.
+
+    A supervising agent that polls an unchanged run gets the whole projection
+    back every time and narrates it again, which is how one delegated session
+    turned twelve fix/test cycles into hundreds of chat messages. Returning the
+    lifecycle position plus an explicit "nothing changed" marker removes the
+    material to re-narrate without hiding anything: by definition this payload
+    carries no information the previous emission did not already carry.
+
+    `--full` bypasses this entirely, so an explicit request still gets
+    everything.
+    """
+    run = shown.get("run") if isinstance(shown.get("run"), dict) else {}
+    run_id = str(budget.get("run_id", ""))
+    return {
+        "schema_version": RUN_UNCHANGED_SCHEMA_VERSION,
+        "run": {
+            "run_id": run_id,
+            "status": str(run.get("status", "")),
+            "phase": str(run.get("phase", "")),
+            "observation_status": str(run.get("observation_status", "")),
+            "updated_at": str(run.get("updated_at", "")),
+        },
+        "unchanged_since_last_emission": True,
+        "delta": {},
+        "context_budget": budget,
+        "next_action": "wait_for_new_observed_evidence_instead_of_repeating_this_command",
+        "full_output_command": f"omh runtime show {run_id} --full",
+        "claim_boundary": (
+            "Nothing observable changed since the previous emission for this run. This is not "
+            "execution, review, CI, merge-readiness, or merge evidence, and repeating the command "
+            "will not produce new evidence."
+        ),
+    }
 
 
 def degrade_run_payload(shown: dict[str, Any], budget: dict[str, Any]) -> dict[str, Any]:

--- a/src/runtime/context_budget.py
+++ b/src/runtime/context_budget.py
@@ -38,14 +38,54 @@ def run_show_surface(*, full: bool, history_limit: object = None) -> str:
     return f"runtime_show:{'full' if full else history_limit}"
 
 
+# Bookkeeping a progress observation rewrites even when it reports nothing.
+# `update_binding_reporter_state` stamps these on every observation, including
+# suppressed ones, so leaving them in the fingerprint means one intervening
+# `progress-observe` makes an otherwise identical projection look new. A
+# supervising agent always observes between status checks, so that defeated the
+# unchanged check entirely in real use while unit tests -- which call `show`
+# twice in a row -- still passed.
+_FINGERPRINT_VOLATILE_KEYS = frozenset(
+    {
+        "updated_at",
+        "last_observed_at",
+        "last_observed_signal_hash",
+        "last_observed_event_count",
+        "last_observed_artifact_sha256",
+        # The tally of observations deliberately not reported. Counting
+        # suppressions is itself a change in the projection, so leaving this in
+        # meant every suppressed observation un-suppressed the next status
+        # check -- the check defeating itself.
+        "suppressed_duplicate_count",
+    }
+)
+
+
+def _without_volatile_bookkeeping(payload: Any) -> Any:
+    if isinstance(payload, dict):
+        return {
+            key: _without_volatile_bookkeeping(value)
+            for key, value in payload.items()
+            if key not in _FINGERPRINT_VOLATILE_KEYS
+        }
+    if isinstance(payload, list):
+        return [_without_volatile_bookkeeping(item) for item in payload]
+    return payload
+
+
 def payload_fingerprint(payload: Any) -> str:
-    """Hash the observable content of a projection.
+    """Hash what a reader would act on, not every byte of the projection.
 
     Fingerprint the projection itself, never the emitted envelope: the envelope
     carries the budget, which changes on every call and would make every
     emission look new.
+
+    Real new content still changes the hash -- a new event lengthens the event
+    list, and a state change rewrites the run record. Only the per-observation
+    bookkeeping above is excluded.
     """
-    return hashlib.sha256(json.dumps(payload, sort_keys=True, default=str).encode("utf-8")).hexdigest()
+    normalized = _without_volatile_bookkeeping(payload)
+    return hashlib.sha256(json.dumps(normalized, sort_keys=True, default=str).encode("utf-8")).hexdigest()
 
 
 def context_budget_ledger_path(paths: OmhPaths) -> Path:

--- a/src/runtime/context_budget.py
+++ b/src/runtime/context_budget.py
@@ -28,6 +28,16 @@ RUN_UNCHANGED_SCHEMA_VERSION = "omh_run_show_unchanged/v1"
 CONTEXT_BUDGET_LEDGER_NAME = "context_budget.json"
 
 
+def run_show_surface(*, full: bool, history_limit: object = None) -> str:
+    """Ledger key for a `runtime show` emission.
+
+    The projection varies with the history limit, so the comparison key has to
+    as well. One shared key across limits means alternating `--limit 20` and
+    `--limit 50` never matches and suppression silently never fires.
+    """
+    return f"runtime_show:{'full' if full else history_limit}"
+
+
 def payload_fingerprint(payload: Any) -> str:
     """Hash the observable content of a projection.
 
@@ -141,6 +151,7 @@ def unchanged_run_payload(shown: dict[str, Any], budget: dict[str, Any]) -> dict
     """
     run = shown.get("run") if isinstance(shown.get("run"), dict) else {}
     run_id = str(budget.get("run_id", ""))
+    budget = public_budget(budget)
     return {
         "schema_version": RUN_UNCHANGED_SCHEMA_VERSION,
         "run": {
@@ -170,6 +181,7 @@ def degrade_run_payload(shown: dict[str, Any], budget: dict[str, Any]) -> dict[s
     journal_events = shown.get("journal_events") if isinstance(shown.get("journal_events"), list) else []
     latest = journal_events[-1] if journal_events and isinstance(journal_events[-1], dict) else {}
     run_id = str(budget.get("run_id", ""))
+    budget = public_budget(budget)
     return {
         "schema_version": "omh_run_show_summary_only/v1",
         "run": {

--- a/src/runtime/context_budget.py
+++ b/src/runtime/context_budget.py
@@ -116,6 +116,16 @@ def record_context_emission(
     return run_context_budget(paths, run_id, surface=surface)
 
 
+def public_budget(budget: dict[str, Any]) -> dict[str, Any]:
+    """Drop internal bookkeeping before the budget is emitted.
+
+    `last_payload_fingerprint` is a hash of the projection the caller is already
+    holding. Emitting it adds bytes, tells the reader nothing, and would make
+    `--full` output differ from before this check existed.
+    """
+    return {key: value for key, value in budget.items() if key != "last_payload_fingerprint"}
+
+
 def unchanged_run_payload(shown: dict[str, Any], budget: dict[str, Any]) -> dict[str, Any]:
     """Replacement for a projection identical to the one already emitted.
 

--- a/src/skills/render.py
+++ b/src/skills/render.py
@@ -676,6 +676,23 @@ process/session id, PID, branch or PR target, and the prepared-vs-observed
 boundary. Do not silently wait for a final result after saying an executor is
 running.
 
+## Narration Ceiling
+
+Active does not mean continuous. Unsolicited narration is capped at roughly one
+status message per meaningful transition, and at most a few per fix/verify
+cycle. Report a transition, not a step.
+
+- If nothing observable changed since the last update, say nothing.
+- If an observe surface returns `unchanged_since_last_emission`, that is the
+  answer; do not restate the previous update in new words.
+- Do not re-list findings that were already reported. Report only what is new,
+  and reference the earlier list instead of repeating it.
+- Do not narrate individual tool calls, file reads, or searches.
+
+This ceiling applies to unsolicited push narration only. When the user asks for
+detail, give the full detail: an explicit request, or an explicit `--full` on an
+observe surface, is never throttled.
+
 ## Progress Cadence
 
 For long-running executor work, use an event-triggered status loop or bounded
@@ -688,6 +705,18 @@ update should separate:
 - changed files or affected area
 - tests/checks started, passed, failed, or still missing
 - commit, push, PR, CI, review, and merge evidence
+
+Separate them within an update; do not send one message per bullet.
+
+## Never Suppressed
+
+The ceiling never applies to these. Report them the first time they occur, even
+if an update was just sent:
+
+- a blocker, failure, or failing verification
+- a claim that the observed state contradicts, such as an edit reported applied
+  while no file changed, or a success report alongside a non-zero exit
+- the first occurrence of any new kind of event
 
 ## Completion Verification
 

--- a/tests/_local_package.py
+++ b/tests/_local_package.py
@@ -1,9 +1,35 @@
 from __future__ import annotations
 
+import atexit
 from importlib.machinery import ModuleSpec
+import os
 import sys
+import tempfile
 from types import ModuleType
 from pathlib import Path
+
+
+def _redirect_home_env_to_temp_root() -> None:
+    """Point OMH/Hermes home defaults at a temp root for the whole test process.
+
+    `default_omh_home()` and `default_hermes_home()` read OMH_HOME/HERMES_HOME
+    and otherwise fall back to ~/.omh and ~/.hermes. Tests that never pass an
+    explicit home therefore wrote into the developer's real home: the observed
+    damage was ~4.7k `plan_artifact_created` events accumulated in
+    ~/.omh/runtime/journal/events.jsonl over a month of test runs.
+
+    The override is unconditional. Honouring a pre-existing OMH_HOME would let a
+    developer's own export reintroduce the leak, which is the exact failure this
+    guards against.
+    """
+    holder = tempfile.TemporaryDirectory(prefix="omh-test-home-")
+    atexit.register(holder.cleanup)
+    root = Path(holder.name)
+    os.environ["OMH_HOME"] = str(root / "omh")
+    os.environ["HERMES_HOME"] = str(root / "hermes")
+
+
+_redirect_home_env_to_temp_root()
 
 
 def load_local_package() -> None:

--- a/tests/test_drift_registry.py
+++ b/tests/test_drift_registry.py
@@ -109,6 +109,7 @@ class DriftReportTests(unittest.TestCase):
 
             payload = drift_report(
                 repo_root=root,
+                include_tap_skills=False,
                 counts=(
                     self._count("first_count", live=60, expected=59),
                     self._count("second_count", live=180, expected=179),
@@ -154,8 +155,29 @@ class DriftReportTests(unittest.TestCase):
                 {"first_count", "second_count", "over_budget", "stale_doc", "missing_doc"},
             )
 
+    def test_generated_skill_files_are_checked_by_default(self) -> None:
+        """Regression: the registry once shipped without this and stayed silent.
+
+        Editing a skill reference template left `skills/*/references/*.md` stale.
+        `docs workflows --check` caught it; `release drift` reported no drift,
+        which is the failure this command exists to prevent.
+        """
+        self.assertIn("tap_skills", drift_report()["checked"])
+
+    def test_stale_generated_skill_files_are_reported(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            payload = drift_report(repo_root=root, counts=(), budgets=(), artifacts=())
+            reported = {item["name"] for item in payload["drift"]}
+            self.assertIn("tap_skills", reported, "an empty skills/ tree must count as drift")
+
     def test_count_drift_names_the_replacement_and_its_sites(self) -> None:
-        payload = drift_report(counts=(self._count("skill_count", live=60, expected=59),), budgets=(), artifacts=())
+        payload = drift_report(
+            counts=(self._count("skill_count", live=60, expected=59),),
+            budgets=(),
+            artifacts=(),
+            include_tap_skills=False,
+        )
         item = payload["drift"][0]
         self.assertEqual(item["kind"], "count")
         self.assertEqual(item["expected"], 59)
@@ -167,6 +189,7 @@ class DriftReportTests(unittest.TestCase):
     def test_budget_drift_reports_the_overage(self) -> None:
         payload = drift_report(
             counts=(),
+            include_tap_skills=False,
             budgets=(
                 BudgetMetric(
                     name="registry_bytes",
@@ -190,6 +213,7 @@ class DriftReportTests(unittest.TestCase):
             (root / "docs" / "ROLES.md").write_text("stale", encoding="utf-8")
             payload = drift_report(
                 repo_root=root,
+                include_tap_skills=False,
                 counts=(),
                 budgets=(),
                 artifacts=(
@@ -210,6 +234,7 @@ class DriftReportTests(unittest.TestCase):
             counts=(self._count("a_count", live=2, expected=1), self._count("b_count", live=4, expected=3)),
             budgets=(),
             artifacts=(),
+            include_tap_skills=False,
         )
         text = format_drift_report(payload)
         self.assertIn("a_count", text)
@@ -217,7 +242,7 @@ class DriftReportTests(unittest.TestCase):
         self.assertEqual(text.count("fix:"), 2)
 
     def test_the_clean_format_says_how_much_was_checked(self) -> None:
-        text = format_drift_report(drift_report(counts=(), budgets=(), artifacts=()))
+        text = format_drift_report(drift_report(counts=(), budgets=(), artifacts=(), include_tap_skills=False))
         self.assertIn("No drift", text)
 
 

--- a/tests/test_drift_registry.py
+++ b/tests/test_drift_registry.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+import json
+import re
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from _cli_harness import run_cli
+from _local_package import load_local_package
+
+load_local_package()
+from omh.maintenance.drift import (
+    BudgetMetric,
+    CountMetric,
+    GeneratedArtifact,
+    budget_metrics,
+    count_metrics,
+    drift_report,
+    format_drift_report,
+    generated_artifacts,
+    repo_root_default,
+)
+
+
+REPO_ROOT = repo_root_default()
+
+
+class DriftRegistryHonestyTests(unittest.TestCase):
+    """Keep the registry from becoming a second stale source of truth.
+
+    The registry claims two things it cannot prove on its own: that its expected
+    value matches reality, and that the sites it lists really do hardcode that
+    value. Both are checked here, so a registry that drifts fails loudly instead
+    of quietly under-reporting.
+    """
+
+    def test_every_count_metric_matches_its_live_producer(self) -> None:
+        for metric in count_metrics():
+            with self.subTest(metric=metric.name):
+                self.assertEqual(
+                    metric.live(),
+                    metric.expected,
+                    f"{metric.name} drifted; run `omh release drift` for the full set",
+                )
+
+    def test_every_declared_site_exists(self) -> None:
+        for metric in count_metrics():
+            for site in metric.sites:
+                with self.subTest(metric=metric.name, site=site):
+                    self.assertTrue((REPO_ROOT / site).is_file(), f"declared site is missing: {site}")
+        for metric in budget_metrics():
+            with self.subTest(metric=metric.name, site=metric.limit_site):
+                self.assertTrue((REPO_ROOT / metric.limit_site).is_file())
+
+    def test_every_declared_site_actually_hardcodes_the_value(self) -> None:
+        """A site that no longer mentions the number is a site that stopped mattering."""
+        for metric in count_metrics():
+            token = re.compile(rf"(?<![\d_]){metric.expected}(?![\d_])")
+            for site in metric.sites:
+                with self.subTest(metric=metric.name, site=site):
+                    text = (REPO_ROOT / site).read_text(encoding="utf-8")
+                    self.assertRegex(
+                        text,
+                        token,
+                        f"{site} no longer contains {metric.expected}; drop it from "
+                        f"{metric.name}.sites or point it at the right file",
+                    )
+
+    def test_every_budget_limit_is_declared_where_the_registry_says(self) -> None:
+        for metric in budget_metrics():
+            with self.subTest(metric=metric.name):
+                text = (REPO_ROOT / metric.limit_site).read_text(encoding="utf-8")
+                self.assertRegex(text, re.compile(rf"(?<![\d_]){metric.limit}(?![\d_])"))
+
+    def test_metric_names_are_unique(self) -> None:
+        names = [m.name for m in count_metrics()] + [m.name for m in budget_metrics()]
+        names += [a.name for a in generated_artifacts()]
+        self.assertEqual(len(names), len(set(names)))
+
+
+class DriftReportTests(unittest.TestCase):
+    def _count(self, name: str, live: int, expected: int) -> CountMetric:
+        return CountMetric(
+            name=name,
+            describe=name,
+            live=lambda: live,
+            expected=expected,
+            sites=("tests/test_drift_registry.py",),
+        )
+
+    def test_a_clean_repo_reports_no_drift(self) -> None:
+        payload = drift_report()
+        self.assertTrue(payload["ok"], payload["drift"])
+        self.assertEqual(payload["drift_count"], 0)
+        self.assertGreater(payload["checked_count"], 0)
+
+    def test_every_simultaneous_drift_is_reported_in_one_pass(self) -> None:
+        """The whole point: one run, the complete list.
+
+        This mirrors the observed session, where a single skill addition
+        invalidated counts, a budget, and generated docs at once and the suite
+        revealed them a few at a time across twelve cycles.
+        """
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "docs").mkdir()
+            (root / "docs" / "STALE.md").write_text("old", encoding="utf-8")
+
+            payload = drift_report(
+                repo_root=root,
+                counts=(
+                    self._count("first_count", live=60, expected=59),
+                    self._count("second_count", live=180, expected=179),
+                    self._count("third_count", live=90, expected=90),
+                ),
+                budgets=(
+                    BudgetMetric(
+                        name="over_budget",
+                        describe="over budget",
+                        live=lambda: 24_305,
+                        limit=24_000,
+                        limit_site="src/maintenance/release.py",
+                    ),
+                    BudgetMetric(
+                        name="within_budget",
+                        describe="within budget",
+                        live=lambda: 10,
+                        limit=24_000,
+                        limit_site="src/maintenance/release.py",
+                    ),
+                ),
+                artifacts=(
+                    GeneratedArtifact(
+                        name="stale_doc",
+                        path="docs/STALE.md",
+                        render=lambda: "new",
+                        regenerate="regenerate me",
+                    ),
+                    GeneratedArtifact(
+                        name="missing_doc",
+                        path="docs/GONE.md",
+                        render=lambda: "anything",
+                        regenerate="regenerate me too",
+                    ),
+                ),
+            )
+
+            self.assertFalse(payload["ok"])
+            self.assertEqual(payload["checked_count"], 7)
+            reported = {item["name"] for item in payload["drift"]}
+            self.assertEqual(
+                reported,
+                {"first_count", "second_count", "over_budget", "stale_doc", "missing_doc"},
+            )
+
+    def test_count_drift_names_the_replacement_and_its_sites(self) -> None:
+        payload = drift_report(counts=(self._count("skill_count", live=60, expected=59),), budgets=(), artifacts=())
+        item = payload["drift"][0]
+        self.assertEqual(item["kind"], "count")
+        self.assertEqual(item["expected"], 59)
+        self.assertEqual(item["live"], 60)
+        self.assertIn("tests/test_drift_registry.py", item["sites"])
+        self.assertIn("59", item["fix"])
+        self.assertIn("60", item["fix"])
+
+    def test_budget_drift_reports_the_overage(self) -> None:
+        payload = drift_report(
+            counts=(),
+            budgets=(
+                BudgetMetric(
+                    name="registry_bytes",
+                    describe="registry",
+                    live=lambda: 24_305,
+                    limit=24_000,
+                    limit_site="src/maintenance/release.py",
+                ),
+            ),
+            artifacts=(),
+        )
+        item = payload["drift"][0]
+        self.assertEqual(item["kind"], "budget")
+        self.assertEqual(item["over_by"], 305)
+        self.assertIn("305", item["fix"])
+
+    def test_generated_drift_carries_the_regenerate_command(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "docs").mkdir()
+            (root / "docs" / "ROLES.md").write_text("stale", encoding="utf-8")
+            payload = drift_report(
+                repo_root=root,
+                counts=(),
+                budgets=(),
+                artifacts=(
+                    GeneratedArtifact(
+                        name="roles_doc",
+                        path="docs/ROLES.md",
+                        render=lambda: "fresh",
+                        regenerate="uv run python -m omh.cli docs roles --output docs/ROLES.md",
+                    ),
+                ),
+            )
+            item = payload["drift"][0]
+            self.assertEqual(item["state"], "stale")
+            self.assertIn("docs roles --output", item["fix"])
+
+    def test_the_human_format_lists_every_finding_with_its_fix(self) -> None:
+        payload = drift_report(
+            counts=(self._count("a_count", live=2, expected=1), self._count("b_count", live=4, expected=3)),
+            budgets=(),
+            artifacts=(),
+        )
+        text = format_drift_report(payload)
+        self.assertIn("a_count", text)
+        self.assertIn("b_count", text)
+        self.assertEqual(text.count("fix:"), 2)
+
+    def test_the_clean_format_says_how_much_was_checked(self) -> None:
+        text = format_drift_report(drift_report(counts=(), budgets=(), artifacts=()))
+        self.assertIn("No drift", text)
+
+
+class DriftCommandTests(unittest.TestCase):
+    def test_the_command_passes_on_a_clean_tree(self) -> None:
+        status, stdout, stderr = run_cli(["release", "drift", "--json"])
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        payload = json.loads(stdout)
+        self.assertTrue(payload["ok"], payload["drift"])
+
+    def test_the_human_output_is_the_default(self) -> None:
+        status, stdout, stderr = run_cli(["release", "drift"], output_json=False)
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        self.assertIn("No drift", stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_executor_progress_quality_floor.py
+++ b/tests/test_executor_progress_quality_floor.py
@@ -15,6 +15,8 @@ from omh.executor_progress import (
     TERMINAL_EVENT_TYPES,
     build_progress_binding,
     build_progress_event,
+    build_safe_progress_signal,
+    infer_progress_event_type,
     reported_event_types,
     should_report_event,
     update_binding_reporter_state,
@@ -189,6 +191,86 @@ class FirstOccurrenceGuaranteeTests(unittest.TestCase):
         should_report, reason = should_report_event(binding, event, now=later)
         self.assertTrue(should_report, reason)
         self.assertEqual(reason, "meaningful_transition")
+
+
+class ClaimMismatchDetectionTests(unittest.TestCase):
+    """The exemption list is worthless if nothing ever emits the exempt types."""
+
+    def _signal(self, **overrides: object) -> dict[str, object]:
+        signal = build_safe_progress_signal(
+            executor_profile="claude_code",
+            profile_progress_summary={
+                "status": "running",
+                "observable_activity": ["Codex changed files."],
+            },
+        )
+        signal.update(overrides)
+        return signal
+
+    def test_reported_change_with_clean_git_is_flagged(self) -> None:
+        signal = build_safe_progress_signal(
+            executor_profile="claude_code",
+            profile_progress_summary={"observable_activity": ["Codex changed files."]},
+            git_status_short="",
+            git_diff_stat="",
+        )
+        self.assertTrue(signal["git_observed"])
+        self.assertEqual(infer_progress_event_type(signal), "reported_change_not_observed")
+
+    def test_reported_change_with_a_real_diff_is_not_flagged(self) -> None:
+        signal = build_safe_progress_signal(
+            executor_profile="claude_code",
+            profile_progress_summary={"observable_activity": ["Codex changed files."]},
+            git_status_short=" M src/coding/executor_progress.py",
+            git_diff_stat="1 file changed, 2 insertions(+)",
+        )
+        self.assertEqual(infer_progress_event_type(signal), "diff_started")
+
+    def test_no_git_observation_never_claims_a_mismatch(self) -> None:
+        """Callers that do not collect git state must not trip the detector."""
+        signal = build_safe_progress_signal(
+            executor_profile="claude_code",
+            profile_progress_summary={"observable_activity": ["Codex changed files."]},
+        )
+        self.assertFalse(signal["git_observed"])
+        self.assertNotEqual(infer_progress_event_type(signal), "reported_change_not_observed")
+
+    def test_clean_git_without_any_change_claim_is_not_a_mismatch(self) -> None:
+        signal = build_safe_progress_signal(
+            executor_profile="claude_code",
+            profile_progress_summary={"observable_activity": ["Codex inspected the repo."]},
+            git_status_short="",
+        )
+        self.assertEqual(infer_progress_event_type(signal), "repo_exploration")
+
+    def test_clean_exit_with_observed_failure_is_flagged(self) -> None:
+        signal = build_safe_progress_signal(
+            executor_profile="claude_code",
+            process_status="exited_zero",
+            profile_progress_summary={"status": "failed_or_error_observed"},
+        )
+        self.assertEqual(infer_progress_event_type(signal), "reported_success_contradicted")
+
+    def test_clean_exit_without_observed_failure_stays_completed(self) -> None:
+        signal = build_safe_progress_signal(executor_profile="claude_code", process_status="exited_zero")
+        self.assertEqual(infer_progress_event_type(signal), "executor_completed")
+
+    def test_failing_exit_with_observed_failure_is_not_a_contradiction(self) -> None:
+        signal = build_safe_progress_signal(
+            executor_profile="claude_code",
+            process_status="failed",
+            profile_progress_summary={"status": "failed_or_error_observed"},
+        )
+        self.assertNotEqual(infer_progress_event_type(signal), "reported_success_contradicted")
+
+    def test_an_explicit_event_type_still_wins(self) -> None:
+        signal = build_safe_progress_signal(
+            executor_profile="claude_code",
+            explicit_event_type="tests_passed",
+            profile_progress_summary={"observable_activity": ["Codex changed files."]},
+            git_status_short="",
+        )
+        self.assertEqual(infer_progress_event_type(signal), "tests_passed")
 
 
 class VendoredBundleParityTests(unittest.TestCase):

--- a/tests/test_executor_progress_quality_floor.py
+++ b/tests/test_executor_progress_quality_floor.py
@@ -10,6 +10,7 @@ from omh.context_safety import (
     build_progress_event as build_chat_progress_event,
 )
 from omh.executor_progress import (
+    CLOSING_EVENT_TYPES,
     DEFAULT_MINIMUM_REPEAT_INTERVAL_SECONDS,
     PROGRESS_EVENT_TYPES,
     TERMINAL_EVENT_TYPES,
@@ -24,7 +25,7 @@ from omh.executor_progress import (
 from omh.plugin_bundle.omh.runtime_reader import EXECUTOR_PROGRESS_EVENT_TYPES
 
 
-CLAIM_MISMATCH_EVENT_TYPES = ("reported_change_not_observed", "reported_success_contradicted")
+CLAIM_MISMATCH_EVENT_TYPES = ("reported_change_not_observed",)
 
 
 def _binding(**overrides: object) -> dict[str, object]:
@@ -107,7 +108,92 @@ class SuppressionExemptFloorTests(unittest.TestCase):
                 self.assertIn(event_type, CODING_PROGRESS_REPORTABLE_EVENTS)
 
 
+class BindingClosureTests(unittest.TestCase):
+    """A binding must still close when the run ends.
+
+    The closing set used to be hardcoded separately from TERMINAL_EVENT_TYPES.
+    Adding a mismatch type that intercepted observations previously classified
+    as `executor_failed` therefore left the binding `active`, and
+    `project_active_executor_status` reported a dead executor as running until
+    freshness aged it out 15 minutes later.
+    """
+
+    def _closed_state(self, event_type: str) -> str:
+        binding = _binding()
+        event = _event(binding, event_type, observed_at="2026-07-25T00:00:01Z")
+        updated = update_binding_reporter_state(
+            binding, event, reported=True, reported_at="2026-07-25T00:00:01Z"
+        )
+        return str(updated["state"])
+
+    def test_every_closing_event_type_closes_the_binding(self) -> None:
+        for event_type in CLOSING_EVENT_TYPES:
+            with self.subTest(event_type=event_type):
+                self.assertEqual(self._closed_state(event_type), "closed")
+
+    def test_a_claim_mismatch_closes_the_binding(self) -> None:
+        for event_type in CLAIM_MISMATCH_EVENT_TYPES:
+            with self.subTest(event_type=event_type):
+                self.assertIn(event_type, CLOSING_EVENT_TYPES)
+                self.assertEqual(self._closed_state(event_type), "closed")
+
+    def test_test_results_are_reportable_but_do_not_close(self) -> None:
+        """The executor may keep working after a test run reports."""
+        for event_type in ("tests_passed", "tests_failed"):
+            with self.subTest(event_type=event_type):
+                self.assertIn(event_type, TERMINAL_EVENT_TYPES)
+                self.assertNotIn(event_type, CLOSING_EVENT_TYPES)
+                self.assertEqual(self._closed_state(event_type), "active")
+
+
 class FirstOccurrenceGuaranteeTests(unittest.TestCase):
+    def test_migrating_a_legacy_binding_does_not_un_suppress_everything(self) -> None:
+        """Seeding the new field with an empty list discards real history.
+
+        A legacy binding that reported `repo_exploration` forty times would,
+        after one unrelated report, treat `repo_exploration` as never seen and
+        report it again -- a burst of un-suppression on a run already in flight.
+        """
+        binding = _binding(
+            last_reported_event_type="repo_exploration",
+            last_reported_at="2026-07-25T00:00:00Z",
+            report_count=40,
+        )
+        binding.pop("reported_event_types")
+
+        closing = _event(binding, "executor_completed", observed_at="2026-07-25T00:00:01Z")
+        binding = update_binding_reporter_state(
+            binding, closing, reported=True, reported_at="2026-07-25T00:00:01Z"
+        )
+        self.assertEqual(reported_event_types(binding), ["repo_exploration", "executor_completed"])
+
+        repeat = _event(
+            binding,
+            "repo_exploration",
+            observed_at="2026-07-25T00:00:05Z",
+            summary="observed repo_exploration again",
+        )
+        _should_report, reason = should_report_event(binding, repeat, now="2026-07-25T00:00:05Z")
+        self.assertNotEqual(
+            reason,
+            "first_occurrence",
+            "a type the legacy binding already reported must not read as new",
+        )
+        # It still reports, as `meaningful_transition` -- the pre-existing
+        # interval rule only guards a repeat of the immediately previous type,
+        # and an intervening `executor_completed` breaks that run. The point of
+        # the seed is that the reason is not `first_occurrence`, which would
+        # bypass the interval rule outright for every remaining type.
+        self.assertEqual(reason, "meaningful_transition")
+
+    def test_a_legacy_binding_with_no_reports_still_treats_types_as_new(self) -> None:
+        binding = _binding(report_count=0)
+        binding.pop("reported_event_types")
+        event = _event(binding, "repo_exploration", observed_at="2026-07-25T00:00:01Z")
+        _should_report, reason = should_report_event(binding, event, now="2026-07-25T00:00:01Z")
+        self.assertEqual(reason, "first_occurrence")
+
+
     def test_first_occurrence_of_a_non_terminal_type_always_reports(self) -> None:
         binding = _binding()
         event = _event(binding, "repo_exploration", observed_at="2026-07-25T00:00:01Z")
@@ -210,6 +296,7 @@ class ClaimMismatchDetectionTests(unittest.TestCase):
     def test_reported_change_with_clean_git_is_flagged(self) -> None:
         signal = build_safe_progress_signal(
             executor_profile="claude_code",
+            process_status="completed",
             profile_progress_summary={"observable_activity": ["Codex changed files."]},
             git_status_short="",
             git_diff_stat="",
@@ -220,6 +307,7 @@ class ClaimMismatchDetectionTests(unittest.TestCase):
     def test_reported_change_with_a_real_diff_is_not_flagged(self) -> None:
         signal = build_safe_progress_signal(
             executor_profile="claude_code",
+            process_status="completed",
             profile_progress_summary={"observable_activity": ["Codex changed files."]},
             git_status_short=" M src/coding/executor_progress.py",
             git_diff_stat="1 file changed, 2 insertions(+)",
@@ -230,6 +318,7 @@ class ClaimMismatchDetectionTests(unittest.TestCase):
         """Callers that do not collect git state must not trip the detector."""
         signal = build_safe_progress_signal(
             executor_profile="claude_code",
+            process_status="completed",
             profile_progress_summary={"observable_activity": ["Codex changed files."]},
         )
         self.assertFalse(signal["git_observed"])
@@ -243,29 +332,72 @@ class ClaimMismatchDetectionTests(unittest.TestCase):
         )
         self.assertEqual(infer_progress_event_type(signal), "repo_exploration")
 
-    def test_clean_exit_with_observed_failure_is_flagged(self) -> None:
+    def test_clean_exit_with_observed_failure_stays_executor_failed(self) -> None:
+        """A clean exit contradicted by an observed failure is already covered.
+
+        This was briefly its own `reported_success_contradicted` type. The
+        existing ladder classifies it as `executor_failed`, which is more
+        actionable and -- unlike a mismatch label -- closes the binding, so the
+        separate type only stole that behaviour.
+        """
         signal = build_safe_progress_signal(
             executor_profile="claude_code",
             process_status="exited_zero",
             profile_progress_summary={"status": "failed_or_error_observed"},
         )
-        self.assertEqual(infer_progress_event_type(signal), "reported_success_contradicted")
+        self.assertEqual(infer_progress_event_type(signal), "executor_failed")
 
     def test_clean_exit_without_observed_failure_stays_completed(self) -> None:
         signal = build_safe_progress_signal(executor_profile="claude_code", process_status="exited_zero")
         self.assertEqual(infer_progress_event_type(signal), "executor_completed")
 
-    def test_failing_exit_with_observed_failure_is_not_a_contradiction(self) -> None:
+    def test_a_mid_flight_run_mentioning_a_diff_is_not_accused(self) -> None:
+        """The upstream change claim is a coarse bucket.
+
+        Codex sets it from any log line containing patch/write/edit/diff, so
+        "let me run git diff to see the state" reads as a change claim against a
+        tree that is legitimately still clean. Only a finished run can
+        contradict itself.
+        """
         signal = build_safe_progress_signal(
             executor_profile="claude_code",
-            process_status="failed",
-            profile_progress_summary={"status": "failed_or_error_observed"},
+            process_status="running",
+            profile_progress_summary={"observable_activity": ["Codex changed files."]},
+            git_status_short="",
+            git_diff_stat="",
         )
-        self.assertNotEqual(infer_progress_event_type(signal), "reported_success_contradicted")
+        self.assertTrue(signal["git_observed"])
+        self.assertNotEqual(infer_progress_event_type(signal), "reported_change_not_observed")
+
+    def test_a_blocker_outranks_the_mismatch(self) -> None:
+        """Blocked text that also mentions a patch is a blocker, not a lie."""
+        signal = build_safe_progress_signal(
+            executor_profile="claude_code",
+            process_status="completed",
+            profile_progress_summary={
+                "status": "blocked",
+                "observable_activity": ["Codex changed files."],
+            },
+            git_status_short="",
+        )
+        self.assertEqual(infer_progress_event_type(signal), "executor_blocked")
+
+    def test_a_failure_outranks_the_mismatch(self) -> None:
+        signal = build_safe_progress_signal(
+            executor_profile="claude_code",
+            process_status="completed",
+            profile_progress_summary={
+                "status": "failed_or_error_observed",
+                "observable_activity": ["Codex changed files."],
+            },
+            git_status_short="",
+        )
+        self.assertEqual(infer_progress_event_type(signal), "executor_failed")
 
     def test_an_explicit_event_type_still_wins(self) -> None:
         signal = build_safe_progress_signal(
             executor_profile="claude_code",
+            process_status="completed",
             explicit_event_type="tests_passed",
             profile_progress_summary={"observable_activity": ["Codex changed files."]},
             git_status_short="",

--- a/tests/test_executor_progress_quality_floor.py
+++ b/tests/test_executor_progress_quality_floor.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import unittest
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.context_safety import (
+    CODING_PROGRESS_REPORTABLE_EVENTS,
+    build_progress_event as build_chat_progress_event,
+)
+from omh.executor_progress import (
+    DEFAULT_MINIMUM_REPEAT_INTERVAL_SECONDS,
+    PROGRESS_EVENT_TYPES,
+    TERMINAL_EVENT_TYPES,
+    build_progress_binding,
+    build_progress_event,
+    reported_event_types,
+    should_report_event,
+    update_binding_reporter_state,
+)
+from omh.plugin_bundle.omh.runtime_reader import EXECUTOR_PROGRESS_EVENT_TYPES
+
+
+CLAIM_MISMATCH_EVENT_TYPES = ("reported_change_not_observed", "reported_success_contradicted")
+
+
+def _binding(**overrides: object) -> dict[str, object]:
+    binding = build_progress_binding(
+        target_type="run",
+        target_id="run-quality-floor",
+        executor_profile="codex",
+        codex_session_ref="codex-session-1",
+        now="2026-07-25T00:00:00Z",
+    )
+    binding.update(overrides)
+    return binding
+
+
+def _event(
+    binding: dict[str, object],
+    event_type: str,
+    *,
+    observed_at: str,
+    summary: str = "",
+) -> dict[str, object]:
+    # `transition_fingerprint` hashes the summary, so a distinct summary is what
+    # separates "the same state observed again" (duplicate_transition) from "the
+    # same kind of thing happened again" (repeat_interval).
+    return build_progress_event(
+        binding,
+        event_type=event_type,
+        summary=summary or f"observed {event_type}",
+        observed_at=observed_at,
+    )
+
+
+class SuppressionExemptFloorTests(unittest.TestCase):
+    """The floor that volume control must never cut through.
+
+    A long delegated coding session drowns its own signal: the observed incident
+    ran twelve fix/test cycles and only surfaced "4 file(s) were NOT modified
+    this turn despite any wording above that may suggest otherwise" at the very
+    end. Claim/observation mismatches and first occurrences have to survive any
+    suppression added for volume.
+    """
+
+    def test_claim_mismatch_types_are_registered_as_progress_events(self) -> None:
+        for event_type in CLAIM_MISMATCH_EVENT_TYPES:
+            with self.subTest(event_type=event_type):
+                self.assertIn(event_type, PROGRESS_EVENT_TYPES)
+
+    def test_claim_mismatch_types_are_suppression_exempt(self) -> None:
+        for event_type in CLAIM_MISMATCH_EVENT_TYPES:
+            with self.subTest(event_type=event_type):
+                self.assertIn(event_type, TERMINAL_EVENT_TYPES)
+
+    def test_claim_mismatch_reports_even_when_the_same_type_just_reported(self) -> None:
+        for event_type in CLAIM_MISMATCH_EVENT_TYPES:
+            with self.subTest(event_type=event_type):
+                binding = _binding(
+                    last_reported_event_type=event_type,
+                    last_reported_at="2026-07-25T00:00:00Z",
+                    report_count=9,
+                    reported_event_types=[event_type],
+                )
+                event = _event(binding, event_type, observed_at="2026-07-25T00:00:01Z")
+                should_report, reason = should_report_event(binding, event, now="2026-07-25T00:00:01Z")
+                self.assertTrue(should_report, reason)
+                self.assertEqual(reason, "terminal_or_blocker")
+
+    def test_claim_mismatch_survives_the_chat_facing_event_builder(self) -> None:
+        for event_type in CLAIM_MISMATCH_EVENT_TYPES:
+            with self.subTest(event_type=event_type):
+                event = build_chat_progress_event(event_type, "patch reported applied; no file changed")
+                self.assertEqual(
+                    event["event_type"],
+                    event_type,
+                    "unregistered types normalize to status_update, erasing the mismatch signal",
+                )
+
+    def test_claim_mismatch_types_are_declared_reportable_in_the_progress_policy(self) -> None:
+        for event_type in CLAIM_MISMATCH_EVENT_TYPES:
+            with self.subTest(event_type=event_type):
+                self.assertIn(event_type, CODING_PROGRESS_REPORTABLE_EVENTS)
+
+
+class FirstOccurrenceGuaranteeTests(unittest.TestCase):
+    def test_first_occurrence_of_a_non_terminal_type_always_reports(self) -> None:
+        binding = _binding()
+        event = _event(binding, "repo_exploration", observed_at="2026-07-25T00:00:01Z")
+        should_report, reason = should_report_event(binding, event, now="2026-07-25T00:00:01Z")
+        self.assertTrue(should_report, reason)
+        self.assertEqual(reason, "first_occurrence")
+
+    def test_repeat_inside_the_interval_is_still_suppressed(self) -> None:
+        binding = _binding()
+        first = _event(binding, "repo_exploration", observed_at="2026-07-25T00:00:01Z")
+        binding = update_binding_reporter_state(
+            binding, first, reported=True, reported_at="2026-07-25T00:00:01Z"
+        )
+        self.assertEqual(reported_event_types(binding), ["repo_exploration"])
+
+        repeat = _event(
+            binding,
+            "repo_exploration",
+            observed_at="2026-07-25T00:00:30Z",
+            summary="observed repo_exploration in another directory",
+        )
+        should_report, reason = should_report_event(binding, repeat, now="2026-07-25T00:00:30Z")
+        self.assertFalse(should_report)
+        self.assertEqual(reason, "repeat_interval")
+
+    def test_identical_state_observed_twice_is_suppressed_as_a_duplicate(self) -> None:
+        binding = _binding()
+        first = _event(binding, "repo_exploration", observed_at="2026-07-25T00:00:01Z")
+        binding = update_binding_reporter_state(
+            binding, first, reported=True, reported_at="2026-07-25T00:00:01Z"
+        )
+        same = _event(binding, "repo_exploration", observed_at="2026-07-25T00:00:30Z")
+        should_report, reason = should_report_event(binding, same, now="2026-07-25T00:00:30Z")
+        self.assertFalse(should_report)
+        self.assertEqual(reason, "duplicate_transition")
+
+    def test_reported_types_accumulate_without_duplicates(self) -> None:
+        binding = _binding()
+        for index, event_type in enumerate(("repo_exploration", "diff_started", "repo_exploration"), start=1):
+            event = _event(binding, event_type, observed_at=f"2026-07-25T00:0{index}:00Z")
+            binding = update_binding_reporter_state(
+                binding, event, reported=True, reported_at=f"2026-07-25T00:0{index}:00Z"
+            )
+        self.assertEqual(reported_event_types(binding), ["repo_exploration", "diff_started"])
+
+    def test_a_suppressed_event_does_not_consume_its_first_occurrence(self) -> None:
+        binding = _binding()
+        event = _event(binding, "repo_exploration", observed_at="2026-07-25T00:00:01Z")
+        binding = update_binding_reporter_state(
+            binding, event, reported=False, reported_at="2026-07-25T00:00:01Z"
+        )
+        self.assertEqual(reported_event_types(binding), [])
+
+        retry = _event(binding, "repo_exploration", observed_at="2026-07-25T00:00:02Z")
+        should_report, reason = should_report_event(binding, retry, now="2026-07-25T00:00:02Z")
+        self.assertTrue(should_report, reason)
+        self.assertEqual(reason, "first_occurrence")
+
+    def test_legacy_bindings_without_the_field_keep_interval_behaviour(self) -> None:
+        """A binding written before the field existed must not be re-opened.
+
+        Treating an unknown history as "nothing reported yet" would un-suppress
+        every type on a run already in flight.
+        """
+        binding = _binding(
+            last_reported_event_type="repo_exploration",
+            last_reported_at="2026-07-25T00:00:00Z",
+            report_count=4,
+        )
+        binding.pop("reported_event_types")
+        event = _event(binding, "repo_exploration", observed_at="2026-07-25T00:00:30Z")
+        should_report, reason = should_report_event(binding, event, now="2026-07-25T00:00:30Z")
+        self.assertFalse(should_report)
+        self.assertEqual(reason, "repeat_interval")
+
+    def test_repeat_after_the_interval_reports_again(self) -> None:
+        binding = _binding(reported_event_types=["repo_exploration"], last_reported_event_type="repo_exploration")
+        binding["last_reported_at"] = "2026-07-25T00:00:00Z"
+        later = f"2026-07-25T00:{DEFAULT_MINIMUM_REPEAT_INTERVAL_SECONDS // 60 + 1:02d}:00Z"
+        event = _event(binding, "repo_exploration", observed_at=later)
+        should_report, reason = should_report_event(binding, event, now=later)
+        self.assertTrue(should_report, reason)
+        self.assertEqual(reason, "meaningful_transition")
+
+
+class VendoredBundleParityTests(unittest.TestCase):
+    def test_bundle_event_types_match_the_source_of_truth(self) -> None:
+        """The plugin bundle keeps its own copy and cannot import from src.
+
+        Nothing enforced parity before, so adding an event type in one place and
+        not the other silently dropped it at the plugin read boundary.
+        """
+        self.assertEqual(EXECUTOR_PROGRESS_EVENT_TYPES, set(PROGRESS_EVENT_TYPES))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_executor_progress_quality_floor.py
+++ b/tests/test_executor_progress_quality_floor.py
@@ -293,7 +293,23 @@ class ClaimMismatchDetectionTests(unittest.TestCase):
         signal.update(overrides)
         return signal
 
-    def test_reported_change_with_clean_git_is_flagged(self) -> None:
+    def test_a_confirmed_edit_with_clean_git_is_flagged(self) -> None:
+        signal = build_safe_progress_signal(
+            executor_profile="claude_code",
+            process_status="completed",
+            profile_progress_summary={"observable_activity": ["Codex applied a file change."]},
+            git_status_short="",
+            git_diff_stat="",
+        )
+        self.assertTrue(signal["git_observed"])
+        self.assertEqual(infer_progress_event_type(signal), "reported_change_not_observed")
+
+    def test_the_broad_edit_bucket_alone_is_not_a_claim(self) -> None:
+        """"Codex changed files." also fires on a line that merely mentions a diff.
+
+        Over-matching is free for the benign `diff_started` label and expensive
+        for an accusation, so only the confirmed label contradicts anything.
+        """
         signal = build_safe_progress_signal(
             executor_profile="claude_code",
             process_status="completed",
@@ -301,14 +317,13 @@ class ClaimMismatchDetectionTests(unittest.TestCase):
             git_status_short="",
             git_diff_stat="",
         )
-        self.assertTrue(signal["git_observed"])
-        self.assertEqual(infer_progress_event_type(signal), "reported_change_not_observed")
+        self.assertNotEqual(infer_progress_event_type(signal), "reported_change_not_observed")
 
     def test_reported_change_with_a_real_diff_is_not_flagged(self) -> None:
         signal = build_safe_progress_signal(
             executor_profile="claude_code",
             process_status="completed",
-            profile_progress_summary={"observable_activity": ["Codex changed files."]},
+            profile_progress_summary={"observable_activity": ["Codex applied a file change."]},
             git_status_short=" M src/coding/executor_progress.py",
             git_diff_stat="1 file changed, 2 insertions(+)",
         )

--- a/tests/test_home_isolation.py
+++ b/tests/test_home_isolation.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import unittest
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.paths import default_hermes_home, default_omh_home, resolve_paths
+
+
+REAL_USER_HOME = Path("~").expanduser().resolve()
+
+
+def _under_real_user_home(path: Path) -> bool:
+    return path.expanduser().resolve().is_relative_to(REAL_USER_HOME)
+
+
+class HomeIsolationTests(unittest.TestCase):
+    """Guard the test process against writing into the developer's real home.
+
+    Before this guard existed, every test that resolved paths without an
+    explicit home wrote to ~/.omh and ~/.hermes. The visible damage was
+    ~4.7k `plan_artifact_created` events accumulated in the real
+    ~/.omh/runtime/journal/events.jsonl across a month of test runs, drowning
+    the four events that came from actual use.
+
+    `tests/_local_package.py` redirects OMH_HOME/HERMES_HOME to a per-process
+    temp root at import time. These tests fail if that redirect is removed,
+    bypassed, or overridden by an exported OMH_HOME.
+    """
+
+    def test_home_env_overrides_are_set_for_the_test_process(self) -> None:
+        for name in ("OMH_HOME", "HERMES_HOME"):
+            with self.subTest(env=name):
+                value = os.environ.get(name, "")
+                self.assertTrue(value, f"{name} must be set by tests/_local_package.py")
+                self.assertFalse(
+                    _under_real_user_home(Path(value)),
+                    f"{name} points inside the real user home: {value}",
+                )
+
+    def test_default_homes_stay_out_of_the_real_user_home(self) -> None:
+        for label, resolved in (("omh", default_omh_home()), ("hermes", default_hermes_home())):
+            with self.subTest(home=label):
+                self.assertFalse(
+                    _under_real_user_home(resolved),
+                    f"default {label} home resolves inside the real user home: {resolved}",
+                )
+
+    def test_resolve_paths_without_explicit_homes_stays_isolated(self) -> None:
+        paths = resolve_paths()
+        for label, resolved in (("omh_home", paths.omh_home), ("hermes_home", paths.hermes_home)):
+            with self.subTest(path=label):
+                self.assertFalse(
+                    _under_real_user_home(resolved),
+                    f"{label} resolves inside the real user home: {resolved}",
+                )
+
+    def test_runtime_journal_target_is_not_the_real_user_journal(self) -> None:
+        journal = resolve_paths().runtime_journal_events_path
+        self.assertFalse(
+            _under_real_user_home(journal),
+            f"test runs would append to the real journal: {journal}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_run_unchanged_suppression.py
+++ b/tests/test_run_unchanged_suppression.py
@@ -10,7 +10,17 @@ from _local_package import load_local_package
 
 load_local_package()
 from omh.paths import resolve_paths
-from omh.runtime.context_budget import payload_fingerprint, record_context_emission, run_context_budget
+from omh.runtime.artifacts import DEFAULT_RUN_HISTORY_LIMIT
+from omh.runtime.context_budget import (
+    payload_fingerprint,
+    record_context_emission,
+    run_context_budget,
+    run_show_surface,
+)
+
+
+DEFAULT_SHOW_SURFACE = run_show_surface(full=False, history_limit=DEFAULT_RUN_HISTORY_LIMIT)
+FULL_SHOW_SURFACE = run_show_surface(full=True)
 
 
 class UnchangedRunSuppressionTests(unittest.TestCase):
@@ -101,7 +111,7 @@ class UnchangedRunSuppressionTests(unittest.TestCase):
             record_context_emission(
                 paths,
                 run_id,
-                surface="runtime_show",
+                surface=DEFAULT_SHOW_SURFACE,
                 byte_count=0,
                 payload_fingerprint_value="the-run-moved-on",
             )
@@ -126,9 +136,31 @@ class UnchangedRunSuppressionTests(unittest.TestCase):
             full = self._show(base, run_id, "--full")
             self.assertNotIn("last_payload_fingerprint", full["context_budget"])
             self.assertTrue(
-                run_context_budget(paths, run_id, surface="runtime_show")["last_payload_fingerprint"],
+                run_context_budget(paths, run_id, surface=FULL_SHOW_SURFACE)["last_payload_fingerprint"],
                 "the ledger still needs the fingerprint it just stopped emitting",
             )
+
+    def test_each_history_limit_keeps_its_own_comparison(self) -> None:
+        """A different limit is a different projection, so it needs its own key.
+
+        Sharing one key across limits meant an agent alternating `--full` and
+        the default view never matched its own previous emission, so suppression
+        silently never fired for either.
+        """
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = self._base(root)
+            run_id = self._recorded_run(base)
+
+            self._show(base, run_id, "--full")
+            self._show(base, run_id)
+            self.assertTrue(
+                self._show(base, run_id)["unchanged_since_last_emission"],
+                "an interleaved --full call must not reset the default view's comparison",
+            )
+
+            self.assertNotIn("unchanged_since_last_emission", self._show(base, run_id, "--limit", "5"))
+            self.assertTrue(self._show(base, run_id, "--limit", "5")["unchanged_since_last_emission"])
 
     def test_the_fingerprint_ignores_the_budget_envelope(self) -> None:
         """The budget changes on every call; fingerprinting it would defeat the check."""
@@ -145,9 +177,9 @@ class UnchangedRunSuppressionTests(unittest.TestCase):
             paths = resolve_paths(root / ".omh", root / ".hermes")
             run_id = self._recorded_run(base)
 
-            self.assertEqual(run_context_budget(paths, run_id, surface="runtime_show")["last_payload_fingerprint"], "")
+            self.assertEqual(run_context_budget(paths, run_id, surface=DEFAULT_SHOW_SURFACE)["last_payload_fingerprint"], "")
             self._show(base, run_id)
-            recorded = run_context_budget(paths, run_id, surface="runtime_show")["last_payload_fingerprint"]
+            recorded = run_context_budget(paths, run_id, surface=DEFAULT_SHOW_SURFACE)["last_payload_fingerprint"]
             self.assertTrue(recorded)
             self.assertEqual(run_context_budget(paths, run_id, surface="fanout_show")["last_payload_fingerprint"], "")
 

--- a/tests/test_run_unchanged_suppression.py
+++ b/tests/test_run_unchanged_suppression.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from _cli_harness import run_cli
+from _local_package import load_local_package
+
+load_local_package()
+from omh.paths import resolve_paths
+from omh.runtime.context_budget import payload_fingerprint, record_context_emission, run_context_budget
+
+
+class UnchangedRunSuppressionTests(unittest.TestCase):
+    """Stop handing a polling agent the same projection to re-narrate.
+
+    The observed 300-message session re-printed an unchanged failure list on
+    every cycle. A second identical projection carries no information the first
+    did not, so the surface returns a marker instead of the material.
+    """
+
+    def _base(self, root: Path) -> list[str]:
+        return ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+
+    def _recorded_run(self, base: list[str]) -> str:
+        status, stdout, stderr = run_cli(
+            base + ["runtime", "record", "--skill", "oh-my-hermes", "--harness", "coding-handling"]
+        )
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        return json.loads(stdout)["run"]["run_id"]
+
+    def _show(self, base: list[str], run_id: str, *extra: str) -> dict:
+        status, stdout, stderr = run_cli(base + ["runtime", "show", run_id, *extra])
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        return json.loads(stdout)
+
+    def test_second_identical_show_returns_an_unchanged_marker(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = self._base(root)
+            run_id = self._recorded_run(base)
+
+            first = self._show(base, run_id)
+            self.assertNotIn("unchanged_since_last_emission", first)
+            self.assertIn("run", first)
+
+            second = self._show(base, run_id)
+            self.assertTrue(second["unchanged_since_last_emission"])
+            self.assertEqual(second["delta"], {})
+            self.assertEqual(second["run"]["run_id"], run_id)
+            self.assertIn("--full", second["full_output_command"])
+
+    def test_the_unchanged_payload_is_smaller_than_the_full_projection(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = self._base(root)
+            run_id = self._recorded_run(base)
+
+            first = self._show(base, run_id)
+            second = self._show(base, run_id)
+
+            self.assertLess(
+                len(json.dumps(second, sort_keys=True)),
+                len(json.dumps(first, sort_keys=True)),
+                "suppression must actually reduce what reaches agent context",
+            )
+
+    def test_full_is_never_suppressed(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = self._base(root)
+            run_id = self._recorded_run(base)
+
+            self._show(base, run_id)
+            for _ in range(3):
+                full = self._show(base, run_id, "--full")
+                self.assertNotIn("unchanged_since_last_emission", full)
+                self.assertIn("events", full)
+                self.assertIsNone(full["history"]["limit"])
+
+    def test_a_changed_projection_reopens_the_full_output(self) -> None:
+        """Suppression must be driven by the comparison, not by the call count.
+
+        Recording a different fingerprint stands in for the run moving on. If
+        this did not reopen, a run that changed after one quiet poll would stay
+        invisible.
+        """
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = self._base(root)
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            run_id = self._recorded_run(base)
+
+            self._show(base, run_id)
+            self.assertTrue(self._show(base, run_id)["unchanged_since_last_emission"])
+
+            record_context_emission(
+                paths,
+                run_id,
+                surface="runtime_show",
+                byte_count=0,
+                payload_fingerprint_value="the-run-moved-on",
+            )
+
+            reopened = self._show(base, run_id)
+            self.assertNotIn("unchanged_since_last_emission", reopened)
+            self.assertIn("run", reopened)
+            self.assertIn("events", reopened)
+
+    def test_the_fingerprint_ignores_the_budget_envelope(self) -> None:
+        """The budget changes on every call; fingerprinting it would defeat the check."""
+        shown = {"run": {"run_id": "run-1", "status": "recorded"}}
+        first = payload_fingerprint(shown)
+        second = payload_fingerprint(dict(shown))
+        self.assertEqual(first, second)
+        self.assertNotEqual(first, payload_fingerprint({**shown, "run": {"run_id": "run-1", "status": "done"}}))
+
+    def test_the_ledger_stores_the_fingerprint_per_surface(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = self._base(root)
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            run_id = self._recorded_run(base)
+
+            self.assertEqual(run_context_budget(paths, run_id, surface="runtime_show")["last_payload_fingerprint"], "")
+            self._show(base, run_id)
+            recorded = run_context_budget(paths, run_id, surface="runtime_show")["last_payload_fingerprint"]
+            self.assertTrue(recorded)
+            self.assertEqual(run_context_budget(paths, run_id, surface="fanout_show")["last_payload_fingerprint"], "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_run_unchanged_suppression.py
+++ b/tests/test_run_unchanged_suppression.py
@@ -111,6 +111,25 @@ class UnchangedRunSuppressionTests(unittest.TestCase):
             self.assertIn("run", reopened)
             self.assertIn("events", reopened)
 
+    def test_the_emitted_budget_hides_the_internal_fingerprint(self) -> None:
+        """`--full` must look exactly as it did before this check existed.
+
+        The fingerprint is a hash of the projection the caller already has. It
+        belongs in the ledger, not in the payload.
+        """
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = self._base(root)
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            run_id = self._recorded_run(base)
+
+            full = self._show(base, run_id, "--full")
+            self.assertNotIn("last_payload_fingerprint", full["context_budget"])
+            self.assertTrue(
+                run_context_budget(paths, run_id, surface="runtime_show")["last_payload_fingerprint"],
+                "the ledger still needs the fingerprint it just stopped emitting",
+            )
+
     def test_the_fingerprint_ignores_the_budget_envelope(self) -> None:
         """The budget changes on every call; fingerprinting it would defeat the check."""
         shown = {"run": {"run_id": "run-1", "status": "recorded"}}


### PR DESCRIPTION
## Feature Report

### What Changed

- `omh release drift` — a new preflight that reports every catalog-driven count, byte budget, generated artifact, and generated skill file that is out of sync, in **one pass** (~0.6s vs ~50s for the full suite).
- `omh runtime show` / `omh coding fanout show` return `unchanged_since_last_emission` plus an empty delta instead of re-emitting a projection identical to the one already sent. `--full` is untouched.
- A new `reported_change_not_observed` progress event: a finished executor claimed it changed files and the working tree says otherwise. Suppression-exempt, and it closes the binding.
- `should_report_event` guarantees the first occurrence of any event type reports, backed by a new `reported_event_types` binding field.
- The generated coding-handoff reference now states a narration ceiling and the push/pull asymmetry.
- The test suite no longer writes into the developer's real `~/.omh` / `~/.hermes`.

### Why This Exists

A delegated coding session on 2026-07-25 (15:18–15:43) produced roughly **300 chat messages** to add **one skill**. The driver was not message verbosity — it was ~12 iterations of the same loop:

```
full test → grep failures → patch → full test → ...
```

Twelve cycles at ~20–25 messages each ≈ 300. The cycles happened because a single skill addition invalidates counts, budgets, and generated artifacts at once, while the suite reveals them a few per run. That session lost four cycles walking one byte budget down `305 → 303 → 299 → 264`, one hunting a limit that lived in `src/maintenance/release.py` rather than in a test, and one reverting a count it had raised by mistake.

Two things were found along the way that made the noise worse and were fixed here:

- `~/.omh/runtime/journal/events.jsonl` held **4,750 events, 4,746 of them test leakage** accumulated over a month, drowning the four events that came from real use.
- The session ended with `File-mutation verifier: 4 file(s) were NOT modified this turn despite any wording above that may suggest otherwise` — three patches had silently failed while narration reported success, and nothing surfaced it until the end.

### User / Operator Impact

| | Before | After |
|---|---|---|
| Adding one skill | ~12 test cycles | drift listed in one command, with the values to write |
| Asking a run for status twice | full projection re-emitted | `unchanged_since_last_emission` (2,911 → 1,008 bytes) |
| Asking explicitly (`--full`) | full output | **unchanged** — verified against `main` |
| A patch that silently did nothing | surfaced late, if at all | its own event type, never suppressed, closes the binding |
| Running the test suite | appended to your real `~/.omh` | writes to a temp root |

### How It Works

- **`src/maintenance/drift.py`** — a declarative registry. Each metric carries a live calculator, an expected value, and the files that hardcode it. Live values come from calling the real producer; there is no source parsing, per the repo's rule. Sites are file paths, never line numbers.
- **The exact-count assertions stay.** They are deliberate contracts (`CLAUDE.md`). Replacing them with a derived manifest was considered and rejected by the owner. The registry is the index that says which ones a change just invalidated.
- **`src/runtime/context_budget.py`** — the ledger stores a fingerprint of the projection per run per surface. The fingerprint covers the projection, never the emitted envelope, which carries the mutating budget. Precedence is `--full` → budget exhausted → unchanged → normal; exhaustion outranks unchanged because the degraded payload points at the artifacts and its shape is an existing contract.
- **`src/coding/executor_progress.py`** — `CLOSING_EVENT_TYPES` is separate from `TERMINAL_EVENT_TYPES` on purpose: `tests_passed` / `tests_failed` are reportable end states after which the executor may still be working, so they must not close a binding.
- **`git_observed`** — a missing git hash is ambiguous on its own (nobody looked, or looked and saw nothing). Only the second can contradict a claim, so `--git-status-short` / `--git-diff-stat` default to `None` rather than `""`.

### Files And Contracts Touched

- `src/maintenance/drift.py` (new), `src/commands/release.py` — `omh release drift`
- `src/runtime/context_budget.py`, `src/commands/runtime.py`, `src/commands/coding.py` — delta suppression, ledger fingerprints
- `src/coding/executor_progress.py`, `src/coding/context_safety.py`, `src/plugin_bundle/omh/runtime_reader.py` — new event type across all four registration sites
- `src/skills/render.py` + regenerated `skills/oh-my-hermes/references/coding-handoff-progress-reporting.md` — narration ceiling. The generated file was regenerated, never hand-edited.
- `tests/_local_package.py` — redirects `OMH_HOME` / `HERMES_HOME` to a per-process temp root

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `python3 -m unittest discover -s tests` — **1764 passed**, 1 skipped
- [x] `python3 -m compileall src`
- [x] `python3 -m omh.cli docs workflows --check` (also `docs roles --check`, `docs capability-families --check`)
- [x] `python3 -m omh.cli harness validate`
- [x] `python3 -m omh.cli release checklist --json`
- [x] `python3 -m omh.cli release hermes-smoke`
- [x] `omh --help`
- [x] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [x] `python3 -m omh.cli release drift` — new gate, no drift
- [x] Journal leak: delta **0** across 6 consecutive full-suite runs; a regression test fails and names the real journal path when the guard is removed
- [x] `--full` compared against a `main` worktree by deep recursive diff: **0 substantive differences** (only the temp home path and a one-second timestamp)
- [x] Drift preflight verified end to end: dirtying `docs/ROLES.md` exits 1 with a paste-ready fix
- [ ] Manual Hermes/TUI check — **not run.** No live delegated coding session was driven through this branch; see Follow-Up.

### Review

An independent review pass returned **REQUEST CHANGES** with two HIGH findings, both real and both fixed in `ecc84d1a`:

1. The new event type intercepted observations that used to classify as `executor_failed`, and the closing set was hardcoded separately — so a dead executor stayed `active` for fifteen minutes.
2. The change claim comes from a coarse upstream bucket (any log line containing `patch`, `write`, `edit`, `diff`), so a mid-flight "let me run git diff" became an unsuppressible accusation.

A third type, `reported_success_contradicted`, was **removed rather than repaired** — once the ordering is correct it is unreachable, since the existing ladder already classifies that case as `executor_failed`.

## Risk

- **Moderate:** the default shape of two observe surfaces changes on repeat calls. Single calls and `--full` are unchanged.
- **Moderate:** `build_safe_progress_signal` changed two parameter defaults from `""` to `None`. All three src callers were audited; two pass no git arguments at all, one forwards argparse values unchanged.
- **Low:** `omh release drift` is read-only and additive.
- The drift registry hardcodes expected values and could itself go stale. `tests/test_drift_registry.py` checks that every declared site exists and still contains the value it claims — the same self-checking shape as `test_broad_exception_policy`.

## Compatibility / Rollout

- No new dependencies. No schema removals; `omh_run_show_unchanged/v1` is new and additive.
- Bindings written before `reported_event_types` existed fall back to the interval rules and seed from `last_reported_event_type`, so a run in flight is neither re-opened nor silenced.
- `reported_change_not_observed` was added and `reported_success_contradicted` added-then-removed **within this branch**, so nothing outside it can depend on either.

## Release / Claims

- [x] Release-channel impact considered — `local`; no release artifacts change.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed. The narration ceiling is guidance text OMH cannot enforce; the mechanical suppression in `context_budget.py` exists precisely because guidance alone is not enforcement.
- [x] Known manual gaps listed below. `omh release hermes-smoke --live` was not run.

## Follow-Up

- Drive a real delegated coding session through this branch and measure the actual message count. The agreed success criterion for this PR was the **proxy** metric (surface return volume fixed in tests), because OMH cannot count Hermes chat messages.
- No producer has emitted `reported_change_not_observed` end to end yet; coverage is unit-level.
- The registry covers the drift classes seen in the 2026-07-25 session, not all 233 hardcoded numeric assertions. Extend it when a new class bites.
- Tool-activity lines (`🔍 Searching…`, `📖 Reading…`) are rendered by the Hermes runtime, outside OMH's reach. Recorded as a capability boundary, not solved here.
- One unexplained observation: a single full-suite run showed the journal growing by 6 events. It never recurred across six subsequent runs and its cause is unconfirmed.
