### PR TITLE
feat: carry the pending consolidation brief into chat on every messenger

### DIFF
--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -31,6 +31,7 @@ from ..operator_productivity import build_agent_operator_productivity_card
 from ..paths import OmhPaths, resolve_paths
 from ..plugin_bundle.omh.awareness import workflow_context_card_for_workflow, workflow_context_cards
 from ..plugin_bundle.omh.degradation import degradation_chat_note
+from ..plugin_bundle.omh.memory_dreaming import read_dreaming_state, read_latest_consolidation
 from ..probe import probe_capabilities
 from ..quickstart import build_quickstart_card
 from ..skills.catalog import (
@@ -2962,7 +2963,7 @@ def build_chat_interaction_payload(
             )
         )
 
-    return _build_chat_interaction_payload_uncached(
+    payload = _build_chat_interaction_payload_uncached(
         event_or_message,
         source=source,
         mode=mode,
@@ -2975,6 +2976,14 @@ def build_chat_interaction_payload(
         paths=paths,
         skill_policy=skill_policy,
     )
+    # Attached at the one point every chat surface passes through -- the plugin
+    # tool's session and no-session paths both land here -- so Slack, Telegram,
+    # Discord, CLI, and desktop all carry the notice from a single seam. The
+    # cached branch above never reaches this: it requires `paths is None`, and
+    # without an OMH home there is no brief to read.
+    if paths is not None:
+        payload = _with_memory_consolidation_notice(payload, paths)
+    return payload
 
 
 def _can_use_chat_interaction_cache(
@@ -6075,6 +6084,80 @@ def _chat_response_with_goal_quality_coaching(
         actions.append(_action("state_goal_success_criteria", "State success criteria", "secondary"))
     updated["actions"] = actions
     return updated
+
+
+# A standing brief is one short sentence in chat, not a dump of the scheduler's
+# reason strings. The raw reasons ride in the structured notice for wrappers;
+# the body line is for a person reading Slack on a phone.
+_CONSOLIDATION_REASON_PHRASES = {
+    "headroom_below_floor": "memory is nearly full",
+    "turn_interval_reached": "several turns since the last tidy-up",
+    "session_ending_with_unconsolidated_turns": "a session ended with work not yet consolidated",
+    "context_compaction_observed": "context was compacted",
+    "duplicate_records": "duplicate memories were detected",
+    "expiring_records": "some memories are expiring",
+}
+
+MEMORY_CONSOLIDATION_NOTICE_SCHEMA_VERSION = "omh_memory_consolidation_notice/v1"
+
+
+def _with_memory_consolidation_notice(payload: dict[str, object], paths: OmhPaths) -> dict[str, object]:
+    """Carry a pending consolidation brief into the chat card, on every surface.
+
+    The scheduler's decision used to reach an operator only through
+    `omh doctor` -- a command. Someone talking to Hermes from Slack or Telegram
+    never runs commands, so for them the brief did not exist. This is the same
+    fact, delivered where the conversation already is.
+
+    Additive on purpose: the routed card keeps its kind, headline, and actions,
+    and the notice is one body sentence plus structured state. It carries no
+    filesystem paths -- messenger copy leaks them to shared channels -- and the
+    body is appended before the render profile is recomputed, so each
+    messenger's own constraints shape it exactly like the rest of the card.
+    """
+    brief = read_latest_consolidation(paths.omh_home)
+    if not brief or not brief.get("due"):
+        return payload
+    reasons = [str(reason) for reason in brief.get("reasons", []) if isinstance(reason, str)]
+    if not reasons:
+        return payload
+    phrases: list[str] = []
+    for reason in reasons:
+        phrase = _CONSOLIDATION_REASON_PHRASES.get(reason.split(":", 1)[0])
+        if phrase and phrase not in phrases:
+            phrases.append(phrase)
+    summary = "; ".join(phrases) if phrases else "a consolidation brief is waiting"
+    payload = dict(payload)
+    payload["memory_consolidation_notice"] = {
+        "schema_version": MEMORY_CONSOLIDATION_NOTICE_SCHEMA_VERSION,
+        "due": True,
+        "trigger": str(brief.get("trigger", "") or ""),
+        "reasons": reasons,
+        "raised_at": str(read_dreaming_state(paths.omh_home).get("last_consolidated_at", "") or ""),
+        "next_action": "ask_hermes_to_consolidate_memory",
+        "redaction_policy": "metadata_only",
+        "claim_boundary": (
+            "A consolidation notice is prepared context. It is not evidence that memory was "
+            "consolidated, that Hermes read the brief, or that any entry changed."
+        ),
+    }
+    response = payload.get("chat_response")
+    if not isinstance(response, dict):
+        return payload
+    updated = dict(response)
+    state = dict(_nested(updated, "state"))
+    state["memory_consolidation"] = {"due": True, "next_action": "ask_hermes_to_consolidate_memory"}
+    updated["state"] = state
+    notice_line = f"Memory tidy-up is pending ({summary}). Ask me to review and consolidate memory."
+    body = str(updated.get("body", ""))
+    if notice_line not in body:
+        updated["body"] = f"{body} {notice_line}".strip()
+    payload["chat_response"] = _chat_response_with_render_profile(
+        updated,
+        source=str(payload.get("source", "generic")),
+        source_metadata=_nested(payload, "source_metadata"),
+    )
+    return payload
 
 
 def _finish_interaction(payload: dict[str, object], target_notice: dict[str, object] | None) -> dict[str, object]:

--- a/tests/test_memory_provider.py
+++ b/tests/test_memory_provider.py
@@ -1026,6 +1026,126 @@ class DoctorSurfacesTheBriefTests(unittest.TestCase):
             self.assertIsNone(read_latest_consolidation(tmp))
 
 
+class ChatNoticeOnEveryMessengerTests(unittest.TestCase):
+    """A pending consolidation brief reaches chat, whatever the messenger.
+
+    `omh doctor` surfaced the brief for people who run commands. Someone talking
+    to Hermes from Slack or Telegram never runs commands, so for them the brief
+    did not exist. The notice attaches at the one seam every chat surface passes
+    through, so covering the seam covers Slack, Telegram, Discord, CLI, and
+    desktop at once.
+    """
+
+    NOTICE_LINE = "Memory tidy-up is pending"
+
+    def _due_paths(self, root: Path):
+        from omh.paths import resolve_paths
+
+        memories = root / ".hermes" / "memories"
+        memories.mkdir(parents=True, exist_ok=True)
+        (memories / "MEMORY.md").write_text("x" * 2100, encoding="utf-8")
+        provider = OmhMemoryProvider(root / ".omh")
+        provider.initialize("s", hermes_home=str(root / ".hermes"), agent_context="primary")
+        return resolve_paths(root / ".omh", root / ".hermes")
+
+    def _payload(self, paths, source: str) -> dict:
+        from omh.wrapper.contract import build_chat_interaction_payload
+
+        return build_chat_interaction_payload("이 레포에 기능 하나 안전하게 추가하고 싶어", source=source, paths=paths)
+
+    def test_every_chat_source_carries_the_notice_in_its_rendered_body(self) -> None:
+        from omh.ingress import CHAT_SOURCES
+
+        with TemporaryDirectory() as tmp:
+            paths = self._due_paths(Path(tmp))
+            for source in sorted(CHAT_SOURCES):
+                with self.subTest(source=source):
+                    payload = self._payload(paths, source)
+                    notice = payload.get("memory_consolidation_notice")
+                    self.assertIsInstance(notice, dict)
+                    self.assertIn("not evidence", str(notice["claim_boundary"]))
+                    body = str(payload["chat_response"]["body"])
+                    self.assertIn(self.NOTICE_LINE, body)
+                    rendering = payload["chat_response"].get("messenger_rendering")
+                    if isinstance(rendering, dict):
+                        self.assertIn(self.NOTICE_LINE, str(rendering.get("body_text", "")))
+
+    def test_the_routed_card_is_not_displaced(self) -> None:
+        # Additive means additive: same kind, same headline, one extra sentence.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            from omh.paths import resolve_paths
+
+            clean = resolve_paths(root / ".clean-omh", root / ".clean-hermes")
+            control = self._payload(clean, "slack")["chat_response"]
+            noticed = self._payload(self._due_paths(root), "slack")["chat_response"]
+            self.assertEqual(noticed["kind"], control["kind"])
+            self.assertEqual(noticed["headline"], control["headline"])
+            self.assertTrue(str(noticed["body"]).startswith(str(control["body"])))
+
+    def test_no_brief_means_no_notice_anywhere(self) -> None:
+        with TemporaryDirectory() as tmp:
+            from omh.paths import resolve_paths
+
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            payload = self._payload(paths, "telegram")
+            self.assertNotIn("memory_consolidation_notice", payload)
+            self.assertNotIn(self.NOTICE_LINE, str(payload["chat_response"]["body"]))
+
+    def test_an_unreadable_brief_degrades_to_no_notice(self) -> None:
+        with TemporaryDirectory() as tmp:
+            from omh.paths import resolve_paths
+
+            root = Path(tmp)
+            broken = root / ".omh" / "memory" / "consolidation.json"
+            broken.parent.mkdir(parents=True, exist_ok=True)
+            broken.write_text("{not json", encoding="utf-8")
+            payload = self._payload(resolve_paths(root / ".omh", root / ".hermes"), "slack")
+            self.assertNotIn("memory_consolidation_notice", payload)
+
+    def test_messenger_copy_carries_no_filesystem_paths(self) -> None:
+        # A Slack channel is a shared surface; a local path in the body leaks
+        # the operator's machine layout to everyone in it.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            payload = self._payload(self._due_paths(root), "slack")
+            body = str(payload["chat_response"]["body"])
+            self.assertNotIn(str(root), body)
+            self.assertNotIn("/Users/", body)
+            self.assertNotIn(".omh", body)
+
+    def test_the_cached_pathless_call_stays_notice_free(self) -> None:
+        # The cache key excludes any OMH home, so a cached payload must never
+        # carry state it could not have read.
+        from omh.wrapper.contract import build_chat_interaction_payload
+
+        payload = build_chat_interaction_payload("hello", source="slack")
+        self.assertNotIn("memory_consolidation_notice", payload)
+
+    def test_the_real_plugin_tool_carries_it_on_both_paths(self) -> None:
+        from omh.plugin_bundle.omh.tools.chat_tool import omh_interact_handler
+
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp).resolve()
+            self._due_paths(root)
+            with patch.dict(os.environ, {"OMH_HOME": str(root / ".omh"), "HERMES_HOME": str(root / ".hermes")}):
+                for record_session in (True, False):
+                    with self.subTest(record_session=record_session):
+                        out = json.loads(
+                            omh_interact_handler(
+                                {
+                                    "message": "PR 하나 올리고 싶은데 도와줘",
+                                    "source": "slack",
+                                    "record_session": record_session,
+                                    "omh_home": str(root / ".omh"),
+                                    "hermes_home": str(root / ".hermes"),
+                                }
+                            )
+                        )
+                        self.assertIn("memory_consolidation_notice", out)
+                        self.assertIn(self.NOTICE_LINE, str(out["chat_response"]["body"]))
+
+
 class BlockBudgetDefaultTests(unittest.TestCase):
     def test_the_default_block_limit_fits_beside_hermes_own_cap(self) -> None:
         # A block that alone exceeded Hermes' 2200-char memory file would make


### PR DESCRIPTION
## Feature Report

### What Changed

When a memory-consolidation brief is pending, every chat payload now carries a `memory_consolidation_notice/v1` field plus one human-readable body sentence — on Slack, Telegram, Discord, CLI, and desktop alike. The routed card is untouched; the notice is additive.

### Why This Exists

#701 surfaced the brief in `omh doctor` — for people who run commands. Someone talking to Hermes from Slack or Telegram never runs commands, so for them the brief still did not exist: the scheduler decided memory needed tidying, and the one place that said so was a CLI they never open.

### User / Operator Impact

While a brief is pending, any chat turn from any messenger ends with:

```
… Memory tidy-up is pending (memory is nearly full). Ask me to review and consolidate memory.
```

Wrappers get the raw reasons, trigger, and claim boundary in the structured field. With no brief pending, payloads are byte-identical to before.

### How It Works

One attach point: `build_chat_interaction_payload` — the seam every chat surface passes through. The `omh_interact` plugin tool reaches it on both its session-recording and no-session paths, so all five `CHAT_SOURCES` are covered by a single change rather than five gateway adapters.

- **Human phrasing, not scheduler strings.** The body says "memory is nearly full"; `headroom_below_floor:289<=300` rides only in the structured field. Slack is read on phones.
- **No filesystem paths in copy.** Messenger surfaces are shared; a local path leaks the operator's machine layout to a channel. Pinned by test.
- **Render-profile aware.** The body is appended *before* the render profile is recomputed, so `messenger_rendering.body_text` for narrow surfaces carries the notice shaped by the same constraints as the rest of the card.
- **Cache-safe.** The cached fast path requires `paths is None`, so it can never have read a brief — and stays notice-free, pinned by test.
- **Defensive read.** `read_latest_consolidation` degrades an unreadable or foreign-schema brief to "no notice".

### Files And Contracts Touched

- `src/wrapper/contract.py` — `_with_memory_consolidation_notice`, wired at the end of `build_chat_interaction_payload`; new `omh_memory_consolidation_notice/v1` contract (additive).
- `tests/test_memory_provider.py` — 7 new cases.
- Frozen chat-card coverage / localized-copy / count gates untouched — they run against homes with no pending brief, and the full suite passes unchanged.

## Validation

- [x] `uv run --group lint ruff check src tests` — All checks passed
- [x] `python3 -m unittest discover -s tests` — **2204 passed**, 1 skipped
- [x] `python3 -m compileall src`
- [x] `python3 -m omh.cli docs workflows --check`, `docs roles --check`, `docs capability-families --check`
- [x] `python3 -m omh.cli harness validate`
- [x] `git diff --check`
- [x] All five `CHAT_SOURCES` verified end to end with a genuinely due brief: notice in payload, body, and `messenger_rendering.body_text`
- [x] Real `omh_interact` handler verified on both `record_session` paths
- [x] Controls: clean home → no notice; unreadable brief → no notice; cached pathless call → no notice
- [ ] Manual Hermes/TUI check — **not run.** No live Slack or Telegram message rendered the card in a real channel; messenger constraints are exercised through the render-profile contract, not a running gateway.

## Risk

Low. One optional field and one body sentence, only while a brief is due. The known repetition trade-off is inherited from #701 deliberately: the notice persists until the condition clears, because marking it consumed would claim knowledge of an action OMH never observed.

## Compatibility / Rollout

Additive contract; no migration. A user's Hermes picks it up on the next `omh update`.

## Release / Claims

- [x] Release-channel impact considered — `local`; no version change.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed — per-source payloads observed; live channel rendering not observed.
- [x] Known manual Hermes checks are listed — no live tap smoke was run.

## Follow-Up

- A "consolidate now" action button on the card (so the reply itself can kick off the consolidation turn) would close the last step of the loop.
