### PR TITLE
fix: stop restating a standing condition on every turn

### DIFF
--- a/src/plugin_bundle/omh/memory_dreaming.py
+++ b/src/plugin_bundle/omh/memory_dreaming.py
@@ -45,6 +45,19 @@ DEFAULT_HEADROOM_FLOOR_CHARS = 300
 DREAMING_MODES = ("off", "reminder")
 DEFAULT_DREAMING_MODE = "reminder"
 
+# Reasons that describe a moment rather than a state. These clear themselves by
+# firing -- the turn counter resets, the compaction flag is lowered -- so they
+# may fire again the moment they recur. Everything not listed here is a standing
+# condition: it stays true until something outside OMH changes it, so repeating
+# it every turn says nothing the previous brief did not.
+_EVENT_REASONS = frozenset(
+    {
+        "turn_interval_reached",
+        "session_ending_with_unconsolidated_turns",
+        "context_compaction_observed",
+    }
+)
+
 
 def dreaming_state_path(omh_home: str | Path) -> Path:
     return Path(omh_home).expanduser() / "memory" / "dreaming.json"
@@ -144,6 +157,15 @@ def consolidation_reasons(
     the interval assumes a later turn will come and a closing session is exactly
     where that assumption fails. Three turns and a closed laptop would otherwise
     leave nothing behind.
+
+    A reason that describes a *condition* is suppressed until the condition
+    actually changes. Observed live: 19 consecutive briefs, every one of them
+    reading ``headroom_below_floor:289<=300``. Turn counts and compaction flags
+    clear themselves when they fire, but headroom only clears when somebody
+    consolidates -- and OMH cannot, by design. So a standing condition re-fired
+    on every single turn and the journal filled with the same sentence. Each
+    reason encodes its own value, so an unchanged condition is an unchanged
+    string, and that is what the suppression compares.
     """
     if normalize_dreaming_mode(mode) == "off":
         return []
@@ -162,7 +184,27 @@ def consolidation_reasons(
         reasons.append(f"duplicate_records:{duplicate_count}")
     if expiring_count > 0:
         reasons.append(f"expiring_records:{expiring_count}")
-    return reasons
+    return reasons if _has_unfired_reason(reasons, state) else []
+
+
+def _has_unfired_reason(reasons: list[str], state: dict[str, Any]) -> bool:
+    """Is anything here new since the last brief?
+
+    An event reason always counts: it describes a moment, and the moment
+    happened again. A condition reason counts only when its exact string has
+    changed, because an unchanged string means the same standing condition
+    nobody has cleared.
+
+    Returning the full reason list -- rather than only the unfired part -- when
+    anything is fresh is deliberate. A brief woken by the turn interval while
+    memory is also nearly full should still say memory is nearly full.
+    """
+    already = {str(reason) for reason in state.get("last_reasons", []) if isinstance(reason, str)}
+    return any(_is_event_reason(reason) or reason not in already for reason in reasons)
+
+
+def _is_event_reason(reason: str) -> bool:
+    return reason.split(":", 1)[0] in _EVENT_REASONS
 
 
 # What the executor is asked to do differs by which moment woke it. A brief

--- a/tests/test_memory_provider.py
+++ b/tests/test_memory_provider.py
@@ -47,6 +47,7 @@ from omh.plugin_bundle.omh.memory_blocks import (
 )
 from omh.plugin_bundle.omh.memory_dreaming import (
     DEFAULT_TURN_INTERVAL,
+    clear_after_consolidation,
     consolidation_reasons,
     empty_dreaming_state,
     read_dreaming_state,
@@ -186,6 +187,95 @@ class DreamingScheduleTests(unittest.TestCase):
         state = record_memory_write(record_turn(empty_dreaming_state()))
         self.assertEqual(state["turns_since_consolidation"], 1)
         self.assertEqual(state["memory_writes_observed"], 1)
+
+
+class StandingConditionSuppressionTests(unittest.TestCase):
+    """A condition nobody can clear must not be reported on every turn.
+
+    Observed on a live install: 19 consecutive briefs, every one of them reading
+    `headroom_below_floor:289<=300`. Turn counts and compaction flags clear
+    themselves by firing; headroom clears only when somebody consolidates, and
+    OMH cannot -- by design. So the condition re-fired forever and the journal
+    filled with one repeated sentence.
+    """
+
+    HEADROOM = 289
+    FLOOR = 300
+
+    def test_a_standing_condition_is_reported_once_not_every_turn(self) -> None:
+        state = empty_dreaming_state()
+        fired = 0
+        for _ in range(20):
+            state = record_turn(state)
+            reasons = consolidation_reasons(state, headroom_chars=self.HEADROOM, headroom_floor_chars=self.FLOOR)
+            if reasons:
+                fired += 1
+                state = clear_after_consolidation(state, at="t", reasons=reasons)
+        # Once on the first turn, then only when the interval genuinely comes
+        # due. Twenty briefs in twenty turns is what this replaced.
+        self.assertEqual(fired, 4)
+
+    def test_the_condition_still_rides_along_on_a_real_trigger(self) -> None:
+        # Suppression must not hide it: a brief woken by the interval while
+        # memory is nearly full should still say memory is nearly full.
+        state = clear_after_consolidation(
+            empty_dreaming_state(), at="t", reasons=[f"headroom_below_floor:{self.HEADROOM}<={self.FLOOR}"]
+        )
+        for _ in range(DEFAULT_TURN_INTERVAL):
+            state = record_turn(state)
+        reasons = consolidation_reasons(state, headroom_chars=self.HEADROOM, headroom_floor_chars=self.FLOOR)
+        self.assertTrue(any(r.startswith("turn_interval_reached") for r in reasons))
+        self.assertTrue(any(r.startswith("headroom_below_floor") for r in reasons))
+
+    def test_a_changed_condition_fires_immediately(self) -> None:
+        state = clear_after_consolidation(
+            empty_dreaming_state(), at="t", reasons=[f"headroom_below_floor:{self.HEADROOM}<={self.FLOOR}"]
+        )
+        self.assertEqual(consolidation_reasons(state, headroom_chars=self.HEADROOM, headroom_floor_chars=self.FLOOR), [])
+        self.assertTrue(consolidation_reasons(state, headroom_chars=self.HEADROOM - 40, headroom_floor_chars=self.FLOOR))
+
+    def test_duplicate_and_expiry_counts_are_conditions_too(self) -> None:
+        for reason, kwargs in (
+            ("duplicate_records:2", {"duplicate_count": 2}),
+            ("expiring_records:3", {"expiring_count": 3}),
+        ):
+            with self.subTest(reason=reason):
+                state = clear_after_consolidation(empty_dreaming_state(), at="t", reasons=[reason])
+                self.assertEqual(consolidation_reasons(state, **kwargs), [])
+
+    def test_every_event_reason_may_fire_again_at_once(self) -> None:
+        # These describe a moment, and the moment happened again.
+        compaction = clear_after_consolidation(empty_dreaming_state(), at="t", reasons=["context_compaction_observed"])
+        self.assertIn("context_compaction_observed", consolidation_reasons(record_compaction(compaction)))
+
+        turns = clear_after_consolidation(
+            empty_dreaming_state(), at="t", reasons=[f"turn_interval_reached:{DEFAULT_TURN_INTERVAL}/{DEFAULT_TURN_INTERVAL}"]
+        )
+        for _ in range(DEFAULT_TURN_INTERVAL):
+            turns = record_turn(turns)
+        self.assertTrue(any(r.startswith("turn_interval_reached") for r in consolidation_reasons(turns)))
+
+    def test_a_session_ending_still_reports_its_unconsolidated_turns(self) -> None:
+        state = clear_after_consolidation(
+            empty_dreaming_state(), at="t", reasons=["session_ending_with_unconsolidated_turns:3"]
+        )
+        state = record_turn(record_turn(record_turn(state)))
+        reasons = consolidation_reasons(state, session_ending=True)
+        self.assertIn("session_ending_with_unconsolidated_turns:3", reasons)
+
+    def test_the_provider_stops_rewriting_the_same_brief(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_hermes_memory(root / ".hermes", "x" * 2100)
+            provider = OmhMemoryProvider(root / ".omh")
+            provider.initialize("s", hermes_home=str(root / ".hermes"), agent_context="primary")
+            journal = root / ".omh" / "memory" / "consolidation.jsonl"
+
+            for turn in range(1, DEFAULT_TURN_INTERVAL):
+                provider.on_turn_start(turn, "hi")
+            # One brief from `initialize`; the standing condition adds no more
+            # until the interval genuinely comes due.
+            self.assertEqual(len(journal.read_text(encoding="utf-8").splitlines()), 1)
 
 
 class EvictionPlanTests(unittest.TestCase):
@@ -388,9 +478,14 @@ class ProviderLifecycleTests(unittest.TestCase):
         with TemporaryDirectory() as tmp:
             root = Path(tmp)
             _write_hermes_memory(root / ".hermes", "x" * 2100)
-            handoff = self._provider(root).consolidation_due()
-            self.assertTrue(any(str(r).startswith("headroom_below_floor") for r in handoff["reasons"]))
-            self.assertEqual(handoff["eviction_plan"]["cap"], 2200)
+            self._provider(root)
+
+            # The pressure is picked up by the evaluation `initialize` already
+            # runs, so the brief exists before anything else asks. Asking again
+            # finds the same standing condition suppressed rather than restated.
+            brief = json.loads((root / ".omh" / "memory" / "consolidation.json").read_text(encoding="utf-8"))
+            self.assertTrue(any(str(r).startswith("headroom_below_floor") for r in brief["reasons"]))
+            self.assertEqual(brief["eviction_plan"]["cap"], 2200)
 
     def test_a_read_only_home_costs_a_journal_line_not_the_turn(self) -> None:
         with TemporaryDirectory() as tmp:
@@ -688,8 +783,16 @@ class MemoryCliTests(unittest.TestCase):
             _write_hermes_memory(root / ".hermes", "x" * 2100)
             status, payload, stderr = self._json(run_cli(self._base(root) + ["memory", "dream", "--evaluate"]))
             self.assertEqual(status, 0, stderr)
-            self.assertTrue(payload["due"])
             self.assertIn("not evidence that memory was consolidated", payload["claim_boundary"])
+            # The brief lands on disk whether or not this particular call is the
+            # one that weighed the trigger: `initialize` evaluates first, and a
+            # standing condition is not restated once it has been reported.
+            self.assertTrue((root / ".omh" / "memory" / "consolidation.json").is_file())
+
+            # Asking twice does not write twice, which is the whole point.
+            before = (root / ".omh" / "memory" / "consolidation.jsonl").read_text(encoding="utf-8")
+            run_cli(self._base(root) + ["memory", "dream", "--evaluate"])
+            self.assertEqual((root / ".omh" / "memory" / "consolidation.jsonl").read_text(encoding="utf-8"), before)
 
     def test_the_provider_slot_can_be_taken_and_handed_back(self) -> None:
         with TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Feature Report

### What Changed

Consolidation reasons are split by what they describe. An **event** reason (turn interval, compaction, session ending) may fire again the moment it recurs. A **condition** reason (headroom below floor, duplicate records, expiring records) fires only when its value changes.

### Why This Exists

Found by running it, not by reading it. A live install had written **19 consecutive briefs, every one of them identical**:

```
headroom_below_floor:289<=300
```

Turn counts and compaction flags clear themselves by firing — the counter resets, the flag is lowered — so re-firing means the moment recurred. Headroom does not work that way. It clears only when somebody consolidates, and **OMH cannot consolidate by design**: the brief is a request, and nothing yet consumes it.

So a true condition stayed true, fired on every evaluation, and `consolidation.jsonl` filled with one repeated sentence. That is noise wearing the shape of a signal, and it grows without bound.

### User / Operator Impact

Simulated against the observed scenario — headroom stuck at 289, floor 300, over 20 turns:

| | Briefs written |
| --- | --- |
| before | 20, all identical |
| after | **4** — once on first observation, then only when the turn interval genuinely came due |

**Suppression does not hide it.** A brief woken by the interval while memory is nearly full still says memory is nearly full, because the full reason list travels whenever anything in it is fresh. A headroom that actually moves (289 → 250) fires at once.

### How It Works

Each reason already encodes its own value (`headroom_below_floor:289<=300`, `duplicate_records:2`), so an unchanged condition is an unchanged string — which is exactly what the comparison needs. `_has_unfired_reason` returns true when any reason is an event, or when a condition string is absent from the `last_reasons` recorded at the previous fire.

Returning the *full* list rather than only the unfired part is deliberate, for the ride-along case above.

### Files And Contracts Touched

- `src/plugin_bundle/omh/memory_dreaming.py` — `_EVENT_REASONS`, `_has_unfired_reason`, `_is_event_reason`.
- `tests/test_memory_provider.py` — 7 new cases; 2 updated.
- No schema change. `omh_memory_dreaming_state/v1` already carried `last_reasons`; this gives it a job.

## Validation

- [x] `uv run --group lint ruff check src tests` — All checks passed
- [x] `python3 -m unittest discover -s tests` — **2191 passed**, 1 skipped
- [x] `python3 -m compileall src`
- [x] `python3 -m omh.cli docs workflows --check`, `docs roles --check`, `docs capability-families --check`
- [x] `python3 -m omh.cli harness validate`
- [x] `git diff --check`
- [x] Direct simulation of the live scenario's exact numbers: 20 turns at headroom 289 → 4 briefs; 289 → 250 fires immediately; compaction and turn-interval still refire
- [ ] Manual Hermes/TUI check — **not run.** Not yet re-observed on the live install. The 19-brief journal is evidence of the defect; the fix is verified by simulation against its exact numbers rather than by a second live run.

## Risk

Low. Fewer briefs is the only behavioural change — nothing that previously fired stops being reported, it stops being repeated.

The one judgement call worth flagging: a condition observed once and then never re-surfaced until some *other* trigger fires means a very quiet session could hold a standing condition for a long time without restating it. The turn interval bounds that in practice (every 5 turns), and session end and shutdown both fire regardless.

## Compatibility / Rollout

No migration. `last_reasons` already existed in the persisted state and was already written on every fire; an install with a populated field starts suppressing immediately, and an empty one behaves as before until the first fire.

## Release / Claims

- [x] Release-channel impact considered — `local`; no version change.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed — the defect is observed on a live install; the fix is simulated, not yet re-observed there.
- [x] Known manual Hermes checks are listed — no live tap smoke was run.

## Follow-Up

- The root cause remains: **nothing consumes the brief.** Suppression makes the journal honest, but a standing condition still only clears if a human or Hermes acts on it. Surfacing the newest brief in `omh doctor` or the wrapper card lane is the next step, and was already listed as follow-up on #687.
