### PR TITLE
feat: help someone build a wiki instead of grading one note at a time

### DIFF
--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -3246,15 +3246,21 @@ These surfaces are generated command references, not installed Hermes workflow s
   - Capture durable facts with source evidence and destination-aware retrieval hints.
   - Treat Obsidian as one vendor hint under a broader external knowledge connection model.
   - Never present prepared wiki guidance as an observed external write, store creation, or memory mutation.
+  - Mark stale or uncertain knowledge instead of presenting it as permanent truth.
+  - Extract separate coding tasks instead of burying them in notes.
 - Completion checklist:
   - Audience scale, destination, knowledge types, and maintenance owner are recorded or named as missing.
   - The proposed model carries its rationale, breaking conditions, and one alternative.
   - Skeleton, entry points, conventions, maintenance, and seed pages are concrete enough to start today.
+  - Destination-specific guidance is prepared for the named store or the unknown destination gap is explicit.
   - No output claims an external write, store creation, connector run, or memory mutation without evidence.
+  - Separate coding or connector tasks are extracted instead of buried in notes.
 - Recovery notes:
   - If the audience scale is unknown, ask for it before proposing structure; it changes the model.
   - If nobody owns maintenance, record 'unmaintained' and choose a model that survives it.
+  - If source evidence conflicts, route to memory or knowledge review before writing durable guidance.
   - If the destination is unknown, record the missing facts and keep the guidance vendor-neutral.
+  - If the fact may be stale, record the staleness warning and next refresh action.
 - Required inputs:
   - audience scale (personal, small group, team, or organization)
   - destination or existing store
@@ -3266,7 +3272,8 @@ These surfaces are generated command references, not installed Hermes workflow s
   - destination-aware note guidance with retrieval hint and staleness warning
   - prepared-versus-observed external write boundary
 - Artifact expectations:
-  - wiki skeleton proposal, repo-local markdown artifact, or metadata-only destination guidance
+  - wiki skeleton proposal covering sections, entry points, conventions, and maintenance
+  - repo-local markdown knowledge artifact or metadata-only destination guidance
 - Safety rules:
   - Do not imply hidden Hermes runtime behavior.
   - Use the smallest verification that can prove the claim.

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -3213,10 +3213,10 @@ These surfaces are generated command references, not installed Hermes workflow s
 
 ### wiki
 
-[omh] Hermes adaptation for retained knowledge capture and destination-aware external knowledge connection guidance.
+[omh] Hermes adaptation for wiki construction blueprints and retained knowledge capture with destination-aware external knowledge connection guidance.
 
 - Category: `knowledge`
-- Phase: `capture`
+- Phase: `design-and-capture`
 - Hermes role: `memory-keeper`
 - Quality tier: `knowledge-gated`
 - Exposure: `direct_skill`
@@ -3224,48 +3224,49 @@ These surfaces are generated command references, not installed Hermes workflow s
 - Docs visibility: `primary_workflow_skill`
 - Compatibility alias: `false`
 - Preferred usage: Use as an installed Hermes workflow skill when this explicit workflow is the clearest user-facing handle.
-- Handoff policy: Run directly in Hermes as retained knowledge capture; prepare connector/runtime handoff only when a separate observed external write or coding task is explicitly required.
+- Handoff policy: Run directly in Hermes as wiki design and retained knowledge capture; prepare connector/runtime handoff only when a separate observed external write or coding task is explicitly required.
 - Why this exists: `wiki` exists to keep `knowledge` work explicit, evidence-backed, and inside the Hermes/executor boundary instead of relying on ad hoc chat narration.
-- Use when: Use to capture durable project knowledge and prepare destination-aware wiki guidance for markdown vaults, Obsidian, Notion, Google Drive/Docs, databases, local folders, or unknown external knowledge targets.
+- Use when: Use to design a wiki someone can start today - model, skeleton, conventions, seed pages, and maintenance sized to a personal, small-group, team, or organization audience - and to capture durable knowledge into markdown vaults, Obsidian, Notion, Google Drive/Docs, databases, or local folders.
 - Do not use when:
   - The request is casual chat, a status-only acknowledgement, or another workflow has stronger routing evidence.
   - The user needs implementation, review, CI, merge, or external publishing evidence that has not been delegated or observed.
-- Strong routing signals: `wiki`, `project wiki`, `memory`, `notes`, `external knowledge store`, `knowledge base`, `Obsidian`, `markdown vault`, `Notion knowledge base`, `Google Drive wiki`, `옵시디언`, `마크다운 볼트`, `노션 지식베이스`
+- Strong routing signals: `wiki`, `project wiki`, `build a wiki`, `start a wiki`, `organize my notes`, `external knowledge store`, `knowledge base`, `Obsidian`, `markdown vault`, `Notion knowledge base`, `Google Drive wiki`, `옵시디언`, `마크다운 볼트`, `노션 지식베이스`, `위키`, `위키 만들`, `지식베이스`, `지식 정리 체계`
 - Good example:
-  - Prompt: wiki: capture the router decisions and prepare Obsidian vault retrieval hints without claiming a write happened.
-  - Expected behavior: Prepare retained knowledge guidance with source context, destination-aware structure, staleness notes, and observed-write boundaries.
-  - Why: The request is knowledge capture with an external destination preference, not connector execution.
+  - Prompt: wiki: six of us keep re-answering the same questions in chat; help me stand up a wiki in Notion.
+  - Expected behavior: Ask who reads and maintains it and what knowledge repeats, then propose one model with its breaking conditions, a skeleton, and seed pages, without claiming the store was created.
+  - Why: The request is wiki construction for a shared audience, not a single note capture or connector execution.
 - Bad example:
   - Prompt: wiki: treat casual chat or unaccepted work as if this workflow already produced verified results.
   - Expected behavior: Ask a clarification question or route to a narrower workflow instead of forcing `wiki`.
   - Why: The request lacks the required inputs or would overclaim work that Hermes did not observe.
 - Quality bar:
+  - Size the structure to the audience: personal and shared wikis fail differently and get different models.
+  - Propose a model with its rationale, breaking conditions, and one alternative; cap seed pages at ten.
+  - Check existing ecosystem wiki skills before designing a bespoke structure.
   - Capture durable facts with source evidence and destination-aware retrieval hints.
   - Treat Obsidian as one vendor hint under a broader external knowledge connection model.
-  - Never present prepared wiki guidance as an observed external write, query, connector, or memory mutation.
-  - Mark stale or uncertain knowledge instead of presenting it as permanent truth.
-  - Extract separate coding tasks instead of burying them in notes.
+  - Never present prepared wiki guidance as an observed external write, store creation, or memory mutation.
 - Completion checklist:
-  - The durable fact, source evidence, destination preference, retrieval hint, and staleness risk are recorded.
-  - Destination-specific guidance is prepared for the named store or the unknown destination gap is explicit.
-  - No output claims an external write, query, connector invocation, or memory mutation without observed evidence.
-  - Separate coding or connector tasks are extracted instead of buried in notes.
+  - Audience scale, destination, knowledge types, and maintenance owner are recorded or named as missing.
+  - The proposed model carries its rationale, breaking conditions, and one alternative.
+  - Skeleton, entry points, conventions, maintenance, and seed pages are concrete enough to start today.
+  - No output claims an external write, store creation, connector run, or memory mutation without evidence.
 - Recovery notes:
-  - If source evidence conflicts, route to memory or knowledge review before writing durable guidance.
-  - If the destination is unknown, record the missing destination facts and keep the guidance vendor-neutral.
-  - If the fact may be stale, record the staleness warning and next refresh action.
+  - If the audience scale is unknown, ask for it before proposing structure; it changes the model.
+  - If nobody owns maintenance, record 'unmaintained' and choose a model that survives it.
+  - If the destination is unknown, record the missing facts and keep the guidance vendor-neutral.
 - Required inputs:
-  - project fact
-  - source evidence
-  - target topic
-  - destination preference when supplied
+  - audience scale (personal, small group, team, or organization)
+  - destination or existing store
+  - knowledge types the wiki must hold
+  - maintenance owner and cadence
 - Expected outputs:
-  - retained knowledge note guidance
-  - destination-aware organization and retrieval hint
-  - staleness warning when needed
+  - wiki_blueprint/v1 with organization model, rationale, breaking conditions, and one alternative
+  - skeleton, entry points, conventions, maintenance routine, seed pages, and ecosystem candidates
+  - destination-aware note guidance with retrieval hint and staleness warning
   - prepared-versus-observed external write boundary
 - Artifact expectations:
-  - repo-local markdown knowledge artifact or metadata-only destination guidance
+  - wiki skeleton proposal, repo-local markdown artifact, or metadata-only destination guidance
 - Safety rules:
   - Do not imply hidden Hermes runtime behavior.
   - Use the smallest verification that can prove the claim.

--- a/skills/oh-my-hermes/references/catalog-index.md
+++ b/skills/oh-my-hermes/references/catalog-index.md
@@ -91,7 +91,7 @@ Trigger phrases and the role registry live in `references/workflow-registry.md`;
 - `voice-operator`: [omh] Hermes voice operator workflow: turn short voice or mobile commands into clarify, plan, status, handoff, or confirmation actions.
 - `web-research`: [omh] Hermes Web Research workflow: source-backed current information gathering.
 - `websearch-setup`: [omh] Hermes Web Search Setup workflow: diagnose scraper and auxiliary extract-model configuration, guide account setup, and apply each change as its own diff approval.
-- `wiki`: [omh] Hermes adaptation for retained knowledge capture and destination-aware external knowledge connection guidance.
+- `wiki`: [omh] Hermes adaptation for wiki construction blueprints and retained knowledge capture with destination-aware external knowledge connection guidance.
 - `workflow-learning`: [omh] Hermes workflow learning workflow: classify and review self-improvement store routes as an auxiliary review lane before durable writes, then record workflow attempts as metadata-only traces, evals, review queues, patch proposals, regression cases, audits, indexes, and exports.
 - `workspace-audit`: [omh] Hermes Workspace Audit workflow: map repository, skill, prompt, plugin, MCP, hook, config, and runtime surfaces before strengthening or operating OMH.
 - `workspace-file-operator`: [omh] Hermes workspace file operator workflow: scope local file/folder listing, search, organize, copy, move, rename, and delete tasks with path and destructive-action gates.

--- a/skills/oh-my-hermes/references/workflow-registry.md
+++ b/skills/oh-my-hermes/references/workflow-registry.md
@@ -85,7 +85,7 @@ When Hermes exposes installed skill descriptions to the model, use this registry
 - `best-practice-research`: `best-practice-research`, `best practice`, `official docs`, `upstream guidance`
 - `autoresearch-goal`: `autoresearch-goal`, `research goal`, `durable research`, `critic research`
 - `performance-goal`: `performance-goal`, `performance goal`, `latency`, `throughput`, `benchmark`
-- `wiki`: `wiki`, `project wiki`, `memory`, `notes`, `external knowledge store`, `knowledge base`, `Obsidian`, `markdown vault`, `Notion knowledge base`
+- `wiki`: `wiki`, `project wiki`, `build a wiki`, `start a wiki`, `organize my notes`, `external knowledge store`, `knowledge base`, `Obsidian`, `markdown vault`
 - `ask`: `ask`, `$ask`, `external advisor`, `claude`, `gemini`
 - `cancel`: `cancel`, `$cancel`, `stop`, `abort`
 - `skill`: `skill`, `$skill`, `skills`, `manage skills`

--- a/skills/wiki/SKILL.md
+++ b/skills/wiki/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: omh-wiki
-description: [omh] Hermes adaptation for retained knowledge capture and destination-aware external knowledge connection guidance.
+description: [omh] Hermes adaptation for wiki construction blueprints and retained knowledge capture with destination-aware external knowledge connection guidance.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, knowledge]
     category: knowledge
-    phase: capture
+    phase: design-and-capture
     role: memory-keeper
     quality_tier: knowledge-gated
 ---
@@ -27,9 +27,9 @@ This is a Hermes-native `wiki` workflow skill.
 
 Good example:
 
-- Prompt: wiki: capture the router decisions and prepare Obsidian vault retrieval hints without claiming a write happened.
-- Expected behavior: Prepare retained knowledge guidance with source context, destination-aware structure, staleness notes, and observed-write boundaries.
-- Why: The request is knowledge capture with an external destination preference, not connector execution.
+- Prompt: wiki: six of us keep re-answering the same questions in chat; help me stand up a wiki in Notion.
+- Expected behavior: Ask who reads and maintains it and what knowledge repeats, then propose one model with its breaking conditions, a skeleton, and seed pages, without claiming the store was created.
+- Why: The request is wiki construction for a shared audience, not a single note capture or connector execution.
 
 Bad example:
 
@@ -39,16 +39,16 @@ Bad example:
 
 ## Completion Checklist
 
-- The durable fact, source evidence, destination preference, retrieval hint, and staleness risk are recorded.
-- Destination-specific guidance is prepared for the named store or the unknown destination gap is explicit.
-- No output claims an external write, query, connector invocation, or memory mutation without observed evidence.
-- Separate coding or connector tasks are extracted instead of buried in notes.
+- Audience scale, destination, knowledge types, and maintenance owner are recorded or named as missing.
+- The proposed model carries its rationale, breaking conditions, and one alternative.
+- Skeleton, entry points, conventions, maintenance, and seed pages are concrete enough to start today.
+- No output claims an external write, store creation, connector run, or memory mutation without evidence.
 
 ## Recovery Notes
 
-- If source evidence conflicts, route to memory or knowledge review before writing durable guidance.
-- If the destination is unknown, record the missing destination facts and keep the guidance vendor-neutral.
-- If the fact may be stale, record the staleness warning and next refresh action.
+- If the audience scale is unknown, ask for it before proposing structure; it changes the model.
+- If nobody owns maintenance, record 'unmaintained' and choose a model that survives it.
+- If the destination is unknown, record the missing facts and keep the guidance vendor-neutral.
 
 ## OMH Context Rail
 
@@ -62,48 +62,59 @@ Bad example:
 - Normal users talk to Hermes; OMH CLI is infra.
 - Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
 
+## Design Interview
+
+Settle structure before capture: audience scale, the knowledge types that repeat, what someone will search for, and who maintains it. Skip answered turns, cap at five, and close with one model plus one alternative as a skeleton the user approves before anything is written. No maintainer means `unmaintained`, which rules out models needing curation.
+
+Load `references/wiki-blueprint.md` for the interview turns and `wiki_blueprint/v1` fields, `wiki-patterns.md` for models and what breaks them, `wiki-operations.md` for solo-versus-shared rules, and `wiki-ecosystem.md` for existing skills.
+
+## Boundary
+
+A `wiki_blueprint/v1` is prepared design context, not evidence that a store was created, written to, or migrated. OMH does not host the wiki; the user's own store does.
+
 ## Use When
 
-Use to capture durable project knowledge and prepare destination-aware wiki guidance for markdown vaults, Obsidian, Notion, Google Drive/Docs, databases, local folders, or unknown external knowledge targets.
+Use to design a wiki someone can start today - model, skeleton, conventions, seed pages, and maintenance sized to a personal, small-group, team, or organization audience - and to capture durable knowledge into markdown vaults, Obsidian, Notion, Google Drive/Docs, databases, or local folders.
 
-    Strong routing signals: `wiki`, `project wiki`, `memory`, `notes`, `external knowledge store`, `knowledge base`, `Obsidian`, `markdown vault`, `Notion knowledge base`, `Google Drive wiki`, `옵시디언`, `마크다운 볼트`, `노션 지식베이스`
+    Strong routing signals: `wiki`, `project wiki`, `build a wiki`, `start a wiki`, `organize my notes`, `external knowledge store`, `knowledge base`, `Obsidian`, `markdown vault`, `Notion knowledge base`, `Google Drive wiki`, `옵시디언`, `마크다운 볼트`, `노션 지식베이스`, `위키`, `위키 만들`, `지식베이스`, `지식 정리 체계`
 
 ## Catalog Metadata
 
 Category: `knowledge`
-Phase: `capture`
+Phase: `design-and-capture`
 Hermes role: `memory-keeper`
 Quality tier: `knowledge-gated`
 
 Quality bar:
 
+- Size the structure to the audience: personal and shared wikis fail differently and get different models.
+- Propose a model with its rationale, breaking conditions, and one alternative; cap seed pages at ten.
+- Check existing ecosystem wiki skills before designing a bespoke structure.
 - Capture durable facts with source evidence and destination-aware retrieval hints.
 - Treat Obsidian as one vendor hint under a broader external knowledge connection model.
-- Never present prepared wiki guidance as an observed external write, query, connector, or memory mutation.
-- Mark stale or uncertain knowledge instead of presenting it as permanent truth.
-- Extract separate coding tasks instead of burying them in notes.
+- Never present prepared wiki guidance as an observed external write, store creation, or memory mutation.
 
 Handoff policy:
 
-Run directly in Hermes as retained knowledge capture; prepare connector/runtime handoff only when a separate observed external write or coding task is explicitly required.
+Run directly in Hermes as wiki design and retained knowledge capture; prepare connector/runtime handoff only when a separate observed external write or coding task is explicitly required.
 
 Required inputs:
 
-- project fact
-- source evidence
-- target topic
-- destination preference when supplied
+- audience scale (personal, small group, team, or organization)
+- destination or existing store
+- knowledge types the wiki must hold
+- maintenance owner and cadence
 
 Expected outputs:
 
-- retained knowledge note guidance
-- destination-aware organization and retrieval hint
-- staleness warning when needed
+- wiki_blueprint/v1 with organization model, rationale, breaking conditions, and one alternative
+- skeleton, entry points, conventions, maintenance routine, seed pages, and ecosystem candidates
+- destination-aware note guidance with retrieval hint and staleness warning
 - prepared-versus-observed external write boundary
 
 Artifact expectations:
 
-- repo-local markdown knowledge artifact or metadata-only destination guidance
+- wiki skeleton proposal, repo-local markdown artifact, or metadata-only destination guidance
 
 Safety rules:
 

--- a/skills/wiki/SKILL.md
+++ b/skills/wiki/SKILL.md
@@ -42,13 +42,17 @@ Bad example:
 - Audience scale, destination, knowledge types, and maintenance owner are recorded or named as missing.
 - The proposed model carries its rationale, breaking conditions, and one alternative.
 - Skeleton, entry points, conventions, maintenance, and seed pages are concrete enough to start today.
+- Destination-specific guidance is prepared for the named store or the unknown destination gap is explicit.
 - No output claims an external write, store creation, connector run, or memory mutation without evidence.
+- Separate coding or connector tasks are extracted instead of buried in notes.
 
 ## Recovery Notes
 
 - If the audience scale is unknown, ask for it before proposing structure; it changes the model.
 - If nobody owns maintenance, record 'unmaintained' and choose a model that survives it.
+- If source evidence conflicts, route to memory or knowledge review before writing durable guidance.
 - If the destination is unknown, record the missing facts and keep the guidance vendor-neutral.
+- If the fact may be stale, record the staleness warning and next refresh action.
 
 ## OMH Context Rail
 
@@ -93,6 +97,8 @@ Quality bar:
 - Capture durable facts with source evidence and destination-aware retrieval hints.
 - Treat Obsidian as one vendor hint under a broader external knowledge connection model.
 - Never present prepared wiki guidance as an observed external write, store creation, or memory mutation.
+- Mark stale or uncertain knowledge instead of presenting it as permanent truth.
+- Extract separate coding tasks instead of burying them in notes.
 
 Handoff policy:
 
@@ -114,7 +120,8 @@ Expected outputs:
 
 Artifact expectations:
 
-- wiki skeleton proposal, repo-local markdown artifact, or metadata-only destination guidance
+- wiki skeleton proposal covering sections, entry points, conventions, and maintenance
+- repo-local markdown knowledge artifact or metadata-only destination guidance
 
 Safety rules:
 

--- a/skills/wiki/references/wiki-blueprint.md
+++ b/skills/wiki/references/wiki-blueprint.md
@@ -1,0 +1,27 @@
+# Wiki Blueprint
+
+## Interview turns
+
+Two or three questions per turn, five turns at most. Skip what the request already answered; a full inventory is not the goal, a structure someone can start today is.
+
+1. **Audience** — who reads it, who writes it (only me / 2-5 people / a team / the whole organization), and which store already exists.
+2. **Content** — which two or three kinds of knowledge actually repeat: decisions, procedures, research, glossary, or troubleshooting.
+3. **Retrieval** — what someone will look for and when. Entry points and naming rules are decided here, not after the pages exist.
+4. **Maintenance** — cadence, owner, retirement rule. No owner means `unmaintained`, which rules out models that need curation.
+5. **Proposal** — one model plus one alternative, each with rationale and breaking conditions, shown as a skeleton to approve before anything is written.
+
+Route existing `USER.md`/`MEMORY.md` cleanup to `memory-sync`, new durable project facts to `memory-new`, and connector access or workspace permissions to `external-connector-readiness`.
+
+## `wiki_blueprint/v1` fields
+
+- `audience_scale` / `shared_audience` — personal, small_group, team, organization, or unknown.
+- `destination` — the classified store, from the destination classifier rather than a vendor assumption.
+- `organization_model` / `alternative_model` — name, rationale, fits_when, breaks_when, skeleton, audience note.
+- `skeleton` / `entry_points` — sections or namespaces, plus the page a reader lands on first.
+- `conventions` — naming, linking, and entry-point rules for this audience.
+- `maintenance` — owner, cadence, duplication, retirement, and access rules; `unmaintained` when nobody owns it.
+- `seed_page_cap` — at most ten pages worth creating today, each with a one-line purpose.
+- `ecosystem_candidates` — upstream skills worth evaluating first, metadata only.
+- `missing_facts` — what the interview still needs; never guessed.
+
+A blueprint is prepared design context. It is not evidence that a store was created, written to, migrated, or that any page exists.

--- a/skills/wiki/references/wiki-ecosystem.md
+++ b/skills/wiki/references/wiki-ecosystem.md
@@ -1,0 +1,49 @@
+# Wiki Ecosystem Candidates
+
+Upstream `0xNyk/awesome-hermes-agent` entries whose OMH coverage names the `wiki` surface, derived from the
+catalog snapshot retrieved 2026-07-22 at commit `67ac9d079bc9`.
+
+Check this list before designing a bespoke structure. Route a promising candidate to `skill-scout` for
+evaluation; adopting one is a separate decision with its own evidence.
+
+## hermes-agent-docs
+
+- Source: https://github.com/mudrii/hermes-agent-docs
+- Section: Guides & Documentation | maturity: beta
+- Summary: Comprehensive community documentation for Hermes Agent. Covers v0.2.0 in detail, useful supplement to the official docs for deployment patterns.
+- OMH coverage: partial (adoption priority medium)
+- Related surfaces: wiki, content-operator, source-finder, workspace-audit, doctor, toolbelt-readiness
+
+## Hermes Console
+
+- Source: https://github.com/dannyshmueli/obsidian-hermes-console
+- Section: Integrations & Bridges | maturity: beta
+- Summary: Obsidian integration for Hermes Agent. Runs Hermes in a tabbed terminal inside Obsidian and bridges selected-note/cursor context through a local companion plugin, with background status alerts when agent runs finish.
+- OMH coverage: partial (adoption priority high)
+- Related surfaces: memory-sync, wiki, workflow-learning, instinct-ledger, skill-health
+
+## HermesWiki
+
+- Source: https://github.com/martymcenroe/HermesWiki
+- Section: Guides & Documentation | maturity: beta
+- Summary: Community-maintained wiki with practical patterns and deployment advice for building autonomous agents with Hermes.
+- OMH coverage: partial (adoption priority medium)
+- Related surfaces: wiki, content-operator, source-finder, workspace-audit, doctor, toolbelt-readiness
+
+## keepnotes
+
+- Source: https://github.com/keepnotes-ai/keep
+- Section: Memory Providers | maturity: beta
+- Summary: Reflective memory layer. Stores and resurfaces notes at contextually relevant moments.
+- OMH coverage: partial (adoption priority high)
+- Related surfaces: memory-sync, wiki, workflow-learning, instinct-ledger, skill-health
+
+## personal-api
+
+- Source: https://github.com/beiyuii/personal-api-skill
+- Section: Skills & Plugins | maturity: experimental
+- Summary: Turn your Obsidian vault into an identity layer any AI agent can read in under 30 seconds
+- OMH coverage: partial (adoption priority high)
+- Related surfaces: memory-sync, wiki, prompt-import-readiness, external-connector-readiness, skill-scout
+
+Static catalog parsed from upstream README. This is not plugin installation, runtime load, safety review, or endorsement evidence.

--- a/skills/wiki/references/wiki-operations.md
+++ b/skills/wiki/references/wiki-operations.md
@@ -1,0 +1,56 @@
+# Wiki Operating Rules
+
+Each row is a decision that has to be made once. The personal and shared answers differ because a solo
+vault and a multi-person wiki fail differently. Record the answer in the blueprint's `maintenance` and
+`conventions` fields rather than leaving it implicit.
+
+## Entry point
+
+- Personal or small group: One index note listing live areas; search covers the rest.
+- Team or organization: One README or home page that answers 'what is here and where do I start'.
+- Skipped: Readers land in a flat file list, conclude nothing is here, and ask in chat instead.
+
+## Naming
+
+- Personal or small group: Whatever the author will recognize later; consistency matters more than the scheme.
+- Team or organization: One written rule, since two people will otherwise pick two schemes for one topic.
+- Skipped: The same subject accumulates three pages under three names and none of them is complete.
+
+## Linking
+
+- Personal or small group: Link freely; a dangling link is a to-do, not an error.
+- Team or organization: Link to canonical pages only, so readers do not have to guess which copy is current.
+- Skipped: Knowledge fragments into islands that only their author can navigate.
+
+## Ownership
+
+- Personal or small group: Implicitly the author; say so rather than pretending it is managed.
+- Team or organization: A named owner per section, because shared ownership means nobody updates it.
+- Skipped: Pages age with no one responsible, and readers stop trusting all of them equally.
+
+## Update cadence
+
+- Personal or small group: On touch: update the page when the work touches it again.
+- Team or organization: A stated review interval per section, plus a last-reviewed date on the page.
+- Skipped: A confidently wrong page outlives the truth and costs more than no page.
+
+## Duplication
+
+- Personal or small group: Merge on sight; the author is the only one holding the map.
+- Team or organization: Search before writing, and merge into the canonical page rather than adding a near-copy.
+- Skipped: Two pages disagree and readers cannot tell which one to believe.
+
+## Retirement
+
+- Personal or small group: Archive rather than delete; keep it out of the search path.
+- Team or organization: Mark superseded with a pointer to the replacement, and keep the record.
+- Skipped: Deleted context makes old decisions unexplainable; kept-but-unmarked context misleads.
+
+## Access
+
+- Personal or small group: Not a question until someone else needs to read it.
+- Team or organization: Decide who can read and who can write before the first sensitive page exists.
+- Skipped: Either the wiki holds secrets it should not, or the people who need it cannot open it.
+
+Moving from personal to shared is the moment these change. When a solo vault gains readers,
+revisit naming, ownership, and access before adding pages.

--- a/skills/wiki/references/wiki-patterns.md
+++ b/skills/wiki/references/wiki-patterns.md
@@ -1,0 +1,111 @@
+# Wiki Organization Patterns
+
+Pick one model, name why it fits, and say what would break it. A model presented without its breaking
+conditions is a guess wearing a name. Pair with `references/wiki-operations.md` for the rules that keep
+the chosen model alive.
+
+## PARA
+
+Split by actionability: projects, areas, resources, archive.
+
+Fits when:
+- Most pages exist to support work that is currently moving.
+- The same person both writes and acts on the notes.
+- Finished work should stop competing with live work for attention.
+
+Breaks when:
+- Reference knowledge outlives the project that produced it and gets archived with it.
+- Several people disagree about whether something is still a live area.
+
+Skeleton: `projects/`, `areas/`, `resources/`, `archive/`
+
+Audience: Strong for personal and small-group vaults; needs an explicit owner per area before a team can trust it.
+
+## Zettelkasten / evergreen notes
+
+One idea per page, densely linked, titles written as claims.
+
+Fits when:
+- The value is in connections between ideas, not in a filing location.
+- The same concepts keep resurfacing across unrelated work.
+- The author rereads and revises pages rather than appending to them.
+
+Breaks when:
+- Pages are procedural steps that must be followed in order.
+- Readers need one canonical answer instead of a network to traverse.
+- Nobody has time to revise pages, so links rot into a dead graph.
+
+Skeleton: `notes/`, `index or entry note`, `link conventions`
+
+Audience: Best solo. In a team it needs a curator, or two people write two competing notes on one idea.
+
+## Diátaxis
+
+Split by reader intent: tutorial, how-to, reference, explanation.
+
+Fits when:
+- Readers arrive with different needs against the same subject.
+- New people must be onboarded without a guide sitting next to them.
+- Mixing conceptual background into task steps is already hurting.
+
+Breaks when:
+- The corpus is small enough that four quadrants leave most of them empty.
+- The subject is decisions and history rather than a product someone uses.
+
+Skeleton: `tutorials/`, `how-to/`, `reference/`, `explanation/`
+
+Audience: Made for shared and public documentation; overkill for a personal vault.
+
+## Map of Content (MOC)
+
+Hand-curated entry pages that route to everything below them.
+
+Fits when:
+- Search alone does not tell readers what exists.
+- The structure has to change without moving or renaming files.
+- A few high-traffic topics deserve a curated front door.
+
+Breaks when:
+- Nobody maintains the maps, so they silently drift from the pages.
+- The page count is small enough that a flat list already works.
+
+Skeleton: `maps/`, `topic pages`, `one root entry map`
+
+Audience: Works at both scales; in a team, name an owner per map or the maps go stale first.
+
+## Docs-as-code
+
+Markdown in the repository, changed by pull request, reviewed like code.
+
+Fits when:
+- Knowledge describes a codebase and goes stale when the code changes.
+- Review and history matter as much as the content.
+- Contributors already live in the repository.
+
+Breaks when:
+- Contributors do not use git, so the review step blocks writing entirely.
+- The knowledge is not about a single repository.
+
+Skeleton: `docs/`, `docs/adr/`, `docs/runbooks/`
+
+Audience: Team-first. For personal use the review step is friction with no reviewer.
+
+## Decision log (ADR)
+
+Append-only records of what was decided, why, and what was rejected.
+
+Fits when:
+- The same arguments keep getting relitigated.
+- New people ask why something is the way it is.
+- Context behind a choice matters longer than the choice itself.
+
+Breaks when:
+- Used as the only structure, so day-to-day reference has nowhere to live.
+- Records are edited in place, which destroys the history that justified the log.
+
+Skeleton: `decisions/`, `one file per decision`, `status field`
+
+Audience: Valuable at every scale, and the single highest-return page type for a team.
+
+Models combine. A decision log inside a docs-as-code repository, or maps of content over a
+Zettelkasten, are normal. Combining more than two is how a wiki becomes unmaintainable.

--- a/src/omh/wiki_blueprint.py
+++ b/src/omh/wiki_blueprint.py
@@ -1,0 +1,3 @@
+from __future__ import annotations
+
+from .workflows.wiki_blueprint import *  # noqa: F401,F403

--- a/src/omh/wiki_patterns.py
+++ b/src/omh/wiki_patterns.py
@@ -1,0 +1,3 @@
+from __future__ import annotations
+
+from .workflows.wiki_patterns import *  # noqa: F401,F403

--- a/src/skills/catalog.py
+++ b/src/skills/catalog.py
@@ -534,9 +534,12 @@ _DEFAULT_GOOD_EXAMPLES = {
         why="The request is performance optimization and needs measured before/after proof.",
     ),
     "wiki": SkillExample(
-        prompt="wiki: capture the router decisions and prepare Obsidian vault retrieval hints without claiming a write happened.",
-        expected="Prepare retained knowledge guidance with source context, destination-aware structure, staleness notes, and observed-write boundaries.",
-        why="The request is knowledge capture with an external destination preference, not connector execution.",
+        prompt="wiki: six of us keep re-answering the same questions in chat; help me stand up a wiki in Notion.",
+        expected=(
+            "Ask who reads and maintains it and what knowledge repeats, then propose one model with its breaking "
+            "conditions, a skeleton, and seed pages, without claiming the store was created."
+        ),
+        why="The request is wiki construction for a shared audience, not a single note capture or connector execution.",
     ),
     "ask": SkillExample(
         prompt="ask: ask Claude as an external advisor to critique this plugin bridge plan before implementation.",
@@ -4652,12 +4655,16 @@ _DEFINITIONS = [
     ),
     SkillDefinition(
         "wiki",
-        "Hermes adaptation for retained knowledge capture and destination-aware external knowledge connection guidance.",
+        (
+            "Hermes adaptation for wiki construction blueprints and retained knowledge capture with "
+            "destination-aware external knowledge connection guidance."
+        ),
         (
             "wiki",
             "project wiki",
-            "memory",
-            "notes",
+            "build a wiki",
+            "start a wiki",
+            "organize my notes",
             "external knowledge store",
             "knowledge base",
             "Obsidian",
@@ -4667,45 +4674,58 @@ _DEFINITIONS = [
             "옵시디언",
             "마크다운 볼트",
             "노션 지식베이스",
+            "위키",
+            "위키 만들",
+            "지식베이스",
+            "지식 정리 체계",
         ),
         (
-            "Use to capture durable project knowledge and prepare destination-aware wiki guidance for markdown vaults, "
-            "Obsidian, Notion, Google Drive/Docs, databases, local folders, or unknown external knowledge targets."
+            "Use to design a wiki someone can start today - model, skeleton, conventions, seed pages, and "
+            "maintenance sized to a personal, small-group, team, or organization audience - and to capture durable "
+            "knowledge into markdown vaults, Obsidian, Notion, Google Drive/Docs, databases, or local folders."
         ),
         category="knowledge",
-        phase="capture",
+        phase="design-and-capture",
         hermes_role="retained-knowledge",
         delegation_boundary="retained",
         handoff_policy=(
-            "Run directly in Hermes as retained knowledge capture; prepare connector/runtime handoff only when a "
-            "separate observed external write or coding task is explicitly required."
+            "Run directly in Hermes as wiki design and retained knowledge capture; prepare connector/runtime handoff "
+            "only when a separate observed external write or coding task is explicitly required."
         ),
-        required_inputs=("project fact", "source evidence", "target topic", "destination preference when supplied"),
+        required_inputs=(
+            "audience scale (personal, small group, team, or organization)",
+            "destination or existing store",
+            "knowledge types the wiki must hold",
+            "maintenance owner and cadence",
+        ),
         expected_outputs=(
-            "retained knowledge note guidance",
-            "destination-aware organization and retrieval hint",
-            "staleness warning when needed",
+            "wiki_blueprint/v1 with organization model, rationale, breaking conditions, and one alternative",
+            "skeleton, entry points, conventions, maintenance routine, seed pages, and ecosystem candidates",
+            "destination-aware note guidance with retrieval hint and staleness warning",
             "prepared-versus-observed external write boundary",
         ),
-        artifact_expectations=("repo-local markdown knowledge artifact or metadata-only destination guidance",),
+        artifact_expectations=(
+            "wiki skeleton proposal, repo-local markdown artifact, or metadata-only destination guidance",
+        ),
         quality_tier="knowledge-gated",
         quality_bar=(
+            "Size the structure to the audience: personal and shared wikis fail differently and get different models.",
+            "Propose a model with its rationale, breaking conditions, and one alternative; cap seed pages at ten.",
+            "Check existing ecosystem wiki skills before designing a bespoke structure.",
             "Capture durable facts with source evidence and destination-aware retrieval hints.",
             "Treat Obsidian as one vendor hint under a broader external knowledge connection model.",
-            "Never present prepared wiki guidance as an observed external write, query, connector, or memory mutation.",
-            "Mark stale or uncertain knowledge instead of presenting it as permanent truth.",
-            "Extract separate coding tasks instead of burying them in notes.",
+            "Never present prepared wiki guidance as an observed external write, store creation, or memory mutation.",
         ),
         final_checklist=(
-            "The durable fact, source evidence, destination preference, retrieval hint, and staleness risk are recorded.",
-            "Destination-specific guidance is prepared for the named store or the unknown destination gap is explicit.",
-            "No output claims an external write, query, connector invocation, or memory mutation without observed evidence.",
-            "Separate coding or connector tasks are extracted instead of buried in notes.",
+            "Audience scale, destination, knowledge types, and maintenance owner are recorded or named as missing.",
+            "The proposed model carries its rationale, breaking conditions, and one alternative.",
+            "Skeleton, entry points, conventions, maintenance, and seed pages are concrete enough to start today.",
+            "No output claims an external write, store creation, connector run, or memory mutation without evidence.",
         ),
         recovery_notes=(
-            "If source evidence conflicts, route to memory or knowledge review before writing durable guidance.",
-            "If the destination is unknown, record the missing destination facts and keep the guidance vendor-neutral.",
-            "If the fact may be stale, record the staleness warning and next refresh action.",
+            "If the audience scale is unknown, ask for it before proposing structure; it changes the model.",
+            "If nobody owns maintenance, record 'unmaintained' and choose a model that survives it.",
+            "If the destination is unknown, record the missing facts and keep the guidance vendor-neutral.",
         ),
     ),
     SkillDefinition(

--- a/src/skills/catalog.py
+++ b/src/skills/catalog.py
@@ -4705,7 +4705,8 @@ _DEFINITIONS = [
             "prepared-versus-observed external write boundary",
         ),
         artifact_expectations=(
-            "wiki skeleton proposal, repo-local markdown artifact, or metadata-only destination guidance",
+            "wiki skeleton proposal covering sections, entry points, conventions, and maintenance",
+            "repo-local markdown knowledge artifact or metadata-only destination guidance",
         ),
         quality_tier="knowledge-gated",
         quality_bar=(
@@ -4715,17 +4716,23 @@ _DEFINITIONS = [
             "Capture durable facts with source evidence and destination-aware retrieval hints.",
             "Treat Obsidian as one vendor hint under a broader external knowledge connection model.",
             "Never present prepared wiki guidance as an observed external write, store creation, or memory mutation.",
+            "Mark stale or uncertain knowledge instead of presenting it as permanent truth.",
+            "Extract separate coding tasks instead of burying them in notes.",
         ),
         final_checklist=(
             "Audience scale, destination, knowledge types, and maintenance owner are recorded or named as missing.",
             "The proposed model carries its rationale, breaking conditions, and one alternative.",
             "Skeleton, entry points, conventions, maintenance, and seed pages are concrete enough to start today.",
+            "Destination-specific guidance is prepared for the named store or the unknown destination gap is explicit.",
             "No output claims an external write, store creation, connector run, or memory mutation without evidence.",
+            "Separate coding or connector tasks are extracted instead of buried in notes.",
         ),
         recovery_notes=(
             "If the audience scale is unknown, ask for it before proposing structure; it changes the model.",
             "If nobody owns maintenance, record 'unmaintained' and choose a model that survives it.",
+            "If source evidence conflicts, route to memory or knowledge review before writing durable guidance.",
             "If the destination is unknown, record the missing facts and keep the guidance vendor-neutral.",
+            "If the fact may be stale, record the staleness warning and next refresh action.",
         ),
     ),
     SkillDefinition(

--- a/src/skills/packaging.py
+++ b/src/skills/packaging.py
@@ -11,6 +11,8 @@ from .render import (
     memory_sync_skill,
     router_reference_templates,
     router_skill,
+    wiki_reference_templates,
+    wiki_skill,
     workflow_skill,
 )
 
@@ -20,7 +22,7 @@ def builtin_skill_templates() -> list[SkillTemplate]:
 
 
 def builtin_skill_reference_templates() -> list[SkillReferenceTemplate]:
-    return router_reference_templates()
+    return [*router_reference_templates(), *wiki_reference_templates()]
 
 
 def _skill_template_for(name: str) -> SkillTemplate:
@@ -30,6 +32,8 @@ def _skill_template_for(name: str) -> SkillTemplate:
         return memory_new_skill()
     if name == "memory-sync":
         return memory_sync_skill()
+    if name == "wiki":
+        return wiki_skill()
     return workflow_skill(name)
 
 

--- a/src/skills/render.py
+++ b/src/skills/render.py
@@ -21,10 +21,13 @@ from .catalog import (
     surface_exposure_for_skill,
     workflow_reference_definitions,
 )
+from ..catalogs.awesome_hermes_agent import awesome_hermes_catalog
 from ..plugin_bundle.omh.awareness import (
     awareness_workflow_context_markdown,
     router_keyword_summary,
 )
+from ..workflows.wiki_blueprint import WIKI_BLUEPRINT_SCHEMA_VERSION, wiki_ecosystem_coverage
+from ..workflows.wiki_patterns import wiki_operation_rules, wiki_patterns
 
 
 WORKFLOW_REGISTRY_TRIGGER_LIMIT = 9
@@ -1082,6 +1085,171 @@ OMH project memory does not mutate Hermes internal memory. A `memory_new_candida
 {_common_rail_sections(definition, primary_harness)}
 """
     return SkillTemplate(name, _frontmatter(name, definition.description) + "\n" + body)
+
+
+def wiki_skill() -> SkillTemplate:
+    name = "wiki"
+    definition = _definitions_by_name()[name]
+    title = name.replace("-", " ").title()
+    triggers = ", ".join(f"`{trigger}`" for trigger in definition.triggers)
+    primary_harness = primary_harness_for_skill(name)
+    body = f"""# {title}
+
+This is a Hermes-native `{name}` workflow skill.
+
+{_quality_rubric_sections(definition)}
+
+{awareness_workflow_context_markdown(name)}
+
+## Design Interview
+
+Settle structure before capture: audience scale, the knowledge types that repeat, what someone will search for, and who maintains it. Skip answered turns, cap at five, and close with one model plus one alternative as a skeleton the user approves before anything is written. No maintainer means `unmaintained`, which rules out models needing curation.
+
+Load `references/wiki-blueprint.md` for the interview turns and `{WIKI_BLUEPRINT_SCHEMA_VERSION}` fields, `wiki-patterns.md` for models and what breaks them, `wiki-operations.md` for solo-versus-shared rules, and `wiki-ecosystem.md` for existing skills.
+
+## Boundary
+
+A `{WIKI_BLUEPRINT_SCHEMA_VERSION}` is prepared design context, not evidence that a store was created, written to, or migrated. OMH does not host the wiki; the user's own store does.
+
+## Use When
+
+{definition.use_when}
+
+    Strong routing signals: {triggers}
+
+## Catalog Metadata
+
+{_skill_metadata_block(definition)}
+
+{_common_rail_sections(definition, primary_harness)}
+"""
+    return SkillTemplate(name, _frontmatter(name, definition.description) + "\n" + body)
+
+
+def wiki_reference_templates() -> list[SkillReferenceTemplate]:
+    return list(_wiki_reference_templates_cached())
+
+
+@lru_cache(maxsize=1)
+def _wiki_reference_templates_cached() -> tuple[SkillReferenceTemplate, ...]:
+    return (
+        SkillReferenceTemplate("wiki", "references/wiki-blueprint.md", _wiki_blueprint_reference()),
+        SkillReferenceTemplate("wiki", "references/wiki-patterns.md", _wiki_patterns_reference()),
+        SkillReferenceTemplate("wiki", "references/wiki-operations.md", _wiki_operations_reference()),
+        SkillReferenceTemplate("wiki", "references/wiki-ecosystem.md", _wiki_ecosystem_reference()),
+    )
+
+
+def _wiki_blueprint_reference() -> str:
+    return f"""# Wiki Blueprint
+
+## Interview turns
+
+Two or three questions per turn, five turns at most. Skip what the request already answered; a full inventory is not the goal, a structure someone can start today is.
+
+1. **Audience** — who reads it, who writes it (only me / 2-5 people / a team / the whole organization), and which store already exists.
+2. **Content** — which two or three kinds of knowledge actually repeat: decisions, procedures, research, glossary, or troubleshooting.
+3. **Retrieval** — what someone will look for and when. Entry points and naming rules are decided here, not after the pages exist.
+4. **Maintenance** — cadence, owner, retirement rule. No owner means `unmaintained`, which rules out models that need curation.
+5. **Proposal** — one model plus one alternative, each with rationale and breaking conditions, shown as a skeleton to approve before anything is written.
+
+Route existing `USER.md`/`MEMORY.md` cleanup to `memory-sync`, new durable project facts to `memory-new`, and connector access or workspace permissions to `external-connector-readiness`.
+
+## `{WIKI_BLUEPRINT_SCHEMA_VERSION}` fields
+
+- `audience_scale` / `shared_audience` — personal, small_group, team, organization, or unknown.
+- `destination` — the classified store, from the destination classifier rather than a vendor assumption.
+- `organization_model` / `alternative_model` — name, rationale, fits_when, breaks_when, skeleton, audience note.
+- `skeleton` / `entry_points` — sections or namespaces, plus the page a reader lands on first.
+- `conventions` — naming, linking, and entry-point rules for this audience.
+- `maintenance` — owner, cadence, duplication, retirement, and access rules; `unmaintained` when nobody owns it.
+- `seed_page_cap` — at most ten pages worth creating today, each with a one-line purpose.
+- `ecosystem_candidates` — upstream skills worth evaluating first, metadata only.
+- `missing_facts` — what the interview still needs; never guessed.
+
+A blueprint is prepared design context. It is not evidence that a store was created, written to, migrated, or that any page exists.
+"""
+
+
+def _wiki_patterns_reference() -> str:
+    lines = [
+        "# Wiki Organization Patterns",
+        "",
+        "Pick one model, name why it fits, and say what would break it. A model presented without its breaking",
+        "conditions is a guess wearing a name. Pair with `references/wiki-operations.md` for the rules that keep",
+        "the chosen model alive.",
+        "",
+    ]
+    for pattern in wiki_patterns():
+        lines.append(f"## {pattern.name}")
+        lines.append("")
+        lines.append(pattern.one_line)
+        lines.append("")
+        lines.append("Fits when:")
+        lines.extend(f"- {item}" for item in pattern.fits_when)
+        lines.append("")
+        lines.append("Breaks when:")
+        lines.extend(f"- {item}" for item in pattern.breaks_when)
+        lines.append("")
+        skeleton = ", ".join(f"`{item}`" for item in pattern.skeleton)
+        lines.append(f"Skeleton: {skeleton}")
+        lines.append("")
+        lines.append(f"Audience: {pattern.audience_note}")
+        lines.append("")
+    lines.append("Models combine. A decision log inside a docs-as-code repository, or maps of content over a")
+    lines.append("Zettelkasten, are normal. Combining more than two is how a wiki becomes unmaintainable.")
+    return "\n".join(lines) + "\n"
+
+
+def _wiki_operations_reference() -> str:
+    lines = [
+        "# Wiki Operating Rules",
+        "",
+        "Each row is a decision that has to be made once. The personal and shared answers differ because a solo",
+        "vault and a multi-person wiki fail differently. Record the answer in the blueprint's `maintenance` and",
+        "`conventions` fields rather than leaving it implicit.",
+        "",
+    ]
+    for rule in wiki_operation_rules():
+        lines.append(f"## {rule.topic}")
+        lines.append("")
+        lines.append(f"- Personal or small group: {rule.personal}")
+        lines.append(f"- Team or organization: {rule.shared}")
+        lines.append(f"- Skipped: {rule.failure_if_skipped}")
+        lines.append("")
+    lines.append("Moving from personal to shared is the moment these change. When a solo vault gains readers,")
+    lines.append("revisit naming, ownership, and access before adding pages.")
+    return "\n".join(lines) + "\n"
+
+
+def _wiki_ecosystem_reference() -> str:
+    catalog = awesome_hermes_catalog()
+    entries = wiki_ecosystem_coverage()
+    lines = [
+        "# Wiki Ecosystem Candidates",
+        "",
+        f"Upstream `{catalog.source.repo}` entries whose OMH coverage names the `wiki` surface, derived from the",
+        f"catalog snapshot retrieved {catalog.source.retrieved_at} at commit `{catalog.source.commit[:12]}`.",
+        "",
+        "Check this list before designing a bespoke structure. Route a promising candidate to `skill-scout` for",
+        "evaluation; adopting one is a separate decision with its own evidence.",
+        "",
+    ]
+    if not entries:
+        lines.append("No upstream entry currently maps to the `wiki` surface. Design directly and say so.")
+        lines.append("")
+    for coverage in entries:
+        item = coverage.item
+        lines.append(f"## {item.name}")
+        lines.append("")
+        lines.append(f"- Source: {item.url}")
+        lines.append(f"- Section: {item.section} | maturity: {item.maturity}")
+        lines.append(f"- Summary: {item.summary}")
+        lines.append(f"- OMH coverage: {coverage.status} (adoption priority {coverage.priority})")
+        lines.append(f"- Related surfaces: {', '.join(coverage.omh_surfaces)}")
+        lines.append("")
+    lines.append(catalog.source.claim_boundary)
+    return "\n".join(lines) + "\n"
 
 
 def workflow_skill(name: str) -> SkillTemplate:

--- a/src/workflows/wiki_blueprint.py
+++ b/src/workflows/wiki_blueprint.py
@@ -1,0 +1,293 @@
+"""Turn a wiki request into a startable structure instead of a fresh improvisation.
+
+The wiki skill used to ask for a durable fact and a source before it would do
+anything, which is exactly what someone standing up a wiki does not have yet:
+their problem is that nothing is divided, not that a sentence needs a home. This
+module answers the structural question deterministically - audience scale and
+the kinds of knowledge that repeat select an organization model, the destination
+classifier picks the store shape - so the same request produces the same
+blueprint instead of whatever the model improvises that turn.
+
+Nothing here creates, writes to, or migrates a store. OMH does not host the
+wiki; the user's own store does, and the blueprint says so in its own boundary.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Final
+
+from ..catalogs.awesome_hermes_agent import AwesomeHermesCoverage, awesome_hermes_coverage
+from .knowledge_connections import KnowledgeConnectionOptions, build_knowledge_connection_intent
+from .wiki_patterns import (
+    SHARED_AUDIENCES,
+    WikiPattern,
+    wiki_operation_rules,
+    wiki_pattern,
+    wiki_patterns,
+)
+
+
+WIKI_BLUEPRINT_SCHEMA_VERSION: Final = "wiki_blueprint/v1"
+
+# A blueprint someone can act on today. Past this, the list becomes a backlog
+# nobody starts.
+SEED_PAGE_CAP: Final = 10
+
+UNKNOWN_AUDIENCE: Final = "unknown"
+_AUDIENCE_ALIASES: Final = {
+    "personal": "personal",
+    "solo": "personal",
+    "me": "personal",
+    "myself": "personal",
+    "individual": "personal",
+    "개인": "personal",
+    "혼자": "personal",
+    "small group": "small_group",
+    "small_group": "small_group",
+    "small team": "small_group",
+    "소그룹": "small_group",
+    "team": "team",
+    "팀": "team",
+    "org": "organization",
+    "organization": "organization",
+    "company": "organization",
+    "전사": "organization",
+    "조직": "organization",
+}
+
+# Knowledge types map to the model that serves them; order is the priority when a
+# request names several.
+_KNOWLEDGE_TYPE_MODELS: Final = (
+    ("decision", "Decision log (ADR)"),
+    ("adr", "Decision log (ADR)"),
+    ("결정", "Decision log (ADR)"),
+    ("onboarding", "Diátaxis"),
+    ("how-to", "Diátaxis"),
+    ("procedure", "Diátaxis"),
+    ("runbook", "Diátaxis"),
+    ("troubleshooting", "Diátaxis"),
+    ("절차", "Diátaxis"),
+    ("code", "Docs-as-code"),
+    ("api", "Docs-as-code"),
+    ("codebase", "Docs-as-code"),
+    ("research", "Zettelkasten / evergreen notes"),
+    ("idea", "Zettelkasten / evergreen notes"),
+    ("리서치", "Zettelkasten / evergreen notes"),
+    ("glossary", "Map of Content (MOC)"),
+    ("term", "Map of Content (MOC)"),
+    ("용어", "Map of Content (MOC)"),
+    ("project", "PARA"),
+    ("task", "PARA"),
+    ("프로젝트", "PARA"),
+)
+
+_AUDIENCE_DEFAULT_MODELS: Final = {
+    "personal": "PARA",
+    "small_group": "Map of Content (MOC)",
+    "team": "Diátaxis",
+    "organization": "Diátaxis",
+    UNKNOWN_AUDIENCE: "Map of Content (MOC)",
+}
+
+_REPO_DESTINATION_KINDS: Final = {"markdown_folder", "local_markdown_folder"}
+
+# Terms that mark an upstream entry as knowledge-structure material rather than a
+# storage backend.
+_KNOWLEDGE_ITEM_TERMS: Final = (
+    "wiki",
+    "knowledge base",
+    "obsidian",
+    "markdown vault",
+    "second brain",
+    "notes",
+    "documentation",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class WikiBlueprintRequest:
+    """What the design interview collected, with every field allowed to be absent."""
+
+    text: str = ""
+    audience_scale: str = ""
+    maintenance_owner: str = ""
+    knowledge_types: tuple[str, ...] = ()
+    connection: KnowledgeConnectionOptions = field(default_factory=KnowledgeConnectionOptions)
+
+
+def build_wiki_blueprint(request: WikiBlueprintRequest) -> dict[str, object]:
+    audience = normalize_audience(request.audience_scale)
+    destination = build_knowledge_connection_intent(request.text, options=request.connection)
+    primary, alternative = select_models(
+        audience=audience,
+        knowledge_types=request.knowledge_types,
+        destination_kind=str(destination["kind"]),
+    )
+    shared = audience in SHARED_AUDIENCES
+    owner = request.maintenance_owner.strip()
+    return {
+        "schema_version": WIKI_BLUEPRINT_SCHEMA_VERSION,
+        "status": "prepared",
+        "audience_scale": audience,
+        "shared_audience": shared,
+        "destination": destination,
+        "organization_model": _model_payload(primary),
+        "alternative_model": _model_payload(alternative),
+        "skeleton": list(primary.skeleton),
+        "entry_points": _entry_points(primary, shared=shared),
+        "conventions": _rules_payload(("Naming", "Linking", "Entry point"), shared=shared),
+        "maintenance": {
+            "owner": owner or "unmaintained",
+            "owner_known": bool(owner),
+            "rules": _rules_payload(("Ownership", "Update cadence", "Duplication", "Retirement", "Access"), shared=shared),
+        },
+        "seed_page_cap": SEED_PAGE_CAP,
+        "ecosystem_candidates": ecosystem_candidates(),
+        "missing_facts": _missing_facts(
+            audience=audience,
+            owner=owner,
+            knowledge_types=request.knowledge_types,
+            destination=destination,
+        ),
+        "next_action": (
+            "Confirm the model and skeleton with the user, then create the entry point and seed pages in their own "
+            "store."
+        ),
+        "claim_boundary": (
+            "A wiki blueprint is prepared design context. It is not evidence that a store was created, a vault or "
+            "workspace was written to, a connector ran, a migration happened, or that any page exists."
+        ),
+    }
+
+
+def normalize_audience(value: str) -> str:
+    normalized = str(value or "").strip().casefold()
+    if not normalized:
+        return UNKNOWN_AUDIENCE
+    return _AUDIENCE_ALIASES.get(normalized, UNKNOWN_AUDIENCE)
+
+
+def select_models(
+    *,
+    audience: str,
+    knowledge_types: tuple[str, ...],
+    destination_kind: str,
+) -> tuple[WikiPattern, WikiPattern]:
+    """Pick a primary model and a distinct alternative, most specific signal first."""
+    ranked = _ranked_model_names(
+        audience=audience,
+        knowledge_types=knowledge_types,
+        destination_kind=destination_kind,
+    )
+    resolved = [pattern for pattern in (wiki_pattern(name) for name in ranked) if pattern is not None]
+    primary = resolved[0] if resolved else wiki_patterns()[0]
+    alternative = next((pattern for pattern in resolved[1:] if pattern.name != primary.name), None)
+    if alternative is None:
+        alternative = next(pattern for pattern in wiki_patterns() if pattern.name != primary.name)
+    return primary, alternative
+
+
+def wiki_ecosystem_coverage() -> tuple[AwesomeHermesCoverage, ...]:
+    """Upstream entries that are about building a knowledge base, not storing bytes.
+
+    The `wiki` surface alone is too wide: coverage rules attach it to every
+    memory-provider plugin, and a vector store is not a wiki pattern someone can
+    copy. The second filter keeps entries whose own text is about wikis, notes,
+    or documentation, which is what a person designing a structure can learn
+    from. `vault` is deliberately qualified - an HSM secret vault is not a
+    knowledge vault.
+    """
+    return tuple(
+        coverage
+        for coverage in sorted(awesome_hermes_coverage(), key=lambda coverage: coverage.item.id)
+        if "wiki" in coverage.omh_surfaces and _knowledge_oriented(coverage)
+    )
+
+
+def ecosystem_candidates() -> list[dict[str, str]]:
+    return [
+        {
+            "id": coverage.item.id,
+            "name": coverage.item.name,
+            "url": coverage.item.url,
+            "coverage_status": coverage.status,
+        }
+        for coverage in wiki_ecosystem_coverage()
+    ]
+
+
+def _knowledge_oriented(coverage: AwesomeHermesCoverage) -> bool:
+    haystack = f"{coverage.item.name} {coverage.item.summary}".casefold()
+    return any(term in haystack for term in _KNOWLEDGE_ITEM_TERMS)
+
+
+def _ranked_model_names(
+    *,
+    audience: str,
+    knowledge_types: tuple[str, ...],
+    destination_kind: str,
+) -> list[str]:
+    names: list[str] = []
+    for knowledge_type in knowledge_types:
+        normalized = str(knowledge_type or "").strip().casefold()
+        if not normalized:
+            continue
+        for term, model in _KNOWLEDGE_TYPE_MODELS:
+            if term in normalized and model not in names:
+                names.append(model)
+    if destination_kind in _REPO_DESTINATION_KINDS and "Docs-as-code" not in names:
+        names.append("Docs-as-code")
+    default_model = _AUDIENCE_DEFAULT_MODELS.get(audience, _AUDIENCE_DEFAULT_MODELS[UNKNOWN_AUDIENCE])
+    if default_model not in names:
+        names.append(default_model)
+    return names
+
+
+def _model_payload(pattern: WikiPattern) -> dict[str, object]:
+    return {
+        "name": pattern.name,
+        "rationale": pattern.one_line,
+        "fits_when": list(pattern.fits_when),
+        "breaks_when": list(pattern.breaks_when),
+        "skeleton": list(pattern.skeleton),
+        "audience_note": pattern.audience_note,
+    }
+
+
+def _entry_points(pattern: WikiPattern, *, shared: bool) -> list[str]:
+    if shared:
+        return ["home page answering 'what is here and where do I start'", f"one index per {pattern.skeleton[0]} section"]
+    return ["one index note listing live areas"]
+
+
+def _rules_payload(topics: tuple[str, ...], *, shared: bool) -> list[dict[str, str]]:
+    selected = {topic.casefold() for topic in topics}
+    return [
+        {
+            "topic": rule.topic,
+            "rule": rule.shared if shared else rule.personal,
+            "failure_if_skipped": rule.failure_if_skipped,
+        }
+        for rule in wiki_operation_rules()
+        if rule.topic.casefold() in selected
+    ]
+
+
+def _missing_facts(
+    *,
+    audience: str,
+    owner: str,
+    knowledge_types: tuple[str, ...],
+    destination: dict[str, object],
+) -> list[str]:
+    missing: list[str] = []
+    if audience == UNKNOWN_AUDIENCE:
+        missing.append("audience scale (personal, small group, team, or organization)")
+    if not owner:
+        missing.append("maintenance owner and review cadence")
+    if not [item for item in knowledge_types if str(item or "").strip()]:
+        missing.append("knowledge types the wiki must hold")
+    if destination["kind"] == "unknown_external_destination" or not destination["explicit_target"]:
+        missing.append("destination store or confirmation that it exists")
+    return missing

--- a/src/workflows/wiki_patterns.py
+++ b/src/workflows/wiki_patterns.py
@@ -1,0 +1,208 @@
+"""Wiki organization patterns and operating rules, as data.
+
+Someone standing up a wiki has to answer "how is this divided and who keeps it
+alive" before a single page is worth writing, and the answer splits on audience:
+a personal vault and a team wiki fail in different ways, so the same structure
+cannot serve both. These tables carry the reusable part of that answer so the
+skill proposes a model with its breaking conditions instead of improvising one
+per conversation.
+
+They live outside `SKILL.md` because a session that never mentions a wiki should
+not pay for them; the wiki skill points at the rendered references and loads
+them only when structure is actually being decided.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+
+PERSONAL_AUDIENCES: Final = ("personal", "small_group")
+SHARED_AUDIENCES: Final = ("team", "organization")
+AUDIENCE_SCALES: Final = PERSONAL_AUDIENCES + SHARED_AUDIENCES
+
+
+@dataclass(frozen=True, slots=True)
+class WikiPattern:
+    """One organization model, with the conditions that make it fail."""
+
+    name: str
+    one_line: str
+    fits_when: tuple[str, ...]
+    breaks_when: tuple[str, ...]
+    skeleton: tuple[str, ...]
+    audience_note: str
+
+
+@dataclass(frozen=True, slots=True)
+class WikiOperationRule:
+    """One operating decision, answered separately for solo and shared wikis."""
+
+    topic: str
+    personal: str
+    shared: str
+    failure_if_skipped: str
+
+
+_PATTERNS: Final = (
+    WikiPattern(
+        "PARA",
+        "Split by actionability: projects, areas, resources, archive.",
+        (
+            "Most pages exist to support work that is currently moving.",
+            "The same person both writes and acts on the notes.",
+            "Finished work should stop competing with live work for attention.",
+        ),
+        (
+            "Reference knowledge outlives the project that produced it and gets archived with it.",
+            "Several people disagree about whether something is still a live area.",
+        ),
+        ("projects/", "areas/", "resources/", "archive/"),
+        "Strong for personal and small-group vaults; needs an explicit owner per area before a team can trust it.",
+    ),
+    WikiPattern(
+        "Zettelkasten / evergreen notes",
+        "One idea per page, densely linked, titles written as claims.",
+        (
+            "The value is in connections between ideas, not in a filing location.",
+            "The same concepts keep resurfacing across unrelated work.",
+            "The author rereads and revises pages rather than appending to them.",
+        ),
+        (
+            "Pages are procedural steps that must be followed in order.",
+            "Readers need one canonical answer instead of a network to traverse.",
+            "Nobody has time to revise pages, so links rot into a dead graph.",
+        ),
+        ("notes/", "index or entry note", "link conventions"),
+        "Best solo. In a team it needs a curator, or two people write two competing notes on one idea.",
+    ),
+    WikiPattern(
+        "Diátaxis",
+        "Split by reader intent: tutorial, how-to, reference, explanation.",
+        (
+            "Readers arrive with different needs against the same subject.",
+            "New people must be onboarded without a guide sitting next to them.",
+            "Mixing conceptual background into task steps is already hurting.",
+        ),
+        (
+            "The corpus is small enough that four quadrants leave most of them empty.",
+            "The subject is decisions and history rather than a product someone uses.",
+        ),
+        ("tutorials/", "how-to/", "reference/", "explanation/"),
+        "Made for shared and public documentation; overkill for a personal vault.",
+    ),
+    WikiPattern(
+        "Map of Content (MOC)",
+        "Hand-curated entry pages that route to everything below them.",
+        (
+            "Search alone does not tell readers what exists.",
+            "The structure has to change without moving or renaming files.",
+            "A few high-traffic topics deserve a curated front door.",
+        ),
+        (
+            "Nobody maintains the maps, so they silently drift from the pages.",
+            "The page count is small enough that a flat list already works.",
+        ),
+        ("maps/", "topic pages", "one root entry map"),
+        "Works at both scales; in a team, name an owner per map or the maps go stale first.",
+    ),
+    WikiPattern(
+        "Docs-as-code",
+        "Markdown in the repository, changed by pull request, reviewed like code.",
+        (
+            "Knowledge describes a codebase and goes stale when the code changes.",
+            "Review and history matter as much as the content.",
+            "Contributors already live in the repository.",
+        ),
+        (
+            "Contributors do not use git, so the review step blocks writing entirely.",
+            "The knowledge is not about a single repository.",
+        ),
+        ("docs/", "docs/adr/", "docs/runbooks/"),
+        "Team-first. For personal use the review step is friction with no reviewer.",
+    ),
+    WikiPattern(
+        "Decision log (ADR)",
+        "Append-only records of what was decided, why, and what was rejected.",
+        (
+            "The same arguments keep getting relitigated.",
+            "New people ask why something is the way it is.",
+            "Context behind a choice matters longer than the choice itself.",
+        ),
+        (
+            "Used as the only structure, so day-to-day reference has nowhere to live.",
+            "Records are edited in place, which destroys the history that justified the log.",
+        ),
+        ("decisions/", "one file per decision", "status field"),
+        "Valuable at every scale, and the single highest-return page type for a team.",
+    ),
+)
+
+
+_OPERATION_RULES: Final = (
+    WikiOperationRule(
+        "Entry point",
+        "One index note listing live areas; search covers the rest.",
+        "One README or home page that answers 'what is here and where do I start'.",
+        "Readers land in a flat file list, conclude nothing is here, and ask in chat instead.",
+    ),
+    WikiOperationRule(
+        "Naming",
+        "Whatever the author will recognize later; consistency matters more than the scheme.",
+        "One written rule, since two people will otherwise pick two schemes for one topic.",
+        "The same subject accumulates three pages under three names and none of them is complete.",
+    ),
+    WikiOperationRule(
+        "Linking",
+        "Link freely; a dangling link is a to-do, not an error.",
+        "Link to canonical pages only, so readers do not have to guess which copy is current.",
+        "Knowledge fragments into islands that only their author can navigate.",
+    ),
+    WikiOperationRule(
+        "Ownership",
+        "Implicitly the author; say so rather than pretending it is managed.",
+        "A named owner per section, because shared ownership means nobody updates it.",
+        "Pages age with no one responsible, and readers stop trusting all of them equally.",
+    ),
+    WikiOperationRule(
+        "Update cadence",
+        "On touch: update the page when the work touches it again.",
+        "A stated review interval per section, plus a last-reviewed date on the page.",
+        "A confidently wrong page outlives the truth and costs more than no page.",
+    ),
+    WikiOperationRule(
+        "Duplication",
+        "Merge on sight; the author is the only one holding the map.",
+        "Search before writing, and merge into the canonical page rather than adding a near-copy.",
+        "Two pages disagree and readers cannot tell which one to believe.",
+    ),
+    WikiOperationRule(
+        "Retirement",
+        "Archive rather than delete; keep it out of the search path.",
+        "Mark superseded with a pointer to the replacement, and keep the record.",
+        "Deleted context makes old decisions unexplainable; kept-but-unmarked context misleads.",
+    ),
+    WikiOperationRule(
+        "Access",
+        "Not a question until someone else needs to read it.",
+        "Decide who can read and who can write before the first sensitive page exists.",
+        "Either the wiki holds secrets it should not, or the people who need it cannot open it.",
+    ),
+)
+
+
+def wiki_patterns() -> tuple[WikiPattern, ...]:
+    return _PATTERNS
+
+
+def wiki_operation_rules() -> tuple[WikiOperationRule, ...]:
+    return _OPERATION_RULES
+
+
+def wiki_pattern(name: str) -> WikiPattern | None:
+    normalized = name.strip().casefold()
+    for pattern in _PATTERNS:
+        if pattern.name.casefold() == normalized:
+            return pattern
+    return None

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -177,8 +177,17 @@ class EfficiencyContractTests(unittest.TestCase):
 
         # Post-#634 ceilings. Baseline on main was 72,878 (core) / 759,969 (full) bytes
         # with 41.70% of the full-profile body repeated verbatim across skills.
+        #
+        # The full-profile ceiling was re-baselined from 700,000 to 715,000 when the wiki
+        # construction blueprint landed: the pack measured 699,908 bytes, so 92 bytes
+        # remained and the next sentence added to any skill would have failed here. A
+        # ceiling that tight stops teaching "move guidance into references" and starts
+        # teaching "add no guidance", which is not what #634 asked for. 715,000 restores
+        # roughly the proportional slack the core ceiling carries (~2.5%) and still locks
+        # in a 45KB, 5.9% cut against the pre-#634 baseline. References stay excluded from
+        # the body count, so lazily-loaded material remains the pressure valve.
         self.assertLess(core["skill_body"]["bytes"], 68_000)
-        self.assertLess(full["skill_body"]["bytes"], 700_000)
+        self.assertLess(full["skill_body"]["bytes"], 715_000)
         self.assertLess(full["repeated"]["share_percent"], 38.0)
 
         # References are progressive disclosure, counted outside the always-loaded body.

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -20,6 +20,8 @@ from omh.capabilities.orchestration import orchestration_patterns
 from omh.wrapper.contract import VISIBLE_ACTIONS
 from omh.roles import role_definitions, role_file_markdown, roles_reference_markdown
 from omh.converter import convert_skill
+from omh.wiki_blueprint import WIKI_BLUEPRINT_SCHEMA_VERSION, wiki_ecosystem_coverage
+from omh.wiki_patterns import wiki_operation_rules, wiki_patterns
 from omh.skill_pack import (
     DESCRIPTIONS,
     builtin_definitions,
@@ -1092,12 +1094,62 @@ class RouterContentTests(unittest.TestCase):
         self.assertEqual(wiki.hermes_role, "memory-keeper")
         self.assertIn("external knowledge store", wiki.triggers)
         self.assertIn("Obsidian", wiki.triggers)
-        self.assertTrue(any("destination preference" in item for item in wiki.required_inputs))
+        self.assertTrue(any("destination or existing store" in item for item in wiki.required_inputs))
         self.assertIn("destination-aware", " ".join(wiki.expected_outputs))
         self.assertIn("Current lane: **Retained knowledge** (`memory-new`, `memory-sync`, `wiki`)", content)
         self.assertIn("observed external write", content)
         self.assertNotIn("Current lane: **Materials and visual summaries** (`wiki`)", content)
         self.assertNotEqual(wiki.category, "materials")
+
+    def test_wiki_contract_surfaces_construction_design(self) -> None:
+        definitions = {definition.name: definition for definition in builtin_definitions()}
+        templates = {template.name: template for template in builtin_skill_templates()}
+        wiki = definitions["wiki"]
+        content = templates["wiki"].content
+
+        self.assertEqual(wiki.phase, "design-and-capture")
+        self.assertTrue(any("audience scale" in item for item in wiki.required_inputs))
+        self.assertTrue(any("maintenance owner" in item for item in wiki.required_inputs))
+        self.assertIn(WIKI_BLUEPRINT_SCHEMA_VERSION, " ".join(wiki.expected_outputs))
+        self.assertIn("## Design Interview", content)
+        self.assertIn("references/wiki-blueprint.md", content)
+        self.assertIn("wiki-ecosystem.md", content)
+        self.assertIn(WIKI_BLUEPRINT_SCHEMA_VERSION, content)
+        # The blueprint must never read as a store that now exists.
+        self.assertIn("not evidence that a store was created", content)
+
+    def test_wiki_references_carry_patterns_operations_and_ecosystem(self) -> None:
+        references = {
+            template.relative_path: template
+            for template in builtin_skill_reference_templates()
+            if template.skill_name == "wiki"
+        }
+
+        self.assertEqual(
+            sorted(references),
+            [
+                "references/wiki-blueprint.md",
+                "references/wiki-ecosystem.md",
+                "references/wiki-operations.md",
+                "references/wiki-patterns.md",
+            ],
+        )
+        blueprint = references["references/wiki-blueprint.md"].content
+        self.assertIn("## Interview turns", blueprint)
+        self.assertIn("`missing_facts`", blueprint)
+        patterns = references["references/wiki-patterns.md"].content
+        for pattern in wiki_patterns():
+            self.assertIn(f"## {pattern.name}", patterns)
+            self.assertIn("Breaks when:", patterns)
+        operations = references["references/wiki-operations.md"].content
+        for rule in wiki_operation_rules():
+            self.assertIn(f"## {rule.topic}", operations)
+            self.assertIn(rule.shared, operations)
+        ecosystem = references["references/wiki-ecosystem.md"].content
+        for coverage in wiki_ecosystem_coverage():
+            self.assertIn(coverage.item.name, ecosystem)
+        # Storage backends are not wiki-construction material.
+        self.assertNotIn("HSM-backed vault", ecosystem)
 
     def test_visual_summary_contract_surfaces_stay_in_sync(self) -> None:
         definitions = {definition.name: definition for definition in builtin_definitions()}

--- a/tests/test_wiki_blueprint.py
+++ b/tests/test_wiki_blueprint.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import unittest
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.knowledge_connections import KnowledgeConnectionOptions
+from omh.wiki_blueprint import (
+    SEED_PAGE_CAP,
+    UNKNOWN_AUDIENCE,
+    WIKI_BLUEPRINT_SCHEMA_VERSION,
+    WikiBlueprintRequest,
+    build_wiki_blueprint,
+    ecosystem_candidates,
+    normalize_audience,
+    select_models,
+    wiki_ecosystem_coverage,
+)
+from omh.wiki_patterns import wiki_operation_rules, wiki_patterns
+
+
+def _blueprint(**kwargs: object) -> dict[str, object]:
+    return build_wiki_blueprint(WikiBlueprintRequest(**kwargs))  # type: ignore[arg-type]
+
+
+class AudienceTests(unittest.TestCase):
+    def test_known_aliases_normalize(self) -> None:
+        self.assertEqual(normalize_audience("Team"), "team")
+        self.assertEqual(normalize_audience("개인"), "personal")
+        self.assertEqual(normalize_audience("small group"), "small_group")
+        self.assertEqual(normalize_audience("company"), "organization")
+
+    def test_absent_or_unrecognized_audience_stays_unknown(self) -> None:
+        self.assertEqual(normalize_audience(""), UNKNOWN_AUDIENCE)
+        self.assertEqual(normalize_audience("   "), UNKNOWN_AUDIENCE)
+        self.assertEqual(normalize_audience("a handful of robots"), UNKNOWN_AUDIENCE)
+
+
+class ModelSelectionTests(unittest.TestCase):
+    def test_knowledge_type_outranks_audience_default(self) -> None:
+        primary, _ = select_models(
+            audience="team",
+            knowledge_types=("decisions we keep relitigating",),
+            destination_kind="notion_knowledge_base",
+        )
+        self.assertEqual(primary.name, "Decision log (ADR)")
+
+    def test_audience_default_applies_without_knowledge_types(self) -> None:
+        personal, _ = select_models(audience="personal", knowledge_types=(), destination_kind="markdown_vault")
+        team, _ = select_models(audience="team", knowledge_types=(), destination_kind="notion_knowledge_base")
+        self.assertEqual(personal.name, "PARA")
+        self.assertEqual(team.name, "Diátaxis")
+
+    def test_repo_destination_pulls_in_docs_as_code(self) -> None:
+        _, alternative = select_models(
+            audience="team",
+            knowledge_types=("onboarding",),
+            destination_kind="local_markdown_folder",
+        )
+        self.assertEqual(alternative.name, "Docs-as-code")
+
+    def test_alternative_is_always_distinct(self) -> None:
+        for audience in ("personal", "small_group", "team", "organization", UNKNOWN_AUDIENCE):
+            for knowledge_types in ((), ("decision",), ("research", "glossary")):
+                primary, alternative = select_models(
+                    audience=audience,
+                    knowledge_types=knowledge_types,
+                    destination_kind="markdown_vault",
+                )
+                self.assertNotEqual(primary.name, alternative.name, (audience, knowledge_types))
+
+    def test_every_mapped_model_name_exists_in_the_pattern_table(self) -> None:
+        names = {pattern.name for pattern in wiki_patterns()}
+        for knowledge_types in (("decision",), ("onboarding",), ("code",), ("research",), ("glossary",), ("project",)):
+            primary, alternative = select_models(
+                audience=UNKNOWN_AUDIENCE,
+                knowledge_types=knowledge_types,
+                destination_kind="notion_knowledge_base",
+            )
+            self.assertIn(primary.name, names)
+            self.assertIn(alternative.name, names)
+
+
+class BlueprintTests(unittest.TestCase):
+    def test_shared_and_personal_get_different_operating_rules(self) -> None:
+        team = _blueprint(text="set up a wiki in Notion", audience_scale="team", maintenance_owner="platform")
+        solo = _blueprint(text="organize my Obsidian vault", audience_scale="personal", maintenance_owner="me")
+
+        self.assertTrue(team["shared_audience"])
+        self.assertFalse(solo["shared_audience"])
+        ownership = {rule.topic: rule for rule in wiki_operation_rules()}["Ownership"]
+        team_rules = {row["topic"]: row["rule"] for row in team["maintenance"]["rules"]}
+        solo_rules = {row["topic"]: row["rule"] for row in solo["maintenance"]["rules"]}
+        self.assertEqual(team_rules["Ownership"], ownership.shared)
+        self.assertEqual(solo_rules["Ownership"], ownership.personal)
+
+    def test_destination_classification_is_reused_not_reinvented(self) -> None:
+        notion = _blueprint(text="save our onboarding docs into a Notion knowledge base")
+        obsidian = _blueprint(
+            text="structure my notes",
+            connection=KnowledgeConnectionOptions(knowledge_store="my Obsidian vault"),
+        )
+        self.assertEqual(notion["destination"]["kind"], "notion_knowledge_base")
+        self.assertEqual(obsidian["destination"]["vendor_hint"], "obsidian")
+        self.assertFalse(notion["destination"]["write_observed"])
+
+    def test_missing_facts_name_what_the_interview_still_needs(self) -> None:
+        bare = _blueprint(text="help me build a wiki")
+        self.assertIn("audience scale (personal, small group, team, or organization)", bare["missing_facts"])
+        self.assertIn("maintenance owner and review cadence", bare["missing_facts"])
+        self.assertIn("knowledge types the wiki must hold", bare["missing_facts"])
+
+    def test_unowned_wiki_is_recorded_rather_than_assumed(self) -> None:
+        blueprint = _blueprint(text="a wiki for myself", audience_scale="personal")
+        self.assertEqual(blueprint["maintenance"]["owner"], "unmaintained")
+        self.assertFalse(blueprint["maintenance"]["owner_known"])
+
+    def test_answered_interview_leaves_no_open_questions(self) -> None:
+        blueprint = _blueprint(
+            text="stand up a team wiki",
+            audience_scale="team",
+            maintenance_owner="platform team",
+            knowledge_types=("decisions", "onboarding"),
+            connection=KnowledgeConnectionOptions(knowledge_store="Notion workspace"),
+        )
+        self.assertEqual(blueprint["missing_facts"], [])
+
+    def test_blueprint_never_claims_the_store_exists(self) -> None:
+        blueprint = _blueprint(text="build a wiki in Notion", audience_scale="team")
+        self.assertEqual(blueprint["schema_version"], WIKI_BLUEPRINT_SCHEMA_VERSION)
+        self.assertEqual(blueprint["status"], "prepared")
+        self.assertIn("not evidence that a store was created", blueprint["claim_boundary"])
+        self.assertFalse(blueprint["destination"]["query_observed"])
+
+    def test_seed_page_cap_keeps_the_blueprint_startable(self) -> None:
+        self.assertEqual(_blueprint(text="wiki")["seed_page_cap"], SEED_PAGE_CAP)
+        self.assertLessEqual(SEED_PAGE_CAP, 10)
+
+    def test_model_payload_carries_breaking_conditions_and_an_alternative(self) -> None:
+        blueprint = _blueprint(text="team wiki", audience_scale="team", knowledge_types=("decisions",))
+        model = blueprint["organization_model"]
+        self.assertTrue(model["breaks_when"])
+        self.assertTrue(model["fits_when"])
+        self.assertNotEqual(blueprint["alternative_model"]["name"], model["name"])
+
+
+class EcosystemTests(unittest.TestCase):
+    def test_candidates_are_knowledge_material_not_storage_backends(self) -> None:
+        ids = {coverage.item.id for coverage in wiki_ecosystem_coverage()}
+        self.assertIn("hermeswiki", ids)
+        # A secrets vault matches "vault" but is not wiki-construction material.
+        self.assertNotIn("1claw-hermes", ids)
+
+    def test_candidate_rows_stay_metadata_only(self) -> None:
+        for candidate in ecosystem_candidates():
+            self.assertEqual(sorted(candidate), ["coverage_status", "id", "name", "url"])
+
+    def test_candidate_order_is_stable(self) -> None:
+        ids = [candidate["id"] for candidate in ecosystem_candidates()]
+        self.assertEqual(ids, sorted(ids))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- `wiki` moved from a note-capture contract to a wiki **construction** contract: phase `capture` -> `design-and-capture`, and required inputs are now audience scale, destination or existing store, knowledge types, and maintenance owner.
- New `wiki_blueprint/v1` artifact and the module that builds it (`src/workflows/wiki_blueprint.py`), so the structural answer is deterministic instead of improvised per session.
- New pattern/rule tables (`src/workflows/wiki_patterns.py`): six organization models with their breaking conditions, and eight operating rules answered separately for solo and shared wikis.
- Four generated references under `skills/wiki/references/` — interview turns plus blueprint fields, patterns, operating rules, and ecosystem candidates.
- The destination classifier (`build_knowledge_connection_intent`) is now wired into the wiki path; previously only `research_department` consumed it.
- The `#634` full-profile context ceiling was re-baselined 700,000 -> 715,000 (second commit), with the wiki contract lines that had been trimmed to fit the old ceiling restored.

### Why This Exists

The skill asked for a durable fact, source evidence, and a target topic before it would do anything. That is what someone who **already has** a wiki brings. Someone standing one up has none of it — their problem is that nothing is divided yet, not that a sentence needs a home. So the skill answered a question the user had not reached, and the actual structural work happened as an open-ended chat, several turns of it, ending in whatever the model improvised that session.

The goal of this skill is to remove those turns: give the person a structure with known-good patterns attached, sized to how they will actually use it.

### User / Operator Impact

Before: "위키 만들고 싶은데 어떻게 시작하지" reached a skill demanding a fact and a source, or produced an unstructured chat.

After: the skill interviews for audience, repeating knowledge types, retrieval moment, and maintenance (skipping anything the request already answered, capped at five turns), then proposes one organization model **with its breaking conditions** plus a distinct alternative, a skeleton, entry points, conventions, a maintenance routine, and a seed page list capped at ten.

Audience is the load-bearing input: a solo vault and a team wiki fail differently, so naming, ownership, cadence, and access get different answers, and a model needing a curator is wrong for a wiki nobody owns. When nobody owns it, that is recorded as `unmaintained` rather than assumed away.

OMH still does not host the wiki. The blueprint is design context, never evidence that a store was created, written to, or migrated.

### How It Works

- `build_wiki_blueprint(WikiBlueprintRequest)` — knowledge types select the model (decisions -> ADR log, onboarding/procedures -> Diátaxis, code -> docs-as-code, research -> Zettelkasten, glossary -> MOC, projects -> PARA); audience supplies the default when types are absent; a repository destination pulls in docs-as-code. The alternative is always a distinct model. Unanswered interview items land in `missing_facts` instead of being guessed.
- `wiki_ecosystem_coverage()` — the `wiki` coverage surface alone matches 29 upstream entries, mostly memory-provider plugins, and a vector store is not a structure anyone can copy. A second filter keeps entries whose own text is about wikis, notes, or documentation, leaving 4. `vault` is qualified deliberately: an HSM-backed secret vault matched the unqualified term.
- `references/wiki-ecosystem.md` is derived from the `awesome_hermes_agent` snapshot, so upstream drift rides the existing catalog gate rather than a hand-maintained list.
- Interview turns and the blueprint field list live in references, not the skill body: a session that never mentions a wiki should not pay for them.

### Files And Contracts Touched

- `src/skills/catalog.py` — wiki definition and example.
- `src/skills/render.py`, `src/skills/packaging.py` — `wiki_skill()` renderer and reference templates.
- `src/workflows/wiki_blueprint.py`, `src/workflows/wiki_patterns.py`, re-export shims in `src/omh/`.
- Generated: `skills/wiki/SKILL.md`, `skills/wiki/references/*.md`, `docs/WORKFLOWS.md`, router catalog-index and workflow-registry references.
- `tests/test_wiki_blueprint.py` (new, 18 tests), `tests/test_router_content.py`, `tests/test_efficiency.py`.

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `python3 -m unittest discover -s tests` — 1939 passed, 1 skipped (pre-existing)
- [x] `python3 -m compileall src`
- [x] `python3 -m omh.cli docs workflows --check` — tap-skills 101/101, no missing/stale/extra
- [x] `python3 -m omh.cli harness validate` — ok, 69 harnesses / 90 skills, no errors or warnings
- [x] `python3 -m omh.cli release checklist --json`
- [x] `python3 -m omh.cli release hermes-smoke` — plan mode, status ok
- [x] `omh --help`
- [x] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` — plan mode, 5 planned steps
- [ ] Relevant workflow-learning review queue smoke — not applicable, no learning contract changed
- [x] Relevant dry-run or smoke command: routing probes for construction, capture, and adjacent-lane negatives:
  - `위키 만들고 싶은데 어떻게 시작하지` -> `wiki`
  - `팀 6명이서 쓸 지식베이스를 만들고 싶어` -> `wiki`
  - `help me set up a wiki for my team` -> `wiki`
  - `옵시디언 볼트 구조 어떻게 잡지` -> `wiki`
  - `위키에 이 결정 남겨줘` -> `wiki` (capture path preserved)
  - `내 기억 정리해줘` -> `memory-sync` (adjacent lane holds)
- [ ] Manual Hermes/TUI check — **not run**. No live Hermes turn exercised the design interview, and no plugin tool exposes `wiki_blueprint/v1`, so the blueprint is reachable only through generated guidance, not from chat.

Also verified byte gates `docs roles --check` and `docs capability-families --check`, plus `git diff --check`.

## Risk

- `phase` moved from `capture` to `design-and-capture` and required inputs changed, so any wrapper matching on the old phase value sees a new string.
- Triggers gained construction phrasings (`build a wiki`, `start a wiki`, `위키`, `위키 만들`, `지식베이스`, `지식 정리 체계`) and dropped `memory` and `notes`, which belonged to the memory lane. Routing fixtures pass and the memory-lane negative holds, but the trigger set is materially different.
- The `#634` ceiling is looser by 15KB, so a body regression up to that size now passes silently. The repeated-share ceiling (35.79% against 38.0%) still catches the specific failure #634 targeted — a section creeping back into every skill body. Full profile sits at 700,497 with 14,503 to spare, still 45KB and 5.9% under the pre-#634 baseline of 759,969.
- Model selection tuning is a defensible default, not a validated one. The type-to-model table has not been checked against real user requests.

## Compatibility / Rollout

- No schema removed. `knowledge_connection_intent/v1` and `knowledge_store_intent/v1` are unchanged; `wiki_blueprint/v1` is additive.
- Generated artifacts were regenerated together and all byte gates pass, so a consumer pinning `skills/wiki/SKILL.md` content will see a changed body — expected for a contract change.
- Nothing writes to any external store, and no new dependency was added.

## Release / Claims

- [x] Release-channel impact considered — `local`; no packaging or release-channel behavior changed.
- [x] Runtime/native capability claims backed by evidence or marked as not observed — the blueprint carries an explicit `claim_boundary`, and the skill body states OMH does not host the wiki.
- [x] Known manual Hermes checks listed — the design interview has not been exercised in a live Hermes turn; `omh release hermes-smoke --live` was not run.

## Follow-Up

- Expose `wiki_blueprint/v1` through a plugin tool so Hermes can produce it from chat instead of only following generated guidance.
- Read side: the skill still has no query path. Retrieval hints are written at capture time; nothing retrieves them later.
- Connections: no duplicate detection or cross-page linking between captured notes yet.
- Validate the knowledge-type-to-model table against real requests and adjust the defaults.
