### PR TITLE
Make every repo-local OMH store consistent and self-ignoring

### DIFF
--- a/src/codegraph/schema.py
+++ b/src/codegraph/schema.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any
 
 from ..local_store import atomic_write_json
+from ..paths import ensure_project_store_ignored
 
 
 CODEGRAPH_SCHEMA_VERSION = "omh_codegraph/v1"
@@ -40,5 +41,8 @@ def write_codegraph_artifact(graph: dict[str, Any]) -> Path:
     if not repo_root:
         raise ValueError("codegraph artifact is missing repo_root")
     path = codegraph_artifact_path(repo_root)
+    # Without this the store is untracked in any repository but this one, so
+    # `git add -A` after a codegraph build commits the artifact.
+    ensure_project_store_ignored(path.parent)
     atomic_write_json(path, graph)
     return path

--- a/src/maintenance/advisory.py
+++ b/src/maintenance/advisory.py
@@ -377,7 +377,58 @@ def check_hermes_memory_staleness(hermes_home: str | Path | None = None) -> Advi
 
 
 # ---------------------------------------------------------------------------
-# 4. installed_skill_context_weight
+# 4. legacy_plan_artifacts
+# ---------------------------------------------------------------------------
+
+def check_legacy_plan_artifacts(hermes_home: str | Path | None = None) -> AdviceEntry:
+    """Report plans left in Hermes' home by the pre-relocation writer."""
+    home = _resolve_hermes_home(hermes_home)
+    legacy_dirs = ((home / "plans", "plans"), (home / "context", "context"))
+    evidence_boundary = (
+        "Local file count of ~/.hermes/plans and ~/.hermes/context only; OMH does not read, "
+        "move, or delete them."
+    )
+    remediation = (
+        "OMH used to write plan artifacts into Hermes' own home. It now writes them to "
+        "`<repo>/.omh/plans`, so these older files are no longer read by anything. They are "
+        "plain markdown: `omh hermes plan-accept <path>` still works on one, and they are "
+        "safe to delete or archive by hand. OMH will not touch them."
+    )
+    counts: list[str] = []
+    try:
+        for directory, label in legacy_dirs:
+            if not directory.is_dir():
+                continue
+            found = len([entry for entry in directory.glob("*.md") if entry.is_file()])
+            if found:
+                counts.append(f"{found} file(s) in {label}")
+    except OSError as error:
+        return AdviceEntry(
+            "legacy_plan_artifacts",
+            "unobserved",
+            remediation,
+            evidence_boundary,
+            f"legacy plan directories unreadable: {error}",
+        )
+    if not counts:
+        return AdviceEntry(
+            "legacy_plan_artifacts",
+            "ok",
+            remediation,
+            evidence_boundary,
+            "no plan artifacts left under ~/.hermes",
+        )
+    return AdviceEntry(
+        "legacy_plan_artifacts",
+        "advice",
+        remediation,
+        evidence_boundary,
+        "; ".join(counts),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. installed_skill_context_weight
 # ---------------------------------------------------------------------------
 
 def _count_skill_dirs(skills_dir: Path) -> int:
@@ -460,13 +511,14 @@ def check_installed_skill_context_weight(
 
 
 def run_config_advisories(hermes_home: str | Path | None = None) -> AdvisoryReport:
-    """Run all four read-only inspectors and return the separate advisory report."""
+    """Run every read-only inspector and return the separate advisory report."""
     return AdvisoryReport(
         contract=CONTRACT,
         entries=[
             check_auxiliary_routing_unset(hermes_home),
             check_soul_missing_or_starter(hermes_home),
             check_hermes_memory_staleness(hermes_home),
+            check_legacy_plan_artifacts(hermes_home),
             check_installed_skill_context_weight(hermes_home),
         ],
     )

--- a/src/system/paths.py
+++ b/src/system/paths.py
@@ -285,11 +285,20 @@ def default_hermes_home() -> Path:
 
 
 def project_omh_home(cwd: str | Path | None = None) -> Path:
-    return expand_path(cwd or Path.cwd()) / ".omh"
+    return _project_anchor(cwd) / ".omh"
 
 
 def project_hermes_home(cwd: str | Path | None = None) -> Path:
-    return expand_path(cwd or Path.cwd()) / ".hermes"
+    return _project_anchor(cwd) / ".hermes"
+
+
+def _project_anchor(cwd: str | Path | None = None) -> Path:
+    """Where `--scope project` puts a store: the repository, not the shell's cwd."""
+    # These used the literal cwd, so running from a subdirectory scattered a
+    # store into `src/whatever/.omh` while repository-scoped artifacts resolved
+    # to the root -- one `--scope project` run, two homes.
+    root = find_project_root(cwd)
+    return root if root is not None else expand_path(cwd or Path.cwd())
 
 
 def find_project_root(cwd: str | Path | None = None) -> Path | None:

--- a/tests/test_codegraph.py
+++ b/tests/test_codegraph.py
@@ -4,8 +4,11 @@ import json
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest.mock import patch
 
 from _cli_harness import run_cli
+from omh.codegraph.scanner import build_codegraph
+from omh.codegraph.schema import write_codegraph_artifact
 from omh.commands.main import build_parser
 
 
@@ -111,6 +114,31 @@ class CodegraphTests(unittest.TestCase):
             if edge["kind"] == "imports_internal"
         }
         self.assertIn(("pkg/cli.py", "pkg/core.py"), internal_imports)
+
+    def test_written_artifact_store_ignores_itself(self) -> None:
+        with TemporaryDirectory() as tmp:
+            repo = Path(tmp).resolve()
+            _sample_repo(repo)
+            # Only oh-my-hermes' own .gitignore lists `.omh/`. In any other
+            # repository the artifact was untracked, so `git add -A` after a
+            # codegraph build committed it.
+            (repo / ".git").mkdir()
+
+            status, _, stderr = run_cli(["codegraph", "build", "--repo", str(repo), "--write"])
+
+            self.assertEqual(status, 0, stderr)
+            self.assertEqual((repo / ".omh" / ".gitignore").read_text(encoding="utf-8"), "*\n")
+
+    def test_written_artifact_outside_a_repository_gets_no_ignore_file(self) -> None:
+        with TemporaryDirectory() as tmp:
+            repo = Path(tmp).resolve()
+            _sample_repo(repo)
+
+            with patch("omh.system.paths.find_project_root", return_value=None):
+                write_codegraph_artifact(build_codegraph(repo))
+
+            self.assertTrue((repo / ".omh" / "codegraph" / "codegraph.json").exists())
+            self.assertFalse((repo / ".omh" / ".gitignore").exists())
 
     def test_build_command_writes_artifact_and_prints_json(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_doctor_advisory.py
+++ b/tests/test_doctor_advisory.py
@@ -17,6 +17,7 @@ from omh.maintenance.advisory import (
     check_auxiliary_routing_unset,
     check_hermes_memory_staleness,
     check_installed_skill_context_weight,
+    check_legacy_plan_artifacts,
     check_soul_missing_or_starter,
     run_config_advisories,
 )
@@ -28,6 +29,7 @@ ADVISORY_CHECK_IDS = {
     "auxiliary_routing_unset",
     "soul_missing_or_starter",
     "hermes_memory_staleness",
+    "legacy_plan_artifacts",
     "installed_skill_context_weight",
 }
 
@@ -170,6 +172,49 @@ class MemoryTests(unittest.TestCase):
         self.assertEqual(check_hermes_memory_staleness(home).status, "advice")
 
 
+class LegacyPlanArtifactTests(unittest.TestCase):
+    """Plans written by the pre-relocation writer are unread; say so out loud.
+
+    Nothing reads `~/.hermes/plans` any more. Staying silent about files that
+    are already on disk is how a user concludes their plans vanished.
+    """
+
+    def _home(self) -> Path:
+        return Path(tempfile.mkdtemp())
+
+    def test_no_legacy_directories_is_ok(self) -> None:
+        self.assertEqual(check_legacy_plan_artifacts(self._home()).status, "ok")
+
+    def test_an_empty_legacy_directory_is_ok(self) -> None:
+        home = self._home()
+        (home / "plans").mkdir(parents=True)
+        self.assertEqual(check_legacy_plan_artifacts(home).status, "ok")
+
+    def test_leftover_plans_are_reported_with_a_count(self) -> None:
+        home = self._home()
+        _write(home / "plans" / "2026-01-01T000000Z-old-plan-abc123.md", "# old\n")
+        _write(home / "plans" / "2026-01-02T000000Z-other-plan-def456.md", "# old\n")
+        entry = check_legacy_plan_artifacts(home)
+        self.assertEqual(entry.status, "advice")
+        self.assertIn("2 file(s) in plans", entry.observed)
+
+    def test_blocked_plan_context_is_counted_too(self) -> None:
+        home = self._home()
+        _write(home / "context" / "2026-01-01T000000Z-old-context-abc123.md", "# old\n")
+        entry = check_legacy_plan_artifacts(home)
+        self.assertEqual(entry.status, "advice")
+        self.assertIn("1 file(s) in context", entry.observed)
+
+    def test_the_remedy_never_offers_to_move_or_delete_them(self) -> None:
+        home = self._home()
+        _write(home / "plans" / "old.md", "# old\n")
+        entry = check_legacy_plan_artifacts(home)
+        # OMH reports on Hermes' home and does not write to it.
+        self.assertIn("OMH will not touch them", entry.remediation)
+        self.assertTrue(entry.read_only)
+        self.assertTrue((home / "plans" / "old.md").exists())
+
+
 class SkillWeightTests(unittest.TestCase):
     def _skills_dir(self, count: int) -> Path:
         skills_dir = Path(tempfile.mkdtemp()) / "skills"
@@ -213,7 +258,7 @@ class ContractShapeTests(unittest.TestCase):
         self.assertEqual(CONTRACT, "hermes_config_advice/v1")
         data = report.to_dict()
         self.assertEqual(data["contract"], CONTRACT)
-        self.assertEqual(len(data["entries"]), 4)
+        self.assertEqual(len(data["entries"]), len(ADVISORY_CHECK_IDS))
         for entry in data["entries"]:
             self.assertEqual(
                 set(entry.keys()),
@@ -279,7 +324,7 @@ class MembershipGuardrailTests(unittest.TestCase):
         os.utime(memory, (old, old))
         return omh_home, hermes_home
 
-    def test_all_four_fire_and_stay_out_of_checks(self) -> None:
+    def test_all_advisories_fire_and_stay_out_of_checks(self) -> None:
         omh_home, hermes_home = self._all_firing_home()
         paths = resolve_paths(omh_home, hermes_home)
 
@@ -291,6 +336,10 @@ class MembershipGuardrailTests(unittest.TestCase):
                 "auxiliary_routing_unset": "advice",
                 "soul_missing_or_starter": "advice",
                 "hermes_memory_staleness": "advice",
+                # The fixture home has no leftover ~/.hermes/plans, so this one
+                # reports ok rather than advice; the firing case is covered in
+                # LegacyPlanArtifactTests.
+                "legacy_plan_artifacts": "ok",
                 "installed_skill_context_weight": "advice",
             },
         )

--- a/tests/test_project_scoped_artifacts.py
+++ b/tests/test_project_scoped_artifacts.py
@@ -23,7 +23,9 @@ from omh.paths import (
     ensure_project_store_ignored,
     find_project_root,
     project_artifact_dir,
+    project_hermes_home,
     project_identity,
+    project_omh_home,
     resolve_paths,
 )
 from omh.workflows.hermes_planning import (
@@ -126,12 +128,40 @@ class ArtifactDirTests(unittest.TestCase):
             nested = root / "nested" / "deep"
             nested.mkdir(parents=True)
             paths = resolve_paths(scope="project")
-            # `--scope project` sets omh_home from the literal cwd, so without
-            # the walk a plan recorded from a subdirectory would land in
-            # nested/deep/.omh instead of the repository's own store.
             self.assertEqual(
                 project_artifact_dir(paths, "plans", cwd=nested), root / ".omh" / "plans"
             )
+
+
+class ScopeProjectAnchorTests(unittest.TestCase):
+    """`--scope project` means the project, not whichever directory you stand in."""
+
+    def test_both_homes_anchor_at_the_repository_root(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = _repo(Path(tmp).resolve())
+            nested = root / "nested" / "deep"
+            nested.mkdir(parents=True)
+            self.assertEqual(project_omh_home(nested), root / ".omh")
+            self.assertEqual(project_hermes_home(nested), root / ".hermes")
+
+    def test_the_store_and_its_artifacts_share_one_home(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = _repo(Path(tmp).resolve())
+            nested = root / "nested" / "deep"
+            nested.mkdir(parents=True)
+            paths = resolve_paths(project_omh_home(nested), project_hermes_home(nested))
+            # The literal-cwd version put manifest.json under nested/deep/.omh
+            # while plans resolved to the root: one run, two homes.
+            self.assertEqual(paths.manifest_path.parent, root / ".omh")
+            self.assertEqual(project_artifact_dir(paths, "plans").parent, root / ".omh")
+
+    def test_outside_a_repository_the_cwd_is_still_the_anchor(self) -> None:
+        with TemporaryDirectory() as tmp:
+            plain = Path(tmp).resolve() / "not-a-repo"
+            plain.mkdir()
+            with patch("omh.system.paths.find_project_root", return_value=None):
+                self.assertEqual(project_omh_home(plain), plain / ".omh")
+                self.assertEqual(project_hermes_home(plain), plain / ".hermes")
 
     def test_constructing_paths_directly_counts_as_naming_the_home(self) -> None:
         with TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Capability

Three gaps left open by the plan relocation in #674 are closed: a codegraph build no longer leaves an untracked `.omh/` in a user's repository, `--scope project` no longer splits its store across two directories, and plans stranded in `~/.hermes/plans` by the old writer are now reported instead of silently ignored.

## Motivation

Each was reproduced before being fixed.

**1. `codegraph build --write` left an un-ignored store.** Only oh-my-hermes' own `.gitignore` lists `.omh/`. In a scratch repository:

```
$ omh codegraph build --write
$ git status --short
?? .omh/                      ← untracked; git add -A commits the artifact
$ git check-ignore -v .omh/codegraph
(nothing)
```

#674 gave the plan writer a self-ignoring store but left the codegraph writer untouched, so a codegraph-only user got no protection.

**2. `--scope project` anchored on the working directory, not the project.** Run from a subdirectory it produced two homes in one invocation:

```
omh_home     → repo/nested/deep/.omh          ← literal cwd
manifest     → repo/nested/deep/.omh/manifest.json
plans        → repo/.omh/plans                 ← repository root
```

This only became visible with #674, which introduced the first resolver that walks to a project root. Before that nothing disagreed, because nothing looked. A project is a repository, not whichever directory the shell is in.

**3. Old plans are unread and unmentioned.** The pre-#674 writer put artifacts in `~/.hermes/plans`. Nothing reads that path now. Files sitting on disk with nothing acknowledging them is how a user concludes their plans disappeared.

## What changed

- **`src/codegraph/schema.py`** — `write_codegraph_artifact` calls `ensure_project_store_ignored` on the store before writing. No-op outside a repository, never overwrites an existing ignore file.
- **`src/system/paths.py`** — `project_omh_home` and `project_hermes_home` anchor at the project root via a shared `_project_anchor`, falling back to the cwd only when there is no repository. `resolve_paths` is their only caller, so the blast radius is one function.
- **`src/maintenance/advisory.py`** — new `legacy_plan_artifacts` advisory counts `*.md` under `~/.hermes/plans` and `~/.hermes/context` and explains what they are. Read-only, like every entry in that lane: it counts files and never moves or deletes one. `run_config_advisories` gained the entry, and the membership guardrail test's `ADVISORY_CHECK_IDS` grew with it.

## Verification observed

```
full suite                1929 passed, 1 skipped
ruff / compileall         clean
byte gates                workflows, roles, capability-families ok
release drift             no drift, 11 checks
git diff --check          clean
omh doctor                28/28
```

Live, in scratch repositories:

```
codegraph build --write    git status clean; check-ignore → .omh/.gitignore:1:*
--scope project from repo/nested/deep
                          omh_home, manifest, runtime, plans all under <repo>/.omh
legacy_plan_artifacts     "ok — no plan artifacts left under ~/.hermes" on this machine
```

The advisory reports `ok` here because `~/.hermes/plans` was never created, so its firing path is covered by fixtures (`LegacyPlanArtifactTests`) rather than by live data — including a test asserting the remedy never offers to move or delete the files and that the fixture file still exists afterwards.

## Risks and follow-ups

- **No migration for an existing `--scope project` install made from a subdirectory.** Such an install now resolves to the repository root and will not find its old store. Nobody is known to have one, and it was in a surprising place to begin with, but nothing moves it.
- **The exact-count assertion moved rather than hardened.** `len(data["entries"])` now derives from `ADVISORY_CHECK_IDS` instead of the literal `4`, so adding an advisory updates one place instead of two.
- `omh doctor` was at 27/28 before this branch because the installed plugin bundle had drifted from the package; `omh setup` refreshed it and it is 28/28 now. That was an install-state repair, not a code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
