### PR TITLE
feat: drop the duplicated ultra from the ulw labels, and fix the round-trip they exposed

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -128,10 +128,10 @@ OMH は **92 個**のインストール可能な workflow skill を、理解し�
 
 | 機能 | 使い方 | 内容 |
 | --- | --- | --- |
-| 🧭 **明確化と計画** | `ulw-deep-interview` · `ulw-ralplan` · `omh-decide` | 曖昧な依頼を、明確な目標・制約・トレードオフ・受け入れ基準、そしてそのまま引き渡せる計画に変えます。 |
-| ⚡ **レバレッジを効かせた実行** | `ulw-ultrawork` · `ulw-ultragoal` · `ulw-team` · `ulw-loop` | 高速な並列作業から持続的な複数ステップの実行までスケールしながら、所有権・チェックポイント・検証を常に可視化します。 |
-| 🔬 **調査と学習** | `ulw-web-research` · `omh-best-practice-research` · `omh-research-brief` | 鮮度・情報源の質・未解決の不確実性の境界を示しながら、根拠に基づく証拠を収集・統合します。 |
-| 🛠️ **安全なコーディングと出荷** | `ulw-ultraprocess` · `omh-code-review` · `ulw-ultraqa` | executor に依存しないコーディング作業を準備し、review・QA・CI・merge に関する主張は観測された証拠にのみ基づかせます。 |
+| 🧭 **明確化と計画** | `ulw-interview` · `ulw-plan` · `omh-decide` | 曖昧な依頼を、明確な目標・制約・トレードオフ・受け入れ基準、そしてそのまま引き渡せる計画に変えます。 |
+| ⚡ **レバレッジを効かせた実行** | `ulw-work` · `ulw-goal` · `ulw-team` · `ulw-loop` | 高速な並列作業から持続的な複数ステップの実行までスケールしながら、所有権・チェックポイント・検証を常に可視化します。 |
+| 🔬 **調査と学習** | `ulw-research` · `omh-best-practice-research` · `omh-research-brief` | 鮮度・情報源の質・未解決の不確実性の境界を示しながら、根拠に基づく証拠を収集・統合します。 |
+| 🛠️ **安全なコーディングと出荷** | `ulw-process` · `omh-code-review` · `ulw-qa` | executor に依存しないコーディング作業を準備し、review・QA・CI・merge に関する主張は観測された証拠にのみ基づかせます。 |
 | 🎨 **洗練された成果物の制作** | `omh-design-quality-gate` · `omh-materials-package` · `omh-deliverable-package` · `omh-img-summary` | コンテンツ・完成度・アクセシビリティ・レンダリング品質ゲートを軸に、Web サイト、ビジュアル、レポート、スライド、ドキュメント、PDF、ポスター、パッケージを制作します。 |
 | 🧠 **記憶と運用** | `omh-memory-new` · `omh-memory-sync` · `omh-ops-observability-card` · `omh-doctor` | プロジェクト記憶をレビュー優先で保ち、運用の準備状況を可視化し、provider やシステム状態を作り話にせず次の修復アクションを示します。 |
 | 🔌 **境界を隠さない接続** | `omh-toolbelt-readiness` · `omh-external-connector-readiness` · `omh-agent-board` | 作業がそれに依存する前に、必要なツール・connector・agent 面が実際に使えるかを確認し、host のロード・ツール利用・外部 provider アクセスを個別に観測可能な状態に保ちます。 |

--- a/README.ko.md
+++ b/README.ko.md
@@ -128,10 +128,10 @@ OMH는 **92개**의 설치형 workflow skill을 사람이 이해하기 쉬운 6�
 
 | 기능 | 사용 방법 | 동작 |
 | --- | --- | --- |
-| 🧭 **명확화와 계획** | `ulw-deep-interview` · `ulw-ralplan` · `omh-decide` | 모호한 요청을 명확한 목표, 제약, trade-off, 완료 기준, 그리고 그대로 전달할 수 있는 계획으로 바꿉니다. |
-| ⚡ **레버리지를 활용한 실행** | `ulw-ultrawork` · `ulw-ultragoal` · `ulw-team` · `ulw-loop` | 빠른 병렬 작업부터 지속적인 다단계 실행까지 확장하면서도 소유권, 체크포인트, 검증을 계속 볼 수 있게 유지합니다. |
-| 🔬 **조사와 학습** | `ulw-web-research` · `omh-best-practice-research` · `omh-research-brief` | 최신성, 출처 품질, 아직 해소되지 않은 불확실성 경계를 함께 표시하며 근거 기반 증거를 찾고 종합합니다. |
-| 🛠️ **안전한 코딩과 배포** | `ulw-ultraprocess` · `omh-code-review` · `ulw-ultraqa` | executor에 종속되지 않는 코딩 작업을 준비하고, review·QA·CI·merge에 대한 주장은 관측된 증거에만 근거하게 만듭니다. |
+| 🧭 **명확화와 계획** | `ulw-interview` · `ulw-plan` · `omh-decide` | 모호한 요청을 명확한 목표, 제약, trade-off, 완료 기준, 그리고 그대로 전달할 수 있는 계획으로 바꿉니다. |
+| ⚡ **레버리지를 활용한 실행** | `ulw-work` · `ulw-goal` · `ulw-team` · `ulw-loop` | 빠른 병렬 작업부터 지속적인 다단계 실행까지 확장하면서도 소유권, 체크포인트, 검증을 계속 볼 수 있게 유지합니다. |
+| 🔬 **조사와 학습** | `ulw-research` · `omh-best-practice-research` · `omh-research-brief` | 최신성, 출처 품질, 아직 해소되지 않은 불확실성 경계를 함께 표시하며 근거 기반 증거를 찾고 종합합니다. |
+| 🛠️ **안전한 코딩과 배포** | `ulw-process` · `omh-code-review` · `ulw-qa` | executor에 종속되지 않는 코딩 작업을 준비하고, review·QA·CI·merge에 대한 주장은 관측된 증거에만 근거하게 만듭니다. |
 | 🎨 **완성도 높은 산출물 제작** | `omh-design-quality-gate` · `omh-materials-package` · `omh-deliverable-package` · `omh-img-summary` | 콘텐츠, 완성도, 접근성, 렌더링 품질 게이트를 기준으로 웹사이트, 시각 자료, 보고서, 발표 자료, 문서, PDF, 포스터, 패키지를 만듭니다. |
 | 🧠 **기억과 운영** | `omh-memory-new` · `omh-memory-sync` · `omh-ops-observability-card` · `omh-doctor` | 프로젝트 기억을 검토 우선으로 유지하고, 운영 준비 상태를 보여주며, provider나 시스템 상태를 지어내지 않고 다음 복구 행동을 제시합니다. |
 | 🔌 **경계를 숨기지 않는 연결** | `omh-toolbelt-readiness` · `omh-external-connector-readiness` · `omh-agent-board` | 작업이 의존하기 전에 필요한 도구·connector·agent 표면이 실제로 준비됐는지 확인하고, host 로드·도구 사용·외부 provider 접근을 각각 별도로 관측할 수 있게 유지합니다. |

--- a/README.md
+++ b/README.md
@@ -138,10 +138,10 @@ The full generated catalog, triggers, harnesses, and evidence rules live in
 
 | Capability | Try it with | What it does |
 | --- | --- | --- |
-| 🧭 **Clarify and plan** | `ulw-deep-interview` · `ulw-ralplan` · `omh-decide` | Turns an ambiguous request into explicit goals, constraints, tradeoffs, acceptance criteria, and a plan that can be handed off. |
-| ⚡ **Build with leverage** | `ulw-ultrawork` · `ulw-ultragoal` · `ulw-team` · `ulw-loop` | Scales from fast parallel work to durable multi-step execution while keeping ownership, checkpoints, and verification visible. |
-| 🔬 **Research and learn** | `ulw-web-research` · `omh-best-practice-research` · `omh-research-brief` | Finds and synthesizes source-backed evidence with freshness, source-quality, and unresolved-uncertainty boundaries. |
-| 🛠️ **Code and ship safely** | `ulw-ultraprocess` · `omh-code-review` · `ulw-ultraqa` | Prepares executor-neutral coding work, then makes review, QA, CI, and merge claims depend on observed evidence. |
+| 🧭 **Clarify and plan** | `ulw-interview` · `ulw-plan` · `omh-decide` | Turns an ambiguous request into explicit goals, constraints, tradeoffs, acceptance criteria, and a plan that can be handed off. |
+| ⚡ **Build with leverage** | `ulw-work` · `ulw-goal` · `ulw-team` · `ulw-loop` | Scales from fast parallel work to durable multi-step execution while keeping ownership, checkpoints, and verification visible. |
+| 🔬 **Research and learn** | `ulw-research` · `omh-best-practice-research` · `omh-research-brief` | Finds and synthesizes source-backed evidence with freshness, source-quality, and unresolved-uncertainty boundaries. |
+| 🛠️ **Code and ship safely** | `ulw-process` · `omh-code-review` · `ulw-qa` | Prepares executor-neutral coding work, then makes review, QA, CI, and merge claims depend on observed evidence. |
 | 🎨 **Create polished deliverables** | `omh-design-quality-gate` · `omh-materials-package` · `omh-deliverable-package` · `omh-img-summary` | Shapes websites, visuals, reports, decks, documents, PDFs, posters, and packages around content, taste, accessibility, and render-quality gates. |
 | 🧠 **Remember and operate** | `omh-memory-new` · `omh-memory-sync` · `omh-ops-observability-card` · `omh-doctor` | Keeps project memory review-first, surfaces operational readiness, and gives the next repair action without inventing provider or system state. |
 | 🔌 **Connect without hiding boundaries** | `omh-toolbelt-readiness` · `omh-external-connector-readiness` · `omh-agent-board` | Checks whether a needed tool, connector, or agent surface is really available before work depends on it, and keeps host load, tool use, and external-provider access separately observable. |

--- a/README.zh.md
+++ b/README.zh.md
@@ -124,10 +124,10 @@ OMH 将 **92 个**可安装的 workflow skill 组织为6个容易理解的能力
 
 | 能力 | 使用方式 | 作用 |
 | --- | --- | --- |
-| 🧭 **澄清与规划** | `ulw-deep-interview` · `ulw-ralplan` · `omh-decide` | 把模糊的请求转化为明确的目标、约束、权衡、验收标准，以及可以直接交接的计划。 |
-| ⚡ **借助杠杆推进工作** | `ulw-ultrawork` · `ulw-ultragoal` · `ulw-team` · `ulw-loop` | 从快速并行工作扩展到持久的多步骤执行，同时保持所有权、检查点和验证始终可见。 |
-| 🔬 **研究与学习** | `ulw-web-research` · `omh-best-practice-research` · `omh-research-brief` | 在标明时效性、来源质量和尚未解决的不确定性边界的同时，查找并综合有依据的证据。 |
-| 🛠️ **安全地编码与交付** | `ulw-ultraprocess` · `omh-code-review` · `ulw-ultraqa` | 准备不依赖特定 executor 的编码工作，并让 review、QA、CI 和 merge 的相关声明只依据实际观测到的证据。 |
+| 🧭 **澄清与规划** | `ulw-interview` · `ulw-plan` · `omh-decide` | 把模糊的请求转化为明确的目标、约束、权衡、验收标准，以及可以直接交接的计划。 |
+| ⚡ **借助杠杆推进工作** | `ulw-work` · `ulw-goal` · `ulw-team` · `ulw-loop` | 从快速并行工作扩展到持久的多步骤执行，同时保持所有权、检查点和验证始终可见。 |
+| 🔬 **研究与学习** | `ulw-research` · `omh-best-practice-research` · `omh-research-brief` | 在标明时效性、来源质量和尚未解决的不确定性边界的同时，查找并综合有依据的证据。 |
+| 🛠️ **安全地编码与交付** | `ulw-process` · `omh-code-review` · `ulw-qa` | 准备不依赖特定 executor 的编码工作，并让 review、QA、CI 和 merge 的相关声明只依据实际观测到的证据。 |
 | 🎨 **打造精致的交付物** | `omh-design-quality-gate` · `omh-materials-package` · `omh-deliverable-package` · `omh-img-summary` | 围绕内容、审美、无障碍性和渲染质量 gate，制作网站、视觉素材、报告、演示文稿、文档、PDF、海报和交付包。 |
 | 🧠 **记忆与运维** | `omh-memory-new` · `omh-memory-sync` · `omh-ops-observability-card` · `omh-doctor` | 让项目记忆保持“先审查后使用”，呈现运维就绪状态，并在不臆造 provider 或系统状态的前提下给出下一步修复动作。 |
 | 🔌 **在不隐藏边界的前提下连接** | `omh-toolbelt-readiness` · `omh-external-connector-readiness` · `omh-agent-board` | 在工作依赖某个工具、connector 或 agent 面之前先确认它是否真的可用，同时让 host 加载、工具使用和外部 provider 访问都能被分别观测。 |

--- a/skills/deep-interview/SKILL.md
+++ b/skills/deep-interview/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: ulw-deep-interview
+name: ulw-interview
 description: [omh] Hermes Deep Interview workflow: one-question-at-a-time clarification.
 metadata:
   hermes:

--- a/skills/ralplan/SKILL.md
+++ b/skills/ralplan/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: ulw-ralplan
+name: ulw-plan
 description: [omh] Hermes Ralplan workflow: consensus planning with review gates.
 metadata:
   hermes:

--- a/skills/ultragoal/SKILL.md
+++ b/skills/ultragoal/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: ulw-ultragoal
+name: ulw-goal
 description: [omh] Hermes Ultragoal workflow: file-backed durable goal ledgers.
 metadata:
   hermes:

--- a/skills/ultraprocess/SKILL.md
+++ b/skills/ultraprocess/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: ulw-ultraprocess
+name: ulw-process
 description: [omh] Ultra Process - Research - Ralplan - Ultragoal - Code Review - Sync Circle: one PR-ready delivery cycle.
 metadata:
   hermes:

--- a/skills/ultraqa/SKILL.md
+++ b/skills/ultraqa/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: ulw-ultraqa
+name: ulw-qa
 description: [omh] Hermes UltraQA workflow: adversarial QA and fix loops.
 metadata:
   hermes:

--- a/skills/ultrawork/SKILL.md
+++ b/skills/ultrawork/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: ulw-ultrawork
+name: ulw-work
 description: [omh] Hermes Ultrawork compatibility workflow: bounded parallel delivery guidance.
 metadata:
   hermes:

--- a/skills/web-research/SKILL.md
+++ b/skills/web-research/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: ulw-web-research
+name: ulw-research
 description: [omh] Hermes Web Research workflow: source-backed current information gathering.
 metadata:
   hermes:

--- a/src/omh/converter.py
+++ b/src/omh/converter.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from .skill_pack import DESCRIPTIONS, SkillTemplate
 from .skills.catalog import (
+    OMH_SKILL_DISPLAY_NAME_OVERRIDES,
     OMH_SKILL_NAME_PREFIX,
     ULW_SKILL_NAME_PREFIX,
     omh_description,
@@ -12,6 +13,11 @@ from .skills.catalog import (
 )
 
 FRONTMATTER_RE = re.compile(r"^---\n(?P<meta>.*?)\n---\n(?P<body>.*)$", re.DOTALL)
+
+
+_CANONICAL_BY_OVERRIDE = {
+    display: canonical for canonical, display in OMH_SKILL_DISPLAY_NAME_OVERRIDES.items()
+}
 
 
 def extract_name(raw: str, fallback: str) -> str:
@@ -33,6 +39,13 @@ def extract_name(raw: str, fallback: str) -> str:
     for line in match.group("meta").splitlines():
         if line.startswith("name:"):
             rendered = line.split(":", 1)[1].strip().strip("'\"")
+            # A hand-picked label is not `prefix + canonical`, so stripping the
+            # prefix invents a name that owns nothing: `omh-routing` became
+            # `routing`, `ulw-work` became `work`. Reverse the override map first
+            # and only fall back to stripping for the mechanical labels.
+            canonical = _CANONICAL_BY_OVERRIDE.get(rendered)
+            if canonical is not None:
+                return canonical
             for prefix in (OMH_SKILL_NAME_PREFIX, ULW_SKILL_NAME_PREFIX):
                 if rendered.startswith(prefix):
                     return rendered.removeprefix(prefix) or fallback

--- a/src/plugin_bundle/omh/awareness.py
+++ b/src/plugin_bundle/omh/awareness.py
@@ -5617,8 +5617,18 @@ def _canonical_workflow_by_display_name() -> dict[str, str]:
     # `skills/catalog_types.OMH_SKILL_DISPLAY_NAME_OVERRIDES`; the copy exists
     # because a copied plugin bundle has no catalog import, and
     # `tests/test_display_names.py` locks the two together.
-    for display, workflow in (("omh-decide", "strategy-brief"),):
+    for display, workflow in (
+        ("omh-decide", "strategy-brief"),
+        ("ulw-interview", "deep-interview"),
+        ("ulw-plan", "ralplan"),
+        ("ulw-research", "web-research"),
+        ("ulw-goal", "ultragoal"),
+        ("ulw-process", "ultraprocess"),
+        ("ulw-qa", "ultraqa"),
+        ("ulw-work", "ultrawork"),
+    ):
         mapping.pop(f"omh-{workflow}", None)
+        mapping.pop(f"ulw-{workflow}", None)
         if workflow in workflows:
             mapping[display] = workflow
     return mapping

--- a/src/skills/catalog_types.py
+++ b/src/skills/catalog_types.py
@@ -42,6 +42,16 @@ OMH_SKILL_DISPLAY_NAME_OVERRIDES = {
     # (directory, manifest, tap URL, triggers); only the label a reader sees
     # changes.
     "strategy-brief": "omh-decide",
+    # `ulw` already carries the "ultra". `ulw-ultrawork` says it twice, and the
+    # duplicated syllable is the part a reader has to skip past to reach the
+    # word that means something. Canonical names are untouched.
+    "deep-interview": "ulw-interview",
+    "ralplan": "ulw-plan",
+    "ultragoal": "ulw-goal",
+    "ultraprocess": "ulw-process",
+    "ultraqa": "ulw-qa",
+    "ultrawork": "ulw-work",
+    "web-research": "ulw-research",
 }
 
 ULW_SKILL_NAME_PREFIX = "ulw-"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6114,7 +6114,7 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
         self.assertIn("Workflow: ralplan", stdout)
         self.assertIn("Next action: preparing a reviewed plan", stdout)
         self.assertNotIn("(`present_plan`)", stdout)
-        self.assertIn("[omh] ralplan - I routed this to `ulw-ralplan`", stdout)
+        self.assertIn("[omh] ralplan - I routed this to `ulw-plan`", stdout)
         self.assertIn("Actions:", stdout)
         self.assertIn("- Accept plan - enabled", stdout)
         self.assertIn("- Prepare handoff - disabled", stdout)

--- a/tests/test_display_names.py
+++ b/tests/test_display_names.py
@@ -38,7 +38,7 @@ class DisplayNamesInBodiesTests(unittest.TestCase):
         # The QA observation: this line used to read "deep-interview, ralplan".
         # Both are workflow engines, so they render the `ulw-` label while the
         # domain skills beside them keep `omh-`.
-        self.assertIn("- Plan and decide: ulw-deep-interview, ulw-ralplan, omh-codebase-onboarding", body)
+        self.assertIn("- Plan and decide: ulw-interview, ulw-plan, omh-codebase-onboarding", body)
         self.assertIn("omh-visual-qa", body)
 
         # A family card also lists capability phrases that are not installable
@@ -79,9 +79,9 @@ class DisplayNamesInBodiesTests(unittest.TestCase):
         # the `ulw-` label. The contract is that prose uses the display form, not
         # that the display form is always `omh-`.
         self.assertTrue(response["headline"].strip())
-        self.assertIn("`ulw-ralplan", response["headline"])
-        self.assertIn("ulw-ralplan", explanation["recommended_reply"])
-        self.assertEqual(str(explanation["primary_action_label"]), "Open ulw-ralplan")
+        self.assertIn("`ulw-plan", response["headline"])
+        self.assertIn("ulw-plan", explanation["recommended_reply"])
+        self.assertEqual(str(explanation["primary_action_label"]), "Open ulw-plan")
 
     def test_router_skill_renders_as_omh_routing_rather_than_the_mechanical_prefix(self) -> None:
         self.assertEqual(omh_skill_display_name("oh-my-hermes"), "omh-routing")

--- a/tests/test_readme_highlights.py
+++ b/tests/test_readme_highlights.py
@@ -71,7 +71,7 @@ class ReadmeHighlightsTests(unittest.TestCase):
         english = Path("README.md").read_text(encoding="utf-8")
         rows = "\n".join(_highlight_rows(english))
 
-        for engine in ("ulw-ultrawork", "ulw-ultragoal", "ulw-team", "ulw-loop"):
+        for engine in ("ulw-work", "ulw-goal", "ulw-team", "ulw-loop"):
             with self.subTest(engine=engine):
                 self.assertIn(f"`{engine}`", rows)
 

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -669,7 +669,7 @@ class RouterContentTests(unittest.TestCase):
         definitions = {definition.name: definition for definition in builtin_definitions()}
 
         ultrawork = templates["ultrawork"]
-        self.assertIn("\nname: ulw-ultrawork\n", ultrawork)
+        self.assertIn("\nname: ulw-work\n", ultrawork)
         self.assertIn("\n    category: execution\n", ultrawork)
         self.assertIn("\n    phase: parallel-delivery\n", ultrawork)
         self.assertIn("\n    role: handoff-guide\n", ultrawork)
@@ -688,10 +688,10 @@ class RouterContentTests(unittest.TestCase):
 
     def test_display_name_helper_keeps_canonical_identifiers_unchanged(self) -> None:
         self.assertEqual(OMH_SKILL_NAME_PREFIX, "omh-")
-        self.assertEqual(OMH_SKILL_DISPLAY_NAME_OVERRIDES, {"oh-my-hermes": "omh-routing", "strategy-brief": "omh-decide"})
+        self.assertEqual(OMH_SKILL_DISPLAY_NAME_OVERRIDES, {'deep-interview': 'ulw-interview', 'oh-my-hermes': 'omh-routing', 'ralplan': 'ulw-plan', 'strategy-brief': 'omh-decide', 'ultragoal': 'ulw-goal', 'ultraprocess': 'ulw-process', 'ultraqa': 'ulw-qa', 'ultrawork': 'ulw-work', 'web-research': 'ulw-research'})
 
         self.assertEqual(omh_skill_display_name("oh-my-hermes"), "omh-routing")
-        self.assertEqual(omh_skill_display_name("ultrawork"), "ulw-ultrawork")
+        self.assertEqual(omh_skill_display_name("ultrawork"), "ulw-work")
         self.assertEqual(omh_skill_display_name("omh-ultrawork"), "omh-ultrawork")
 
         # Branch order: the override lookup must run before the idempotency guard.
@@ -712,6 +712,21 @@ class RouterContentTests(unittest.TestCase):
         for name in names & {path.parent.name for path in Path("skills").glob("*/SKILL.md")}:
             self.assertTrue((Path("skills") / name / "SKILL.md").exists())
 
+    def test_every_display_override_round_trips_to_its_canonical_name(self) -> None:
+        """A hand-picked label must restore the skill it belongs to, not a made-up one.
+
+        `extract_name()` stripped the prefix mechanically, so every override
+        resolved to a name that owns nothing: `omh-routing` gave `routing`,
+        `ulw-work` gave `work`. `omh setup --source <dir>` re-importing a
+        generated tap would then install the skill into the wrong directory.
+        """
+        from omh.omh.converter import extract_name
+
+        for canonical, display in OMH_SKILL_DISPLAY_NAME_OVERRIDES.items():
+            with self.subTest(display=display):
+                raw = f"---\nname: {display}\ndescription: [omh] x\n---\n\nbody\n"
+                self.assertEqual(extract_name(raw, "fallback"), canonical)
+
     def test_converter_round_trip_restores_canonical_identity(self) -> None:
         """`omh setup --source <dir>` must not degrade a generated tap.
 
@@ -725,7 +740,7 @@ class RouterContentTests(unittest.TestCase):
 
         self.assertEqual(template.name, "ultrawork")
         self.assertIn(f"\ndescription: {DESCRIPTIONS['ultrawork']}\n", template.content)
-        self.assertIn("\nname: ulw-ultrawork\n", template.content)
+        self.assertIn("\nname: ulw-work\n", template.content)
 
         # Imported third-party skills carry the prefix too, so nothing installed by
         # omh reads as a Hermes built-in - but the directory identity stays canonical.


### PR DESCRIPTION
## Feature Report

### What Changed

The ten workflow-engine labels lose the duplicated "ultra":

| Before | After |
| --- | --- |
| `ulw-ultrawork` | **`ulw-work`** |
| `ulw-ultraprocess` | **`ulw-process`** |
| `ulw-ultragoal` | **`ulw-goal`** |
| `ulw-ultraqa` | **`ulw-qa`** |
| `ulw-deep-interview` | **`ulw-interview`** |
| `ulw-ralplan` | **`ulw-plan`** |
| `ulw-web-research` | **`ulw-research`** |
| `ulw-team` `ulw-loop` `ulw-ralph` | unchanged |

Plus a **round-trip defect** these exposed — see below.

### Why This Exists

`ulw` already carries the "ultra". `ulw-ultrawork` says it twice, and the repeated syllable is exactly the part a reader skips past to reach the word that means something.

Canonical names are untouched: `skills/ultrawork/`, the manifest, the tap URL, triggers, and CLI arguments all still say `ultrawork`. Every label was routed before being written — all ten resolve to their canonical skill.

### The defect this uncovered

`converter.extract_name()` recovered a canonical name by **stripping the prefix**, which only works when the label is `prefix + canonical`. A hand-picked label is not:

```
omh-routing  -> routing          (should be oh-my-hermes)
omh-decide   -> decide           (should be strategy-brief)
ulw-work     -> work             (should be ultrawork)
```

`omh setup --source <dir>` re-importing a generated tap would install the skill into the **wrong directory** under a name nothing routes to.

**`omh-routing` has been in that override map since PR #657, so this was already broken before today.** The round-trip test only covered `ultrawork` — a mechanical label — so it never looked. `extract_name()` now reverses the override map first and falls back to stripping only for mechanical labels, and the new test walks **every entry** in the map instead of one example.

### Files And Contracts Touched

- `src/skills/catalog_types.py` — seven override entries.
- `src/plugin_bundle/omh/awareness.py` — the vendored display map mirrors them.
- `src/omh/converter.py` — reverse lookup before prefix stripping.
- Four READMEs, ten regenerated `skills/*/SKILL.md`, `docs/WORKFLOWS.md`.
- `tests/test_router_content.py` — new per-override round-trip test; label contracts updated in `test_cli.py`, `test_display_names.py`, `test_readme_highlights.py`.

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `python3 -m unittest discover -s tests` — 2177 passed, 1 skipped
- [x] `python3 -m compileall src`
- [x] `python3 -m omh.cli docs workflows --check` (also `docs roles`, `docs capability-families`, `release drift`)
- [ ] `python3 -m omh.cli harness validate` — not rerun; no harness contract touched
- [ ] `python3 -m omh.cli release checklist --json` — not rerun
- [ ] `python3 -m omh.cli release hermes-smoke` — not rerun
- [x] `omh --help`
- [ ] `omh --omh-home … release hermes-smoke --include-command-smoke` — not rerun
- [ ] Relevant workflow-learning review queue smoke — not applicable
- [x] Relevant dry-run or smoke command: all ten labels routed to their canonical skill; every override round-tripped through `extract_name`
- [ ] **Manual Hermes/TUI check — not run.** No live Hermes turn rendered a shortened label, and no real `omh setup --source <dir>` re-import ran against a generated tap.

## Risk

- Display-only for the labels.
- The converter change alters what `omh setup --source` computes as an install identity — in the correct direction, and only for labels that previously produced a wrong name. Mechanical labels (`omh-code-review` → `code-review`) are unaffected.
- Anyone who learned `ulw-ultrawork` loses that label. The canonical `ultrawork`, `$ultrawork`, and bare `ulw` triggers all still work, so the loss is cosmetic.

## Compatibility / Rollout

- No schema or CLI change. A refreshed skill pack picks up the new labels; `omh update` now refreshes everything (PR #695), so one command is enough.

## Release / Claims

- [x] Release-channel impact considered (`stable`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Known manual Hermes checks are listed

## Follow-Up

- The override map is now seven entries and growing. If it keeps growing, the mechanical-prefix rule is the wrong default and the catalog should carry an explicit `display_name` field per skill instead — worth revisiting rather than adding a tenth override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
