### PR TITLE
fix: make a present-but-unsafe messenger body warn instead of passing silently

### DIFF
--- a/src/wrapper/native_commands.py
+++ b/src/wrapper/native_commands.py
@@ -2,6 +2,13 @@ from __future__ import annotations
 
 from typing import Any
 
+# `contract` never imports this module (only `commands.chat` and tests import
+# it), so the edge is one-way and cycle-free, matching the existing
+# `route_hints -> contract` reuse. Sharing the helper keeps the detector on the
+# exact transform the producers ship against instead of a second copy that
+# could drift into disagreeing about what "messenger-safe" means.
+from .contract import RENDER_PROFILE_LIMITED_MARKDOWN, _messenger_safe_body
+
 
 NATIVE_COMMAND_SURFACE_SCHEMA_VERSION = "omh_native_command_surface/v1"
 NATIVE_COMMAND_RENDER_SCHEMA_VERSION = "omh_native_command_render/v1"
@@ -108,14 +115,15 @@ def render_native_command_response(interaction: dict[str, object], *, source: st
         return payload
     rendering = _nested(response, "messenger_rendering")
     body_text = rendering.get("body_text")
+    render_warnings: list[str] = []
     if isinstance(body_text, str):
         rendered_body_text = body_text
         body_text_source = "messenger_rendering.body_text"
-        render_warnings: list[str] = []
     else:
         rendered_body_text = str(response.get("body", ""))
         body_text_source = "missing_messenger_rendering.body_text"
-        render_warnings = ["missing_messenger_safe_body"]
+        render_warnings.append("missing_messenger_safe_body")
+    render_warnings.extend(_unsafe_rendering_warnings(rendering))
     payload.update(
         {
             "render_kind": "chat_response",
@@ -128,6 +136,57 @@ def render_native_command_response(interaction: dict[str, object], *, source: st
         }
     )
     return payload
+
+
+def _unsafe_rendering_warnings(rendering: dict[str, object]) -> list[str]:
+    """Warn when a *present* `messenger_rendering` block is unsafe, not just absent.
+
+    `missing_messenger_safe_body` only fires when `body_text` is absent, so a
+    producer that ships a present-but-untransformed body warned nothing at all.
+    That blind spot is exactly why the route-hint render-profile defect could
+    ship silently until it was fixed producer-side: `body_text` existed the
+    whole time, it just was never made messenger-safe. These codes make the
+    present-but-unsafe states loud so the *next* producer regression is caught
+    by the detector rather than by a reader:
+
+    - `missing_render_profile`: the rendering block never resolved a profile.
+      This is the pre-fix producer shape, where `profile` held a raw source
+      string and no resolved `render_profile` existed. It is a purely
+      structural tripwire, so it catches the whole class - a third rendering
+      path, a refactor that drops the resolve step, a hand-built dict - without
+      needing to inspect the body at all.
+    - `unsafe_limited_markdown_body`: the block declares `limited_markdown` but
+      `body_text` still changes under `_messenger_safe_body`, so an
+      untransformed body is shipping under a profile that promised
+      messenger-safe text.
+
+    An absent `transforms_applied` deliberately gets no code of its own. An
+    empty transform list is legitimate for a body that needed no rewrite, so
+    absence is not evidence of a defect, and a producer that omits the key
+    entirely is already the incomplete shape `missing_render_profile` catches.
+    A third code there would only add noise on payloads the first two already
+    classify.
+
+    These stay warnings rather than errors because `render_warnings` is this
+    module's only severity channel: the render path always falls back to
+    something renderable and reports provenance in `body_text_source`. Raising
+    would turn a legacy-but-renderable payload into a dead wrapper response,
+    which is the opposite of what the fallback exists for.
+    """
+    if not rendering:
+        return []
+    warnings: list[str] = []
+    if "render_profile" not in rendering:
+        warnings.append("missing_render_profile")
+    body_text = rendering.get("body_text")
+    if rendering.get("render_profile") == RENDER_PROFILE_LIMITED_MARKDOWN and isinstance(body_text, str):
+        # `_messenger_safe_body` is lru_cached on the body string, so a repeated
+        # body costs a dict lookup. The transform is idempotent, so a healthy
+        # limited-profile body compares equal and stays silent.
+        safe_body_text, _ = _messenger_safe_body(body_text)
+        if safe_body_text != body_text:
+            warnings.append("unsafe_limited_markdown_body")
+    return warnings
 
 
 def _fallback_card(source: str, *, insert_text: str | None = None) -> dict[str, object]:

--- a/tests/test_wrapper_contract.py
+++ b/tests/test_wrapper_contract.py
@@ -1287,6 +1287,149 @@ class WrapperContractTests(unittest.TestCase):
         self.assertEqual(rendered["body_text_source"], "missing_messenger_rendering.body_text")
         self.assertIn("missing_messenger_safe_body", rendered["render_warnings"])
 
+    def test_native_render_warns_on_producer_shape_without_a_resolved_render_profile(self) -> None:
+        """The regression the old detector could not see.
+
+        This hand-builds the exact route-hint rendering block from before the
+        render-profile fix: seven keys, `profile` holding a raw source string,
+        and no resolved `render_profile`. Back then `body_text` was present, so
+        `missing_messenger_safe_body` stayed silent and the unsafe body shipped
+        unannounced. Rebuilding that shape by hand keeps the tripwire honest
+        even after the producer is fixed - it is the shape, not the current
+        producer, that has to stay loud.
+        """
+        body = "\n".join(
+            [
+                "| 계열 | 강점 |",
+                "| --- | --- |",
+                "| Hermes | Gateway |",
+            ]
+        )
+        legacy_rendering = {
+            "schema_version": "messenger_route_hint_rendering/v1",
+            "profile": "discord",
+            "title": "[omh] hint:code-review",
+            "body_text": body,
+            "checkpoint_text": "체크포인트",
+            "primary_action": {"id": "open_picker", "label": "Open omh"},
+            "secondary_actions": [],
+        }
+        self.assertEqual(len(legacy_rendering), 7)
+        self.assertNotIn("render_profile", legacy_rendering)
+
+        rendered = render_native_command_response(
+            {
+                "thread_key": "discord:c1:m1",
+                "chat_response": {
+                    "kind": "hint",
+                    "headline": "[omh] hint:code-review",
+                    "body": body,
+                    "messenger_rendering": legacy_rendering,
+                    "actions": [],
+                },
+            },
+            source="discord",
+        )
+
+        self.assertEqual(rendered["render_kind"], "chat_response")
+        self.assertIn("missing_render_profile", rendered["render_warnings"])
+        # The old code path stays intact: `body_text` was present, so the
+        # absence-only warning correctly does not fire and the body is still
+        # sourced from the rendering block.
+        self.assertNotIn("missing_messenger_safe_body", rendered["render_warnings"])
+        self.assertEqual(rendered["body_text_source"], "messenger_rendering.body_text")
+
+    def test_native_render_warns_when_limited_profile_ships_an_untransformed_body(self) -> None:
+        body = "\n".join(
+            [
+                "| 계열 | 강점 |",
+                "| --- | --- |",
+                "| Hermes | Gateway |",
+            ]
+        )
+
+        rendered = render_native_command_response(
+            {
+                "thread_key": "discord:c1:m1",
+                "chat_response": {
+                    "kind": "plan",
+                    "headline": "[omh] web-research - 비교 결과입니다.",
+                    "body": body,
+                    "messenger_rendering": {
+                        "schema_version": "omh_messenger_rendering/v1",
+                        "render_profile": "limited_markdown",
+                        "body_text": body,
+                        "transforms_applied": [],
+                    },
+                    "actions": [],
+                },
+            },
+            source="discord",
+        )
+
+        self.assertIn("unsafe_limited_markdown_body", rendered["render_warnings"])
+        # A resolved profile is present, so only the body-level code fires.
+        self.assertNotIn("missing_render_profile", rendered["render_warnings"])
+
+    def test_native_render_stays_silent_for_a_rich_profile_body_that_keeps_tables(self) -> None:
+        body = "\n".join(
+            [
+                "| 계열 | 강점 |",
+                "| --- | --- |",
+                "| Hermes | Gateway |",
+            ]
+        )
+        rendering = messenger_rendering_contract(
+            visible_prefix="[omh] web-research",
+            first_line="[omh] web-research - 비교 결과입니다.",
+            body=body,
+            claim_boundary="Not execution evidence.",
+            render_profile="rich_markdown",
+        )
+
+        rendered = render_native_command_response(
+            {
+                "thread_key": "hermes:c1:m1",
+                "chat_response": {
+                    "kind": "plan",
+                    "headline": "[omh] web-research - 비교 결과입니다.",
+                    "body": body,
+                    "messenger_rendering": rendering,
+                    "actions": [],
+                },
+            },
+            source="hermes",
+        )
+
+        # A rich-markdown body is *supposed* to keep its table, so the
+        # untransformed-body check must not treat it as a defect.
+        self.assertIn("| --- | --- |", rendered["body_text"])
+        self.assertEqual(rendered["render_warnings"], [])
+
+    def test_native_render_reports_no_warnings_for_healthy_producer_payloads(self) -> None:
+        messages = ("코드 리뷰 해줘", "결제 실패 이슈가 자주 나와", "쿠버네티스 장애 상황에서 Cloudy가 적절히 진단하나?")
+        checked = 0
+        for source in ("discord", "slack", "telegram"):
+            for message in messages:
+                interaction = build_chat_interaction_payload(message, source=source)
+                route_hint = build_chat_route_hint_payload(message, source=source)
+                for path, payload in (("interaction", interaction), ("route_hint", route_hint)):
+                    with self.subTest(source=source, message=message, path=path):
+                        rendered = render_native_command_response(payload, source=source)
+                        if rendered["render_kind"] != "chat_response":
+                            continue
+                        rendering = payload["chat_response"]["messenger_rendering"]
+                        # Assert the payload is real before asserting it is
+                        # clean, so an empty body could never make the
+                        # no-warnings assertion pass vacuously.
+                        self.assertEqual(rendering["render_profile"], "limited_markdown")
+                        self.assertTrue(rendering["body_text"])
+                        self.assertTrue(rendered["body_text"])
+                        self.assertEqual(rendered["body_text_source"], "messenger_rendering.body_text")
+                        self.assertEqual(rendered["render_warnings"], [])
+                        checked += 1
+        self.assertEqual(checked, 18)
+
     def test_route_mode_exposes_visible_omh_usage_trace_for_multiple_workflows(self) -> None:
         cases = (
             ("릴리즈 전에 README claim이 실제 코드와 맞는가 봐줘", "code-review"),


### PR DESCRIPTION
## Feature Report

### What Changed

- `render_native_command_response` now detects a `messenger_rendering` block that is *present but unsafe*, not only one that is missing. Two new codes join `missing_messenger_safe_body` in `render_warnings`:
  - **`missing_render_profile`** — a non-empty `messenger_rendering` block carries no resolved `render_profile` key.
  - **`unsafe_limited_markdown_body`** — the block declares `render_profile == "limited_markdown"` but `body_text` still changes under `_messenger_safe_body`, so an untransformed body is shipping under a profile that promised messenger-safe text.
- Detector-only. No producer behavior changed, no rendering builder touched, no skill-name rendering touched.

### Why This Exists

QA found (and re-confirmed) that the old check read `messenger_rendering.body_text` and warned **only when the key was absent**. It could never fire on present-but-unsafe.

That is precisely how the route-hint render-profile defect fixed in #659 shipped silently: `body_text` existed the whole time, it just was never made messenger-safe, so nothing warned and a Discord/Slack/Telegram surface got a raw Markdown table.

#659 closed the *producer* bug — both rendering paths now resolve a profile. But the detector was still blind to the same class, so the next producer to regress would be just as silent: a third rendering path, a refactor that drops the transform, or another hand-built dict like the one `route_hints.py` used to carry. This PR closes the detector gap so the class is caught structurally rather than by a reader noticing.

### User / Operator Impact

A wrapper consuming `omh_native_command_render/v1` now gets a machine-readable signal when the payload it is about to render is unsafe for a narrow messenger surface, instead of silently rendering a raw table into Discord/Slack/Telegram. Previously the only signal was for a wholly absent body.

### How It Works

`_unsafe_rendering_warnings(rendering)` runs after the existing body-source resolution and appends to the same `render_warnings` list.

**`missing_render_profile`** is a purely structural tripwire — a `"render_profile" not in rendering` membership test. It never inspects the body, which is the point: it catches the whole class of legacy/incomplete producer shapes (the pre-#659 seven-key dict with `profile` holding a raw source echo, a future third rendering path, a refactor that drops the resolve step) without needing to know what "unsafe" looks like for any particular body. It is gated on the block being non-empty, so a chat response with no `messenger_rendering` at all still reports only `missing_messenger_safe_body` rather than warning twice about the same absence.

**`unsafe_limited_markdown_body`** is the body-level check, reusing `_messenger_safe_body` from `contract`.

#### Judgment calls

- **`transforms_applied` absence gets no code of its own.** An empty transform list is legitimate for a body that needed no rewrite, so absence is not evidence of a defect; and a producer that omits the key entirely is already the incomplete shape `missing_render_profile` catches. A third code would only add noise on payloads the first two already classify. Subsumed by (1), as suspected.
- **Warnings, not errors.** `render_warnings` is this module's only severity channel today, and the render path always falls back to something renderable while recording provenance in `body_text_source`. Raising would turn a legacy-but-renderable payload into a dead wrapper response — the opposite of what the fallback exists for. No new severity model was invented.
- **Import topology verified, no restructuring needed.** `contract` never imports `native_commands`; the only importers are `src/commands/chat.py` and the tests. So `native_commands -> contract` is one-way and cycle-free, exactly like the `route_hints -> contract` edge #659 established. The helper was imported, not copied — a second copy could drift into disagreeing with the producers about what "messenger-safe" means. No helper move was forced.
- **Performance is not meaningful.** `_messenger_safe_body` is `lru_cache(maxsize=4096)`. Measured on a real 251-char Discord payload: **0.47 µs cold** (cache cleared before every call, so a full transform pass) and **0.14 µs warm**. This is a per-response adapter call, not a loop.
- **Correctness depends on the transform being idempotent** — if `safe(safe(x)) != safe(x)`, every healthy limited-profile payload would falsely warn. Verified empirically before writing the check: 140 real payloads across every chat source and both producer paths, zero non-idempotent bodies. Recorded as a `Directive:` trailer so a future change to that transform revisits this check.

### Files And Contracts Touched

- `src/wrapper/native_commands.py` — added `_unsafe_rendering_warnings`, imported `_messenger_safe_body` / `RENDER_PROFILE_LIMITED_MARKDOWN` from `.contract`, changed `render_warnings` from a branch-local literal to an accumulator.
- `tests/test_wrapper_contract.py` — four tests (below).
- Contract surface: `omh_native_command_render/v1` gains two possible `render_warnings` values. No schema version bump — the field is an open list and the existing code is unchanged. No generated artifact enumerates these codes, so nothing needed regeneration (all byte gates confirmed green anyway).

### The Regression Test That Motivated This PR

`test_native_render_warns_on_producer_shape_without_a_resolved_render_profile` rebuilds the **exact pre-#659 rendering block by hand** — seven keys, `profile: "discord"` holding a raw source string, no `render_profile` — and asserts `missing_render_profile` fires. It also asserts the shape is genuinely that shape (`len == 7`, `render_profile` absent) so it cannot drift into testing something else, and asserts `missing_messenger_safe_body` does *not* fire, pinning the point: `body_text` was present, which is why the old detector said nothing.

**Proof it is a real regression test**, by stashing the source change and rerunning:

```
FAIL: test_native_render_warns_on_producer_shape_without_a_resolved_render_profile
    self.assertIn("missing_render_profile", rendered["render_warnings"])
AssertionError: 'missing_render_profile' not found in []

FAIL: test_native_render_warns_when_limited_profile_ships_an_untransformed_body
    self.assertIn("unsafe_limited_markdown_body", rendered["render_warnings"])
AssertionError: 'unsafe_limited_markdown_body' not found in []

Ran 4 tests — FAILED (failures=2)
```

`render_warnings == []` against the old detector for the exact shape that shipped the defect. Both pass after.

Three supporting tests:

- `test_native_render_warns_when_limited_profile_ships_an_untransformed_body` — limited profile + raw table body; asserts `missing_render_profile` does *not* also fire, so the two codes stay independently meaningful.
- `test_native_render_reports_no_warnings_for_healthy_producer_payloads` — both real producers (`build_chat_interaction_payload` and `build_chat_route_hint_payload`) across all three limited-markdown sources. **Guards against a vacuous pass**: asserts `render_profile == "limited_markdown"` and non-empty `body_text` on both the payload and the render *before* asserting `render_warnings == []`, and asserts an exact `checked == 18` count so a skipped branch cannot silently empty the loop.
- `test_native_render_stays_silent_for_a_rich_profile_body_that_keeps_tables` — a `rich_markdown` body is *supposed* to keep its table; asserts the new check does not treat that as a defect.

## Validation

- [x] `uv run --group lint ruff check src tests` — `All checks passed!`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests` — `Ran 1790 tests in 49.909s / OK (skipped=1)` (the skip is pre-existing)
- [x] `uv run python -m compileall -q src tests` — clean
- [x] `uv run python -m omh.cli docs workflows --check` — `"ok":true`, tap_skills `checked:97 expected:97`, no missing/stale/extra
- [x] `uv run python -m omh.cli docs roles --check` — `"ok":true`
- [x] `uv run python -m omh.cli docs capability-families --check` — `"ok":true`
- [x] `uv run --group lint ruff check --select BLE001 src` — `Found 11 errors` (unchanged; no broad `except` added)
- [x] `git diff --check` — clean
- [x] `uv run python -m omh.cli harness validate` — `"ok":true`, harnesses 69, skills 90, no errors/warnings
- [x] `uv run python -m omh.cli release checklist --json` — `"ok":true`, mode `plan`, 34 required items
- [x] `uv run python -m omh.cli release hermes-smoke` — plan-only render, boundary text intact
- [x] `omh --help` — renders
- [x] Targeted regression evidence: new tests confirmed **failing** against the pre-change detector via `git stash`, passing after (output above)
- [x] Idempotency probe: 140 real payloads across every chat source and both producer paths, `non_idempotent=0`
- [x] Performance probe: detector 0.47 µs cold / 0.14 µs warm per call
- [ ] Workflow-learning review queue smoke — not applicable, no learning contracts changed
- [ ] `omh ... release hermes-smoke --install-path setup --include-command-smoke` — not run; this change touches no packaging, install, or console-script surface
- [ ] Manual Hermes/TUI check — **not run**. The new codes are contract output only; verifying a wrapper *renders* them needs a live Discord/Slack/Telegram adapter, which is outside this repo. Recorded as `Not-tested:` in the commit.

## Risk

- **Low, and bounded to a new field value.** Existing `render_warnings` values and all other payload keys are unchanged, so a consumer that ignores the list is unaffected.
- The one consumer-visible behavior change: a wrapper asserting `render_warnings == []` on a *legacy-shaped* payload would now see a warning. That is the intended signal, and no in-repo consumer does this — the full suite passes unchanged apart from the new tests.
- `unsafe_limited_markdown_body` rests on `_messenger_safe_body` being idempotent. Verified over 140 real payloads today, but it is an assumption about another module, so it is called out in the `Directive:` trailer.

## Compatibility / Rollout

- No schema version bump. `omh_native_command_render/v1` keeps its shape; `render_warnings` is an open list that gains two possible values.
- Backward compatible for any wrapper that treats the list as advisory, which is what the `claim_boundary` on this payload already states.
- No migration, no persisted state, no generated artifact regeneration.

## Release / Claims

- [x] Release-channel impact considered — no packaging, install, or version surface touched; `local` only
- [x] Runtime/native capability claims are backed by evidence or marked as not observed — all claims above are observed command output; the wrapper-rendering gap is explicitly marked not observed
- [x] Known manual Hermes checks are listed, including the `omh release hermes-smoke --live` gap (not run; no install surface touched)

## Follow-Up

- If a wrapper adapter ever surfaces `render_warnings` to operators, these two codes would want human-readable copy. Not needed while they stay machine-facing.
- The `omh-` display-name question is being handled in parallel and is deliberately untouched here.
