### PR TITLE
fix: read Hermes' memory cap from its config instead of assuming the default

### DIFF
--- a/src/maintenance/advisory.py
+++ b/src/maintenance/advisory.py
@@ -44,10 +44,12 @@ AUXILIARY_TASK_SLOTS = (
     "title",
 )
 
-# Hermes memory files and the character caps Hermes enforces on write. Sourced
-# from the reader so the cap and the unit it is measured in cannot drift apart.
-MEMORY_FILE_CAP_CHARS = hermes_memory.MEMORY_FILE_CAP_CHARS
-USER_FILE_CAP_CHARS = hermes_memory.USER_FILE_CAP_CHARS
+# Hermes memory files and the caps Hermes falls back to when config.yaml does
+# not override them. Sourced from the reader so the cap and the unit it is
+# measured in cannot drift apart; the per-file cap actually in force comes from
+# the reading, not from these.
+DEFAULT_MEMORY_FILE_CAP_CHARS = hermes_memory.DEFAULT_MEMORY_FILE_CAP_CHARS
+DEFAULT_USER_FILE_CAP_CHARS = hermes_memory.DEFAULT_USER_FILE_CAP_CHARS
 MEMORY_STALE_AFTER_DAYS = 30
 
 # Conservative SOUL starter heuristic knobs.
@@ -331,9 +333,10 @@ def check_hermes_memory_staleness(hermes_home: str | Path | None = None) -> Advi
         "OMH reports on Hermes memory and cannot change Hermes memory."
     )
     remediation = (
-        "OMH reports only and cannot change Hermes memory (memories/MEMORY.md ~2,200 "
-        "chars, USER.md ~1,375 chars). If these look stale, update them from inside "
-        "Hermes; OMH will not write to them."
+        "OMH reports only and cannot change Hermes memory (memories/MEMORY.md and "
+        "USER.md, each capped by memory.memory_char_limit / memory.user_char_limit in "
+        "Hermes config.yaml). If these look stale, update them from inside Hermes; "
+        "OMH will not write to them."
     )
     readings = hermes_memory.read_hermes_memory(home, now=_now_seconds())
     if not any(reading.exists for reading in readings):

--- a/src/plugin_bundle/omh/hermes_memory.py
+++ b/src/plugin_bundle/omh/hermes_memory.py
@@ -13,6 +13,13 @@ Counting characters fixes the unit. Splitting the entries is what lets the rest
 of OMH say *which* entry is stale or already duplicated in its own store,
 instead of only how full the file is.
 
+The cap itself is read rather than assumed. Hermes takes it from
+``memory.memory_char_limit`` / ``memory.user_char_limit`` in ``config.yaml`` and
+only falls back to 2200/1375, so hardcoding those two numbers reported a raised
+limit as exhausted headroom on any host that had changed them. Each reading
+carries the cap it was measured against and whether that cap was observed in
+config or assumed.
+
 Read-only by construction: nothing here opens a file for writing. Hermes owns
 these files, and the `memory` tool it exposes to the model is the surface that
 edits them.
@@ -31,13 +38,19 @@ from typing import Any
 # Hermes' own entry separator; see ENTRY_DELIMITER in its memory tool.
 HERMES_MEMORY_DELIMITER = "§"
 
-# Hermes memory files and the character caps it enforces on write.
-MEMORY_FILE_CAP_CHARS = 2200
-USER_FILE_CAP_CHARS = 1375
+# The caps Hermes falls back to, not the caps it necessarily enforces. Hermes
+# builds its memory tool with ``mem_config.get("memory_char_limit", 2200)`` and
+# ``mem_config.get("user_char_limit", 1375)`` (``agent/agent_init.py``), so a
+# user who raises either limit in ``config.yaml`` keeps writing while OMH -- which
+# used to hardcode these two numbers -- reported the file over cap and its
+# headroom exhausted. Read the config; treat these as the fallback they are.
+DEFAULT_MEMORY_FILE_CAP_CHARS = 2200
+DEFAULT_USER_FILE_CAP_CHARS = 1375
 
+# Memory file, the ``memory`` config key that overrides its cap, and the default.
 HERMES_MEMORY_FILES = (
-    ("MEMORY.md", MEMORY_FILE_CAP_CHARS),
-    ("USER.md", USER_FILE_CAP_CHARS),
+    ("MEMORY.md", "memory_char_limit", DEFAULT_MEMORY_FILE_CAP_CHARS),
+    ("USER.md", "user_char_limit", DEFAULT_USER_FILE_CAP_CHARS),
 )
 
 
@@ -53,6 +66,7 @@ class HermesMemoryFile:
     entries: tuple[str, ...]
     age_days: float
     error: str = ""
+    cap_source: str = "default"
 
     @property
     def over_cap(self) -> bool:
@@ -72,6 +86,7 @@ class HermesMemoryFile:
             "exists": self.exists,
             "chars": self.chars,
             "cap": self.cap,
+            "cap_source": self.cap_source,
             "over_cap": self.over_cap,
             "headroom_chars": self.headroom_chars,
             "entry_count": len(self.entries),
@@ -92,24 +107,56 @@ def memory_char_count(entries: tuple[str, ...] | list[str]) -> int:
     return len(HERMES_MEMORY_DELIMITER.join(entries))
 
 
+def resolve_memory_caps(hermes_home: str | Path) -> tuple[tuple[str, int, str], ...]:
+    """Per-file ``(label, cap, cap_source)`` for one Hermes home.
+
+    ``cap_source`` is ``"config"`` when ``config.yaml`` overrode the cap and
+    ``"default"`` otherwise, so a reader can tell an observed limit from an
+    assumed one instead of trusting every cap equally.
+
+    A key that is absent, unparseable, or not a positive integer falls back to
+    the default: OMH reports on Hermes memory and must not turn a malformed
+    config into a headroom figure that looks measured.
+    """
+    config_text = _read_hermes_config(hermes_home)
+    resolved: list[tuple[str, int, str]] = []
+    for label, config_key, default_cap in HERMES_MEMORY_FILES:
+        configured = _positive_int(_config_section_scalar(config_text, "memory", config_key))
+        if configured is None:
+            resolved.append((label, default_cap, "default"))
+        else:
+            resolved.append((label, configured, "config"))
+    return tuple(resolved)
+
+
 def read_hermes_memory_file(
     path: Path,
     *,
     label: str,
     cap: int,
     now: float | None = None,
+    cap_source: str = "default",
 ) -> HermesMemoryFile:
     """Read one memory file. Never raises: an unreadable file reports its error."""
     moment = time.time() if now is None else now
     if not path.exists():
-        return HermesMemoryFile(label, path, False, 0, cap, (), 0.0)
+        return HermesMemoryFile(label, path, False, 0, cap, (), 0.0, cap_source=cap_source)
     try:
         text = path.read_text(encoding="utf-8")
         age_days = max(0.0, (moment - path.stat().st_mtime) / 86400.0)
     except (OSError, UnicodeDecodeError) as error:
-        return HermesMemoryFile(label, path, True, 0, cap, (), 0.0, error=str(error))
+        return HermesMemoryFile(label, path, True, 0, cap, (), 0.0, error=str(error), cap_source=cap_source)
     entries = parse_memory_entries(text)
-    return HermesMemoryFile(label, path, True, memory_char_count(entries), cap, entries, age_days)
+    return HermesMemoryFile(
+        label,
+        path,
+        True,
+        memory_char_count(entries),
+        cap,
+        entries,
+        age_days,
+        cap_source=cap_source,
+    )
 
 
 def read_hermes_memory(
@@ -117,12 +164,83 @@ def read_hermes_memory(
     *,
     now: float | None = None,
 ) -> tuple[HermesMemoryFile, ...]:
-    """Read every Hermes memory file under one Hermes home."""
+    """Read every Hermes memory file under one Hermes home, at its configured cap."""
     memories_dir = Path(hermes_home).expanduser() / "memories"
     return tuple(
-        read_hermes_memory_file(memories_dir / name, label=name, cap=cap, now=now)
-        for name, cap in HERMES_MEMORY_FILES
+        read_hermes_memory_file(memories_dir / label, label=label, cap=cap, now=now, cap_source=cap_source)
+        for label, cap, cap_source in resolve_memory_caps(hermes_home)
     )
+
+
+def _read_hermes_config(hermes_home: str | Path) -> str:
+    """Hermes' ``config.yaml`` as text, or empty when it cannot be read."""
+    path = Path(hermes_home).expanduser() / "config.yaml"
+    try:
+        return path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return ""
+
+
+def _positive_int(value: str) -> int | None:
+    """A positive integer scalar, or None when the text is not one."""
+    try:
+        parsed = int(value)
+    except ValueError:
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _config_section_scalar(config_text: str, section: str, key: str) -> str:
+    """One scalar under one top-level section, in dotted or nested form.
+
+    Vendored rather than imported: this module is loaded inside the Hermes
+    process, where the `omh` package is absent, so it cannot reach OMH's own
+    reader in `workflows/hermes_retained_context_probes.py`. Same two forms,
+    same comment and quote handling.
+    """
+    dotted = f"{section}.{key}:"
+    section_header = f"{section}:"
+    in_section = False
+    for line in config_text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if stripped.startswith(dotted):
+            return _clean_config_scalar(stripped[len(dotted) :])
+        if not line.startswith(" "):
+            in_section = stripped == section_header
+            continue
+        if in_section and line.startswith("  ") and not line.startswith("    "):
+            prefix = f"{key}:"
+            if stripped.startswith(prefix):
+                return _clean_config_scalar(stripped[len(prefix) :])
+    return ""
+
+
+def _clean_config_scalar(value: str) -> str:
+    stripped = _strip_unquoted_yaml_comment(value).strip()
+    if len(stripped) >= 2 and stripped[0] == stripped[-1] and stripped[0] in {"'", '"'}:
+        return stripped[1:-1]
+    return stripped
+
+
+def _strip_unquoted_yaml_comment(value: str) -> str:
+    in_single_quote = False
+    in_double_quote = False
+    for index, character in enumerate(value):
+        if character == "'" and not in_double_quote:
+            in_single_quote = not in_single_quote
+            continue
+        if character == '"' and not in_single_quote:
+            in_double_quote = not in_double_quote
+            continue
+        if character == "#" and not in_single_quote and not in_double_quote and _starts_yaml_comment(value, index):
+            return value[:index]
+    return value
+
+
+def _starts_yaml_comment(value: str, index: int) -> bool:
+    return index == 0 or value[index - 1].isspace()
 
 
 # A fact restated in Hermes' own words shares most of its nouns but almost none

--- a/tests/test_hermes_memory_bridge.py
+++ b/tests/test_hermes_memory_bridge.py
@@ -27,12 +27,14 @@ load_local_package()
 from omh.maintenance import advisory
 from omh.maintenance.advisory import MEMORY_STALE_AFTER_DAYS, check_hermes_memory_staleness
 from omh.plugin_bundle.omh.hermes_memory import (
+    DEFAULT_MEMORY_FILE_CAP_CHARS,
+    DEFAULT_USER_FILE_CAP_CHARS,
     HERMES_MEMORY_DELIMITER,
-    MEMORY_FILE_CAP_CHARS,
     memory_char_count,
     nearest_entry,
     parse_memory_entries,
     read_hermes_memory,
+    resolve_memory_caps,
     similarity,
 )
 from omh.memory import (
@@ -81,8 +83,8 @@ class UnitTests(unittest.TestCase):
         with TemporaryDirectory() as tmp:
             home = Path(tmp)
             path = _write_memory(home, KOREAN_ENTRY)
-            self.assertGreater(path.stat().st_size, MEMORY_FILE_CAP_CHARS)
-            self.assertLess(len(KOREAN_ENTRY), MEMORY_FILE_CAP_CHARS)
+            self.assertGreater(path.stat().st_size, DEFAULT_MEMORY_FILE_CAP_CHARS)
+            self.assertLess(len(KOREAN_ENTRY), DEFAULT_MEMORY_FILE_CAP_CHARS)
 
             entry = check_hermes_memory_staleness(home)
             self.assertEqual(entry.status, "ok")
@@ -98,14 +100,14 @@ class UnitTests(unittest.TestCase):
             self.assertEqual(len(reading.entries), 2)
             self.assertEqual(reading.chars, memory_char_count(("alpha", KOREAN_ENTRY)))
             self.assertFalse(reading.over_cap)
-            self.assertEqual(reading.headroom_chars, MEMORY_FILE_CAP_CHARS - reading.chars)
+            self.assertEqual(reading.headroom_chars, DEFAULT_MEMORY_FILE_CAP_CHARS - reading.chars)
 
 
 class CapTests(unittest.TestCase):
     def test_over_cap_is_advice_even_when_freshly_written(self) -> None:
         with TemporaryDirectory() as tmp:
             home = Path(tmp)
-            _write_memory(home, "x" * (MEMORY_FILE_CAP_CHARS + 1))
+            _write_memory(home, "x" * (DEFAULT_MEMORY_FILE_CAP_CHARS + 1))
             entry = check_hermes_memory_staleness(home)
             # Age alone used to decide this, so a full file touched today read
             # as ok while Hermes was already rejecting the next write.
@@ -123,7 +125,131 @@ class CapTests(unittest.TestCase):
         with TemporaryDirectory() as tmp:
             reading = read_hermes_memory(Path(tmp))[0]
             self.assertFalse(reading.exists)
-            self.assertEqual(reading.headroom_chars, MEMORY_FILE_CAP_CHARS)
+            self.assertEqual(reading.headroom_chars, DEFAULT_MEMORY_FILE_CAP_CHARS)
+
+
+class ConfiguredCapTests(unittest.TestCase):
+    """The cap is Hermes' config, not OMH's constant.
+
+    Hermes builds its memory tool with ``mem_config.get("memory_char_limit",
+    2200)``, so 2200/1375 are its fallbacks. OMH hardcoded them, which reported
+    a file as over cap with no headroom left while Hermes was still accepting
+    writes -- invisible on any host that had never changed the default.
+    """
+
+    def _home(self, tmp: str, config: str | None = None) -> Path:
+        home = Path(tmp)
+        if config is not None:
+            home.mkdir(parents=True, exist_ok=True)
+            (home / "config.yaml").write_text(config, encoding="utf-8")
+        return home
+
+    def test_a_raised_cap_leaves_headroom_the_default_would_deny(self) -> None:
+        with TemporaryDirectory() as tmp:
+            home = self._home(tmp, "memory:\n  memory_char_limit: 5000\n")
+            _write_memory(home, "x" * (DEFAULT_MEMORY_FILE_CAP_CHARS + 500))
+
+            reading = read_hermes_memory(home)[0]
+            self.assertEqual(reading.cap, 5000)
+            self.assertEqual(reading.cap_source, "config")
+            self.assertFalse(reading.over_cap)
+            self.assertEqual(reading.headroom_chars, 5000 - reading.chars)
+
+    def test_a_lowered_cap_is_honoured_too(self) -> None:
+        with TemporaryDirectory() as tmp:
+            home = self._home(tmp, "memory:\n  memory_char_limit: 500\n")
+            _write_memory(home, "x" * 600)
+
+            reading = read_hermes_memory(home)[0]
+            self.assertEqual(reading.cap, 500)
+            self.assertTrue(reading.over_cap)
+            self.assertEqual(reading.headroom_chars, 0)
+
+    def test_each_file_reads_its_own_key(self) -> None:
+        with TemporaryDirectory() as tmp:
+            home = self._home(tmp, "memory:\n  memory_char_limit: 5000\n  user_char_limit: 4000\n")
+            self.assertEqual(
+                resolve_memory_caps(home),
+                (("MEMORY.md", 5000, "config"), ("USER.md", 4000, "config")),
+            )
+
+    def test_one_configured_key_leaves_the_other_on_its_default(self) -> None:
+        with TemporaryDirectory() as tmp:
+            home = self._home(tmp, "memory:\n  user_char_limit: 4000\n")
+            self.assertEqual(
+                resolve_memory_caps(home),
+                (
+                    ("MEMORY.md", DEFAULT_MEMORY_FILE_CAP_CHARS, "default"),
+                    ("USER.md", 4000, "config"),
+                ),
+            )
+
+    def test_absent_config_falls_back_to_the_defaults(self) -> None:
+        with TemporaryDirectory() as tmp:
+            self.assertEqual(
+                resolve_memory_caps(Path(tmp)),
+                (
+                    ("MEMORY.md", DEFAULT_MEMORY_FILE_CAP_CHARS, "default"),
+                    ("USER.md", DEFAULT_USER_FILE_CAP_CHARS, "default"),
+                ),
+            )
+
+    def test_the_dotted_config_form_is_read(self) -> None:
+        with TemporaryDirectory() as tmp:
+            home = self._home(tmp, "memory.memory_char_limit: 3300\n")
+            self.assertEqual(resolve_memory_caps(home)[0], ("MEMORY.md", 3300, "config"))
+
+    def test_quotes_and_inline_comments_are_stripped(self) -> None:
+        with TemporaryDirectory() as tmp:
+            home = self._home(tmp, 'memory:\n  memory_char_limit: "3300"  # raised for Korean\n')
+            self.assertEqual(resolve_memory_caps(home)[0], ("MEMORY.md", 3300, "config"))
+
+    def test_a_key_outside_the_memory_section_is_not_borrowed(self) -> None:
+        with TemporaryDirectory() as tmp:
+            home = self._home(tmp, "other:\n  memory_char_limit: 9999\n")
+            self.assertEqual(resolve_memory_caps(home)[0][1], DEFAULT_MEMORY_FILE_CAP_CHARS)
+
+    def test_an_unusable_value_reports_the_default_rather_than_a_measured_cap(self) -> None:
+        # A malformed cap must not become a headroom figure that reads as observed.
+        for value in ("abc", "0", "-1", "", "5000.5"):
+            with self.subTest(value=value), TemporaryDirectory() as tmp:
+                home = self._home(tmp, f"memory:\n  memory_char_limit: {value}\n")
+                self.assertEqual(
+                    resolve_memory_caps(home)[0],
+                    ("MEMORY.md", DEFAULT_MEMORY_FILE_CAP_CHARS, "default"),
+                )
+
+    def test_an_unreadable_config_falls_back_instead_of_raising(self) -> None:
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            (home / "config.yaml").mkdir(parents=True)
+            self.assertEqual(resolve_memory_caps(home)[0][2], "default")
+
+    def test_advisory_does_not_flag_a_file_under_its_raised_cap(self) -> None:
+        with TemporaryDirectory() as tmp:
+            home = self._home(tmp, "memory:\n  memory_char_limit: 5000\n")
+            _write_memory(home, "x" * (DEFAULT_MEMORY_FILE_CAP_CHARS + 500))
+            # Hardcoding 2200 made this "advice" while Hermes still accepted writes.
+            self.assertEqual(check_hermes_memory_staleness(home).status, "ok")
+
+    def test_promotion_headroom_follows_the_configured_cap(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            hermes_home = root / ".hermes"
+            hermes_home.mkdir(parents=True, exist_ok=True)
+            (hermes_home / "config.yaml").write_text(
+                "memory:\n  memory_char_limit: 5000\n", encoding="utf-8"
+            )
+            capture = capture_project_memory_candidate(paths, "격리된 사실 " * 40, scope_ref="demo")
+            approve_project_memory_candidate(paths, str(capture["candidate"]["candidate_id"]))
+            _write_memory(hermes_home, "x" * (DEFAULT_MEMORY_FILE_CAP_CHARS - 10))
+
+            bridge = build_hermes_memory_bridge(paths)
+            # The same record does not fit under the default cap; it does under 5000.
+            self.assertTrue(bridge["promotable"][0]["fits_headroom"])
+            self.assertEqual(bridge["files"][0]["cap"], 5000)
+            self.assertEqual(bridge["files"][0]["cap_source"], "config")
 
 
 class SimilarityTests(unittest.TestCase):
@@ -175,7 +301,7 @@ class BridgeTests(unittest.TestCase):
             root = Path(tmp)
             paths = resolve_paths(root / ".omh", root / ".hermes")
             self._approved(paths, "격리된 사실 " * 40)
-            _write_memory(root / ".hermes", "x" * (MEMORY_FILE_CAP_CHARS - 10))
+            _write_memory(root / ".hermes", "x" * (DEFAULT_MEMORY_FILE_CAP_CHARS - 10))
 
             promotable = build_hermes_memory_bridge(paths)["promotable"]
             self.assertEqual(len(promotable), 1)


### PR DESCRIPTION
## Feature Report

### What Changed

- `resolve_memory_caps()` reads `memory.memory_char_limit` / `memory.user_char_limit` from Hermes' `config.yaml` instead of OMH hardcoding 2200 / 1375.
- Every `HermesMemoryFile` reading now carries a `cap_source` of `"config"` or `"default"`, surfaced through `to_dict()` and therefore through the `hermes_memory_bridge/v1` payload, `omh memory status`, and the `omh_memory` plugin tool.
- `MEMORY_FILE_CAP_CHARS` / `USER_FILE_CAP_CHARS` became `DEFAULT_MEMORY_FILE_CAP_CHARS` / `DEFAULT_USER_FILE_CAP_CHARS`, because they are Hermes' fallbacks and never were the cap.
- The advisory lane's remediation text stopped quoting "~2,200 chars, USER.md ~1,375 chars" as fact and names the two config keys instead.

### Why This Exists

OMH reported how full Hermes memory was by comparing the file against two numbers written into OMH. Hermes does not treat those as the cap — it builds its memory tool with `mem_config.get("memory_char_limit", 2200)` and `mem_config.get("user_char_limit", 1375)` (`agent/agent_init.py:1621`, `tools/memory_tool.py:167`), so `config.yaml` overrides them.

The defect is invisible on a host that never changed the default, which is why it survived. Raise `memory.memory_char_limit` to 5000 and OMH keeps measuring against 2200: a 2,700-character `MEMORY.md` reads as over cap with zero headroom, `check_hermes_memory_staleness` returns `advice`, and every approved record reports `fits_headroom: false` — while Hermes accepts the next write without complaint. The bridge exists to say what will and will not fit; on those hosts it answered from an assumption.

### User / Operator Impact

- On a host with a raised cap, `omh memory status` and the `omh_memory` tool now report real headroom, so record promotion is offered instead of denied.
- On a host with a lowered cap, OMH now flags a file Hermes is already rejecting, which it previously called healthy.
- A reader can now tell an observed cap from an assumed one: `cap_source` says which, so a default is never mistaken for a measurement.
- No behaviour change on a host that never set either key.

### How It Works

`resolve_memory_caps(hermes_home)` returns `(label, cap, cap_source)` per file. `read_hermes_memory()` resolves caps once and passes each to `read_hermes_memory_file()`. An absent, unparseable, or non-positive value falls back to the default and reports `cap_source: "default"` — a malformed config must not become a headroom figure that reads as measured.

The scalar reader is vendored rather than imported. This module is loaded inside the Hermes process, where the `omh` package is absent (the same reason `read_approved_records` was vendored here), so it cannot reach OMH's reader in `workflows/hermes_retained_context_probes.py`. It handles the same two forms — nested and dotted — with the same quote and inline-comment handling. No YAML parser, so no new dependency.

### Files And Contracts Touched

- `src/plugin_bundle/omh/hermes_memory.py` — cap resolution, `cap_source`, vendored config scalar reader.
- `src/maintenance/advisory.py` — renamed re-exports; remediation text no longer asserts the two numbers.
- `tests/test_hermes_memory_bridge.py` — new `ConfiguredCapTests` (12 cases) plus the constant rename.
- Contract note: `hermes_memory_bridge/v1` payload gains a `cap_source` key per file. Additive; the schema version is unchanged because no existing key changed shape or meaning.

## Validation

- [x] `uv run --group lint ruff check src tests` — All checks passed
- [x] `python3 -m unittest discover -s tests` — 2050 passed, 1 skipped
- [x] `python3 -m compileall src`
- [x] `python3 -m omh.cli docs workflows --check` — ok, tap_skills 104/104
- [x] `python3 -m omh.cli harness validate` — ok, 72 harnesses / 93 skills, no errors or warnings
- [x] `python3 -m omh.cli release checklist --json` — ok
- [x] `python3 -m omh.cli release hermes-smoke` — plan renders
- [x] `omh --help`
- [x] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` — nested `installed_command_smoke` mode=live, observed=true, ok=true
- [x] Also run: `docs roles --check`, `docs capability-families --check`, `git diff --check`
- [ ] Relevant workflow-learning review queue smoke — not applicable, no learning contract changed
- [ ] Manual Hermes/TUI check — **not run.** Confirming end to end needs a Hermes profile with a raised cap plus a live memory write at the new limit. The override path was read in the installed Hermes source rather than exercised, so the claim that Hermes accepts a write above 2200 rests on reading `agent/agent_init.py` and `tools/memory_tool.py`, not on an observed write.

## Risk

Low. The only behavioural difference on a host that never set the two keys is the additive `cap_source` field. The rename is source-compatible within the repo — both call sites moved with it, and no generated artifact or doc referenced the old names.

The reader is deliberately narrow: it covers the nested and dotted scalar forms Hermes' own config uses. Exotic YAML around those keys — anchors, flow maps, multi-line scalars — is out of scope and untested, and falls back to the default rather than misreading.

## Compatibility / Rollout

`hermes_memory_bridge/v1` gains one key per file entry; consumers that read known keys are unaffected. No install, setup, or state migration. A user's Hermes needs `omh setup` after merge for the updated bundle to reach `~/.hermes/plugins/omh/`.

## Release / Claims

- [x] Release-channel impact considered — `local`; no release artifact or version change.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed — the Hermes-side override path is cited by file and line as *read*, not observed; no live Hermes write was made.
- [x] Known manual Hermes checks are listed, including the `omh release hermes-smoke --live` gap — no live tap smoke was run; this change does not touch install or registration.

## Follow-Up

- The bridge could warn when `cap_source` is `default` but a `memory:` section exists with an unusable value, which currently degrades silently to the default.
- `tests/test_hermes_memory_bridge.py` has a pre-existing `if __name__ == "__main__": unittest.main()` above the `MemoryToolTests` class, so direct execution of the file skips that class. Untouched here; discovery is unaffected.
