### PR TITLE
fix: resolve a named skill wherever it sits in the sentence

### DIFF
--- a/src/routing/chat.py
+++ b/src/routing/chat.py
@@ -1555,6 +1555,7 @@ def _route_chat_message_cached(
     task_card_overrides_explicit = _task_card_overrides_explicit_invocation(
         task_card,
         explicit_prefix=explicit_prefix,
+        explicit_skill=explicit_skill or "",
     )
     if task_card and (not explicit_skill or task_card_overrides_explicit):
         full_recommendations = _prioritize_recommendation(full_recommendations, task_card_recommendation(task_card))
@@ -1959,6 +1960,19 @@ def _maintenance_task_fast_path_decision(
     if _maintenance_task_should_yield_to_catalog(routing_message, task_card):
         return None
     selected_skill = str(task_card.get("selected_workflow_rail", _ROUTER_SKILL))
+    # This card is matched by alias substring, so it also claims the four skills
+    # whose own names contain one -- `codegraph-refresh`, `model-setup`,
+    # `websearch-setup`, `skill-health`. Naming a workflow outranks an alias
+    # found inside that workflow's name, and the same rule is applied to the
+    # slower path in `_task_card_overrides_explicit_invocation`.
+    #
+    # A prefixed message is left alone: `./omh update` and `/omh update` resolve
+    # through the `/omh` alias to `meta-router`, which is the command lane, not
+    # a user naming a different workflow to run instead.
+    if not _has_explicit_invocation_prefix(routing_message):
+        explicit_skill = explicit_skill_invocation(routing_message)
+        if explicit_skill and explicit_skill != selected_skill:
+            return None
     selected_harness = primary_harness_for_skill(selected_skill)
     recommendation = _task_card_fast_path_recommendation(task_card, message)
     reason = str(
@@ -5044,12 +5058,23 @@ def _task_card_overrides_explicit_invocation(
     task_card: dict[str, object] | None,
     *,
     explicit_prefix: bool,
+    explicit_skill: str = "",
 ) -> bool:
     if not isinstance(task_card, dict):
         return False
     task_type = task_card.get("task_type")
     if task_type == "omh_cli_maintenance":
-        return True
+        # The maintenance card is matched by alias substring, so a skill whose
+        # own name contains one is claimed by it: `codegraph-refresh` reads as
+        # `refresh`, `model-setup` and `websearch-setup` as `setup`,
+        # `skill-health` as `health`. Overriding unconditionally meant naming
+        # any of those four ran the maintenance path instead.
+        #
+        # A named workflow outranks an alias found inside its own name. Nothing
+        # is lost for the real commands: of update/setup/doctor/uninstall/
+        # install/list only `doctor` is also a routable skill, and its card
+        # already routes to `doctor`, so the two agree.
+        return not explicit_skill or explicit_skill == task_card.get("selected_workflow_rail")
     if task_type == "router_design_feedback":
         return not explicit_prefix
     return False

--- a/src/routing/policy.py
+++ b/src/routing/policy.py
@@ -4771,6 +4771,37 @@ def meets_confidence_threshold(confidence: str, threshold: str) -> bool:
     return _CONFIDENCE_RANK[confidence] >= _CONFIDENCE_RANK[threshold]
 
 
+# Words that mark a message as "I am naming a skill to run", independent of
+# where they sit in the sentence.
+OMH_INVOCATION_MARKERS = frozenset({"omh", "oh-my-hermes", "oh-my-hermes-agent", "ohmyhermes"})
+SKILL_INVOCATION_MARKERS = frozenset({"skill", "workflow", "스킬", "워크플로우", "워크플로"})
+
+# Korean attaches particles to the noun, so a skill named in Korean word order
+# arrives as "wiki를" or "wiki로" rather than as a bare token.
+_KOREAN_PARTICLES = ("으로", "로", "를", "을", "는", "은", "이", "가", "에게", "에", "도", "만")
+
+# A marker alone is not an invocation: "does OMH support skill health
+# dashboards?" and "what is oh-my-hermes?" both name a marker and a skill while
+# asking a question about the catalog. Requiring a cue that means *run it* is
+# what separates the two.
+_INVOCATION_RUN_CUES = (
+    "use",
+    "run",
+    "execute",
+    "invoke",
+    "start",
+    "써줘",
+    "써",
+    "쓰자",
+    "사용",
+    "실행",
+    "돌려",
+    "해줘",
+    "해주세요",
+    "부탁",
+)
+
+
 def explicit_skill_invocation(message: str, names: set[str]) -> str | None:
     stripped = message.strip()
     words = [word.strip(":,").lower() for word in stripped.split()]
@@ -4803,7 +4834,81 @@ def explicit_skill_invocation(message: str, names: set[str]) -> str | None:
             alias = _PREFIXED_BARE_SKILL_ALIASES.get(first, alias)
         if alias in names:
             return None if _explicit_skill_candidate_is_negated(stripped, first, alias) else alias
-    return None
+    return _marker_scoped_skill_invocation(stripped, words, names)
+
+
+def _marker_scoped_skill_invocation(stripped: str, words: list[str], names: set[str]) -> str | None:
+    """Resolve "run this named skill" wherever the name sits in the sentence.
+
+    Every form above assumes English word order: `use omh <skill>` needs the
+    name third, and the prefix and bare-first-word forms need it first. Korean
+    puts the verb last, so `omh wiki 써줘` matched none of them and fell through
+    to trigger scoring -- which is right only when the name happens to be a
+    distinctive token. Measured across all routable skills, that form resolved
+    81 of 92, and `use the <skill> skill` 86 of 92; the failures were the skills
+    with ordinary names, exactly the ones a user cannot rescue by rephrasing.
+
+    Slack and Discord are why this matters. There is no slash-command surface
+    there, so naming the skill in a sentence is the explicit path, and it has to
+    work in the language the sentence is written in.
+
+    Three things are required together, and each one removes a real overroute
+    found while building this:
+
+    - A marker word, so a bare mention is never promoted to an invocation.
+    - A run cue. "does OMH support skill health dashboards?" names a marker and
+      a skill while asking a catalog question; answering it by running the skill
+      is exactly the wrong move.
+    - The name adjacent to the marker. Several skills are named with ordinary
+      words -- loop, plan, team, ask -- so "Run a loop to find and fix OMH
+      router bugs" carries a marker, a cue, and the token `loop` while meaning
+      none of it as an invocation.
+
+    Two names is ambiguity, not a decision, so the router scores it instead.
+    """
+    tokens = [_invocation_token(word) for word in words]
+    marker_positions = {
+        index
+        for index, token in enumerate(tokens)
+        if token in OMH_INVOCATION_MARKERS or token in SKILL_INVOCATION_MARKERS
+    }
+    if not marker_positions or not _contains_run_cue(stripped):
+        return None
+    candidates: list[str] = []
+    for index, token in enumerate(tokens):
+        if not {index - 1, index + 1} & marker_positions:
+            continue
+        name = _resolved_skill_name(token, names)
+        if name and name not in candidates:
+            candidates.append(name)
+    if len(candidates) != 1:
+        return None
+    candidate = candidates[0]
+    return None if _explicit_skill_candidate_is_negated(stripped, candidate) else candidate
+
+
+def _contains_run_cue(message: str) -> bool:
+    # Both sides go through the same fold. `normalized_phrase` decomposes
+    # Hangul to jamo, so a composed literal like "써줘" never matches a folded
+    # message unless it is folded too -- which is how this first shipped
+    # silently doing nothing for every Korean cue.
+    normalized = normalized_phrase(message)
+    return any(normalized_phrase(cue) in normalized for cue in _INVOCATION_RUN_CUES)
+
+
+def _invocation_token(word: str) -> str:
+    token = word.strip(":,.!?~…'\"()[]").lower()
+    for particle in _KOREAN_PARTICLES:
+        if token.endswith(particle) and len(token) > len(particle):
+            return token[: -len(particle)]
+    return token
+
+
+def _resolved_skill_name(token: str, names: set[str]) -> str:
+    if token in names:
+        return token
+    alias = _EXPLICIT_SKILL_ALIASES.get(token, "")
+    return alias if alias in names else ""
 
 
 def _explicit_skill_candidate_is_negated(message: str, *candidates: str) -> bool:

--- a/tests/test_explicit_invocation_word_order.py
+++ b/tests/test_explicit_invocation_word_order.py
@@ -1,0 +1,180 @@
+"""Naming a skill has to work in the language the sentence is written in.
+
+OMH resolves intent two ways. Ordinary prose goes to the router, which scores
+candidates and hands ambiguity to model selection -- that is the main path and
+this file does not touch it. The other way is naming a skill outright, and on
+Slack or Discord there is no slash-command surface, so naming it in a sentence
+*is* the explicit path.
+
+That path assumed English word order. `use omh <skill>` needs the name third;
+the prefix and bare-first-word forms need it first. Korean puts the verb last,
+so `omh wiki 써줘` matched none of them and fell through to trigger scoring,
+which is right only when the name happens to be a distinctive token. Measured
+across every routable skill before the fix:
+
+    omh <skill> 써줘        81/92
+    use the <skill> skill  86/92
+
+The failures were the skills with ordinary names -- the ones a user cannot
+rescue by rephrasing.
+
+Three conditions gate the new resolution, and each removed a real overroute
+found while building it: a marker word, a run cue, and the name adjacent to the
+marker. The guards below are that evidence, not decoration.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.routing.chat import route_chat_message
+from omh.routing.policy import explicit_skill_invocation
+from omh.skills.catalog import routable_definitions
+
+# `meta-router` is the `/omh` command lane rather than a workflow a user names,
+# so it resolves through the prefix path and is excluded from name-form sweeps.
+COMMAND_LANE_SKILL = "meta-router"
+
+
+def _routable_names() -> list[str]:
+    return [definition.name for definition in routable_definitions()]
+
+
+def _named(name: str) -> set[str]:
+    return set(_routable_names())
+
+
+class ExplicitInvocationFormTests(unittest.TestCase):
+    """Every naming form resolves every skill, whatever the word order."""
+
+    def _sweep(self, template) -> list[str]:
+        return [
+            name
+            for name in _routable_names()
+            if name != COMMAND_LANE_SKILL
+            and route_chat_message(template(name)).get("selected_skill") != name
+        ]
+
+    def test_korean_verb_final_invocation_resolves_every_skill(self) -> None:
+        # The form this was built for: no slash surface, name in a sentence.
+        self.assertEqual(self._sweep(lambda name: f"omh {name} 써줘"), [])
+
+    def test_korean_particle_form_resolves_every_skill(self) -> None:
+        # Korean attaches particles to the noun: "omh로" rather than "omh".
+        self.assertEqual(self._sweep(lambda name: f"omh로 {name} 해줘"), [])
+
+    def test_korean_skill_word_form_resolves_every_skill(self) -> None:
+        self.assertEqual(self._sweep(lambda name: f"{name} 스킬 실행해줘"), [])
+
+    def test_english_trailing_skill_word_resolves_every_skill(self) -> None:
+        # `use the <skill> skill` puts the name second, not third.
+        self.assertEqual(self._sweep(lambda name: f"use the {name} skill"), [])
+
+    def test_the_forms_that_already_worked_still_do(self) -> None:
+        self.assertEqual(self._sweep(lambda name: f"use omh {name}"), [])
+        self.assertEqual(self._sweep(lambda name: f"/{name}"), [])
+
+
+class ExplicitInvocationGuardTests(unittest.TestCase):
+    """What must never be read as "run this skill"."""
+
+    def test_a_catalog_question_is_not_an_invocation(self) -> None:
+        # Marker and skill name both present, and answering it by running the
+        # skill is exactly wrong. The missing ingredient is a run cue.
+        for message in (
+            "does OMH support skill health dashboards?",
+            "does OMH support skill candidate scouting?",
+            "what is oh-my-hermes?",
+        ):
+            with self.subTest(message=message):
+                self.assertIsNone(explicit_skill_invocation(message, _named(message)))
+
+    def test_an_ordinary_word_that_is_also_a_skill_name_is_not_an_invocation(self) -> None:
+        # `loop`, `plan`, `team`, `ask` are ordinary words. A sentence carrying a
+        # marker and a cue still does not mean the user named the workflow.
+        message = "Run a loop to find and fix OMH router context-loss and coding handoff bugs with progress evidence."
+        self.assertIsNone(explicit_skill_invocation(message, _named(message)))
+
+    def test_a_marker_without_a_run_cue_is_not_an_invocation(self) -> None:
+        self.assertIsNone(explicit_skill_invocation("omh wiki", _named("omh wiki")))
+
+    def test_a_name_far_from_the_marker_is_not_an_invocation(self) -> None:
+        message = "use the tooling we discussed and then think about wiki someday"
+        self.assertIsNone(explicit_skill_invocation(message, _named(message)))
+
+    def test_two_names_each_beside_a_marker_are_ambiguity_not_a_choice(self) -> None:
+        message = "omh wiki 랑 doctor 스킬 써줘"
+        self.assertIsNone(explicit_skill_invocation(message, _named(message)))
+
+    def test_only_the_name_beside_the_marker_is_read_as_the_invocation(self) -> None:
+        # Adjacency decides rather than declaring ambiguity here: the user put
+        # `wiki` against the marker and `doctor` further along, which is a
+        # weaker signal than two names each introduced by their own marker.
+        message = "omh wiki doctor 써줘"
+        self.assertEqual(explicit_skill_invocation(message, _named(message)), "wiki")
+
+    def test_a_negated_name_is_not_an_invocation(self) -> None:
+        for message in ("omh wiki 말고 다른 스킬 써줘", "use the skill instead of wiki"):
+            with self.subTest(message=message):
+                self.assertIsNone(explicit_skill_invocation(message, _named(message)))
+
+    def test_a_bare_mention_without_a_marker_is_not_an_invocation(self) -> None:
+        self.assertIsNone(explicit_skill_invocation("자 이제 실행해줘", _named("자 이제 실행해줘")))
+
+
+class MaintenanceCommandBoundaryTests(unittest.TestCase):
+    """`omh <command>` and `omh <skill>` are different requests.
+
+    The maintenance card matches by alias substring, so it also claimed the four
+    skills whose own names contain one: `codegraph-refresh` reads as `refresh`,
+    `model-setup` and `websearch-setup` as `setup`, `skill-health` as `health`.
+    Naming any of them ran the maintenance path instead of the workflow.
+    """
+
+    def _route(self, message: str) -> str:
+        return str(route_chat_message(message).get("selected_skill"))
+
+    def test_a_skill_whose_name_contains_a_command_alias_wins(self) -> None:
+        for name in ("codegraph-refresh", "model-setup", "websearch-setup", "skill-health"):
+            with self.subTest(skill=name):
+                self.assertEqual(self._route(f"omh {name} 써줘"), name)
+
+    def test_the_real_maintenance_commands_still_route_to_maintenance(self) -> None:
+        for message, expected in (
+            ("omh doctor", "doctor"),
+            ("omh update", "oh-my-hermes"),
+            ("omh setup", "oh-my-hermes"),
+            ("omh list", "oh-my-hermes"),
+            ("omh 업데이트 해줘", "oh-my-hermes"),
+        ):
+            with self.subTest(message=message):
+                self.assertEqual(self._route(message), expected)
+
+    def test_the_prefixed_command_lane_is_left_alone(self) -> None:
+        # `./omh update` resolves through the `/omh` alias to the command lane;
+        # that is not a user naming a different workflow to run instead.
+        for message in ("./omh update", "/omh update"):
+            with self.subTest(message=message):
+                self.assertEqual(self._route(message), "oh-my-hermes")
+
+
+class KoreanCueFoldingTests(unittest.TestCase):
+    """Both sides of a Korean comparison must be folded the same way.
+
+    `normalized_phrase` decomposes Hangul to jamo, so a composed literal never
+    matches a folded message. This shipped once doing nothing at all for every
+    Korean cue, and the symptom was silence rather than an error.
+    """
+
+    def test_a_korean_run_cue_is_recognised(self) -> None:
+        self.assertEqual(explicit_skill_invocation("omh wiki 써줘", _named("omh wiki 써줘")), "wiki")
+
+    def test_an_english_run_cue_is_recognised(self) -> None:
+        self.assertEqual(explicit_skill_invocation("use the wiki skill", _named("x")), "wiki")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

Explicit skill invocation no longer assumes English word order. Naming a skill now resolves whenever a marker word, a run cue, and the skill name adjacent to the marker appear together — in any order, in any of the supported languages.

A second bug fixed underneath: the CLI maintenance card matched by alias substring, so it hijacked the four skills whose names contain one.

### Why This Exists

OMH resolves intent two ways:

1. **Prose → router.** Scores candidates, hands ambiguity to model selection. This is the main path and this PR does not touch it.
2. **Naming a skill outright.** On Hermes CLI or desktop there is a slash surface. **On Slack and Discord there is not** — so naming the skill in a sentence *is* the explicit path there.

Path 2 only recognised English word order: `use omh <skill>` needs the name third, prefix and bare-first-word forms need it first. Korean puts the verb last, so `omh wiki 써줘` matched none of them and fell through to trigger scoring — right only when the name happens to be a distinctive token.

Swept across all 92 routable skills:

| Form | Before | After |
| --- | --- | --- |
| `omh <skill> 써줘` | 81/92 | **91/92** |
| `omh로 <skill> 해줘` | 81/92 | **91/92** |
| `use the <skill> skill` | 86/92 | **91/92** |
| `<skill> 스킬 실행해줘` | 92/92 | 92/92 |
| `use omh <skill>` | 92/92 | 92/92 |
| `/<skill>` | 92/92 | 92/92 |

The failures were skills with ordinary names — exactly the ones a user cannot rescue by rephrasing. `meta-router` is the remaining miss in every name form: it is the `/omh` command lane, reached by prefix, not a workflow someone names.

### User / Operator Impact

On Slack and Discord, `omh <skill> 써줘` and `use the <skill> skill` now reach the skill the user named, for every skill rather than for the ones with unusual names.

`omh codegraph-refresh 써줘`, `omh model-setup 써줘`, `omh websearch-setup 써줘`, and `omh skill-health 써줘` reach their workflows instead of the maintenance path.

### How It Works

Three conditions gate the resolution, and **each one removed a real overroute found while building it**:

- **A marker word** (`omh`, `oh-my-hermes`, `skill`, `스킬`, …) — a bare mention is never promoted to an invocation.
- **A run cue** (`use`, `run`, `써줘`, `실행`, …) — without it, "does OMH support skill health dashboards?" reads as an instruction to run `skill-health`.
- **The name adjacent to the marker** — several skills are named with ordinary words (loop, plan, team, ask), so "Run a loop to find and fix OMH router bugs" otherwise carried a marker, a cue, and the token `loop` while meaning none of it.

**The maintenance-card fix.** `codegraph-refresh` contains `refresh`, `model-setup`/`websearch-setup` contain `setup`, `skill-health` contains `health`. A named workflow now outranks an alias found inside its own name, on both the fast path and the slow one. Nothing is lost for the real commands: of update/setup/doctor/uninstall/install/list only `doctor` is also a routable skill, and its card already routes to `doctor`. Prefixed forms are untouched, because `./omh update` resolves through the `/omh` alias to the command lane.

**A Hangul folding bug** shipped inside this change once doing nothing at all: `normalized_phrase` decomposes Hangul to jamo, so the composed literal `"써줘"` never matched a folded message. Both sides are folded now — the symptom was silence, not an error, which is why it has its own test.

### Files And Contracts Touched

- `src/routing/policy.py` — `_marker_scoped_skill_invocation`, run cues, particle stripping, marker sets.
- `src/routing/chat.py` — maintenance fast-path guard and `_task_card_overrides_explicit_invocation`.
- `tests/test_explicit_invocation_word_order.py` — new.
- **No trigger phrases added.** `tests/test_routing_language_policy` freezes per-skill Hangul trigger counts precisely so routing misses are not answered with more tokens; the counts are untouched. The fix is in the parser.

## Validation

- [x] `uv run --group lint ruff check src tests` — All checks passed
- [x] `python3 -m unittest discover -s tests` — **2160 passed**, 1 skipped
- [x] `python3 -m compileall src`
- [x] `python3 -m omh.cli docs workflows --check`, `docs roles --check`, `docs capability-families --check`
- [x] `python3 -m omh.cli harness validate`
- [x] `git diff --check`
- [x] Coverage sweep over all 92 routable skills in 8 invocation forms, before and after
- [ ] Manual Hermes/TUI check — **not run.** No live Slack or Discord message was routed through a running gateway, so platform-specific text mangling (mention markup, smart quotes) is unverified.

## Risk

Medium, and it is the honest one: this widens what counts as an explicit invocation, and explicit invocation outranks scoring.

The three gates are the bound. An earlier, looser version of this change **broke 20 existing router tests** — catalog questions, help questions, the picker guards — and narrowing it against those failures is how the gates were chosen. Each is pinned by a guard test now.

## Compatibility / Rollout

No schema or contract change. Existing forms behave identically; the widening is additive.

## Follow-Up

- `meta-router` is unreachable by name in every form. That is arguably correct (it is the `/omh` lane) but it is undocumented, and a user typing `omh meta-router 써줘` gets `workflow-learning`.
- Platform text mangling on Slack/Discord (mention markup around `@omh`, smart quotes) has no coverage.
