### PR TITLE
Read Hermes memory instead of measuring its file size

### DIFF
--- a/src/maintenance/advisory.py
+++ b/src/maintenance/advisory.py
@@ -21,6 +21,7 @@ from pathlib import Path
 
 from ..config_adapter import external_dirs, read_config
 from ..paths import default_hermes_home
+from . import hermes_memory
 
 CONTRACT = "hermes_config_advice/v1"
 
@@ -43,9 +44,10 @@ AUXILIARY_TASK_SLOTS = (
     "title",
 )
 
-# Hermes memory files and their observed soft caps (chars).
-MEMORY_FILE_CAP_CHARS = 2200
-USER_FILE_CAP_CHARS = 1375
+# Hermes memory files and the character caps Hermes enforces on write. Sourced
+# from the reader so the cap and the unit it is measured in cannot drift apart.
+MEMORY_FILE_CAP_CHARS = hermes_memory.MEMORY_FILE_CAP_CHARS
+USER_FILE_CAP_CHARS = hermes_memory.USER_FILE_CAP_CHARS
 MEMORY_STALE_AFTER_DAYS = 30
 
 # Conservative SOUL starter heuristic knobs.
@@ -324,10 +326,8 @@ def _now_seconds() -> float:
 
 def check_hermes_memory_staleness(hermes_home: str | Path | None = None) -> AdviceEntry:
     home = _resolve_hermes_home(hermes_home)
-    memory_path = home / "memories" / "MEMORY.md"
-    user_path = home / "memories" / "USER.md"
     evidence_boundary = (
-        "Local size/mtime read of ~/.hermes/memories/MEMORY.md and USER.md only; "
+        "Local character/entry/mtime read of ~/.hermes/memories/MEMORY.md and USER.md only; "
         "OMH reports on Hermes memory and cannot change Hermes memory."
     )
     remediation = (
@@ -335,48 +335,45 @@ def check_hermes_memory_staleness(hermes_home: str | Path | None = None) -> Advi
         "chars, USER.md ~1,375 chars). If these look stale, update them from inside "
         "Hermes; OMH will not write to them."
     )
-    try:
-        if not memory_path.exists() and not user_path.exists():
-            return AdviceEntry(
-                "hermes_memory_staleness",
-                "unobserved",
-                remediation,
-                evidence_boundary,
-                "no memories/MEMORY.md or USER.md found",
-            )
-        now = _now_seconds()
-        details: list[str] = []
-        stale = False
-        for label, path, cap in (
-            ("MEMORY.md", memory_path, MEMORY_FILE_CAP_CHARS),
-            ("USER.md", user_path, USER_FILE_CAP_CHARS),
-        ):
-            if not path.exists():
-                details.append(f"{label} missing")
-                continue
-            stat = path.stat()
-            age_days = max(0.0, (now - stat.st_mtime) / 86400.0)
-            details.append(
-                f"{label} {stat.st_size} bytes (cap ~{cap}), {age_days:.0f}d since mtime"
-            )
-            if age_days >= MEMORY_STALE_AFTER_DAYS:
-                stale = True
-        status = "advice" if stale else "ok"
-        return AdviceEntry(
-            "hermes_memory_staleness",
-            status,
-            remediation,
-            evidence_boundary,
-            "; ".join(details),
-        )
-    except OSError as error:
+    readings = hermes_memory.read_hermes_memory(home, now=_now_seconds())
+    if not any(reading.exists for reading in readings):
         return AdviceEntry(
             "hermes_memory_staleness",
             "unobserved",
             remediation,
             evidence_boundary,
-            f"memory files unreadable: {error}",
+            "no memories/MEMORY.md or USER.md found",
         )
+    unreadable = [reading for reading in readings if reading.error]
+    if unreadable:
+        return AdviceEntry(
+            "hermes_memory_staleness",
+            "unobserved",
+            remediation,
+            evidence_boundary,
+            "; ".join(f"{reading.label} unreadable: {reading.error}" for reading in unreadable),
+        )
+    details: list[str] = []
+    flagged = False
+    for reading in readings:
+        if not reading.exists:
+            details.append(f"{reading.label} missing")
+            continue
+        details.append(
+            f"{reading.label} {reading.chars} chars of {reading.cap} in "
+            f"{len(reading.entries)} entries, {reading.age_days:.0f}d since mtime"
+        )
+        # A file at or over the cap is the condition Hermes rejects the next
+        # write on, so it is advice even when the file was touched today.
+        if reading.over_cap or reading.age_days >= MEMORY_STALE_AFTER_DAYS:
+            flagged = True
+    return AdviceEntry(
+        "hermes_memory_staleness",
+        "advice" if flagged else "ok",
+        remediation,
+        evidence_boundary,
+        "; ".join(details),
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/maintenance/hermes_memory.py
+++ b/src/maintenance/hermes_memory.py
@@ -1,0 +1,157 @@
+"""Read what Hermes actually remembers, not just how large the file is.
+
+Hermes keeps its built-in memory in ``~/.hermes/memories/MEMORY.md`` and
+``USER.md`` as a ``§``-delimited entry list, and enforces a *character* cap per
+file on write (``hermes-agent/tools/memory_tool.py``). OMH's advisory lane used
+``stat().st_size`` for that comparison, which is a different unit: UTF-8 spends
+three bytes on a Hangul syllable, so a Korean MEMORY.md reads about 1.2x its own
+length. A 1,933-character file reports as ``2347 bytes (cap ~2200)`` and looks
+over budget while Hermes still accepts writes. An ASCII file of the same length
+reports correctly, which is why the mismatch went unnoticed.
+
+Counting characters fixes the unit. Splitting the entries is what lets the rest
+of OMH say *which* entry is stale or already duplicated in its own store,
+instead of only how full the file is.
+
+Read-only by construction: nothing here opens a file for writing. Hermes owns
+these files, and the `memory` tool it exposes to the model is the surface that
+edits them.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+# Hermes' own entry separator; see ENTRY_DELIMITER in its memory tool.
+HERMES_MEMORY_DELIMITER = "§"
+
+# Hermes memory files and the character caps it enforces on write.
+MEMORY_FILE_CAP_CHARS = 2200
+USER_FILE_CAP_CHARS = 1375
+
+HERMES_MEMORY_FILES = (
+    ("MEMORY.md", MEMORY_FILE_CAP_CHARS),
+    ("USER.md", USER_FILE_CAP_CHARS),
+)
+
+
+@dataclass(frozen=True)
+class HermesMemoryFile:
+    """One Hermes memory file as OMH observed it."""
+
+    label: str
+    path: Path
+    exists: bool
+    chars: int
+    cap: int
+    entries: tuple[str, ...]
+    age_days: float
+    error: str = ""
+
+    @property
+    def over_cap(self) -> bool:
+        return self.exists and self.chars > self.cap
+
+    @property
+    def headroom_chars(self) -> int:
+        """Characters a new entry may occupy, delimiter included."""
+        if not self.exists:
+            return self.cap
+        return max(0, self.cap - self.chars)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "label": self.label,
+            "path": str(self.path),
+            "exists": self.exists,
+            "chars": self.chars,
+            "cap": self.cap,
+            "over_cap": self.over_cap,
+            "headroom_chars": self.headroom_chars,
+            "entry_count": len(self.entries),
+            "age_days": round(self.age_days, 1),
+            "error": self.error,
+        }
+
+
+def parse_memory_entries(text: str) -> tuple[str, ...]:
+    """Split one Hermes memory file into its entries."""
+    return tuple(entry.strip() for entry in text.split(HERMES_MEMORY_DELIMITER) if entry.strip())
+
+
+def memory_char_count(entries: tuple[str, ...] | list[str]) -> int:
+    """Count characters the way Hermes counts them when enforcing the cap."""
+    if not entries:
+        return 0
+    return len(HERMES_MEMORY_DELIMITER.join(entries))
+
+
+def read_hermes_memory_file(
+    path: Path,
+    *,
+    label: str,
+    cap: int,
+    now: float | None = None,
+) -> HermesMemoryFile:
+    """Read one memory file. Never raises: an unreadable file reports its error."""
+    moment = time.time() if now is None else now
+    if not path.exists():
+        return HermesMemoryFile(label, path, False, 0, cap, (), 0.0)
+    try:
+        text = path.read_text(encoding="utf-8")
+        age_days = max(0.0, (moment - path.stat().st_mtime) / 86400.0)
+    except (OSError, UnicodeDecodeError) as error:
+        return HermesMemoryFile(label, path, True, 0, cap, (), 0.0, error=str(error))
+    entries = parse_memory_entries(text)
+    return HermesMemoryFile(label, path, True, memory_char_count(entries), cap, entries, age_days)
+
+
+def read_hermes_memory(
+    hermes_home: str | Path,
+    *,
+    now: float | None = None,
+) -> tuple[HermesMemoryFile, ...]:
+    """Read every Hermes memory file under one Hermes home."""
+    memories_dir = Path(hermes_home).expanduser() / "memories"
+    return tuple(
+        read_hermes_memory_file(memories_dir / name, label=name, cap=cap, now=now)
+        for name, cap in HERMES_MEMORY_FILES
+    )
+
+
+# A fact restated in Hermes' own words shares most of its nouns but almost none
+# of its punctuation or particles, so token overlap separates "already known"
+# from "new" where exact matching cannot. The threshold is deliberately loose:
+# this only decides what to *show* a reviewer, never what to write.
+DUPLICATE_SIMILARITY_THRESHOLD = 0.6
+
+_TOKEN_PATTERN = re.compile(r"[0-9A-Za-z가-힣]{2,}")
+
+
+def text_tokens(text: str) -> frozenset[str]:
+    """Comparable tokens for one memory summary or entry."""
+    return frozenset(_TOKEN_PATTERN.findall(text.lower()))
+
+
+def similarity(left: str, right: str) -> float:
+    """Jaccard overlap of two memory texts, 0.0 when either side has no tokens."""
+    left_tokens = text_tokens(left)
+    right_tokens = text_tokens(right)
+    union = left_tokens | right_tokens
+    if not union:
+        return 0.0
+    return len(left_tokens & right_tokens) / len(union)
+
+
+def nearest_entry(text: str, entries: tuple[str, ...] | list[str]) -> tuple[int, float]:
+    """Index and score of the entry closest to ``text``; ``(-1, 0.0)`` when none."""
+    best_index = -1
+    best_score = 0.0
+    for index, entry in enumerate(entries):
+        score = similarity(text, entry)
+        if score > best_score:
+            best_index, best_score = index, score
+    return best_index, best_score

--- a/src/workflows/memory.py
+++ b/src/workflows/memory.py
@@ -7,6 +7,11 @@ from pathlib import Path
 from typing import Any
 
 from ..local_store import atomic_write_json, ensure_dir, file_lock, read_json_object, read_json_object_result, utc_now
+from ..maintenance.hermes_memory import (
+    DUPLICATE_SIMILARITY_THRESHOLD,
+    nearest_entry,
+    read_hermes_memory,
+)
 from ..paths import OmhPaths
 from ..profiles.setup import read_setup_profile
 from ..targets import summarize_target_registry
@@ -28,6 +33,7 @@ PROJECT_MEMORY_REVIEW_CARD_SCHEMA_VERSION = "project_memory_review_card/v1"
 PROJECT_MEMORY_REVIEW_QUEUE_SCHEMA_VERSION = "project_memory_review_queue/v1"
 PROJECT_MEMORY_REVIEW_RECORD_SCHEMA_VERSION = "project_memory_review_record/v1"
 PROJECT_MEMORY_RECALL_PACK_SCHEMA_VERSION = "project_memory_recall_pack/v1"
+HERMES_MEMORY_BRIDGE_SCHEMA_VERSION = "hermes_memory_bridge/v1"
 
 SOURCE_TRUTH_LEVELS = {
     "runtime_evidence": "observed_evidence",
@@ -173,6 +179,77 @@ def read_project_memory_policy(paths: OmhPaths) -> dict[str, object]:
     return build_project_memory_policy(paths)
 
 
+def build_hermes_memory_bridge(paths: OmhPaths) -> dict[str, object]:
+    """Relate OMH's approved records to what Hermes already remembers.
+
+    The two stores have no shared identifier, so neither could see the other:
+    OMH deduplicated only against itself, and Hermes' memory tool rejects only
+    exact-string duplicates. A fact approved in OMH and then restated by hand in
+    MEMORY.md therefore lived in both, worded differently, with nothing linking
+    them.
+
+    This is the read side of that link. It reports which approved record Hermes
+    already carries, which one it does not, and whether the next one would fit
+    under the cap Hermes enforces on write. Nothing here writes to Hermes: the
+    `memory` tool Hermes exposes to the model is what edits MEMORY.md.
+    """
+    readings = read_hermes_memory(paths.hermes_home)
+    records = _read_project_memory_records(paths)
+    memory_file = next((reading for reading in readings if reading.label == "MEMORY.md"), None)
+    entries = memory_file.entries if memory_file else ()
+    already_present: list[dict[str, object]] = []
+    promotable: list[dict[str, object]] = []
+    matched_entries: set[int] = set()
+    for record in records:
+        summary = str(record.get("summary", "") or "")
+        index, score = nearest_entry(summary, entries)
+        row: dict[str, object] = {
+            "record_id": str(record.get("record_id", "")),
+            "summary_length": len(summary),
+            "scope": record.get("scope", {}),
+            "nearest_entry_index": index,
+            "similarity": round(score, 2),
+        }
+        if score >= DUPLICATE_SIMILARITY_THRESHOLD:
+            matched_entries.add(index)
+            already_present.append(row)
+            continue
+        # `+ 1` is the delimiter Hermes inserts before an appended entry.
+        row["fits_headroom"] = bool(memory_file) and len(summary) + 1 <= memory_file.headroom_chars
+        promotable.append(row)
+    return {
+        "schema_version": HERMES_MEMORY_BRIDGE_SCHEMA_VERSION,
+        "files": [reading.to_dict() for reading in readings],
+        "approved_records": len(records),
+        "already_in_hermes": already_present,
+        "promotable": promotable,
+        "hermes_entries_without_omh_record": _unsourced_entry_rows(entries, matched_entries),
+        "duplicate_similarity_threshold": DUPLICATE_SIMILARITY_THRESHOLD,
+        "redaction_policy": "metadata_only",
+        "next_action": (
+            "Promote a record by asking Hermes to add it through its own memory tool; free headroom first "
+            "when nothing fits."
+        ),
+        "claim_boundary": (
+            "OMH reads Hermes memory and cannot change it. This comparison is prepared review context only; "
+            "it is not a Hermes memory write, execution, review, CI, or merge evidence."
+        ),
+    }
+
+
+def _unsourced_entry_rows(entries: tuple[str, ...], matched: set[int]) -> list[dict[str, object]]:
+    """Hermes entries no approved OMH record explains, as metadata only."""
+    return [
+        {
+            "entry_index": index,
+            "chars": len(entry),
+            "sha256": hashlib.sha256(entry.encode("utf-8")).hexdigest(),
+        }
+        for index, entry in enumerate(entries)
+        if index not in matched
+    ]
+
+
 def build_project_memory_status(paths: OmhPaths) -> dict[str, object]:
     candidates = _read_project_memory_candidates(paths)
     records = _read_project_memory_records(paths)
@@ -200,6 +277,7 @@ def build_project_memory_status(paths: OmhPaths) -> dict[str, object]:
             "review_records": len(reviews),
             "candidate_statuses": candidate_status_counts,
         },
+        "hermes_memory": build_hermes_memory_bridge(paths),
         "redaction_policy": "metadata_only",
         "claim_boundary": "Project memory status is prepared local context only; it is not execution, review, CI, merge, or Hermes internal-memory evidence.",
     }

--- a/tests/test_hermes_memory_bridge.py
+++ b/tests/test_hermes_memory_bridge.py
@@ -1,0 +1,214 @@
+"""OMH reads Hermes memory in Hermes' own unit, and relates it to its own store.
+
+Two defects motivate this file:
+
+- The advisory lane compared `stat().st_size` against a character cap. Korean
+  memory costs three bytes per syllable, so a file well under the cap reported
+  as over it. Only a non-ASCII fixture can catch that, so every size assertion
+  here uses Hangul.
+- OMH deduplicated approved records against itself only. A fact approved in OMH
+  and restated by hand in MEMORY.md lived in both stores with nothing linking
+  them, because Hermes' memory tool rejects exact strings and nothing compared
+  the rewordings.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.maintenance import advisory
+from omh.maintenance.advisory import MEMORY_STALE_AFTER_DAYS, check_hermes_memory_staleness
+from omh.maintenance.hermes_memory import (
+    HERMES_MEMORY_DELIMITER,
+    MEMORY_FILE_CAP_CHARS,
+    memory_char_count,
+    nearest_entry,
+    parse_memory_entries,
+    read_hermes_memory,
+    similarity,
+)
+from omh.memory import (
+    approve_project_memory_candidate,
+    build_hermes_memory_bridge,
+    build_project_memory_status,
+    capture_project_memory_candidate,
+)
+from omh.paths import resolve_paths
+
+# 1,119 characters but 2,631 UTF-8 bytes: comfortably under the 2,200-character
+# cap, and comfortably over it if bytes are counted by mistake. Stripped here
+# because Hermes stores entries stripped.
+KOREAN_ENTRY = ("문서 하네스는 에이전트가 HTML을 먼저 작성하고 변환하는 시스템이다. " * 28).strip()
+
+
+def _write_memory(home: Path, *entries: str) -> Path:
+    path = home / "memories" / "MEMORY.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(HERMES_MEMORY_DELIMITER.join(entries), encoding="utf-8")
+    return path
+
+
+class EntryParsingTests(unittest.TestCase):
+    def test_entries_split_on_the_delimiter_and_drop_blanks(self) -> None:
+        text = f"first{HERMES_MEMORY_DELIMITER}\n  second  {HERMES_MEMORY_DELIMITER}{HERMES_MEMORY_DELIMITER}"
+        self.assertEqual(parse_memory_entries(text), ("first", "second"))
+
+    def test_empty_file_has_no_entries_and_costs_nothing(self) -> None:
+        self.assertEqual(parse_memory_entries(""), ())
+        self.assertEqual(memory_char_count(()), 0)
+
+    def test_char_count_matches_hermes_delimiter_join(self) -> None:
+        entries = ("alpha", "beta", "gamma")
+        # Hermes computes len(ENTRY_DELIMITER.join(entries)) before allowing a
+        # write, so OMH's headroom is wrong unless it counts the delimiters too.
+        self.assertEqual(memory_char_count(entries), len("alpha§beta§gamma"))
+
+
+class UnitTests(unittest.TestCase):
+    """Characters, not bytes. The distinction only shows up outside ASCII."""
+
+    def test_korean_memory_under_cap_is_not_flagged(self) -> None:
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            path = _write_memory(home, KOREAN_ENTRY)
+            self.assertGreater(path.stat().st_size, MEMORY_FILE_CAP_CHARS)
+            self.assertLess(len(KOREAN_ENTRY), MEMORY_FILE_CAP_CHARS)
+
+            entry = check_hermes_memory_staleness(home)
+            self.assertEqual(entry.status, "ok")
+            self.assertIn("chars", entry.observed)
+            self.assertNotIn("bytes", entry.observed)
+
+    def test_reading_reports_characters_and_entry_count(self) -> None:
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            _write_memory(home, "alpha", KOREAN_ENTRY)
+            reading = read_hermes_memory(home)[0]
+            self.assertEqual(reading.label, "MEMORY.md")
+            self.assertEqual(len(reading.entries), 2)
+            self.assertEqual(reading.chars, memory_char_count(("alpha", KOREAN_ENTRY)))
+            self.assertFalse(reading.over_cap)
+            self.assertEqual(reading.headroom_chars, MEMORY_FILE_CAP_CHARS - reading.chars)
+
+
+class CapTests(unittest.TestCase):
+    def test_over_cap_is_advice_even_when_freshly_written(self) -> None:
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            _write_memory(home, "x" * (MEMORY_FILE_CAP_CHARS + 1))
+            entry = check_hermes_memory_staleness(home)
+            # Age alone used to decide this, so a full file touched today read
+            # as ok while Hermes was already rejecting the next write.
+            self.assertEqual(entry.status, "advice")
+
+    def test_stale_mtime_is_still_advice(self) -> None:
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            path = _write_memory(home, "short note")
+            old = advisory._now_seconds() - (MEMORY_STALE_AFTER_DAYS + 5) * 86400
+            os.utime(path, (old, old))
+            self.assertEqual(check_hermes_memory_staleness(home).status, "advice")
+
+    def test_headroom_is_the_cap_when_no_file_exists(self) -> None:
+        with TemporaryDirectory() as tmp:
+            reading = read_hermes_memory(Path(tmp))[0]
+            self.assertFalse(reading.exists)
+            self.assertEqual(reading.headroom_chars, MEMORY_FILE_CAP_CHARS)
+
+
+class SimilarityTests(unittest.TestCase):
+    def test_reworded_fact_scores_above_the_duplicate_threshold(self) -> None:
+        left = "document-harness: sionic-ai 레포의 에이전트 하네스 기반 문서 작성 시스템"
+        right = "document-harness는 sionic-ai 레포의 에이전트 하네스 기반 문서 작성 시스템이다"
+        self.assertGreaterEqual(similarity(left, right), 0.6)
+
+    def test_unrelated_texts_score_low(self) -> None:
+        self.assertLess(similarity("release script dry run flag", "커피 원두 보관 방법"), 0.6)
+
+    def test_nearest_entry_reports_no_match_against_an_empty_store(self) -> None:
+        self.assertEqual(nearest_entry("anything", ()), (-1, 0.0))
+
+
+class BridgeTests(unittest.TestCase):
+    def _approved(self, paths, summary: str) -> None:
+        capture = capture_project_memory_candidate(paths, summary, scope_ref="demo")
+        approve_project_memory_candidate(paths, str(capture["candidate"]["candidate_id"]))
+
+    def test_record_already_in_hermes_is_not_offered_for_promotion(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            summary = "document-harness는 HTML을 먼저 작성하고 PPTX로 변환하는 문서 시스템이다"
+            self._approved(paths, summary)
+            _write_memory(root / ".hermes", "document-harness: HTML을 먼저 작성하고 PPTX로 변환하는 문서 시스템")
+
+            bridge = build_hermes_memory_bridge(paths)
+            self.assertEqual(bridge["approved_records"], 1)
+            self.assertEqual(len(bridge["already_in_hermes"]), 1)
+            self.assertEqual(bridge["promotable"], [])
+            self.assertEqual(bridge["already_in_hermes"][0]["nearest_entry_index"], 0)
+
+    def test_novel_record_is_promotable_when_it_fits_the_headroom(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            self._approved(paths, "release 스크립트는 --dry-run 플래그로 계획만 출력한다")
+            _write_memory(root / ".hermes", "커피 원두는 밀봉 용기에 보관한다")
+
+            bridge = build_hermes_memory_bridge(paths)
+            self.assertEqual(bridge["already_in_hermes"], [])
+            self.assertEqual(len(bridge["promotable"]), 1)
+            self.assertTrue(bridge["promotable"][0]["fits_headroom"])
+
+    def test_record_larger_than_the_headroom_does_not_fit(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            self._approved(paths, "격리된 사실 " * 40)
+            _write_memory(root / ".hermes", "x" * (MEMORY_FILE_CAP_CHARS - 10))
+
+            promotable = build_hermes_memory_bridge(paths)["promotable"]
+            self.assertEqual(len(promotable), 1)
+            self.assertFalse(promotable[0]["fits_headroom"])
+
+    def test_hermes_entries_without_a_record_are_reported_as_metadata_only(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            secret = "루트 비밀번호는 hunter2 이다"
+            _write_memory(root / ".hermes", secret)
+
+            bridge = build_hermes_memory_bridge(paths)
+            rows = bridge["hermes_entries_without_omh_record"]
+            self.assertEqual([row["entry_index"] for row in rows], [0])
+            self.assertEqual(rows[0]["chars"], len(secret))
+            # The rows describe entries; they must never carry their text.
+            self.assertNotIn("hunter2", repr(bridge))
+
+    def test_bridge_is_attached_to_memory_status(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            bridge = build_project_memory_status(paths)["hermes_memory"]
+            self.assertEqual(bridge["schema_version"], "hermes_memory_bridge/v1")
+            self.assertIn("cannot change it", str(bridge["claim_boundary"]))
+
+    def test_unreadable_memory_is_unobserved_rather_than_ok(self) -> None:
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            path = home / "memories" / "MEMORY.md"
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(b"\xff\xfe not utf-8")
+            entry = check_hermes_memory_staleness(home)
+            # Guessing "ok" here would report a healthy memory OMH never read.
+            self.assertEqual(entry.status, "unobserved")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Capability

`omh doctor` and `omh memory status` now read what Hermes actually remembers, in the unit Hermes measures it in, and relate it to OMH's own approved records.

Before, OMH reported on `~/.hermes/memories/MEMORY.md` without ever opening it, and kept a governed record store that nothing consumed.

## Motivation

Two defects, both found by inspecting a real install.

**1. The advisory compared bytes against a character cap.** Hermes enforces `memory_char_limit = 2200` on write (`hermes-agent/tools/memory_tool.py`). OMH compared `stat().st_size` to it. UTF-8 spends three bytes on a Hangul syllable, so a Korean `MEMORY.md` reads about 1.2x its own length:

```
before:  MEMORY.md 2347 bytes (cap ~2200), 0d since mtime      → status ok
after:   MEMORY.md 1921 chars of 2200 in 7 entries, 0d ...     → status ok
```

The verdict happened to be right; the number was not. An ASCII file of the same length reported correctly, which is why this survived. A Korean user at 87% capacity reads "over cap".

Nothing flagged a genuinely full file either — only mtime age set the status, so a file Hermes was already rejecting writes on could report `ok`.

**2. The two memory stores could not see each other.** OMH deduplicated approved records against itself; Hermes' memory tool rejects only exact strings. A fact approved in OMH and then restated by hand in `MEMORY.md` lived in both, worded differently, with nothing linking them. On the install inspected:

```
MEMORY.md entry[0]  ↔  omh record[0]   similarity 0.97
MEMORY.md entry[1]  ↔  omh record[3]   similarity 0.66
MEMORY.md entry[3]  =  a hand-written pointer to ~/.omh/memory
```

That last entry is the tell: the user spent scarce cap budget on a note bridging two stores that should have known about each other.

## What you can do now

```
$ omh memory status
"hermes_memory": {
  "files": [{"label": "MEMORY.md", "chars": 1921, "cap": 2200,
             "headroom_chars": 279, "entry_count": 7, "over_cap": false}, ...],
  "already_in_hermes": [{"record_id": "mem_1db6…", "similarity": 0.97,
                         "nearest_entry_index": 0}, ...],
  "promotable":        [{"record_id": "mem_9077…", "summary_length": 240,
                         "fits_headroom": true}],
  "hermes_entries_without_omh_record": [{"entry_index": 3, "chars": 159, "sha256": "…"}]
}
```

Three questions that had no answer before: what does Hermes already know, what does OMH hold that it does not, and will the next one fit.

## Implementation

- **`src/maintenance/hermes_memory.py`** (new leaf module, stdlib only). Reads both files, splits on Hermes' `§` delimiter, counts with `len(§.join(entries))` so headroom matches what Hermes computes before allowing a write. Non-throwing: an unreadable file carries its error rather than raising. Also holds the token-overlap similarity used for reworded-duplicate detection.
- **`src/maintenance/advisory.py`** — `check_hermes_memory_staleness` reads characters and entries instead of `st_size`; `over_cap` now sets `advice` alongside stale mtime; unreadable files report `unobserved` rather than a guessed verdict. The cap constants now come from the reader so unit and value cannot drift apart.
- **`src/workflows/memory.py`** — `build_hermes_memory_bridge()`, attached to `build_project_memory_status()` under `hermes_memory`.

**Nothing writes.** Hermes owns these files, and the `memory` tool it exposes to the model is what edits them. OMH computes and proposes; `next_action` points at that tool.

**Metadata only**, matching every other OMH ledger: record ids, character lengths, similarity scores, entry indices and SHA-256 — never entry text. `test_hermes_entries_without_a_record_are_reported_as_metadata_only` puts a secret in a fixture entry and asserts it does not appear in the payload.

## Verification observed

| Gate | Result |
| --- | --- |
| Full suite (`PYTHONPATH=tests`) | 1853 passed, 1 skipped |
| `tests/test_hermes_memory_bridge.py` | 17 passed |
| `docs workflows / roles / capability-families --check` | ok |
| `omh release drift` | no drift, 11 checks |
| ruff, compileall, `git diff --check` | clean |
| `omh doctor` | 28/28 |
| Journal delta across a full suite run | 0 |

The Korean fixture is load-bearing: 1,119 characters / 2,631 bytes. An ASCII fixture cannot fail the old code, so `test_korean_memory_under_cap_is_not_flagged` asserts `st_size > cap` before asserting the check says `ok`.

## Risks and follow-ups

- **The 0.6 similarity threshold is a judgement call.** It only decides what a reviewer is shown, never what is written, so a miss costs a duplicate suggestion rather than data. Verified on the real store: 0.97 and 0.66 pairs land above it, unrelated text lands below.
- **No plugin tool exposes this.** OMH registers nine tools and none is memory, so Hermes cannot reach the bridge from chat — it is CLI and doctor only. Follow-up.
- **`scope.ref` is still unused here.** The bridge compares every approved record against `MEMORY.md` regardless of scope. Per-project filtering belongs with the plan-storage work that follows.
- No live Hermes turn exercised the bridge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
