### PR TITLE
Record whether OMH awareness actually reached the model

### DIFF
--- a/src/maintenance/doctor.py
+++ b/src/maintenance/doctor.py
@@ -251,6 +251,7 @@ def run_doctor(paths: OmhPaths) -> list[Check]:
                     observed=bool(latest_plugin_observation and latest_plugin_observation.get("observed")),
                 ),
                 _plugin_enabled_check(paths),
+                _awareness_delivery_check(paths),
             ]
         )
     profile_installs = state.get("last_team_profile_install") if isinstance(state, dict) else None
@@ -368,6 +369,50 @@ def recommended_next_action(checks: list[Check]) -> str:
     if prioritized_warnings:
         return prioritized_warnings[0].next_action
     return DEFAULT_DOCTOR_NEXT_ACTION
+
+
+def _awareness_delivery_check(paths: OmhPaths) -> Check:
+    """Has OMH's primer and route hint actually reached the model?
+
+    Reported, never blocking. A fresh install has legitimately delivered
+    nothing, and Hermes may not have been restarted since the bundle changed, so
+    a zero here is ambiguous in a way `plugin_enabled_in_hermes` is not. What it
+    buys is a way to tell "the bridge is on but silent" from "the bridge is
+    working", which previously nothing could distinguish.
+    """
+    from ..plugin_bundle.omh.awareness_delivery import read_awareness_delivery
+
+    record = read_awareness_delivery(str(paths.omh_home))
+    if record.get("unreadable"):
+        return Check(
+            "awareness_delivery",
+            True,
+            "awareness delivery ledger is unreadable",
+            severity="warning",
+            observed=False,
+            next_action="Delete the ledger and run one Hermes turn to repopulate it.",
+        )
+    delivered = int(record.get("delivery_count", 0) or 0)
+    if not delivered:
+        return Check(
+            "awareness_delivery",
+            True,
+            (
+                "no OMH awareness delivered to a model yet; run one Hermes turn, "
+                "restarting Hermes first if the bundle changed"
+            ),
+            severity="ok",
+            observed=False,
+        )
+    return Check(
+        "awareness_delivery",
+        True,
+        (
+            f"{delivered} awareness injection(s) observed, "
+            f"{int(record.get('route_hint_count', 0) or 0)} with a route hint; "
+            f"last at {record.get('last_delivered_at', 'unknown')}"
+        ),
+    )
 
 
 def _plugin_enabled_check(paths: OmhPaths) -> Check:

--- a/src/plugin_bundle/omh/awareness_delivery.py
+++ b/src/plugin_bundle/omh/awareness_delivery.py
@@ -1,0 +1,104 @@
+"""Did OMH's awareness actually reach the model?
+
+`pre_llm_call` is how OMH gets its primer and route hint in front of Hermes.
+Nothing recorded whether that ever happened:
+
+- `host_observation` drops a record entirely unless the caller supplies `host`
+  and `session_id`, and Hermes does not pass either to `pre_llm_call`. The
+  ledger therefore stayed at eight `pre_verify` rows from a single day while
+  live turns ran.
+- Hermes wraps every hook callback in try/except and only logs a warning, so a
+  hook that raises disappears without a user-visible trace.
+
+Between those two, awareness could be dead for weeks and the only symptom would
+be a user learning to type "load OMH" by hand. This records the one fact that
+distinguishes those worlds.
+
+Counters, not an append-only log. A per-turn log on the hottest path in the
+system is how a journal reached ~4.7k rows of noise; a fixed-shape counter file
+cannot grow.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+
+AWARENESS_DELIVERY_SCHEMA_VERSION = "omh_awareness_delivery/v1"
+AWARENESS_DELIVERY_FILE = "awareness_delivery.json"
+
+
+def _runtime_dir(omh_home: str = "") -> Path:
+    root = Path(os.path.expandvars(omh_home or os.environ.get("OMH_HOME", "~/.omh"))).expanduser()
+    return root / "runtime"
+
+
+def awareness_delivery_path(omh_home: str = "") -> Path:
+    return _runtime_dir(omh_home) / AWARENESS_DELIVERY_FILE
+
+
+def read_awareness_delivery(omh_home: str = "") -> dict[str, Any]:
+    """Current counters, or an empty record when nothing has been delivered."""
+    try:
+        data = json.loads(awareness_delivery_path(omh_home).read_text(encoding="utf-8"))
+    except (FileNotFoundError, NotADirectoryError):
+        return _empty()
+    except (OSError, json.JSONDecodeError):
+        return {**_empty(), "unreadable": True}
+    if not isinstance(data, dict):
+        return {**_empty(), "unreadable": True}
+    return {**_empty(), **data}
+
+
+def _empty() -> dict[str, Any]:
+    return {
+        "schema_version": AWARENESS_DELIVERY_SCHEMA_VERSION,
+        "delivery_count": 0,
+        "route_hint_count": 0,
+        "suppressed_count": 0,
+        "first_delivered_at": "",
+        "last_delivered_at": "",
+        "last_context_chars": 0,
+        "unreadable": False,
+    }
+
+
+def record_awareness_delivery(
+    *,
+    delivered: bool,
+    route_hint: bool,
+    context_chars: int,
+    observed_at: str,
+    omh_home: str = "",
+) -> dict[str, Any] | None:
+    """Bump the counters for one `pre_llm_call`. Best-effort and metadata-only.
+
+    Records that awareness was assembled and how big it was, never what it said:
+    the prompt and the hint text stay out of this file, as they stay out of
+    every other OMH ledger.
+
+    A write failure returns None rather than raising. Losing a counter is
+    acceptable; breaking the hook that feeds the model is not.
+    """
+    current = read_awareness_delivery(omh_home)
+    updated = {
+        "schema_version": AWARENESS_DELIVERY_SCHEMA_VERSION,
+        "delivery_count": int(current["delivery_count"]) + (1 if delivered else 0),
+        "route_hint_count": int(current["route_hint_count"]) + (1 if route_hint else 0),
+        "suppressed_count": int(current["suppressed_count"]) + (0 if delivered else 1),
+        "first_delivered_at": current["first_delivered_at"] or (observed_at if delivered else ""),
+        "last_delivered_at": observed_at if delivered else current["last_delivered_at"],
+        "last_context_chars": max(0, int(context_chars)) if delivered else int(current["last_context_chars"]),
+    }
+    path = awareness_delivery_path(omh_home)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(updated, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        tmp.replace(path)
+    except OSError:
+        return None
+    return updated

--- a/src/plugin_bundle/omh/hooks/llm_hooks.py
+++ b/src/plugin_bundle/omh/hooks/llm_hooks.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
+
 from ..awareness import (
     awareness_context_match_degradation,
     awareness_context_matches_message,
@@ -14,6 +16,7 @@ from ..degradation import (
     degradation_payload,
     safe_error_type,
 )
+from ..awareness_delivery import record_awareness_delivery
 from ..host_observation import observe_plugin_hook_call
 from ..omh_roles import extract_role_marker, role_context_payload
 from ..runtime_reader import read_omh_hud, read_omh_status
@@ -28,6 +31,19 @@ def _token_metadata_from_kwargs(kwargs: dict) -> dict[str, object]:
         "context_remaining_percent",
     )
     return {key: kwargs[key] for key in keys if kwargs.get(key) is not None}
+
+
+def _record_delivery(*, delivered: bool, route_hint: bool, context_chars: int) -> None:
+    """Note that this hook ran. Never let bookkeeping break the hook itself."""
+    try:
+        record_awareness_delivery(
+            delivered=delivered,
+            route_hint=route_hint,
+            context_chars=context_chars,
+            observed_at=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        )
+    except (OSError, ValueError, TypeError):
+        return
 
 
 def pre_llm_call(**kwargs) -> dict[str, object] | None:
@@ -123,6 +139,7 @@ def pre_llm_call(**kwargs) -> dict[str, object] | None:
         and not status.get("runtime_state_present")
         and not status.get("runs")
     ):
+        _record_delivery(delivered=False, route_hint=False, context_chars=0)
         return None
 
     if status.get("runtime_state_present") or status.get("runs"):
@@ -161,4 +178,9 @@ def pre_llm_call(**kwargs) -> dict[str, object] | None:
             "that failure only: not execution, review, CI, merge-readiness, or merge evidence."
         )
     payload["context"] = "\n\n".join(context_parts)
+    _record_delivery(
+        delivered=True,
+        route_hint=bool(route_hint_context),
+        context_chars=len(payload["context"]),
+    )
     return payload

--- a/tests/test_awareness_delivery.py
+++ b/tests/test_awareness_delivery.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.plugin_bundle.omh.awareness_delivery import (
+    AWARENESS_DELIVERY_SCHEMA_VERSION,
+    awareness_delivery_path,
+    read_awareness_delivery,
+    record_awareness_delivery,
+)
+
+
+class AwarenessDeliveryLedgerTests(unittest.TestCase):
+    """Whether OMH's primer and route hint actually reached the model.
+
+    Nothing recorded this. `host_observation` drops a record unless the caller
+    supplies `host` and `session_id`, and Hermes passes neither to
+    `pre_llm_call`, so its ledger sat at eight rows from a single day while live
+    turns kept running. Hermes also swallows hook exceptions with a log warning.
+    Awareness could be dead for weeks and the only symptom would be a user
+    learning to type "load OMH" by hand.
+    """
+
+    def test_an_empty_ledger_reads_as_zero(self) -> None:
+        with TemporaryDirectory() as tmp:
+            record = read_awareness_delivery(tmp)
+            self.assertEqual(record["delivery_count"], 0)
+            self.assertEqual(record["route_hint_count"], 0)
+            self.assertEqual(record["last_delivered_at"], "")
+            self.assertFalse(record["unreadable"])
+
+    def test_a_delivery_is_counted_with_its_size(self) -> None:
+        with TemporaryDirectory() as tmp:
+            record_awareness_delivery(
+                delivered=True, route_hint=True, context_chars=2768,
+                observed_at="2026-07-26T04:28:50Z", omh_home=tmp,
+            )
+            record = read_awareness_delivery(tmp)
+            self.assertEqual(record["delivery_count"], 1)
+            self.assertEqual(record["route_hint_count"], 1)
+            self.assertEqual(record["last_context_chars"], 2768)
+            self.assertEqual(record["first_delivered_at"], "2026-07-26T04:28:50Z")
+            self.assertEqual(record["schema_version"], AWARENESS_DELIVERY_SCHEMA_VERSION)
+
+    def test_a_turn_with_nothing_to_inject_is_counted_separately(self) -> None:
+        """"Ran and had nothing to say" must not look like "never ran"."""
+        with TemporaryDirectory() as tmp:
+            record_awareness_delivery(
+                delivered=False, route_hint=False, context_chars=0,
+                observed_at="2026-07-26T04:27:20Z", omh_home=tmp,
+            )
+            record = read_awareness_delivery(tmp)
+            self.assertEqual(record["suppressed_count"], 1)
+            self.assertEqual(record["delivery_count"], 0)
+            self.assertEqual(record["last_delivered_at"], "")
+
+    def test_route_hints_are_counted_only_when_present(self) -> None:
+        with TemporaryDirectory() as tmp:
+            for hint in (False, True, False):
+                record_awareness_delivery(
+                    delivered=True, route_hint=hint, context_chars=100,
+                    observed_at="2026-07-26T04:30:00Z", omh_home=tmp,
+                )
+            record = read_awareness_delivery(tmp)
+            self.assertEqual(record["delivery_count"], 3)
+            self.assertEqual(record["route_hint_count"], 1)
+
+    def test_first_delivered_at_is_kept_and_last_moves(self) -> None:
+        with TemporaryDirectory() as tmp:
+            record_awareness_delivery(
+                delivered=True, route_hint=False, context_chars=10,
+                observed_at="2026-07-26T01:00:00Z", omh_home=tmp,
+            )
+            record_awareness_delivery(
+                delivered=True, route_hint=False, context_chars=20,
+                observed_at="2026-07-26T02:00:00Z", omh_home=tmp,
+            )
+            record = read_awareness_delivery(tmp)
+            self.assertEqual(record["first_delivered_at"], "2026-07-26T01:00:00Z")
+            self.assertEqual(record["last_delivered_at"], "2026-07-26T02:00:00Z")
+
+    def test_the_file_has_a_fixed_shape_and_cannot_grow(self) -> None:
+        """Counters, not an append-only log.
+
+        A per-turn log on the hottest path is how a journal reached ~4.7k rows
+        of test noise. This runs on every LLM call, so its size must not depend
+        on how many calls happened.
+        """
+        with TemporaryDirectory() as tmp:
+            for index in range(50):
+                record_awareness_delivery(
+                    delivered=True, route_hint=True, context_chars=index,
+                    observed_at="2026-07-26T04:30:00Z", omh_home=tmp,
+                )
+            size_after_50 = awareness_delivery_path(tmp).stat().st_size
+            for index in range(200):
+                record_awareness_delivery(
+                    delivered=True, route_hint=True, context_chars=index,
+                    observed_at="2026-07-26T04:31:00Z", omh_home=tmp,
+                )
+            size_after_250 = awareness_delivery_path(tmp).stat().st_size
+            self.assertEqual(read_awareness_delivery(tmp)["delivery_count"], 250)
+            self.assertLess(abs(size_after_250 - size_after_50), 40)
+
+    def test_no_prompt_text_is_ever_stored(self) -> None:
+        with TemporaryDirectory() as tmp:
+            record_awareness_delivery(
+                delivered=True, route_hint=True, context_chars=2768,
+                observed_at="2026-07-26T04:28:50Z", omh_home=tmp,
+            )
+            written = awareness_delivery_path(tmp).read_text(encoding="utf-8")
+            stored = json.loads(written)
+            self.assertEqual(
+                set(stored),
+                {
+                    "schema_version", "delivery_count", "route_hint_count", "suppressed_count",
+                    "first_delivered_at", "last_delivered_at", "last_context_chars",
+                },
+            )
+            self.assertNotIn("2768 chars of prompt", written)
+            for key in ("context", "user_message", "prompt", "route_hint"):
+                self.assertNotIn(key, stored, f"{key} would put model-facing text in a ledger")
+
+    def test_a_corrupt_ledger_reads_as_unreadable_rather_than_zero(self) -> None:
+        """Zero deliveries and an unparseable file mean different things."""
+        with TemporaryDirectory() as tmp:
+            path = awareness_delivery_path(tmp)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("{not json", encoding="utf-8")
+            record = read_awareness_delivery(tmp)
+            self.assertTrue(record["unreadable"])
+            self.assertEqual(record["delivery_count"], 0)
+
+    def test_a_write_failure_never_raises(self) -> None:
+        """Losing a counter is fine; breaking the hook that feeds the model is not."""
+        with TemporaryDirectory() as tmp:
+            with patch.object(Path, "mkdir", side_effect=OSError("read-only")):
+                self.assertIsNone(
+                    record_awareness_delivery(
+                        delivered=True, route_hint=True, context_chars=10,
+                        observed_at="2026-07-26T04:30:00Z", omh_home=tmp,
+                    )
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- OMH's `pre_llm_call` hook now records whether it delivered awareness to the model: delivery count, route-hint count, turns that ran with nothing to inject, last timestamp, and context size.
- `omh doctor` reports it (`awareness_delivery`).

### Why This Exists

Follow-up to #665. `pre_llm_call` is how OMH gets its primer and route hint in front of Hermes — it is the entire mechanism behind "deterministic hint, LLM decides." **Nothing recorded whether it ever ran.** Two independent reasons:

1. `host_observation` drops a record entirely unless the caller supplies `host` and `session_id`, and Hermes passes **neither** to `pre_llm_call`. Its ledger sat at 8 `pre_verify` rows from a single day in July while live turns kept running.
2. Hermes wraps every hook callback in `try/except` and only logs a warning (`hermes_cli/plugins.py`), so a hook that raises disappears without a user-visible trace.

Between those two, awareness could be dead for weeks and the only symptom would be a user learning to type "load OMH" by hand — which is the report that started this thread.

### What it immediately settled

Two live `hermes -z` turns, with the ledger in place:

```json
{ "delivery_count": 2, "route_hint_count": 1, "last_context_chars": 2768, ... }
```

- The hook **is** firing, injecting 1,540–2,768 chars per turn.
- The route hint fired on `"Have a coding agent refactor src/calc.py..."` and **not** on `"Say OK."`.

So the keyword matcher is not a router being used where an LLM should be — it is a hint generator feeding the LLM, and it discriminates correctly. It had simply been invisible, and before #665 it had also been switched off entirely.

### User / Operator Impact

| | Before | After |
|---|---|---|
| Is OMH awareness reaching the model? | unknowable | counted, with a timestamp |
| Hook raises and awareness vanishes | silent; user compensates by hand | counter stops advancing, visible in doctor |
| `omh doctor` | no signal | `2 awareness injection(s) observed, 1 with a route hint; last at ...` |

### How It Works

- `src/plugin_bundle/omh/awareness_delivery.py` — a fixed-shape counter file under `~/.omh/runtime/`. The bundle is vendored and cannot import from `src`, so it is self-contained.
- The hook records at **both** exits, so "ran and had nothing to inject" is distinguishable from "never ran".
- Metadata only. No prompt text, no hint text, no user message. A test pins the exact key set.
- Best-effort: a write failure returns `None` rather than raising. Losing a counter is acceptable; breaking the hook that feeds the model is not.

**Counters, not an append-only log** — deliberately. This runs on the hottest path in the system, and a per-turn log there is exactly how a journal reached ~4.7k rows of noise earlier in this series. A test asserts 250 deliveries occupy the same space as 50.

### Files And Contracts Touched

- `src/plugin_bundle/omh/awareness_delivery.py` (new), `omh_awareness_delivery/v1`
- `src/plugin_bundle/omh/hooks/llm_hooks.py` — records at both exits
- `src/maintenance/doctor.py` — `awareness_delivery` check
- `tests/test_awareness_delivery.py` (new)

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `python3 -m unittest discover -s tests` — **1836 passed**, 1 skipped
- [x] `python3 -m compileall src`
- [x] `docs workflows/roles/capability-families --check`
- [x] `harness validate`, `release hermes-smoke`, `release drift`
- [x] **Two live Hermes turns** produced the expected counters; doctor renders them
- [ ] Manual Hermes/TUI check — **not run.**

## Risk

- **Low.** One counter file, best-effort, on a path that already tolerates failure. The doctor check is reported-only and never blocks.
- A zero count is ambiguous — fresh install, or Hermes not restarted since the bundle changed. That is why it does not block, and the message says which actions resolve it.

## Compatibility / Rollout

- No new dependencies. New schema is additive; nothing removed or renamed.
- The ledger appears on the first turn after the bundle is refreshed. Existing installs see no behaviour change until then.

## Release / Claims

- [x] Release-channel impact considered — `local`.
- [x] Every number here came from live Hermes turns, not simulation.
- [x] Manual gaps listed above.

## Follow-Up

- **A raising hook and an absent hook both leave the counter unchanged.** This signal proves delivery happened; it cannot yet distinguish the two failure modes. Recording an entry before the body runs would separate them.
- With delivery now measurable, the remaining question from the original report is answerable: whether route hints actually improve the LLM's routing choice. Previously unmeasurable.
- Korean coding requests still misroute (`workflow-learning` instead of `ultraprocess`). Untouched here; worth revisiting now that hint delivery can be confirmed.
