### PR TITLE
Stop paying a full binding record to report silence on progress-observe

### DIFF
--- a/src/coding/executor_progress.py
+++ b/src/coding/executor_progress.py
@@ -550,6 +550,34 @@ def observe_executor_progress(
     }
 
 
+def compact_suppressed_observation(payload: dict[str, Any]) -> dict[str, Any]:
+    """Shrink an observation that reported nothing, for emission only.
+
+    A suppressed observation still returned the whole binding record -- hashes,
+    instance ids, correlation aliases, transition fingerprints -- which measured
+    at 1,728 of its 2,096 bytes. None of that helps a caller who was just told
+    there is nothing to report, and a polling agent pays it on every quiet call.
+
+    Only the emission path is trimmed. `observe_executor_progress` keeps
+    returning the full binding, because in-process callers feed it straight back
+    into the next observation.
+    """
+    binding = payload.get("binding") if isinstance(payload.get("binding"), dict) else {}
+    return {
+        **{key: value for key, value in payload.items() if key != "binding"},
+        "binding_ref": {
+            "binding_id": str(binding.get("binding_id", "")),
+            "target_type": str(binding.get("target_type", "")),
+            "target_id": str(binding.get("target_id", "")),
+            "executor_profile": str(binding.get("executor_profile", "")),
+            "state": str(binding.get("state", "")),
+            "report_count": int(binding.get("report_count", 0) or 0),
+            "last_reported_event_type": str(binding.get("last_reported_event_type", "")),
+        },
+        "full_output_hint": "re-run with --full for the complete binding record",
+    }
+
+
 def append_progress_event(paths: OmhPaths, binding: dict[str, Any], event: dict[str, Any]) -> dict[str, Any]:
     _require_valid("binding", validate_progress_binding(binding))
     _require_valid("event", validate_progress_event(event))

--- a/src/commands/runtime.py
+++ b/src/commands/runtime.py
@@ -9,6 +9,7 @@ from ..executor_progress import (
     PROGRESS_EVENT_TYPES,
     build_progress_binding,
     build_safe_progress_signal,
+    compact_suppressed_observation,
     observe_executor_progress,
     project_active_executor_status,
     read_progress_binding,
@@ -463,6 +464,8 @@ def cmd_runtime_progress_observe(args: argparse.Namespace) -> int:
         )
     except (OSError, ValueError, ExecutorProgressError) as exc:
         raise OmhError(str(exc)) from exc
+    if not bool(getattr(args, "full", False)) and not payload.get("reported"):
+        payload = compact_suppressed_observation(payload)
     _print_json(payload)
     return 0
 
@@ -630,6 +633,11 @@ def _add_progress_bind_args(parser: argparse.ArgumentParser) -> None:
 
 def _add_progress_observe_args(parser: argparse.ArgumentParser) -> None:
     _add_progress_target_args(parser)
+    parser.add_argument(
+        "--full",
+        action="store_true",
+        help="Print the complete binding record even when the observation reported nothing.",
+    )
     parser.add_argument("--process-status", default="")
     # Default None, not "": passing the flag with an empty value means "git was
     # checked and reports nothing changed", which is what contradicts a reported

--- a/tests/test_progress_observe_suppression.py
+++ b/tests/test_progress_observe_suppression.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from _cli_harness import run_cli
+from _local_package import load_local_package
+
+load_local_package()
+from omh.executor_progress import compact_suppressed_observation
+
+
+class SuppressedObservationEmissionTests(unittest.TestCase):
+    """An observation that reports nothing should not cost a full binding record.
+
+    A ten-workflow simulation measured 27 suppressed `progress-observe` calls at
+    ~2,014 bytes each -- 54KB spent saying nothing happened -- of which the
+    binding record was 1,728 of every 2,096. Hashes, instance ids, correlation
+    aliases, and transition fingerprints do not help a caller who was just told
+    there is nothing to report.
+    """
+
+    def _base(self, root: Path) -> list[str]:
+        return ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+
+    def _bound_run(self, base: list[str]) -> str:
+        status, stdout, stderr = run_cli(
+            base + ["runtime", "record", "--skill", "oh-my-hermes", "--harness", "coding-handling"]
+        )
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        run_id = json.loads(stdout)["run"]["run_id"]
+        status, _stdout, stderr = run_cli(
+            base
+            + [
+                "runtime", "progress-bind", "--run", run_id,
+                "--executor-profile", "claude_code", "--claude-session-ref", "sess-1",
+            ]
+        )
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        return run_id
+
+    def _observe(self, base: list[str], run_id: str, *extra: str) -> dict:
+        status, stdout, stderr = run_cli(
+            base
+            + [
+                "runtime", "progress-observe", "--run", run_id,
+                "--process-status", "running",
+                "--profile-status", "running",
+                "--profile-latest-event", "repo_exploration",
+                "--profile-summary", "inspecting",
+                *extra,
+            ]
+        )
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        return json.loads(stdout)
+
+    def test_a_suppressed_observation_returns_a_binding_reference(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = self._base(root)
+            run_id = self._bound_run(base)
+
+            first = self._observe(base, run_id)
+            self.assertTrue(first["reported"])
+            self.assertIn("binding", first)
+
+            repeated = self._observe(base, run_id)
+            self.assertFalse(repeated["reported"])
+            self.assertEqual(repeated["suppressed_reason"], "duplicate_transition")
+            self.assertNotIn("binding", repeated)
+            self.assertEqual(repeated["binding_ref"]["state"], "active")
+            # The reference must still carry what the caller needs to correlate
+            # and to see where the binding stands.
+            self.assertEqual(
+                repeated["binding_ref"]["last_reported_event_type"],
+                first["event"]["event_type"],
+            )
+            self.assertEqual(repeated["binding_ref"]["target_id"], run_id)
+            self.assertEqual(repeated["binding_ref"]["executor_profile"], "claude_code")
+            self.assertLess(
+                len(json.dumps(repeated, sort_keys=True)),
+                len(json.dumps(first, sort_keys=True)),
+            )
+
+    def test_the_reporting_contract_keys_survive_compaction(self) -> None:
+        """Existing callers read these three; compaction must not disturb them."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = self._base(root)
+            run_id = self._bound_run(base)
+            self._observe(base, run_id)
+
+            repeated = self._observe(base, run_id)
+            self.assertFalse(repeated["reported"])
+            self.assertEqual(repeated["reporting_action"], "suppress")
+            self.assertEqual(repeated["suppressed_reason"], "duplicate_transition")
+            self.assertEqual(repeated["event"], {})
+            self.assertEqual(repeated["report"], {})
+            self.assertIn("not result", repeated["claim_boundary"])
+
+    def test_full_returns_the_complete_binding(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = self._base(root)
+            run_id = self._bound_run(base)
+            self._observe(base, run_id)
+
+            repeated = self._observe(base, run_id, "--full")
+            self.assertFalse(repeated["reported"])
+            self.assertIn("binding", repeated)
+            self.assertNotIn("binding_ref", repeated)
+            self.assertIn("correlation_root", repeated["binding"])
+
+    def test_a_reported_observation_is_never_compacted(self) -> None:
+        """Only silence is cheap; an actual report keeps its full shape."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = self._base(root)
+            run_id = self._bound_run(base)
+
+            first = self._observe(base, run_id)
+            self.assertTrue(first["reported"])
+            self.assertIn("binding", first)
+            self.assertNotIn("binding_ref", first)
+            self.assertTrue(first["event"]["event_type"])
+
+    def test_compaction_drops_only_the_binding_record(self) -> None:
+        payload = {
+            "schema_version": "omh_executor_progress_observation/v1",
+            "binding": {
+                "binding_id": "run:r1:codex",
+                "target_type": "run",
+                "target_id": "r1",
+                "executor_profile": "codex",
+                "state": "active",
+                "report_count": 3,
+                "last_reported_event_type": "repo_exploration",
+                "correlation_aliases": {"codex_session_ref": "s1"},
+                "last_transition_fingerprint": "deadbeef",
+            },
+            "event": {},
+            "report": {},
+            "reported": False,
+            "suppressed_reason": "repeat_interval",
+            "reporting_action": "suppress",
+            "chat_report": "",
+            "claim_boundary": "not result evidence",
+        }
+        compacted = compact_suppressed_observation(payload)
+        self.assertNotIn("binding", compacted)
+        self.assertEqual(compacted["binding_ref"]["report_count"], 3)
+        self.assertEqual(compacted["binding_ref"]["executor_profile"], "codex")
+        for key in ("reported", "suppressed_reason", "reporting_action", "event", "report", "claim_boundary"):
+            with self.subTest(key=key):
+                self.assertEqual(compacted[key], payload[key])
+        rendered = json.dumps(compacted)
+        self.assertNotIn("deadbeef", rendered, "internal fingerprints must not survive compaction")
+        self.assertNotIn("correlation_aliases", rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- A suppressed `omh runtime progress-observe` emits a compact `binding_ref` instead of the entire binding record.
- `progress-observe` gains `--full`, matching the other two observe surfaces.

### Why This Exists

Final follow-up to #658 and #660. `progress-observe` already suppressed at the event level, but a suppressed observation still returned the whole binding.

A ten-workflow CLI simulation measured **27 suppressed calls at ~2,014 bytes each — 54KB spent reporting silence** — of which the binding record was **1,728 of every 2,096**: hashes, instance ids, correlation aliases, transition fingerprints. None of that helps a caller who was just told there is nothing to report, and a polling agent pays it on every quiet call.

### User / Operator Impact

| | Before | After |
|---|---|---|
| Observation that reports something | full payload | **unchanged** |
| Observation suppressed as a duplicate/repeat | full binding (~2,096 bytes) | `binding_ref` (~764 bytes) |
| `progress-observe --full` | flag did not exist | complete record |

**Measured: 2,096 → 764 bytes per suppressed call, 54KB → 20KB across the simulation.**

`binding_ref` keeps what a caller needs to correlate the observation and see where the binding stands: id, target, executor profile, state, report count, last reported event type.

### How It Works

Only the emission path is trimmed. `observe_executor_progress` keeps returning the full binding, because `src/wrapper/lifecycle.py`, `src/wrapper/executor_sessions.py`, and several tests feed the returned binding straight into the next observation.

With this, all three observe surfaces have both a quiet path and a `--full` escape hatch:

| Surface | Quiet path | Escape hatch |
|---|---|---|
| `runtime show` | `unchanged_since_last_emission` | `--full` |
| `runtime progress-status` | `unchanged_since_last_emission` | `--full` |
| `runtime progress-observe` | `binding_ref` on suppression | `--full` |

### Files And Contracts Touched

- `src/coding/executor_progress.py` — `compact_suppressed_observation`
- `src/commands/runtime.py` — emission path, `--full`
- `tests/test_progress_observe_suppression.py` (new)

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `python3 -m unittest discover -s tests` — **1779 passed**, 1 skipped
- [x] `python3 -m compileall src`
- [x] `python3 -m omh.cli docs workflows --check` (also `docs roles`, `docs capability-families`)
- [x] `python3 -m omh.cli harness validate`
- [x] `python3 -m omh.cli release hermes-smoke`
- [x] `python3 -m omh.cli release drift`
- [x] Ten-workflow simulation re-measured on **both** executor profiles; codex classifications still all correct and the profile-flag guard still exits 2
- [ ] Manual Hermes/TUI check — **not run.** No live session exercised the new `--full` flag.

## Risk

- **Low.** Only the suppressed emission path changes. Reported observations and `--full` are byte-identical.
- A consumer that reads `payload["binding"]` unconditionally after a suppressed observation will find it absent. `reported: false` is the discriminator, `binding_ref` carries the identity fields, and `--full` restores the old shape.
- `reported`, `reporting_action`, `suppressed_reason`, `event`, `report`, and `claim_boundary` are asserted unchanged through compaction.

## Compatibility / Rollout

- No new dependencies, no schema removed or renamed. `binding_ref` and `full_output_hint` are additive on a path that previously carried neither.
- In-process callers are unaffected: the library return value is untouched.

## Release / Claims

- [x] Release-channel impact considered — `local`.
- [x] Every number here comes from the simulation, not from inspection.
- [x] Manual gaps listed above. `omh release hermes-smoke --live` was not run.

## Follow-Up

- Still no live Hermes session measurement of end-to-end chat message counts; the proxy metric remains surface return volume. This is the one claim in this series that has never been measured directly, and it stays open.
