### PR TITLE
docs: make the README highlights table advertise things that actually work

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -128,7 +128,7 @@ OMH は **92 個**のインストール可能な workflow skill を、理解し�
 
 | 機能 | 使い方 | 内容 |
 | --- | --- | --- |
-| 🧭 **明確化と計画** | `ulw-deep-interview` · `ulw-ralplan` · `omh-strategy-brief` | 曖昧な依頼を、明確な目標・制約・トレードオフ・受け入れ基準、そしてそのまま引き渡せる計画に変えます。 |
+| 🧭 **明確化と計画** | `ulw-deep-interview` · `ulw-ralplan` · `omh-decide` | 曖昧な依頼を、明確な目標・制約・トレードオフ・受け入れ基準、そしてそのまま引き渡せる計画に変えます。 |
 | ⚡ **レバレッジを効かせた実行** | `ulw-ultrawork` · `ulw-ultragoal` · `ulw-team` · `ulw-loop` | 高速な並列作業から持続的な複数ステップの実行までスケールしながら、所有権・チェックポイント・検証を常に可視化します。 |
 | 🔬 **調査と学習** | `ulw-web-research` · `omh-best-practice-research` · `omh-research-brief` | 鮮度・情報源の質・未解決の不確実性の境界を示しながら、根拠に基づく証拠を収集・統合します。 |
 | 🛠️ **安全なコーディングと出荷** | `ulw-ultraprocess` · `omh-code-review` · `ulw-ultraqa` | executor に依存しないコーディング作業を準備し、review・QA・CI・merge に関する主張は観測された証拠にのみ基づかせます。 |

--- a/README.ja.md
+++ b/README.ja.md
@@ -128,13 +128,13 @@ OMH は **92 個**のインストール可能な workflow skill を、理解し�
 
 | 機能 | 使い方 | 内容 |
 | --- | --- | --- |
-| 🧭 **明確化と計画** | `$deep-interview` · `$ralplan` · `$strategy-brief` | 曖昧な依頼を、明確な目標・制約・トレードオフ・受け入れ基準、そしてそのまま引き渡せる計画に変えます。 |
-| ⚡ **レバレッジを効かせた実行** | `$ultrawork` · `$ultragoal` · `$team` · `$loop` | 高速な並列作業から持続的な複数ステップの実行までスケールしながら、所有権・チェックポイント・検証を常に可視化します。 |
-| 🔬 **調査と学習** | `$best-practice-research` · `$web-research` · `$research-brief` | 鮮度・情報源の質・未解決の不確実性の境界を示しながら、根拠に基づく証拠を収集・統合します。 |
-| 🛠️ **安全なコーディングと出荷** | `$request-to-handoff` · `$code-review` · `$ultraqa` | executor に依存しないコーディング作業を準備し、review・QA・CI・merge に関する主張は観測された証拠にのみ基づかせます。 |
-| 🎨 **洗練された成果物の制作** | `$design-quality-gate` · `$materials-package` · `$deliverable-package` · `$img-summary` | コンテンツ・完成度・アクセシビリティ・レンダリング品質ゲートを軸に、Web サイト、ビジュアル、レポート、スライド、ドキュメント、PDF、ポスター、パッケージを制作します。 |
-| 🧠 **記憶と運用** | `$memory` · `$ops-observability-card` · `$doctor` | プロジェクト記憶をレビュー優先で保ち、運用の準備状況を可視化し、provider やシステム状態を作り話にせず次の修復アクションを示します。 |
-| 🔌 **境界を隠さない接続** | `omh mcp` · `omh plugin` · `$agent-board` | Hermes および互換 host 向けにローカルな metadata 専用 contract を公開しつつ、host のロード・ツール利用・外部 provider アクセスを個別に観測可能な状態に保ちます。 |
+| 🧭 **明確化と計画** | `ulw-deep-interview` · `ulw-ralplan` · `omh-strategy-brief` | 曖昧な依頼を、明確な目標・制約・トレードオフ・受け入れ基準、そしてそのまま引き渡せる計画に変えます。 |
+| ⚡ **レバレッジを効かせた実行** | `ulw-ultrawork` · `ulw-ultragoal` · `ulw-team` · `ulw-loop` | 高速な並列作業から持続的な複数ステップの実行までスケールしながら、所有権・チェックポイント・検証を常に可視化します。 |
+| 🔬 **調査と学習** | `ulw-web-research` · `omh-best-practice-research` · `omh-research-brief` | 鮮度・情報源の質・未解決の不確実性の境界を示しながら、根拠に基づく証拠を収集・統合します。 |
+| 🛠️ **安全なコーディングと出荷** | `ulw-ultraprocess` · `omh-code-review` · `ulw-ultraqa` | executor に依存しないコーディング作業を準備し、review・QA・CI・merge に関する主張は観測された証拠にのみ基づかせます。 |
+| 🎨 **洗練された成果物の制作** | `omh-design-quality-gate` · `omh-materials-package` · `omh-deliverable-package` · `omh-img-summary` | コンテンツ・完成度・アクセシビリティ・レンダリング品質ゲートを軸に、Web サイト、ビジュアル、レポート、スライド、ドキュメント、PDF、ポスター、パッケージを制作します。 |
+| 🧠 **記憶と運用** | `omh-memory-new` · `omh-memory-sync` · `omh-ops-observability-card` · `omh-doctor` | プロジェクト記憶をレビュー優先で保ち、運用の準備状況を可視化し、provider やシステム状態を作り話にせず次の修復アクションを示します。 |
+| 🔌 **境界を隠さない接続** | `omh-toolbelt-readiness` · `omh-external-connector-readiness` · `omh-agent-board` | 作業がそれに依存する前に、必要なツール・connector・agent 面が実際に使えるかを確認し、host のロード・ツール利用・外部 provider アクセスを個別に観測可能な状態に保ちます。 |
 
 ## 実務向けの設計
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -128,7 +128,7 @@ OMH는 **92개**의 설치형 workflow skill을 사람이 이해하기 쉬운 6�
 
 | 기능 | 사용 방법 | 동작 |
 | --- | --- | --- |
-| 🧭 **명확화와 계획** | `ulw-deep-interview` · `ulw-ralplan` · `omh-strategy-brief` | 모호한 요청을 명확한 목표, 제약, trade-off, 완료 기준, 그리고 그대로 전달할 수 있는 계획으로 바꿉니다. |
+| 🧭 **명확화와 계획** | `ulw-deep-interview` · `ulw-ralplan` · `omh-decide` | 모호한 요청을 명확한 목표, 제약, trade-off, 완료 기준, 그리고 그대로 전달할 수 있는 계획으로 바꿉니다. |
 | ⚡ **레버리지를 활용한 실행** | `ulw-ultrawork` · `ulw-ultragoal` · `ulw-team` · `ulw-loop` | 빠른 병렬 작업부터 지속적인 다단계 실행까지 확장하면서도 소유권, 체크포인트, 검증을 계속 볼 수 있게 유지합니다. |
 | 🔬 **조사와 학습** | `ulw-web-research` · `omh-best-practice-research` · `omh-research-brief` | 최신성, 출처 품질, 아직 해소되지 않은 불확실성 경계를 함께 표시하며 근거 기반 증거를 찾고 종합합니다. |
 | 🛠️ **안전한 코딩과 배포** | `ulw-ultraprocess` · `omh-code-review` · `ulw-ultraqa` | executor에 종속되지 않는 코딩 작업을 준비하고, review·QA·CI·merge에 대한 주장은 관측된 증거에만 근거하게 만듭니다. |

--- a/README.ko.md
+++ b/README.ko.md
@@ -128,13 +128,13 @@ OMH는 **92개**의 설치형 workflow skill을 사람이 이해하기 쉬운 6�
 
 | 기능 | 사용 방법 | 동작 |
 | --- | --- | --- |
-| 🧭 **명확화와 계획** | `$deep-interview` · `$ralplan` · `$strategy-brief` | 모호한 요청을 명확한 목표, 제약, trade-off, 완료 기준, 그리고 그대로 전달할 수 있는 계획으로 바꿉니다. |
-| ⚡ **레버리지를 활용한 실행** | `$ultrawork` · `$ultragoal` · `$team` · `$loop` | 빠른 병렬 작업부터 지속적인 다단계 실행까지 확장하면서도 소유권, 체크포인트, 검증을 계속 볼 수 있게 유지합니다. |
-| 🔬 **조사와 학습** | `$best-practice-research` · `$web-research` · `$research-brief` | 최신성, 출처 품질, 아직 해소되지 않은 불확실성 경계를 함께 표시하며 근거 기반 증거를 찾고 종합합니다. |
-| 🛠️ **안전한 코딩과 배포** | `$request-to-handoff` · `$code-review` · `$ultraqa` | executor에 종속되지 않는 코딩 작업을 준비하고, review·QA·CI·merge에 대한 주장은 관측된 증거에만 근거하게 만듭니다. |
-| 🎨 **완성도 높은 산출물 제작** | `$design-quality-gate` · `$materials-package` · `$deliverable-package` · `$img-summary` | 콘텐츠, 완성도, 접근성, 렌더링 품질 게이트를 기준으로 웹사이트, 시각 자료, 보고서, 발표 자료, 문서, PDF, 포스터, 패키지를 만듭니다. |
-| 🧠 **기억과 운영** | `$memory` · `$ops-observability-card` · `$doctor` | 프로젝트 기억을 검토 우선으로 유지하고, 운영 준비 상태를 보여주며, provider나 시스템 상태를 지어내지 않고 다음 복구 행동을 제시합니다. |
-| 🔌 **경계를 숨기지 않는 연결** | `omh mcp` · `omh plugin` · `$agent-board` | Hermes와 호환 host를 위한 로컬 metadata 전용 계약을 제공하면서, host 로드·도구 사용·외부 provider 접근을 각각 별도로 관측할 수 있게 유지합니다. |
+| 🧭 **명확화와 계획** | `ulw-deep-interview` · `ulw-ralplan` · `omh-strategy-brief` | 모호한 요청을 명확한 목표, 제약, trade-off, 완료 기준, 그리고 그대로 전달할 수 있는 계획으로 바꿉니다. |
+| ⚡ **레버리지를 활용한 실행** | `ulw-ultrawork` · `ulw-ultragoal` · `ulw-team` · `ulw-loop` | 빠른 병렬 작업부터 지속적인 다단계 실행까지 확장하면서도 소유권, 체크포인트, 검증을 계속 볼 수 있게 유지합니다. |
+| 🔬 **조사와 학습** | `ulw-web-research` · `omh-best-practice-research` · `omh-research-brief` | 최신성, 출처 품질, 아직 해소되지 않은 불확실성 경계를 함께 표시하며 근거 기반 증거를 찾고 종합합니다. |
+| 🛠️ **안전한 코딩과 배포** | `ulw-ultraprocess` · `omh-code-review` · `ulw-ultraqa` | executor에 종속되지 않는 코딩 작업을 준비하고, review·QA·CI·merge에 대한 주장은 관측된 증거에만 근거하게 만듭니다. |
+| 🎨 **완성도 높은 산출물 제작** | `omh-design-quality-gate` · `omh-materials-package` · `omh-deliverable-package` · `omh-img-summary` | 콘텐츠, 완성도, 접근성, 렌더링 품질 게이트를 기준으로 웹사이트, 시각 자료, 보고서, 발표 자료, 문서, PDF, 포스터, 패키지를 만듭니다. |
+| 🧠 **기억과 운영** | `omh-memory-new` · `omh-memory-sync` · `omh-ops-observability-card` · `omh-doctor` | 프로젝트 기억을 검토 우선으로 유지하고, 운영 준비 상태를 보여주며, provider나 시스템 상태를 지어내지 않고 다음 복구 행동을 제시합니다. |
+| 🔌 **경계를 숨기지 않는 연결** | `omh-toolbelt-readiness` · `omh-external-connector-readiness` · `omh-agent-board` | 작업이 의존하기 전에 필요한 도구·connector·agent 표면이 실제로 준비됐는지 확인하고, host 로드·도구 사용·외부 provider 접근을 각각 별도로 관측할 수 있게 유지합니다. |
 
 ## 실제 업무를 위한 설계
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ The full generated catalog, triggers, harnesses, and evidence rules live in
 
 | Capability | Try it with | What it does |
 | --- | --- | --- |
-| 🧭 **Clarify and plan** | `ulw-deep-interview` · `ulw-ralplan` · `omh-strategy-brief` | Turns an ambiguous request into explicit goals, constraints, tradeoffs, acceptance criteria, and a plan that can be handed off. |
+| 🧭 **Clarify and plan** | `ulw-deep-interview` · `ulw-ralplan` · `omh-decide` | Turns an ambiguous request into explicit goals, constraints, tradeoffs, acceptance criteria, and a plan that can be handed off. |
 | ⚡ **Build with leverage** | `ulw-ultrawork` · `ulw-ultragoal` · `ulw-team` · `ulw-loop` | Scales from fast parallel work to durable multi-step execution while keeping ownership, checkpoints, and verification visible. |
 | 🔬 **Research and learn** | `ulw-web-research` · `omh-best-practice-research` · `omh-research-brief` | Finds and synthesizes source-backed evidence with freshness, source-quality, and unresolved-uncertainty boundaries. |
 | 🛠️ **Code and ship safely** | `ulw-ultraprocess` · `omh-code-review` · `ulw-ultraqa` | Prepares executor-neutral coding work, then makes review, QA, CI, and merge claims depend on observed evidence. |

--- a/README.md
+++ b/README.md
@@ -138,13 +138,13 @@ The full generated catalog, triggers, harnesses, and evidence rules live in
 
 | Capability | Try it with | What it does |
 | --- | --- | --- |
-| 🧭 **Clarify and plan** | `$deep-interview` · `$ralplan` · `$strategy-brief` | Turns an ambiguous request into explicit goals, constraints, tradeoffs, acceptance criteria, and a plan that can be handed off. |
-| ⚡ **Build with leverage** | `$ultrawork` · `$ultragoal` · `$team` · `$loop` | Scales from fast parallel work to durable multi-step execution while keeping ownership, checkpoints, and verification visible. |
-| 🔬 **Research and learn** | `$best-practice-research` · `$web-research` · `$research-brief` | Finds and synthesizes source-backed evidence with freshness, source-quality, and unresolved-uncertainty boundaries. |
-| 🛠️ **Code and ship safely** | `$request-to-handoff` · `$code-review` · `$ultraqa` | Prepares executor-neutral coding work, then makes review, QA, CI, and merge claims depend on observed evidence. |
-| 🎨 **Create polished deliverables** | `$design-quality-gate` · `$materials-package` · `$deliverable-package` · `$img-summary` | Shapes websites, visuals, reports, decks, documents, PDFs, posters, and packages around content, taste, accessibility, and render-quality gates. |
-| 🧠 **Remember and operate** | `$memory` · `$ops-observability-card` · `$doctor` | Keeps project memory review-first, surfaces operational readiness, and gives the next repair action without inventing provider or system state. |
-| 🔌 **Connect without hiding boundaries** | `omh mcp` · `omh plugin` · `$agent-board` | Exposes local metadata-only contracts for Hermes and compatible hosts while keeping host load, tool use, and external-provider access separately observable. |
+| 🧭 **Clarify and plan** | `ulw-deep-interview` · `ulw-ralplan` · `omh-strategy-brief` | Turns an ambiguous request into explicit goals, constraints, tradeoffs, acceptance criteria, and a plan that can be handed off. |
+| ⚡ **Build with leverage** | `ulw-ultrawork` · `ulw-ultragoal` · `ulw-team` · `ulw-loop` | Scales from fast parallel work to durable multi-step execution while keeping ownership, checkpoints, and verification visible. |
+| 🔬 **Research and learn** | `ulw-web-research` · `omh-best-practice-research` · `omh-research-brief` | Finds and synthesizes source-backed evidence with freshness, source-quality, and unresolved-uncertainty boundaries. |
+| 🛠️ **Code and ship safely** | `ulw-ultraprocess` · `omh-code-review` · `ulw-ultraqa` | Prepares executor-neutral coding work, then makes review, QA, CI, and merge claims depend on observed evidence. |
+| 🎨 **Create polished deliverables** | `omh-design-quality-gate` · `omh-materials-package` · `omh-deliverable-package` · `omh-img-summary` | Shapes websites, visuals, reports, decks, documents, PDFs, posters, and packages around content, taste, accessibility, and render-quality gates. |
+| 🧠 **Remember and operate** | `omh-memory-new` · `omh-memory-sync` · `omh-ops-observability-card` · `omh-doctor` | Keeps project memory review-first, surfaces operational readiness, and gives the next repair action without inventing provider or system state. |
+| 🔌 **Connect without hiding boundaries** | `omh-toolbelt-readiness` · `omh-external-connector-readiness` · `omh-agent-board` | Checks whether a needed tool, connector, or agent surface is really available before work depends on it, and keeps host load, tool use, and external-provider access separately observable. |
 
 <br>
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -124,13 +124,13 @@ OMH 将 **92 个**可安装的 workflow skill 组织为6个容易理解的能力
 
 | 能力 | 使用方式 | 作用 |
 | --- | --- | --- |
-| 🧭 **澄清与规划** | `$deep-interview` · `$ralplan` · `$strategy-brief` | 把模糊的请求转化为明确的目标、约束、权衡、验收标准，以及可以直接交接的计划。 |
-| ⚡ **借助杠杆推进工作** | `$ultrawork` · `$ultragoal` · `$team` · `$loop` | 从快速并行工作扩展到持久的多步骤执行，同时保持所有权、检查点和验证始终可见。 |
-| 🔬 **研究与学习** | `$best-practice-research` · `$web-research` · `$research-brief` | 在标明时效性、来源质量和尚未解决的不确定性边界的同时，查找并综合有依据的证据。 |
-| 🛠️ **安全地编码与交付** | `$request-to-handoff` · `$code-review` · `$ultraqa` | 准备不依赖特定 executor 的编码工作，并让 review、QA、CI 和 merge 的相关声明只依据实际观测到的证据。 |
-| 🎨 **打造精致的交付物** | `$design-quality-gate` · `$materials-package` · `$deliverable-package` · `$img-summary` | 围绕内容、审美、无障碍性和渲染质量 gate，制作网站、视觉素材、报告、演示文稿、文档、PDF、海报和交付包。 |
-| 🧠 **记忆与运维** | `$memory` · `$ops-observability-card` · `$doctor` | 让项目记忆保持“先审查后使用”，呈现运维就绪状态，并在不臆造 provider 或系统状态的前提下给出下一步修复动作。 |
-| 🔌 **在不隐藏边界的前提下连接** | `omh mcp` · `omh plugin` · `$agent-board` | 为 Hermes 及兼容的 host 提供仅含元数据的本地 contract，同时让 host 加载、工具使用和外部 provider 访问都能被分别观测。 |
+| 🧭 **澄清与规划** | `ulw-deep-interview` · `ulw-ralplan` · `omh-strategy-brief` | 把模糊的请求转化为明确的目标、约束、权衡、验收标准，以及可以直接交接的计划。 |
+| ⚡ **借助杠杆推进工作** | `ulw-ultrawork` · `ulw-ultragoal` · `ulw-team` · `ulw-loop` | 从快速并行工作扩展到持久的多步骤执行，同时保持所有权、检查点和验证始终可见。 |
+| 🔬 **研究与学习** | `ulw-web-research` · `omh-best-practice-research` · `omh-research-brief` | 在标明时效性、来源质量和尚未解决的不确定性边界的同时，查找并综合有依据的证据。 |
+| 🛠️ **安全地编码与交付** | `ulw-ultraprocess` · `omh-code-review` · `ulw-ultraqa` | 准备不依赖特定 executor 的编码工作，并让 review、QA、CI 和 merge 的相关声明只依据实际观测到的证据。 |
+| 🎨 **打造精致的交付物** | `omh-design-quality-gate` · `omh-materials-package` · `omh-deliverable-package` · `omh-img-summary` | 围绕内容、审美、无障碍性和渲染质量 gate，制作网站、视觉素材、报告、演示文稿、文档、PDF、海报和交付包。 |
+| 🧠 **记忆与运维** | `omh-memory-new` · `omh-memory-sync` · `omh-ops-observability-card` · `omh-doctor` | 让项目记忆保持“先审查后使用”，呈现运维就绪状态，并在不臆造 provider 或系统状态的前提下给出下一步修复动作。 |
+| 🔌 **在不隐藏边界的前提下连接** | `omh-toolbelt-readiness` · `omh-external-connector-readiness` · `omh-agent-board` | 在工作依赖某个工具、connector 或 agent 面之前先确认它是否真的可用，同时让 host 加载、工具使用和外部 provider 访问都能被分别观测。 |
 
 ## 面向真实工作的设计
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -124,7 +124,7 @@ OMH 将 **92 个**可安装的 workflow skill 组织为6个容易理解的能力
 
 | 能力 | 使用方式 | 作用 |
 | --- | --- | --- |
-| 🧭 **澄清与规划** | `ulw-deep-interview` · `ulw-ralplan` · `omh-strategy-brief` | 把模糊的请求转化为明确的目标、约束、权衡、验收标准，以及可以直接交接的计划。 |
+| 🧭 **澄清与规划** | `ulw-deep-interview` · `ulw-ralplan` · `omh-decide` | 把模糊的请求转化为明确的目标、约束、权衡、验收标准，以及可以直接交接的计划。 |
 | ⚡ **借助杠杆推进工作** | `ulw-ultrawork` · `ulw-ultragoal` · `ulw-team` · `ulw-loop` | 从快速并行工作扩展到持久的多步骤执行，同时保持所有权、检查点和验证始终可见。 |
 | 🔬 **研究与学习** | `ulw-web-research` · `omh-best-practice-research` · `omh-research-brief` | 在标明时效性、来源质量和尚未解决的不确定性边界的同时，查找并综合有依据的证据。 |
 | 🛠️ **安全地编码与交付** | `ulw-ultraprocess` · `omh-code-review` · `ulw-ultraqa` | 准备不依赖特定 executor 的编码工作，并让 review、QA、CI 和 merge 的相关声明只依据实际观测到的证据。 |

--- a/skills/strategy-brief/SKILL.md
+++ b/skills/strategy-brief/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: omh-strategy-brief
+name: omh-decide
 description: [omh] Hermes Strategy Brief workflow: options, tradeoffs, recommendation, and decision notes.
 metadata:
   hermes:

--- a/src/plugin_bundle/omh/awareness.py
+++ b/src/plugin_bundle/omh/awareness.py
@@ -5613,6 +5613,14 @@ def _canonical_workflow_by_display_name() -> dict[str, str]:
         f"{'ulw-' if workflow in _ULW_ENGINE_WORKFLOWS else 'omh-'}{workflow}": workflow for workflow in workflows
     }
     mapping["omh-routing"] = "oh-my-hermes"
+    # Hand-picked labels the mechanical prefix rule cannot derive. Mirrors
+    # `skills/catalog_types.OMH_SKILL_DISPLAY_NAME_OVERRIDES`; the copy exists
+    # because a copied plugin bundle has no catalog import, and
+    # `tests/test_display_names.py` locks the two together.
+    for display, workflow in (("omh-decide", "strategy-brief"),):
+        mapping.pop(f"omh-{workflow}", None)
+        if workflow in workflows:
+            mapping[display] = workflow
     return mapping
 
 

--- a/src/skills/catalog_types.py
+++ b/src/skills/catalog_types.py
@@ -34,7 +34,15 @@ OMH_SKILL_NAME_PREFIX = "omh-"
 # starts with `omh-`, which a prefix-first implementation would short-circuit
 # before ever reaching its override. No current key does, so the ordering is a
 # forward-looking contract rather than a live behavior.
-OMH_SKILL_DISPLAY_NAME_OVERRIDES = {"oh-my-hermes": "omh-routing"}
+OMH_SKILL_DISPLAY_NAME_OVERRIDES = {
+    "oh-my-hermes": "omh-routing",
+    # `strategy-brief` says what the output is, not what the skill does for
+    # you. The skill turns goals and evidence into options, tradeoffs, and a
+    # recommendation - it helps you decide. The canonical name stays put
+    # (directory, manifest, tap URL, triggers); only the label a reader sees
+    # changes.
+    "strategy-brief": "omh-decide",
+}
 
 ULW_SKILL_NAME_PREFIX = "ulw-"
 

--- a/tests/test_readme_highlights.py
+++ b/tests/test_readme_highlights.py
@@ -1,0 +1,80 @@
+"""The README must not advertise a skill you cannot invoke.
+
+The Highlights table tells a reader what to type. It listed `$memory`, which is
+not a skill and routes to a picker, and `$request-to-handoff`, which is a
+playbook id rather than an installable skill - both sat there unnoticed because
+nothing checked the table against the catalog.
+
+This gate reads every label out of the "Try it with" column in all four READMEs
+and requires it to be a real installable skill's display name. It also keeps
+operator-only CLI commands out of that column: `AGENTS.md` reserves `omh …`
+commands for operators and wrappers, and a normal user should only ever need
+`omh setup`, `omh update`, and `omh doctor`.
+"""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+from omh.skills.catalog import installable_skill_names, omh_skill_display_name
+
+
+READMES = ("README.md", "README.ko.md", "README.ja.md", "README.zh.md")
+
+# The "Try it with" column is the second cell of each Highlights row.
+_LABEL_RE = re.compile(r"`([^`]+)`")
+
+
+def _highlight_rows(text: str) -> list[str]:
+    rows: list[str] = []
+    inside = False
+    for line in text.splitlines():
+        if line.strip().startswith("**") and "ighlight" in line or "하이라이트" in line or "ハイライト" in line or "亮点" in line:
+            inside = True
+            continue
+        if inside:
+            if line.startswith("|") and line.count("|") >= 4 and not set(line) <= set("|- "):
+                rows.append(line)
+            elif rows and not line.startswith("|"):
+                break
+    return rows
+
+
+class ReadmeHighlightsTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.display_names = {omh_skill_display_name(name) for name in installable_skill_names()}
+
+    def test_every_advertised_label_is_an_installable_skill(self) -> None:
+        for rel in READMES:
+            rows = _highlight_rows(Path(rel).read_text(encoding="utf-8"))
+            self.assertTrue(rows, f"{rel}: no Highlights rows found")
+            for row in rows:
+                cells = [cell.strip() for cell in row.strip().strip("|").split("|")]
+                for label in _LABEL_RE.findall(cells[1]):
+                    with self.subTest(readme=rel, label=label):
+                        self.assertIn(label, self.display_names)
+
+    def test_the_try_it_column_holds_no_operator_cli_commands(self) -> None:
+        # `omh mcp` and `omh plugin` used to live here. AGENTS.md keeps the
+        # control-plane commands in the operator reference, not in the table a
+        # chat user reads to learn what to say.
+        for rel in READMES:
+            for row in _highlight_rows(Path(rel).read_text(encoding="utf-8")):
+                cells = [cell.strip() for cell in row.strip().strip("|").split("|")]
+                for label in _LABEL_RE.findall(cells[1]):
+                    with self.subTest(readme=rel, label=label):
+                        self.assertFalse(label.startswith("omh "), f"{label} is an operator command")
+
+    def test_the_workflow_engines_are_advertised_with_their_ulw_label(self) -> None:
+        english = Path("README.md").read_text(encoding="utf-8")
+        rows = "\n".join(_highlight_rows(english))
+
+        for engine in ("ulw-ultrawork", "ulw-ultragoal", "ulw-team", "ulw-loop"):
+            with self.subTest(engine=engine):
+                self.assertIn(f"`{engine}`", rows)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -688,7 +688,7 @@ class RouterContentTests(unittest.TestCase):
 
     def test_display_name_helper_keeps_canonical_identifiers_unchanged(self) -> None:
         self.assertEqual(OMH_SKILL_NAME_PREFIX, "omh-")
-        self.assertEqual(OMH_SKILL_DISPLAY_NAME_OVERRIDES, {"oh-my-hermes": "omh-routing"})
+        self.assertEqual(OMH_SKILL_DISPLAY_NAME_OVERRIDES, {"oh-my-hermes": "omh-routing", "strategy-brief": "omh-decide"})
 
         self.assertEqual(omh_skill_display_name("oh-my-hermes"), "omh-routing")
         self.assertEqual(omh_skill_display_name("ultrawork"), "ulw-ultrawork")


### PR DESCRIPTION
## Feature Report

### What Changed

The README **Highlights** table now advertises labels that actually work, in all four READMEs (en/ko/ja/zh):

| Row | Before | After |
| --- | --- | --- |
| Clarify and plan | `$deep-interview` `$ralplan` `$strategy-brief` | `ulw-deep-interview` `ulw-ralplan` `omh-strategy-brief` |
| Build with leverage | `$ultrawork` `$ultragoal` `$team` `$loop` | `ulw-ultrawork` `ulw-ultragoal` `ulw-team` `ulw-loop` |
| Research and learn | `$best-practice-research` `$web-research` `$research-brief` | `ulw-web-research` `omh-best-practice-research` `omh-research-brief` |
| Code and ship safely | **`$request-to-handoff`** `$code-review` `$ultraqa` | `ulw-ultraprocess` `omh-code-review` `ulw-ultraqa` |
| Create polished deliverables | `$design-quality-gate` … | `omh-design-quality-gate` … |
| Remember and operate | **`$memory`** `$ops-observability-card` `$doctor` | `omh-memory-new` `omh-memory-sync` `omh-ops-observability-card` `omh-doctor` |
| Connect without hiding boundaries | **`omh mcp`** · **`omh plugin`** · `$agent-board` | `omh-toolbelt-readiness` `omh-external-connector-readiness` `omh-agent-board` |

### Why This Exists

Two entries could not be typed:

- **`$memory` is not a skill.** It routes to a picker. The catalog has `memory-new` and `memory-sync`.
- **`$request-to-handoff` is a playbook id**, not an installable skill — it routes to the router rather than to a workflow.

Nothing compared the table against the catalog, so both sat there.

The connector row was a different failure. It advertised `omh mcp` and `omh plugin`, but `AGENTS.md` **Command Audience** reserves control-plane commands for operators and wrappers — a normal user should only ever need `omh setup`, `omh update`, and `omh doctor`. The user-facing highlights table was contradicting the repo's own contract.

### User / Operator Impact

Every label in the table is now paste-able. The column carries **display names**, the same form a host status line shows and the one the router already accepts — `canonical_display_mentions` resolves `ulw-ultrawork` back to `ultrawork`. Each replacement was routed before being written, not assumed.

It also makes the engine split visible where it counts: a reader sees `ulw-` on the ten workflow engines and `omh-` on everything else without having to read the paragraph above the table.

### How It Works

`tests/test_readme_highlights.py` is the part that keeps this fixed. It reads every label out of the "Try it with" column in all four READMEs and requires it to be an installable skill's display name, and separately rejects `omh …` operator commands in that column.

**The gate was proven to bite**: reverting one cell to `$memory` fails it; restoring passes.

### Files And Contracts Touched

- `README.md`, `README.ko.md`, `README.ja.md`, `README.zh.md` — Highlights table cells plus the connector row description.
- New: `tests/test_readme_highlights.py`.

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `python3 -m unittest discover -s tests` — 2145 passed, 1 skipped
- [x] `python3 -m compileall src`
- [x] `python3 -m omh.cli docs workflows --check` (also `docs roles`, `docs capability-families`, `release drift`)
- [ ] `python3 -m omh.cli harness validate` — not rerun; docs-only change
- [ ] `python3 -m omh.cli release checklist --json` — not rerun
- [ ] `python3 -m omh.cli release hermes-smoke` — not rerun
- [x] `omh --help`
- [ ] `omh --omh-home … release hermes-smoke --include-command-smoke` — not rerun
- [ ] Relevant workflow-learning review queue smoke — not applicable
- [x] Relevant dry-run or smoke command: every replacement label routed through `route_chat_message` and confirmed to dispatch to its canonical skill
- [ ] **Manual Hermes/TUI check — not run.** The GitHub Pages site was not rebuilt, so how the wider table wraps there is unobserved.

## Risk

- Docs and one test; no runtime behavior changes.
- The labels depend on `canonical_display_mentions` continuing to resolve display names. That path is covered by `tests/test_display_names.py`; if it were removed, these labels would stop resolving and the table would be wrong again — worth knowing before touching the display-mention regex.

## Compatibility / Rollout

- The old `$name` invocation form still works; it is simply no longer what the table shows.

## Release / Claims

- [x] Release-channel impact considered (`stable`; docs only)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Known manual Hermes checks are listed

## Follow-Up

- The same "does the doc match the catalog" question applies to the six capability-family rows above the Highlights table and to `docs/README.md`. Those describe families rather than individual skills, so they need a different check than this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Second commit: `strategy-brief` renders as `omh-decide`

`strategy-brief` names the artifact, not the job. The skill turns goals and evidence into options, tradeoffs, a recommendation, and a decision note — it is the one you reach for when you have to **choose**. Nobody scanning the README for that stops on "strategy brief".

It now renders as **`omh-decide`**, through the same `OMH_SKILL_DISPLAY_NAME_OVERRIDES` map that already turns `oh-my-hermes` into `omh-routing`. **Only the label moves** — the canonical name still owns `skills/strategy-brief/`, the install manifest, the tap URL, every trigger, and every CLI argument.

Backward compatible, verified by routing each one:

```
omh-decide                       -> strategy-brief
omh-strategy-brief               -> strategy-brief   (old label still works)
strategy-brief                   -> strategy-brief
"our pricing strategy needs work" -> strategy-brief   (plain language unaffected)
```

**Not `ulw-decide`.** `strategy-brief` is a domain skill, not one of the ten workflow engines, so it takes `omh-`. The suggestion that started this was `ulw-idea`, which would have been wrong twice — wrong prefix, and the skill decides *between* options rather than generating them.

The plugin bundle carried its own display map that derived every label mechanically as `omh-<workflow>` and could not express an override at all. It now mirrors the map; `tests/test_display_names.py` locks the copy against the catalog, and that test is what caught the gap.

Updated verification for both commits: **2145 tests passed, 1 skipped**; all three `--check` gates rc=0; `release drift` clean; ruff clean.
