### PR TITLE
Enable the plugin setup installs, and let doctor notice when it is off

### DIFF
--- a/src/commands/setup.py
+++ b/src/commands/setup.py
@@ -22,7 +22,14 @@ from ..version import __version__
 from ..command_path import COMMAND_PATH_MISSING_NEXT_ACTION, inspect_omh_command_path
 from ..capabilities.registry import capability_summary
 from ..capabilities.skills import skill_capabilities
-from ..config_adapter import ensure_external_dir, external_dirs, read_config, remove_external_dir, write_config
+from ..config_adapter import (
+    ensure_external_dir,
+    ensure_plugin_enabled,
+    external_dirs,
+    read_config,
+    remove_external_dir,
+    write_config,
+)
 from ..install.compression_defaults import ensure_compression_defaults
 from ..doctor import DEFAULT_DOCTOR_NEXT_ACTION, doctor_ok, recommended_next_action, run_doctor
 from ..maintenance.doctor import run_doctor_advisories
@@ -41,7 +48,7 @@ from ..manifest import read_manifest
 from ..menubar_app import setup_menubar_app, uninstall_menubar_app
 from ..mcp.host_config import install_mcp_host_config
 from ..mcp_bridge import MCP_HOST_CONFIG_RECIPE_HOSTS
-from ..plugin_pack import PluginPackError, install_plugin_bundle
+from ..plugin_pack import PLUGIN_NAME, PluginPackError, install_plugin_bundle
 from ..probe import probe_capabilities
 from ..release import RELEASE_CHANNELS, package_url_for
 from ..routing.recommend import recommend_skills
@@ -686,10 +693,14 @@ def _apply_result(args: argparse.Namespace) -> dict[str, object]:
     try:
         change = ensure_external_dir(current, paths.skills_dir)
         compression = ensure_compression_defaults(change.text)
+        # Installing the bridge and switching it on are separate steps in
+        # Hermes. Doing only the first leaves an install that passes every
+        # structural check while no OMH tool is reachable in chat.
+        plugin_enable = ensure_plugin_enabled(compression.text, PLUGIN_NAME)
     except ValueError as exc:
         raise OmhError(str(exc)) from exc
-    if not args.dry_run and (change.changed or compression.changed):
-        write_config(paths.hermes_config_path, compression.text)
+    if not args.dry_run and (change.changed or compression.changed or plugin_enable.changed):
+        write_config(paths.hermes_config_path, plugin_enable.text)
     if not args.dry_run:
         update_state(
             paths,
@@ -706,6 +717,7 @@ def _apply_result(args: argparse.Namespace) -> dict[str, object]:
         "skills_dir": str(paths.skills_dir),
         "dry_run": args.dry_run,
         "compression_defaults": {"changed": compression.changed, "message": compression.message},
+        "plugin_enabled": {"changed": plugin_enable.changed, "message": plugin_enable.message},
     }
 
 

--- a/src/install/config_adapter.py
+++ b/src/install/config_adapter.py
@@ -128,6 +128,95 @@ def external_dirs(config_text: str) -> list[str]:
     return result
 
 
+def plugin_enablement(config_text: str) -> dict[str, list[str]]:
+    """Read Hermes' `plugins.enabled` / `plugins.disabled` lists.
+
+    Read-only, and shaped like `external_dirs` above rather than pulling in a
+    YAML parser, since the core stays dependency-free.
+
+    A bundle can be installed, importable, and register cleanly while Hermes
+    still refuses to load it, because enablement lives here and nowhere else.
+    `omh doctor` reported `Hermes registration: ok (4/4)` against exactly that
+    state, so every OMH tool was unreachable in chat while the install looked
+    healthy.
+    """
+    lists: dict[str, list[str]] = {"enabled": [], "disabled": []}
+    in_plugins = False
+    current = ""
+    for line in config_text.splitlines():
+        stripped = line.strip()
+        if not line.startswith(" ") and stripped:
+            in_plugins = stripped == "plugins:"
+            current = ""
+            continue
+        if not in_plugins or not stripped:
+            continue
+        if line.startswith("  ") and not line.startswith("    "):
+            key, _, rest = stripped.partition(":")
+            key = key.strip()
+            inline = _parse_inline_list(rest.strip()) if rest.strip() else None
+            if key in lists and inline is not None:
+                lists[key] = list(inline)
+                current = ""
+                continue
+            current = key if key in lists else ""
+            continue
+        if current and stripped.startswith("- "):
+            lists[current].append(stripped[2:].strip().strip("\"'"))
+    return lists
+
+
+def plugin_is_enabled(config_text: str, name: str) -> bool:
+    listed = plugin_enablement(config_text)
+    return name in listed["enabled"] and name not in listed["disabled"]
+
+
+def ensure_plugin_enabled(config_text: str, name: str) -> ConfigChange:
+    """Add `name` to `plugins.enabled` so Hermes will actually load the bridge.
+
+    Installing the bundle and enabling it are separate steps, and setup only did
+    the first. The result is an install that passes every structural check while
+    no OMH tool is reachable in chat.
+
+    Never un-disables: if the plugin is listed under `plugins.disabled` that is a
+    deliberate opt-out, and setup must not override it. `omh doctor` reports that
+    state instead.
+    """
+    listed = plugin_enablement(config_text)
+    if name in listed["disabled"]:
+        return ConfigChange(False, f"{name} is explicitly disabled; leaving it alone", config_text)
+    if name in listed["enabled"]:
+        return ConfigChange(False, "plugin already enabled", config_text)
+
+    lines = config_text.splitlines()
+    plugins_index = next(
+        (idx for idx, line in enumerate(lines) if line.strip() == "plugins:" and not line.startswith(" ")),
+        None,
+    )
+    if plugins_index is None:
+        text = (config_text.rstrip() + f"\n\nplugins:\n  enabled:\n    - {name}\n").lstrip("\n")
+        return ConfigChange(True, "appended plugins.enabled", text)
+
+    for idx in range(plugins_index + 1, len(lines)):
+        line = lines[idx]
+        if line.strip() and not line.startswith(" "):
+            break
+        if line.startswith("  ") and not line.startswith("    "):
+            key, _, rest = line.strip().partition(":")
+            if key.strip() != "enabled":
+                continue
+            inline = _parse_inline_list(rest.strip()) if rest.strip() else None
+            if inline is not None:
+                lines[idx:idx + 1] = ["  enabled:", *[f"    - {value}" for value in [*inline, name]]]
+                return ConfigChange(True, "expanded inline plugins.enabled", "\n".join(lines) + "\n")
+            lines.insert(idx + 1, f"    - {name}")
+            return ConfigChange(True, "added plugin to plugins.enabled", "\n".join(lines) + "\n")
+
+    lines.insert(plugins_index + 1, f"    - {name}")
+    lines.insert(plugins_index + 1, "  enabled:")
+    return ConfigChange(True, "inserted plugins.enabled", "\n".join(lines) + "\n")
+
+
 def ensure_external_dir(config_text: str, skill_dir: str | Path) -> ConfigChange:
     _validate_external_dirs_mutation_shape(config_text)
     target = _normalize(skill_dir)

--- a/src/maintenance/doctor.py
+++ b/src/maintenance/doctor.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from .advisory import AdvisoryReport, run_config_advisories
 from ..command_path import inspect_omh_command_path
-from ..config_adapter import external_dirs, read_config
+from ..config_adapter import external_dirs, plugin_enablement, plugin_is_enabled, read_config
 from ..hashutil import sha256_file
 from ..local_store import can_write_dir
 from ..manifest import local_modifications, read_manifest
@@ -15,7 +15,7 @@ from ..plugin_observations import (
     latest_plugin_host_observation,
     plugin_host_runtime_readiness,
 )
-from ..plugin_pack import inspect_plugin_bundle
+from ..plugin_pack import PLUGIN_NAME, inspect_plugin_bundle
 from ..runtime.artifacts import read_state, read_state_error
 from ..skill_pack import CORE_SKILLS
 from ..targets import read_target_registry_result, summarize_target_registry
@@ -250,6 +250,7 @@ def run_doctor(paths: OmhPaths) -> list[Check]:
                     ),
                     observed=bool(latest_plugin_observation and latest_plugin_observation.get("observed")),
                 ),
+                _plugin_enabled_check(paths),
             ]
         )
     profile_installs = state.get("last_team_profile_install") if isinstance(state, dict) else None
@@ -367,6 +368,56 @@ def recommended_next_action(checks: list[Check]) -> str:
     if prioritized_warnings:
         return prioritized_warnings[0].next_action
     return DEFAULT_DOCTOR_NEXT_ACTION
+
+
+def _plugin_enabled_check(paths: OmhPaths) -> Check:
+    """Is the installed bridge actually switched on in Hermes?
+
+    Every other plugin check asks whether the bundle is installed, importable,
+    and registrable. None of them ask whether Hermes will load it, and that is a
+    separate switch in `plugins.enabled`. An install can pass all of them while
+    the plugin sits disabled, which is exactly what a live check found: doctor
+    reported `Hermes registration: ok (4/4)` while no OMH tool was reachable in
+    chat, so the whole tool surface was dark with nothing reporting it.
+    """
+    config_path = paths.hermes_config_path
+    try:
+        config_text = config_path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return Check(
+            "plugin_enabled_in_hermes",
+            True,
+            f"no Hermes config at {config_path} yet; enablement cannot be read",
+            severity="ok",
+            observed=False,
+        )
+    except OSError as exc:
+        return Check(
+            "plugin_enabled_in_hermes",
+            True,
+            f"Hermes config unreadable: {exc}",
+            severity="warning",
+            observed=False,
+            next_action="Make the Hermes config readable, then rerun `omh doctor`.",
+        )
+    if plugin_is_enabled(config_text, PLUGIN_NAME):
+        return Check(
+            "plugin_enabled_in_hermes",
+            True,
+            f"`{PLUGIN_NAME}` is enabled in {config_path}",
+        )
+    listed = plugin_enablement(config_text)
+    reason = "listed as disabled" if PLUGIN_NAME in listed["disabled"] else "not in plugins.enabled"
+    return Check(
+        "plugin_enabled_in_hermes",
+        False,
+        (
+            f"`{PLUGIN_NAME}` is installed but {reason} in {config_path}; "
+            "Hermes will not load it, so no OMH tool is reachable in chat"
+        ),
+        remediation=f"Run `hermes plugins enable {PLUGIN_NAME}`.",
+        next_action=f"Run `hermes plugins enable {PLUGIN_NAME}`, then restart or reload Hermes and rerun `omh doctor`.",
+    )
 
 
 def _plugin_bridge_message(plugin: dict) -> str:

--- a/tests/test_plugin_enablement_check.py
+++ b/tests/test_plugin_enablement_check.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from _cli_harness import run_cli
+from _local_package import load_local_package
+
+load_local_package()
+from omh.config_adapter import plugin_enablement, plugin_is_enabled
+from omh.maintenance.doctor import run_doctor
+from omh.paths import resolve_paths
+from omh.plugin_pack import PLUGIN_NAME
+
+
+ENABLED_CONFIG = """skills:
+  external_dirs: []
+
+plugins:
+  enabled:
+    - omh
+  disabled: []
+  entries:
+    omh:
+      allow_tool_override: false
+"""
+
+DISABLED_CONFIG = ENABLED_CONFIG.replace("  enabled:\n    - omh\n", "  enabled:\n")
+
+
+class PluginEnablementReaderTests(unittest.TestCase):
+    """Hermes keeps enablement in `plugins.enabled` and nowhere else."""
+
+    def test_block_list_form(self) -> None:
+        self.assertTrue(plugin_is_enabled(ENABLED_CONFIG, PLUGIN_NAME))
+        self.assertFalse(plugin_is_enabled(DISABLED_CONFIG, PLUGIN_NAME))
+
+    def test_inline_list_form(self) -> None:
+        self.assertTrue(plugin_is_enabled("plugins:\n  enabled: [omh, other]\n  disabled: []\n", PLUGIN_NAME))
+        self.assertFalse(plugin_is_enabled("plugins:\n  enabled: []\n  disabled: []\n", PLUGIN_NAME))
+
+    def test_explicitly_disabled_outranks_enabled(self) -> None:
+        text = "plugins:\n  enabled:\n    - omh\n  disabled:\n    - omh\n"
+        self.assertFalse(plugin_is_enabled(text, PLUGIN_NAME))
+
+    def test_quoted_items_are_read(self) -> None:
+        self.assertTrue(plugin_is_enabled('plugins:\n  enabled:\n    - "omh"\n  disabled: []\n', PLUGIN_NAME))
+
+    def test_a_config_without_a_plugins_block_is_not_enabled(self) -> None:
+        self.assertFalse(plugin_is_enabled("skills:\n  external_dirs: []\n", PLUGIN_NAME))
+
+    def test_another_plugin_does_not_count(self) -> None:
+        self.assertFalse(plugin_is_enabled("plugins:\n  enabled:\n    - browser\n  disabled: []\n", PLUGIN_NAME))
+
+    def test_enablement_reports_both_lists(self) -> None:
+        listed = plugin_enablement("plugins:\n  enabled:\n    - omh\n  disabled:\n    - browser\n")
+        self.assertEqual(listed, {"enabled": ["omh"], "disabled": ["browser"]})
+
+
+class DoctorPluginEnabledCheckTests(unittest.TestCase):
+    """The gap this closes: everything installed, nothing reachable.
+
+    A live check found `omh doctor` reporting `Hermes registration: ok (4/4)`
+    while the plugin sat disabled in Hermes, so no OMH tool was callable in chat
+    and no check said so. Bundle installed, importable, and registrable are all
+    separate questions from whether Hermes will load it.
+    """
+
+    def _paths(self, root: Path, config_text: str):
+        hermes = root / ".hermes"
+        (hermes / "plugins" / PLUGIN_NAME).mkdir(parents=True)
+        (hermes / "config.yaml").write_text(config_text, encoding="utf-8")
+        return resolve_paths(root / ".omh", hermes)
+
+    def _check(self, checks, name: str):
+        return next((c for c in checks if c.name == name), None)
+
+    def test_a_disabled_plugin_is_a_blocking_check(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = self._paths(Path(tmp), DISABLED_CONFIG)
+            check = self._check(run_doctor(paths), "plugin_enabled_in_hermes")
+            self.assertIsNotNone(check)
+            self.assertFalse(check.ok)
+            self.assertEqual(check.severity, "blocking")
+            self.assertIn("not in plugins.enabled", check.message)
+            self.assertIn("no OMH tool is reachable", check.message)
+            self.assertIn(f"hermes plugins enable {PLUGIN_NAME}", check.remediation)
+
+    def test_an_enabled_plugin_passes(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = self._paths(Path(tmp), ENABLED_CONFIG)
+            check = self._check(run_doctor(paths), "plugin_enabled_in_hermes")
+            self.assertIsNotNone(check)
+            self.assertTrue(check.ok, check.message)
+
+    def test_an_explicitly_disabled_plugin_says_so(self) -> None:
+        with TemporaryDirectory() as tmp:
+            text = "plugins:\n  enabled:\n    - omh\n  disabled:\n    - omh\n"
+            paths = self._paths(Path(tmp), text)
+            check = self._check(run_doctor(paths), "plugin_enabled_in_hermes")
+            self.assertFalse(check.ok)
+            self.assertIn("listed as disabled", check.message)
+
+    def test_a_missing_config_does_not_block(self) -> None:
+        """Before setup runs there is nothing to enable, and that is not a fault."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / ".hermes" / "plugins" / PLUGIN_NAME).mkdir(parents=True)
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            check = self._check(run_doctor(paths), "plugin_enabled_in_hermes")
+            self.assertTrue(check.ok)
+            self.assertFalse(check.observed)
+
+    def test_the_check_only_runs_when_a_bundle_is_installed(self) -> None:
+        """No installed bridge means nothing to enable; doctor must not invent a fault."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / ".hermes").mkdir(parents=True)
+            (root / ".hermes" / "config.yaml").write_text(DISABLED_CONFIG, encoding="utf-8")
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            self.assertIsNone(self._check(run_doctor(paths), "plugin_enabled_in_hermes"))
+
+
+class SetupEnablesThePluginTests(unittest.TestCase):
+    """Installing the bridge without switching it on is the same as not shipping it."""
+
+    def test_setup_leaves_the_plugin_enabled_and_doctor_clean(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+
+            status, _stdout, stderr = run_cli(base + ["setup"])
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+
+            config_text = (root / ".hermes" / "config.yaml").read_text(encoding="utf-8")
+            self.assertTrue(
+                plugin_is_enabled(config_text, PLUGIN_NAME),
+                f"setup installed the bridge without enabling it: {plugin_enablement(config_text)}",
+            )
+
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            check = next((c for c in run_doctor(paths) if c.name == "plugin_enabled_in_hermes"), None)
+            self.assertIsNotNone(check)
+            self.assertTrue(check.ok, check.message)
+
+    def test_setup_does_not_re_enable_a_deliberate_opt_out(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+            status, _stdout, stderr = run_cli(base + ["setup"])
+            self.assertEqual(status, 0, stderr)
+
+            config_path = root / ".hermes" / "config.yaml"
+            opted_out = config_path.read_text(encoding="utf-8").replace(
+                "  enabled:\n    - omh\n", "  enabled:\n  disabled:\n    - omh\n"
+            )
+            config_path.write_text(opted_out, encoding="utf-8")
+
+            status, _stdout, stderr = run_cli(base + ["setup"])
+            self.assertEqual(status, 0, stderr)
+            self.assertFalse(
+                plugin_is_enabled(config_path.read_text(encoding="utf-8"), PLUGIN_NAME),
+                "setup must not override an explicit opt-out",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- `omh setup` now adds the plugin to `plugins.enabled` in the Hermes config, alongside the `skills.external_dirs` entry it already writes.
- `omh doctor` gains a `plugin_enabled_in_hermes` check that blocks, with the exact repair command, when the installed bridge is not enabled.

### Why This Exists

I ran a real Hermes delegation to count messages and found **zero OMH tool calls**. The cause was not routing or prompts:

```
$ hermes plugins list
omh    not enabled    1.0.2    Oh My Hermes native bridge
```

The bundle was installed. Hermes simply never loaded it, so the entire OMH tool surface was unreachable in chat.

Meanwhile `omh doctor` said:

```
Status: ok        Checks: 26/26 passing        Issues: 0 blocking
Hermes registration: ok (4/4)
Plugin bridge: ready locally; import/register smoke passed.
```

Every existing plugin check asks whether the bundle is **installed**, **importable**, or **registrable**. None asks whether Hermes will **load** it, because enablement is a separate switch that lives only in `plugins.enabled`. An install can pass all four checks and still be completely dark.

### The suite proved the second half on its own

Adding the doctor check first turned **fifteen** existing setup-then-doctor tests red — because setup genuinely was not enabling the plugin. Teaching setup to enable it turned all fifteen green **without touching a single expectation**. The failures were the finding, not noise.

### User / Operator Impact

| | Before | After |
|---|---|---|
| After `omh setup` | bundle installed, plugin off, no OMH tool in chat | plugin enabled and usable |
| `omh doctor` with the plugin off | `ok, 26/26` | blocking, names the repair command |
| Explicit `plugins.disabled` opt-out | n/a | respected; setup never overrides it |

### How It Works

- `plugin_enablement` / `plugin_is_enabled` read `plugins.enabled` and `plugins.disabled`. Line-based, in the same shape `external_dirs` already uses — the core stays dependency-free, so no YAML parser was added.
- `ensure_plugin_enabled` handles every config shape observed: block list, inline list, empty `enabled:`, a `plugins:` block with only `entries:`, no `plugins:` block at all, and an empty file.
- Doctor diagnoses; setup repairs. Doctor never edits the config.

### Files And Contracts Touched

- `src/install/config_adapter.py` — `plugin_enablement`, `plugin_is_enabled`, `ensure_plugin_enabled`
- `src/maintenance/doctor.py` — `plugin_enabled_in_hermes`
- `src/commands/setup.py` — apply step, plus a `plugin_enabled` field in its result payload
- `tests/test_plugin_enablement_check.py` (new)

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `python3 -m unittest discover -s tests` — **1827 passed**, 1 skipped
- [x] `python3 -m compileall src`
- [x] `python3 -m omh.cli docs workflows --check` (also `docs roles`, `docs capability-families`)
- [x] `python3 -m omh.cli harness validate`
- [x] `python3 -m omh.cli release checklist --json`
- [x] `python3 -m omh.cli release hermes-smoke`
- [x] `python3 -m omh.cli release drift`
- [x] **Reproduced the live failure**: a copy of the real Hermes config with `omh` removed from `plugins.enabled` makes doctor report `needs attention, 26/27, 1 blocking` with `Run \`hermes plugins enable omh\``
- [x] Live doctor against the real config: `27/27 passing`
- [ ] Manual Hermes/TUI check of the enabled plugin in a fresh install — **not run.**

## Risk

- **Moderate:** `omh setup` now writes one additional key into the user's Hermes config. It is the same block setup already manages, and an explicit `plugins.disabled` entry is never overridden.
- The reader is line-based rather than a YAML parse. Seven config shapes are covered by tests, but an exotic hand-edited layout could read as "not enabled" and produce a false blocking check. The remediation is harmless if run against an already-enabled plugin.

## Compatibility / Rollout

- No new dependencies. No schema removed or renamed.
- Existing installs with the plugin already enabled see no config change (`ConfigChange.changed` is false).
- Installs currently in the broken state get repaired on the next `omh setup`.

## Release / Claims

- [x] Release-channel impact considered — `local`.
- [x] The diagnosis came from a live Hermes run and a real config, not from inspection.
- [x] Manual gaps listed above.

## Follow-Up

- **Message-count measurement is still unproven.** One delegated run with the plugin off produced 49 messages and one with it on produced 36. That is n=1 per side with a single `omh_context` call, so it is not a causal claim. Repeated runs are needed before anyone quotes a percentage.
- Korean coding requests misroute: `코딩 에이전트한테 ... 시켜줘` routes to `workflow-learning` while the English equivalent routes to `ultraprocess`. Separate defect, not addressed here.
