### PR TITLE
fix: stop update and install from reinstalling a cached archive

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -310,7 +310,7 @@ install_into_venv() {
   run_step "$(step_label 2)" "$(msg step_install_package)" sh -c '
     # Intentional shell splitting: OMH_PIP_ARGS is an advanced operator escape hatch.
     # shellcheck disable=SC2086
-    PIP_DISABLE_PIP_VERSION_CHECK=1 "$1" -m pip install --disable-pip-version-check -q --force-reinstall $2 --upgrade "$3"
+    PIP_DISABLE_PIP_VERSION_CHECK=1 "$1" -m pip install --disable-pip-version-check -q --no-cache-dir --force-reinstall $2 --upgrade "$3"
   ' sh "$OMH_RUNTIME_PYTHON" "$OMH_PIP_ARGS" "$OMH_PACKAGE_URL"
   OMH_COMMAND_HINT="$OMH_VENV_DIR/bin/omh"
   link_omh_command
@@ -324,7 +324,7 @@ install_into_python() {
   run_step "$(step_label 1)" "$(msg step_install_python)" sh -c '
     # Intentional shell splitting: OMH_DIRECT_PIP_ARGS is an advanced operator escape hatch.
     # shellcheck disable=SC2086
-    PIP_DISABLE_PIP_VERSION_CHECK=1 "$1" -m pip install --disable-pip-version-check -q --force-reinstall $2 --upgrade "$3"
+    PIP_DISABLE_PIP_VERSION_CHECK=1 "$1" -m pip install --disable-pip-version-check -q --no-cache-dir --force-reinstall $2 --upgrade "$3"
   ' sh "$OMH_PYTHON" "$OMH_DIRECT_PIP_ARGS" "$OMH_PACKAGE_URL"
   OMH_RUNTIME_PYTHON="$OMH_PYTHON"
 }

--- a/src/commands/setup.py
+++ b/src/commands/setup.py
@@ -297,6 +297,15 @@ def _run_command_package_self_update(args: argparse.Namespace, plan: dict[str, o
             "install",
             "--disable-pip-version-check",
             "-q",
+            # A branch archive keeps one URL while its contents change, and pip
+            # caches by URL. Without this, `omh update` reinstalls whatever
+            # `main.zip` was downloaded last - it reports success, the version
+            # string does not move, and the user gets an older tree. Observed:
+            # a fresh venv still printed "Using cached main.zip" and installed
+            # a build from before the merge it was run to pick up.
+            # `--force-reinstall` does not help; it forces the reinstall, not
+            # the download.
+            "--no-cache-dir",
             "--force-reinstall",
             "--upgrade",
             package_url,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2805,6 +2805,10 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
         pip_args = run.call_args_list[0].args[0]
         self.assertEqual(pip_args[:4], [sys.executable, "-m", "pip", "install"])
         self.assertIn("--force-reinstall", pip_args)
+        # A branch archive keeps one URL while its contents change, so pip
+        # would reinstall a cached `main.zip` and report success on an older
+        # tree. `--force-reinstall` forces the reinstall, not the download.
+        self.assertIn("--no-cache-dir", pip_args)
         self.assertIn("https://example.invalid/omh.zip", pip_args)
         reentry_args = run.call_args_list[1].args[0]
         self.assertEqual(reentry_args[:3], [sys.executable, "-m", "omh.cli"])

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -2953,6 +2953,7 @@ class RouterContentTests(unittest.TestCase):
         self.assertIn("Install OMH package", install_sh)
         self.assertIn("--disable-pip-version-check -q", install_sh)
         self.assertIn("--force-reinstall", install_sh)
+        self.assertIn("--no-cache-dir", install_sh)
         self.assertIn("wrapper_actions", harness_quality)
         self.assertIn("overclaim_guards", harness_quality)
         self.assertIn("harness_progress/v1", harness_quality)


### PR DESCRIPTION
## Feature Report

### What Changed

`omh update` and `install.sh` now pass `--no-cache-dir` to pip, so the command package is fetched fresh instead of reinstalled from pip's HTTP cache.

### Why This Exists

**`omh update` could report success and leave the machine on an older tree.**

The package URL is a *branch archive* — one URL whose contents change every merge:

```
https://github.com/rlaope/oh-my-hermes/archive/refs/heads/main.zip
```

pip caches by URL, so `pip install main.zip` served whatever copy it had downloaded last. The version string does not move on a branch install either, so nothing in the output disagreed with itself. Today that looked like a user updating twice and still seeing the previous release's skill labels.

`--force-reinstall` does not help — it forces the *reinstall*, not the *download*.

### Reproduced, not inferred

Against a **brand-new venv**:

```
$ pip install --force-reinstall --upgrade .../main.zip
  Using cached main.zip          ← never touched the network

$ pip install --no-cache-dir --force-reinstall --upgrade .../main.zip
  Downloading main.zip           ← current tree, 9 display overrides
```

The cached install landed a build from *before* the merge it was run to pick up.

### User / Operator Impact

`omh update` now means what it says. A user who runs it after a release gets that release, not whatever archive their pip happened to keep.

`install.sh` had the same invocation twice, so a **first install** could pick up a stale archive the same way. Both are hardened.

### Files And Contracts Touched

- `src/commands/setup.py` — the update path's pip argv.
- `install.sh` — both pip invocations.
- `tests/test_cli.py`, `tests/test_router_content.py` — assert the flag is present in the argv and in the shipped installer script.

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `python3 -m unittest discover -s tests` — 2184 passed, 1 skipped
- [x] `python3 -m compileall src`
- [x] `python3 -m omh.cli docs workflows --check` (also `docs roles`, `docs capability-families`, `release drift`)
- [ ] `python3 -m omh.cli harness validate` — not rerun; no harness contract touched
- [ ] `python3 -m omh.cli release checklist --json` — not rerun
- [ ] `python3 -m omh.cli release hermes-smoke` — not rerun
- [x] `omh --help`
- [ ] `omh --omh-home … release hermes-smoke --include-command-smoke` — not rerun
- [ ] Relevant workflow-learning review queue smoke — not applicable
- [x] Relevant dry-run or smoke command: fresh-venv reproduction of both the stale and the fixed path, shown above
- [ ] **Manual Hermes/TUI check — not run.** No run exercised a slow or offline network, so how the extra download behaves on a failing connection is unobserved — pip's own error path is unchanged.

## Risk

- Every update now re-downloads the archive instead of reusing a cached copy, so updates cost one download each. That is the price of the command meaning what it says.
- No behavior change when the cache was already cold or the archive already current.

## Compatibility / Rollout

- No CLI, schema, or contract change. Users on an old `install.sh` still benefit as soon as they run `omh update` from a package that carries this fix.

## Release / Claims

- [x] Release-channel impact considered (`preview`/branch installs are the affected case; pinned version installs were never subject to it)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Known manual Hermes checks are listed

## Follow-Up

- A branch install reports `1.0.3 -> 1.0.3 (updated)` whether or not the tree moved, which is what made this invisible. Reporting the resolved commit alongside the version would make a no-op update legible — separate change to the update summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
