### PR TITLE
fix: let an update keep the skill profile it was installed with

### DIFF
--- a/src/commands/setup.py
+++ b/src/commands/setup.py
@@ -46,6 +46,7 @@ from ..installer import (
     uninstall_skill_pack,
 )
 from ..local_store import atomic_write_text
+from ..install.installer import DEFAULT_SKILL_PROFILE, SKILL_PROFILES
 from ..manifest import read_manifest
 from ..menubar_app import setup_menubar_app, uninstall_menubar_app
 from ..mcp.host_config import install_mcp_host_config
@@ -119,7 +120,7 @@ def _install_result(args: argparse.Namespace) -> dict[str, object]:
     previous_release = _previous_release_update_state(paths)
     # Read before install_skill_pack rewrites the manifest.
     previous_manifest_sha256 = _previous_manifest_sha256(paths)
-    skill_profile = "full" if getattr(args, "full", False) else "core"
+    skill_profile = _resolved_skill_profile(args, paths)
     result = install_skill_pack(
         paths,
         source=source,
@@ -443,6 +444,25 @@ def _explicit_release_metadata_supplied(args: argparse.Namespace) -> bool:
         str(getattr(args, key, "") or "").strip()
         for key in ("source_ref", "version", "package_url")
     )
+
+
+def _resolved_skill_profile(args: argparse.Namespace, paths) -> str:
+    """The profile this run should record: what was asked for, else what is installed.
+
+    This used to be `"full" if --full else "core"`, which reset the recorded
+    profile on every run. An operator who installed the full catalog and then
+    ran plain `omh update` had their manifest rewritten to `core` while all the
+    full-only skills stayed on disk -- installs never delete -- so the install
+    reported a profile it did not have and told them to run `omh skill-profile
+    reconcile` to resolve a divergence nothing had asked for.
+
+    An update carries the install forward. Only `--full` and an explicit
+    reconcile change the profile, and reconcile stays the one path that deletes.
+    """
+    if bool(getattr(args, "full", False)):
+        return "full"
+    installed = str((read_manifest(paths.manifest_path) or {}).get("skill_profile") or "")
+    return installed if installed in SKILL_PROFILES else DEFAULT_SKILL_PROFILE
 
 
 def _previous_manifest_sha256(paths) -> str:

--- a/tests/test_skill_profile_inheritance.py
+++ b/tests/test_skill_profile_inheritance.py
@@ -1,0 +1,114 @@
+"""An update carries the installed skill profile forward instead of resetting it.
+
+The profile was chosen as `"full" if --full else "core"` on every run, so a
+plain `omh update` rewrote the manifest to `core` regardless of what was
+installed. Installs never delete skills, so the full-only skills stayed on
+disk, and the summary then reported the gap it had just created:
+
+    Skill profile: core requested, but 83 full-only skill(s) are still
+    installed and still cost per-turn context. Installs never delete skills;
+    run `omh skill-profile reconcile --to core` to shrink explicitly.
+
+Nobody had asked for core. The operator installed the full catalog, ran the
+command whose job is to keep it current, and was handed a reconcile chore for a
+divergence the update invented.
+
+`reconcile` is deliberately the only path that deletes managed skill
+directories, and it stays that way. Nothing here removes anything; the fix is
+that an update stops changing the recorded profile on its own.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from _cli_harness import run_cli
+from _local_package import load_local_package
+
+load_local_package()
+from omh.skill_pack import CORE_PROFILE_SKILLS
+
+
+class SkillProfileInheritanceTests(unittest.TestCase):
+    def _base(self, root: Path) -> list[str]:
+        return ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+
+    def _profile(self, root: Path) -> str:
+        return str(json.loads((root / ".omh" / "manifest.json").read_text(encoding="utf-8"))["skill_profile"])
+
+    def _installed(self, root: Path) -> int:
+        return len([child for child in (root / ".omh" / "skills").iterdir() if child.is_dir()])
+
+    def test_update_keeps_a_full_install_full(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            run_cli(self._base(root) + ["install", "--full"])
+            installed = self._installed(root)
+            self.assertEqual(self._profile(root), "full")
+
+            status, _, stderr = run_cli(self._base(root) + ["update"])
+            self.assertEqual(status, 0, stderr)
+            self.assertEqual(self._profile(root), "full")
+            self.assertEqual(self._installed(root), installed)
+
+    def test_repeated_updates_do_not_drift(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            run_cli(self._base(root) + ["install", "--full"])
+            for _ in range(3):
+                run_cli(self._base(root) + ["update"])
+            self.assertEqual(self._profile(root), "full")
+
+    def test_a_core_install_stays_core(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            run_cli(self._base(root) + ["install"])
+            self.assertEqual(self._profile(root), "core")
+            self.assertEqual(self._installed(root), len(CORE_PROFILE_SKILLS))
+
+            run_cli(self._base(root) + ["update"])
+            self.assertEqual(self._profile(root), "core")
+            self.assertEqual(self._installed(root), len(CORE_PROFILE_SKILLS))
+
+    def test_a_first_install_with_no_flag_is_core(self) -> None:
+        # Inheritance must not turn the default into "whatever was there", and
+        # there is nothing to inherit on a fresh machine.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            run_cli(self._base(root) + ["update"])
+            self.assertEqual(self._profile(root), "core")
+
+    def test_the_full_flag_still_widens_a_core_install(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            run_cli(self._base(root) + ["install"])
+            self.assertEqual(self._profile(root), "core")
+
+            run_cli(self._base(root) + ["update", "--full"])
+            self.assertEqual(self._profile(root), "full")
+            self.assertGreater(self._installed(root), len(CORE_PROFILE_SKILLS))
+
+    def test_update_no_longer_reports_a_divergence_it_created(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            run_cli(self._base(root) + ["install", "--full"])
+            _, stdout, _ = run_cli(self._base(root) + ["update"], output_json=False)
+            self.assertNotIn("skill-profile reconcile", stdout)
+            self.assertNotIn("full-only skill", stdout)
+
+    def test_narrowing_is_still_reconcile_only(self) -> None:
+        # Update carries the profile forward; it never shrinks one. Deleting
+        # managed skill directories stays the one thing only reconcile does.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            run_cli(self._base(root) + ["install", "--full"])
+            installed = self._installed(root)
+            run_cli(self._base(root) + ["update"])
+            self.assertEqual(self._installed(root), installed)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

`omh update` now carries the installed skill profile forward instead of resetting the manifest to `core` on every run. `--full` still widens; narrowing is still `omh skill-profile reconcile` alone.

### Why This Exists

The profile was picked as `"full" if --full else "core"` on every run and written straight into the manifest. So a plain `omh update` on a full install rewrote the record to `core` while every full-only skill stayed on disk — installs never delete — and the summary then reported the gap it had just created:

```
Skill profile: core requested, but 83 full-only skill(s) are still installed
and still cost per-turn context. Installs never delete skills; run
`omh skill-profile reconcile --to core` to shrink explicitly.
```

**Nobody had asked for core.** The operator installed the full catalog, ran the command whose job is to keep it current, and was handed a reconcile chore for a divergence the update invented. Running reconcile then removed nothing that mattered, because the install was not actually wrong — only its record was.

### User / Operator Impact

Measured on a full install, plain `omh update`:

| | Output |
| --- | --- |
| before | `Skill profile: core requested, but 83 full-only skill(s) are still installed…` |
| after | `OMH workflows: 92 ready` |

No reconcile chore, no divergence, and the recorded profile matches what is on disk.

### How It Works

`_resolved_skill_profile(args, paths)` returns `full` when `--full` is passed, otherwise the profile already recorded in the manifest, otherwise the `core` default. A first install on a fresh machine has nothing to inherit, so it is still `core`.

**What this deliberately does not do:** wire `reconcile_skill_profile` into update. That function is documented as the only OMH path that deletes managed skill directories and as never running inside setup/install/update. Calling it from update would have traded a wrong number for deleted files. The record was the thing that was wrong, so the record is what this fixes.

### Files And Contracts Touched

- `src/commands/setup.py` — `_resolved_skill_profile`, used by the install/update path.
- `tests/test_skill_profile_inheritance.py` — new.
- No schema or contract change; `skill_profile` in the manifest keeps its shape and values.

## Validation

- [x] `uv run --group lint ruff check src tests` — All checks passed
- [x] `python3 -m unittest discover -s tests` — **2175 passed**, 1 skipped
- [x] `python3 -m compileall src`
- [x] `python3 -m omh.cli docs workflows --check`, `docs roles --check`, `docs capability-families --check`
- [x] `python3 -m omh.cli harness validate`
- [x] `git diff --check`
- [x] Manual: `install --full` → `update` → `update` keeps `full` and 92 skills; `install` → `update` keeps `core` and 9; first-run `update` records `core`; `update --full` widens
- [x] Manual before/after of the summary line quoted above
- [ ] Manual Hermes/TUI check — **not run.** This changes what OMH records and installs, not how Hermes reads it.

## Risk

Low. The only behavioural change is that a plain update stops narrowing the recorded profile. A first install with no flag is still `core`, because there is nothing to inherit.

The deletion invariant is untouched: nothing here removes a skill, and `reconcile` remains the single path that does.

Honest limitation: no upgrade across two published OMH versions was run — inheritance is exercised by repeated installs of the same build.

## Compatibility / Rollout

An existing install picks this up on its next `omh update`. A manifest already reset to `core` by a previous update keeps saying `core` until the operator runs `--full` or reconciles; this stops the reset from happening again, it does not retroactively restore a record an earlier run overwrote.

## Release / Claims

- [x] Release-channel impact considered — `local`; no version change.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] Known manual Hermes checks are listed — no live tap smoke was run.

## Follow-Up

- An install whose record was already narrowed by an earlier update has no way back to `full` except `omh update --full`. That is discoverable only from this PR; `omh doctor` could say so when the effective profile is wider than the recorded one.
