### PR TITLE
fix: show the version omh update actually moved between

### DIFF
--- a/src/commands/setup.py
+++ b/src/commands/setup.py
@@ -414,6 +414,7 @@ def _release_update_status(
     previous_version = _string_value(previous.get("release_version") or previous.get("version"))
     previous_package_url = _string_value(previous.get("release_package_url") or previous.get("package_url"))
     previous_ref = _string_value(previous.get("release_source_ref") or previous.get("source_ref"))
+    previous_package_version = _string_value(previous.get("package_version"))
     current = {
         "release_channel": release_channel,
         "release_version": release_version,
@@ -421,6 +422,10 @@ def _release_update_status(
         "release_source_ref": source_ref,
         "package_version": __version__,
     }
+    previous_effective_version = _effective_release_version(
+        {"release_version": previous_version, "package_version": previous_package_version}
+    )
+    current_effective_version = _effective_release_version(current)
     command_status = str(command_package.get("status", ""))
     command_package_changed = bool(command_package.get("updated")) or command_status == "would_update"
     metadata_changed = any(
@@ -456,10 +461,11 @@ def _release_update_status(
             "release_version": previous_version,
             "release_package_url": previous_package_url,
             "release_source_ref": previous_ref,
+            "package_version": previous_package_version,
         },
         "current": current,
         "display": {
-            "version_change": _change_label(previous_version, release_version),
+            "version_change": _change_label(previous_effective_version, current_effective_version),
             "source_ref_change": _change_label(previous_ref, source_ref),
             "package_url_change": _change_label(previous_package_url, release_package_url),
         },
@@ -474,6 +480,23 @@ def _metadata_value_changed(previous: str, current: str, *, explicit: bool) -> b
     if explicit and current:
         return previous != current
     return bool(previous and previous != current)
+
+
+def _effective_release_version(release: dict[str, object]) -> str:
+    """Version to show a user for one release record.
+
+    `release_version` is only populated when the operator pinned one, which in
+    practice means the stable channel. Preview installs track a branch archive and
+    leave it empty, so fall back to the package version the command itself reports.
+    Without this an update reads `main -> main` and hides the upgrade that happened.
+    """
+
+    if not isinstance(release, dict):
+        return ""
+    pinned = _string_value(release.get("release_version") or release.get("version"))
+    if pinned:
+        return pinned
+    return _string_value(release.get("package_version"))
 
 
 def _change_label(previous: str, current: str) -> str:
@@ -2056,7 +2079,7 @@ def _print_update_release_card(
 
 
 def _release_card_identity(release: dict[str, object], *, language: str) -> str:
-    version = _string_value(release.get("release_version") or release.get("version"))
+    version = _effective_release_version(release)
     if version:
         return version
     source_ref = _string_value(release.get("release_source_ref") or release.get("source_ref"))
@@ -2079,8 +2102,8 @@ def _command_package_display_change(payload: dict[str, object], release_update: 
     version_change = str(display.get("version_change", "")).strip()
     source_ref_change = str(display.get("source_ref_change", "")).strip()
     package_url_change = str(display.get("package_url_change", "")).strip()
-    previous_version = str(previous.get("release_version", "")).strip()
-    current_version = str(current.get("release_version", "")).strip()
+    previous_version = _effective_release_version(previous)
+    current_version = _effective_release_version(current)
     previous_ref = str(previous.get("release_source_ref", "")).strip()
     current_ref = str(current.get("release_source_ref", "")).strip()
     previous_package_url = str(previous.get("release_package_url", "")).strip()
@@ -2088,7 +2111,10 @@ def _command_package_display_change(payload: dict[str, object], release_update: 
     version_changed = bool(current_version and previous_version != current_version)
     source_ref_changed = bool(current_ref and previous_ref != current_ref)
     package_url_changed = bool(current_package_url and previous_package_url != current_package_url)
-    if channel == "stable" and version_changed and version_change:
+    # A real version move is the most useful thing to show on any channel. Preview
+    # installs track a branch, so without this they report `main -> main` and the
+    # upgrade is invisible.
+    if version_changed and version_change:
         return version_change
     if channel == "stable" and current_version and source_ref_changed and source_ref_change:
         return f"{current_version} ({source_ref_change})"
@@ -2098,7 +2124,7 @@ def _command_package_display_change(payload: dict[str, object], release_update: 
         return source_ref_change
     if package_url_changed and package_url_change:
         return package_url_change
-    if channel == "stable" and current_version:
+    if current_version:
         return f"{current_version} -> {current_version}" if previous_version == current_version else current_version
     if current_ref:
         return f"{current_ref} -> {current_ref}" if previous_ref == current_ref else current_ref

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10638,7 +10638,12 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
             self.assertEqual(stderr, "")
             stable = json.loads(stdout)
             self.assertEqual(stable["release_update"]["status"], "updated")
-            self.assertEqual(stable["release_update"]["display"]["version_change"], "(none) -> 1.0.1")
+            # The preview steps above ran the current package, so pinning 1.0.1 is a move
+            # away from that version rather than a first-ever version record.
+            self.assertEqual(
+                stable["release_update"]["display"]["version_change"],
+                f"{setup_commands.__version__} -> 1.0.1",
+            )
             self.assertEqual(stable["release_update"]["display"]["source_ref_change"], "main@human -> v1.0.1")
 
             status, stdout, stderr = run_cli(

--- a/tests/test_release_version_display.py
+++ b/tests/test_release_version_display.py
@@ -1,0 +1,141 @@
+"""`omh update` must show the version it moved between, on every channel.
+
+Preview installs track a branch archive, so `release_version` stays empty and the
+release identity used to fall back to the source ref. An operator upgrading
+1.0.2 -> 1.0.3 saw `main -> main` and could not tell whether anything changed.
+The package version is already recorded; these tests pin that it is used.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from omh.commands.setup import (
+    _command_package_display_change,
+    _release_card_identity,
+    _release_update_status,
+)
+from omh.version import __version__
+
+PREVIEW_URL = "https://github.com/rlaope/oh-my-hermes/archive/refs/heads/main.zip"
+
+
+def _preview_state(package_version: str) -> dict[str, object]:
+    return {
+        "release_channel": "preview",
+        "release_version": "",
+        "release_package_url": PREVIEW_URL,
+        "release_source_ref": "main",
+        "package_version": package_version,
+    }
+
+
+def _status(
+    previous: dict[str, object],
+    *,
+    channel: str = "preview",
+    version: str = "",
+    source_ref: str = "main",
+    package_url: str = PREVIEW_URL,
+    updated: bool = True,
+) -> dict[str, object]:
+    return _release_update_status(
+        release_channel=channel,
+        release_version=version,
+        release_package_url=package_url,
+        source_ref=source_ref,
+        explicit_metadata=bool(version),
+        previous=previous,
+        command_package={"updated": updated, "status": "updated" if updated else "refreshed"},
+        dry_run=False,
+    )
+
+
+def _command_line(status: dict[str, object], *, channel: str = "preview", package_url: str = PREVIEW_URL) -> str:
+    return _command_package_display_change(
+        {"release_channel": channel, "release_package_url": package_url},
+        status,
+    )
+
+
+class PreviewChannelVersionDisplayTests(unittest.TestCase):
+    def test_upgrade_reports_the_package_version_move(self) -> None:
+        status = _status(_preview_state("1.0.2"))
+        self.assertEqual(status["display"]["version_change"], f"1.0.2 -> {__version__}")
+        self.assertEqual(_command_line(status), f"1.0.2 -> {__version__}")
+
+    def test_release_cards_show_versions_not_the_branch_name(self) -> None:
+        status = _status(_preview_state("1.0.2"))
+        self.assertEqual(_release_card_identity(status["previous"], language="en"), "1.0.2")
+        self.assertEqual(_release_card_identity(status["current"], language="en"), __version__)
+
+    def test_source_ref_is_still_reported_separately(self) -> None:
+        # The branch is real information; showing the version must not hide it.
+        status = _status(_preview_state("1.0.2"))
+        self.assertEqual(status["display"]["source_ref_change"], "main -> main")
+        self.assertEqual(status["current"]["release_source_ref"], "main")
+
+    def test_previous_package_version_is_carried_forward(self) -> None:
+        status = _status(_preview_state("1.0.2"))
+        self.assertEqual(status["previous"]["package_version"], "1.0.2")
+
+    def test_rerun_without_a_version_move_is_not_reported_as_a_move(self) -> None:
+        status = _status(_preview_state(__version__), updated=False)
+        self.assertEqual(status["display"]["version_change"], f"{__version__} -> {__version__}")
+        self.assertEqual(_command_line(status), f"{__version__} -> {__version__}")
+
+
+class StableChannelVersionDisplayTests(unittest.TestCase):
+    def test_pinned_version_still_wins_over_the_package_version(self) -> None:
+        previous = {
+            "release_channel": "stable",
+            "release_version": "1.0.2",
+            "release_package_url": "https://example.invalid/v1.0.2.zip",
+            "release_source_ref": "v1.0.2",
+            "package_version": "1.0.2",
+        }
+        status = _status(
+            previous,
+            channel="stable",
+            version="1.0.3",
+            source_ref="v1.0.3",
+            package_url="https://example.invalid/v1.0.3.zip",
+        )
+        self.assertEqual(status["display"]["version_change"], "1.0.2 -> 1.0.3")
+        self.assertEqual(_release_card_identity(status["current"], language="en"), "1.0.3")
+
+    def test_pin_disagreeing_with_the_package_is_reported_as_pinned(self) -> None:
+        # An operator pinning an older archive should see the pin they asked for,
+        # not the version of the command that happens to be running.
+        previous = {
+            "release_channel": "stable",
+            "release_version": "1.0.1",
+            "release_source_ref": "v1.0.1",
+            "package_version": "1.0.1",
+        }
+        status = _status(previous, channel="stable", version="1.0.2", source_ref="v1.0.2")
+        self.assertEqual(_release_card_identity(status["current"], language="en"), "1.0.2")
+
+
+class LegacyAndFirstRunTests(unittest.TestCase):
+    def test_first_run_has_no_previous_version_to_report(self) -> None:
+        status = _status({})
+        self.assertEqual(_release_card_identity(status["current"], language="en"), __version__)
+        self.assertEqual(status["previous"]["package_version"], "")
+
+    def test_legacy_state_without_a_package_version_falls_back_to_the_ref(self) -> None:
+        # Pre-existing installs never recorded package_version. The old version is
+        # genuinely unknown, so the ref is the honest answer rather than a guess.
+        legacy = {
+            "release_channel": "preview",
+            "release_version": "",
+            "release_package_url": PREVIEW_URL,
+            "release_source_ref": "main",
+        }
+        status = _status(legacy)
+        self.assertEqual(_release_card_identity(status["previous"], language="en"), "main")
+        self.assertEqual(_release_card_identity(status["current"], language="en"), __version__)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Capability

`omh update` now reports the version it moved between on every channel.

Before, upgrading 1.0.2 → 1.0.3 on the preview channel printed:

```
  Previous release: main
  Installed release: main
  OMH command: main -> main (updated)
```

After:

```
  Previous release: 1.0.2
  Installed release: 1.0.3
  OMH command: 1.0.2 -> 1.0.3 (updated)
  Source ref: main -> main
```

## Motivation

Reported after the 1.0.3 release: the update ran, 82 workflows refreshed, the command package updated — and every line that should have said what changed said `main`. There was no way to tell from the output whether the upgrade landed.

`release_version` is only populated when an operator pins one with `--version`, which in practice means the stable channel. Preview installs track `refs/heads/main.zip` and leave it empty, so `_release_card_identity()` fell through to the source ref for both sides of the comparison.

## Implementation

The version was already being recorded — `release_update.current` has carried `package_version` all along. It was simply never read back.

- `_effective_release_version()` (new): prefers an explicit pin, otherwise falls back to the recorded package version.
- `_release_update_status()`: reads `package_version` out of the previous state, carries it into the `previous` block so there is something to compare against, and computes `display.version_change` from the effective versions.
- `_release_card_identity()` and `_command_package_display_change()` both resolve through the same helper.
- `_command_package_display_change()` additionally lets a genuine version move win on **any** channel, not only stable. Without that the preview case still fell through to the source-ref label.

`Source ref: main -> main` is unchanged and still shown — the branch is real information the version should not hide.

## Behavior across cases

| Case | Before | After |
| --- | --- | --- |
| preview upgrade 1.0.2 → 1.0.3 | `main -> main` | `1.0.2 -> 1.0.3` |
| preview re-run, same version | `main -> main` | `1.0.3 -> 1.0.3` |
| stable pin 1.0.2 → 1.0.3 | `1.0.2 -> 1.0.3` | unchanged |
| stable pin to an older archive | pinned version | pinned version (pin still wins over the running package) |
| first install | `(none) -> …` | current version |
| legacy state with no `package_version` | source ref | source ref (old version genuinely unknown) |

## One existing assertion changed meaning

`test_installer_reported_update_records_version_and_ref_movement` expected `version_change == "(none) -> 1.0.1"` when pinning stable after a chain of preview updates. Those preview steps ran the current package, so `(none)` claimed no version was installed when one was — the old expectation was inaccurate, not a contract this PR breaks. It now asserts the package-version move and derives the value from `__version__` rather than hardcoding a literal that every future release would have to chase.

## Verification observed

Full suite **1869 passed** (1860 + 9 new). Mutation check: removing the package-version fallback fails 5 of the 9 new tests, so they bind rather than passing vacuously. `ruff` clean, `docs workflows --check` green, `git diff --check` clean.

The reported output was reproduced from the shape of a real `.omh/runtime/state.json` (`release_version: ""`, `release_source_ref: "main"`, `package_version: "1.0.3"`) before fixing, and the corrected output verified for all six cases in the table above.

**Not observed:** a live `omh update` against an installed profile — the regression tests drive the same functions the CLI renders from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)