### PR TITLE
feat: surface the pending consolidation brief in `omh doctor`

### DIFF
--- a/src/maintenance/doctor.py
+++ b/src/maintenance/doctor.py
@@ -16,6 +16,7 @@ from ..hashutil import sha256_file
 from ..local_store import can_write_dir
 from ..manifest import local_modifications, read_manifest
 from ..paths import OmhPaths
+from ..plugin_bundle.omh.memory_dreaming import read_dreaming_state, read_latest_consolidation
 from ..plugin_bundle.omh.metadata import MEMORY_PROVIDER_NAME
 from ..plugin_observations import (
     PLUGIN_HOST_ACTIVE_OBSERVATION_EVENTS,
@@ -127,6 +128,7 @@ def run_doctor(paths: OmhPaths) -> list[Check]:
     checks.append(Check("external_dir", external_registered, f"{paths.skills_dir} in skills.external_dirs"))
     checks.append(_skill_shadowing_check(paths, dirs))
     checks.append(_memory_provider_check(config_text))
+    checks.append(_memory_consolidation_check(paths))
     checks.append(
         Check(
             "runtime_context",
@@ -284,6 +286,35 @@ def run_doctor(paths: OmhPaths) -> list[Check]:
             )
         )
     return checks
+
+
+def _memory_consolidation_check(paths: OmhPaths) -> Check:
+    """Say what the newest consolidation brief is asking for.
+
+    The scheduler decided memory was worth consolidating and wrote a brief. Up
+    to now nothing read it back, so the decision lived in a JSON file an
+    operator had no reason to open: OMH knew memory was nearly full and said so
+    only to itself.
+
+    Never a fault. OMH cannot run the consolidation -- that needs a model -- and
+    it cannot tell whether Hermes already did, so an outstanding brief is a
+    thing to know rather than a thing that is broken.
+    """
+    brief = read_latest_consolidation(paths.omh_home)
+    if not brief:
+        return Check("memory_consolidation", True, "No memory consolidation is pending", observed=True)
+    reasons = [str(reason) for reason in brief.get("reasons", []) if isinstance(reason, str)]
+    if not brief.get("due") or not reasons:
+        return Check("memory_consolidation", True, "No memory consolidation is pending", observed=True)
+    at = str(read_dreaming_state(paths.omh_home).get("last_consolidated_at", "") or "unknown time")
+    return Check(
+        "memory_consolidation",
+        True,
+        f"Memory consolidation is due ({', '.join(reasons)}), raised at {at} by {brief.get('trigger', 'unknown')}. "
+        "Ask Hermes to review and consolidate its memory; OMH prepared the brief and cannot run it.",
+        severity="warning",
+        observed=True,
+    )
 
 
 def _memory_provider_check(config_text: str) -> Check:

--- a/src/plugin_bundle/omh/memory_dreaming.py
+++ b/src/plugin_bundle/omh/memory_dreaming.py
@@ -270,6 +270,29 @@ def build_consolidation_handoff(
     }
 
 
+def consolidation_path(omh_home: str | Path) -> Path:
+    return Path(omh_home).expanduser() / "memory" / "consolidation.json"
+
+
+def read_latest_consolidation(omh_home: str | Path) -> dict[str, Any] | None:
+    """The newest brief on disk, or None when there is none to read.
+
+    Never raises. A brief nobody can read is a brief nobody has to act on, and
+    an unreadable file must not take down whatever asked -- `omh doctor`, in
+    the case this exists for.
+    """
+    path = consolidation_path(omh_home)
+    try:
+        if path.is_symlink() or not path.is_file():
+            return None
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, ValueError):
+        return None
+    if not isinstance(data, dict) or data.get("schema_version") != DREAMING_HANDOFF_SCHEMA_VERSION:
+        return None
+    return data
+
+
 def normalize_dreaming_mode(value: str | None) -> str:
     mode = str(value or "").strip().lower()
     return mode if mode in DREAMING_MODES else DEFAULT_DREAMING_MODE

--- a/tests/test_memory_provider.py
+++ b/tests/test_memory_provider.py
@@ -51,6 +51,7 @@ from omh.plugin_bundle.omh.memory_dreaming import (
     consolidation_reasons,
     empty_dreaming_state,
     read_dreaming_state,
+    read_latest_consolidation,
     record_compaction,
     record_memory_write,
     record_turn,
@@ -952,6 +953,77 @@ class SetupTurnsMemoryOnTests(unittest.TestCase):
             self.assertEqual(status, 0, stderr)
             self.assertTrue(json.loads(stdout)["changed"])
             self.assertFalse(json.loads(stdout)["is_omh"])
+
+
+class DoctorSurfacesTheBriefTests(unittest.TestCase):
+    """The scheduler's decision has to reach a human somewhere.
+
+    A brief was written to `consolidation.json` and nothing read it back, so
+    OMH knew memory was nearly full and said so only to itself. Doctor is where
+    an operator already looks.
+
+    It is a warning, never a fault: OMH cannot run the consolidation, and it
+    cannot tell whether Hermes already did.
+    """
+
+    def _checks(self, root: Path) -> dict[str, dict]:
+        status, stdout, stderr = run_cli(
+            ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes"), "doctor"]
+        )
+        self.assertIn(status, (0, 1), stderr)
+        return {check["name"]: check for check in json.loads(stdout)["checks"]}
+
+    def _fire_a_brief(self, root: Path) -> None:
+        _write_hermes_memory(root / ".hermes", "x" * 2100)
+        provider = OmhMemoryProvider(root / ".omh")
+        provider.initialize("s", hermes_home=str(root / ".hermes"), agent_context="primary")
+
+    def test_a_pending_brief_is_reported_with_its_reasons(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._fire_a_brief(root)
+            check = self._checks(root)["memory_consolidation"]
+            self.assertEqual(check["severity"], "warning")
+            self.assertIn("headroom_below_floor", check["message"])
+            self.assertIn("consolidat", check["message"].lower())
+
+    def test_a_pending_brief_never_fails_the_install(self) -> None:
+        # OMH cannot run the consolidation and cannot tell whether Hermes has,
+        # so an outstanding brief is a thing to know, not a thing that is broken.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._fire_a_brief(root)
+            self.assertTrue(self._checks(root)["memory_consolidation"]["ok"])
+
+    def test_no_brief_reads_as_nothing_pending(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            check = self._checks(root)["memory_consolidation"]
+            self.assertEqual(check["severity"], "ok")
+            self.assertIn("No memory consolidation is pending", check["message"])
+
+    def test_an_unreadable_brief_reads_as_nothing_pending(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            path = root / ".omh" / "memory" / "consolidation.json"
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("{not json", encoding="utf-8")
+            self.assertEqual(self._checks(root)["memory_consolidation"]["severity"], "ok")
+
+    def test_a_brief_that_was_not_due_is_not_reported_as_pending(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            provider = OmhMemoryProvider(root / ".omh")
+            provider.initialize("s", hermes_home=str(root / ".hermes"), agent_context="primary")
+            # Nothing fired, so no brief was written at all.
+            self.assertEqual(self._checks(root)["memory_consolidation"]["severity"], "ok")
+
+    def test_the_reader_is_defensive_about_the_schema(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "memory" / "consolidation.json"
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(json.dumps({"schema_version": "something_else/v1"}), encoding="utf-8")
+            self.assertIsNone(read_latest_consolidation(tmp))
 
 
 class BlockBudgetDefaultTests(unittest.TestCase):


### PR DESCRIPTION
## Feature Report

### What Changed

`omh doctor` now reports the newest consolidation brief — the reasons that raised it, when, and which trigger woke it — as a **warning**, never a fault.

### Why This Exists

The scheduler decided memory was worth consolidating, wrote a brief, and **nothing ever read it back**. OMH knew memory was nearly full and said so only to itself, in a JSON file an operator had no reason to open.

That is the root cause standing behind the repetition fixed in #700. Suppression made the journal honest, but a standing condition still only clears when somebody acts on it, and nobody was being told there was anything to act on.

### User / Operator Impact

Run against the live install:

```
[ok]      memory_provider: OMH memory is on; it recalls and consolidates across sessions
[warning] memory_consolidation: Memory consolidation is due
          (session_ending_with_unconsolidated_turns:1, headroom_below_floor:289<=300),
          raised at 2026-07-27T09:02:31Z by session_end. Ask Hermes to review and
          consolidate its memory; OMH prepared the brief and cannot run it.
```

`omh doctor` is where an operator already looks, and it still exits green.

### How It Works

`read_latest_consolidation(omh_home)` reads `consolidation.json` defensively — a missing, unreadable, or foreign-schema file returns `None` and the check reports nothing pending. The timestamp comes from the dreaming state's existing `last_consolidated_at`, so no schema changed to carry it.

**Deliberately a warning, not a failure.** OMH cannot run the consolidation — that needs a model — and it cannot tell whether Hermes already did. An outstanding brief is a thing to know, not a thing that is broken.

### Files And Contracts Touched

- `src/plugin_bundle/omh/memory_dreaming.py` — `consolidation_path`, `read_latest_consolidation`.
- `src/maintenance/doctor.py` — `_memory_consolidation_check`.
- `tests/test_memory_provider.py` — 6 new cases.
- No schema change.

## Validation

- [x] `uv run --group lint ruff check src tests` — All checks passed
- [x] `python3 -m unittest discover -s tests` — **2197 passed**, 1 skipped
- [x] `python3 -m compileall src`
- [x] `python3 -m omh.cli docs workflows --check`, `docs roles --check`, `docs capability-families --check`
- [x] `python3 -m omh.cli harness validate`
- [x] `git diff --check`
- [x] **Live `omh doctor` against the real install** — reported the real outstanding brief with its real reasons and timestamp (output quoted above)
- [ ] Manual Hermes/TUI check — not applicable; this is a CLI-side read of local state.

## Risk

Low. One additional read-only check. `omh doctor` gains a warning line on installs that have a brief waiting and is otherwise unchanged; nothing is written, nothing is marked consumed.

The judgement call worth naming: the brief is never marked as read. Doctor will keep reporting the same outstanding brief until the underlying condition changes. That is intentional — marking it consumed would claim knowledge of an action doctor never observed — but it does mean the warning persists for as long as the condition does.

## Compatibility / Rollout

No migration. An install with no brief reads as nothing pending, which is the state every install starts in.

## Release / Claims

- [x] Release-channel impact considered — `local`; no version change.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed — the doctor output above is observed on the live install; whether acting on the brief clears the condition is not.
- [x] Known manual Hermes checks are listed — no live tap smoke was run.

## Follow-Up

- The loop still is not closed: doctor reports the brief, and an operator or Hermes still has to act on it. The next step would be the wrapper card lane, so a Hermes chat turn can raise it without the operator running a command at all.
