### PR TITLE
feat: OMH as a Hermes memory provider — tiered blocks, budgets, scheduled dreaming

### DIFF
--- a/src/commands/memory.py
+++ b/src/commands/memory.py
@@ -5,7 +5,25 @@ import json
 import sys
 from pathlib import Path
 
+from ..install.config_adapter import (
+    clear_memory_provider,
+    memory_provider_selection,
+    read_config,
+    set_memory_provider,
+    write_config,
+)
 from ..installer import OmhError
+from ..plugin_bundle.omh.memory_blocks import (
+    MemoryBlockError,
+    blocks_dir,
+    build_memory_block,
+    delete_memory_block,
+    read_memory_blocks,
+    write_memory_block,
+)
+from ..plugin_bundle.omh.memory_dreaming import read_dreaming_state
+from ..plugin_bundle.omh.memory_provider import OmhMemoryProvider
+from ..plugin_bundle.omh.metadata import MEMORY_PROVIDER_NAME
 from ..memory import (
     RejectedDecisionRecallRequest,
     apply_memory_update_batch,
@@ -187,6 +205,103 @@ def cmd_memory_apply(args: argparse.Namespace) -> int:
     except (OSError, json.JSONDecodeError, ValueError) as exc:
         raise OmhError(str(exc)) from exc
     _print_json(result)
+    return 0
+
+
+def cmd_memory_blocks(args: argparse.Namespace) -> int:
+    paths = _paths(args)
+    blocks = read_memory_blocks(paths.omh_home, tier=args.tier)
+    _print_json(
+        {
+            "schema_version": "omh_memory_block_listing/v1",
+            "blocks": [block.to_summary() for block in blocks],
+            "block_count": len(blocks),
+            "store_dir": str(blocks_dir(paths.omh_home)),
+            "claim_boundary": (
+                "Block listings are prepared OMH context; they are not evidence that Hermes read "
+                "a block or that any memory was written."
+            ),
+        }
+    )
+    return 0
+
+
+def cmd_memory_block_set(args: argparse.Namespace) -> int:
+    try:
+        value = sys.stdin.read() if args.stdin else str(args.value or "")
+        block = build_memory_block(
+            args.label,
+            value,
+            description=args.description,
+            limit=args.limit,
+            tier=args.tier,
+        )
+        path = write_memory_block(_paths(args).omh_home, block)
+    except MemoryBlockError as exc:
+        raise OmhError(str(exc)) from exc
+    except (OSError, ValueError) as exc:
+        raise OmhError(str(exc)) from exc
+    _print_json({"schema_version": "omh_memory_block_write/v1", "written": True, "path": str(path), "block": block.to_summary()})
+    return 0
+
+
+def cmd_memory_block_remove(args: argparse.Namespace) -> int:
+    try:
+        removed = delete_memory_block(_paths(args).omh_home, args.label, args.tier)
+    except MemoryBlockError as exc:
+        raise OmhError(str(exc)) from exc
+    _print_json({"schema_version": "omh_memory_block_remove/v1", "removed": removed, "label": args.label, "tier": args.tier})
+    return 0
+
+
+def cmd_memory_dream(args: argparse.Namespace) -> int:
+    """Report whether consolidation is due. Never consolidates: that needs a model."""
+    paths = _paths(args)
+    provider = OmhMemoryProvider(paths.omh_home)
+    provider.initialize("", hermes_home=str(paths.hermes_home))
+    payload = dict(provider.consolidation_due()) if args.evaluate else {}
+    payload["state"] = read_dreaming_state(paths.omh_home)
+    payload["evaluated"] = bool(args.evaluate)
+    _print_json(payload)
+    return 0
+
+
+def cmd_memory_provider(args: argparse.Namespace) -> int:
+    """Show, take, or hand back Hermes' single external memory-provider slot."""
+    paths = _paths(args)
+    path = paths.hermes_config_path
+    text = read_config(path)
+    change = None
+    if args.enable:
+        change = set_memory_provider(text, MEMORY_PROVIDER_NAME)
+    elif args.disable:
+        change = clear_memory_provider(text, MEMORY_PROVIDER_NAME)
+    if change is not None and change.changed and not args.dry_run:
+        try:
+            write_config(path, change.text)
+        except OSError as exc:
+            raise OmhError(str(exc)) from exc
+    selection = memory_provider_selection(change.text if change is not None else text)
+    _print_json(
+        {
+            "schema_version": "omh_memory_provider_status/v1",
+            "provider": selection,
+            "is_omh": selection == MEMORY_PROVIDER_NAME,
+            "config_path": str(path),
+            "config_exists": path.is_file(),
+            "changed": bool(change.changed) if change is not None else False,
+            "reason": change.message if change is not None else "status only",
+            "dry_run": bool(args.dry_run),
+            "next_action": (
+                "Restart Hermes for a provider change to take effect; run `omh setup` first if the "
+                "bundle is not installed."
+            ),
+            "claim_boundary": (
+                "This reports and edits Hermes' config selection only. It is not evidence that "
+                "Hermes loaded the provider, ran a hook, or changed any memory."
+            ),
+        }
+    )
     return 0
 
 

--- a/src/commands/memory_parser.py
+++ b/src/commands/memory_parser.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 
+from ..plugin_bundle.omh.memory_blocks import DEFAULT_BLOCK_LIMIT_CHARS
 from . import memory
 
 
@@ -88,3 +89,32 @@ def add_memory_commands(sub: argparse._SubParsersAction[argparse.ArgumentParser]
     apply.add_argument("--batch", required=True, help="Path to memory_update_batch/v1 JSON, or '-' to read from stdin.")
     apply.add_argument("--dry-run", action="store_true", help="Validate and preview the batch without writing .omh/memory.")
     apply.set_defaults(func=memory.cmd_memory_apply)
+
+    blocks = memory_sub.add_parser("blocks", help="List OMH memory blocks by label, without their values.")
+    blocks.add_argument("--tier", choices=("system", "reference"), default=None, help="Limit the listing to one tier.")
+    blocks.set_defaults(func=memory.cmd_memory_blocks)
+
+    block_set = memory_sub.add_parser("block-set", help="Create or replace one OMH memory block.")
+    block_set.add_argument("label", help="Block label: lowercase letters, digits, '-' or '_'.")
+    block_set.add_argument("--value", default="", help="Block content. Rejected when longer than --limit.")
+    block_set.add_argument("--stdin", action="store_true", help="Read block content from stdin instead of --value.")
+    block_set.add_argument("--description", default="", help="What the block is for; shown to the model beside the value.")
+    block_set.add_argument("--limit", type=int, default=DEFAULT_BLOCK_LIMIT_CHARS, help="Per-block character budget.")
+    block_set.add_argument("--tier", choices=("system", "reference"), default="system", help="'system' renders every turn; 'reference' is listed by label and read on request.")
+    block_set.set_defaults(func=memory.cmd_memory_block_set)
+
+    block_remove = memory_sub.add_parser("block-remove", help="Remove one OMH memory block.")
+    block_remove.add_argument("label")
+    block_remove.add_argument("--tier", choices=("system", "reference"), default="system")
+    block_remove.set_defaults(func=memory.cmd_memory_block_remove)
+
+    dream = memory_sub.add_parser("dream", help="Report whether memory consolidation is due, and why. Never consolidates.")
+    dream.add_argument("--evaluate", action="store_true", help="Weigh the triggers now and write the consolidation handoff when they fire.")
+    dream.set_defaults(func=memory.cmd_memory_dream)
+
+    provider = memory_sub.add_parser("provider", help="Show or change Hermes' single external memory-provider selection.")
+    provider_slot = provider.add_mutually_exclusive_group()
+    provider_slot.add_argument("--enable", action="store_true", help="Point Hermes' memory.provider at OMH. Refused when another provider holds the slot.")
+    provider_slot.add_argument("--disable", action="store_true", help="Hand the slot back, only when OMH currently holds it.")
+    provider.add_argument("--dry-run", action="store_true", help="Report the change without writing Hermes config.")
+    provider.set_defaults(func=memory.cmd_memory_provider)

--- a/src/commands/setup.py
+++ b/src/commands/setup.py
@@ -187,7 +187,37 @@ def cmd_update(args: argparse.Namespace) -> int:
     self_update = _command_package_self_update_plan(args)
     if self_update.get("should_update"):
         return _run_command_package_self_update(args, self_update)
-    return cmd_install(args)
+    code = cmd_install(args)
+    if code == 0:
+        _refresh_installed_plugin_bundle(args)
+    return code
+
+
+def _refresh_installed_plugin_bundle(args: argparse.Namespace) -> dict[str, object] | None:
+    """Bring an already-installed plugin bundle up to the running version.
+
+    `omh update` used to refresh skills and stop there: `install_plugin_bundle`
+    was reachable only from `cmd_setup`, so the tools, hooks, and memory
+    provider under `$HERMES_HOME/plugins/omh/` stayed at whatever version last
+    ran setup. The three commands AGENTS.md tells ordinary users to know are
+    setup, update, and doctor -- and update was the one that did not update.
+
+    Only refreshes what is already there. Installing the bundle for the first
+    time is setup's job, because that is also where Hermes registration and
+    enablement happen, and half of that pair is worse than neither.
+    """
+    paths = _paths(args)
+    if not paths.hermes_plugin_dir.is_dir():
+        return None
+    try:
+        result = install_plugin_bundle(paths, force=args.force, dry_run=args.dry_run)
+    except PluginPackError:
+        # An update must not fail over a bundle a later `omh setup --force` can
+        # repair; `omh doctor` reports the drift with the instruction to run it.
+        return None
+    if not args.dry_run:
+        update_state(paths, {"last_plugin_distribution": result})
+    return result
 
 
 def _command_package_self_update_plan(args: argparse.Namespace) -> dict[str, object]:

--- a/src/install/config_adapter.py
+++ b/src/install/config_adapter.py
@@ -217,6 +217,102 @@ def ensure_plugin_enabled(config_text: str, name: str) -> ConfigChange:
     return ConfigChange(True, "inserted plugins.enabled", "\n".join(lines) + "\n")
 
 
+def memory_provider_selection(config_text: str) -> str:
+    """The name in `memory.provider`, or "" when Hermes is on its built-in memory."""
+    return _section_scalar(config_text, "memory", "provider")
+
+
+def set_memory_provider(config_text: str, name: str) -> ConfigChange:
+    """Point `memory.provider` at `name`, unless another product already holds it.
+
+    Hermes runs at most one external memory provider
+    (`agent/memory_manager.py`), so this key is a slot rather than a list.
+    Overwriting a different provider would silently switch off whatever the
+    operator chose -- honcho, mem0, hindsight -- so it is refused and reported
+    instead. Clearing the slot is the operator's call, made explicitly.
+    """
+    current = memory_provider_selection(config_text)
+    if current == name:
+        return ConfigChange(False, f"memory.provider is already {name}", config_text)
+    if current:
+        return ConfigChange(
+            False,
+            f"memory.provider is {current}; Hermes runs one external provider, so clear it first",
+            config_text,
+        )
+
+    lines = config_text.splitlines()
+    memory_index = next(
+        (idx for idx, line in enumerate(lines) if line.strip() == "memory:" and not line.startswith(" ")),
+        None,
+    )
+    if memory_index is None:
+        text = (config_text.rstrip() + f"\n\nmemory:\n  provider: {name}\n").lstrip("\n")
+        return ConfigChange(True, "appended memory.provider", text)
+
+    for idx in range(memory_index + 1, len(lines)):
+        line = lines[idx]
+        if line.strip() and not line.startswith(" "):
+            break
+        if line.startswith("  ") and not line.startswith("    "):
+            key, _, _rest = line.strip().partition(":")
+            if key.strip() == "provider":
+                lines[idx] = f"  provider: {name}"
+                return ConfigChange(True, "set memory.provider", "\n".join(lines) + "\n")
+
+    lines.insert(memory_index + 1, f"  provider: {name}")
+    return ConfigChange(True, "inserted memory.provider", "\n".join(lines) + "\n")
+
+
+def clear_memory_provider(config_text: str, name: str) -> ConfigChange:
+    """Hand the slot back, but only when `name` is the one holding it."""
+    current = memory_provider_selection(config_text)
+    if not current:
+        return ConfigChange(False, "memory.provider is already unset", config_text)
+    if current != name:
+        return ConfigChange(False, f"memory.provider is {current}, not {name}; leaving it alone", config_text)
+
+    lines = config_text.splitlines()
+    for idx, line in enumerate(lines):
+        if not line.startswith("  ") or line.startswith("    "):
+            continue
+        key, _, _rest = line.strip().partition(":")
+        if key.strip() == "provider" and _enclosing_section(lines, idx) == "memory":
+            lines[idx] = "  provider: ''"
+            return ConfigChange(True, "cleared memory.provider", "\n".join(lines) + "\n")
+    return ConfigChange(False, "memory.provider line not found", config_text)
+
+
+def _section_scalar(config_text: str, section: str, key: str) -> str:
+    dotted = f"{section}.{key}:"
+    for index, line in enumerate(config_text.splitlines()):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if stripped.startswith(dotted) and not line.startswith(" "):
+            return _scalar_value(stripped[len(dotted) :])
+        if line.startswith("  ") and not line.startswith("    "):
+            candidate, separator, rest = stripped.partition(":")
+            if separator and candidate.strip() == key and _enclosing_section(config_text.splitlines(), index) == section:
+                return _scalar_value(rest)
+    return ""
+
+
+def _enclosing_section(lines: list[str], index: int) -> str:
+    for cursor in range(index - 1, -1, -1):
+        line = lines[cursor]
+        if line.strip() and not line.startswith(" "):
+            return line.strip().rstrip(":")
+    return ""
+
+
+def _scalar_value(value: str) -> str:
+    stripped = value.split("#")[0].strip() if not value.strip().startswith(("'", '"')) else value.strip()
+    if len(stripped) >= 2 and stripped[0] == stripped[-1] and stripped[0] in {"'", '"'}:
+        return stripped[1:-1]
+    return stripped
+
+
 def ensure_external_dir(config_text: str, skill_dir: str | Path) -> ConfigChange:
     _validate_external_dirs_mutation_shape(config_text)
     target = _normalize(skill_dir)

--- a/src/maintenance/doctor.py
+++ b/src/maintenance/doctor.py
@@ -5,11 +5,18 @@ from pathlib import Path
 
 from .advisory import AdvisoryReport, run_config_advisories
 from ..command_path import inspect_omh_command_path
-from ..config_adapter import external_dirs, plugin_enablement, plugin_is_enabled, read_config
+from ..config_adapter import (
+    external_dirs,
+    memory_provider_selection,
+    plugin_enablement,
+    plugin_is_enabled,
+    read_config,
+)
 from ..hashutil import sha256_file
 from ..local_store import can_write_dir
 from ..manifest import local_modifications, read_manifest
 from ..paths import OmhPaths
+from ..plugin_bundle.omh.metadata import MEMORY_PROVIDER_NAME
 from ..plugin_observations import (
     PLUGIN_HOST_ACTIVE_OBSERVATION_EVENTS,
     latest_plugin_host_observation,
@@ -119,6 +126,7 @@ def run_doctor(paths: OmhPaths) -> list[Check]:
     external_registered = str(paths.skills_dir) in dirs
     checks.append(Check("external_dir", external_registered, f"{paths.skills_dir} in skills.external_dirs"))
     checks.append(_skill_shadowing_check(paths, dirs))
+    checks.append(_memory_provider_check(config_text))
     checks.append(
         Check(
             "runtime_context",
@@ -276,6 +284,32 @@ def run_doctor(paths: OmhPaths) -> list[Check]:
             )
         )
     return checks
+
+
+def _memory_provider_check(config_text: str) -> Check:
+    """Report who holds Hermes' single external memory-provider slot.
+
+    Hermes runs at most one. Leaving the slot empty is a perfectly good state --
+    Hermes falls back to its built-in memory -- so this never fails on an unset
+    provider. It exists because a slot silently held by something else is the
+    reason OMH's hooks would not be running, and that is invisible otherwise.
+    """
+    selection = memory_provider_selection(config_text)
+    if selection == MEMORY_PROVIDER_NAME:
+        return Check("memory_provider", True, "Hermes memory.provider is omh")
+    if selection:
+        return Check(
+            "memory_provider",
+            True,
+            f"Hermes memory.provider is {selection}; OMH memory hooks are not running. "
+            "Run `omh memory provider --enable` after clearing it to switch.",
+        )
+    return Check(
+        "memory_provider",
+        True,
+        "Hermes memory.provider is unset (built-in memory). Run `omh memory provider --enable` "
+        "to let OMH recall and journal memory automatically.",
+    )
 
 
 def _skill_shadowing_check(paths: OmhPaths, configured_dirs: list[str]) -> Check:

--- a/src/plugin_bundle/omh/__init__.py
+++ b/src/plugin_bundle/omh/__init__.py
@@ -28,7 +28,25 @@ def _register_optional_hook(ctx, hook_name: str, callback: object) -> None:
 
 
 def register(ctx):
-    """Register the OMH thin native bridge with Hermes."""
+    """Register the OMH thin native bridge with Hermes.
+
+    Two different loaders call this with two different contexts. The plugin
+    loader passes a context that registers tools and hooks. The *memory
+    provider* loader in ``plugins/memory/__init__.py`` passes a collector whose
+    only real method is ``register_memory_provider`` -- it no-ops the rest -- so
+    running the tool wiring for it would import ten modules to no effect.
+
+    The real plugin context has no ``register_memory_provider``, which is what
+    makes the two safely distinguishable. Mentioning the name here is also what
+    makes this directory visible to Hermes' provider discovery, which text-scans
+    ``__init__.py`` for it.
+    """
+    if hasattr(ctx, "register_memory_provider"):
+        from .memory_provider import OmhMemoryProvider
+
+        ctx.register_memory_provider(OmhMemoryProvider())
+        return
+
     from .hooks.llm_hooks import pre_llm_call
     from .hooks.session_hooks import on_session_end
     from .hooks.tool_hooks import pre_tool_call

--- a/src/plugin_bundle/omh/memory_blocks.py
+++ b/src/plugin_bundle/omh/memory_blocks.py
@@ -1,0 +1,283 @@
+"""Memory blocks: the tier Hermes does not have.
+
+Hermes keeps one flat, character-capped entry list per file (``MEMORY.md``,
+``USER.md``). There is no label, no per-topic budget, and no way to say "this
+belongs in context every turn but that only when asked" -- so everything
+competes for the same 2200 characters and the file fills up.
+
+Letta's answer, which this file borrows, is the memory block: a labelled record
+with its own character limit, rendered into the prompt by string templating with
+its fill level shown alongside the value. Blocks live in two tiers, after
+MemFS: ``system`` renders every turn, ``reference`` is listed by label and read
+only when something asks for it. The split is what keeps an always-on budget
+small while the store itself stays unbounded.
+
+Everything here is deterministic file work -- no model call decides what a block
+says, only what a prepared handoff proposes. Stdlib only, and vendored in the
+bundle rather than in ``workflows/`` because this module is imported inside the
+Hermes process, where the ``omh`` package does not exist.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+MEMORY_BLOCK_SCHEMA_VERSION = "omh_memory_block/v1"
+
+SYSTEM_TIER = "system"
+REFERENCE_TIER = "reference"
+BLOCK_TIERS = (SYSTEM_TIER, REFERENCE_TIER)
+
+# Per-block ceiling. Letta's documented persona example uses 5000 and its
+# framework defaults are larger still, but a block here has to share a Hermes
+# turn with the rest of OMH's context, so the default is deliberately smaller
+# than anything it renders beside.
+DEFAULT_BLOCK_LIMIT_CHARS = 2000
+
+# Ceiling for one rendered system-tier pack. A per-block limit alone cannot
+# bound the render: ten blocks under their own limits still overflow a turn.
+DEFAULT_SYSTEM_RENDER_BUDGET_CHARS = 6000
+
+# Labels name files, so they are constrained to what is safe as a filename and
+# stable as an identifier.
+_LABEL = re.compile(r"^[a-z0-9][a-z0-9_-]{0,62}$")
+
+
+class MemoryBlockError(ValueError):
+    """A block was rejected before anything was written."""
+
+
+@dataclass(frozen=True)
+class MemoryBlock:
+    """One labelled, budgeted piece of durable context."""
+
+    label: str
+    description: str
+    value: str
+    limit: int
+    tier: str
+
+    @property
+    def chars(self) -> int:
+        return len(self.value)
+
+    @property
+    def over_limit(self) -> bool:
+        return self.chars > self.limit
+
+    @property
+    def headroom_chars(self) -> int:
+        return max(0, self.limit - self.chars)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": MEMORY_BLOCK_SCHEMA_VERSION,
+            "label": self.label,
+            "description": self.description,
+            "value": self.value,
+            "limit": self.limit,
+            "tier": self.tier,
+        }
+
+    def to_summary(self) -> dict[str, object]:
+        """Metadata without the value, for listings and status payloads."""
+        return {
+            "label": self.label,
+            "description": self.description,
+            "tier": self.tier,
+            "chars": self.chars,
+            "limit": self.limit,
+            "headroom_chars": self.headroom_chars,
+            "over_limit": self.over_limit,
+        }
+
+
+def normalize_label(value: str) -> str:
+    """A label usable as both an identifier and a filename."""
+    label = str(value or "").strip().lower()
+    if not _LABEL.match(label):
+        raise MemoryBlockError(
+            "block label must be 1-63 chars of lowercase letters, digits, '-' or '_', "
+            f"starting alphanumeric; got {label!r}"
+        )
+    return label
+
+
+def normalize_tier(value: str) -> str:
+    tier = str(value or "").strip().lower()
+    if tier not in BLOCK_TIERS:
+        raise MemoryBlockError(f"block tier must be one of {BLOCK_TIERS}; got {tier!r}")
+    return tier
+
+
+def blocks_dir(omh_home: str | Path) -> Path:
+    return Path(omh_home).expanduser() / "memory" / "blocks"
+
+
+def block_path(omh_home: str | Path, label: str, tier: str) -> Path:
+    return blocks_dir(omh_home) / normalize_tier(tier) / f"{normalize_label(label)}.json"
+
+
+def build_memory_block(
+    label: str,
+    value: str,
+    *,
+    description: str = "",
+    limit: int = DEFAULT_BLOCK_LIMIT_CHARS,
+    tier: str = SYSTEM_TIER,
+) -> MemoryBlock:
+    """Validate one block. Raises rather than truncating.
+
+    Silent truncation would make the store disagree with what a caller believes
+    it wrote, and the disagreement would only surface as a missing sentence in a
+    later prompt. An over-limit block is a caller error, so it is one here.
+    """
+    normalized_label = normalize_label(label)
+    normalized_tier = normalize_tier(tier)
+    if not isinstance(limit, int) or isinstance(limit, bool) or limit <= 0:
+        raise MemoryBlockError(f"block limit must be a positive integer; got {limit!r}")
+    text = str(value or "")
+    if len(text) > limit:
+        raise MemoryBlockError(
+            f"block {normalized_label!r} is {len(text)} chars against a {limit}-char limit"
+        )
+    return MemoryBlock(normalized_label, str(description or ""), text, limit, normalized_tier)
+
+
+def write_memory_block(omh_home: str | Path, block: MemoryBlock) -> Path:
+    """Persist one block, creating its tier directory when needed."""
+    path = block_path(omh_home, block.label, block.tier)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(block.to_dict(), ensure_ascii=False, sort_keys=True), encoding="utf-8")
+    return path
+
+
+def read_memory_block(path: str | Path) -> MemoryBlock | None:
+    """One block from disk, or None when the file is absent or unusable.
+
+    Never raises: an unreadable block must degrade to "not present" rather than
+    take down the turn that was rendering it.
+    """
+    candidate = Path(path)
+    try:
+        if candidate.is_symlink() or not candidate.is_file():
+            return None
+        data = json.loads(candidate.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, ValueError):
+        return None
+    if not isinstance(data, dict) or data.get("schema_version") != MEMORY_BLOCK_SCHEMA_VERSION:
+        return None
+    try:
+        return build_memory_block(
+            str(data.get("label", "")),
+            str(data.get("value", "")),
+            description=str(data.get("description", "")),
+            limit=_int_or(data.get("limit"), DEFAULT_BLOCK_LIMIT_CHARS),
+            tier=str(data.get("tier", "")),
+        )
+    except MemoryBlockError:
+        return None
+
+
+def read_memory_blocks(omh_home: str | Path, *, tier: str | None = None) -> tuple[MemoryBlock, ...]:
+    """Every readable block, label-ordered so a render is reproducible."""
+    tiers = (normalize_tier(tier),) if tier is not None else BLOCK_TIERS
+    found: list[MemoryBlock] = []
+    for tier_name in tiers:
+        directory = blocks_dir(omh_home) / tier_name
+        try:
+            candidates = sorted(directory.glob("*.json"))
+        except OSError:
+            continue
+        for candidate in candidates:
+            block = read_memory_block(candidate)
+            if block is not None and block.tier == tier_name:
+                found.append(block)
+    return tuple(sorted(found, key=lambda item: item.label))
+
+
+def delete_memory_block(omh_home: str | Path, label: str, tier: str) -> bool:
+    """Remove one block. False when it was not there to begin with."""
+    path = block_path(omh_home, label, tier)
+    try:
+        path.unlink()
+    except OSError:
+        return False
+    return True
+
+
+def render_memory_blocks(
+    blocks: tuple[MemoryBlock, ...] | list[MemoryBlock],
+    *,
+    budget_chars: int = DEFAULT_SYSTEM_RENDER_BUDGET_CHARS,
+) -> str:
+    """Blocks as prompt text, with each block's fill level beside its value.
+
+    The shape follows Letta's documented rendering: an XML-ish wrapper, one
+    element per label, and a metadata line carrying chars_current/chars_limit so
+    the model can see how much room a block has before it proposes an edit.
+    Pure templating -- no model call is involved in producing this.
+
+    Blocks are emitted in label order until the budget is spent; the first block
+    that would exceed it, and every block after, is dropped rather than clipped,
+    and the omission is stated in the output. A half-sentence would read as
+    something the store actually holds.
+    """
+    if not blocks:
+        return ""
+    lines = ["<memory_blocks>"]
+    used = 0
+    omitted: list[str] = []
+    for block in blocks:
+        element = _render_block(block)
+        if omitted or used + len(element) > max(budget_chars, 0):
+            omitted.append(block.label)
+            continue
+        used += len(element)
+        lines.append(element)
+    if omitted:
+        lines.append(
+            f"  <omitted reason=\"render_budget_exhausted\" budget_chars=\"{budget_chars}\">"
+            f"{', '.join(omitted)}</omitted>"
+        )
+    lines.append("</memory_blocks>")
+    return "\n".join(lines)
+
+
+def render_block_index(blocks: tuple[MemoryBlock, ...] | list[MemoryBlock]) -> str:
+    """Reference-tier blocks as a label listing, without their values.
+
+    This is the half of the tier split that makes it worth having: the model
+    learns a block exists and what it is for, and pays its characters only when
+    it asks for the block by label.
+    """
+    if not blocks:
+        return ""
+    lines = ["<memory_block_index>"]
+    for block in blocks:
+        lines.append(
+            f'  <block label="{block.label}" chars="{block.chars}" limit="{block.limit}">'
+            f"{block.description}</block>"
+        )
+    lines.append("</memory_block_index>")
+    return "\n".join(lines)
+
+
+def _render_block(block: MemoryBlock) -> str:
+    return (
+        f"  <{block.label}>\n"
+        f"    <description>{block.description}</description>\n"
+        f"    <metadata>chars_current={block.chars} chars_limit={block.limit}</metadata>\n"
+        f"    <value>{block.value}</value>\n"
+        f"  </{block.label}>"
+    )
+
+
+def _int_or(value: Any, fallback: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        return fallback
+    return value

--- a/src/plugin_bundle/omh/memory_dreaming.py
+++ b/src/plugin_bundle/omh/memory_dreaming.py
@@ -132,12 +132,18 @@ def consolidation_reasons(
     headroom_floor_chars: int = DEFAULT_HEADROOM_FLOOR_CHARS,
     duplicate_count: int = 0,
     expiring_count: int = 0,
+    session_ending: bool = False,
 ) -> list[str]:
     """Why consolidation is due now, or an empty list when it is not.
 
     Reasons are returned rather than a bare boolean so the handoff can state its
     own cause. "It is time" and "the file is nearly full" ask for different work,
     and a brief that cannot tell them apart is a brief that says nothing.
+
+    ``session_ending`` lowers the bar to a single unconsolidated turn, because
+    the interval assumes a later turn will come and a closing session is exactly
+    where that assumption fails. Three turns and a closed laptop would otherwise
+    leave nothing behind.
     """
     if normalize_dreaming_mode(mode) == "off":
         return []
@@ -146,6 +152,8 @@ def consolidation_reasons(
     turns = _non_negative_int(state.get("turns_since_consolidation"))
     if turns >= interval:
         reasons.append(f"turn_interval_reached:{turns}/{interval}")
+    elif session_ending and turns > 0:
+        reasons.append(f"session_ending_with_unconsolidated_turns:{turns}")
     if bool(state.get("compaction_pending")):
         reasons.append("context_compaction_observed")
     if headroom_chars is not None and headroom_chars <= max(headroom_floor_chars, 0):
@@ -157,30 +165,61 @@ def consolidation_reasons(
     return reasons
 
 
+# What the executor is asked to do differs by which moment woke it. A brief
+# written because the context is about to be discarded is asking for something
+# a routine interval brief is not.
+_TRIGGER_INSTRUCTIONS = {
+    "compaction": (
+        "Context compression is about to discard messages. Extract anything durable from them "
+        "FIRST -- that material does not survive this turn."
+    ),
+    "shutdown": (
+        "Hermes is closing. Save what is worth keeping now; there is no later turn in this session."
+    ),
+    "session_end": "The session ended. Consolidate what it produced before it is only a transcript.",
+    "session_start_recovery": (
+        "A previous session ended without consolidating -- a closed laptop, a killed process, a lost "
+        "gateway. Its counters are below and its work was never reviewed."
+    ),
+    "turn": "The turn interval came due. Review recent work and consolidate what proved durable.",
+}
+
+
 def build_consolidation_handoff(
     reasons: list[str],
     *,
     block_summaries: list[dict[str, object]] | None = None,
     eviction_plan: dict[str, object] | None = None,
     mode: str = DEFAULT_DREAMING_MODE,
+    trigger: str = "manual",
+    messages_at_risk: int = 0,
+    session_id: str = "",
 ) -> dict[str, object]:
     """A prepared brief for whoever actually consolidates.
 
     OMH never executes this. It states what it observed and what it would like
     decided; Hermes' own memory tool is the only thing that can act on it.
     """
+    requested = [_TRIGGER_INSTRUCTIONS.get(trigger, "Review what is below and consolidate what is durable.")]
+    if messages_at_risk:
+        requested.append(f"{messages_at_risk} message(s) are in the buffer being compressed.")
+    requested.extend(
+        [
+            "Rewrite or merge memory through Hermes' own memory tool, not through OMH.",
+            "Leave anything you cannot source; an unsourced entry is not evidence it is wrong.",
+        ]
+    )
     return {
         "schema_version": DREAMING_HANDOFF_SCHEMA_VERSION,
         "mode": normalize_dreaming_mode(mode),
         "due": bool(reasons),
+        "trigger": trigger,
+        "session_id": session_id,
+        "messages_at_risk": messages_at_risk,
         "reasons": list(reasons),
         "blocks": list(block_summaries or []),
         "eviction_plan": dict(eviction_plan or {}),
-        "requested_of_executor": [
-            "Review the reasons and the eviction plan below.",
-            "Rewrite or merge memory through Hermes' own memory tool, not through OMH.",
-            "Leave anything you cannot source; an unsourced entry is not evidence it is wrong.",
-        ],
+        "requested_of_executor": requested,
         "redaction_policy": "metadata_only",
         "claim_boundary": (
             "A consolidation handoff is prepared context. It is not evidence that memory was "

--- a/src/plugin_bundle/omh/memory_dreaming.py
+++ b/src/plugin_bundle/omh/memory_dreaming.py
@@ -1,0 +1,200 @@
+"""Scheduling for memory consolidation -- the deterministic half of "dreaming".
+
+Letta surfaces sleep-time compute as dreaming: background subagents that review
+recent turns, consolidate what was learned, and rewrite memory without blocking
+the foreground session. The consolidation is model work. The *trigger* is not --
+it fires after a configured number of user messages, or on a context-compaction
+event.
+
+That split is the whole reason this file exists. OMH makes no model call, so it
+cannot dream. It can decide precisely when dreaming is due, on what evidence,
+and hand Hermes a prepared brief -- and Hermes already runs the consolidation
+loop itself (``agent/background_review.py`` forks after each turn with the
+memory and skill tools). The gap this closes is that the loop runs with no
+statement of what is duplicated, expiring, or out of room. It supplies that.
+
+Counting turns is deliberate and unglamorous. The sleep-time compute paper is
+explicit that the technique pays off in proportion to how predictable the next
+query is, so a scheduler that fires on a fixed interval should not be sold as
+one that fires when consolidation would help most.
+
+Stdlib only; vendored in the bundle because it is imported inside the Hermes
+process, where the ``omh`` package does not exist.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+DREAMING_STATE_SCHEMA_VERSION = "omh_memory_dreaming_state/v1"
+DREAMING_HANDOFF_SCHEMA_VERSION = "omh_memory_consolidation_handoff/v1"
+
+# Letta's server-side sleeptime default is every 5 steps; matched so the cadence
+# has a stated origin rather than being picked here.
+DEFAULT_TURN_INTERVAL = 5
+
+# Free characters below which the memory file is treated as under pressure,
+# whatever the turn count says. A full file is the failure this is meant to
+# reach before it happens, not after.
+DEFAULT_HEADROOM_FLOOR_CHARS = 300
+
+# Modes. There is no auto-launch: OMH cannot start Hermes' consolidation, so
+# offering the word would claim a capability the wrapper does not have.
+DREAMING_MODES = ("off", "reminder")
+DEFAULT_DREAMING_MODE = "reminder"
+
+
+def dreaming_state_path(omh_home: str | Path) -> Path:
+    return Path(omh_home).expanduser() / "memory" / "dreaming.json"
+
+
+def empty_dreaming_state() -> dict[str, object]:
+    return {
+        "schema_version": DREAMING_STATE_SCHEMA_VERSION,
+        "turns_since_consolidation": 0,
+        "compaction_pending": False,
+        "memory_writes_observed": 0,
+        "last_consolidated_at": "",
+        "last_reasons": [],
+    }
+
+
+def read_dreaming_state(omh_home: str | Path) -> dict[str, object]:
+    """Persisted counters, or a fresh state when absent or unusable.
+
+    Never raises. A corrupt counter file must cost at most one missed
+    consolidation, not the turn that read it.
+    """
+    path = dreaming_state_path(omh_home)
+    try:
+        if path.is_symlink() or not path.is_file():
+            return empty_dreaming_state()
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, ValueError):
+        return empty_dreaming_state()
+    if not isinstance(data, dict) or data.get("schema_version") != DREAMING_STATE_SCHEMA_VERSION:
+        return empty_dreaming_state()
+    state = empty_dreaming_state()
+    state["turns_since_consolidation"] = _non_negative_int(data.get("turns_since_consolidation"))
+    state["compaction_pending"] = bool(data.get("compaction_pending"))
+    state["memory_writes_observed"] = _non_negative_int(data.get("memory_writes_observed"))
+    state["last_consolidated_at"] = str(data.get("last_consolidated_at", "") or "")
+    state["last_reasons"] = [str(item) for item in data.get("last_reasons", []) if isinstance(item, str)]
+    return state
+
+
+def write_dreaming_state(omh_home: str | Path, state: dict[str, Any]) -> Path:
+    path = dreaming_state_path(omh_home)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(state, ensure_ascii=False, sort_keys=True), encoding="utf-8")
+    return path
+
+
+def record_turn(state: dict[str, Any]) -> dict[str, object]:
+    """One more user turn since the last consolidation."""
+    updated = dict(state)
+    updated["turns_since_consolidation"] = _non_negative_int(state.get("turns_since_consolidation")) + 1
+    return updated
+
+
+def record_compaction(state: dict[str, Any]) -> dict[str, object]:
+    """Hermes is about to discard messages; consolidation is due next chance."""
+    updated = dict(state)
+    updated["compaction_pending"] = True
+    return updated
+
+
+def record_memory_write(state: dict[str, Any]) -> dict[str, object]:
+    """Hermes wrote its own memory; the two stores may have diverged."""
+    updated = dict(state)
+    updated["memory_writes_observed"] = _non_negative_int(state.get("memory_writes_observed")) + 1
+    return updated
+
+
+def clear_after_consolidation(state: dict[str, Any], *, at: str, reasons: list[str]) -> dict[str, object]:
+    updated = dict(state)
+    updated["turns_since_consolidation"] = 0
+    updated["compaction_pending"] = False
+    updated["memory_writes_observed"] = 0
+    updated["last_consolidated_at"] = at
+    updated["last_reasons"] = list(reasons)
+    return updated
+
+
+def consolidation_reasons(
+    state: dict[str, Any],
+    *,
+    mode: str = DEFAULT_DREAMING_MODE,
+    turn_interval: int = DEFAULT_TURN_INTERVAL,
+    headroom_chars: int | None = None,
+    headroom_floor_chars: int = DEFAULT_HEADROOM_FLOOR_CHARS,
+    duplicate_count: int = 0,
+    expiring_count: int = 0,
+) -> list[str]:
+    """Why consolidation is due now, or an empty list when it is not.
+
+    Reasons are returned rather than a bare boolean so the handoff can state its
+    own cause. "It is time" and "the file is nearly full" ask for different work,
+    and a brief that cannot tell them apart is a brief that says nothing.
+    """
+    if normalize_dreaming_mode(mode) == "off":
+        return []
+    reasons: list[str] = []
+    interval = turn_interval if isinstance(turn_interval, int) and turn_interval > 0 else DEFAULT_TURN_INTERVAL
+    turns = _non_negative_int(state.get("turns_since_consolidation"))
+    if turns >= interval:
+        reasons.append(f"turn_interval_reached:{turns}/{interval}")
+    if bool(state.get("compaction_pending")):
+        reasons.append("context_compaction_observed")
+    if headroom_chars is not None and headroom_chars <= max(headroom_floor_chars, 0):
+        reasons.append(f"headroom_below_floor:{headroom_chars}<={headroom_floor_chars}")
+    if duplicate_count > 0:
+        reasons.append(f"duplicate_records:{duplicate_count}")
+    if expiring_count > 0:
+        reasons.append(f"expiring_records:{expiring_count}")
+    return reasons
+
+
+def build_consolidation_handoff(
+    reasons: list[str],
+    *,
+    block_summaries: list[dict[str, object]] | None = None,
+    eviction_plan: dict[str, object] | None = None,
+    mode: str = DEFAULT_DREAMING_MODE,
+) -> dict[str, object]:
+    """A prepared brief for whoever actually consolidates.
+
+    OMH never executes this. It states what it observed and what it would like
+    decided; Hermes' own memory tool is the only thing that can act on it.
+    """
+    return {
+        "schema_version": DREAMING_HANDOFF_SCHEMA_VERSION,
+        "mode": normalize_dreaming_mode(mode),
+        "due": bool(reasons),
+        "reasons": list(reasons),
+        "blocks": list(block_summaries or []),
+        "eviction_plan": dict(eviction_plan or {}),
+        "requested_of_executor": [
+            "Review the reasons and the eviction plan below.",
+            "Rewrite or merge memory through Hermes' own memory tool, not through OMH.",
+            "Leave anything you cannot source; an unsourced entry is not evidence it is wrong.",
+        ],
+        "redaction_policy": "metadata_only",
+        "claim_boundary": (
+            "A consolidation handoff is prepared context. It is not evidence that memory was "
+            "consolidated, that Hermes read it, or that any entry was written, changed, or removed."
+        ),
+    }
+
+
+def normalize_dreaming_mode(value: str | None) -> str:
+    mode = str(value or "").strip().lower()
+    return mode if mode in DREAMING_MODES else DEFAULT_DREAMING_MODE
+
+
+def _non_negative_int(value: Any) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        return 0
+    return value

--- a/src/plugin_bundle/omh/memory_eviction.py
+++ b/src/plugin_bundle/omh/memory_eviction.py
@@ -1,0 +1,139 @@
+"""What could be freed when Hermes' memory file has no room left.
+
+Hermes enforces its cap by refusing the write. There is no eviction policy
+behind it: the file fills, and the next thing worth remembering is simply lost.
+MemGPT -- the architecture Letta grew from -- handles the same pressure with a
+queue manager that evicts a fixed share of the oldest messages at a numeric
+threshold, which is mechanical enough for a wrapper to reproduce.
+
+Reproducing *oldest-first* is the part this deliberately does not do. Hermes
+memory entries carry no timestamp, so "oldest" is unavailable, and position in
+the file is not age. What is available is redundancy: two entries that restate
+each other cost twice and are worth once. Those are proposed here.
+
+Nothing else is. An entry that no OMH record explains is not thereby wrong --
+it is unexplained, which is a reason to ask and not a reason to delete -- so it
+is counted and left alone. The plan reports how far short the file is and what
+is provably redundant; choosing what actually goes is the executor's, through
+Hermes' own memory tool.
+
+Metadata only: indices, character counts, similarity scores. Never entry text.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .hermes_memory import DUPLICATE_SIMILARITY_THRESHOLD, HERMES_MEMORY_DELIMITER, similarity
+
+EVICTION_PLAN_SCHEMA_VERSION = "omh_memory_eviction_plan/v1"
+
+
+def build_eviction_plan(
+    entries: tuple[str, ...] | list[str],
+    *,
+    cap: int,
+    cap_source: str = "default",
+    required_chars: int = 0,
+    threshold: float = DUPLICATE_SIMILARITY_THRESHOLD,
+) -> dict[str, object]:
+    """What is redundant, and whether shedding it would make room.
+
+    ``required_chars`` is what a caller wants to write. Pass 0 to ask only
+    whether the file is redundant, not whether a specific write would fit.
+    """
+    items = [str(entry) for entry in entries]
+    chars = len(HERMES_MEMORY_DELIMITER.join(items)) if items else 0
+    headroom = max(0, cap - chars)
+    # The delimiter Hermes inserts before an appended entry is part of the cost.
+    needed = required_chars + 1 if required_chars > 0 else 0
+    shortfall = max(0, needed - headroom)
+
+    clusters = _duplicate_clusters(items, threshold)
+    reclaimable = sum(int(cluster["reclaimable_chars"]) for cluster in clusters)
+
+    return {
+        "schema_version": EVICTION_PLAN_SCHEMA_VERSION,
+        "cap": cap,
+        "cap_source": cap_source,
+        "chars": chars,
+        "entry_count": len(items),
+        "headroom_chars": headroom,
+        "required_chars": needed,
+        "shortfall_chars": shortfall,
+        "duplicate_clusters": clusters,
+        "reclaimable_chars": reclaimable,
+        "sufficient": shortfall == 0 or reclaimable >= shortfall,
+        "unexplained_entries_are_not_candidates": True,
+        "redaction_policy": "metadata_only",
+        "claim_boundary": (
+            "An eviction plan proposes what is redundant. It is not a deletion, not evidence "
+            "that Hermes memory changed, and not a judgement that an unexplained entry is wrong."
+        ),
+        "next_action": (
+            "Ask Hermes to merge or drop one entry per cluster through its own memory tool; "
+            "OMH cannot write to Hermes memory."
+        ),
+    }
+
+
+def _duplicate_clusters(entries: list[str], threshold: float) -> list[dict[str, object]]:
+    """Groups of entries that restate one another.
+
+    Single-link grouping: an entry joins a cluster when it is close enough to
+    any member, so a chain of rewordings lands in one group rather than several
+    overlapping pairs. The character count kept is the longest member's, on the
+    assumption that the fullest statement is the one worth keeping -- which is a
+    proposal for a reader, not a decision taken here.
+    """
+    clusters: list[list[int]] = []
+    for index, entry in enumerate(entries):
+        for cluster in clusters:
+            if any(similarity(entry, entries[member]) >= threshold for member in cluster):
+                cluster.append(index)
+                break
+        else:
+            clusters.append([index])
+
+    rows: list[dict[str, object]] = []
+    for cluster in clusters:
+        if len(cluster) < 2:
+            continue
+        sizes = [len(entries[member]) for member in cluster]
+        keep = max(sizes)
+        rows.append(
+            {
+                "entry_indices": list(cluster),
+                "entry_chars": sizes,
+                "keep_chars": keep,
+                # Dropping every member but the longest, delimiters included.
+                "reclaimable_chars": sum(sizes) - keep + (len(cluster) - 1),
+                "min_similarity": round(_min_pairwise_similarity(entries, cluster), 2),
+            }
+        )
+    return rows
+
+
+def _min_pairwise_similarity(entries: list[str], cluster: list[int]) -> float:
+    scores = [
+        similarity(entries[left], entries[right])
+        for position, left in enumerate(cluster)
+        for right in cluster[position + 1 :]
+    ]
+    return min(scores) if scores else 0.0
+
+
+def eviction_plan_summary(plan: dict[str, Any]) -> str:
+    """One line an operator can read without opening the payload."""
+    if not isinstance(plan, dict):
+        return "No eviction plan."
+    shortfall = int(plan.get("shortfall_chars", 0) or 0)
+    reclaimable = int(plan.get("reclaimable_chars", 0) or 0)
+    clusters = len(plan.get("duplicate_clusters", []) or [])
+    if shortfall == 0:
+        if clusters == 0:
+            return "Memory has room and no redundant entries."
+        return f"Memory has room; {clusters} redundant group(s) worth {reclaimable} chars remain."
+    if reclaimable >= shortfall:
+        return f"Short {shortfall} chars; {clusters} redundant group(s) could free {reclaimable}."
+    return f"Short {shortfall} chars; only {reclaimable} chars are provably redundant."

--- a/src/plugin_bundle/omh/memory_provider.py
+++ b/src/plugin_bundle/omh/memory_provider.py
@@ -1,0 +1,283 @@
+"""OMH as a Hermes memory provider: the lane that runs without being called.
+
+Everything OMH knew about memory used to require someone to ask. `omh memory
+status` had the comparison, the `omh_memory` tool had it after PR #672, and both
+waited for a question. Meanwhile Hermes' own memory kept being written by
+``agent/background_review.py``, which forks after each turn and decides for
+itself what to save -- with nothing telling it what OMH already holds, what is
+duplicated, or how little room is left.
+
+Hermes exposes the seam for this and OMH was not standing in it.
+``plugins/memory/__init__.py`` scans ``$HERMES_HOME/plugins/<name>/`` as well as
+its own bundled directory, which is where the OMH bundle already installs, and
+``agent/memory_provider.py`` defines the lifecycle. Four of its hooks are the
+ones that matter here:
+
+- ``prefetch``       -- runs before every API call, so recall arrives unasked
+- ``on_pre_compress``-- runs before compression discards messages
+- ``on_memory_write``-- runs when Hermes writes its own memory, giving provenance
+- ``on_session_end`` -- runs at a session boundary, where consolidation belongs
+
+No tool schemas are exposed. ``memory_provider.py`` gives tool-schema bloat as
+the reason only one external provider may run at a time, and OMH already
+registers ten tools through the plugin path; the on-demand block read belongs on
+``omh_memory``, which exists, rather than on a second registration path that
+Hermes gates behind toolset config.
+
+OMH still makes no model call and still cannot write Hermes memory. This
+provider reads OMH's own store, renders it, and records what it saw.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+try:  # Present only inside the Hermes process.
+    from agent.memory_provider import MemoryProvider as _MemoryProviderBase
+except ImportError:  # pragma: no cover - exercised by the repo's own test run
+    _MemoryProviderBase = object
+
+from .hermes_memory import read_hermes_memory
+from .memory_blocks import (
+    DEFAULT_SYSTEM_RENDER_BUDGET_CHARS,
+    REFERENCE_TIER,
+    SYSTEM_TIER,
+    read_memory_blocks,
+    render_block_index,
+    render_memory_blocks,
+)
+from .memory_dreaming import (
+    build_consolidation_handoff,
+    clear_after_consolidation,
+    consolidation_reasons,
+    read_dreaming_state,
+    record_compaction,
+    record_memory_write,
+    record_turn,
+    write_dreaming_state,
+)
+from .memory_eviction import build_eviction_plan
+
+PROVIDER_NAME = "omh"
+WRITE_JOURNAL_SCHEMA_VERSION = "omh_memory_write_journal_entry/v1"
+
+# Hermes states that only a primary agent should write; a cron or subagent
+# context replaying its own system prompt would otherwise move the counters that
+# decide when consolidation is due.
+_WRITING_CONTEXTS = frozenset({"", "primary"})
+
+
+class OmhMemoryProvider(_MemoryProviderBase):
+    """Deterministic, file-backed recall for Hermes. No model call, no network."""
+
+    def __init__(self, omh_home: str | Path | None = None) -> None:
+        self._omh_home = Path(omh_home).expanduser() if omh_home else _default_omh_home()
+        self._hermes_home: Path | None = None
+        self._session_id = ""
+        self._writes_enabled = True
+        # prefetch() is called before every API call and the base class asks for
+        # it to be fast, so the pack is rendered off the hot path and served
+        # from here.
+        self._pack = ""
+
+    @property
+    def name(self) -> str:
+        return PROVIDER_NAME
+
+    # -- Core lifecycle -----------------------------------------------------
+
+    def is_available(self) -> bool:
+        """True when there is an OMH home to read. Never touches the network."""
+        try:
+            return self._omh_home.is_dir()
+        except OSError:
+            return False
+
+    def initialize(self, session_id: str, **kwargs: Any) -> None:
+        self._session_id = str(session_id or "")
+        hermes_home = kwargs.get("hermes_home")
+        self._hermes_home = Path(str(hermes_home)).expanduser() if hermes_home else None
+        self._writes_enabled = str(kwargs.get("agent_context", "") or "") in _WRITING_CONTEXTS
+        self._pack = self.render_pack()
+
+    def get_tool_schemas(self) -> list[dict[str, Any]]:
+        """None. The on-demand block read lives on the existing `omh_memory` tool."""
+        return []
+
+    def prefetch(self, query: str = "", *, session_id: str = "") -> str:
+        return self._pack
+
+    def queue_prefetch(self, query: str = "", *, session_id: str = "") -> None:
+        """Re-render for the next turn, which is where the base class puts this work."""
+        self._pack = self.render_pack()
+
+    def shutdown(self) -> None:
+        self._pack = ""
+
+    # -- Optional hooks -----------------------------------------------------
+
+    def on_turn_start(self, turn_number: int, message: str = "", **kwargs: Any) -> None:
+        if not self._writes_enabled:
+            return
+        self._mutate_state(record_turn)
+
+    def on_pre_compress(self, messages: list[dict[str, Any]] | None = None) -> str:
+        """Hand the compressor what must survive it, and note that it happened.
+
+        Compaction is one of the two triggers Letta uses for dreaming, and it is
+        the more informative one: the session just proved it outgrew its context.
+        """
+        if self._writes_enabled:
+            self._mutate_state(record_compaction)
+        blocks = read_memory_blocks(self._omh_home, tier=SYSTEM_TIER)
+        if not blocks:
+            return ""
+        return render_memory_blocks(blocks, budget_chars=DEFAULT_SYSTEM_RENDER_BUDGET_CHARS)
+
+    def on_memory_write(
+        self,
+        action: str,
+        target: str,
+        content: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        """Record that Hermes wrote, and what shape the entry was -- never its text.
+
+        This is the hook that closes the provenance gap. Entries written by the
+        background review used to appear in MEMORY.md with nothing recording that
+        they had been written, by what, or when; OMH could only observe, later,
+        that some entry matched no record it held.
+        """
+        if not self._writes_enabled:
+            return
+        self._append_write_journal(action, target, content, metadata)
+        self._mutate_state(record_memory_write)
+
+    def on_session_end(self, messages: list[dict[str, Any]] | None = None) -> None:
+        if not self._writes_enabled:
+            return
+        self.consolidation_due()
+
+    # -- Deterministic work, exposed for the CLI and for tests --------------
+
+    def render_pack(self) -> str:
+        """System blocks in full, reference blocks by label only."""
+        system = render_memory_blocks(
+            read_memory_blocks(self._omh_home, tier=SYSTEM_TIER),
+            budget_chars=DEFAULT_SYSTEM_RENDER_BUDGET_CHARS,
+        )
+        index = render_block_index(read_memory_blocks(self._omh_home, tier=REFERENCE_TIER))
+        return "\n".join(part for part in (system, index) if part)
+
+    def consolidation_due(self) -> dict[str, object]:
+        """Decide whether dreaming is due; write the brief when it is.
+
+        Returns the handoff either way so a caller can see the reasons that were
+        weighed, not only the ones that fired.
+        """
+        state = read_dreaming_state(self._omh_home)
+        reading = self._memory_reading()
+        headroom = reading.headroom_chars if reading is not None else None
+        plan = (
+            build_eviction_plan(reading.entries, cap=reading.cap, cap_source=reading.cap_source)
+            if reading is not None
+            else {}
+        )
+        reasons = consolidation_reasons(
+            state,
+            headroom_chars=headroom,
+            duplicate_count=len(plan.get("duplicate_clusters", []) or []),
+        )
+        handoff = build_consolidation_handoff(
+            reasons,
+            block_summaries=[block.to_summary() for block in read_memory_blocks(self._omh_home)],
+            eviction_plan=plan,
+        )
+        if reasons:
+            self._write_handoff(handoff)
+            write_dreaming_state(
+                self._omh_home,
+                clear_after_consolidation(state, at=_utc_now(), reasons=reasons),
+            )
+        return handoff
+
+    # -- Internals ----------------------------------------------------------
+
+    def _memory_reading(self):
+        if self._hermes_home is None:
+            return None
+        try:
+            readings = read_hermes_memory(self._hermes_home)
+        except OSError:
+            return None
+        return next((item for item in readings if item.label == "MEMORY.md" and item.exists), None)
+
+    def _mutate_state(self, mutate) -> None:
+        state = read_dreaming_state(self._omh_home)
+        self._safely(lambda: write_dreaming_state(self._omh_home, mutate(state)))
+
+    def _write_handoff(self, handoff: dict[str, object]) -> None:
+        path = self._omh_home / "memory" / "consolidation.json"
+        self._safely(
+            lambda: _write_text(path, json.dumps(handoff, ensure_ascii=False, sort_keys=True))
+        )
+
+    def _append_write_journal(
+        self,
+        action: str,
+        target: str,
+        content: str,
+        metadata: dict[str, Any] | None,
+    ) -> None:
+        text = str(content or "")
+        entry = {
+            "schema_version": WRITE_JOURNAL_SCHEMA_VERSION,
+            "observed_at": _utc_now(),
+            "action": str(action or ""),
+            "target": str(target or ""),
+            "chars": len(text),
+            "sha256": hashlib.sha256(text.encode("utf-8")).hexdigest(),
+            "session_id": self._session_id,
+            "write_origin": str((metadata or {}).get("write_origin", "") or ""),
+            "execution_context": str((metadata or {}).get("execution_context", "") or ""),
+            "redaction_policy": "metadata_only",
+        }
+        path = self._omh_home / "memory" / "write_journal.jsonl"
+        self._safely(lambda: _append_line(path, json.dumps(entry, ensure_ascii=False, sort_keys=True)))
+
+    @staticmethod
+    def _safely(write) -> None:
+        """A memory-provider write must never take down the turn that triggered it.
+
+        Hermes calls these hooks inside a live conversation. A read-only home, a
+        full disk, or a racing writer is a lost journal line -- not a failed turn
+        -- so the failure is swallowed here and nowhere else in this module.
+        """
+        try:
+            write()
+        except OSError:
+            return
+
+
+def _write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _append_line(path: Path, line: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(line + "\n")
+
+
+def _default_omh_home() -> Path:
+    return Path(os.path.expandvars(os.environ.get("OMH_HOME", "") or "~/.omh")).expanduser()
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")

--- a/src/plugin_bundle/omh/memory_provider.py
+++ b/src/plugin_bundle/omh/memory_provider.py
@@ -71,6 +71,12 @@ WRITE_JOURNAL_SCHEMA_VERSION = "omh_memory_write_journal_entry/v1"
 # decide when consolidation is due.
 _WRITING_CONTEXTS = frozenset({"", "primary"})
 
+# Moments after which this session gets no further turn. The turn interval
+# assumes a later turn will come; at these it will not, so a single
+# unconsolidated turn is enough. `session_start_recovery` belongs here because
+# it is settling the account of a session that already ended without one.
+_SESSION_ENDING_TRIGGERS = frozenset({"session_end", "shutdown", "session_start_recovery"})
+
 
 class OmhMemoryProvider(_MemoryProviderBase):
     """Deterministic, file-backed recall for Hermes. No model call, no network."""
@@ -104,6 +110,11 @@ class OmhMemoryProvider(_MemoryProviderBase):
         self._hermes_home = Path(str(hermes_home)).expanduser() if hermes_home else None
         self._writes_enabled = str(kwargs.get("agent_context", "") or "") in _WRITING_CONTEXTS
         self._pack = self.render_pack()
+        # A session that died rather than ended -- a killed process, a closed
+        # laptop, a lost gateway -- never reaches on_session_end, so nothing
+        # would ever act on the turns it accumulated. The counters survived on
+        # disk; this is where they are honoured.
+        self._evaluate_if_due("session_start_recovery")
 
     def get_tool_schemas(self) -> list[dict[str, Any]]:
         """None. The on-demand block read lives on the existing `omh_memory` tool."""
@@ -117,6 +128,8 @@ class OmhMemoryProvider(_MemoryProviderBase):
         self._pack = self.render_pack()
 
     def shutdown(self) -> None:
+        """Hermes is closing. Last chance to leave a brief behind."""
+        self._evaluate_if_due("shutdown")
         self._pack = ""
 
     # -- Optional hooks -----------------------------------------------------
@@ -125,15 +138,21 @@ class OmhMemoryProvider(_MemoryProviderBase):
         if not self._writes_enabled:
             return
         self._mutate_state(record_turn)
+        self._evaluate_if_due("turn")
 
     def on_pre_compress(self, messages: list[dict[str, Any]] | None = None) -> str:
         """Hand the compressor what must survive it, and note that it happened.
 
         Compaction is one of the two triggers Letta uses for dreaming, and it is
         the more informative one: the session just proved it outgrew its context.
+        It is also the one place where waiting costs something real -- the brief
+        has to exist *before* the messages go, not at whatever later moment the
+        session happens to end -- so the evaluation runs here rather than being
+        deferred with a flag.
         """
         if self._writes_enabled:
             self._mutate_state(record_compaction)
+            self._evaluate_if_due("compaction", messages_at_risk=len(messages or []))
         blocks = read_memory_blocks(self._omh_home, tier=SYSTEM_TIER)
         if not blocks:
             return ""
@@ -159,11 +178,22 @@ class OmhMemoryProvider(_MemoryProviderBase):
         self._mutate_state(record_memory_write)
 
     def on_session_end(self, messages: list[dict[str, Any]] | None = None) -> None:
-        if not self._writes_enabled:
-            return
-        self.consolidation_due()
+        self._evaluate_if_due("session_end")
 
     # -- Deterministic work, exposed for the CLI and for tests --------------
+
+    def _evaluate_if_due(self, trigger: str, *, messages_at_risk: int = 0) -> dict[str, object] | None:
+        """Weigh the triggers at one of the moments memory can be lost.
+
+        Every trigger point calls this: each turn, compaction, session end,
+        shutdown, and the start of the next session. Deferring the decision to
+        session end alone -- which is what this did first -- means a laptop that
+        closes mid-session writes nothing at all, and a turn interval that comes
+        due at turn 5 waits until whenever the session happens to stop.
+        """
+        if not self._writes_enabled:
+            return None
+        return self.consolidation_due(trigger=trigger, messages_at_risk=messages_at_risk)
 
     def render_pack(self) -> str:
         """System blocks in full, reference blocks by label only."""
@@ -174,7 +204,7 @@ class OmhMemoryProvider(_MemoryProviderBase):
         index = render_block_index(read_memory_blocks(self._omh_home, tier=REFERENCE_TIER))
         return "\n".join(part for part in (system, index) if part)
 
-    def consolidation_due(self) -> dict[str, object]:
+    def consolidation_due(self, *, trigger: str = "manual", messages_at_risk: int = 0) -> dict[str, object]:
         """Decide whether dreaming is due; write the brief when it is.
 
         Returns the handoff either way so a caller can see the reasons that were
@@ -192,11 +222,15 @@ class OmhMemoryProvider(_MemoryProviderBase):
             state,
             headroom_chars=headroom,
             duplicate_count=len(plan.get("duplicate_clusters", []) or []),
+            session_ending=trigger in _SESSION_ENDING_TRIGGERS,
         )
         handoff = build_consolidation_handoff(
             reasons,
             block_summaries=[block.to_summary() for block in read_memory_blocks(self._omh_home)],
             eviction_plan=plan,
+            trigger=trigger,
+            messages_at_risk=messages_at_risk,
+            session_id=self._session_id,
         )
         if reasons:
             self._write_handoff(handoff)
@@ -222,10 +256,17 @@ class OmhMemoryProvider(_MemoryProviderBase):
         self._safely(lambda: write_dreaming_state(self._omh_home, mutate(state)))
 
     def _write_handoff(self, handoff: dict[str, object]) -> None:
-        path = self._omh_home / "memory" / "consolidation.json"
-        self._safely(
-            lambda: _write_text(path, json.dumps(handoff, ensure_ascii=False, sort_keys=True))
-        )
+        """Latest brief where a reader looks; every brief where none is lost.
+
+        Consolidation can come due more than once before anyone acts on it -- a
+        turn interval, then a compaction, then a shutdown. Writing only the
+        latest would mean the compaction brief, the one whose material is
+        already gone, is the one overwritten.
+        """
+        directory = self._omh_home / "memory"
+        payload = json.dumps(handoff, ensure_ascii=False, sort_keys=True)
+        self._safely(lambda: _write_text(directory / "consolidation.json", payload))
+        self._safely(lambda: _append_line(directory / "consolidation.jsonl", payload))
 
     def _append_write_journal(
         self,

--- a/src/plugin_bundle/omh/metadata.py
+++ b/src/plugin_bundle/omh/metadata.py
@@ -30,3 +30,8 @@ TOOL_FILE_STEMS = {
 }
 
 TOOLS_REQUIRING_ROLE_CATALOG = frozenset({"omh_role"})
+
+# The name Hermes' `memory.provider` config key must carry for OMH's provider to
+# load. Hermes runs at most one external provider, so selecting it is an opt-in
+# the operator makes, never something setup does on their behalf.
+MEMORY_PROVIDER_NAME = "omh"

--- a/src/plugin_bundle/omh/plugin.yaml
+++ b/src/plugin_bundle/omh/plugin.yaml
@@ -1,7 +1,8 @@
 name: omh
 version: "1.0.3"
-description: "Oh My Hermes native bridge for metadata-only runtime status, HUD, role context, bounded evidence probes, and evidence-boundary context."
+description: "Oh My Hermes native bridge for metadata-only runtime status, HUD, role context, bounded evidence probes, evidence-boundary context, and a deterministic file-backed memory provider."
 author: oh-my-hermes maintainers
+provides_memory_provider: omh
 provides_tools:
   - omh_capabilities
   - omh_context

--- a/src/plugin_bundle/omh/tools/memory_tool.py
+++ b/src/plugin_bundle/omh/tools/memory_tool.py
@@ -1,14 +1,27 @@
 """Let Hermes see how its own memory relates to OMH's approved records.
 
-PR #672 built the comparison but left it CLI-only: `omh memory status` carries
+PR #672 built the comparison but left it CLI-only: `omh memory status` carried
 it, and none of the nine registered tools did, so the model could not reach it
 from chat. That is the half of the problem #672 did not close -- the store had
 governance and no outlet.
 
-Metadata only, like every other OMH ledger: record ids, character counts,
-similarity scores, entry indices and hashes. Never the text of a memory entry.
-Read-only: Hermes owns `~/.hermes/memories`, and the `memory` tool Hermes
-exposes to the model is what edits it.
+The tool later grew a second job. OMH's memory blocks split into a tier that
+renders every turn and a tier that is listed by label and read on request, and
+the second tier only means anything if something can perform the read. That
+something is this tool rather than a memory-provider tool schema: Hermes gates
+provider tools behind toolset config (``memory_provider_tools_enabled`` in
+``agent/memory_manager.py``), so a tier built on one would disappear for any
+operator whose toolsets exclude memory, and ``agent/memory_provider.py`` names
+tool-schema bloat as the reason only one external provider may run at all.
+
+Two different redaction rules meet here, and they do not merge. OMH block values
+are OMH's own content and are returned in full. Hermes memory entries are not
+OMH's, are never returned, and appear only as counts, hashes, and similarity
+scores -- the same boundary this file has always held.
+
+Read-only with respect to Hermes: nothing here opens a Hermes file for writing.
+Hermes owns ``~/.hermes/memories``, and the `memory` tool Hermes exposes to the
+model is what edits it.
 """
 
 from __future__ import annotations
@@ -19,18 +32,35 @@ import os
 from ..degradation import safe_error_type as _safe_error_type
 from ..hermes_memory import build_hermes_memory_bridge
 from ..host_observation import OBSERVATION_SCHEMA, attach_public_observation, observe_plugin_tool_call
+from ..memory_blocks import read_memory_block, read_memory_blocks
+from ..memory_dreaming import read_dreaming_state
+from ..memory_provider import OmhMemoryProvider
+
+MEMORY_ACTIONS = ("status", "blocks", "read", "consolidation")
 
 OMH_MEMORY_SCHEMA = {
     "name": "omh_memory",
     "description": (
-        "Compare Hermes' built-in memory (MEMORY.md, USER.md) against OMH's approved project "
-        "records: what Hermes already holds, what OMH holds that it does not, and whether the "
-        "next record fits under Hermes' character cap. Metadata-only and read-only; OMH cannot "
+        "Read OMH's durable memory and how it relates to Hermes' own. Actions: 'status' "
+        "compares Hermes' built-in memory (MEMORY.md, USER.md) against OMH's approved records "
+        "and reports what fits under Hermes' character cap; 'blocks' lists OMH memory blocks by "
+        "label without their values; 'read' returns one block's value by label; 'consolidation' "
+        "reports whether memory consolidation is due and why. OMH block values are returned in "
+        "full; Hermes memory entries are never returned, only counted and hashed. OMH cannot "
         "change Hermes memory."
     ),
     "parameters": {
         "type": "object",
         "properties": {
+            "action": {
+                "type": "string",
+                "enum": list(MEMORY_ACTIONS),
+                "description": "Which view to return. Defaults to 'status'.",
+            },
+            "label": {
+                "type": "string",
+                "description": "Block label, required by the 'read' action.",
+            },
             "observation": OBSERVATION_SCHEMA,
         },
     },
@@ -39,8 +69,19 @@ OMH_MEMORY_SCHEMA = {
 
 def omh_memory_handler(args: dict, **kwargs) -> str:
     observation = observe_plugin_tool_call("omh_memory", args, kwargs)
-    payload, backend = _memory_bridge()
+    action = str((args or {}).get("action", "") or "status").strip().lower()
+    if action not in MEMORY_ACTIONS:
+        payload, backend = _unknown_action(action), "bundle_memory"
+    elif action == "blocks":
+        payload, backend = _blocks(), "bundle_memory"
+    elif action == "read":
+        payload, backend = _read_block(str((args or {}).get("label", "") or "")), "bundle_memory"
+    elif action == "consolidation":
+        payload, backend = _consolidation()
+    else:
+        payload, backend = _memory_bridge()
     payload["plugin_tool"] = "omh_memory"
+    payload["action"] = action
     payload["source_backend"] = backend
     return json.dumps(attach_public_observation(payload, observation), sort_keys=True)
 
@@ -67,6 +108,83 @@ def _memory_bridge() -> tuple[dict[str, object], str]:
         return _unavailable(_safe_error_type(type(exc).__name__)), "bundle_memory_error"
 
 
+def _blocks() -> dict[str, object]:
+    """Every block by label, without values -- the listing the tier split needs."""
+    blocks = read_memory_blocks(_home("OMH_HOME", "~/.omh"))
+    return {
+        "schema_version": "omh_memory_block_listing/v1",
+        "blocks": [block.to_summary() for block in blocks],
+        "block_count": len(blocks),
+        "next_action": "Call this tool again with action='read' and a label to read one block.",
+        "claim_boundary": (
+            "Block metadata is prepared OMH context. It is not evidence that Hermes read a "
+            "block, or that any memory was written or changed."
+        ),
+    }
+
+
+def _read_block(label: str) -> dict[str, object]:
+    """One block's value, or a stated miss.
+
+    A missing block returns ``found: false`` rather than an empty value, so an
+    absent block is never mistaken for a block that has nothing to say.
+    """
+    if not label:
+        return {
+            "schema_version": "omh_memory_block_read/v1",
+            "found": False,
+            "reason": "label_required",
+            "next_action": "Call action='blocks' to list available labels.",
+        }
+    for block in read_memory_blocks(_home("OMH_HOME", "~/.omh")):
+        if block.label == label:
+            return {
+                "schema_version": "omh_memory_block_read/v1",
+                "found": True,
+                "block": block.to_dict(),
+                "claim_boundary": (
+                    "A block value is prepared OMH context, not execution, review, CI, merge, "
+                    "or Hermes internal-memory evidence."
+                ),
+            }
+    return {
+        "schema_version": "omh_memory_block_read/v1",
+        "found": False,
+        "reason": "unknown_label",
+        "label": label,
+        "next_action": "Call action='blocks' to list available labels.",
+    }
+
+
+def _consolidation() -> tuple[dict[str, object], str]:
+    """Whether dreaming is due, and on what evidence.
+
+    This never runs consolidation. OMH cannot: the work needs a model, and the
+    only thing that consolidates Hermes memory is Hermes.
+    """
+    omh_home = _home("OMH_HOME", "~/.omh")
+    try:
+        provider = OmhMemoryProvider(omh_home)
+        provider.initialize("", hermes_home=_home("HERMES_HOME", "~/.hermes"))
+        payload = dict(provider.consolidation_due())
+        payload["state"] = read_dreaming_state(omh_home)
+        return payload, "bundle_memory"
+    except Exception as exc:
+        return _unavailable(_safe_error_type(type(exc).__name__)), "bundle_memory_error"
+
+
+def _unknown_action(action: str) -> dict[str, object]:
+    return {
+        "schema_version": "omh_memory_unknown_action/v1",
+        "status": "unavailable",
+        "reason": "unknown_action",
+        "requested_action": action,
+        "supported_actions": list(MEMORY_ACTIONS),
+        "next_action": f"Retry with one of: {', '.join(MEMORY_ACTIONS)}.",
+        "claim_boundary": "No memory view was produced. This is not evidence about memory state.",
+    }
+
+
 def _home(variable: str, default: str) -> str:
     return os.path.expandvars(os.environ.get(variable, "") or default)
 
@@ -82,3 +200,6 @@ def _unavailable(reason: str) -> dict[str, object]:
             "in sync, or readable."
         ),
     }
+
+
+__all__ = ["MEMORY_ACTIONS", "OMH_MEMORY_SCHEMA", "omh_memory_handler", "read_memory_block"]

--- a/tests/test_broad_exception_policy.py
+++ b/tests/test_broad_exception_policy.py
@@ -153,6 +153,14 @@ CLASSIFIED_SITES: tuple[ClassifiedSite, ...] = (
         "the truth is that OMH could not read the file.",
     ),
     ClassifiedSite(
+        "src/plugin_bundle/omh/tools/memory_tool.py",
+        "_consolidation",
+        INTENTIONAL,
+        "Returns the distinct `bundle_memory_error` source plus a sanitized error type. Reporting "
+        "`due: false` instead would say consolidation is not needed when the truth is that OMH "
+        "could not work out whether it was.",
+    ),
+    ClassifiedSite(
         "src/plugin_bundle/omh/tools/recommend_tool.py",
         "_recommendations",
         INTENTIONAL,
@@ -164,8 +172,8 @@ CLASSIFIED_SITES: tuple[ClassifiedSite, ...] = (
 # Ruff reports one hit per handler; the inventory is keyed per enclosing
 # function, and `_is_catalog_question` holds two handlers, so the two totals
 # differ by exactly one.
-EXPECTED_HANDLER_COUNT = 12
-EXPECTED_ANCHOR_COUNT = 11
+EXPECTED_HANDLER_COUNT = 13
+EXPECTED_ANCHOR_COUNT = 12
 
 
 class DerivedSite(NamedTuple):

--- a/tests/test_memory_provider.py
+++ b/tests/test_memory_provider.py
@@ -348,14 +348,18 @@ class ProviderLifecycleTests(unittest.TestCase):
             provider.on_memory_write("add", "memory", "text")
             self.assertEqual(read_dreaming_state(root / ".omh"), empty_dreaming_state())
 
-    def test_compaction_hands_back_system_blocks_and_arms_the_trigger(self) -> None:
+    def test_compaction_hands_back_system_blocks_and_consolidates_at_once(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)
             write_memory_block(root / ".omh", build_memory_block("facts", "must survive compaction"))
             provider = self._provider(root)
             preserved = provider.on_pre_compress([{"role": "user", "content": "hi"}])
+
             self.assertIn("must survive compaction", preserved)
-            self.assertTrue(read_dreaming_state(root / ".omh")["compaction_pending"])
+            # The flag is cleared because the brief was written here rather than
+            # deferred; waiting would put it after the material it describes.
+            self.assertFalse(read_dreaming_state(root / ".omh")["compaction_pending"])
+            self.assertTrue((root / ".omh" / "memory" / "consolidation.json").exists())
 
     def test_consolidation_writes_a_brief_only_when_it_is_due(self) -> None:
         with TemporaryDirectory() as tmp:
@@ -366,13 +370,13 @@ class ProviderLifecycleTests(unittest.TestCase):
             self.assertFalse(provider.consolidation_due()["due"])
             self.assertFalse(handoff_path.exists())
 
-            for _ in range(DEFAULT_TURN_INTERVAL):
-                provider.on_turn_start(1, "hello")
-            handoff = provider.consolidation_due()
-            self.assertTrue(handoff["due"])
+            for turn in range(1, DEFAULT_TURN_INTERVAL + 1):
+                provider.on_turn_start(turn, "hello")
             self.assertTrue(handoff_path.exists())
-            # Firing resets the counters, so the next turn does not re-fire.
+            # The interval fired on the turn itself and reset the counters, so
+            # asking again straight after finds nothing further due.
             self.assertEqual(read_dreaming_state(root / ".omh")["turns_since_consolidation"], 0)
+            self.assertFalse(provider.consolidation_due()["due"])
 
     def test_the_brief_never_claims_consolidation_happened(self) -> None:
         with TemporaryDirectory() as tmp:
@@ -394,6 +398,142 @@ class ProviderLifecycleTests(unittest.TestCase):
             provider = self._provider(root)
             with patch("omh.plugin_bundle.omh.memory_provider._append_line", side_effect=OSError("read-only")):
                 provider.on_memory_write("add", "memory", "text")  # must not raise
+
+
+class LossPreventionTests(unittest.TestCase):
+    """The four moments memory can be lost, and that each one leaves a brief.
+
+    The first implementation evaluated only at `on_session_end`. Turns and
+    compaction set counters nobody read until then, so a laptop closed
+    mid-session wrote nothing at all and a turn interval that came due at turn 5
+    waited for whenever the session happened to stop. These pin the fix.
+    """
+
+    def _provider(self, root: Path, session: str = "s1") -> OmhMemoryProvider:
+        provider = OmhMemoryProvider(root / ".omh")
+        provider.initialize(session, hermes_home=str(root / ".hermes"), agent_context="primary")
+        return provider
+
+    def _briefs(self, root: Path) -> list[dict]:
+        path = root / ".omh" / "memory" / "consolidation.jsonl"
+        return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()] if path.exists() else []
+
+    def test_the_turn_interval_fires_mid_session_not_at_the_end(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            provider = self._provider(root)
+            for turn in range(1, DEFAULT_TURN_INTERVAL):
+                provider.on_turn_start(turn, "hi")
+            self.assertEqual(self._briefs(root), [])
+
+            provider.on_turn_start(DEFAULT_TURN_INTERVAL, "hi")
+            briefs = self._briefs(root)
+            self.assertEqual(len(briefs), 1)
+            self.assertEqual(briefs[0]["trigger"], "turn")
+
+    def test_the_interval_keeps_firing_on_every_further_cycle(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            provider = self._provider(root)
+            for turn in range(1, DEFAULT_TURN_INTERVAL * 2 + 1):
+                provider.on_turn_start(turn, "hi")
+            self.assertEqual(len(self._briefs(root)), 2)
+
+    def test_compaction_writes_its_brief_before_the_messages_go(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            provider = self._provider(root)
+            provider.on_turn_start(1, "hi")
+            provider.on_pre_compress([{"role": "user", "content": "x"}] * 40)
+
+            briefs = self._briefs(root)
+            self.assertEqual(len(briefs), 1)
+            self.assertEqual(briefs[0]["trigger"], "compaction")
+            self.assertEqual(briefs[0]["messages_at_risk"], 40)
+            self.assertIn("about to discard", briefs[0]["requested_of_executor"][0])
+
+    def test_shutdown_consolidates_even_below_the_interval(self) -> None:
+        # Three turns and a closed lid would otherwise leave nothing behind: the
+        # interval assumes a later turn, and a closing session has none.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            provider = self._provider(root)
+            for turn in range(1, 4):
+                provider.on_turn_start(turn, "hi")
+            provider.shutdown()
+
+            briefs = self._briefs(root)
+            self.assertEqual(len(briefs), 1)
+            self.assertEqual(briefs[0]["trigger"], "shutdown")
+            self.assertIn("session_ending_with_unconsolidated_turns:3", briefs[0]["reasons"])
+
+    def test_session_end_consolidates_even_below_the_interval(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            provider = self._provider(root)
+            provider.on_turn_start(1, "hi")
+            provider.on_session_end([])
+            self.assertEqual(self._briefs(root)[0]["trigger"], "session_end")
+
+    def test_a_session_that_died_is_settled_when_the_next_one_starts(self) -> None:
+        # A killed process reaches no hook at all. The counters are on disk, so
+        # the next startup is the first moment anything can act on them.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            died = self._provider(root, "dead-session")
+            for turn in range(1, 4):
+                died.on_turn_start(turn, "hi")
+            self.assertEqual(self._briefs(root), [])
+            del died
+
+            self._provider(root, "next-session")
+            briefs = self._briefs(root)
+            self.assertEqual(len(briefs), 1)
+            self.assertEqual(briefs[0]["trigger"], "session_start_recovery")
+            self.assertIn("closed laptop", briefs[0]["requested_of_executor"][0])
+
+    def test_a_clean_start_recovers_nothing_and_says_nothing(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._provider(root)
+            self.assertEqual(self._briefs(root), [])
+
+    def test_briefs_accumulate_so_an_earlier_one_is_never_overwritten(self) -> None:
+        # The compaction brief describes material that is already gone; losing
+        # it to a later shutdown brief would defeat the point.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            provider = self._provider(root)
+            provider.on_turn_start(1, "hi")
+            provider.on_pre_compress([{"role": "user"}])
+            provider.on_turn_start(2, "hi")
+            provider.shutdown()
+
+            triggers = [brief["trigger"] for brief in self._briefs(root)]
+            self.assertEqual(triggers, ["compaction", "shutdown"])
+            latest = json.loads((root / ".omh" / "memory" / "consolidation.json").read_text(encoding="utf-8"))
+            self.assertEqual(latest["trigger"], "shutdown")
+
+    def test_a_fired_trigger_does_not_immediately_refire(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            provider = self._provider(root)
+            for turn in range(1, DEFAULT_TURN_INTERVAL + 1):
+                provider.on_turn_start(turn, "hi")
+            self.assertEqual(len(self._briefs(root)), 1)
+            provider.on_session_end([])
+            self.assertEqual(len(self._briefs(root)), 1)
+
+    def test_a_non_primary_context_never_writes_a_brief(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            provider = OmhMemoryProvider(root / ".omh")
+            provider.initialize("cron-1", hermes_home=str(root / ".hermes"), agent_context="cron")
+            for turn in range(1, DEFAULT_TURN_INTERVAL + 2):
+                provider.on_turn_start(turn, "hi")
+            provider.on_pre_compress([{"role": "user"}])
+            provider.shutdown()
+            self.assertEqual(self._briefs(root), [])
 
 
 class MemoryToolActionTests(unittest.TestCase):

--- a/tests/test_memory_provider.py
+++ b/tests/test_memory_provider.py
@@ -1,0 +1,640 @@
+"""OMH's memory blocks, dreaming scheduler, eviction plan, and Hermes provider.
+
+The defect these close is that everything OMH knew about memory had to be asked
+for. Hermes wrote its own memory after every turn through
+``agent/background_review.py`` with no statement of what OMH already held, and
+OMH could only notice afterwards that some entry matched no record it kept.
+
+Three boundaries are load-bearing enough to be pinned here rather than described:
+
+- A block value is OMH's own content and is returned in full. A Hermes memory
+  entry is not, and never appears outside a count or a hash.
+- The provider never runs consolidation. It decides that consolidation is due
+  and writes a brief; a model does the rest.
+- The provider is not permitted to take a memory-provider slot another product
+  holds, because Hermes runs exactly one.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+from _cli_harness import run_cli
+from _local_package import load_local_package
+
+load_local_package()
+from omh.install.config_adapter import (
+    clear_memory_provider,
+    memory_provider_selection,
+    set_memory_provider,
+)
+from omh.plugin_bundle.omh import register
+from omh.plugin_bundle.omh.memory_blocks import (
+    DEFAULT_BLOCK_LIMIT_CHARS,
+    MemoryBlockError,
+    build_memory_block,
+    delete_memory_block,
+    read_memory_block,
+    read_memory_blocks,
+    render_block_index,
+    render_memory_blocks,
+    write_memory_block,
+)
+from omh.plugin_bundle.omh.memory_dreaming import (
+    DEFAULT_TURN_INTERVAL,
+    consolidation_reasons,
+    empty_dreaming_state,
+    read_dreaming_state,
+    record_compaction,
+    record_memory_write,
+    record_turn,
+    write_dreaming_state,
+)
+from omh.plugin_bundle.omh.memory_eviction import build_eviction_plan, eviction_plan_summary
+from omh.plugin_bundle.omh.memory_provider import PROVIDER_NAME, OmhMemoryProvider
+from omh.plugin_bundle.omh.metadata import MEMORY_PROVIDER_NAME
+from omh.plugin_bundle.omh.tools.memory_tool import MEMORY_ACTIONS, OMH_MEMORY_SCHEMA, omh_memory_handler
+
+HERMES_DELIMITER = "§"
+
+
+def _write_hermes_memory(hermes_home: Path, *entries: str) -> Path:
+    path = hermes_home / "memories" / "MEMORY.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(HERMES_DELIMITER.join(entries), encoding="utf-8")
+    return path
+
+
+class BlockStoreTests(unittest.TestCase):
+    def test_a_block_round_trips_through_disk(self) -> None:
+        with TemporaryDirectory() as tmp:
+            block = build_memory_block("project-facts", "OMH wraps Hermes.", description="Facts.")
+            write_memory_block(tmp, block)
+            self.assertEqual(read_memory_blocks(tmp), (block,))
+
+    def test_an_over_limit_block_is_rejected_rather_than_truncated(self) -> None:
+        # Truncating would make the store disagree with what the caller believes
+        # it wrote, and the disagreement only shows up as a missing sentence later.
+        with self.assertRaises(MemoryBlockError):
+            build_memory_block("facts", "x" * 51, limit=50)
+
+    def test_labels_are_constrained_because_they_name_files(self) -> None:
+        for label in ("", "Has Caps", "../escape", "-leading", "a" * 64):
+            with self.subTest(label=label), self.assertRaises(MemoryBlockError):
+                build_memory_block(label, "value")
+
+    def test_an_unknown_tier_is_rejected(self) -> None:
+        with self.assertRaises(MemoryBlockError):
+            build_memory_block("facts", "value", tier="archival")
+
+    def test_blocks_are_read_in_label_order_so_a_render_is_reproducible(self) -> None:
+        with TemporaryDirectory() as tmp:
+            for label in ("zulu", "alpha", "mike"):
+                write_memory_block(tmp, build_memory_block(label, "v"))
+            self.assertEqual([block.label for block in read_memory_blocks(tmp)], ["alpha", "mike", "zulu"])
+
+    def test_tiers_are_stored_and_listed_separately(self) -> None:
+        with TemporaryDirectory() as tmp:
+            write_memory_block(tmp, build_memory_block("always", "v", tier="system"))
+            write_memory_block(tmp, build_memory_block("sometimes", "v", tier="reference"))
+            self.assertEqual([b.label for b in read_memory_blocks(tmp, tier="system")], ["always"])
+            self.assertEqual([b.label for b in read_memory_blocks(tmp, tier="reference")], ["sometimes"])
+            self.assertEqual(len(read_memory_blocks(tmp)), 2)
+
+    def test_an_unreadable_block_is_absent_rather_than_fatal(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "memory" / "blocks" / "system" / "broken.json"
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("{not json", encoding="utf-8")
+            self.assertIsNone(read_memory_block(path))
+            self.assertEqual(read_memory_blocks(tmp), ())
+
+    def test_removing_a_block_reports_whether_it_was_there(self) -> None:
+        with TemporaryDirectory() as tmp:
+            write_memory_block(tmp, build_memory_block("facts", "v"))
+            self.assertTrue(delete_memory_block(tmp, "facts", "system"))
+            self.assertFalse(delete_memory_block(tmp, "facts", "system"))
+
+
+class RenderTests(unittest.TestCase):
+    def test_a_render_shows_the_model_how_full_each_block_is(self) -> None:
+        block = build_memory_block("facts", "abc", description="What we know.", limit=100)
+        rendered = render_memory_blocks([block])
+        self.assertIn("<memory_blocks>", rendered)
+        self.assertIn("chars_current=3 chars_limit=100", rendered)
+        self.assertIn("<value>abc</value>", rendered)
+
+    def test_an_empty_store_renders_nothing_at_all(self) -> None:
+        self.assertEqual(render_memory_blocks([]), "")
+        self.assertEqual(render_block_index([]), "")
+
+    def test_the_budget_drops_whole_blocks_and_says_which(self) -> None:
+        # A clipped block would read as something the store actually holds.
+        blocks = [build_memory_block(f"b{index}", "x" * 200) for index in range(5)]
+        rendered = render_memory_blocks(blocks, budget_chars=400)
+        self.assertIn("render_budget_exhausted", rendered)
+        self.assertIn("b4", rendered)
+        self.assertNotIn("<b4>", rendered)
+
+    def test_the_index_lists_reference_blocks_without_their_values(self) -> None:
+        block = build_memory_block("runbook", "SECRET-VALUE", description="How to deploy.", tier="reference")
+        index = render_block_index([block])
+        self.assertIn('label="runbook"', index)
+        self.assertIn("How to deploy.", index)
+        self.assertNotIn("SECRET-VALUE", index)
+
+
+class DreamingScheduleTests(unittest.TestCase):
+    def test_counters_round_trip_and_survive_a_corrupt_file(self) -> None:
+        with TemporaryDirectory() as tmp:
+            write_dreaming_state(tmp, record_turn(empty_dreaming_state()))
+            self.assertEqual(read_dreaming_state(tmp)["turns_since_consolidation"], 1)
+            (Path(tmp) / "memory" / "dreaming.json").write_text("{", encoding="utf-8")
+            self.assertEqual(read_dreaming_state(tmp), empty_dreaming_state())
+
+    def test_the_turn_interval_is_the_baseline_trigger(self) -> None:
+        state = empty_dreaming_state()
+        for _ in range(DEFAULT_TURN_INTERVAL - 1):
+            state = record_turn(state)
+        self.assertEqual(consolidation_reasons(state), [])
+        state = record_turn(state)
+        self.assertTrue(any(reason.startswith("turn_interval_reached") for reason in consolidation_reasons(state)))
+
+    def test_compaction_triggers_consolidation_on_its_own(self) -> None:
+        reasons = consolidation_reasons(record_compaction(empty_dreaming_state()))
+        self.assertIn("context_compaction_observed", reasons)
+
+    def test_low_headroom_triggers_before_the_file_is_full(self) -> None:
+        reasons = consolidation_reasons(empty_dreaming_state(), headroom_chars=100, headroom_floor_chars=300)
+        self.assertTrue(any(reason.startswith("headroom_below_floor") for reason in reasons))
+
+    def test_reasons_are_named_so_a_brief_can_state_its_own_cause(self) -> None:
+        reasons = consolidation_reasons(record_compaction(empty_dreaming_state()), duplicate_count=2)
+        self.assertIn("context_compaction_observed", reasons)
+        self.assertIn("duplicate_records:2", reasons)
+
+    def test_mode_off_silences_every_trigger(self) -> None:
+        state = record_compaction(empty_dreaming_state())
+        self.assertEqual(consolidation_reasons(state, mode="off", headroom_chars=0), [])
+
+    def test_memory_writes_are_counted_separately_from_turns(self) -> None:
+        state = record_memory_write(record_turn(empty_dreaming_state()))
+        self.assertEqual(state["turns_since_consolidation"], 1)
+        self.assertEqual(state["memory_writes_observed"], 1)
+
+
+class EvictionPlanTests(unittest.TestCase):
+    def test_rewordings_of_one_fact_group_into_a_single_cluster(self) -> None:
+        entries = (
+            "document-harness는 sionic-ai 레포의 에이전트 하네스 기반 문서 작성 시스템이다",
+            "document-harness: sionic-ai 레포의 에이전트 하네스 기반 문서 작성 시스템",
+            "커피 원두는 밀봉 용기에 보관한다",
+        )
+        plan = build_eviction_plan(entries, cap=2200)
+        self.assertEqual(len(plan["duplicate_clusters"]), 1)
+        self.assertEqual(plan["duplicate_clusters"][0]["entry_indices"], [0, 1])
+        self.assertGreater(plan["reclaimable_chars"], 0)
+
+    def test_distinct_entries_produce_no_cluster(self) -> None:
+        plan = build_eviction_plan(("release 스크립트 dry-run", "커피 원두 보관"), cap=2200)
+        self.assertEqual(plan["duplicate_clusters"], [])
+        self.assertEqual(plan["reclaimable_chars"], 0)
+
+    def test_a_shortfall_counts_the_delimiter_the_write_will_cost(self) -> None:
+        plan = build_eviction_plan(("x" * 90,), cap=100, required_chars=10)
+        # 90 used, 10 free, and the write needs 10 + 1 for the delimiter.
+        self.assertEqual(plan["headroom_chars"], 10)
+        self.assertEqual(plan["required_chars"], 11)
+        self.assertEqual(plan["shortfall_chars"], 1)
+
+    def test_a_plan_that_cannot_free_enough_says_so(self) -> None:
+        plan = build_eviction_plan(("x" * 99,), cap=100, required_chars=500)
+        self.assertFalse(plan["sufficient"])
+        self.assertIn("provably redundant", eviction_plan_summary(plan))
+
+    def test_an_unexplained_entry_is_never_an_eviction_candidate(self) -> None:
+        # Unexplained is a reason to ask, not a reason to delete.
+        plan = build_eviction_plan(("a fact nothing in OMH explains",), cap=2200)
+        self.assertTrue(plan["unexplained_entries_are_not_candidates"])
+        self.assertEqual(plan["duplicate_clusters"], [])
+
+    def test_the_plan_carries_no_entry_text(self) -> None:
+        secret = "루트 비밀번호는 hunter2 이다"
+        plan = build_eviction_plan((secret, secret + " 확실히"), cap=2200)
+        self.assertNotIn("hunter2", json.dumps(plan, ensure_ascii=False))
+
+
+class ProviderRegistrationTests(unittest.TestCase):
+    class _Collector:
+        """Mirrors Hermes' `_ProviderCollector`: one real method, the rest no-ops."""
+
+        def __init__(self) -> None:
+            self.provider = None
+            self.tools: list[str] = []
+
+        def register_memory_provider(self, provider) -> None:
+            self.provider = provider
+
+        def register_tool(self, *args, **kwargs) -> None:
+            self.tools.append(args[0] if args else "")
+
+        def register_hook(self, *args, **kwargs) -> None:
+            pass
+
+    class _PluginCtx:
+        """Mirrors the real Hermes plugin context, which has no provider method."""
+
+        def __init__(self) -> None:
+            self.tools: list[str] = []
+            self.hooks: list[str] = []
+
+        def register_tool(self, name, *args, **kwargs) -> None:
+            self.tools.append(name)
+
+        def register_hook(self, name, callback) -> None:
+            self.hooks.append(name)
+
+    def test_the_memory_loader_gets_a_provider_and_no_tools(self) -> None:
+        collector = self._Collector()
+        register(collector)
+        self.assertIsInstance(collector.provider, OmhMemoryProvider)
+        # Registering ten tools into a collector that discards them is work the
+        # provider load should never do.
+        self.assertEqual(collector.tools, [])
+
+    def test_the_plugin_loader_still_gets_every_tool_and_hook(self) -> None:
+        ctx = self._PluginCtx()
+        register(ctx)
+        self.assertIn("omh_memory", ctx.tools)
+        self.assertEqual(len(ctx.tools), 10)
+        self.assertIn("on_session_end", ctx.hooks)
+
+    def test_the_provider_exposes_no_tool_schemas(self) -> None:
+        # `agent/memory_provider.py` names tool-schema bloat as the reason only
+        # one external provider may run; the block read lives on `omh_memory`.
+        self.assertEqual(OmhMemoryProvider().get_tool_schemas(), [])
+
+    def test_the_provider_name_matches_what_config_must_carry(self) -> None:
+        self.assertEqual(OmhMemoryProvider().name, MEMORY_PROVIDER_NAME)
+        self.assertEqual(PROVIDER_NAME, MEMORY_PROVIDER_NAME)
+
+
+class ProviderLifecycleTests(unittest.TestCase):
+    def _provider(self, root: Path, *, agent_context: str = "primary") -> OmhMemoryProvider:
+        provider = OmhMemoryProvider(root / ".omh")
+        provider.initialize("session-1", hermes_home=str(root / ".hermes"), agent_context=agent_context)
+        return provider
+
+    def test_availability_is_a_local_check_with_no_network(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.assertFalse(OmhMemoryProvider(root / "absent").is_available())
+            (root / ".omh").mkdir()
+            self.assertTrue(OmhMemoryProvider(root / ".omh").is_available())
+
+    def test_prefetch_serves_a_pack_rendered_off_the_hot_path(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_memory_block(root / ".omh", build_memory_block("facts", "OMH wraps Hermes."))
+            provider = self._provider(root)
+            self.assertIn("OMH wraps Hermes.", provider.prefetch("anything"))
+
+            # A block written mid-session is not served until the next turn is
+            # queued, which is where the base class puts the work.
+            write_memory_block(root / ".omh", build_memory_block("later", "added mid-session"))
+            self.assertNotIn("added mid-session", provider.prefetch(""))
+            provider.queue_prefetch("")
+            self.assertIn("added mid-session", provider.prefetch(""))
+
+    def test_reference_blocks_reach_prefetch_as_labels_not_values(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_memory_block(
+                root / ".omh",
+                build_memory_block("runbook", "SECRET-VALUE", description="How to deploy.", tier="reference"),
+            )
+            pack = self._provider(root).prefetch("")
+            self.assertIn("runbook", pack)
+            self.assertIn("How to deploy.", pack)
+            self.assertNotIn("SECRET-VALUE", pack)
+
+    def test_a_memory_write_is_journalled_without_its_text(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            provider = self._provider(root)
+            secret = "루트 비밀번호는 hunter2 이다"
+            provider.on_memory_write("add", "memory", secret, {"write_origin": "background_review"})
+
+            journal = (root / ".omh" / "memory" / "write_journal.jsonl").read_text(encoding="utf-8")
+            self.assertNotIn("hunter2", journal)
+            entry = json.loads(journal.splitlines()[0])
+            self.assertEqual(entry["action"], "add")
+            self.assertEqual(entry["chars"], len(secret))
+            self.assertEqual(entry["write_origin"], "background_review")
+            self.assertEqual(entry["redaction_policy"], "metadata_only")
+
+    def test_a_non_primary_context_moves_no_counters(self) -> None:
+        # Hermes states that cron and subagent contexts must not write; letting
+        # them would move the counters that decide when consolidation is due.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            provider = self._provider(root, agent_context="cron")
+            provider.on_turn_start(1, "hello")
+            provider.on_memory_write("add", "memory", "text")
+            self.assertEqual(read_dreaming_state(root / ".omh"), empty_dreaming_state())
+
+    def test_compaction_hands_back_system_blocks_and_arms_the_trigger(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_memory_block(root / ".omh", build_memory_block("facts", "must survive compaction"))
+            provider = self._provider(root)
+            preserved = provider.on_pre_compress([{"role": "user", "content": "hi"}])
+            self.assertIn("must survive compaction", preserved)
+            self.assertTrue(read_dreaming_state(root / ".omh")["compaction_pending"])
+
+    def test_consolidation_writes_a_brief_only_when_it_is_due(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            provider = self._provider(root)
+            handoff_path = root / ".omh" / "memory" / "consolidation.json"
+
+            self.assertFalse(provider.consolidation_due()["due"])
+            self.assertFalse(handoff_path.exists())
+
+            for _ in range(DEFAULT_TURN_INTERVAL):
+                provider.on_turn_start(1, "hello")
+            handoff = provider.consolidation_due()
+            self.assertTrue(handoff["due"])
+            self.assertTrue(handoff_path.exists())
+            # Firing resets the counters, so the next turn does not re-fire.
+            self.assertEqual(read_dreaming_state(root / ".omh")["turns_since_consolidation"], 0)
+
+    def test_the_brief_never_claims_consolidation_happened(self) -> None:
+        with TemporaryDirectory() as tmp:
+            provider = self._provider(Path(tmp))
+            boundary = str(provider.consolidation_due()["claim_boundary"])
+            self.assertIn("not evidence", boundary)
+
+    def test_headroom_pressure_reaches_the_scheduler_from_hermes(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_hermes_memory(root / ".hermes", "x" * 2100)
+            handoff = self._provider(root).consolidation_due()
+            self.assertTrue(any(str(r).startswith("headroom_below_floor") for r in handoff["reasons"]))
+            self.assertEqual(handoff["eviction_plan"]["cap"], 2200)
+
+    def test_a_read_only_home_costs_a_journal_line_not_the_turn(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            provider = self._provider(root)
+            with patch("omh.plugin_bundle.omh.memory_provider._append_line", side_effect=OSError("read-only")):
+                provider.on_memory_write("add", "memory", "text")  # must not raise
+
+
+class MemoryToolActionTests(unittest.TestCase):
+    def _call(self, root: Path, **args) -> dict:
+        with patch.dict(os.environ, {"OMH_HOME": str(root / ".omh"), "HERMES_HOME": str(root / ".hermes")}):
+            return json.loads(omh_memory_handler(args))
+
+    def test_the_default_action_is_still_the_bridge(self) -> None:
+        with TemporaryDirectory() as tmp:
+            payload = self._call(Path(tmp).resolve())
+            self.assertEqual(payload["action"], "status")
+            self.assertEqual(payload["schema_version"], "hermes_memory_bridge/v1")
+
+    def test_every_advertised_action_is_handled(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp).resolve()
+            for action in MEMORY_ACTIONS:
+                with self.subTest(action=action):
+                    self.assertEqual(self._call(root, action=action)["action"], action)
+
+    def test_the_schema_advertises_exactly_the_handled_actions(self) -> None:
+        enum = OMH_MEMORY_SCHEMA["parameters"]["properties"]["action"]["enum"]
+        self.assertEqual(tuple(enum), MEMORY_ACTIONS)
+
+    def test_blocks_lists_labels_and_read_returns_the_value(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp).resolve()
+            write_memory_block(root / ".omh", build_memory_block("runbook", "deploy steps", tier="reference"))
+
+            listing = self._call(root, action="blocks")
+            self.assertEqual(listing["block_count"], 1)
+            self.assertNotIn("deploy steps", json.dumps(listing))
+
+            read = self._call(root, action="read", label="runbook")
+            self.assertTrue(read["found"])
+            self.assertEqual(read["block"]["value"], "deploy steps")
+
+    def test_a_missing_block_is_a_stated_miss_not_an_empty_value(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp).resolve()
+            self.assertEqual(self._call(root, action="read", label="absent")["reason"], "unknown_label")
+            self.assertEqual(self._call(root, action="read")["reason"], "label_required")
+
+    def test_an_unknown_action_names_what_is_supported(self) -> None:
+        with TemporaryDirectory() as tmp:
+            payload = self._call(Path(tmp).resolve(), action="delete-everything")
+            self.assertEqual(payload["status"], "unavailable")
+            self.assertEqual(tuple(payload["supported_actions"]), MEMORY_ACTIONS)
+
+    def test_hermes_entry_text_still_never_reaches_the_payload(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp).resolve()
+            secret = "루트비밀번호는hunter2이다"
+            _write_hermes_memory(root / ".hermes", secret)
+            for action in MEMORY_ACTIONS:
+                with self.subTest(action=action):
+                    self.assertNotIn(secret, json.dumps(self._call(root, action=action), ensure_ascii=False))
+
+
+class ProviderSlotTests(unittest.TestCase):
+    def test_the_slot_is_taken_when_it_is_free(self) -> None:
+        change = set_memory_provider("memory:\n  memory_char_limit: 2200\n", "omh")
+        self.assertTrue(change.changed)
+        self.assertEqual(memory_provider_selection(change.text), "omh")
+
+    def test_a_config_without_a_memory_section_grows_one(self) -> None:
+        change = set_memory_provider("plugins:\n  enabled:\n    - omh\n", "omh")
+        self.assertTrue(change.changed)
+        self.assertEqual(memory_provider_selection(change.text), "omh")
+
+    def test_an_empty_provider_key_is_treated_as_free(self) -> None:
+        change = set_memory_provider("memory:\n  provider: ''\n", "omh")
+        self.assertTrue(change.changed)
+        self.assertEqual(memory_provider_selection(change.text), "omh")
+
+    def test_another_product_holding_the_slot_is_never_overwritten(self) -> None:
+        # Hermes runs one external provider, so a silent overwrite would switch
+        # off whatever the operator actually chose.
+        original = "memory:\n  provider: honcho\n"
+        change = set_memory_provider(original, "omh")
+        self.assertFalse(change.changed)
+        self.assertEqual(change.text, original)
+        self.assertIn("honcho", change.message)
+
+    def test_taking_a_slot_omh_already_holds_is_a_no_op(self) -> None:
+        self.assertFalse(set_memory_provider("memory:\n  provider: omh\n", "omh").changed)
+
+    def test_only_omh_may_release_the_slot_omh_took(self) -> None:
+        self.assertTrue(clear_memory_provider("memory:\n  provider: omh\n", "omh").changed)
+        self.assertFalse(clear_memory_provider("memory:\n  provider: honcho\n", "omh").changed)
+        self.assertFalse(clear_memory_provider("memory:\n  provider: ''\n", "omh").changed)
+
+    def test_a_provider_key_in_another_section_is_not_mistaken_for_this_one(self) -> None:
+        self.assertEqual(memory_provider_selection("image_gen:\n  provider: openai\n"), "")
+
+
+class MemoryCliTests(unittest.TestCase):
+    def _base(self, root: Path) -> list[str]:
+        return ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+
+    @staticmethod
+    def _json(result: tuple[int, str, str]) -> tuple[int, dict, str]:
+        status, stdout, stderr = result
+        return status, (json.loads(stdout) if stdout.strip() else {}), stderr
+
+    def test_a_block_can_be_written_listed_and_removed_from_the_cli(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = self._base(root)
+            status, payload, stderr = self._json(run_cli(base + ["memory", "block-set", "facts", "--value", "OMH wraps Hermes."]))
+            self.assertEqual(status, 0, stderr)
+            self.assertTrue(payload["written"])
+
+            status, payload, _ = self._json(run_cli(base + ["memory", "blocks"]))
+            self.assertEqual(status, 0)
+            self.assertEqual(payload["block_count"], 1)
+            self.assertEqual(payload["blocks"][0]["label"], "facts")
+
+            status, payload, _ = self._json(run_cli(base + ["memory", "block-remove", "facts"]))
+            self.assertEqual(status, 0)
+            self.assertTrue(payload["removed"])
+
+    def test_an_over_limit_block_fails_the_command_rather_than_truncating(self) -> None:
+        with TemporaryDirectory() as tmp:
+            status, _, stderr = run_cli(
+                self._base(Path(tmp)) + ["memory", "block-set", "facts", "--value", "x" * 40, "--limit", "10"]
+            )
+            self.assertNotEqual(status, 0)
+            self.assertIn("40 chars", stderr)
+
+    def test_the_listing_can_be_narrowed_to_one_tier(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = self._base(root)
+            self._json(run_cli(base + ["memory", "block-set", "always", "--value", "v", "--tier", "system"]))
+            self._json(run_cli(base + ["memory", "block-set", "sometimes", "--value", "v", "--tier", "reference"]))
+            _, payload, _ = self._json(run_cli(base + ["memory", "blocks", "--tier", "reference"]))
+            self.assertEqual([block["label"] for block in payload["blocks"]], ["sometimes"])
+
+    def test_dream_reports_without_evaluating_unless_asked(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            status, payload, stderr = self._json(run_cli(self._base(root) + ["memory", "dream"]))
+            self.assertEqual(status, 0, stderr)
+            self.assertFalse(payload["evaluated"])
+            self.assertNotIn("due", payload)
+            self.assertFalse((root / ".omh" / "memory" / "consolidation.json").exists())
+
+    def test_dream_evaluate_weighs_the_triggers_and_never_consolidates(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_hermes_memory(root / ".hermes", "x" * 2100)
+            status, payload, stderr = self._json(run_cli(self._base(root) + ["memory", "dream", "--evaluate"]))
+            self.assertEqual(status, 0, stderr)
+            self.assertTrue(payload["due"])
+            self.assertIn("not evidence that memory was consolidated", payload["claim_boundary"])
+
+    def test_the_provider_slot_can_be_taken_and_handed_back(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = self._base(root)
+            status, payload, stderr = self._json(run_cli(base + ["memory", "provider", "--enable"]))
+            self.assertEqual(status, 0, stderr)
+            self.assertTrue(payload["is_omh"])
+
+            _, payload, _ = self._json(run_cli(base + ["memory", "provider"]))
+            self.assertEqual(payload["provider"], MEMORY_PROVIDER_NAME)
+            self.assertFalse(payload["changed"])
+
+            _, payload, _ = self._json(run_cli(base + ["memory", "provider", "--disable"]))
+            self.assertTrue(payload["changed"])
+            self.assertFalse(payload["is_omh"])
+
+    def test_enabling_never_evicts_another_product_from_the_slot(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            config = root / ".hermes" / "config.yaml"
+            config.parent.mkdir(parents=True, exist_ok=True)
+            config.write_text("memory:\n  provider: honcho\n", encoding="utf-8")
+
+            status, payload, stderr = self._json(run_cli(self._base(root) + ["memory", "provider", "--enable"]))
+            self.assertEqual(status, 0, stderr)
+            self.assertFalse(payload["changed"])
+            self.assertEqual(payload["provider"], "honcho")
+            self.assertEqual(config.read_text(encoding="utf-8"), "memory:\n  provider: honcho\n")
+
+    def test_a_dry_run_reports_the_change_without_writing_config(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            status, payload, stderr = self._json(run_cli(self._base(root) + ["memory", "provider", "--enable", "--dry-run"]))
+            self.assertEqual(status, 0, stderr)
+            self.assertTrue(payload["changed"])
+            self.assertFalse((root / ".hermes" / "config.yaml").exists())
+
+
+class DoctorSlotReportTests(unittest.TestCase):
+    """A slot held by something else is why OMH's hooks would not be running."""
+
+    def _doctor(self, root: Path) -> dict:
+        status, stdout, stderr = run_cli(
+            ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes"), "doctor"]
+        )
+        self.assertIn(status, (0, 1), stderr)
+        return json.loads(stdout)
+
+    def _message(self, payload: dict) -> str:
+        return next(
+            str(check["message"]) for check in payload["checks"] if check["name"] == "memory_provider"
+        )
+
+    def test_an_unset_slot_is_reported_without_failing(self) -> None:
+        # Hermes' built-in memory is a fine state; this is an invitation, not a fault.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / ".hermes").mkdir(parents=True)
+            (root / ".hermes" / "config.yaml").write_text("memory:\n  provider: ''\n", encoding="utf-8")
+            self.assertIn("unset", self._message(self._doctor(root)))
+
+    def test_a_slot_held_by_another_product_is_named(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / ".hermes").mkdir(parents=True)
+            (root / ".hermes" / "config.yaml").write_text("memory:\n  provider: honcho\n", encoding="utf-8")
+            message = self._message(self._doctor(root))
+            self.assertIn("honcho", message)
+            self.assertIn("not running", message)
+
+    def test_omh_holding_the_slot_reads_as_healthy(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / ".hermes").mkdir(parents=True)
+            (root / ".hermes" / "config.yaml").write_text("memory:\n  provider: omh\n", encoding="utf-8")
+            self.assertIn("is omh", self._message(self._doctor(root)))
+
+
+class BlockBudgetDefaultTests(unittest.TestCase):
+    def test_the_default_block_limit_fits_beside_hermes_own_cap(self) -> None:
+        # A block that alone exceeded Hermes' 2200-char memory file would make
+        # the always-rendered tier the largest thing in the turn.
+        self.assertLessEqual(DEFAULT_BLOCK_LIMIT_CHARS, 2200)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_plugin_distribution.py
+++ b/tests/test_plugin_distribution.py
@@ -894,5 +894,76 @@ print(json.dumps(observed, ensure_ascii=False))
             self.assertNotIn("do not leak this mid-session prompt", mid_session_role_context["context"])
 
 
+class UpdateRefreshesTheBundleTests(unittest.TestCase):
+    """`omh update` used to leave the installed bundle at its old version.
+
+    `install_plugin_bundle` was reachable only from `cmd_setup`, so an operator
+    who ran `omh update` got new workflows against old plugin code -- the tools,
+    hooks, and now the memory provider under `$HERMES_HOME/plugins/omh/` stayed
+    where the last `omh setup` left them. AGENTS.md tells ordinary users they
+    need setup, update, and doctor; update was the one not doing its name.
+    """
+
+    def _bundle_dir(self, hermes_home: Path) -> Path:
+        return hermes_home / "plugins" / "omh"
+
+    def test_update_reinstalls_the_bundle_tree(self) -> None:
+        # The bundle is replaced wholesale by an atomic rename of a freshly
+        # copied tree, so a file the source does not contain cannot survive a
+        # real reinstall. That makes a stray file the honest observable: editing
+        # a managed file instead would trip the drift guard, which is a
+        # different behaviour and correctly refuses.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+            status, _, stderr = run_cli(base + ["setup"])
+            self.assertEqual(status, 0, stderr)
+
+            stray = self._bundle_dir(root / ".hermes") / "stray_from_an_older_version.py"
+            stray.write_text("# left behind by an older bundle\n", encoding="utf-8")
+
+            status, _, stderr = run_cli(base + ["update"])
+            self.assertEqual(status, 0, stderr)
+            self.assertFalse(stray.exists())
+            self.assertTrue((self._bundle_dir(root / ".hermes") / "memory_provider.py").is_file())
+
+    def test_update_does_not_install_a_bundle_setup_never_installed(self) -> None:
+        # Installing it here would write plugin files without the Hermes
+        # enablement setup also does, and half that pair is worse than neither.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+            status, _, stderr = run_cli(base + ["update"])
+            self.assertEqual(status, 0, stderr)
+            self.assertFalse(self._bundle_dir(root / ".hermes").exists())
+
+    def test_a_dry_run_update_leaves_the_installed_bundle_alone(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+            run_cli(base + ["setup"])
+            stray = self._bundle_dir(root / ".hermes") / "stray_from_an_older_version.py"
+            stray.write_text("# left behind by an older bundle\n", encoding="utf-8")
+
+            status, _, stderr = run_cli(base + ["update", "--dry-run"])
+            self.assertEqual(status, 0, stderr)
+            self.assertTrue(stray.exists())
+
+    def test_a_drifted_bundle_does_not_fail_the_update(self) -> None:
+        # A managed file edited outside OMH makes the reinstall refuse. Update
+        # must still succeed for everything else; `omh doctor` reports the drift
+        # with the `omh setup --force` instruction that repairs it.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+            run_cli(base + ["setup"])
+            marker = self._bundle_dir(root / ".hermes") / "__init__.py"
+            marker.write_text("# edited outside OMH\n", encoding="utf-8")
+
+            status, _, stderr = run_cli(base + ["update"])
+            self.assertEqual(status, 0, stderr)
+            self.assertEqual(marker.read_text(encoding="utf-8"), "# edited outside OMH\n")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- **Memory blocks** (`memory_blocks.py`): labelled records with a per-block character limit, stored under `.omh/memory/blocks/<tier>/`, rendered as XML-ish prompt text with `chars_current`/`chars_limit` beside each value. Two tiers, after Letta's MemFS: `system` renders every turn, `reference` is listed by label and read on request.
- **A Hermes memory provider** (`memory_provider.py`): OMH registers into Hermes' `MemoryProvider` lifecycle and implements `prefetch`, `queue_prefetch`, `on_turn_start`, `on_pre_compress`, `on_memory_write`, `on_session_end`, and `shutdown`. **Zero tool schemas.**
- **A dreaming scheduler** (`memory_dreaming.py`): evaluates at every moment memory can be lost — each turn (interval 5), compaction, session end, shutdown, and the start of the next session — and writes a consolidation brief naming which trigger fired. It never consolidates.
- **An eviction plan** (`memory_eviction.py`): clusters entries that reword one another and reports the shortfall against Hermes' cap.
- **`omh_memory` gained an `action` parameter**: `status` (unchanged default), `blocks`, `read`, `consolidation`.
- **New operator surfaces**: `omh memory blocks | block-set | block-remove | dream | provider`, plus a `memory_provider` check in `omh doctor`.
- **`omh update` now refreshes the installed plugin bundle** (second commit; see below).

### Why This Exists

Everything OMH knew about memory had to be asked for. `omh memory status` held the comparison, the `omh_memory` tool carried it after #672, and both waited for a question.

Meanwhile Hermes writes its own memory after every turn. `agent/background_review.py` is a daemon thread that forks the agent, replays the conversation, and decides for itself what to save, restricted to the memory and skill tools. It runs with no statement of what OMH already holds, what is duplicated, or how little room is left.

On the host this was built against, that shows as: `MEMORY.md` at **1921 of 2200 characters, 279 free**, four of seven entries matching no OMH record, and three approved records already restated in Hermes in different words. The loop was running without its materials.

Hermes exposes the seam and OMH was not standing in it. `plugins/memory/__init__.py` scans `$HERMES_HOME/plugins/<name>/` as well as its own bundled directory — which is exactly where the OMH bundle already installs — and `agent/memory_provider.py` defines the lifecycle. No Hermes patching is involved.

### User / Operator Impact

Once an operator runs `omh memory provider --enable`:

- Recall arrives without being asked for, on every turn, instead of only when someone runs a command.
- Every Hermes memory write gets a provenance line, so the "four entries nothing explains" state stops accumulating at the source.
- Durable context survives compaction instead of being discarded with the messages.
- When memory is nearly full, a plan says what is provably redundant rather than the next write simply failing.
- `omh doctor` says who holds the provider slot, which is otherwise invisible.

With the provider disabled, nothing changes: the blocks and CLI still work, and the hooks do not run.

### How It Works

`register(ctx)` serves two loaders. Hermes' plugin loader passes a context that registers tools and hooks; its *memory provider* loader passes a collector whose only real method is `register_memory_provider`. The real plugin context has no such method, which makes the two safely distinguishable by `hasattr` — and naming it in `__init__.py` is also what makes the directory visible to Hermes' provider discovery, which text-scans that file for it.

`prefetch` is called before every API call and the base class asks for it to be fast, so the pack is rendered in `initialize`/`queue_prefetch` and served from memory.

All new modules live in the bundle rather than `workflows/` because they are imported inside the Hermes process, where the `omh` package does not exist — the same reason `read_approved_records` was vendored there. Core `omh` imports them back, following the existing direction of dependency.

**Two redaction rules meet in the tool and do not merge.** OMH block values are OMH's own content and are returned in full. Hermes memory entries are not OMH's, are never returned, and appear only as counts, hashes, and similarity scores. The write journal records an action, a length, and a sha256 — never the entry.

### When Consolidation Fires

The first pass recorded triggers and acted on none of them — only `on_session_end` ever weighed anything, so the interval never fired mid-session and a compaction brief would have been written after the messages were gone. The third commit fixes that; these four scenarios were each run end to end:

| Moment | Fires | Brief says |
| --- | --- | --- |
| Every N turns (default 5) | `turn` | the interval came due |
| Context compaction | `compaction` | messages are about to be discarded, and how many |
| Hermes closes / session ends | `shutdown`, `session_end` | no later turn is coming |
| Laptop closed, process killed | `session_start_recovery`, at the next startup | a previous session ended without consolidating |

Session-ending triggers lower the bar to a **single** unconsolidated turn: the interval assumes a later turn will come, and at a close it will not. Three turns and a closed lid leave a brief rather than nothing.

The abrupt-termination case has no hook at all, so it is handled by durability instead: counters are written on every hook, and the next `initialize` settles whatever the dead session left. Briefs accumulate in `consolidation.jsonl` beside the latest in `consolidation.json`, because a later brief must not overwrite the compaction one — that is the brief whose material is already gone.

### Files And Contracts Touched

- New: `memory_blocks.py`, `memory_dreaming.py`, `memory_eviction.py`, `memory_provider.py` in `src/plugin_bundle/omh/`.
- `tools/memory_tool.py` — `action` parameter; `plugin.yaml`/`metadata.py` — provider name.
- `src/install/config_adapter.py` — `memory_provider_selection`, `set_memory_provider`, `clear_memory_provider`.
- `src/commands/memory.py`, `memory_parser.py`, `src/maintenance/doctor.py`, `src/commands/setup.py`.
- New contracts: `omh_memory_block/v1`, `omh_memory_dreaming_state/v1`, `omh_memory_consolidation_handoff/v1`, `omh_memory_eviction_plan/v1`, `omh_memory_write_journal_entry/v1`, `omh_memory_provider_status/v1`.
- **Contract change:** `omh_memory` gained an `action` parameter. The default is still `status` and still returns `hermes_memory_bridge/v1`; a test pins that.

## Validation

- [x] `uv run --group lint ruff check src tests` — All checks passed
- [x] `python3 -m unittest discover -s tests` — **2129 passed**, 1 skipped (was 2050 on main)
- [x] `python3 -m compileall src`
- [x] `python3 -m omh.cli docs workflows --check` — ok, tap_skills 104/104
- [x] `python3 -m omh.cli harness validate` — ok, 72 harnesses / 93 skills
- [x] `python3 -m omh.cli release checklist --json` — ok
- [x] `python3 -m omh.cli release hermes-smoke` — plan renders
- [x] `omh --help`
- [x] Installed-command smoke against temp homes — nested `installed_command_smoke` mode=live, observed=true, ok=true
- [x] Also run: `docs roles --check`, `docs capability-families --check`, `git diff --check`
- [x] **Live provider load against the installed Hermes** (`~/.hermes/hermes-agent`, temp `HERMES_HOME`): discovery returns `omh`; `load_memory_provider("omh")` returns `OmhMemoryProvider`; `isinstance(p, agent.memory_provider.MemoryProvider)` is `True`; `get_tool_schemas()` is `[]`; `is_available()` is `True`.
- [ ] Relevant workflow-learning review queue smoke — not applicable, no learning contract changed
- [ ] Manual Hermes/TUI check — **not run.** No Hermes turn has called `prefetch`, `on_pre_compress`, `on_memory_write`, or `on_session_end` in a live conversation. The hooks are exercised directly in tests and the provider is proven loadable, but that they fire in a running session rests on reading Hermes' lifecycle, not on observing one.

## Risk

Medium, concentrated in one place: `omh_memory` changed shape for an existing caller. The default action is unchanged and pinned by test, so a caller passing no `action` sees exactly what it saw before.

Everything else is inert until an operator opts in. The provider is not selected by setup, refuses to take a slot another product holds, and does nothing at all while `memory.provider` names something else.

Two deliberate non-goals, both tested: an over-limit block is rejected rather than truncated, and an entry no OMH record explains is never an eviction candidate.

**No efficacy claim is made.** Letta's published sleep-time-compute results are self-reported (its own authors, its own benchmarks), and no benchmark evidence survived verification during the research behind this. Everything above is a capability that did not exist, not a measured improvement to one that did.

## Compatibility / Rollout

Additive except for the `omh_memory` parameter. No state migration; block, dreaming, and journal files are created on first use. `memory.provider` is only ever written by an explicit `omh memory provider --enable`.

A user's Hermes needs the updated bundle — which, as of the second commit, `omh update` now delivers.

## Release / Claims

- [x] Release-channel impact considered — `local`; no version change.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed — the provider load is **observed**; hook firing in a live session is explicitly **not observed**; Letta efficacy numbers are flagged self-reported and not relied on.
- [x] Known manual Hermes checks are listed, including the `omh release hermes-smoke --live` gap — no live tap smoke was run.

## Follow-Up

- Nothing consumes the consolidation brief yet beyond writing it; surfacing it in the wrapper card lane is the obvious next step.
- Recall ranking still uses token overlap. BM25 in pure Python is the researched substitute for vector search and would slot in behind the same interface.
- `tests/test_hermes_memory_bridge.py` has a pre-existing `if __name__ == "__main__"` block above its last class, so direct execution of that file skips it. Untouched; discovery is unaffected.

