### PR TITLE
Make omh_memory work on the host it exists for

### DIFF
--- a/src/maintenance/advisory.py
+++ b/src/maintenance/advisory.py
@@ -20,8 +20,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from ..config_adapter import external_dirs, read_config
-from ..paths import default_hermes_home
-from . import hermes_memory
+from ..paths import default_hermes_home, expand_path, find_project_root
+from ..plugin_bundle.omh import hermes_memory
 
 CONTRACT = "hermes_config_advice/v1"
 
@@ -428,7 +428,86 @@ def check_legacy_plan_artifacts(hermes_home: str | Path | None = None) -> Advice
 
 
 # ---------------------------------------------------------------------------
-# 5. installed_skill_context_weight
+# 5. orphaned_project_scope_store
+# ---------------------------------------------------------------------------
+
+def check_orphaned_project_scope_store(
+    hermes_home: str | Path | None = None,
+    *,
+    cwd: str | Path | None = None,
+) -> AdviceEntry:
+    """Report a `--scope project` store stranded below the repository root.
+
+    `--scope project` used to anchor on the literal working directory, so
+    running it from a subdirectory installed into `<subdir>/.omh`. It now
+    anchors at the repository root, which leaves any such install unreachable.
+    This is the exact inverse of that change, not a guess: it looks only between
+    the current directory and the root, so it can fire only for a store the
+    change actually orphaned.
+    """
+    del hermes_home  # this check reads the working directory, not Hermes' home
+    evidence_boundary = (
+        "Local existence check of `.omh/manifest.json` in directories between the working "
+        "directory and the repository root; OMH does not read, move, or delete them."
+    )
+    remediation = (
+        "`--scope project` now anchors at the repository root, so a store installed from a "
+        "subdirectory is no longer found. Re-run `omh --scope project setup` from the "
+        "repository root, then delete the old directory by hand. OMH will not move it."
+    )
+    try:
+        root = find_project_root(cwd)
+        start = expand_path(cwd or Path.cwd())
+        if root is None or start == root:
+            return AdviceEntry(
+                "orphaned_project_scope_store",
+                "ok",
+                remediation,
+                evidence_boundary,
+                "no subdirectory between the working directory and a repository root",
+            )
+        stranded = [
+            str(candidate)
+            for candidate in _ancestors_below(start, root)
+            if (candidate / ".omh" / "manifest.json").is_file()
+        ]
+    except OSError as error:
+        return AdviceEntry(
+            "orphaned_project_scope_store",
+            "unobserved",
+            remediation,
+            evidence_boundary,
+            f"working directory unreadable: {error}",
+        )
+    if not stranded:
+        return AdviceEntry(
+            "orphaned_project_scope_store",
+            "ok",
+            remediation,
+            evidence_boundary,
+            "no project-scope store below the repository root",
+        )
+    return AdviceEntry(
+        "orphaned_project_scope_store",
+        "advice",
+        remediation,
+        evidence_boundary,
+        "; ".join(f"stranded store in {path}" for path in stranded),
+    )
+
+
+def _ancestors_below(start: Path, root: Path) -> list[Path]:
+    """`start` and its parents, stopping before `root`."""
+    below: list[Path] = []
+    for candidate in (start, *start.parents):
+        if candidate == root:
+            break
+        below.append(candidate)
+    return below
+
+
+# ---------------------------------------------------------------------------
+# 6. installed_skill_context_weight
 # ---------------------------------------------------------------------------
 
 def _count_skill_dirs(skills_dir: Path) -> int:
@@ -519,6 +598,7 @@ def run_config_advisories(hermes_home: str | Path | None = None) -> AdvisoryRepo
             check_soul_missing_or_starter(hermes_home),
             check_hermes_memory_staleness(hermes_home),
             check_legacy_plan_artifacts(hermes_home),
+            check_orphaned_project_scope_store(hermes_home),
             check_installed_skill_context_weight(hermes_home),
         ],
     )

--- a/src/plugin_bundle/omh/awareness.py
+++ b/src/plugin_bundle/omh/awareness.py
@@ -5262,7 +5262,15 @@ def awareness_primer_context() -> str:
             str(payload["first_turn_rule"]),
             "Use message-specific route hints when present; they should outrank this always-on rail.",
             "Boundary: " + str(payload["evidence_boundary"]),
-            "Expand only when needed with omh_context, omh_capabilities, and omh_status/omh_hud.",
+            # `tool_hints` in the context brief is not this rail: `pre_llm_call`
+            # injects `payload["context"]` and nothing else, so a hint recorded
+            # only there never reaches the model. Measured: with the hint in
+            # `tool_hints` alone, a "remember this" turn called Hermes' native
+            # `memory` tool directly and omh_memory zero times.
+            (
+                "Expand only when needed with omh_context, omh_capabilities, and omh_status/omh_hud; "
+                "check omh_memory before writing Hermes memory."
+            ),
         ]
     )
 

--- a/src/plugin_bundle/omh/hermes_memory.py
+++ b/src/plugin_bundle/omh/hermes_memory.py
@@ -20,10 +20,13 @@ edits them.
 
 from __future__ import annotations
 
+import hashlib
+import json
 import re
 import time
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 # Hermes' own entry separator; see ENTRY_DELIMITER in its memory tool.
 HERMES_MEMORY_DELIMITER = "§"
@@ -155,3 +158,105 @@ def nearest_entry(text: str, entries: tuple[str, ...] | list[str]) -> tuple[int,
         if score > best_score:
             best_index, best_score = index, score
     return best_index, best_score
+
+
+HERMES_MEMORY_BRIDGE_SCHEMA_VERSION = "hermes_memory_bridge/v1"
+PROJECT_MEMORY_RECORD_SCHEMA_VERSION = "project_memory_record/v1"
+
+
+def read_approved_records(omh_home: str | Path) -> list[dict[str, Any]]:
+    """Approved OMH project-memory records, read with stdlib only.
+
+    The bundle has to reach these itself. The `omh` package is not importable
+    from the Hermes process -- it lives in its own environment -- so a tool that
+    delegated the read would answer "package absent" on the one host that
+    matters, which is exactly what shipped before this was vendored.
+    """
+    directory = Path(omh_home).expanduser() / "memory" / "records"
+    records: list[dict[str, Any]] = []
+    try:
+        candidates = sorted(directory.glob("*.json"))
+    except OSError:
+        return records
+    for path in candidates:
+        try:
+            if path.is_symlink() or not path.is_file():
+                continue
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        if not isinstance(data, dict):
+            continue
+        if data.get("schema_version") != PROJECT_MEMORY_RECORD_SCHEMA_VERSION:
+            continue
+        if data.get("review_status") != "approved":
+            continue
+        records.append(data)
+    return records
+
+
+def build_hermes_memory_bridge(omh_home: str | Path, hermes_home: str | Path) -> dict[str, object]:
+    """Relate OMH's approved records to what Hermes already remembers.
+
+    The two stores share no identifier, so neither could see the other: OMH
+    deduplicated against itself, and Hermes' memory tool rejects only exact
+    strings. A fact approved in OMH and restated by hand in MEMORY.md lived in
+    both, worded differently, with nothing linking them.
+
+    Read-only. Hermes owns these files; its own `memory` tool is what edits them.
+    """
+    readings = read_hermes_memory(hermes_home)
+    records = read_approved_records(omh_home)
+    memory_file = next((reading for reading in readings if reading.label == "MEMORY.md"), None)
+    entries = memory_file.entries if memory_file else ()
+    already_present: list[dict[str, object]] = []
+    promotable: list[dict[str, object]] = []
+    matched_entries: set[int] = set()
+    for record in records:
+        summary = str(record.get("summary", "") or "")
+        index, score = nearest_entry(summary, entries)
+        row: dict[str, object] = {
+            "record_id": str(record.get("record_id", "")),
+            "summary_length": len(summary),
+            "scope": record.get("scope", {}),
+            "nearest_entry_index": index,
+            "similarity": round(score, 2),
+        }
+        if score >= DUPLICATE_SIMILARITY_THRESHOLD:
+            matched_entries.add(index)
+            already_present.append(row)
+            continue
+        # `+ 1` is the delimiter Hermes inserts before an appended entry.
+        row["fits_headroom"] = bool(memory_file) and len(summary) + 1 <= memory_file.headroom_chars
+        promotable.append(row)
+    return {
+        "schema_version": HERMES_MEMORY_BRIDGE_SCHEMA_VERSION,
+        "files": [reading.to_dict() for reading in readings],
+        "approved_records": len(records),
+        "already_in_hermes": already_present,
+        "promotable": promotable,
+        "hermes_entries_without_omh_record": _unsourced_entry_rows(entries, matched_entries),
+        "duplicate_similarity_threshold": DUPLICATE_SIMILARITY_THRESHOLD,
+        "redaction_policy": "metadata_only",
+        "next_action": (
+            "Promote a record by asking Hermes to add it through its own memory tool; free headroom first "
+            "when nothing fits."
+        ),
+        "claim_boundary": (
+            "OMH reads Hermes memory and cannot change it. This comparison is prepared review context only; "
+            "it is not a Hermes memory write, execution, review, CI, or merge evidence."
+        ),
+    }
+
+
+def _unsourced_entry_rows(entries: tuple[str, ...], matched: set[int]) -> list[dict[str, object]]:
+    """Hermes entries no approved OMH record explains, as metadata only."""
+    return [
+        {
+            "entry_index": index,
+            "chars": len(entry),
+            "sha256": hashlib.sha256(entry.encode("utf-8")).hexdigest(),
+        }
+        for index, entry in enumerate(entries)
+        if index not in matched
+    ]

--- a/src/plugin_bundle/omh/tools/memory_tool.py
+++ b/src/plugin_bundle/omh/tools/memory_tool.py
@@ -14,8 +14,10 @@ exposes to the model is what edits it.
 from __future__ import annotations
 
 import json
+import os
 
 from ..degradation import safe_error_type as _safe_error_type
+from ..hermes_memory import build_hermes_memory_bridge
 from ..host_observation import OBSERVATION_SCHEMA, attach_public_observation, observe_plugin_tool_call
 
 OMH_MEMORY_SCHEMA = {
@@ -44,20 +46,29 @@ def omh_memory_handler(args: dict, **kwargs) -> str:
 
 
 def _memory_bridge() -> tuple[dict[str, object], str]:
+    """Compare the two stores using the bundle's own reader.
+
+    This used to delegate to `omh.memory` and fall back when the import failed.
+    The Hermes process cannot import that package -- it lives in its own
+    environment -- so the fallback was the *only* path taken on the host this
+    tool exists for, and the tool answered "package_absent" every time. Measured
+    live before the fix: the model called it, got nothing, and shelled out to
+    `omh memory status` instead. The reader is vendored here now, which is what
+    every other working bundle surface already does.
+    """
     try:
-        from omh.memory import build_hermes_memory_bridge
-        from omh.paths import resolve_paths
-    except (ImportError, ModuleNotFoundError):
-        # A host without the OMH package must stay indistinguishable from today:
-        # answer with the boundary rather than a broken payload.
-        return _unavailable("package_absent"), "standalone_plugin_bundle_fallback"
-    try:
-        return build_hermes_memory_bridge(resolve_paths()), "package_memory"
+        return (
+            build_hermes_memory_bridge(_home("OMH_HOME", "~/.omh"), _home("HERMES_HOME", "~/.hermes")),
+            "bundle_memory",
+        )
     except Exception as exc:
-        # The package imported but the delegated call raised. Labelling this as
-        # the missing-package fallback above would hide a real failure behind a
-        # response that looks identical to a host that never had OMH.
-        return _unavailable(_safe_error_type(type(exc).__name__)), "package_memory_error"
+        # A read failure must stay distinguishable from an empty comparison, or
+        # an unreadable memory file reads as a memory with nothing in it.
+        return _unavailable(_safe_error_type(type(exc).__name__)), "bundle_memory_error"
+
+
+def _home(variable: str, default: str) -> str:
+    return os.path.expandvars(os.environ.get(variable, "") or default)
 
 
 def _unavailable(reason: str) -> dict[str, object]:

--- a/src/workflows/memory.py
+++ b/src/workflows/memory.py
@@ -7,11 +7,7 @@ from pathlib import Path
 from typing import Any
 
 from ..local_store import atomic_write_json, ensure_dir, file_lock, read_json_object, read_json_object_result, utc_now
-from ..maintenance.hermes_memory import (
-    DUPLICATE_SIMILARITY_THRESHOLD,
-    nearest_entry,
-    read_hermes_memory,
-)
+from ..plugin_bundle.omh.hermes_memory import build_hermes_memory_bridge as _bundle_memory_bridge
 from ..paths import OmhPaths
 from ..profiles.setup import read_setup_profile
 from ..targets import summarize_target_registry
@@ -182,72 +178,12 @@ def read_project_memory_policy(paths: OmhPaths) -> dict[str, object]:
 def build_hermes_memory_bridge(paths: OmhPaths) -> dict[str, object]:
     """Relate OMH's approved records to what Hermes already remembers.
 
-    The two stores have no shared identifier, so neither could see the other:
-    OMH deduplicated only against itself, and Hermes' memory tool rejects only
-    exact-string duplicates. A fact approved in OMH and then restated by hand in
-    MEMORY.md therefore lived in both, worded differently, with nothing linking
-    them.
-
-    This is the read side of that link. It reports which approved record Hermes
-    already carries, which one it does not, and whether the next one would fit
-    under the cap Hermes enforces on write. Nothing here writes to Hermes: the
-    `memory` tool Hermes exposes to the model is what edits MEMORY.md.
+    One implementation, kept in the plugin bundle. The Hermes process cannot
+    import this package, so a bundle that delegated here would answer "package
+    absent" on the only host that matters; the dependency has to point the other
+    way.
     """
-    readings = read_hermes_memory(paths.hermes_home)
-    records = _read_project_memory_records(paths)
-    memory_file = next((reading for reading in readings if reading.label == "MEMORY.md"), None)
-    entries = memory_file.entries if memory_file else ()
-    already_present: list[dict[str, object]] = []
-    promotable: list[dict[str, object]] = []
-    matched_entries: set[int] = set()
-    for record in records:
-        summary = str(record.get("summary", "") or "")
-        index, score = nearest_entry(summary, entries)
-        row: dict[str, object] = {
-            "record_id": str(record.get("record_id", "")),
-            "summary_length": len(summary),
-            "scope": record.get("scope", {}),
-            "nearest_entry_index": index,
-            "similarity": round(score, 2),
-        }
-        if score >= DUPLICATE_SIMILARITY_THRESHOLD:
-            matched_entries.add(index)
-            already_present.append(row)
-            continue
-        # `+ 1` is the delimiter Hermes inserts before an appended entry.
-        row["fits_headroom"] = bool(memory_file) and len(summary) + 1 <= memory_file.headroom_chars
-        promotable.append(row)
-    return {
-        "schema_version": HERMES_MEMORY_BRIDGE_SCHEMA_VERSION,
-        "files": [reading.to_dict() for reading in readings],
-        "approved_records": len(records),
-        "already_in_hermes": already_present,
-        "promotable": promotable,
-        "hermes_entries_without_omh_record": _unsourced_entry_rows(entries, matched_entries),
-        "duplicate_similarity_threshold": DUPLICATE_SIMILARITY_THRESHOLD,
-        "redaction_policy": "metadata_only",
-        "next_action": (
-            "Promote a record by asking Hermes to add it through its own memory tool; free headroom first "
-            "when nothing fits."
-        ),
-        "claim_boundary": (
-            "OMH reads Hermes memory and cannot change it. This comparison is prepared review context only; "
-            "it is not a Hermes memory write, execution, review, CI, or merge evidence."
-        ),
-    }
-
-
-def _unsourced_entry_rows(entries: tuple[str, ...], matched: set[int]) -> list[dict[str, object]]:
-    """Hermes entries no approved OMH record explains, as metadata only."""
-    return [
-        {
-            "entry_index": index,
-            "chars": len(entry),
-            "sha256": hashlib.sha256(entry.encode("utf-8")).hexdigest(),
-        }
-        for index, entry in enumerate(entries)
-        if index not in matched
-    ]
+    return _bundle_memory_bridge(paths.omh_home, paths.hermes_home)
 
 
 def build_project_memory_status(paths: OmhPaths) -> dict[str, object]:

--- a/tests/test_broad_exception_policy.py
+++ b/tests/test_broad_exception_policy.py
@@ -148,9 +148,9 @@ CLASSIFIED_SITES: tuple[ClassifiedSite, ...] = (
         "src/plugin_bundle/omh/tools/memory_tool.py",
         "_memory_bridge",
         INTENTIONAL,
-        "Returns the distinct `package_memory_error` source plus a sanitized error type, so a "
-        "package runtime failure never reads as `standalone_plugin_bundle_fallback` -- the label "
-        "a host that genuinely lacks OMH would get.",
+        "Returns the distinct `bundle_memory_error` source plus a sanitized error type. The "
+        "alternative is an empty comparison, which would read as `Hermes remembers nothing` when "
+        "the truth is that OMH could not read the file.",
     ),
     ClassifiedSite(
         "src/plugin_bundle/omh/tools/recommend_tool.py",

--- a/tests/test_doctor_advisory.py
+++ b/tests/test_doctor_advisory.py
@@ -7,6 +7,7 @@ import tempfile
 import unittest
 from contextlib import redirect_stdout
 from pathlib import Path
+from unittest import mock
 
 from omh.maintenance import advisory
 from omh.maintenance.advisory import (
@@ -18,6 +19,7 @@ from omh.maintenance.advisory import (
     check_hermes_memory_staleness,
     check_installed_skill_context_weight,
     check_legacy_plan_artifacts,
+    check_orphaned_project_scope_store,
     check_soul_missing_or_starter,
     run_config_advisories,
 )
@@ -30,6 +32,7 @@ ADVISORY_CHECK_IDS = {
     "soul_missing_or_starter",
     "hermes_memory_staleness",
     "legacy_plan_artifacts",
+    "orphaned_project_scope_store",
     "installed_skill_context_weight",
 }
 
@@ -215,6 +218,68 @@ class LegacyPlanArtifactTests(unittest.TestCase):
         self.assertTrue((home / "plans" / "old.md").exists())
 
 
+class OrphanedProjectScopeStoreTests(unittest.TestCase):
+    """`--scope project` moved its anchor to the repository root in #676.
+
+    A store installed from a subdirectory before that is now unreachable. This
+    check is the exact inverse of the change, so it must fire for that case and
+    stay quiet for every other shape.
+    """
+
+    def _repo(self, root: Path) -> Path:
+        (root / ".git").mkdir(parents=True)
+        return root
+
+    def test_a_store_below_the_root_is_reported(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = self._repo(Path(tmp).resolve())
+            nested = root / "nested" / "deep"
+            _write(nested / ".omh" / "manifest.json", "{}")
+            entry = check_orphaned_project_scope_store(cwd=nested)
+            self.assertEqual(entry.status, "advice")
+            self.assertIn(str(nested), entry.observed)
+
+    def test_a_store_at_the_root_is_not_reported(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = self._repo(Path(tmp).resolve())
+            _write(root / ".omh" / "manifest.json", "{}")
+            # The root store is the supported location, not an orphan.
+            self.assertEqual(check_orphaned_project_scope_store(cwd=root).status, "ok")
+
+    def test_a_subdirectory_without_a_store_is_quiet(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = self._repo(Path(tmp).resolve())
+            nested = root / "nested"
+            nested.mkdir()
+            self.assertEqual(check_orphaned_project_scope_store(cwd=nested).status, "ok")
+
+    def test_an_omh_directory_without_a_manifest_is_not_an_install(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = self._repo(Path(tmp).resolve())
+            nested = root / "nested"
+            # A plans/codegraph store is not a `--scope project` install, and
+            # reporting one would fire on every repository that records a plan.
+            _write(nested / ".omh" / "plans" / "some-plan.md", "# plan\n")
+            self.assertEqual(check_orphaned_project_scope_store(cwd=nested).status, "ok")
+
+    def test_outside_a_repository_there_is_nothing_to_orphan(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            plain = Path(tmp).resolve()
+            with mock.patch("omh.maintenance.advisory.find_project_root", return_value=None):
+                self.assertEqual(check_orphaned_project_scope_store(cwd=plain).status, "ok")
+
+    def test_the_remedy_never_offers_to_move_the_store(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = self._repo(Path(tmp).resolve())
+            nested = root / "nested"
+            manifest = nested / ".omh" / "manifest.json"
+            _write(manifest, "{}")
+            entry = check_orphaned_project_scope_store(cwd=nested)
+            self.assertIn("OMH will not move it", entry.remediation)
+            self.assertTrue(entry.read_only)
+            self.assertTrue(manifest.exists())
+
+
 class SkillWeightTests(unittest.TestCase):
     def _skills_dir(self, count: int) -> Path:
         skills_dir = Path(tempfile.mkdtemp()) / "skills"
@@ -340,6 +405,8 @@ class MembershipGuardrailTests(unittest.TestCase):
                 # reports ok rather than advice; the firing case is covered in
                 # LegacyPlanArtifactTests.
                 "legacy_plan_artifacts": "ok",
+                # No subdirectory store below a repository root in the fixture home.
+                "orphaned_project_scope_store": "ok",
                 "installed_skill_context_weight": "advice",
             },
         )

--- a/tests/test_hermes_memory_bridge.py
+++ b/tests/test_hermes_memory_bridge.py
@@ -26,7 +26,7 @@ from _local_package import load_local_package
 load_local_package()
 from omh.maintenance import advisory
 from omh.maintenance.advisory import MEMORY_STALE_AFTER_DAYS, check_hermes_memory_staleness
-from omh.maintenance.hermes_memory import (
+from omh.plugin_bundle.omh.hermes_memory import (
     HERMES_MEMORY_DELIMITER,
     MEMORY_FILE_CAP_CHARS,
     memory_char_count,
@@ -235,7 +235,7 @@ class MemoryToolTests(unittest.TestCase):
             root = Path(tmp).resolve()
             _write_memory(root / ".hermes", "커피 원두는 밀봉 용기에 보관한다")
             payload = self._payload(root)
-            self.assertEqual(payload["source_backend"], "package_memory")
+            self.assertEqual(payload["source_backend"], "bundle_memory")
             self.assertEqual(payload["schema_version"], "hermes_memory_bridge/v1")
             self.assertEqual(payload["plugin_tool"], "omh_memory")
 
@@ -246,14 +246,16 @@ class MemoryToolTests(unittest.TestCase):
             _write_memory(root / ".hermes", secret)
             self.assertNotIn(secret, json.dumps(self._payload(root), ensure_ascii=False))
 
-    def test_a_package_failure_is_not_labelled_as_a_missing_package(self) -> None:
+    def test_a_read_failure_stays_distinguishable_from_an_empty_comparison(self) -> None:
         with patch(
-            "omh.memory.build_hermes_memory_bridge", side_effect=RuntimeError("boom")
+            "omh.plugin_bundle.omh.tools.memory_tool.build_hermes_memory_bridge",
+            side_effect=RuntimeError("boom"),
         ):
             payload = json.loads(omh_memory_handler({}))
-        # Reusing the standalone-fallback label here would make a real failure
-        # indistinguishable from a host that never had OMH installed.
-        self.assertEqual(payload["source_backend"], "package_memory_error")
+        # Answering with an empty comparison would read as "Hermes remembers
+        # nothing" when the truth is that OMH could not read the file.
+        self.assertEqual(payload["source_backend"], "bundle_memory_error")
         self.assertEqual(payload["status"], "unavailable")
         self.assertEqual(payload["reason"], "RuntimeError")
         self.assertIn("not evidence", payload["claim_boundary"])
+        self.assertNotIn("boom", json.dumps(payload))

--- a/tests/test_plugin_distribution.py
+++ b/tests/test_plugin_distribution.py
@@ -184,6 +184,46 @@ print(json.dumps(observed, ensure_ascii=False))
         self.assertNotIn("package-context-boom", serialized)
         self.assertNotIn("secret-token-123", serialized)
 
+    def test_memory_tool_needs_no_package_and_still_answers(self) -> None:
+        from omh.plugin_bundle.omh.tools import memory_tool
+
+        # The Hermes process cannot import the `omh` package, so a tool that
+        # delegated there answered "package_absent" on the only host it exists
+        # for. Blocking the package must now change nothing: the reader is in
+        # the bundle, which is what makes the tool work at all.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            memories = root / ".hermes" / "memories"
+            memories.mkdir(parents=True)
+            (memories / "MEMORY.md").write_text("a remembered fact", encoding="utf-8")
+            env = {"OMH_HOME": str(root / ".omh"), "HERMES_HOME": str(root / ".hermes")}
+
+            with mock.patch.dict(sys.modules, {"omh.memory": None, "omh.paths": None}):
+                with mock.patch.dict(os.environ, env):
+                    payload = json.loads(memory_tool.omh_memory_handler({}))
+
+        self.assertEqual(payload["source_backend"], "bundle_memory")
+        self.assertEqual(payload["schema_version"], "hermes_memory_bridge/v1")
+        self.assertNotIn("status", payload)  # not the unavailable shape
+        self.assertEqual([f["label"] for f in payload["files"]], ["MEMORY.md", "USER.md"])
+        self.assertEqual(payload["files"][0]["chars"], len("a remembered fact"))
+
+    def test_memory_tool_keeps_a_read_failure_apart_from_an_empty_comparison(self) -> None:
+        from omh.plugin_bundle.omh.tools import memory_tool
+
+        with mock.patch.object(
+            memory_tool, "build_hermes_memory_bridge", side_effect=RuntimeError("bundle-memory-boom")
+        ):
+            error_payload = json.loads(memory_tool.omh_memory_handler({}))
+        # Returning an empty comparison here would read as "Hermes remembers
+        # nothing" when OMH simply could not read the file.
+        self.assertEqual(error_payload["source_backend"], "bundle_memory_error")
+        self.assertEqual(error_payload["status"], "unavailable")
+        self.assertEqual(error_payload["reason"], "RuntimeError")
+        self.assertNotIn("bundle-memory-boom", json.dumps(error_payload, sort_keys=True))
+        for absent in ("files", "already_in_hermes", "promotable", "approved_records"):
+            self.assertNotIn(absent, error_payload)
+
     def test_recommend_tool_distinguishes_missing_package_from_package_call_failure(self) -> None:
         from omh.plugin_bundle.omh.tools import recommend_tool
 


### PR DESCRIPTION
## Capability

`omh_memory` now returns real data inside Hermes. Before this it returned nothing, on every call, on the only host it exists for.

```
live hermes -z turn, after the fix:
  source_backend    bundle_memory
  MEMORY.md         1921/2200, headroom 279
  approved records  5  →  3 already in Hermes, 2 promotable
```

Also included, from the same follow-up sweep: an advisory for `--scope project` stores orphaned by #676, and a rewritten standalone guard for the tool.

## Motivation

**#677 shipped an inert tool.** It delegated to `omh.memory` and fell back when the import failed. The Hermes process cannot import that package — it lives in its own environment — so the fallback was not a fallback, it was the only path:

```
omh_memory   → {"source_backend": "standalone_plugin_bundle_fallback",
                "reason": "package_absent",
                "claim_boundary": "No memory comparison was produced. …"}
```

Unit tests and the register smoke were green the whole time, because both run where the package *is* importable. `omh_context` works standalone for the opposite reason: its logic is vendored into the bundle. In #677 I explicitly rejected vendoring, reasoning that two copies would drift. That call was wrong, and it is what made the tool useless.

**How it surfaced.** Adding the primer hint made the model actually call the tool — and the call came back empty, so the model shelled out to `omh memory status` through `terminal` instead. That path needs shell approval, which is precisely what the tool existed to avoid. Nothing short of a live turn would have shown this.

**The hint had to move too.** `tool_hints` lives in the context brief, and `pre_llm_call` injects `payload["context"]` and nothing else. A hint recorded only in `tool_hints` never reaches the model. The primer now carries it (777/900 chars).

## Implementation

- **`src/plugin_bundle/omh/hermes_memory.py`** (moved from `src/maintenance/`) — the reader plus `build_hermes_memory_bridge(omh_home, hermes_home)` and `read_approved_records`, stdlib only.
- **`src/workflows/memory.py`** — `build_hermes_memory_bridge(paths)` delegates to the bundle. Signature unchanged.
- **`src/maintenance/advisory.py`** — imports the reader from the bundle; adds `orphaned_project_scope_store`.
- **`tools/memory_tool.py`** — no package import at all. `bundle_memory` on success, `bundle_memory_error` on a read failure, so an unreadable file never reads as an empty memory.

**One implementation, not two.** The dependency points package → bundle, so there is nothing to drift and no byte-equality gate needed. Verified directly: both paths return identical JSON for the same homes.

**`orphaned_project_scope_store`** looks only at directories between the working directory and the repository root, and requires `manifest.json` — so it can only fire for a store #676 actually orphaned, and a plans-only `.omh` is not mistaken for an install. Read-only; the remedy says OMH will not move it.

## Verification observed

| Gate | Result |
| --- | --- |
| Full suite | 1941 passed, 1 skipped |
| ruff, compileall, `git diff --check` | clean |
| byte gates + release drift | ok, no drift (11 checks) |
| `omh doctor` | 28/28 |
| Bundle copied to a package-less `python3` | `bundle_memory`, real data |
| Live `hermes -z` turn | `bundle_memory`, 1921/2200, 5 records, MEMORY.md unchanged |

The package-less run is the load-bearing one: the previous version returned `package_absent` there, which is what Hermes was getting.

## Risks and follow-ups

- **The primer hint's effect is n=1 per side** — 0 calls before, 1 after. Directionally right, not a measurement I would defend as strong.
- **Hermes reports MEMORY.md as 1,933 chars; OMH reports 1,921.** OMH counts the way Hermes' own cap check does (`len(§.join(entries))`, entries stripped); Hermes' display counts the raw file. Nothing reconciles the two, and the model noticed the discrepancy unprompted in the live turn.
- **No migration** for an orphaned `--scope project` store; the advisory reports it and stops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
