### PR TITLE
fix: size the wiki blueprint to who is actually reading and writing it

### DIFF
--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -3263,6 +3263,7 @@ These surfaces are generated command references, not installed Hermes workflow s
   - If the fact may be stale, record the staleness warning and next refresh action.
 - Required inputs:
   - audience scale (personal, small group, team, or organization)
+  - whether an agent is one of the readers
   - destination or existing store
   - knowledge types the wiki must hold
   - maintenance owner and cadence

--- a/skills/wiki/SKILL.md
+++ b/skills/wiki/SKILL.md
@@ -68,7 +68,7 @@ Bad example:
 
 ## Design Interview
 
-Settle structure before capture: audience scale, the knowledge types that repeat, what someone will search for, and who maintains it. Skip answered turns, cap at five, and close with one model plus one alternative as a skeleton the user approves before anything is written. No maintainer means `unmaintained`, which rules out models needing curation.
+Settle structure before capture: audience scale, whether an agent reads it, the knowledge types that repeat, what someone will search for, and who maintains it. Skip answered turns, cap at five, and close with one model plus one alternative as a skeleton the user approves before anything is written. No maintainer means `unmaintained`, which rules out models needing curation.
 
 Load `references/wiki-blueprint.md` for the interview turns and `wiki_blueprint/v1` fields, `wiki-patterns.md` for models and what breaks them, `wiki-operations.md` for solo-versus-shared rules, and `wiki-ecosystem.md` for existing skills.
 
@@ -107,6 +107,7 @@ Run directly in Hermes as wiki design and retained knowledge capture; prepare co
 Required inputs:
 
 - audience scale (personal, small group, team, or organization)
+- whether an agent is one of the readers
 - destination or existing store
 - knowledge types the wiki must hold
 - maintenance owner and cadence

--- a/skills/wiki/references/wiki-blueprint.md
+++ b/skills/wiki/references/wiki-blueprint.md
@@ -4,7 +4,7 @@
 
 Two or three questions per turn, five turns at most. Skip what the request already answered; a full inventory is not the goal, a structure someone can start today is.
 
-1. **Audience** — who reads it, who writes it (only me / 2-5 people / a team / the whole organization), and which store already exists.
+1. **Audience** — who reads it, who writes it (only me / 2-5 people / a team / the whole organization), **whether an agent is one of the readers**, and which store already exists.
 2. **Content** — which two or three kinds of knowledge actually repeat: decisions, procedures, research, glossary, or troubleshooting.
 3. **Retrieval** — what someone will look for and when. Entry points and naming rules are decided here, not after the pages exist.
 4. **Maintenance** — cadence, owner, retirement rule. No owner means `unmaintained`, which rules out models that need curation.
@@ -14,7 +14,8 @@ Route existing `USER.md`/`MEMORY.md` cleanup to `memory-sync`, new durable proje
 
 ## `wiki_blueprint/v1` fields
 
-- `audience_scale` / `shared_audience` — personal, small_group, team, organization, or unknown.
+- `audience_scale` / `shared_audience` — personal, small_group, team, organization, or unknown. Shared means more than one writer, which starts at two.
+- `agent_readers` / `agent_reader_rules` — whether a machine reads the wiki, and the requirements that appear when it does.
 - `destination` — the classified store, from the destination classifier rather than a vendor assumption.
 - `organization_model` / `alternative_model` — name, rationale, fits_when, breaks_when, skeleton, audience note.
 - `skeleton` / `entry_points` — sections or namespaces, plus the page a reader lands on first.

--- a/skills/wiki/references/wiki-operations.md
+++ b/skills/wiki/references/wiki-operations.md
@@ -52,5 +52,22 @@ vault and a multi-person wiki fail differently. Record the answer in the bluepri
 - Team or organization: Decide who can read and who can write before the first sensitive page exists.
 - Skipped: Either the wiki holds secrets it should not, or the people who need it cannot open it.
 
-Moving from personal to shared is the moment these change. When a solo vault gains readers,
-revisit naming, ownership, and access before adding pages.
+Moving from personal to shared is the moment these change, and shared starts at two writers.
+When a solo vault gains a second writer, revisit naming, ownership, and access before adding pages.
+
+## When an agent is one of the readers
+
+A person skimming a page infers its scope from layout and recovers from a moved file. An agent does
+neither: it cites paths, retrieves whole pages without their neighbours, and cannot tell a stale page
+from a fresh one. These are additional to the rules above, not a replacement for them.
+
+- **Stable page identity** — Give each page a path that survives reorganization, and redirect rather than move.
+  - Skipped: An agent cites a page by its location, so every earlier answer points at a file that is no longer there.
+- **One topic per page** — Split a page that answers more than one question.
+  - Skipped: Retrieval returns whole pages, so a page covering five topics drags four irrelevant ones into context.
+- **Machine-readable header** — Put title, one-line summary, and last-reviewed date in front matter on every page.
+  - Skipped: An agent cannot infer scope or freshness from visual layout the way a person skimming can.
+- **Self-contained pages** — Avoid 'see above', 'as mentioned', and meaning that depends on the neighbouring page.
+  - Skipped: Retrieval delivers one page without its siblings, so the missing context is silently filled in wrong.
+- **Enumerable index** — Keep a listing file an agent can read, not only a visual home page.
+  - Skipped: The agent cannot discover what exists and answers from whatever it happened to match.

--- a/src/skills/catalog.py
+++ b/src/skills/catalog.py
@@ -4694,6 +4694,7 @@ _DEFINITIONS = [
         ),
         required_inputs=(
             "audience scale (personal, small group, team, or organization)",
+            "whether an agent is one of the readers",
             "destination or existing store",
             "knowledge types the wiki must hold",
             "maintenance owner and cadence",

--- a/src/skills/render.py
+++ b/src/skills/render.py
@@ -27,7 +27,7 @@ from ..plugin_bundle.omh.awareness import (
     router_keyword_summary,
 )
 from ..workflows.wiki_blueprint import WIKI_BLUEPRINT_SCHEMA_VERSION, wiki_ecosystem_coverage
-from ..workflows.wiki_patterns import wiki_operation_rules, wiki_patterns
+from ..workflows.wiki_patterns import wiki_agent_reader_rules, wiki_operation_rules, wiki_patterns
 
 
 WORKFLOW_REGISTRY_TRIGGER_LIMIT = 9
@@ -1103,7 +1103,7 @@ This is a Hermes-native `{name}` workflow skill.
 
 ## Design Interview
 
-Settle structure before capture: audience scale, the knowledge types that repeat, what someone will search for, and who maintains it. Skip answered turns, cap at five, and close with one model plus one alternative as a skeleton the user approves before anything is written. No maintainer means `unmaintained`, which rules out models needing curation.
+Settle structure before capture: audience scale, whether an agent reads it, the knowledge types that repeat, what someone will search for, and who maintains it. Skip answered turns, cap at five, and close with one model plus one alternative as a skeleton the user approves before anything is written. No maintainer means `unmaintained`, which rules out models needing curation.
 
 Load `references/wiki-blueprint.md` for the interview turns and `{WIKI_BLUEPRINT_SCHEMA_VERSION}` fields, `wiki-patterns.md` for models and what breaks them, `wiki-operations.md` for solo-versus-shared rules, and `wiki-ecosystem.md` for existing skills.
 
@@ -1147,7 +1147,7 @@ def _wiki_blueprint_reference() -> str:
 
 Two or three questions per turn, five turns at most. Skip what the request already answered; a full inventory is not the goal, a structure someone can start today is.
 
-1. **Audience** — who reads it, who writes it (only me / 2-5 people / a team / the whole organization), and which store already exists.
+1. **Audience** — who reads it, who writes it (only me / 2-5 people / a team / the whole organization), **whether an agent is one of the readers**, and which store already exists.
 2. **Content** — which two or three kinds of knowledge actually repeat: decisions, procedures, research, glossary, or troubleshooting.
 3. **Retrieval** — what someone will look for and when. Entry points and naming rules are decided here, not after the pages exist.
 4. **Maintenance** — cadence, owner, retirement rule. No owner means `unmaintained`, which rules out models that need curation.
@@ -1157,7 +1157,8 @@ Route existing `USER.md`/`MEMORY.md` cleanup to `memory-sync`, new durable proje
 
 ## `{WIKI_BLUEPRINT_SCHEMA_VERSION}` fields
 
-- `audience_scale` / `shared_audience` — personal, small_group, team, organization, or unknown.
+- `audience_scale` / `shared_audience` — personal, small_group, team, organization, or unknown. Shared means more than one writer, which starts at two.
+- `agent_readers` / `agent_reader_rules` — whether a machine reads the wiki, and the requirements that appear when it does.
 - `destination` — the classified store, from the destination classifier rather than a vendor assumption.
 - `organization_model` / `alternative_model` — name, rationale, fits_when, breaks_when, skeleton, audience note.
 - `skeleton` / `entry_points` — sections or namespaces, plus the page a reader lands on first.
@@ -1217,8 +1218,18 @@ def _wiki_operations_reference() -> str:
         lines.append(f"- Team or organization: {rule.shared}")
         lines.append(f"- Skipped: {rule.failure_if_skipped}")
         lines.append("")
-    lines.append("Moving from personal to shared is the moment these change. When a solo vault gains readers,")
-    lines.append("revisit naming, ownership, and access before adding pages.")
+    lines.append("Moving from personal to shared is the moment these change, and shared starts at two writers.")
+    lines.append("When a solo vault gains a second writer, revisit naming, ownership, and access before adding pages.")
+    lines.append("")
+    lines.append("## When an agent is one of the readers")
+    lines.append("")
+    lines.append("A person skimming a page infers its scope from layout and recovers from a moved file. An agent does")
+    lines.append("neither: it cites paths, retrieves whole pages without their neighbours, and cannot tell a stale page")
+    lines.append("from a fresh one. These are additional to the rules above, not a replacement for them.")
+    lines.append("")
+    for rule in wiki_agent_reader_rules():
+        lines.append(f"- **{rule.topic}** — {rule.rule}")
+        lines.append(f"  - Skipped: {rule.failure_if_skipped}")
     return "\n".join(lines) + "\n"
 
 

--- a/src/workflows/wiki_blueprint.py
+++ b/src/workflows/wiki_blueprint.py
@@ -14,13 +14,13 @@ wiki; the user's own store does, and the blueprint says so in its own boundary.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Final
 
 from ..catalogs.awesome_hermes_agent import AwesomeHermesCoverage, awesome_hermes_coverage
 from .knowledge_connections import KnowledgeConnectionOptions, build_knowledge_connection_intent
 from .wiki_patterns import (
-    SHARED_AUDIENCES,
+    MULTI_WRITER_AUDIENCES,
     WikiPattern,
     wiki_operation_rules,
     wiki_pattern,
@@ -90,7 +90,28 @@ _AUDIENCE_DEFAULT_MODELS: Final = {
     UNKNOWN_AUDIENCE: "Map of Content (MOC)",
 }
 
-_REPO_DESTINATION_KINDS: Final = {"markdown_folder", "local_markdown_folder"}
+# Only a folder the user actually asked for. `local_markdown_folder` is the
+# classifier's default when no destination was named at all, so treating it as a
+# repository signal would hand docs-as-code - review-gated and team-first - to a
+# solo user who said nothing about where the wiki lives.
+_REPO_DESTINATION_KINDS: Final = {"markdown_folder"}
+
+UNKNOWN_DESTINATION_KIND: Final = "unknown_external_destination"
+
+# Vault wording the shared classifier reads only from an explicit target. Bare
+# "vault" is left out on purpose: a secrets vault is not a knowledge vault.
+_VAULT_TERMS: Final = ("obsidian", "옵시디언", "markdown vault", "마크다운 볼트")
+
+# Kinds the classifier only returns when the request actually identified a store,
+# by message text or by option. `local_markdown_folder` is missing on purpose: it
+# is what comes back when nothing was said.
+_CLASSIFIED_DESTINATION_KINDS: Final = {
+    "markdown_vault",
+    "notion_knowledge_base",
+    "google_document_store",
+    "database",
+    "markdown_folder",
+}
 
 # Terms that mark an upstream entry as knowledge-structure material rather than a
 # storage backend.
@@ -118,13 +139,15 @@ class WikiBlueprintRequest:
 
 def build_wiki_blueprint(request: WikiBlueprintRequest) -> dict[str, object]:
     audience = normalize_audience(request.audience_scale)
-    destination = build_knowledge_connection_intent(request.text, options=request.connection)
+    destination = build_knowledge_connection_intent(request.text, options=_destination_options(request))
     primary, alternative = select_models(
         audience=audience,
         knowledge_types=request.knowledge_types,
         destination_kind=str(destination["kind"]),
     )
-    shared = audience in SHARED_AUDIENCES
+    # More than one writer, not "big". Two people already need agreed naming, a
+    # canonical link target, and a named owner.
+    shared = audience in MULTI_WRITER_AUDIENCES
     owner = request.maintenance_owner.strip()
     return {
         "schema_version": WIKI_BLUEPRINT_SCHEMA_VERSION,
@@ -161,6 +184,26 @@ def build_wiki_blueprint(request: WikiBlueprintRequest) -> dict[str, object]:
     }
 
 
+def _destination_options(request: WikiBlueprintRequest) -> KnowledgeConnectionOptions:
+    """Read a vault named in the message as the destination it plainly is.
+
+    The shared classifier resolves Notion, Google Drive, databases, and markdown
+    folders from message text, but Obsidian only from an explicit option, so
+    "structure my Obsidian vault" fell through to the unnamed-folder default.
+    Research-department depends on that asymmetry - a passing "using Obsidian if
+    possible" in a recurring-ops request must not become a store commitment - so
+    the promotion happens here, where naming a vault *is* choosing where the wiki
+    lives, instead of in the classifier both lanes share.
+    """
+    if request.connection.knowledge_store.strip() or request.connection.storage.strip():
+        return request.connection
+    haystack = request.text.casefold()
+    for term in _VAULT_TERMS:
+        if term in haystack:
+            return replace(request.connection, knowledge_store=term)
+    return request.connection
+
+
 def normalize_audience(value: str) -> str:
     normalized = str(value or "").strip().casefold()
     if not normalized:
@@ -184,7 +227,14 @@ def select_models(
     primary = resolved[0] if resolved else wiki_patterns()[0]
     alternative = next((pattern for pattern in resolved[1:] if pattern.name != primary.name), None)
     if alternative is None:
-        alternative = next(pattern for pattern in wiki_patterns() if pattern.name != primary.name)
+        # Falling back to the first catalog entry hands an organization-wide wiki
+        # a personal-scale model as its second option. Prefer one that fits the
+        # audience, and only then take whatever is left.
+        remaining = [pattern for pattern in wiki_patterns() if pattern.name != primary.name]
+        alternative = next(
+            (pattern for pattern in remaining if _suits_audience(pattern.name, audience)),
+            remaining[0],
+        )
     return primary, alternative
 
 
@@ -241,7 +291,22 @@ def _ranked_model_names(
     default_model = _AUDIENCE_DEFAULT_MODELS.get(audience, _AUDIENCE_DEFAULT_MODELS[UNKNOWN_AUDIENCE])
     if default_model not in names:
         names.append(default_model)
-    return names
+    # What the knowledge is about cannot outrank who the wiki is for. A solo
+    # developer documenting a repository matches docs-as-code on content and
+    # fails it on audience: the review step is friction with no reviewer. Models
+    # outside the audience drop behind the ones inside it, and behind the
+    # audience default, rather than disappearing - they stay available as the
+    # alternative, where the audience note explains the cost.
+    suited = [name for name in names if _suits_audience(name, audience)]
+    unsuited = [name for name in names if name not in suited]
+    return suited + unsuited
+
+
+def _suits_audience(model_name: str, audience: str) -> bool:
+    if audience == UNKNOWN_AUDIENCE:
+        return True
+    pattern = wiki_pattern(model_name)
+    return pattern is None or audience in pattern.suits_audiences
 
 
 def _model_payload(pattern: WikiPattern) -> dict[str, object]:
@@ -288,6 +353,12 @@ def _missing_facts(
         missing.append("maintenance owner and review cadence")
     if not [item for item in knowledge_types if str(item or "").strip()]:
         missing.append("knowledge types the wiki must hold")
-    if destination["kind"] == "unknown_external_destination" or not destination["explicit_target"]:
+    # Asking again for something the message already said is the round-trip this
+    # skill exists to remove. "Set up a wiki in Notion" names the store even
+    # though no `--knowledge-store` option was passed, so only a named-but-
+    # unverified target or a bare default stays open.
+    if destination["kind"] == UNKNOWN_DESTINATION_KIND:
+        missing.append("confirmation that the named destination exists")
+    elif str(destination["kind"]) not in _CLASSIFIED_DESTINATION_KINDS and not destination["explicit_target"]:
         missing.append("destination store or confirmation that it exists")
     return missing

--- a/src/workflows/wiki_blueprint.py
+++ b/src/workflows/wiki_blueprint.py
@@ -22,6 +22,7 @@ from .knowledge_connections import KnowledgeConnectionOptions, build_knowledge_c
 from .wiki_patterns import (
     MULTI_WRITER_AUDIENCES,
     WikiPattern,
+    wiki_agent_reader_rules,
     wiki_operation_rules,
     wiki_pattern,
     wiki_patterns,
@@ -94,6 +95,9 @@ _AUDIENCE_DEFAULT_MODELS: Final = {
 # classifier's default when no destination was named at all, so treating it as a
 # repository signal would hand docs-as-code - review-gated and team-first - to a
 # solo user who said nothing about where the wiki lives.
+# Stable paths, an enumerable index, and it works at every scale.
+_AGENT_SAFE_DEFAULT_MODEL: Final = "Map of Content (MOC)"
+
 _REPO_DESTINATION_KINDS: Final = {"markdown_folder"}
 
 UNKNOWN_DESTINATION_KIND: Final = "unknown_external_destination"
@@ -101,6 +105,20 @@ UNKNOWN_DESTINATION_KIND: Final = "unknown_external_destination"
 # Vault wording the shared classifier reads only from an explicit target. Bare
 # "vault" is left out on purpose: a secrets vault is not a knowledge vault.
 _VAULT_TERMS: Final = ("obsidian", "옵시디언", "markdown vault", "마크다운 볼트")
+
+# Wording that means a machine is one of the readers.
+_AGENT_READER_TERMS: Final = (
+    "agent",
+    "assistant",
+    "hermes",
+    "claude",
+    "codex",
+    "llm",
+    " ai ",
+    "에이전트",
+    "어시스턴트",
+    "에이아이",
+)
 
 # Kinds the classifier only returns when the request actually identified a store,
 # by message text or by option. `local_markdown_folder` is missing on purpose: it
@@ -134,16 +152,22 @@ class WikiBlueprintRequest:
     audience_scale: str = ""
     maintenance_owner: str = ""
     knowledge_types: tuple[str, ...] = ()
+    # Who reads it, which is a different question from how many people write it.
+    # Left empty, the message is scanned: people say "Hermes will read this" long
+    # before anyone thinks to answer an interview field.
+    readers: tuple[str, ...] = ()
     connection: KnowledgeConnectionOptions = field(default_factory=KnowledgeConnectionOptions)
 
 
 def build_wiki_blueprint(request: WikiBlueprintRequest) -> dict[str, object]:
     audience = normalize_audience(request.audience_scale)
     destination = build_knowledge_connection_intent(request.text, options=_destination_options(request))
+    agent_readers = has_agent_readers(request)
     primary, alternative = select_models(
         audience=audience,
         knowledge_types=request.knowledge_types,
         destination_kind=str(destination["kind"]),
+        agent_readers=agent_readers,
     )
     # More than one writer, not "big". Two people already need agreed naming, a
     # canonical link target, and a named owner.
@@ -154,6 +178,8 @@ def build_wiki_blueprint(request: WikiBlueprintRequest) -> dict[str, object]:
         "status": "prepared",
         "audience_scale": audience,
         "shared_audience": shared,
+        "agent_readers": agent_readers,
+        "agent_reader_rules": _agent_reader_payload(agent_readers),
         "destination": destination,
         "organization_model": _model_payload(primary),
         "alternative_model": _model_payload(alternative),
@@ -211,17 +237,27 @@ def normalize_audience(value: str) -> str:
     return _AUDIENCE_ALIASES.get(normalized, UNKNOWN_AUDIENCE)
 
 
+def has_agent_readers(request: WikiBlueprintRequest) -> bool:
+    """Whether an agent is among the readers, from the interview field or the message."""
+    for reader in request.readers:
+        if _contains_any(str(reader or "").casefold(), _AGENT_READER_TERMS):
+            return True
+    return _contains_any(request.text.casefold(), _AGENT_READER_TERMS)
+
+
 def select_models(
     *,
     audience: str,
     knowledge_types: tuple[str, ...],
     destination_kind: str,
+    agent_readers: bool = False,
 ) -> tuple[WikiPattern, WikiPattern]:
     """Pick a primary model and a distinct alternative, most specific signal first."""
     ranked = _ranked_model_names(
         audience=audience,
         knowledge_types=knowledge_types,
         destination_kind=destination_kind,
+        agent_readers=agent_readers,
     )
     resolved = [pattern for pattern in (wiki_pattern(name) for name in ranked) if pattern is not None]
     primary = resolved[0] if resolved else wiki_patterns()[0]
@@ -277,6 +313,7 @@ def _ranked_model_names(
     audience: str,
     knowledge_types: tuple[str, ...],
     destination_kind: str,
+    agent_readers: bool = False,
 ) -> list[str]:
     names: list[str] = []
     for knowledge_type in knowledge_types:
@@ -291,15 +328,49 @@ def _ranked_model_names(
     default_model = _AUDIENCE_DEFAULT_MODELS.get(audience, _AUDIENCE_DEFAULT_MODELS[UNKNOWN_AUDIENCE])
     if default_model not in names:
         names.append(default_model)
+    if agent_readers and not any(
+        _suits_audience(name, audience) and _suits_agent_readers(name) for name in names
+    ):
+        # Demotion needs something to promote. Without this, a solo user whose
+        # agent reads the wiki chooses between PARA, which relocates pages by
+        # design, and a model built for a team - one fails each axis.
+        names.append(_AGENT_SAFE_DEFAULT_MODEL)
     # What the knowledge is about cannot outrank who the wiki is for. A solo
     # developer documenting a repository matches docs-as-code on content and
     # fails it on audience: the review step is friction with no reviewer. Models
     # outside the audience drop behind the ones inside it, and behind the
     # audience default, rather than disappearing - they stay available as the
     # alternative, where the audience note explains the cost.
-    suited = [name for name in names if _suits_audience(name, audience)]
-    unsuited = [name for name in names if name not in suited]
-    return suited + unsuited
+    # Both fit tests at once, audience first. Applying them as two successive
+    # re-sorts let the later one undo the earlier: a solo user documenting code
+    # for an agent had docs-as-code demoted for audience, then promoted straight
+    # back because the model it lost to relocates pages. Sorting is stable, so
+    # signal order survives inside a tier.
+    return sorted(
+        names,
+        key=lambda name: (
+            0 if _suits_audience(name, audience) else 1,
+            0 if not agent_readers or _suits_agent_readers(name) else 1,
+        ),
+    )
+
+
+def _suits_agent_readers(model_name: str) -> bool:
+    pattern = wiki_pattern(model_name)
+    return pattern is None or pattern.suits_agent_readers
+
+
+def _agent_reader_payload(agent_readers: bool) -> list[dict[str, str]]:
+    if not agent_readers:
+        return []
+    return [
+        {"topic": rule.topic, "rule": rule.rule, "failure_if_skipped": rule.failure_if_skipped}
+        for rule in wiki_agent_reader_rules()
+    ]
+
+
+def _contains_any(haystack: str, terms: tuple[str, ...]) -> bool:
+    return any(term in haystack for term in terms)
 
 
 def _suits_audience(model_name: str, audience: str) -> bool:

--- a/src/workflows/wiki_patterns.py
+++ b/src/workflows/wiki_patterns.py
@@ -43,6 +43,19 @@ class WikiPattern:
     # audience is still offered as the alternative rather than dropped, because
     # the audience note explains what it would cost.
     suits_audiences: tuple[str, ...] = AUDIENCE_SCALES
+    # Whether the model holds up when an agent is one of the readers. The test is
+    # path stability: an agent cites a page by its location, so a model that
+    # moves pages as a matter of routine breaks every citation it made.
+    suits_agent_readers: bool = True
+
+
+@dataclass(frozen=True, slots=True)
+class WikiAgentReaderRule:
+    """One requirement that appears once an agent reads the wiki, not only people."""
+
+    topic: str
+    rule: str
+    failure_if_skipped: str
 
 
 @dataclass(frozen=True, slots=True)
@@ -71,6 +84,9 @@ _PATTERNS: Final = (
         ("projects/", "areas/", "resources/", "archive/"),
         "Strong for personal and small-group vaults; needs an explicit owner per area before a team can trust it.",
         suits_audiences=PERSONAL_AUDIENCES,
+        # Moving a page from projects/ to archive/ as work finishes is the whole
+        # mechanic, so paths churn by design and an agent's citations rot.
+        suits_agent_readers=False,
     ),
     WikiPattern(
         "Zettelkasten / evergreen notes",
@@ -204,6 +220,42 @@ _OPERATION_RULES: Final = (
         "Either the wiki holds secrets it should not, or the people who need it cannot open it.",
     ),
 )
+
+
+_AGENT_READER_RULES: Final = (
+    WikiAgentReaderRule(
+        "Stable page identity",
+        "Give each page a path that survives reorganization, and redirect rather than move.",
+        "An agent cites a page by its location, so every earlier answer points at a file that is no longer there.",
+    ),
+    WikiAgentReaderRule(
+        "One topic per page",
+        "Split a page that answers more than one question.",
+        "Retrieval returns whole pages, so a page covering five topics drags four irrelevant ones into context.",
+    ),
+    WikiAgentReaderRule(
+        "Machine-readable header",
+        "Put title, one-line summary, and last-reviewed date in front matter on every page.",
+        "An agent cannot infer scope or freshness from visual layout the way a person skimming can.",
+    ),
+    WikiAgentReaderRule(
+        "Self-contained pages",
+        "Avoid 'see above', 'as mentioned', and meaning that depends on the neighbouring page.",
+        "Retrieval delivers one page without its siblings, so the missing context is silently filled in wrong.",
+    ),
+    WikiAgentReaderRule(
+        "Enumerable index",
+        "Keep a listing file an agent can read, not only a visual home page.",
+        "The agent cannot discover what exists and answers from whatever it happened to match.",
+    ),
+)
+
+AGENT_READER: Final = "agent"
+HUMAN_READER: Final = "human"
+
+
+def wiki_agent_reader_rules() -> tuple[WikiAgentReaderRule, ...]:
+    return _AGENT_READER_RULES
 
 
 def wiki_patterns() -> tuple[WikiPattern, ...]:

--- a/src/workflows/wiki_patterns.py
+++ b/src/workflows/wiki_patterns.py
@@ -18,8 +18,14 @@ from dataclasses import dataclass
 from typing import Final
 
 
+# Two different axes, and conflating them gives a pair of people the operating
+# rules of a solo vault. Model fit asks how big the corpus and its readership
+# are, so a small group still suits the personal-scale models. Operating rules
+# ask how many people write, and the answer stops being "one" at two: naming has
+# to be agreed, links need a canonical target, and sections need an owner.
 PERSONAL_AUDIENCES: Final = ("personal", "small_group")
 SHARED_AUDIENCES: Final = ("team", "organization")
+MULTI_WRITER_AUDIENCES: Final = ("small_group", "team", "organization")
 AUDIENCE_SCALES: Final = PERSONAL_AUDIENCES + SHARED_AUDIENCES
 
 
@@ -33,6 +39,10 @@ class WikiPattern:
     breaks_when: tuple[str, ...]
     skeleton: tuple[str, ...]
     audience_note: str
+    # Audiences this model is a primary recommendation for. A model outside its
+    # audience is still offered as the alternative rather than dropped, because
+    # the audience note explains what it would cost.
+    suits_audiences: tuple[str, ...] = AUDIENCE_SCALES
 
 
 @dataclass(frozen=True, slots=True)
@@ -60,6 +70,7 @@ _PATTERNS: Final = (
         ),
         ("projects/", "areas/", "resources/", "archive/"),
         "Strong for personal and small-group vaults; needs an explicit owner per area before a team can trust it.",
+        suits_audiences=PERSONAL_AUDIENCES,
     ),
     WikiPattern(
         "Zettelkasten / evergreen notes",
@@ -76,6 +87,7 @@ _PATTERNS: Final = (
         ),
         ("notes/", "index or entry note", "link conventions"),
         "Best solo. In a team it needs a curator, or two people write two competing notes on one idea.",
+        suits_audiences=PERSONAL_AUDIENCES,
     ),
     WikiPattern(
         "Diátaxis",
@@ -91,6 +103,7 @@ _PATTERNS: Final = (
         ),
         ("tutorials/", "how-to/", "reference/", "explanation/"),
         "Made for shared and public documentation; overkill for a personal vault.",
+        suits_audiences=SHARED_AUDIENCES,
     ),
     WikiPattern(
         "Map of Content (MOC)",
@@ -121,6 +134,7 @@ _PATTERNS: Final = (
         ),
         ("docs/", "docs/adr/", "docs/runbooks/"),
         "Team-first. For personal use the review step is friction with no reviewer.",
+        suits_audiences=SHARED_AUDIENCES,
     ),
     WikiPattern(
         "Decision log (ADR)",

--- a/tests/test_wiki_blueprint.py
+++ b/tests/test_wiki_blueprint.py
@@ -17,7 +17,7 @@ from omh.wiki_blueprint import (
     select_models,
     wiki_ecosystem_coverage,
 )
-from omh.wiki_patterns import wiki_operation_rules, wiki_pattern, wiki_patterns
+from omh.wiki_patterns import wiki_agent_reader_rules, wiki_operation_rules, wiki_pattern, wiki_patterns
 
 
 def _blueprint(**kwargs: object) -> dict[str, object]:
@@ -110,6 +110,51 @@ class ModelSelectionTests(unittest.TestCase):
             )
             self.assertIn(primary.name, names)
             self.assertIn(alternative.name, names)
+
+
+class AgentReaderTests(unittest.TestCase):
+    def test_an_agent_reader_is_detected_from_the_message(self) -> None:
+        for text in (
+            "my colleague and the Hermes agent will read this",
+            "개인 볼트인데 에이전트도 읽어",
+            "a wiki Claude can search",
+        ):
+            with self.subTest(text=text):
+                self.assertTrue(_blueprint(text=text)["agent_readers"])
+
+    def test_a_human_only_wiki_carries_no_agent_rules(self) -> None:
+        blueprint = _blueprint(text="a wiki for my teammates", audience_scale="team")
+        self.assertFalse(blueprint["agent_readers"])
+        self.assertEqual(blueprint["agent_reader_rules"], [])
+
+    def test_agent_readers_get_the_requirements_a_person_does_not_need(self) -> None:
+        blueprint = _blueprint(text="the agent reads this too", audience_scale="team")
+        topics = {row["topic"] for row in blueprint["agent_reader_rules"]}
+        self.assertIn("Stable page identity", topics)
+        self.assertIn("One topic per page", topics)
+        self.assertEqual(len(topics), len(wiki_agent_reader_rules()))
+
+    def test_a_model_that_relocates_pages_is_not_primary_for_an_agent(self) -> None:
+        """PARA moves pages between projects/ and archive/, so an agent's citations rot."""
+        human = _blueprint(text="my own vault", audience_scale="personal")
+        agent = _blueprint(text="my own vault, and Claude reads it", audience_scale="personal")
+
+        self.assertEqual(human["organization_model"]["name"], "PARA")
+        self.assertNotEqual(agent["organization_model"]["name"], "PARA")
+        self.assertEqual(agent["alternative_model"]["name"], "PARA")
+
+    def test_audience_fit_still_outranks_agent_fit(self) -> None:
+        """Two demotions applied in sequence let the second undo the first."""
+        blueprint = _blueprint(
+            text="my own repo docs, and an agent reads them",
+            audience_scale="personal",
+            knowledge_types=("code",),
+        )
+        primary = blueprint["organization_model"]["name"]
+        self.assertNotEqual(primary, "Docs-as-code")
+        self.assertNotEqual(primary, "PARA")
+        self.assertIn("personal", wiki_pattern(primary).suits_audiences)
+        self.assertTrue(wiki_pattern(primary).suits_agent_readers)
 
 
 class BlueprintTests(unittest.TestCase):

--- a/tests/test_wiki_blueprint.py
+++ b/tests/test_wiki_blueprint.py
@@ -17,7 +17,7 @@ from omh.wiki_blueprint import (
     select_models,
     wiki_ecosystem_coverage,
 )
-from omh.wiki_patterns import wiki_operation_rules, wiki_patterns
+from omh.wiki_patterns import wiki_operation_rules, wiki_pattern, wiki_patterns
 
 
 def _blueprint(**kwargs: object) -> dict[str, object]:
@@ -56,9 +56,39 @@ class ModelSelectionTests(unittest.TestCase):
         _, alternative = select_models(
             audience="team",
             knowledge_types=("onboarding",),
-            destination_kind="local_markdown_folder",
+            destination_kind="markdown_folder",
         )
         self.assertEqual(alternative.name, "Docs-as-code")
+
+    def test_unstated_destination_is_not_a_repository_signal(self) -> None:
+        """`local_markdown_folder` is the classifier's default when nothing was said."""
+        primary, _ = select_models(
+            audience="personal",
+            knowledge_types=(),
+            destination_kind="local_markdown_folder",
+        )
+        self.assertNotEqual(primary.name, "Docs-as-code")
+        self.assertEqual(primary.name, "PARA")
+
+    def test_audience_outranks_knowledge_type_when_the_model_does_not_fit(self) -> None:
+        """A solo developer documenting a repo matches docs-as-code on content, not on audience."""
+        primary, alternative = select_models(
+            audience="personal",
+            knowledge_types=("code",),
+            destination_kind="markdown_folder",
+        )
+        self.assertNotEqual(primary.name, "Docs-as-code")
+        # Demoted, not dropped: its audience note explains what it would cost.
+        self.assertEqual(alternative.name, "Docs-as-code")
+
+    def test_fallback_alternative_fits_the_audience(self) -> None:
+        _, alternative = select_models(
+            audience="organization",
+            knowledge_types=("procedures",),
+            destination_kind="local_markdown_folder",
+        )
+        self.assertNotEqual(alternative.name, "PARA")
+        self.assertIn("organization", wiki_pattern(alternative.name).suits_audiences)
 
     def test_alternative_is_always_distinct(self) -> None:
         for audience in ("personal", "small_group", "team", "organization", UNKNOWN_AUDIENCE):
@@ -104,6 +134,56 @@ class BlueprintTests(unittest.TestCase):
         self.assertEqual(notion["destination"]["kind"], "notion_knowledge_base")
         self.assertEqual(obsidian["destination"]["vendor_hint"], "obsidian")
         self.assertFalse(notion["destination"]["write_observed"])
+
+    def test_two_writers_get_multi_writer_rules_not_solo_ones(self) -> None:
+        """Two people plus an agent is not a solo vault: naming has to be agreed."""
+        pair = _blueprint(
+            text="my colleague, an agent, and I will read and write this",
+            audience_scale="small group",
+            maintenance_owner="the two of us",
+        )
+        rules = {rule.topic: rule for rule in wiki_operation_rules()}
+        conventions = {row["topic"]: row["rule"] for row in pair["conventions"]}
+
+        self.assertTrue(pair["shared_audience"])
+        self.assertEqual(conventions["Naming"], rules["Naming"].shared)
+        self.assertEqual(conventions["Linking"], rules["Linking"].shared)
+
+    def test_a_store_named_in_the_message_is_not_asked_for_again(self) -> None:
+        """Re-asking for what the message already said is the round-trip this removes."""
+        for text in (
+            "set up a Notion knowledge base for the team",
+            "keep our docs in Google Drive",
+            "structure my Obsidian vault",
+            "a markdown folder in the repo",
+        ):
+            with self.subTest(text=text):
+                blueprint = _blueprint(
+                    text=text,
+                    audience_scale="team",
+                    maintenance_owner="me",
+                    knowledge_types=("decisions",),
+                )
+                self.assertEqual(blueprint["missing_facts"], [], blueprint["destination"]["kind"])
+
+    def test_a_vault_named_in_the_message_is_the_destination(self) -> None:
+        """Naming a vault while designing a wiki is choosing where it lives."""
+        for text in ("structure my Obsidian vault", "옵시디언 볼트 구조 잡아줘"):
+            with self.subTest(text=text):
+                destination = _blueprint(text=text, audience_scale="personal")["destination"]
+                self.assertEqual(destination["kind"], "markdown_vault")
+                self.assertEqual(destination["vendor_hint"], "obsidian")
+
+    def test_research_department_vendor_neutrality_is_left_alone(self) -> None:
+        """The promotion is wiki-local; a passing mention in research ops is not a commitment."""
+        from omh.workflows.research_department import build_research_department_plan
+
+        plan = build_research_department_plan(
+            "daily research department using NotebookLM and Obsidian if possible",
+            created_at="2026-06-17T00:00:00Z",
+        )
+        self.assertEqual(plan["knowledge_store"]["type"], "local_markdown_folder")
+        self.assertEqual(plan["knowledge_store"]["vendor_hint"], "")
 
     def test_missing_facts_name_what_the_interview_still_needs(self) -> None:
         bare = _blueprint(text="help me build a wiki")


### PR DESCRIPTION
## Feature Report

### What Changed

- Six defects in the `wiki_blueprint/v1` selection logic shipped by #675, all found by simulation rather than by unit tests.
- An agent reading the wiki is now a first-class reader with its own requirements, instead of being counted as one more person.

### Why This Exists

A 2,160-case sweep across destinations, audiences, knowledge types, and owners was run against the blueprint that shipped in #675. Every defect it found handed someone a structure built for a different person — the exact failure the skill exists to prevent. The sweep grew to 10,800 cases once readers were added as an axis, and caught one more defect introduced by the fix for the others.

### User / Operator Impact

| Request | Before | After |
| --- | --- | --- |
| "help me build a wiki" (solo, no store named) | **Docs-as-code** — PR-reviewed, team-first | PARA |
| solo dev documenting own repo | Docs-as-code primary | PARA primary, docs-as-code as the alternative |
| "set up a wiki in Notion" | still asked "which store?" | no open question |
| 2 people + an agent | solo naming rules: "whatever you will recognize later" | agreed naming, canonical links, named owner |
| organization-wide wiki | alternative was **PARA** (personal-scale) | alternative fits the audience |
| "structure my Obsidian vault" | classified as an unnamed local folder | Obsidian vault |
| any wiki an agent reads | nothing | five machine-reader requirements, and models that relocate pages demoted |

### How It Works

- **Unstated destination is not a repository.** `local_markdown_folder` is what the classifier returns when nobody named a store; it was in the repo-signal set, so silence read as "in a repo" and selected docs-as-code. 132 of 2,160 cases.
- **Audience outranks content.** Patterns carry `suits_audiences`. A model outside the audience drops behind the ones inside it rather than disappearing — it stays as the alternative, where its own audience note explains the cost.
- **`missing_facts` stops re-asking.** It tested `explicit_target`, which only fills from the `--knowledge-store` option, so a store named in the message was classified correctly and still listed as an open question.
- **Shared starts at two.** `SHARED_AUDIENCES` conflated model fit (how large the readership is) with operating rules (how many people write). `MULTI_WRITER_AUDIENCES` splits them.
- **Agent readers** (`readers` field, or detected from the message) add five requirements: stable page identity, one topic per page, machine-readable header, self-contained pages, enumerable index. PARA is marked `suits_agent_readers=False` because relocating pages between `projects/` and `archive/` is its mechanic, and an agent cites paths.
- **One sort key, not two passes.** Audience fit and agent fit applied in sequence let the second undo the first; the 10,800-case sweep caught it. When nothing satisfies both axes, a map-of-content default is added rather than shipping a structure that fails somewhere.

### Files And Contracts Touched

- `src/workflows/wiki_blueprint.py` — selection, reader detection, `missing_facts`, destination promotion.
- `src/workflows/wiki_patterns.py` — `suits_audiences`, `suits_agent_readers`, `MULTI_WRITER_AUDIENCES`, agent-reader rule table.
- `src/skills/catalog.py`, `src/skills/render.py` — interview turn 1 asks about agent readers; operations reference gains an agent section.
- Generated: `skills/wiki/SKILL.md`, `skills/wiki/references/wiki-blueprint.md`, `skills/wiki/references/wiki-operations.md`, `docs/WORKFLOWS.md`.
- `tests/test_wiki_blueprint.py` — 35 tests, one per defect plus the agent-reader contract.

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `python3 -m unittest discover -s tests` — 1965 passed, 1 skipped (pre-existing)
- [x] `python3 -m compileall src`
- [x] `python3 -m omh.cli docs workflows --check` — tap-skills clean
- [x] `python3 -m omh.cli docs roles --check`, `docs capability-families --check`
- [x] Simulation: 10,800 cases (10 destinations x 9 audiences x 8 knowledge-type sets x 3 owners x 5 reader sets), 0 failures, including a determinism check per case
- [x] Eight persona blueprints reviewed by hand: solo vault, two people plus an agent, six-person team, organization, open-source repo, unmaintained wiki, unstated request, solo developer documenting a repo
- [ ] Manual Hermes/TUI check — **not run**. No live Hermes turn exercised the interview.

Context budget after the change: 700,565 of 715,000.

## Risk

- `wiki_blueprint/v1` gains `agent_readers` and `agent_reader_rules`; a consumer reading the payload as a fixed shape sees two new keys.
- `shared_audience` is true for `small_group` now. A wrapper reading it as "team or bigger" sees a changed value.
- Model choice changes for personal audiences with code or repo signals, and for any request whose text mentions an agent. That is the intent, but agent detection is triggered by message content rather than an explicit field, so an incidental mention of Claude or Hermes flips it on.
- PARA is the only pattern marked agent-unsafe. The call rests on path churn being intrinsic to it rather than incidental.

## Compatibility / Rollout

- Additive to the schema; no field removed or renamed.
- `knowledge_connections` is untouched. An earlier attempt fixed the Obsidian-from-text gap there and broke `test_research_department_request_vendor_mentions_stay_concept_first_without_adapter`; a passing "using Obsidian if possible" in a recurring-ops request must not become a store commitment. The promotion now happens in the wiki path only, and both behaviors are locked by tests.

## Release / Claims

- [x] Release-channel impact considered — `local`.
- [x] Claims backed by evidence or marked as not observed — the blueprint's `claim_boundary` is unchanged and still disclaims store creation.
- [x] Known manual Hermes checks listed — the interview has not run in a live Hermes turn.

## Follow-Up

- Expose `wiki_blueprint/v1` through a plugin tool so Hermes can produce it from chat.
- Read side: the skill still has no query path.
- Validate the knowledge-type-to-model table, and the PARA agent-safety judgement, against real requests.
