### PR TITLE
perf: reduce catalog and skill context overhead

### DIFF
--- a/src/catalogs/awesome_hermes_agent.py
+++ b/src/catalogs/awesome_hermes_agent.py
@@ -157,13 +157,15 @@ def awesome_hermes_coverage(
     maturity: str = "",
     status: str = "",
 ) -> tuple[AwesomeHermesCoverage, ...]:
+    from .awesome_hermes_agent_rules import RULE_SET_VERSION
+
     filters = {
         "section": section.strip().lower(),
         "subsection": subsection.strip().lower(),
         "maturity": maturity.strip().lower(),
         "status": status.strip().lower(),
     }
-    coverage = tuple(_coverage_for_item(item) for item in awesome_hermes_items())
+    coverage = _awesome_hermes_coverage_cached(awesome_hermes_items(), RULE_SET_VERSION)
     return tuple(item for item in coverage if _coverage_matches(item, filters))
 
 
@@ -203,6 +205,14 @@ def awesome_hermes_coverage_payload(
             "plugin installation, safety approval, live connector evidence, or feature parity."
         ),
     }
+
+
+@lru_cache(maxsize=1)
+def _awesome_hermes_coverage_cached(
+    items: tuple[AwesomeHermesItem, ...],
+    _rule_set_version: str,
+) -> tuple[AwesomeHermesCoverage, ...]:
+    return tuple(_coverage_for_item(item) for item in items)
 
 
 @lru_cache(maxsize=1)

--- a/src/skills/context_cost.py
+++ b/src/skills/context_cost.py
@@ -26,6 +26,8 @@ from dataclasses import dataclass
 
 from .catalog import CORE_PROFILE_SKILLS
 from .packaging import builtin_skill_reference_templates, builtin_skill_templates
+from .render import SkillReferenceTemplate as _SkillReferenceTemplate
+from .render import SkillTemplate as _SkillTemplate
 
 SKILL_CONTEXT_COST_SCHEMA_VERSION = "omh_skill_context_cost/v1"
 
@@ -76,16 +78,16 @@ def _size_payload(text_chars: int, line_count: int) -> dict[str, int]:
     }
 
 
-def _profile_skill_names(profile: str) -> set[str]:
-    names = {template.name for template in builtin_skill_templates()}
+def _profile_skill_names(profile: str, templates: list[_SkillTemplate]) -> set[str]:
+    names = {template.name for template in templates}
     if profile == "full":
         return names
     return {name for name in names if name in CORE_PROFILE_SKILLS}
 
 
-def _section_slices(names: set[str]) -> list[SectionSlice]:
+def _section_slices(names: set[str], templates: list[_SkillTemplate]) -> list[SectionSlice]:
     slices: list[SectionSlice] = []
-    for template in builtin_skill_templates():
+    for template in templates:
         if template.name not in names:
             continue
         for heading, body in _split_sections(template.content):
@@ -117,9 +119,9 @@ def _heading_repetition(slices: list[SectionSlice]) -> list[dict[str, object]]:
     return rows
 
 
-def _reference_payload(names: set[str]) -> dict[str, object]:
+def _reference_payload(names: set[str], reference_templates: list[_SkillReferenceTemplate]) -> dict[str, object]:
     templates = [
-        template for template in builtin_skill_reference_templates() if template.skill_name in names
+        template for template in reference_templates if template.skill_name in names
     ]
     total_chars = sum(len(template.content) for template in templates)
     total_lines = sum(len(template.content.splitlines()) for template in templates)
@@ -136,9 +138,13 @@ def _percent(part: int, whole: int) -> float:
     return round(part * 100 / whole, 2)
 
 
-def skill_context_cost_profile(profile: str) -> dict[str, object]:
-    names = _profile_skill_names(profile)
-    slices = _section_slices(names)
+def _skill_context_cost_profile(
+    profile: str,
+    templates: list[_SkillTemplate],
+    reference_templates: list[_SkillReferenceTemplate],
+) -> dict[str, object]:
+    names = _profile_skill_names(profile, templates)
+    slices = _section_slices(names, templates)
     headings = _heading_repetition(slices)
     total_chars = sum(len(section.body) for section in slices)
     total_lines = sum(len(section.body.splitlines()) for section in slices)
@@ -155,12 +161,18 @@ def skill_context_cost_profile(profile: str) -> dict[str, object]:
             **_size_payload(total_chars - duplicate_bytes, 0),
             "share_percent": _percent(total_chars - duplicate_bytes, total_chars),
         },
-        "references": _reference_payload(names),
+        "references": _reference_payload(names, reference_templates),
         "headings": headings,
     }
 
 
+def skill_context_cost_profile(profile: str) -> dict[str, object]:
+    return _skill_context_cost_profile(profile, builtin_skill_templates(), builtin_skill_reference_templates())
+
+
 def skill_context_cost_payload() -> dict[str, object]:
+    templates = builtin_skill_templates()
+    reference_templates = builtin_skill_reference_templates()
     return {
         "schema_version": SKILL_CONTEXT_COST_SCHEMA_VERSION,
         "description": (
@@ -170,7 +182,9 @@ def skill_context_cost_payload() -> dict[str, object]:
             "always-loaded skill-body total."
         ),
         "chars_per_token_estimate": CHARS_PER_TOKEN_ESTIMATE,
-        "profiles": [skill_context_cost_profile(profile) for profile in ("core", "full")],
+        "profiles": [
+            _skill_context_cost_profile(profile, templates, reference_templates) for profile in ("core", "full")
+        ],
     }
 
 

--- a/tests/test_awesome_hermes_agent_efficiency.py
+++ b/tests/test_awesome_hermes_agent_efficiency.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+from _local_package import load_local_package
+
+
+load_local_package()
+
+from omh.catalogs import awesome_hermes_agent as awesome_catalog
+from omh.skills import context_cost
+
+
+class AwesomeHermesAgentEfficiencyTests(unittest.TestCase):
+    def test_coverage_preparation_is_shared_by_repeated_and_composite_reads(self) -> None:
+        awesome_catalog._awesome_hermes_coverage_cached.cache_clear()
+        self.addCleanup(awesome_catalog._awesome_hermes_coverage_cached.cache_clear)
+        with patch.object(
+            awesome_catalog,
+            "_coverage_for_item",
+            wraps=awesome_catalog._coverage_for_item,
+        ) as coverage_for_item:
+            first = awesome_catalog.awesome_hermes_coverage()
+            second = awesome_catalog.awesome_hermes_coverage()
+            payload = awesome_catalog.awesome_hermes_coverage_payload()
+
+        cache_info = awesome_catalog._awesome_hermes_coverage_cached.cache_info()
+        self.assertEqual(first, second)
+        self.assertEqual(payload["item_count"], len(first))
+        self.assertEqual(coverage_for_item.call_count, len(first))
+        self.assertEqual(cache_info.misses, 1)
+        self.assertGreaterEqual(cache_info.hits, 3)
+
+    def test_coverage_cache_refreshes_after_a_rule_set_version_change(self) -> None:
+        awesome_catalog._awesome_hermes_coverage_cached.cache_clear()
+        self.addCleanup(awesome_catalog._awesome_hermes_coverage_cached.cache_clear)
+        original = awesome_catalog.awesome_hermes_coverage()
+
+        with patch("omh.catalogs.awesome_hermes_agent_rules.RULE_SET_VERSION", "test-rule-set/v2"):
+            refreshed = awesome_catalog.awesome_hermes_coverage()
+
+        self.assertNotEqual(refreshed[0].rule_set_version, original[0].rule_set_version)
+        self.assertEqual(refreshed[0].rule_set_version, "test-rule-set/v2")
+
+    def test_context_cost_reuses_one_rendered_template_snapshot(self) -> None:
+        with patch.object(
+            context_cost,
+            "builtin_skill_templates",
+            wraps=context_cost.builtin_skill_templates,
+        ) as templates, patch.object(
+            context_cost,
+            "builtin_skill_reference_templates",
+            wraps=context_cost.builtin_skill_reference_templates,
+        ) as reference_templates:
+            payload = context_cost.skill_context_cost_payload()
+
+        self.assertEqual({profile["profile"] for profile in payload["profiles"]}, {"core", "full"})
+        self.assertEqual(templates.call_count, 1)
+        self.assertEqual(reference_templates.call_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What changed

This PR reduces repeated CPU/allocation work on two read-only reporting paths without changing their public behavior.

- Caches Awesome Hermes Agent derived coverage by the immutable catalog-item snapshot and `RULE_SET_VERSION`, so repeated coverage, summary, and payload requests reuse the same prepared coverage.
- Reuses one rendered skill-template snapshot and one reference-template snapshot while generating the `core` and `full` skill context-cost profiles.
- Adds focused regression tests for cache reuse, rule-set-version invalidation, and one-snapshot context-cost generation.

### Why

The catalog JSON was already cached, but derived coverage was rebuilt for every read, including twice inside a composite payload. The context-cost command independently rebuilt/traversed the same rendered template lists for its two profiles. Those operations add avoidable work to user-visible CLI/reporting paths.

### User and operator impact

Users receive the same ecosystem coverage and skill context-cost JSON/human output with less repeated in-process work:

- Plugin filter output remains 33 items.
- Skill body totals remain 66,289 bytes for `core` and 698,200 bytes for `full`.
- No routing decision, generated skill content, payload schema, CLI option, configuration, or dependency changes.

### Implementation boundary

- `src/catalogs/awesome_hermes_agent.py` keeps filtering and serialization untouched; only immutable derived coverage preparation is memoized with a bounded cache.
- `src/skills/context_cost.py` preserves the public `skill_context_cost_profile(profile)` API and shares local snapshots only during the composite payload call.
- `tests/test_awesome_hermes_agent_efficiency.py` locks the reuse and invalidation contract.

### Verification

- [x] Full suite: `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — 1,894 passed, 1 skipped.
- [x] `uv run --group lint ruff check src tests`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `git diff --check`
- [x] Manual CLI QA: ecosystem list/summary/filter/error paths; Plugins JSON retained 33 items.
- [x] Manual CLI QA: skill-context-cost JSON and human output retained core/full totals of 66,289 / 698,200 bytes.
- [x] Exact-SHA five-lane review: goal/constraint, hands-on CLI QA, code quality, security, and repository-context checks all passed.

### Risks and compatibility

- The cache is intentionally bounded to one entry and keys on both the immutable catalog snapshot and `RULE_SET_VERSION`.
- Semantic rule changes must continue to bump the existing `RULE_SET_VERSION`; the new regression test verifies that version changes refresh coverage.
- No migration, rollout step, or compatibility action is required.

### Follow-up

None for this user goal.