### PR TITLE
Put plan artifacts in the repository they describe

### DIFF
--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -2908,6 +2908,7 @@ These surfaces are generated command references, not installed Hermes workflow s
   - Observed repo facts and source/web evidence gaps are named.
   - At least two options or one chosen option plus rejected alternatives are recorded.
   - Risks, acceptance criteria, and verification commands are testable or explicitly blocked.
+  - The plan exists as a recorded file-backed artifact, not only as chat narration.
   - The implementation handoff is prepared only after plan acceptance and remains prepared_not_observed.
 - Recovery notes:
   - If requirements are still fuzzy, route back to deep-interview before planning.
@@ -2927,7 +2928,8 @@ These surfaces are generated command references, not installed Hermes workflow s
   - verification commands
   - handoff guidance
 - Artifact expectations:
-  - plan and review artifacts when a wrapper supports file-backed planning
+  - record the plan with `omh hermes plan --record`, which writes `<repo>/.omh/plans/<slug>.md` inside a repository and the user-scope OMH store outside one
+  - mark acceptance with `omh hermes plan-accept <path>` so acceptance_recorded and handoff_ready point at a real artifact
 - Safety rules:
   - Do not implement directly from the planning lane.
   - Do not invent codebase or web evidence; label missing evidence and source gaps.

--- a/skills/ralplan/SKILL.md
+++ b/skills/ralplan/SKILL.md
@@ -43,6 +43,7 @@ Bad example:
 - Observed repo facts and source/web evidence gaps are named.
 - At least two options or one chosen option plus rejected alternatives are recorded.
 - Risks, acceptance criteria, and verification commands are testable or explicitly blocked.
+- The plan exists as a recorded file-backed artifact, not only as chat narration.
 - The implementation handoff is prepared only after plan acceptance and remains prepared_not_observed.
 
 ## Recovery Notes
@@ -108,7 +109,8 @@ Expected outputs:
 
 Artifact expectations:
 
-- plan and review artifacts when a wrapper supports file-backed planning
+- record the plan with `omh hermes plan --record`, which writes `<repo>/.omh/plans/<slug>.md` inside a repository and the user-scope OMH store outside one
+- mark acceptance with `omh hermes plan-accept <path>` so acceptance_recorded and handoff_ready point at a real artifact
 
 Safety rules:
 

--- a/src/commands/hermes.py
+++ b/src/commands/hermes.py
@@ -155,7 +155,11 @@ def _add_hermes_commands(sub) -> None:
         default=None,
         help="Read a Slack/Discord/Hermes-like JSON event from this path, or '-' for stdin.",
     )
-    plan.add_argument("--record", action="store_true", help="Write the plan under .hermes/plans.")
+    plan.add_argument(
+        "--record",
+        action="store_true",
+        help="Write the plan under <repo>/.omh/plans, or the OMH home when outside a repository.",
+    )
     plan.add_argument("--source-event-id", default="", help="Optional source message/event id to store as metadata.")
     plan.add_argument("--channel-ref", default="", help="Optional channel reference to store as metadata.")
     plan.add_argument("--user-ref", default="", help="Optional user reference to store as metadata.")

--- a/src/skills/catalog.py
+++ b/src/skills/catalog.py
@@ -4426,7 +4426,14 @@ _DEFINITIONS = [
         handoff_policy="Keep consensus planning and review in Hermes; produce explicit selected executor/runtime handoff guidance only after the plan is accepted.",
         required_inputs=("requirements", "codebase facts", "source or web evidence when needed", "options", "tradeoffs", "test shape"),
         expected_outputs=("reviewed plan", "acceptance criteria", "risk register", "verification commands", "handoff guidance"),
-        artifact_expectations=("plan and review artifacts when a wrapper supports file-backed planning",),
+        # Naming the commands is the point. This used to read "plan and review
+        # artifacts when a wrapper supports file-backed planning", which names
+        # no path and no command, so no plan file was ever produced and the
+        # planning harness rungs below had nothing to record.
+        artifact_expectations=(
+            "record the plan with `omh hermes plan --record`, which writes `<repo>/.omh/plans/<slug>.md` inside a repository and the user-scope OMH store outside one",
+            "mark acceptance with `omh hermes plan-accept <path>` so acceptance_recorded and handoff_ready point at a real artifact",
+        ),
         safety_rules=(
             "Do not implement directly from the planning lane.",
             "Do not invent codebase or web evidence; label missing evidence and source gaps.",
@@ -4463,6 +4470,7 @@ _DEFINITIONS = [
             "Observed repo facts and source/web evidence gaps are named.",
             "At least two options or one chosen option plus rejected alternatives are recorded.",
             "Risks, acceptance criteria, and verification commands are testable or explicitly blocked.",
+            "The plan exists as a recorded file-backed artifact, not only as chat narration.",
             "The implementation handoff is prepared only after plan acceptance and remains prepared_not_observed.",
         ),
         recovery_notes=(

--- a/src/system/paths.py
+++ b/src/system/paths.py
@@ -4,11 +4,16 @@ import os
 from dataclasses import dataclass
 from pathlib import Path
 
+from .local_store import atomic_write_text
+
 
 @dataclass(frozen=True)
 class OmhPaths:
     omh_home: Path
     hermes_home: Path
+    # Whether the caller named `omh_home` rather than accepting the default.
+    # True by default: constructing OmhPaths directly always names one.
+    omh_home_named: bool = True
 
     @property
     def skills_dir(self) -> Path:
@@ -287,6 +292,55 @@ def project_hermes_home(cwd: str | Path | None = None) -> Path:
     return expand_path(cwd or Path.cwd()) / ".hermes"
 
 
+def find_project_root(cwd: str | Path | None = None) -> Path | None:
+    """Nearest ancestor holding a `.git` entry, or None outside a repository."""
+    # Filesystem-only: `git rev-parse` would be a subprocess in a core that makes
+    # no external calls. `.git` is a directory in a checkout and a file in a
+    # linked worktree, so both shapes count.
+    start = expand_path(cwd or Path.cwd())
+    for candidate in (start, *start.parents):
+        if (candidate / ".git").exists():
+            return candidate
+    return None
+
+
+def project_artifact_dir(paths: OmhPaths, *segments: str, cwd: str | Path | None = None) -> Path:
+    """Repo-local `.omh/<segments>` inside a project, user-scope store outside one."""
+    # A named home wins over the inferred repository: `--omh-home` exists to say
+    # where the store is, and writing elsewhere would make the flag a lie.
+    if paths.omh_home_named:
+        return paths.omh_home.joinpath(*segments)
+    root = find_project_root(cwd)
+    base = root / ".omh" if root is not None else paths.omh_home
+    return base.joinpath(*segments)
+
+
+def ensure_project_store_ignored(directory: Path) -> None:
+    """Give a repo-local OMH store a `.gitignore` so it stays out of `git status`."""
+    # Only this repository's own .gitignore lists `.omh/`; a user's project has
+    # no such rule, so a recorded plan would be untracked and `git add -A` would
+    # commit it. Skipped outside a repository, where there is nothing to ignore
+    # against. An existing file is left alone in case the user wrote their own.
+    store = next((parent for parent in (directory, *directory.parents) if parent.name == ".omh"), None)
+    if store is None or find_project_root(store.parent) is None:
+        return
+    marker = store / ".gitignore"
+    if marker.exists():
+        return
+    try:
+        atomic_write_text(marker, "*\n")
+    except OSError:
+        return  # losing the ignore file is not worth failing the artifact over
+
+
+def project_identity(cwd: str | Path | None = None) -> str:
+    """Repository directory name, or "default" outside one."""
+    # A name rather than a hash: people read this in `scope.ref` next to values
+    # like `document-harness`. Same-named checkouts share a label.
+    root = find_project_root(cwd)
+    return root.name if root is not None and root.name else "default"
+
+
 def resolve_paths(
     omh_home: str | Path | None = None,
     hermes_home: str | Path | None = None,
@@ -301,4 +355,8 @@ def resolve_paths(
     return OmhPaths(
         omh_home=expand_path(omh_home) if omh_home else default_omh,
         hermes_home=expand_path(hermes_home) if hermes_home else default_hermes,
+        # Recorded here, while the caller's intent is still known: comparing the
+        # resolved home against the default later cannot tell a named home from
+        # an unnamed one that happens to match it.
+        omh_home_named=omh_home is not None,
     )

--- a/src/workflows/hermes_planning.py
+++ b/src/workflows/hermes_planning.py
@@ -15,7 +15,7 @@ from ..ingress import CHAT_SOURCES, extract_message_text, extract_source_metadat
 from ..local_store import atomic_write_json, atomic_write_text, utc_now
 from ..memory import validate_handoff_context_pack
 from ..observation_journal import append_observation_event
-from ..paths import OmhPaths
+from ..paths import OmhPaths, ensure_project_store_ignored, project_artifact_dir, project_identity
 from ..routing.recommend import recommend_skills
 from ..skills.catalog import (
     DEEP_INTERVIEW_CLARITY_DIMENSIONS,
@@ -188,11 +188,14 @@ def build_hermes_plan_event_payload(
 
 
 def write_hermes_plan(paths: OmhPaths, payload: dict[str, object]) -> dict[str, object]:
+    """Write the file-backed plan artifact into OMH's store for this repository."""
     plan = payload.get("plan")
     if not isinstance(plan, dict):
         raise ValueError("hermes plan payload is missing plan")
     slug = _slugify(str(plan.get("task_statement", "plan")))
-    path = _unique_artifact_path(paths.hermes_home / "plans", slug, ".md")
+    plans_dir = project_artifact_dir(paths, "plans")
+    ensure_project_store_ignored(plans_dir)
+    path = _unique_artifact_path(plans_dir, slug, ".md")
     content = render_plan_markdown(payload, path.name)
     atomic_write_text(path, content, private=True)
     artifact: dict[str, object] = {
@@ -202,7 +205,9 @@ def write_hermes_plan(paths: OmhPaths, payload: dict[str, object]) -> dict[str, 
         "status": plan.get("status", "draft"),
     }
     if plan.get("status") == "blocked":
-        context_path = _unique_artifact_path(paths.hermes_home / "context", f"{slug}-context", ".md")
+        context_path = _unique_artifact_path(
+            project_artifact_dir(paths, "plan-context"), f"{slug}-context", ".md"
+        )
         atomic_write_text(context_path, render_context_markdown(payload, context_path.name), private=True)
         artifact["context_path"] = str(context_path)
     try:
@@ -325,11 +330,13 @@ def build_plan_handoff_message(artifact: dict[str, object]) -> str:
 
 def build_plan_handoff_context_pack(artifact: dict[str, object], *, executor_target: str = "codex") -> dict[str, object]:
     plan_artifact_path = str(artifact.get("path", ""))
+    # Copied into each consumer below so editing one scope cannot rewrite the others.
+    scope = {"kind": "project", "ref": project_identity()}
     pack = {
         "schema_version": "handoff_context_pack/v1",
         "executor_target": executor_target,
         "session_id": "",
-        "scope": {"kind": "project", "ref": "default"},
+        "scope": dict(scope),
         "metadata": {
             "plan_artifact_path": plan_artifact_path,
             "plan_artifact_ref": plan_artifact_path,
@@ -356,7 +363,7 @@ def build_plan_handoff_context_pack(artifact: dict[str, object], *, executor_tar
                 "artifact_ref": plan_artifact_path,
                 "source": "hermes_plan",
                 "truth_level": "approved_context",
-                "scope": {"kind": "project", "ref": "default"},
+                "scope": dict(scope),
             }
         ],
         "excluded_context": [],

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9425,13 +9425,16 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
                 self.assertFalse(coding_delegate["available"])
                 self.assertEqual(coding_delegate["unavailable_reason"], "task is not implementation-shaped")
 
-    def test_hermes_plan_records_under_hermes_home(self) -> None:
+    def test_hermes_plan_records_under_the_omh_store(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)
             hermes_home = root / ".hermes"
+            omh_home = root / ".omh"
 
             status, stdout, stderr = run_cli(
                 [
+                    "--omh-home",
+                    str(omh_home),
                     "--hermes-home",
                     str(hermes_home),
                     "hermes",
@@ -9456,7 +9459,9 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
             self.assertTrue(contract_artifact["recorded"])
             self.assertEqual(contract_artifact["path"], artifact["path"])
             self.assertEqual(contract_artifact["status"], "draft")
-            self.assertEqual(plan_path.parent.resolve(), (hermes_home / "plans").resolve())
+            # Plans belong to OMH's store, not to Hermes' home directory.
+            self.assertEqual(plan_path.parent.resolve(), (omh_home / "plans").resolve())
+            self.assertFalse((hermes_home / "plans").exists())
             self.assertTrue(plan_path.exists())
             self.assertFalse((root / ("." + "om" + "x") / "plans").exists())
             text = plan_path.read_text(encoding="utf-8")
@@ -9583,8 +9588,20 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
         with TemporaryDirectory() as tmp:
             root = Path(tmp)
             hermes_home = root / ".hermes"
+            omh_home = root / ".omh"
 
-            status, stdout, stderr = run_cli(["--hermes-home", str(hermes_home), "hermes", "plan", "--record", "help"])
+            status, stdout, stderr = run_cli(
+                [
+                    "--omh-home",
+                    str(omh_home),
+                    "--hermes-home",
+                    str(hermes_home),
+                    "hermes",
+                    "plan",
+                    "--record",
+                    "help",
+                ]
+            )
 
             self.assertEqual(stderr, "")
             self.assertEqual(status, 0)
@@ -9605,8 +9622,9 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
             self.assertEqual(payload["wrapper_contract"]["plan_artifact"]["context_path"], artifact["context_path"])
             plan_path = Path(artifact["path"])
             context_path = Path(artifact["context_path"])
-            self.assertEqual(plan_path.parent.resolve(), (hermes_home / "plans").resolve())
-            self.assertEqual(context_path.parent.resolve(), (hermes_home / "context").resolve())
+            self.assertEqual(plan_path.parent.resolve(), (omh_home / "plans").resolve())
+            self.assertEqual(context_path.parent.resolve(), (omh_home / "plan-context").resolve())
+            self.assertFalse((hermes_home / "context").exists())
             self.assertTrue(plan_path.exists())
             self.assertTrue(context_path.exists())
             context_text = context_path.read_text(encoding="utf-8")

--- a/tests/test_project_scoped_artifacts.py
+++ b/tests/test_project_scoped_artifacts.py
@@ -1,0 +1,278 @@
+"""Repository-specific OMH artifacts resolve to the repository they describe.
+
+Plans used to be written into `~/.hermes/plans`: Hermes' own home, one flat
+directory for every project, with `scope.ref` hardcoded to "default" so nothing
+in the artifact said which repository it came from. These tests pin the four
+decisions that replaced it -- how a root is found, which store wins, whether the
+store is ignored, and what identity the artifact carries.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.paths import (
+    OmhPaths,
+    ensure_project_store_ignored,
+    find_project_root,
+    project_artifact_dir,
+    project_identity,
+    resolve_paths,
+)
+from omh.workflows.hermes_planning import (
+    build_hermes_plan_payload,
+    build_plan_handoff_context_pack,
+    write_hermes_plan,
+)
+
+
+def _repo(root: Path, *, git_as_file: bool = False) -> Path:
+    """A directory that looks like a git checkout to the resolver."""
+    marker = root / ".git"
+    if git_as_file:
+        # What a linked worktree actually leaves behind.
+        marker.write_text("gitdir: /elsewhere/.git/worktrees/x\n", encoding="utf-8")
+    else:
+        marker.mkdir()
+    return root
+
+
+class FindProjectRootTests(unittest.TestCase):
+    def test_nested_directory_resolves_to_the_repository_root(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = _repo(Path(tmp).resolve())
+            nested = root / "src" / "deep" / "nested"
+            nested.mkdir(parents=True)
+            self.assertEqual(find_project_root(nested), root)
+
+    def test_git_as_a_file_resolves_like_git_as_a_directory(self) -> None:
+        with TemporaryDirectory() as tmp:
+            # A linked worktree writes `.git` as a file. Testing only for a
+            # directory would send every worktree to the user-scope fallback.
+            root = _repo(Path(tmp).resolve(), git_as_file=True)
+            self.assertEqual(find_project_root(root), root)
+
+    def test_the_nearest_repository_root_wins(self) -> None:
+        with TemporaryDirectory() as tmp:
+            outer = _repo(Path(tmp).resolve())
+            inner = outer / "vendor" / "lib"
+            inner.mkdir(parents=True)
+            _repo(inner)
+            (inner / "src").mkdir()
+            # Returning the outermost root would put a vendored library's plans
+            # in its host repository.
+            self.assertEqual(find_project_root(inner / "src"), inner)
+
+    def test_resolution_runs_no_subprocess(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = _repo(Path(tmp).resolve())
+            # PATH emptied: a `git rev-parse` implementation would fail here.
+            previous = os.environ.get("PATH", "")
+            os.environ["PATH"] = ""
+            try:
+                self.assertEqual(find_project_root(root), root)
+            finally:
+                os.environ["PATH"] = previous
+
+
+class ArtifactDirTests(unittest.TestCase):
+    def test_inside_a_repository_artifacts_sit_beside_the_code(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = _repo(Path(tmp).resolve())
+            paths = resolve_paths()  # default home, so the repository decides
+            self.assertEqual(
+                project_artifact_dir(paths, "plans", cwd=root),
+                root / ".omh" / "plans",
+            )
+
+    def test_an_explicit_omh_home_wins_over_the_repository(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = _repo(Path(tmp).resolve())
+            named = root / "explicit-home"
+            paths = resolve_paths(named, root / ".hermes")
+            # `--omh-home` says where the store is; inferring past it would make
+            # the flag a lie and would scatter test output into the source tree.
+            self.assertEqual(project_artifact_dir(paths, "plans", cwd=root), named / "plans")
+
+    def test_an_explicit_home_equal_to_the_default_still_wins(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = _repo(Path(tmp).resolve())
+            named = Path(os.environ["OMH_HOME"]).resolve()  # what resolve_paths would default to
+            paths = resolve_paths(named, root / ".hermes")
+            # Detecting "explicit" by comparing the resolved home against the
+            # default cannot see this case: a caller that passes the same value
+            # the default resolves to is still a caller that named it. Any
+            # script passing --omh-home for reproducibility hits this.
+            self.assertTrue(paths.omh_home_named)
+            self.assertEqual(project_artifact_dir(paths, "plans", cwd=root), named / "plans")
+
+    def test_an_unnamed_home_lets_the_repository_decide(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = _repo(Path(tmp).resolve())
+            paths = resolve_paths()
+            self.assertFalse(paths.omh_home_named)
+            self.assertEqual(project_artifact_dir(paths, "plans", cwd=root), root / ".omh" / "plans")
+
+    def test_scope_project_still_resolves_to_the_repository_root(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = _repo(Path(tmp).resolve())
+            nested = root / "nested" / "deep"
+            nested.mkdir(parents=True)
+            paths = resolve_paths(scope="project")
+            # `--scope project` sets omh_home from the literal cwd, so without
+            # the walk a plan recorded from a subdirectory would land in
+            # nested/deep/.omh instead of the repository's own store.
+            self.assertEqual(
+                project_artifact_dir(paths, "plans", cwd=nested), root / ".omh" / "plans"
+            )
+
+    def test_constructing_paths_directly_counts_as_naming_the_home(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = _repo(Path(tmp).resolve())
+            # Call sites that build OmhPaths by hand always pass a home, so the
+            # default must not silently divert them into a repository.
+            paths = OmhPaths(omh_home=root / "direct", hermes_home=root / ".hermes")
+            self.assertEqual(project_artifact_dir(paths, "plans", cwd=root), root / "direct" / "plans")
+
+    def test_outside_a_repository_artifacts_fall_back_to_the_user_store(self) -> None:
+        # Patched rather than inferred: whether a temp dir sits under a
+        # repository is machine-dependent, and recomputing the expected value
+        # from find_project_root would just restate the implementation.
+        paths = resolve_paths()
+        with patch("omh.system.paths.find_project_root", return_value=None):
+            self.assertEqual(project_artifact_dir(paths, "plans"), paths.omh_home / "plans")
+
+
+class ProjectIdentityTests(unittest.TestCase):
+    def test_identity_falls_back_to_default_outside_a_repository(self) -> None:
+        with patch("omh.system.paths.find_project_root", return_value=None):
+            self.assertEqual(project_identity(), "default")
+
+    def test_identity_is_the_repository_directory_name(self) -> None:
+        with TemporaryDirectory() as tmp:
+            named = Path(tmp).resolve() / "acme-service"
+            named.mkdir()
+            self.assertEqual(project_identity(_repo(named)), "acme-service")
+
+    def test_identity_is_stable_across_calls_in_one_repository(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = _repo(Path(tmp).resolve())
+            nested = root / "src"
+            nested.mkdir()
+            self.assertEqual(project_identity(root), project_identity(nested))
+
+
+class StoreIgnoreTests(unittest.TestCase):
+    """A repo-local store must not turn up in the user's `git status`."""
+
+    def test_the_store_ignores_itself(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = _repo(Path(tmp).resolve())
+            ensure_project_store_ignored(root / ".omh" / "plans")
+            self.assertEqual((root / ".omh" / ".gitignore").read_text(encoding="utf-8"), "*\n")
+
+    def test_an_existing_ignore_file_is_left_alone(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = _repo(Path(tmp).resolve())
+            marker = root / ".omh" / ".gitignore"
+            marker.parent.mkdir(parents=True)
+            marker.write_text("!keep-me\n", encoding="utf-8")
+            ensure_project_store_ignored(marker.parent / "plans")
+            self.assertEqual(marker.read_text(encoding="utf-8"), "!keep-me\n")
+
+    def test_a_store_outside_a_repository_is_left_alone(self) -> None:
+        with TemporaryDirectory() as tmp:
+            # The user-scope ~/.omh is not version controlled, so an ignore file
+            # there would be litter rather than protection.
+            store = Path(tmp).resolve() / ".omh" / "plans"
+            with patch("omh.system.paths.find_project_root", return_value=None):
+                ensure_project_store_ignored(store)
+            self.assertEqual(list(Path(tmp).rglob(".gitignore")), [])
+
+    def test_a_directory_outside_a_store_is_untouched(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = _repo(Path(tmp).resolve())
+            ensure_project_store_ignored(root / "somewhere" / "plans")
+            self.assertEqual(list(root.rglob(".gitignore")), [])
+
+    def test_no_temp_file_survives_the_write(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = _repo(Path(tmp).resolve())
+            ensure_project_store_ignored(root / ".omh" / "plans")
+            self.assertEqual(list((root / ".omh").glob("*.tmp")), [])
+
+    def test_recording_a_plan_writes_the_ignore_file(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = _repo(Path(tmp).resolve())
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            write_hermes_plan(paths, build_hermes_plan_payload("build a coding delegation flow"))
+            self.assertEqual((paths.omh_home / ".gitignore").read_text(encoding="utf-8"), "*\n")
+
+
+class HandoffScopeTests(unittest.TestCase):
+    """`scope.ref` shipped as the literal "default" in every pack ever built."""
+
+    def _pack(self) -> dict:
+        return build_plan_handoff_context_pack(
+            {"path": "/tmp/plan.md", "status": "accepted", "schema_version": "hermes_plan/v1", "sha256": "abc"}
+        )
+
+    def test_scope_names_the_repository_rather_than_default(self) -> None:
+        pack = self._pack()
+        # The suite runs inside this repository, so a resolved identity is
+        # available and "default" would mean the resolver never fired.
+        self.assertEqual(pack["scope"]["kind"], "project")
+        self.assertNotEqual(pack["scope"]["ref"], "default")
+        self.assertEqual(pack["scope"]["ref"], project_identity())
+
+    def test_included_context_carries_the_same_scope(self) -> None:
+        pack = self._pack()
+        self.assertEqual(pack["included_context"][0]["scope"], pack["scope"])
+
+    def test_each_pack_owns_its_scope_dict(self) -> None:
+        pack = self._pack()
+        pack["scope"]["ref"] = "mutated"
+        # Sharing one dict between the pack and its rows would let a caller
+        # editing the top-level scope silently rewrite every included row.
+        self.assertNotEqual(pack["included_context"][0]["scope"]["ref"], "mutated")
+
+
+class PlanWriteTests(unittest.TestCase):
+    def test_a_recorded_plan_never_touches_the_hermes_home(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp).resolve()
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            payload = build_hermes_plan_payload("build a coding delegation flow")
+
+            artifact = write_hermes_plan(paths, payload)
+
+            plan_path = Path(str(artifact["path"]))
+            self.assertEqual(plan_path.parent, paths.omh_home / "plans")
+            self.assertTrue(plan_path.exists())
+            self.assertFalse((paths.hermes_home / "plans").exists())
+            self.assertFalse((paths.hermes_home / "context").exists())
+
+    def test_a_blocked_plan_puts_its_context_in_the_same_store(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp).resolve()
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            payload = build_hermes_plan_payload("help")
+
+            artifact = write_hermes_plan(paths, payload)
+
+            self.assertEqual(payload["plan"]["status"], "blocked")
+            context_path = Path(str(artifact["context_path"]))
+            self.assertEqual(context_path.parent, paths.omh_home / "plan-context")
+            self.assertTrue(context_path.exists())
+            self.assertFalse((paths.hermes_home / "context").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Capability

OMH's file-backed plan artifacts now live in OMH's own store, scoped to the repository they describe, and `ralplan` actually tells Hermes to produce one.

```
before   ~/.hermes/plans/2026-...-add-a-retry-9a9208.md     (Hermes' home, one flat dir, no project)
after    <repo>/.omh/plans/2026-...-add-a-retry-9a9208.md   (gitignored, beside the code it plans)
```

## Motivation

**The location was wrong on two counts.** `~/.hermes` is Hermes' home directory, not OMH's. And it is a single flat directory: the filename carries a timestamp and a slug but no project, `scope.ref` was the hardcoded literal `"default"` (`hermes_planning.py:327`, `:354`), and nothing in the repo ever listed or pruned it. Two repositories planning similar work produced indistinguishable files that accumulated forever.

A plan describes one repository — exactly like the codegraph artifact OMH already writes to `<repo>/.omh/codegraph/codegraph.json`. Splitting those two, one project-local and one global, had no reason behind it.

**Nothing ever created one.** `skills/ralplan/SKILL.md` said only:

> plan and review artifacts when a wrapper supports file-backed planning

No path, no command. So on a real install with `ralplan` present, `~/.hermes/plans` did not exist, `omh hermes plan-accept|plan-revise|plan-cancel` had nothing to operate on, and the `planning` harness rungs `acceptance_recorded` and `handoff_ready` could not be filled. Guidance text that names no command is not guidance.

## What you can do now

```
$ cd ~/work/some-service
$ omh hermes plan --record "add a retry to the release script"
  → /Users/me/work/some-service/.omh/plans/2026-07-26T...-add-a-retry-...md
$ git status --short          # empty: the store ignores itself
$ omh hermes plan-accept <path>
```

Outside a repository it falls back to the user-scope OMH home, so nothing breaks when Hermes runs from an arbitrary directory.

## Implementation

**`src/system/paths.py`** — a new field and four helpers:

- `OmhPaths.omh_home_named: bool = True` records whether the caller named `omh_home`. `resolve_paths` sets it from `omh_home is not None`, capturing intent where it is still known. The first draft inferred this by comparing the resolved home against `default_omh_home()`, which cannot distinguish "the user named this home" from "the user named nothing and the default happens to be this" — so `--omh-home ~/.omh`, or any script that passes the flag for reproducibility, read as unset and got silently redirected into the repository. Review caught it; `test_an_explicit_home_equal_to_the_default_still_wins` pins it. The default is `True` because building `OmhPaths` by hand always names a home, which keeps the ~15 direct construction sites behaving as before.
- `find_project_root(cwd)` walks up to the nearest ancestor holding `.git`, else `None`. Filesystem-only: `git rev-parse` would put a subprocess in a core that makes no external calls and would disagree with the walk when git is off PATH. `.git` is matched as a **file or** a directory, so linked worktrees resolve to the worktree root instead of falling through.
- `project_artifact_dir(paths, *segments)` returns `<repo>/.omh/<segments>` with a root and `paths.omh_home/<segments>` without, unless the home was named — then the named home wins.
- `ensure_project_store_ignored(dir)` writes `*` into `<repo>/.omh/.gitignore` via the existing `atomic_write_text`. Skipped when the store is not inside a repository, since `~/.omh` is not version controlled and an ignore file there would be litter. Never overwrites an existing file.
- `project_identity(cwd)` is the repository directory name — read by people in `scope.ref` alongside values like `document-harness`, so a name beats a hash.

**`src/workflows/hermes_planning.py`** — `write_hermes_plan` targets the resolved dirs (`plans`, `plan-context`) and both `scope.ref` sites carry `project_identity()`. The returned artifact dict is unchanged, so the CLI and `attach_plan_artifact_to_wrapper_contract` needed no edit, and `plan-accept`/`plan-revise`/`plan-cancel` keep working because they take a path.

**`src/skills/catalog.py`** — the ralplan entry names `omh hermes plan --record` and `omh hermes plan-accept`, plus a checklist line that the plan must exist as a recorded artifact rather than chat narration. `skills/ralplan/SKILL.md` and `docs/WORKFLOWS.md` regenerated.

## Verification observed

| Gate | Result |
| --- | --- |
| Full suite (`PYTHONPATH=tests`) | 1916 passed, 1 skipped |
| Baseline with every change stashed | 1891 — so +25, exactly the new test file |
| ruff, compileall, `git diff --check` | clean |
| `docs workflows / roles / capability-families --check` | ok, tap_skills 97/97 |
| `omh release drift` | no drift, 11 checks |
| Journal delta across a full suite run | 0 |

The new tests were mutation-checked against `origin/main`: all five behavioural expectations — plan location, `~/.hermes` untouched, blocked-context location, `scope.ref != "default"`, store self-ignores — fail against the pre-change code, so they are not self-fulfilling.

Live, in a scratch git repo with a fake `HOME`:

```
plan → <repo>/.omh/plans/2026-...-add-a-retry-...md
fake HOME/.hermes            never created
git status --short           (empty)
git check-ignore -v          .omh/.gitignore:1:*   .omh/plans
plan-accept → revise → cancel   frontmatter ends at `status: cancelled`
```

## Risks and follow-ups

- **`omh doctor` reports 27/28, not 28/28.** `plugin_bundle_current` calls the installed `~/.hermes/plugins/omh` bundle stale against the package. It reproduces with every change in this branch stashed, so it is the dev worktree differing from the installed bundle, not a regression.
- **Existing `~/.hermes/plans` files are orphaned.** Nothing reads the old location now. They are plain markdown and the lifecycle commands take a path, so an old plan can still be accepted by pointing at it; nothing migrates them automatically.
- **`project_identity` is the directory basename**, so two checkouts sharing a name share a `scope.ref`. Today that only mislabels provenance in a handoff pack: the memory-recall scope matcher (`workflows/memory.py`) is a separate mechanism and never receives this value, so there is no cross-project context bleed. Worth revisiting if the two are ever joined.
- **`--scope project` from a subdirectory now splits the effective home.** `paths.manifest_path`, `paths.runtime_dir` and every other `OmhPaths` property still resolve under the literal `<cwd>/.omh`, while `plans` alone walks to the repository root. Before this change `--scope project` was internally consistent — everything, plans included, sat under the literal cwd. Impact is low because the plan path is always returned in the artifact JSON and never reconstructed from `paths.omh_home`, and the combination is narrow, but it is a new inconsistency rather than a pre-existing one.
- **`codegraph build --write` does not yet call `ensure_project_store_ignored`.** It gets the ignore file for free once a plan is recorded in the same repo, but a codegraph-only user still sees an untracked `.omh/`. Follow-up.
- **`plan-context` shares its leaf name** with the pre-existing `runtime_plan_context_dir` (`runtime/plan-context`). Different purpose and depth; left alone rather than churn an existing path for a readability nit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
