### PR TITLE
Give omh runtime progress-status the same unchanged check as its sibling observe surfaces

### DIFF
--- a/src/commands/runtime.py
+++ b/src/commands/runtime.py
@@ -41,12 +41,14 @@ from ..runtime.artifacts import (
     write_wrapper_contract,
 )
 from ..runtime.context_budget import (
+    PROGRESS_STATUS_LEDGER_KEY,
     degrade_run_payload,
     payload_fingerprint,
     public_budget,
     record_context_emission,
     run_context_budget,
     run_show_surface,
+    unchanged_progress_status_payload,
     unchanged_run_payload,
 )
 from ..executors import CODING_RUNTIME_HANDOFF_TARGETS
@@ -466,7 +468,27 @@ def cmd_runtime_progress_observe(args: argparse.Namespace) -> int:
 
 
 def cmd_runtime_progress_status(args: argparse.Namespace) -> int:
-    _print_json(project_active_executor_status(_paths(args), limit=_bounded_limit(args)))
+    paths = _paths(args)
+    full = bool(getattr(args, "full", False))
+    limit = _bounded_limit(args)
+    shown = project_active_executor_status(paths, limit=limit)
+    # Keyed by limit for the same reason `runtime show` is keyed by history
+    # limit: a different limit is a different projection.
+    surface = f"progress_status:{limit}"
+    ledger = run_context_budget(paths, PROGRESS_STATUS_LEDGER_KEY, surface=surface)
+    fingerprint = payload_fingerprint(shown)
+    if not full and fingerprint == ledger["last_payload_fingerprint"]:
+        payload = unchanged_progress_status_payload(shown, ledger)
+    else:
+        payload = shown
+    _print_json(payload)
+    record_context_emission(
+        paths,
+        PROGRESS_STATUS_LEDGER_KEY,
+        surface=surface,
+        byte_count=len(json.dumps(payload, sort_keys=True)),
+        payload_fingerprint_value=fingerprint,
+    )
     return 0
 
 
@@ -629,6 +651,11 @@ def _add_progress_observe_args(parser: argparse.ArgumentParser) -> None:
 def _add_progress_status_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--limit", type=int, default=50)
     parser.add_argument("--all", action="store_true")
+    parser.add_argument(
+        "--full",
+        action="store_true",
+        help="Always print the full projection, even when nothing changed since the last call.",
+    )
     parser.set_defaults(func=cmd_runtime_progress_status)
 
 

--- a/src/runtime/context_budget.py
+++ b/src/runtime/context_budget.py
@@ -25,7 +25,13 @@ from ..paths import OmhPaths
 
 RUN_CONTEXT_BUDGET_SCHEMA_VERSION = "omh_run_context_budget/v1"
 RUN_UNCHANGED_SCHEMA_VERSION = "omh_run_show_unchanged/v1"
+PROGRESS_STATUS_UNCHANGED_SCHEMA_VERSION = "omh_progress_status_unchanged/v1"
 CONTEXT_BUDGET_LEDGER_NAME = "context_budget.json"
+
+# `progress-status` spans every binding rather than one run, so it needs a
+# ledger bucket that is not a run id. The double underscores keep it from
+# colliding with a real one.
+PROGRESS_STATUS_LEDGER_KEY = "__executor_progress_status__"
 
 
 def run_show_surface(*, full: bool, history_limit: object = None) -> str:
@@ -210,6 +216,32 @@ def unchanged_run_payload(shown: dict[str, Any], budget: dict[str, Any]) -> dict
             "Nothing observable changed since the previous emission for this run. This is not "
             "execution, review, CI, merge-readiness, or merge evidence, and repeating the command "
             "will not produce new evidence."
+        ),
+    }
+
+
+def unchanged_progress_status_payload(shown: dict[str, Any], budget: dict[str, Any]) -> dict[str, Any]:
+    """Replacement for an executor-status projection nothing has moved since.
+
+    "What is running?" is the most repeatable question a supervising agent asks,
+    and the answer is the largest single payload in a delegated session -- one
+    full binding record per executor. Repeating it unchanged is pure cost, so
+    keep only the counts a reader needs to decide whether to look closer.
+    """
+    active = shown.get("active_executors") if isinstance(shown.get("active_executors"), list) else []
+    stale = shown.get("stale_executors") if isinstance(shown.get("stale_executors"), list) else []
+    return {
+        "schema_version": PROGRESS_STATUS_UNCHANGED_SCHEMA_VERSION,
+        "unchanged_since_last_emission": True,
+        "active_executor_count": len(active),
+        "stale_executor_count": len(stale),
+        "delta": {},
+        "context_budget": public_budget(budget),
+        "next_action": "wait_for_new_observed_evidence_instead_of_repeating_this_command",
+        "full_output_command": "omh runtime progress-status --full",
+        "claim_boundary": (
+            "No executor progress changed since the previous emission. This is not result, "
+            "verification, review, CI, merge-readiness, or merge evidence."
         ),
     }
 

--- a/tests/test_progress_status_suppression.py
+++ b/tests/test_progress_status_suppression.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from _cli_harness import run_cli
+from _local_package import load_local_package
+
+load_local_package()
+from omh.paths import resolve_paths
+from omh.runtime.context_budget import PROGRESS_STATUS_LEDGER_KEY, run_context_budget
+
+
+class ProgressStatusSuppressionTests(unittest.TestCase):
+    """"What is running?" is the most repeatable question, and the biggest answer.
+
+    A ten-workflow CLI simulation measured `progress-status` at roughly 8KB per
+    call -- one full binding record per executor -- with no budget of its own,
+    while the two other observe surfaces already had one. Repeating that
+    unchanged is pure cost.
+    """
+
+    def _base(self, root: Path) -> list[str]:
+        return ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+
+    def _bound_run(self, base: list[str], ref: str) -> str:
+        status, stdout, stderr = run_cli(
+            base + ["runtime", "record", "--skill", "oh-my-hermes", "--harness", "coding-handling"]
+        )
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        run_id = json.loads(stdout)["run"]["run_id"]
+        status, _stdout, stderr = run_cli(
+            base
+            + [
+                "runtime", "progress-bind", "--run", run_id,
+                "--executor-profile", "claude_code", "--claude-session-ref", ref,
+            ]
+        )
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        return run_id
+
+    def _observe(self, base: list[str], run_id: str, latest: str, summary: str) -> None:
+        status, _stdout, stderr = run_cli(
+            base
+            + [
+                "runtime", "progress-observe", "--run", run_id,
+                "--process-status", "running",
+                "--profile-status", "running",
+                "--profile-latest-event", latest,
+                "--profile-summary", summary,
+            ]
+        )
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+
+    def _status(self, base: list[str], *extra: str) -> dict:
+        status, stdout, stderr = run_cli(base + ["runtime", "progress-status", *extra])
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        return json.loads(stdout)
+
+    def test_a_repeated_status_call_returns_counts_instead_of_every_binding(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = self._base(root)
+            run_id = self._bound_run(base, "sess-1")
+            self._observe(base, run_id, "repo_exploration", "inspecting")
+
+            first = self._status(base)
+            self.assertNotIn("unchanged_since_last_emission", first)
+            self.assertIn("active_executors", first)
+
+            second = self._status(base)
+            self.assertTrue(second["unchanged_since_last_emission"])
+            self.assertEqual(second["active_executor_count"], len(first["active_executors"]))
+            self.assertNotIn("active_executors", second)
+            self.assertLess(
+                len(json.dumps(second, sort_keys=True)),
+                len(json.dumps(first, sort_keys=True)),
+                "suppression must actually reduce what reaches agent context",
+            )
+
+    def test_full_is_never_suppressed(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = self._base(root)
+            run_id = self._bound_run(base, "sess-1")
+            self._observe(base, run_id, "repo_exploration", "inspecting")
+
+            self._status(base)
+            for _ in range(3):
+                full = self._status(base, "--full")
+                self.assertNotIn("unchanged_since_last_emission", full)
+                self.assertIn("active_executors", full)
+
+    def test_new_executor_activity_reopens_the_full_projection(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = self._base(root)
+            run_id = self._bound_run(base, "sess-1")
+            self._observe(base, run_id, "repo_exploration", "inspecting")
+
+            self._status(base)
+            self.assertTrue(self._status(base)["unchanged_since_last_emission"])
+
+            self._observe(base, run_id, "diff_started", "changed files")
+            reopened = self._status(base)
+            self.assertNotIn("unchanged_since_last_emission", reopened)
+            self.assertIn("active_executors", reopened)
+
+    def test_a_second_executor_reopens_the_full_projection(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = self._base(root)
+            first_run = self._bound_run(base, "sess-1")
+            self._observe(base, first_run, "repo_exploration", "inspecting")
+            self._status(base)
+            self.assertTrue(self._status(base)["unchanged_since_last_emission"])
+
+            second_run = self._bound_run(base, "sess-2")
+            self._observe(base, second_run, "repo_exploration", "inspecting")
+            reopened = self._status(base)
+            self.assertNotIn("unchanged_since_last_emission", reopened)
+            self.assertEqual(len(reopened["active_executors"]), 2)
+
+    def test_each_limit_keeps_its_own_comparison(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = self._base(root)
+            run_id = self._bound_run(base, "sess-1")
+            self._observe(base, run_id, "repo_exploration", "inspecting")
+
+            self._status(base)
+            self.assertTrue(self._status(base)["unchanged_since_last_emission"])
+            self.assertNotIn("unchanged_since_last_emission", self._status(base, "--limit", "5"))
+            self.assertTrue(self._status(base, "--limit", "5")["unchanged_since_last_emission"])
+
+    def test_the_ledger_bucket_is_not_a_run_id(self) -> None:
+        """The projection spans every binding, so it cannot be charged to one run."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = self._base(root)
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            run_id = self._bound_run(base, "sess-1")
+            self._observe(base, run_id, "repo_exploration", "inspecting")
+            self._status(base)
+
+            self.assertNotEqual(PROGRESS_STATUS_LEDGER_KEY, run_id)
+            recorded = run_context_budget(paths, PROGRESS_STATUS_LEDGER_KEY, surface="progress_status:50")
+            self.assertTrue(recorded["last_payload_fingerprint"])
+            self.assertGreater(recorded["emitted_bytes"], 0)
+            self.assertEqual(
+                run_context_budget(paths, run_id, surface="progress_status:50")["emitted_bytes"],
+                0,
+                "progress-status must not spend an individual run's budget",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- `omh runtime progress-status` returns active/stale **counts** plus `unchanged_since_last_emission` when no executor has moved since the previous call, instead of re-emitting every binding record.
- It gains a `--full` flag, so the pull path stays unthrottled like the other observe surfaces.

### Why This Exists

Follow-up to #658. A ten-workflow CLI simulation measured `progress-status` at roughly **12KB per call** — one full binding record per executor — and it was the only observe surface with **no budget at all**, while `runtime show` and `omh coding fanout show` both had one.

"What is running?" is the most repeatable question a supervising agent asks while it waits, so repeating that answer unchanged was the largest remaining cost in a delegated coding session.

### User / Operator Impact

| | Before | After |
|---|---|---|
| First status call | full projection | **unchanged** |
| Repeat call, nothing moved | full projection again (~12KB) | counts + marker (~856 bytes) |
| New executor, or existing one advances | full projection | **unchanged** — reopens |
| `omh runtime progress-status --full` | flag did not exist | always full |

Measured on the same ten-workflow simulation: **18 of 27 status calls suppressed, 12,028 → 856 bytes each, ~201KB avoided.**

### How It Works

- The projection spans every binding rather than one run, so it gets its own ledger bucket (`__executor_progress_status__`) instead of charging an arbitrary run's budget. A test asserts an individual run's budget stays at zero.
- The ledger key includes the limit, for the same reason `runtime show` is keyed by history limit: a different limit is a different projection.
- Reuses `payload_fingerprint`, which already excludes per-observation bookkeeping — the fix from #658 that made these checks fire at all.

### Files And Contracts Touched

- `src/runtime/context_budget.py` — `PROGRESS_STATUS_LEDGER_KEY`, `unchanged_progress_status_payload`, new `omh_progress_status_unchanged/v1`
- `src/commands/runtime.py` — `cmd_runtime_progress_status`, `--full`
- `tests/test_progress_status_suppression.py` (new)

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `python3 -m unittest discover -s tests` — **1774 passed**, 1 skipped
- [x] `python3 -m compileall src`
- [x] `python3 -m omh.cli docs workflows --check` (also `docs roles`, `docs capability-families`)
- [x] `python3 -m omh.cli harness validate`
- [x] `python3 -m omh.cli release checklist --json`
- [x] `python3 -m omh.cli release hermes-smoke`
- [x] `python3 -m omh.cli release drift`
- [x] `omh --help`
- [x] Ten-workflow CLI simulation re-measured after the change
- [ ] Manual Hermes/TUI check — **not run.** No live session exercised the new `--full` flag.

### A measurement note worth recording

The first run of this change measured as having **zero effect**: 0 of 9 status calls suppressed, byte-identical totals. That was not a broken feature — the simulation called `progress-status` once per scenario and bound a new executor between scenarios, so every call legitimately differed and suppression correctly never fired.

Repeated polling is the shape that actually costs, and the simulation was not exercising it. After adding repeated polls the effect showed up immediately. A change that measures as doing nothing deserves a check that the measurement targets the right shape before any conclusion is drawn.

## Risk

- **Low.** Additive flag plus a smaller repeat payload. The first call and `--full` are unchanged.
- A consumer that polls `progress-status` in a loop and parses `active_executors` unconditionally will now see that key absent on repeat calls. `unchanged_since_last_emission` is the discriminator, and `--full` restores the old behaviour verbatim.

## Compatibility / Rollout

- No new dependencies. `omh_progress_status_unchanged/v1` is new and additive; no schema was removed or renamed.
- The ledger bucket is a reserved non-run key, so no existing run's budget accounting changes.

## Release / Claims

- [x] Release-channel impact considered — `local`.
- [x] Claims backed by evidence: every number here comes from the simulation, not from inspection.
- [x] Manual gaps listed above. `omh release hermes-smoke --live` was not run.

## Follow-Up

- Still no live Hermes session measurement of end-to-end chat message counts; the proxy metric remains surface return volume.
- `progress-observe` itself averages ~2.5KB per call and has no unchanged check. It is a write path rather than a status read, so the same treatment may not fit — worth a look, not assumed.
