### PR TITLE
fix: make update, install, and setup actually refresh every installed skill

### DIFF
--- a/src/install/installer.py
+++ b/src/install/installer.py
@@ -80,9 +80,17 @@ def install_skill_pack(
     if source_dir or profile == "full":
         templates = all_templates
     else:
-        templates = [template for template in all_templates if template.name in CORE_PROFILE_SKILLS]
+        # The profile decides what gets ADDED, never what gets REFRESHED. A skill
+        # already on disk is refreshed whichever profile is recorded, because
+        # `omh update` promising "updated" while leaving installed skills on an
+        # older render is the same as lying: that is how an install ended up
+        # serving `name: ultrawork` long after the catalog had moved to
+        # `ulw-ultrawork`. Shedding full-only skills stays an explicit act -
+        # `omh skill-profile reconcile --to core`.
+        refreshable = set(CORE_PROFILE_SKILLS) | _installed_skill_names(paths.skills_dir)
+        templates = [template for template in all_templates if template.name in refreshable]
         reference_templates = [
-            template for template in reference_templates if template.skill_name in CORE_PROFILE_SKILLS
+            template for template in reference_templates if template.skill_name in refreshable
         ]
     manifest = read_manifest(paths.manifest_path)
     modified = local_modifications(manifest, paths.skills_dir)
@@ -125,6 +133,18 @@ def install_skill_pack(
     manifest_data["skill_profile_state"] = skill_profile_state(paths.skills_dir, manifest_data)
     write_manifest(paths.manifest_path, manifest_data)
     return manifest_data
+
+
+def _installed_skill_names(skills_dir: Path) -> set[str]:
+    """Skill directories already present, whatever profile put them there.
+
+    Read from disk rather than the manifest on purpose: a core-profile manifest
+    records only the core skills, so the full-only directories beside them are
+    exactly the ones the manifest cannot see and the ones that were going stale.
+    """
+    if not skills_dir.is_dir():
+        return set()
+    return {entry.name for entry in skills_dir.iterdir() if entry.is_dir() and not entry.is_symlink()}
 
 
 def _prune_orphaned_skills(

--- a/tests/test_installer_skill_profile.py
+++ b/tests/test_installer_skill_profile.py
@@ -20,7 +20,39 @@ from omh.paths import resolve_paths
 from omh.skill_pack import CORE_PROFILE_SKILLS, CORE_SKILLS, builtin_skill_templates
 
 
+def _installed_names(paths) -> set[str]:
+    return {entry.name for entry in paths.skills_dir.iterdir() if entry.is_dir()}
+
+
 class InstallerSkillProfileTests(unittest.TestCase):
+    def test_a_core_refresh_updates_full_only_skills_already_on_disk(self) -> None:
+        """`omh update` must leave nothing stale, whatever profile is recorded.
+
+        A core-profile refresh used to write only the core skills, so a machine
+        that had once installed `--full` kept 73 skills frozen at whatever render
+        they were installed with. That is how an install kept serving
+        `name: ultrawork` long after the catalog had moved to `ulw-ultrawork`,
+        while `omh update` still reported success.
+        """
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            install_skill_pack(paths, profile="full")
+            full_only = sorted(set(name for name in _installed_names(paths)) - set(CORE_PROFILE_SKILLS))
+            self.assertTrue(full_only, "fixture needs at least one full-only skill")
+
+            victim = paths.skills_dir / full_only[0] / "SKILL.md"
+            fresh = victim.read_text(encoding="utf-8")
+            victim.write_text("---\nname: stale-on-purpose\n" + fresh.split("---\n", 2)[2], encoding="utf-8")
+
+            before = _installed_names(paths)
+
+            install_skill_pack(paths, profile="core", force=True)
+
+            self.assertEqual(victim.read_text(encoding="utf-8"), fresh)
+            # Refreshing must not shed skills either; that stays an explicit
+            # `omh skill-profile reconcile --to core`.
+            self.assertEqual(_installed_names(paths), before)
+
     def test_core_profile_is_a_strict_subset_of_full_and_covers_doctor_core_skills(self) -> None:
         full_names = {template.name for template in builtin_skill_templates()}
 


### PR DESCRIPTION
## Feature Report

### What Changed

`omh update`, `omh install`, and `omh setup` now refresh **every skill already installed**, not just the ones in the recorded profile.

### Why This Exists

A user updated, was told it worked, and half their skill list stayed old.

Their install had once run `omh install --full` (92 skills) but carried a `core` profile (9 managed). Under `core`, `install_skill_pack()` wrote **only** `CORE_PROFILE_SKILLS` — so the other 73 directories were never a write target again, by any command. All three commands funnel through that one function.

The visible symptom: `~/.omh/skills/ultrawork/SKILL.md` still read

```
name: ultrawork
```

long after the catalog had moved to `ulw-ultrawork` — and `omh update` kept reporting `Release state: updated`.

### User / Operator Impact

After any of the three commands, nothing installed is stale. The profile now decides what gets **added**, never what gets **refreshed**.

Shedding full-only skills stays an explicit act — `omh skill-profile reconcile --to core` is unchanged. Refreshing is non-destructive: the fix widens what is written and touches nothing about removal.

### How It Works

```python
# before: core wrote only the core set
templates = [t for t in all_templates if t.name in CORE_PROFILE_SKILLS]

# after: core set ∪ whatever is already on disk
refreshable = set(CORE_PROFILE_SKILLS) | _installed_skill_names(paths.skills_dir)
templates = [t for t in all_templates if t.name in refreshable]
```

Installed names are read **from the directory, not the manifest**, on purpose: a core-profile manifest records only the core skills, so the full-only directories beside them are exactly the ones the manifest cannot see — and exactly the ones that were going stale.

### Files And Contracts Touched

- `src/install/installer.py` — the profile branch, plus `_installed_skill_names()`.
- `tests/test_installer_skill_profile.py` — regression test.

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `python3 -m unittest discover -s tests` — 2151 passed, 1 skipped
- [x] `python3 -m compileall src`
- [x] `python3 -m omh.cli docs workflows --check` (also `docs roles`, `docs capability-families`, `release drift`)
- [ ] `python3 -m omh.cli harness validate` — not rerun; no harness contract touched
- [ ] `python3 -m omh.cli release checklist --json` — not rerun
- [ ] `python3 -m omh.cli release hermes-smoke` — not rerun
- [x] `omh --help`
- [ ] `omh --omh-home … release hermes-smoke --include-command-smoke` — not rerun
- [ ] Relevant workflow-learning review queue smoke — not applicable
- [x] Relevant dry-run or smoke command: reproduced end-to-end against a clean temp install — `--full` (92 skills) → stage a stale full-only skill → `core` refresh restores it byte-for-byte, 92 skills still present
- [ ] **Manual Hermes/TUI check — not run.** Verified against temp installs, not against the reporting user's own Hermes home, which was repaired by hand before this fix existed.

**The regression test was proven to bite**: reverting the one-line fix makes it fail; restoring passes.

## Risk

- A core install that previously skipped 73 writes now performs them, so a refresh does more file IO. Skill count and profile record are unchanged — asserted by comparing the installed set before and after.
- Locally modified skills are still protected by the existing `local_modifications` guard; this change does not alter that path.

## Compatibility / Rollout

- No schema, CLI, or profile-semantics change. A `core` install stays `core`; it simply stops leaving neighbours behind.

## Release / Claims

- [x] Release-channel impact considered (`stable`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Known manual Hermes checks are listed

## Follow-Up

- `omh update` reports `Release state: updated` regardless of whether anything actually changed on disk. With this fix the report is at least true, but a count of refreshed files would make it useful — that is a separate change to the update summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
