### PR TITLE
fix: let `omh update` carry registration so setup stays a one-time act

### DIFF
--- a/src/commands/setup.py
+++ b/src/commands/setup.py
@@ -193,7 +193,33 @@ def cmd_update(args: argparse.Namespace) -> int:
     code = cmd_install(args)
     if code == 0:
         _refresh_installed_plugin_bundle(args)
+        _refresh_hermes_registration(args)
     return code
+
+
+def _refresh_hermes_registration(args: argparse.Namespace) -> dict[str, object] | None:
+    """Carry a registered install forward to what the running version needs.
+
+    `omh setup` is meant to be a one-time act. It stopped being one the moment
+    a release added something to Hermes' config that only setup wrote: update
+    refreshed skills and the bundle, the new key never landed, and the fix was
+    to tell people to run setup again. The memory-provider slot was exactly
+    that, and it will not be the last.
+
+    Only for an install that is already registered -- the skills directory is
+    already in `skills.external_dirs`. Registering a fresh one stays setup's
+    job, and someone who deliberately unregistered OMH must not have update
+    put it back.
+    """
+    paths = _paths(args)
+    if str(paths.skills_dir) not in external_dirs(read_config(paths.hermes_config_path)):
+        return None
+    try:
+        return _apply_result(args)
+    except OmhError:
+        # An update must not fail over a config it cannot rewrite; `omh doctor`
+        # reports the gap with the command that repairs it.
+        return None
 
 
 def _refresh_installed_plugin_bundle(args: argparse.Namespace) -> dict[str, object] | None:

--- a/tests/test_plugin_distribution.py
+++ b/tests/test_plugin_distribution.py
@@ -965,5 +965,95 @@ class UpdateRefreshesTheBundleTests(unittest.TestCase):
             self.assertEqual(marker.read_text(encoding="utf-8"), "# edited outside OMH\n")
 
 
+class UpdateCarriesRegistrationTests(unittest.TestCase):
+    """`omh setup` is meant to be run once, and it stopped being.
+
+    Every release that added something to Hermes' config which only setup wrote
+    made setup a recurring chore: update refreshed skills and the bundle, the
+    new key never landed, and the instruction became "run setup again". The
+    memory-provider slot was the latest instance and will not be the last.
+    """
+
+    def _base(self, root: Path) -> list[str]:
+        return ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+
+    def _config(self, root: Path) -> Path:
+        return root / ".hermes" / "config.yaml"
+
+    def _downgrade(self, root: Path) -> None:
+        """Make a registered install look like one from before the slot existed."""
+        config = self._config(root)
+        config.write_text(config.read_text(encoding="utf-8").replace("  provider: omh", "  provider: ''"), encoding="utf-8")
+
+    def test_update_alone_brings_a_registered_install_up_to_date(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            run_cli(self._base(root) + ["setup"])
+            self._downgrade(root)
+            self.assertIn("provider: ''", self._config(root).read_text(encoding="utf-8"))
+
+            status, _, stderr = run_cli(self._base(root) + ["update"])
+            self.assertEqual(status, 0, stderr)
+            self.assertIn("provider: omh", self._config(root).read_text(encoding="utf-8"))
+
+    def test_update_does_not_register_an_install_setup_never_registered(self) -> None:
+        # Someone who unregistered OMH deliberately must not have update put it
+        # back, and a first registration stays setup's to make.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            status, _, stderr = run_cli(self._base(root) + ["update"])
+            self.assertEqual(status, 0, stderr)
+            self.assertFalse(self._config(root).exists())
+
+    def test_update_never_takes_a_slot_another_product_holds(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            run_cli(self._base(root) + ["setup"])
+            config = self._config(root)
+            config.write_text(config.read_text(encoding="utf-8").replace("  provider: omh", "  provider: honcho"), encoding="utf-8")
+
+            status, _, stderr = run_cli(self._base(root) + ["update"])
+            self.assertEqual(status, 0, stderr)
+            self.assertIn("provider: honcho", config.read_text(encoding="utf-8"))
+
+    def test_a_dry_run_update_rewrites_no_config(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            run_cli(self._base(root) + ["setup"])
+            self._downgrade(root)
+            before = self._config(root).read_text(encoding="utf-8")
+
+            status, _, stderr = run_cli(self._base(root) + ["update", "--dry-run"])
+            self.assertEqual(status, 0, stderr)
+            self.assertEqual(self._config(root).read_text(encoding="utf-8"), before)
+
+    def test_update_is_idempotent_once_registration_is_current(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            run_cli(self._base(root) + ["setup"])
+            run_cli(self._base(root) + ["update"])
+            before = self._config(root).read_text(encoding="utf-8")
+            run_cli(self._base(root) + ["update"])
+            self.assertEqual(self._config(root).read_text(encoding="utf-8"), before)
+
+    def test_setup_is_not_needed_a_second_time_for_a_new_registration(self) -> None:
+        # The whole point: one setup, then update forever.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            run_cli(self._base(root) + ["setup"])
+            self._downgrade(root)
+            (self._bundle_stray(root)).write_text("# older bundle\n", encoding="utf-8")
+
+            run_cli(self._base(root) + ["update"])
+
+            config = self._config(root).read_text(encoding="utf-8")
+            self.assertIn("provider: omh", config)
+            self.assertIn(str(root / ".omh" / "skills"), config)
+            self.assertFalse(self._bundle_stray(root).exists())
+
+    def _bundle_stray(self, root: Path) -> Path:
+        return root / ".hermes" / "plugins" / "omh" / "stray_from_an_older_version.py"
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

`omh update` now reapplies Hermes registration for an install that is **already registered**, so config the running version needs — including the memory-provider slot — arrives through update instead of requiring a second `omh setup`.

### Why This Exists

`omh setup` is supposed to be run once. It stopped being that the moment a release added anything to Hermes' config that only setup wrote: update refreshed skills and the bundle, the new key never landed, and the answer became "run setup again".

#689 shipped exactly that failure. The memory-provider slot was claimed only in setup, so the upgrade instruction was `omh update && omh setup`. **That instruction was the bug, not the workaround** — it makes setup a recurring chore and puts the burden on the user to know which release needed which command.

### User / Operator Impact

One command, forever:

```
omh update
```

Setup is for the first install. After that, update carries skills, the plugin bundle, and Hermes registration together.

Nothing new is claimed on someone else's behalf: an install that was never registered stays unregistered, and a memory-provider slot held by honcho, mem0, or hindsight is left alone.

### How It Works

`_refresh_hermes_registration` gates on the skills directory already being present in `skills.external_dirs`, then calls the same `_apply_result` setup uses. A first registration stays setup's to make — that is where the user consents to OMH touching Hermes at all — and someone who deliberately unregistered OMH must not have update put it back.

A config it cannot rewrite returns `None` rather than failing the run; `omh doctor` reports that gap with the command that repairs it. Same shape as the bundle refresh next to it.

### Files And Contracts Touched

- `src/commands/setup.py` — `_refresh_hermes_registration`, called from `cmd_update`.
- `tests/test_plugin_distribution.py` — 6 new cases.
- No contract or schema change.

## Validation

- [x] `uv run --group lint ruff check src tests` — All checks passed
- [x] `python3 -m unittest discover -s tests` — **2142 passed**, 1 skipped
- [x] `python3 -m compileall src`
- [x] `python3 -m omh.cli docs workflows --check`, `docs roles --check`, `docs capability-families --check`
- [x] `python3 -m omh.cli harness validate`
- [x] `git diff --check`
- [x] Manual run of the motivating sequence: set up, blank the slot to look like a pre-provider install, run **only** `omh update` → slot is `omh` again, no second setup
- [x] Manual run, unregistered install: `omh update` creates no config
- [x] Manual run, slot held by `honcho`: untouched after update
- [ ] Manual Hermes/TUI check — **not run.** Config writes are observed; Hermes reading them at startup rests on its documented config path.

## Risk

Low. Update now rewrites Hermes config only where setup already had on that profile, so it gains no authority setup did not exercise. The gate is a positive check on existing registration rather than an absence check, so an unregistered profile is never touched.

The honest limitation is in the test: an older install is simulated by clearing the key, not by installing a genuinely older release.

## Compatibility / Rollout

No schema change. Existing installs pick this up on their next `omh update`.

## Release / Claims

- [x] Release-channel impact considered — `local`; no version change.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] Known manual Hermes checks are listed — no live tap smoke was run.

## Follow-Up

- The same class of gap exists for anything else a future release adds outside `_apply_result`; this fixes the config path but a release adding a new *file* location would need its own carry-forward.
