### PR TITLE
fix(progress): stop leaking absolute filesystem paths into chat-facing progress copy

### DIFF
--- a/src/coding/context_safety.py
+++ b/src/coding/context_safety.py
@@ -41,6 +41,19 @@ _RAW_CODEX_JSONL_RE = re.compile(
     re.IGNORECASE,
 )
 _SELF_IMPROVEMENT_REVIEW_RE = re.compile(r"\bSelf-improvement\s+review\s*:", re.IGNORECASE)
+# Absolute filesystem paths in chat-facing progress copy leak the operator's
+# home directory -- on this repo's own machines that segment is an email-shaped
+# account name -- into whatever surface renders the progress line, and they pad
+# a one-line status with machine layout nobody reading chat can act on. The
+# useful part of "/Users/<account>/work/<repo>/src/skills/render.py" is the tail
+# after the repo root, so keep a bounded tail and drop the rooted prefix.
+#
+# Matching is deliberately conservative: an absolute POSIX path with at least
+# two segments, or a drive-lettered Windows path. Relative paths are already
+# safe and are left untouched, so `src/skills/render.py` survives verbatim.
+_ABSOLUTE_POSIX_PATH_RE = re.compile(r"(?<![\w./])/(?:[\w.@+-]+/){1,}[\w.@+-]+")
+_ABSOLUTE_WINDOWS_PATH_RE = re.compile(r"(?<![\w\\])[A-Za-z]:\\(?:[\w.@+ -]+\\)*[\w.@+ -]+")
+_REDACTED_PATH_TAIL_SEGMENTS = 3
 
 CODING_PROGRESS_REPORTABLE_EVENTS = (
     "workflow_started",
@@ -98,9 +111,34 @@ def compact_visible_text(value: Any, *, max_chars: int) -> str:
     return f"{text[: max_chars - 3]}..."
 
 
+def redact_absolute_paths(value: Any) -> str:
+    """Reduce absolute filesystem paths to a bounded, account-free tail.
+
+    `/Users/someone/work/repo/src/skills/render.py` becomes
+    `.../repo/src/skills/render.py`. Relative paths are returned unchanged,
+    because they carry no home directory and are already the readable form.
+    """
+    text = str(value)
+    if not text.strip():
+        return ""
+    return _ABSOLUTE_WINDOWS_PATH_RE.sub(
+        lambda match: _shorten_path(match.group(0), "\\"),
+        _ABSOLUTE_POSIX_PATH_RE.sub(lambda match: _shorten_path(match.group(0), "/"), text),
+    )
+
+
+def _shorten_path(path: str, separator: str) -> str:
+    segments = [segment for segment in path.split(separator) if segment]
+    if len(segments) <= _REDACTED_PATH_TAIL_SEGMENTS:
+        # Short enough to carry no home directory; keep it byte-identical so
+        # `/etc/hosts` does not silently lose its leading separator.
+        return path
+    return "..." + separator + separator.join(segments[-_REDACTED_PATH_TAIL_SEGMENTS:])
+
+
 def sanitize_user_facing_progress_text(value: Any, *, max_chars: int | None = None) -> str:
     """Drop raw process/JSONL maintenance noise from chat-facing progress copy."""
-    text = str(value)
+    text = redact_absolute_paths(value)
     if not text.strip():
         return ""
     clean_lines: list[str] = []

--- a/tests/test_progress_path_redaction.py
+++ b/tests/test_progress_path_redaction.py
@@ -1,0 +1,75 @@
+"""Chat-facing progress copy must not carry absolute filesystem paths.
+
+Progress lines reach chat surfaces verbatim. An absolute path in one of them
+publishes the operator's home directory — on this project's own machines that
+segment is an email-shaped account name — to whatever channel renders the
+line, and pads a one-line status with machine layout the reader cannot act on.
+
+The sanitizer already dropped JSONL noise and background-process wrappers but
+passed paths through untouched, so a "file was not modified" progress line
+arrived in chat as a full `/Users/<account>/work/<repo>/src/...` string. These
+tests lock the redaction and, just as importantly, lock what must NOT change:
+relative paths are the readable form already, and URLs are not filesystem
+paths.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from omh.coding.context_safety import (
+    redact_absolute_paths,
+    sanitize_user_facing_progress_text,
+)
+
+
+class ProgressPathRedactionTest(unittest.TestCase):
+    def test_absolute_home_path_loses_the_account_segment(self) -> None:
+        line = (
+            "4 file(s) were NOT modified this turn: "
+            "/Users/someone@example.com/work/oh-my-hermes/src/skills/render.py"
+        )
+        cleaned = sanitize_user_facing_progress_text(line)
+        self.assertNotIn("someone@example.com", cleaned)
+        self.assertNotIn("/Users/", cleaned)
+        self.assertIn("src/skills/render.py", cleaned)
+
+    def test_redaction_keeps_a_bounded_identifying_tail(self) -> None:
+        redacted = redact_absolute_paths("/Users/a/work/repo/src/skills/render.py")
+        self.assertEqual(redacted, ".../src/skills/render.py")
+
+    def test_windows_paths_are_redacted_too(self) -> None:
+        redacted = redact_absolute_paths(r"wrote C:\Users\someone\repo\src\main.py")
+        self.assertNotIn("someone", redacted)
+        self.assertIn(r"src\main.py", redacted)
+
+    def test_relative_paths_are_left_alone(self) -> None:
+        # The readable form already; rewriting it would be pure churn.
+        for line in ("edited src/skills/render.py", "see tests/test_cli.py hunk 2"):
+            with self.subTest(line=line):
+                self.assertEqual(sanitize_user_facing_progress_text(line), line)
+
+    def test_short_absolute_paths_keep_their_leading_separator(self) -> None:
+        # Nothing to redact, so the string must survive byte-identical rather
+        # than silently becoming a relative-looking path.
+        self.assertEqual(redact_absolute_paths("see /etc/hosts"), "see /etc/hosts")
+
+    def test_urls_and_ratios_are_not_mistaken_for_paths(self) -> None:
+        for line in ("visit https://example.com/a/b/c now", "ratio 3/4 done"):
+            with self.subTest(line=line):
+                self.assertEqual(redact_absolute_paths(line), line)
+
+    def test_redaction_runs_before_the_existing_noise_filters(self) -> None:
+        # A path riding inside a background-process wrapper must be dropped
+        # with the wrapper, not resurrected by the redaction pass.
+        line = (
+            "[Background process abc finished with exit code 0~ Here's the final output:] "
+            "/Users/someone/work/repo/src/skills/render.py changed"
+        )
+        cleaned = sanitize_user_facing_progress_text(line)
+        self.assertNotIn("/Users/", cleaned)
+        self.assertNotIn("Background process", cleaned)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

`sanitize_user_facing_progress_text()` — the sanitizer every chat-facing progress line already passes through — now redacts absolute filesystem paths.

## Why

Reported from live Slack use. A progress line arrived as:

```
4 file(s) were NOT modified this turn:
/Users/<account>/work/oh-my-hermes-memory-sync/src/skills/render.py
```

Two defects in one string:

1. **The home-directory segment is an email-shaped account name** on this project's machines, so every such line publishes it to whatever channel renders the progress.
2. **The rooted prefix is machine layout** nobody reading chat can act on. The actionable part is the tail after the repo root.

The sanitizer already dropped raw JSONL, background-process wrappers, and self-review noise — paths were simply an uncovered case. Verified before the fix: the pre-change function returned the full `/Users/...` string unmodified.

## What is different now

| Input | Before | After |
| --- | --- | --- |
| `/Users/<acct>/work/repo/src/skills/render.py` | unchanged | `.../src/skills/render.py` |
| `C:\Users\<acct>\repo\src\main.py` | unchanged | `...\repo\src\main.py` |
| `src/skills/render.py` | unchanged | unchanged |
| `/etc/hosts` | unchanged | unchanged |
| `https://example.com/a/b/c` | unchanged | unchanged |
| `ratio 3/4 done` | unchanged | unchanged |

## Implementation

- `src/coding/context_safety.py` — new `redact_absolute_paths()`, run first inside the existing sanitizer. Conservative regexes: absolute POSIX paths with ≥2 segments, and drive-lettered Windows paths. Paths longer than three segments collapse to a `.../` tail; shorter ones are returned byte-identical so `/etc/hosts` does not lose its leading separator.

Placed in the sanitizer rather than at call sites because it is the shared contract — `executor_progress.py` and `codex_progress.py` both route user-facing copy through it, and per-site fixes would drift.

## Verification observed

- `tests/test_progress_path_redaction.py` (new, 7 cases) — includes negative controls proving relative paths, short absolute paths, URLs, and ratios are untouched, and that a path embedded in a background-process wrapper is dropped with the wrapper rather than resurrected
- Full suite: **2154 passed**, 1 pre-existing skip
- `compileall`, `ruff`, `git diff --check` — clean

## Risks and scope

- Narrow: one function, run first in an existing pipeline. No schema, routing, or catalog surface touched; no generated artifact affected.
- **Out of scope:** the upstream footer that motivated the report (`File-mutation verifier: N file(s) were NOT modified this turn`) is emitted by the Hermes runtime, not OMH, and is unchanged here. OMH does not patch Hermes core. This PR fixes OMH's own leak on the same class of text; if that footer is routed through an OMH surface it now benefits automatically.
- Not addressed: the repeated-cause verbosity in that footer (one failed patch reported once per affected file). That formatting belongs to the emitter.
