### PR TITLE
fix: honor the render-profile contract on the chat route-hint path

### DIFF
--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -7149,10 +7149,7 @@ def messenger_rendering_contract(
         "fallback_body_blocks": _messenger_body_blocks(safe_body_text),
         "preferred_blocks": preferred_blocks,
         "avoid_blocks": avoid_blocks,
-        "chunking": {
-            "max_recommended_chars": 1800,
-            "split_on": ["headings", "bullets", "paragraphs"],
-        },
+        "chunking": _messenger_chunking_hint(),
         "transforms_applied": transforms,
         "fallback_transforms_applied": safe_transforms,
         "prefix_policy": {
@@ -7244,10 +7241,20 @@ def _default_delivery_obligation_claim_boundary() -> str:
 
 
 def render_profile_for_source(source: str, source_metadata: dict[str, object] | None = None) -> str:
+    """Resolve the render profile an adapter should use for ``source``.
+
+    An adapter that sets ``render_profile`` at all has told us the surface is
+    narrow enough to care. If the value it sent is not a known profile (a typo,
+    a renamed profile, a future value), falling back to the source default would
+    hand rich Markdown to exactly the adapter that asked to be treated
+    carefully. Explicit-but-unknown therefore coerces down to
+    ``limited_markdown``, matching ``_normalize_render_profile``. Only absent or
+    empty metadata keeps the per-source default.
+    """
     metadata = source_metadata or {}
     explicit = str(metadata.get("render_profile", "")).strip()
-    if explicit in RENDER_PROFILES:
-        return explicit
+    if explicit:
+        return _normalize_render_profile(explicit)
     if source in _LIMITED_MARKDOWN_SOURCES:
         return RENDER_PROFILE_LIMITED_MARKDOWN
     return RENDER_PROFILE_RICH_MARKDOWN
@@ -7257,6 +7264,18 @@ def _normalize_render_profile(render_profile: str) -> str:
     if render_profile in RENDER_PROFILES:
         return render_profile
     return RENDER_PROFILE_LIMITED_MARKDOWN
+
+
+def _messenger_chunking_hint() -> dict[str, object]:
+    """Return the advisory chunking hint shared by every messenger rendering block.
+
+    OMH advises, adapters split. A fresh dict per call so a caller embedding it
+    in a payload cannot mutate the hint for every other caller.
+    """
+    return {
+        "max_recommended_chars": 1800,
+        "split_on": ["headings", "bullets", "paragraphs"],
+    }
 
 
 def _render_body_blocks(body: str, *, render_profile: str) -> list[dict[str, object]]:

--- a/src/wrapper/route_hints.py
+++ b/src/wrapper/route_hints.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from ..ingress import CHAT_SOURCES
 from ..plugin_bundle.omh.awareness import (
     awareness_generic_tool_checkpoint_payload,
     awareness_route_hint,
@@ -8,6 +9,17 @@ from ..plugin_bundle.omh.awareness import (
 from ..plugin_bundle.omh.degradation import degradation_chat_note
 from ..routing.catalog_questions import is_skill_catalog_question
 from ..routing.action_copy import next_action_label
+
+# `contract` never imports this module, so the edge is one-way and cycle-free.
+# Reusing its helpers keeps the route-hint path on the same messenger-safe
+# rendering rules as the main interaction path instead of a second copy.
+from .contract import (
+    RENDER_PROFILE_RICH_MARKDOWN,
+    _messenger_chunking_hint,
+    _messenger_safe_body,
+    _render_body_blocks,
+    render_profile_for_source,
+)
 
 CHAT_ROUTE_HINT_SCHEMA_VERSION = "chat_route_hint/v1"
 CHAT_ROUTE_HINT_RESPONSE_SCHEMA_VERSION = "chat_route_hint_response/v1"
@@ -22,6 +34,9 @@ def build_chat_route_hint_payload(
     include_prompt_context: bool = False,
 ) -> dict[str, object]:
     """Return a wrapper-facing route hint without storing or echoing raw prompt text."""
+    if source not in CHAT_SOURCES:
+        raise ValueError(f"unsupported chat route hint source: {source}")
+    metadata = dict(source_metadata or {})
     route_hint = awareness_route_hint(message, max_hints=max_hints)
     route_hint = _route_hint_with_catalog_picker(route_hint, message)
     generic_tool_checkpoint = _generic_tool_checkpoint()
@@ -32,13 +47,14 @@ def build_chat_route_hint_payload(
         hints,
         route_hint=route_hint,
         source=source,
+        render_profile=render_profile_for_source(source, metadata),
         generic_tool_checkpoint=generic_tool_checkpoint,
     )
     payload: dict[str, object] = {
         "schema_version": CHAT_ROUTE_HINT_SCHEMA_VERSION,
         "source": source,
         "message_length": len(message),
-        "source_metadata": dict(source_metadata or {}),
+        "source_metadata": metadata,
         "route_hint": route_hint,
         "generic_tool_checkpoint": generic_tool_checkpoint,
         "chat_response": response,
@@ -139,6 +155,7 @@ def _response_for_hint(
     *,
     route_hint: dict[str, object],
     source: str,
+    render_profile: str,
     generic_tool_checkpoint: dict[str, object],
 ) -> dict[str, object]:
     checkpoint_body = _checkpoint_body_text(generic_tool_checkpoint)
@@ -243,6 +260,16 @@ def _response_for_hint(
     # request must keep exactly today's key set.
     if isinstance(degradation, dict) and degradation:
         state_route_hint["degradation"] = degradation
+    # Built from the final `body`, so the degradation note (appended above) is
+    # inside the messenger-safe text exactly once instead of being re-added or
+    # dropped by the transform.
+    fallback_body_text, fallback_transforms = _messenger_safe_body(body)
+    if render_profile == RENDER_PROFILE_RICH_MARKDOWN:
+        rendered_body_text = body
+        transforms_applied: list[str] = []
+    else:
+        rendered_body_text = fallback_body_text
+        transforms_applied = fallback_transforms
     return {
         "schema_version": CHAT_ROUTE_HINT_RESPONSE_SCHEMA_VERSION,
         "kind": render_kind,
@@ -253,9 +280,17 @@ def _response_for_hint(
         "actions": actions,
         "messenger_rendering": {
             "schema_version": "messenger_route_hint_rendering/v1",
+            # `profile` is the raw source echo kept for backward compatibility.
+            # Deprecated in favour of `render_profile`, which is the resolved
+            # render profile a wrapper should actually render against.
             "profile": source,
+            "render_profile": render_profile,
             "title": headline,
-            "body_text": body,
+            "body_text": rendered_body_text,
+            "body_blocks": _render_body_blocks(rendered_body_text, render_profile=render_profile),
+            "fallback_body_text": fallback_body_text,
+            "transforms_applied": transforms_applied,
+            "chunking": _messenger_chunking_hint(),
             "checkpoint_text": checkpoint_body,
             "primary_action": actions[0],
             "secondary_actions": actions[1:],

--- a/tests/test_degradation_signal.py
+++ b/tests/test_degradation_signal.py
@@ -504,6 +504,39 @@ class WrapperSurfaceDegradationTests(DegradationSignalTestCase):
         self.assertTrue(body.endswith(DEGRADATION_CHAT_NOTE))
         self.assertIn(DEGRADATION_CHAT_NOTE, response["messenger_rendering"]["body_text"])
 
+    def test_a_degraded_route_hint_renders_the_note_once_in_the_messenger_safe_body(self) -> None:
+        """The note survives the render-profile transform on an opted-in generic surface.
+
+        The route-hint messenger body is now profile-resolved, so the note is
+        appended before the safe-body transform runs. It must land in the safe
+        text exactly once: neither dropped by the transform nor re-appended
+        after it.
+        """
+        message = "Users report a wrapper-surface messenger rendering bug"
+
+        with self.locale_failure():
+            payload = build_chat_route_hint_payload(
+                message,
+                source="generic",
+                source_metadata={"render_profile": "limited_markdown"},
+            )
+
+        rendering = payload["chat_response"]["messenger_rendering"]
+        self.assertEqual(rendering["render_profile"], "limited_markdown")
+        body_text = rendering["body_text"]
+        self.assertTrue(body_text.strip())
+        self.assertEqual(body_text.count(DEGRADATION_CHAT_NOTE), 1)
+        self.assertTrue(body_text.endswith(DEGRADATION_CHAT_NOTE))
+        self.assertEqual(rendering["fallback_body_text"].count(DEGRADATION_CHAT_NOTE), 1)
+        block_text = "\n".join(str(block.get("text", "")) for block in rendering["body_blocks"])
+        self.assertTrue(block_text.strip())
+        self.assertEqual(block_text.count(DEGRADATION_CHAT_NOTE), 1)
+
+        serialized = json.dumps(rendering, ensure_ascii=False, sort_keys=True)
+        self.assertNotIn(message, serialized)
+        self.assertNotIn(LOCALE_BOOM, serialized)
+        self.assertNotIn(COMPONENT_LOCALIZED_ROUTING_TEXT, serialized)
+
     def test_a_degraded_route_hint_never_renders_request_or_exception_message_text(self) -> None:
         with self.locale_failure():
             payload = build_chat_route_hint_payload(self.ROUTE_HINT_MESSAGE, source="discord")

--- a/tests/test_wrapper_contract.py
+++ b/tests/test_wrapper_contract.py
@@ -4,11 +4,13 @@ import json
 from pathlib import Path
 from tempfile import TemporaryDirectory
 import unittest
+from unittest import mock
 
 from _local_package import load_local_package
 
 load_local_package()
 from omh.context_safety import CONTEXT_ARTIFACT_REF_SCHEMA_VERSION
+from omh.ingress import CHAT_SOURCES
 from omh.paths import OmhPaths, resolve_paths
 from omh.profiles.setup import write_setup_profile
 from omh.runtime.records import build_wrapper_session_record
@@ -18,6 +20,7 @@ from omh.wrapper_contract import (
     build_chat_status_interaction,
     build_status_card_from_status,
     messenger_rendering_contract,
+    render_profile_for_source,
 )
 from omh.wrapper.localized_copy import detect_copy_locale
 from omh.wrapper.native_commands import build_native_command_surface, render_native_command_response
@@ -189,6 +192,150 @@ class WrapperContractTests(unittest.TestCase):
         self.assertIn("route_for_me", action_ids)
         self.assertIn("open_picker", action_ids)
         self.assertNotIn(message, json.dumps(payload))
+
+    def test_route_hint_rendering_honors_explicit_limited_markdown_for_generic_sources(self) -> None:
+        # Eleven of the fourteen Hermes-supported platforms reach OMH as
+        # `generic`; `source_metadata={"render_profile": ...}` is their only
+        # route to messenger-safe rendering. Parity with a natively limited
+        # source is the contract.
+        message = "please review my pull request diff"
+
+        limited = build_chat_route_hint_payload(
+            message,
+            source="generic",
+            source_metadata={"render_profile": "limited_markdown"},
+        )["chat_response"]["messenger_rendering"]
+        discord = build_chat_route_hint_payload(message, source="discord")["chat_response"][
+            "messenger_rendering"
+        ]
+
+        # Non-emptiness before shape: comparing two empty dicts proves nothing.
+        self.assertTrue(limited)
+        self.assertTrue(discord)
+        self.assertTrue(limited["body_text"].strip())
+        self.assertTrue(limited["body_blocks"])
+        self.assertEqual(limited["render_profile"], "limited_markdown")
+        self.assertEqual(discord["render_profile"], "limited_markdown")
+        # `profile` is the deprecated raw source echo and is the only field
+        # allowed to vary between an opted-in generic surface and discord.
+        self.assertEqual(limited["profile"], "generic")
+        self.assertEqual(discord["profile"], "discord")
+        self.assertEqual(
+            {key: value for key, value in limited.items() if key != "profile"},
+            {key: value for key, value in discord.items() if key != "profile"},
+        )
+
+    def test_route_hint_rendering_keeps_rich_markdown_for_generic_without_metadata(self) -> None:
+        message = "please review my pull request diff"
+
+        payload = build_chat_route_hint_payload(message, source="generic")
+        response = payload["chat_response"]
+        rendering = response["messenger_rendering"]
+
+        self.assertTrue(rendering)
+        self.assertTrue(response["body"].strip())
+        self.assertEqual(rendering["render_profile"], "rich_markdown")
+        # Regression pin: the rich path must render the untransformed body
+        # exactly as it did before the route-hint rendering fix.
+        self.assertEqual(rendering["body_text"], response["body"])
+        self.assertEqual(rendering["transforms_applied"], [])
+
+    def test_route_hint_rendering_runs_the_messenger_safe_body_under_the_limited_profile(self) -> None:
+        # The generated route-hint prose never contains a table, so the safe-body
+        # transform is proved through the one body fragment a wrapper can carry
+        # arbitrary Markdown into: the generic-tool checkpoint.
+        checkpoint_body = "\n".join(
+            [
+                "Route table follows.",
+                "| Surface | Result |",
+                "| --- | --- |",
+                "| Discord | convert to bullets |",
+            ]
+        )
+        message = "please review my pull request diff"
+
+        with mock.patch(
+            "omh.wrapper.route_hints.awareness_generic_tool_checkpoint_payload",
+            return_value={"body": checkpoint_body},
+        ):
+            limited = build_chat_route_hint_payload(message, source="discord")["chat_response"]
+            rich = build_chat_route_hint_payload(message, source="hermes")["chat_response"]
+
+        limited_rendering = limited["messenger_rendering"]
+        rich_rendering = rich["messenger_rendering"]
+        self.assertTrue(limited_rendering["body_text"].strip())
+        self.assertTrue(rich_rendering["body_text"].strip())
+        self.assertIn("markdown_table_to_bullets", limited_rendering["transforms_applied"])
+        self.assertNotIn("| --- |", limited_rendering["body_text"])
+        self.assertIn("- Discord: Result: convert to bullets", limited_rendering["body_text"])
+        self.assertIn("bullet", [block["type"] for block in limited_rendering["body_blocks"]])
+        # The unsafe source body is preserved for rich surfaces and for wrappers
+        # that read `body` directly.
+        self.assertIn("| --- |", limited["body"])
+        self.assertEqual(rich_rendering["transforms_applied"], [])
+        self.assertIn("| --- |", rich_rendering["body_text"])
+        self.assertIn("- Discord: Result: convert to bullets", rich_rendering["fallback_body_text"])
+
+    def test_route_hint_rendering_extends_v1_without_dropping_existing_keys(self) -> None:
+        rendering = build_chat_route_hint_payload("please review my pull request diff", source="discord")[
+            "chat_response"
+        ]["messenger_rendering"]
+
+        self.assertTrue(rendering)
+        self.assertEqual(rendering["schema_version"], "messenger_route_hint_rendering/v1")
+        self.assertLessEqual(
+            {
+                "schema_version",
+                "profile",
+                "title",
+                "body_text",
+                "checkpoint_text",
+                "primary_action",
+                "secondary_actions",
+            },
+            set(rendering),
+        )
+        self.assertLessEqual(
+            {"render_profile", "body_blocks", "fallback_body_text", "transforms_applied", "chunking"},
+            set(rendering),
+        )
+        self.assertEqual(rendering["chunking"]["max_recommended_chars"], 1800)
+
+    def test_route_hint_payload_rejects_sources_outside_the_chat_source_registry(self) -> None:
+        with self.assertRaises(ValueError) as raised:
+            build_chat_route_hint_payload("please review my pull request diff", source="whatsapp")
+        self.assertIn("unsupported chat route hint source", str(raised.exception))
+
+        for source in CHAT_SOURCES:
+            with self.subTest(source=source):
+                payload = build_chat_route_hint_payload("please review my pull request diff", source=source)
+                self.assertEqual(payload["source"], source)
+                self.assertIn(
+                    payload["chat_response"]["messenger_rendering"]["render_profile"],
+                    {"limited_markdown", "rich_markdown"},
+                )
+
+    def test_render_profile_for_source_coerces_an_explicit_unknown_profile_to_limited(self) -> None:
+        # An adapter that sends the key at all has told us the surface is narrow.
+        # A typo must not silently upgrade it to rich Markdown.
+        self.assertEqual(
+            render_profile_for_source("generic", {"render_profile": "limted_markdown"}),
+            "limited_markdown",
+        )
+        self.assertEqual(
+            render_profile_for_source("hermes", {"render_profile": "html"}),
+            "limited_markdown",
+        )
+        # Absent, empty, or whitespace-only metadata keeps the source default in
+        # both directions.
+        self.assertEqual(render_profile_for_source("generic", None), "rich_markdown")
+        self.assertEqual(render_profile_for_source("generic", {}), "rich_markdown")
+        self.assertEqual(render_profile_for_source("generic", {"render_profile": "   "}), "rich_markdown")
+        self.assertEqual(render_profile_for_source("discord", {}), "limited_markdown")
+        self.assertEqual(
+            render_profile_for_source("discord", {"render_profile": "rich_markdown"}),
+            "rich_markdown",
+        )
 
     def test_route_hint_payload_prioritizes_missed_route_feedback(self) -> None:
         message = "missed route: Hermes skipped OMH for my image request with secret-token-123"


### PR DESCRIPTION
## Feature Report

### What Changed

- The chat route-hint path (`omh chat route-hint`, `build_chat_route_hint_payload`) now honors the wrapper render-profile contract. It resolves the profile through `render_profile_for_source(source, source_metadata)` and builds `messenger_rendering` with the same guarantees as the main interaction path: a real `render_profile`, a `body_text` run through the messenger-safe transform under the limited profile, `body_blocks`, `fallback_body_text`, `transforms_applied`, and the advisory `chunking` hint.
- `build_chat_route_hint_payload` gained the source guard its siblings already had: a source outside `CHAT_SOURCES` now raises `ValueError` instead of silently producing a payload for a surface OMH does not model.
- `render_profile_for_source` now treats an *explicitly provided but unknown* `render_profile` as `limited_markdown` instead of falling through to the per-source default.

### Why This Exists

This came out of a QA pass over the messenger rendering matrix (270 assertions across the Hermes-supported platform set). The matrix's M4 case was a hard failure.

Eleven of the fourteen Hermes-supported platforms — whatsapp, signal, iMessage/bluebubbles, weixin, qqbot, msgraph, matrix, email, irc, webhook, api — reach OMH as `source="generic"`. They are not in `_LIMITED_MARKDOWN_SOURCES` (only discord, slack, telegram are), so their **only** route to messenger-safe rendering is passing `source_metadata={"render_profile": "limited_markdown"}`.

On the route-hint path that opt-in was completely inert:

- `build_chat_route_hint_payload` accepted `source_metadata` but only echoed it into `payload["source_metadata"]`. It never reached `render_profile_for_source`.
- `_response_for_hint` hand-built the rendering block with `"profile": source` — the raw source string, not a render profile — and put the untransformed body straight into `body_text`. `_messenger_safe_body` never ran on this path.
- `src/wrapper/native_commands.py` only warns when `body_text` is *absent*, so an unsafe body sailed through the adapter shim without a single signal.

Repro against `origin/main` @ `2c8a2249`:

```python
from omh.wrapper.route_hints import build_chat_route_hint_payload
d = build_chat_route_hint_payload("please review my pull request diff", source="discord")
o = build_chat_route_hint_payload("please review my pull request diff", source="generic",
                                  source_metadata={"render_profile": "limited_markdown"})
```

Before:

```
discord keys : ['body_text', 'checkpoint_text', 'primary_action', 'profile', 'schema_version', 'secondary_actions', 'title']
override keys: ['body_text', 'checkpoint_text', 'primary_action', 'profile', 'schema_version', 'secondary_actions', 'title']
```

No `render_profile`, no `body_blocks`, no `fallback_body_text`, no `transforms_applied`, no `chunking`. The opted-in generic payload differed from discord's only in the `profile` echo — the opt-in bought the caller nothing.

After:

```
keys                    : ['body_blocks', 'body_text', 'checkpoint_text', 'chunking', 'fallback_body_text',
                           'primary_action', 'profile', 'render_profile', 'schema_version',
                           'secondary_actions', 'title', 'transforms_applied']
override render_profile : limited_markdown | discord: limited_markdown | generic (no metadata): rich_markdown
parity (modulo `profile`)          : True
rich-path body_text byte-identical : True
```

The third change is a separate fail-safe on the same contract. `render_profile_for_source` used to check `if explicit in RENDER_PROFILES` and otherwise fall through to the source default. An adapter that typoed the key while asking for limited rendering got **rich** Markdown — the worst possible outcome for the narrowest surfaces, and silent. An adapter that sends `render_profile` at all has told us the surface is narrow enough to care, so an unknown value now coerces down rather than up, matching `_normalize_render_profile`'s documented coercion.

### User / Operator Impact

- A Hermes wrapper on any of the 11 generic-source platforms can now opt into messenger-safe route-hint rendering with `source_metadata={"render_profile": "limited_markdown"}` and get real parity with a natively limited source (discord/slack/telegram), including bullet-converted tables, profile-appropriate `body_blocks`, a `fallback_body_text`, and a `transforms_applied` audit list.
- Wrappers reading `messenger_rendering.render_profile` can now trust it. Previously the field did not exist on this path and `profile` looked like one but was the raw source name.
- An adapter that misspells `render_profile` degrades to the safe rendering instead of silently receiving rich Markdown.
- `omh chat route-hint` with an unmodelled `--source` now fails loudly. In practice the CLI already constrains `--source` to `choices=CHAT_SOURCES`, so this only closes the library-level hole.

### How It Works

Schema decision: **additive extension of `messenger_route_hint_rendering/v1`, no version bump.** No existing key changes meaning, so healthy consumers stay byte-compatible. All seven original keys remain. `profile` is kept as the raw source echo and is now documented in-code as deprecated in favour of `render_profile`; `render_profile`, `body_blocks`, `fallback_body_text`, `transforms_applied`, and `chunking` are new. `body_text`'s *meaning* is unchanged ("the body to render"); its value now respects the declared profile, which is the defect being fixed. Because generated route-hint prose contains no Markdown tables, the rich-path `body_text` is in fact byte-identical to before — pinned by a regression test.

Import topology: checked before writing any code. `contract.py` does not import `route_hints.py`, directly or transitively (`src/commands/chat.py` is the only importer of `route_hints`, and it sits above both). So `route_hints -> contract` is a clean one-way edge and **no restructuring was needed** — no new shared module, no copy-paste of `_messenger_safe_body`. `route_hints` imports `render_profile_for_source`, `RENDER_PROFILE_RICH_MARKDOWN`, `_messenger_safe_body`, `_render_body_blocks`, and `_messenger_chunking_hint` from `contract`, matching the repo's existing habit of importing sibling private helpers within a package.

The one shared-literal cleanup: the advisory chunking dict was inlined in `messenger_rendering_contract` and would otherwise have had to be duplicated. It is now `_messenger_chunking_hint()`, returning a fresh dict per call so an embedded copy cannot be mutated by one caller for every other. `messenger_rendering_contract`'s emitted payload is unchanged.

The degradation note from #656 is appended to `body` in `_response_for_hint` before the safe-body transform runs, so it lands in the messenger-safe text exactly once — neither dropped by the transform nor re-appended after it. This is pinned by a test that counts occurrences in `body_text`, `fallback_body_text`, and the joined `body_blocks` text.

### Files And Contracts Touched

- `src/wrapper/route_hints.py` — source guard, profile resolution, profile-aware `messenger_rendering` block.
- `src/wrapper/contract.py` — `render_profile_for_source` fail-safe coercion + docstring; new `_messenger_chunking_hint()` shared by both rendering paths.
- `tests/test_wrapper_contract.py` — six new tests (M4 parity, rich-path regression pin, safe-body transform proof, additive-v1 key pin, source guard, profile fail-safe).
- `tests/test_degradation_signal.py` — degradation note exactly-once on the new profile-resolved route-hint body.
- Contracts: `messenger_route_hint_rendering/v1` extended additively; `chat_route_hint/v1` unchanged; `omh_messenger_rendering/v1` output unchanged.

Tests are written non-vacuously per repo discipline — every structural comparison asserts non-emptiness before shape, so an empty payload cannot pass. The safe-body transform is proved end-to-end by mocking the generic-tool checkpoint to carry a Markdown table (the one body fragment a wrapper can put arbitrary Markdown into), then asserting the limited profile converts it to bullets while the rich profile preserves it and still exposes the bullets in `fallback_body_text`.

## Validation

- [x] `uv run --group lint ruff check src tests` -> `All checks passed!`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests` -> `Ran 1718 tests in 57.179s` / `OK (skipped=1)`
- [x] `uv run python -m compileall -q src tests` -> clean
- [x] `uv run python -m omh.cli docs workflows --check` -> `"ok":true`, tap_skills 97/97, no missing/stale/extra
- [x] `uv run python -m omh.cli docs roles --check` -> `"ok":true`
- [x] `uv run python -m omh.cli docs capability-families --check` -> `"ok":true`
- [x] `uv run --group lint ruff check --select BLE001 src` -> `Found 11 errors` (unchanged; the #652 policy budget holds)
- [x] `uv run python -m omh.cli harness validate` -> `{"ok":true,"counts":{"harnesses":69,"skills":90},"errors":[],"warnings":[]}`
- [x] `uv run python -m omh.cli release hermes-smoke` -> plan mode, exit 0 (plan mode is not observed install evidence)
- [x] `git diff --check` -> clean
- [x] QA repro run before and after; output quoted above
- [x] End-to-end through the real ingress path: `omh chat route-hint --source generic --event-json <event carrying render_profile> --json` -> `source_metadata {'render_profile': 'limited_markdown'}`, `profile generic`, `render_profile limited_markdown`, `chunking {'max_recommended_chars': 1800, 'split_on': [...]}`
- [ ] `omh release checklist --json` — not run.
- [ ] Manual Hermes/TUI check — not run. No Hermes profile is attached to this worktree; `release hermes-smoke --live --target-confirmed` is the observed path and was deliberately not run against a real profile.

## Risk

- A consumer that pattern-matched on the exact seven-key set of `messenger_route_hint_rendering/v1` (rather than reading the keys it needs) will now see five extra keys. The version stays `/v1` because no existing key changed meaning; strict-schema consumers are the compatibility surface to watch.
- `body_text` values change on the route-hint path **only** for limited-profile surfaces whose body contains Markdown tables. Generated route-hint prose never does today, so the observable rich-path output is byte-identical (pinned by test). A future body that does contain a table will now be transformed — that is the intended behavior.
- The `render_profile_for_source` fail-safe changes behavior for every caller of that function, not just route hints: `build_chat_interaction_payload`, `build_chat_status_interaction`, and `src/wrapper/sessions.py` share it. The change only affects the explicit-but-unknown case, and it moves toward the safer profile. No existing test pinned the old fall-through; the full suite passes unchanged.
- The source guard is a new `ValueError` on a previously permissive function. Swept `src/` and `tests/` first: the only production caller is `src/commands/chat.py`, whose argparse already constrains `--source` to `choices=CHAT_SOURCES`; the `src/quality/*` modules use `awareness_route_hint`, not this function; all test and golden-example call sites use `discord`/`slack`/`generic`/`hermes`.

## Compatibility / Rollout

- No schema version bump, no generated-artifact regeneration, no new dependency, no network or LLM call. Pure additive contract widening plus two behavior corrections.
- Wrappers should migrate from `messenger_rendering.profile` to `messenger_rendering.render_profile`. `profile` is retained and keeps echoing the raw source; it is marked deprecated in code, not removed.
- No state, no persisted artifact, and no CLI surface changed. Existing `omh chat route-hint` invocations produce a superset of their previous JSON.

## Release / Claims

- [x] Release-channel impact considered — `local`; wrapper contract widening only, no installer or catalog change.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed — all validation output above is observed locally; the Hermes live smoke is explicitly marked not observed.
- [x] Known manual Hermes checks are listed, including the `omh release hermes-smoke --live` gap.

## Follow-Up

- QA observation #4 (the `omh-` display-name question in rendered bodies) is a different user goal and is deliberately not addressed here.
- Message splitting/chunking enforcement stays out of scope: OMH advises via the `chunking` hint, adapters split. Unchanged by design.
- `native_commands.py` still only warns when `body_text` is *absent*, not when it is present-but-unsafe. Now that both rendering paths resolve a profile there is no known way to produce an unsafe body, but a positive `render_profile`-aware assertion in the adapter shim would close the detection gap that let this defect ship silently.
