### PR TITLE
Never let suppression make a payload bigger

### DIFF
--- a/src/commands/coding.py
+++ b/src/commands/coding.py
@@ -626,7 +626,7 @@ def cmd_coding_fanout_validate(args: argparse.Namespace) -> int:
 def cmd_coding_fanout_show(args: argparse.Namespace) -> int:
     from ..coding.fanout_artifacts import read_fanout_contract
     from ..runtime.artifacts import show_run
-    from ..runtime.context_budget import payload_fingerprint, run_context_budget
+    from ..runtime.context_budget import payload_fingerprint, run_context_budget, smaller_payload
 
     paths = _paths(args)
     try:
@@ -693,7 +693,8 @@ def cmd_coding_fanout_show(args: argparse.Namespace) -> int:
         ),
     }
     if not full and _fanout_board_unchanged(paths, watched_runs, fingerprint):
-        payload = {
+        full_board = {**board, "context_budget": context_budget, "claim_boundary": contract.get("claim_boundary", "")}
+        payload = smaller_payload(full_board, {
             "schema_version": "fanout_board_unchanged/v1",
             "fanout_id": contract.get("fanout_id"),
             "unchanged_since_last_emission": True,
@@ -702,7 +703,7 @@ def cmd_coding_fanout_show(args: argparse.Namespace) -> int:
             "next_action": "wait_for_new_observed_evidence_instead_of_repeating_this_command",
             "full_output_command": f"omh coding fanout show {contract.get('fanout_id')} --full",
             "claim_boundary": contract.get("claim_boundary", ""),
-        }
+        })
     else:
         payload = {**board, "context_budget": context_budget, "claim_boundary": contract.get("claim_boundary", "")}
     _print_json(payload)

--- a/src/commands/runtime.py
+++ b/src/commands/runtime.py
@@ -49,6 +49,7 @@ from ..runtime.context_budget import (
     record_context_emission,
     run_context_budget,
     run_show_surface,
+    smaller_payload,
     unchanged_progress_status_payload,
     unchanged_run_payload,
 )
@@ -135,7 +136,7 @@ def cmd_runtime_show(args: argparse.Namespace) -> int:
         # artifacts, and its shape is an existing contract.
         payload = degrade_run_payload(shown, budget)
     elif unchanged:
-        payload = unchanged_run_payload(shown, budget)
+        payload = smaller_payload({**shown, "context_budget": budget}, unchanged_run_payload(shown, budget))
     else:
         payload = {**shown, "context_budget": budget}
     _print_json(payload)
@@ -465,7 +466,7 @@ def cmd_runtime_progress_observe(args: argparse.Namespace) -> int:
     except (OSError, ValueError, ExecutorProgressError) as exc:
         raise OmhError(str(exc)) from exc
     if not bool(getattr(args, "full", False)) and not payload.get("reported"):
-        payload = compact_suppressed_observation(payload)
+        payload = smaller_payload(payload, compact_suppressed_observation(payload))
     _print_json(payload)
     return 0
 
@@ -481,7 +482,7 @@ def cmd_runtime_progress_status(args: argparse.Namespace) -> int:
     ledger = run_context_budget(paths, PROGRESS_STATUS_LEDGER_KEY, surface=surface)
     fingerprint = payload_fingerprint(shown)
     if not full and fingerprint == ledger["last_payload_fingerprint"]:
-        payload = unchanged_progress_status_payload(shown, ledger)
+        payload = smaller_payload(shown, unchanged_progress_status_payload(shown, ledger))
     else:
         payload = shown
     _print_json(payload)

--- a/src/runtime/context_budget.py
+++ b/src/runtime/context_budget.py
@@ -79,6 +79,25 @@ def _without_volatile_bookkeeping(payload: Any) -> Any:
     return payload
 
 
+def smaller_payload(original: dict[str, Any], compacted: dict[str, Any]) -> dict[str, Any]:
+    """Return whichever payload is actually smaller.
+
+    A compact replacement carries fixed overhead -- schema version, claim
+    boundary, next action, the full-output hint -- so when the real projection
+    is nearly empty the "compact" form is the larger of the two. Measured on a
+    live fanout dispatch: `progress-status` with no active binding cost 280
+    bytes in full and 854 once "compacted".
+
+    Suppression exists to shrink what reaches agent context. It must never be
+    the reason output grew.
+    """
+    if len(json.dumps(compacted, sort_keys=True, default=str)) < len(
+        json.dumps(original, sort_keys=True, default=str)
+    ):
+        return compacted
+    return original
+
+
 def payload_fingerprint(payload: Any) -> str:
     """Hash what a reader would act on, not every byte of the projection.
 

--- a/tests/test_suppression_never_grows.py
+++ b/tests/test_suppression_never_grows.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from _cli_harness import run_cli
+from _local_package import load_local_package
+
+load_local_package()
+from omh.runtime.context_budget import smaller_payload
+
+
+class SmallerPayloadTests(unittest.TestCase):
+    """Suppression must never be the reason output grew.
+
+    A compact replacement carries fixed overhead -- schema version, claim
+    boundary, next action, full-output hint -- so on a nearly-empty projection
+    it is the larger of the two. Measured on a live fanout dispatch:
+    `progress-status` with no active binding cost 280 bytes in full and 856
+    once "compacted".
+    """
+
+    def test_the_compact_form_wins_when_it_is_smaller(self) -> None:
+        original = {"rows": ["x" * 500], "detail": "y" * 500}
+        compacted = {"count": 1, "unchanged_since_last_emission": True}
+        self.assertIs(smaller_payload(original, compacted), compacted)
+
+    def test_the_original_wins_when_the_compact_form_is_larger(self) -> None:
+        original = {"rows": []}
+        compacted = {
+            "unchanged_since_last_emission": True,
+            "claim_boundary": "a long contract sentence " * 10,
+            "next_action": "wait_for_new_observed_evidence_instead_of_repeating_this_command",
+        }
+        self.assertIs(smaller_payload(original, compacted), original)
+
+    def test_it_handles_values_json_cannot_serialize_directly(self) -> None:
+        original = {"path": Path("/tmp/x"), "rows": ["x" * 200]}
+        compacted = {"count": 0}
+        self.assertIs(smaller_payload(original, compacted), compacted)
+
+
+class SuppressionNeverGrowsOnRealSurfacesTests(unittest.TestCase):
+    def _base(self, root: Path) -> list[str]:
+        return ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+
+    def test_progress_status_with_no_bindings_never_grows_when_repeated(self) -> None:
+        """The exact shape a live fanout dispatch produced: nothing bound."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = self._base(root)
+
+            sizes = []
+            for _ in range(4):
+                status, stdout, stderr = run_cli(base + ["runtime", "progress-status"])
+                self.assertEqual(stderr, "")
+                self.assertEqual(status, 0)
+                sizes.append(len(stdout.strip()))
+
+            self.assertEqual(
+                max(sizes),
+                sizes[0],
+                f"a repeated call must not be larger than the first: {sizes}",
+            )
+
+    def test_a_repeated_run_show_never_grows(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = self._base(root)
+            status, stdout, stderr = run_cli(
+                base + ["runtime", "record", "--skill", "oh-my-hermes", "--harness", "coding-handling"]
+            )
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            run_id = json.loads(stdout)["run"]["run_id"]
+
+            sizes = []
+            for _ in range(3):
+                status, stdout, stderr = run_cli(base + ["runtime", "show", run_id])
+                self.assertEqual(stderr, "")
+                self.assertEqual(status, 0)
+                sizes.append(len(stdout.strip()))
+
+            self.assertEqual(max(sizes), sizes[0], f"repeat calls must not grow: {sizes}")
+
+    def test_a_suppressed_observation_never_grows(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = self._base(root)
+            status, stdout, stderr = run_cli(
+                base + ["runtime", "record", "--skill", "oh-my-hermes", "--harness", "coding-handling"]
+            )
+            self.assertEqual(status, 0, stderr)
+            run_id = json.loads(stdout)["run"]["run_id"]
+            status, _stdout, stderr = run_cli(
+                base
+                + [
+                    "runtime", "progress-bind", "--run", run_id,
+                    "--executor-profile", "claude_code", "--claude-session-ref", "s1",
+                ]
+            )
+            self.assertEqual(status, 0, stderr)
+
+            observe = base + [
+                "runtime", "progress-observe", "--run", run_id,
+                "--process-status", "running",
+                "--profile-status", "running",
+                "--profile-latest-event", "repo_exploration",
+                "--profile-summary", "inspecting",
+            ]
+            sizes = []
+            for _ in range(3):
+                status, stdout, stderr = run_cli(observe)
+                self.assertEqual(stderr, "")
+                self.assertEqual(status, 0)
+                sizes.append(len(stdout.strip()))
+
+            self.assertEqual(max(sizes), sizes[0], f"suppressed calls must not grow: {sizes}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

Every compact/suppressed payload now goes through `smaller_payload`, which emits the compact form **only when it is genuinely smaller**. Applied at all four suppression points: `runtime show`, `runtime progress-status`, `runtime progress-observe`, and the fanout board.

### Why This Exists

Follow-up to #658 / #660 / #661, and the first finding in this series that came from a **real dispatch** rather than a simulation.

I ran an actual delegated coding job through `omh coding fanout dispatch` — two units, `claude-code` and `codex`, in separate worktrees — then polled the observe surfaces the way a supervising agent would and counted bytes. `progress-status` came back costing **more** with suppression on:

```
progress-status    quiet 2,841 bytes    --full 1,120 bytes
```

A fanout dispatch creates no executor progress bindings, so the real projection is nearly empty — **280 bytes** — while the compact replacement carries fixed overhead for schema version, claim boundary, next action, and full-output hint: **854 bytes**. Suppression was inflating output by 3x on the exact shape it was supposed to shrink.

The simulation never surfaced this because every simulated scenario had bindings, so the projection was never small enough for the overhead to dominate.

### User / Operator Impact

Measured on the same live session, cold ledger:

| Surface | Before this fix | After | `--full` |
|---|---|---|---|
| `runtime show` (both units) | 16,338 | 16,338 | 40,105 |
| `fanout show` | 3,428 | 3,428 | 4,492 |
| `progress-status` | **2,841** | **1,120** | 1,120 |
| **Total, 16 calls** | 22,607 | **20,886** | 45,690 |

`progress-status` now costs exactly what `--full` costs on an empty projection, instead of two and a half times more. Overall the supervising session is **54% smaller than `--full`**.

### How It Works

One helper, one rule: compare the serialized length and return the shorter payload. It can only return something that was already going to be correct — whichever is shorter — so it cannot change semantics.

### Files And Contracts Touched

- `src/runtime/context_budget.py` — `smaller_payload`
- `src/commands/runtime.py`, `src/commands/coding.py` — the four suppression points
- `tests/test_suppression_never_grows.py` (new)

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `python3 -m unittest discover -s tests` — **1792 passed**, 1 skipped
- [x] `python3 -m compileall src`
- [x] `python3 -m omh.cli docs workflows --check` (also `docs roles`, `docs capability-families`)
- [x] `python3 -m omh.cli harness validate`
- [x] `python3 -m omh.cli release hermes-smoke`
- [x] `python3 -m omh.cli release drift`
- [x] **Live `omh coding fanout dispatch`** — two units, both exit 0, each producing the scoped commit it was asked for
- [x] Negative check reproduces the measured `[280, 853, 854, 854]` when the guard is removed
- [ ] Manual Hermes/TUI check — **not run.**

### Measurement honesty note

An intermediate measurement showed 71% reduction. That number was inflated: the ledger was still warm from the previous measurement run, so the first quiet call already matched and suppressed. Clearing this fanout's ledger entries and measuring once gives **54%**, which is the number reported above.

## Risk

- **Low.** The guard can only return one of two payloads that were both already correct.
- Callers that assumed a repeated call always carries `unchanged_since_last_emission` will not see it when the full projection was already smaller. The flag was never a guarantee of suppression, and the full payload is a superset.

## Compatibility / Rollout

- No new dependencies, no schema changes. Purely a choice between two existing shapes.

## Release / Claims

- [x] Release-channel impact considered — `local`.
- [x] Every number comes from a live dispatch, not from inspection or simulation.
- [x] Manual gaps listed above.

## Follow-Up

- Hermes chat **message counts** remain unmeasured. OMH cannot observe them; this measures what the surfaces hand a supervising agent, which is the closest thing OMH can prove.
