### PR TITLE
fix: harden, retire, and localize the consolidation chat notice

### DIFF
--- a/docs/HERMES_AGENT_INTEGRATION_RUNBOOK.md
+++ b/docs/HERMES_AGENT_INTEGRATION_RUNBOOK.md
@@ -92,6 +92,12 @@ The returned envelope is safe for a wrapper to render without parsing prose:
   topology changed from one target to many or many to one.
 - `target_topology`: optional `omh_target_topology/v1` summary with
   `active_agent_count`, `current_target_id`, and `requires_skill_scope_awareness`.
+- `memory_consolidation_notice`: optional `omh_memory_consolidation_notice/v1`
+  carried while a memory-consolidation brief is pending, with `reasons`,
+  `trigger`, `raised_at`, and `next_action: ask_hermes_to_consolidate_memory`.
+  The matching localized sentence is already appended to `chat_response.body`;
+  the notice is prepared context, never consolidation evidence, and it retires
+  once the underlying conditions clear.
 - `plan`, `delegation`, or `status`: optional machine-readable payload for the
   selected mode.
 

--- a/src/maintenance/doctor.py
+++ b/src/maintenance/doctor.py
@@ -306,7 +306,7 @@ def _memory_consolidation_check(paths: OmhPaths) -> Check:
     reasons = [str(reason) for reason in brief.get("reasons", []) if isinstance(reason, str)]
     if not brief.get("due") or not reasons:
         return Check("memory_consolidation", True, "No memory consolidation is pending", observed=True)
-    at = str(read_dreaming_state(paths.omh_home).get("last_consolidated_at", "") or "unknown time")
+    at = str(brief.get("raised_at", "") or read_dreaming_state(paths.omh_home).get("last_consolidated_at", "") or "unknown time")
     return Check(
         "memory_consolidation",
         True,

--- a/src/plugin_bundle/omh/memory_dreaming.py
+++ b/src/plugin_bundle/omh/memory_dreaming.py
@@ -146,6 +146,7 @@ def consolidation_reasons(
     duplicate_count: int = 0,
     expiring_count: int = 0,
     session_ending: bool = False,
+    suppress: bool = True,
 ) -> list[str]:
     """Why consolidation is due now, or an empty list when it is not.
 
@@ -184,6 +185,13 @@ def consolidation_reasons(
         reasons.append(f"duplicate_records:{duplicate_count}")
     if expiring_count > 0:
         reasons.append(f"expiring_records:{expiring_count}")
+    # ``suppress=False`` answers a different question: not "should a new brief
+    # fire now" but "is anything still true at all". Retirement needs the
+    # second -- a suppressed standing condition is still standing, and retiring
+    # its brief because the scheduler declined to repeat it would clear a
+    # notice whose fact had not cleared.
+    if not suppress:
+        return reasons
     return reasons if _has_unfired_reason(reasons, state) else []
 
 
@@ -236,6 +244,7 @@ def build_consolidation_handoff(
     trigger: str = "manual",
     messages_at_risk: int = 0,
     session_id: str = "",
+    raised_at: str = "",
 ) -> dict[str, object]:
     """A prepared brief for whoever actually consolidates.
 
@@ -256,6 +265,10 @@ def build_consolidation_handoff(
         "mode": normalize_dreaming_mode(mode),
         "due": bool(reasons),
         "trigger": trigger,
+        # The brief's own timestamp. `last_consolidated_at` in the dreaming
+        # state is when the PREVIOUS brief fired, which is strictly earlier;
+        # labelling that "raised_at" mislabelled it for every consumer.
+        "raised_at": raised_at,
         "session_id": session_id,
         "messages_at_risk": messages_at_risk,
         "reasons": list(reasons),
@@ -277,9 +290,13 @@ def consolidation_path(omh_home: str | Path) -> Path:
 def read_latest_consolidation(omh_home: str | Path) -> dict[str, Any] | None:
     """The newest brief on disk, or None when there is none to read.
 
-    Never raises. A brief nobody can read is a brief nobody has to act on, and
-    an unreadable file must not take down whatever asked -- `omh doctor`, in
-    the case this exists for.
+    Never raises, and never returns fields a consumer has to type-check. The
+    first version validated only that the file was a dict with the right
+    schema string and passed everything else through -- so a brief whose
+    ``reasons`` was an int survived the read and raised ``TypeError`` in the
+    consumer, which for the chat notice meant one malformed local file took
+    down every reply on every messenger. Fields are normalized here, once,
+    for every consumer.
     """
     path = consolidation_path(omh_home)
     try:
@@ -290,7 +307,18 @@ def read_latest_consolidation(omh_home: str | Path) -> dict[str, Any] | None:
         return None
     if not isinstance(data, dict) or data.get("schema_version") != DREAMING_HANDOFF_SCHEMA_VERSION:
         return None
-    return data
+    raw_reasons = data.get("reasons")
+    normalized = dict(data)
+    normalized["due"] = bool(data.get("due"))
+    normalized["reasons"] = (
+        [reason for reason in raw_reasons if isinstance(reason, str)] if isinstance(raw_reasons, list) else []
+    )
+    normalized["trigger"] = str(data.get("trigger", "") or "")
+    normalized["raised_at"] = str(data.get("raised_at", "") or "")
+    if normalized["due"] and not normalized["reasons"]:
+        # A brief that claims to be due but cannot say why is not actionable.
+        normalized["due"] = False
+    return normalized
 
 
 def normalize_dreaming_mode(value: str | None) -> str:

--- a/src/plugin_bundle/omh/memory_provider.py
+++ b/src/plugin_bundle/omh/memory_provider.py
@@ -56,6 +56,7 @@ from .memory_dreaming import (
     clear_after_consolidation,
     consolidation_reasons,
     read_dreaming_state,
+    read_latest_consolidation,
     record_compaction,
     record_memory_write,
     record_turn,
@@ -176,6 +177,11 @@ class OmhMemoryProvider(_MemoryProviderBase):
             return
         self._append_write_journal(action, target, content, metadata)
         self._mutate_state(record_memory_write)
+        # A Hermes memory write is what an actual consolidation looks like from
+        # here -- its memory tool is the only thing that edits the store. This
+        # is the promptest moment a standing brief can be found no longer true
+        # and retired, instead of waiting for the next turn or session edge.
+        self._evaluate_if_due("memory_write")
 
     def on_session_end(self, messages: list[dict[str, Any]] | None = None) -> None:
         self._evaluate_if_due("session_end")
@@ -218,12 +224,18 @@ class OmhMemoryProvider(_MemoryProviderBase):
             if reading is not None
             else {}
         )
-        reasons = consolidation_reasons(
-            state,
-            headroom_chars=headroom,
-            duplicate_count=len(plan.get("duplicate_clusters", []) or []),
-            session_ending=trigger in _SESSION_ENDING_TRIGGERS,
-        )
+        # Two different questions, one evaluation. `reasons` (suppressed) asks
+        # "should a new brief fire now"; `standing` asks "is anything still
+        # true at all". A suppressed standing condition returns [] for the
+        # first while remaining true for the second, and only the second may
+        # decide retirement.
+        reason_kwargs = {
+            "headroom_chars": headroom,
+            "duplicate_count": len(plan.get("duplicate_clusters", []) or []),
+            "session_ending": trigger in _SESSION_ENDING_TRIGGERS,
+        }
+        reasons = consolidation_reasons(state, **reason_kwargs)
+        standing = consolidation_reasons(state, suppress=False, **reason_kwargs)
         handoff = build_consolidation_handoff(
             reasons,
             block_summaries=[block.to_summary() for block in read_memory_blocks(self._omh_home)],
@@ -231,6 +243,7 @@ class OmhMemoryProvider(_MemoryProviderBase):
             trigger=trigger,
             messages_at_risk=messages_at_risk,
             session_id=self._session_id,
+            raised_at=_utc_now(),
         )
         if reasons:
             self._write_handoff(handoff)
@@ -238,7 +251,34 @@ class OmhMemoryProvider(_MemoryProviderBase):
                 self._omh_home,
                 clear_after_consolidation(state, at=_utc_now(), reasons=reasons),
             )
+        elif not standing and trigger == "memory_write":
+            self._retire_stale_brief(trigger)
         return handoff
+
+    def _retire_stale_brief(self, trigger: str) -> None:
+        """Mark the on-disk brief not-due once consolidation was observed.
+
+        Nothing used to clear `consolidation.json`: it was written when
+        consolidation came due and never touched again, so the doctor warning
+        and every messenger's chat notice repeated forever -- including after
+        the user actually consolidated.
+
+        Retirement is gated on the `memory_write` trigger on purpose. A Hermes
+        memory write is what an actual consolidation looks like from here, and
+        it is the only observable signal of one. An empty standing set alone is
+        not enough: event reasons clear themselves the moment they fire -- the
+        turn counter resets -- so an interval-raised brief always looks
+        "no longer standing" one turn later, and retiring on that would erase
+        every notice before anyone could act on it.
+        """
+        brief = read_latest_consolidation(self._omh_home)
+        if not brief or not brief.get("due"):
+            return
+        retired = dict(brief)
+        retired["due"] = False
+        retired["superseded_at"] = _utc_now()
+        retired["superseded_by_trigger"] = trigger
+        self._write_handoff(retired)
 
     # -- Internals ----------------------------------------------------------
 

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -31,7 +31,7 @@ from ..operator_productivity import build_agent_operator_productivity_card
 from ..paths import OmhPaths, resolve_paths
 from ..plugin_bundle.omh.awareness import workflow_context_card_for_workflow, workflow_context_cards
 from ..plugin_bundle.omh.degradation import degradation_chat_note
-from ..plugin_bundle.omh.memory_dreaming import read_dreaming_state, read_latest_consolidation
+from ..plugin_bundle.omh.memory_dreaming import read_latest_consolidation
 from ..probe import probe_capabilities
 from ..quickstart import build_quickstart_card
 from ..skills.catalog import (
@@ -54,6 +54,7 @@ from .hermes_runtime import (
 )
 from .localized_copy import (
     chat_copy,
+    consolidation_notice_line,
     detect_copy_locale,
     is_localized_locale,
     skill_picker_body as localized_skill_picker_body,
@@ -6086,18 +6087,6 @@ def _chat_response_with_goal_quality_coaching(
     return updated
 
 
-# A standing brief is one short sentence in chat, not a dump of the scheduler's
-# reason strings. The raw reasons ride in the structured notice for wrappers;
-# the body line is for a person reading Slack on a phone.
-_CONSOLIDATION_REASON_PHRASES = {
-    "headroom_below_floor": "memory is nearly full",
-    "turn_interval_reached": "several turns since the last tidy-up",
-    "session_ending_with_unconsolidated_turns": "a session ended with work not yet consolidated",
-    "context_compaction_observed": "context was compacted",
-    "duplicate_records": "duplicate memories were detected",
-    "expiring_records": "some memories are expiring",
-}
-
 MEMORY_CONSOLIDATION_NOTICE_SCHEMA_VERSION = "omh_memory_consolidation_notice/v1"
 
 
@@ -6114,26 +6103,29 @@ def _with_memory_consolidation_notice(payload: dict[str, object], paths: OmhPath
     filesystem paths -- messenger copy leaks them to shared channels -- and the
     body is appended before the render profile is recomputed, so each
     messenger's own constraints shape it exactly like the rest of the card.
+
+    ``read_latest_consolidation`` normalizes every field it returns, so
+    ``reasons`` is always a list of strings here and a malformed brief on disk
+    degrades to "nothing pending" instead of failing the turn. The sentence is
+    rendered in the card's own language -- the body copy was already localized,
+    and an English suffix on a Korean card reads as a glitch.
     """
     brief = read_latest_consolidation(paths.omh_home)
     if not brief or not brief.get("due"):
         return payload
-    reasons = [str(reason) for reason in brief.get("reasons", []) if isinstance(reason, str)]
+    reasons = list(brief.get("reasons", []))
     if not reasons:
         return payload
-    phrases: list[str] = []
-    for reason in reasons:
-        phrase = _CONSOLIDATION_REASON_PHRASES.get(reason.split(":", 1)[0])
-        if phrase and phrase not in phrases:
-            phrases.append(phrase)
-    summary = "; ".join(phrases) if phrases else "a consolidation brief is waiting"
+    response = payload.get("chat_response")
+    if not isinstance(response, dict):
+        return payload
     payload = dict(payload)
     payload["memory_consolidation_notice"] = {
         "schema_version": MEMORY_CONSOLIDATION_NOTICE_SCHEMA_VERSION,
         "due": True,
-        "trigger": str(brief.get("trigger", "") or ""),
+        "trigger": str(brief.get("trigger", "")),
         "reasons": reasons,
-        "raised_at": str(read_dreaming_state(paths.omh_home).get("last_consolidated_at", "") or ""),
+        "raised_at": str(brief.get("raised_at", "")),
         "next_action": "ask_hermes_to_consolidate_memory",
         "redaction_policy": "metadata_only",
         "claim_boundary": (
@@ -6141,15 +6133,14 @@ def _with_memory_consolidation_notice(payload: dict[str, object], paths: OmhPath
             "consolidated, that Hermes read the brief, or that any entry changed."
         ),
     }
-    response = payload.get("chat_response")
-    if not isinstance(response, dict):
-        return payload
     updated = dict(response)
     state = dict(_nested(updated, "state"))
     state["memory_consolidation"] = {"due": True, "next_action": "ask_hermes_to_consolidate_memory"}
     updated["state"] = state
-    notice_line = f"Memory tidy-up is pending ({summary}). Ask me to review and consolidate memory."
     body = str(updated.get("body", ""))
+    notice_line = consolidation_notice_line(
+        detect_copy_locale(f"{updated.get('headline', '')} {body}"), reasons
+    )
     if notice_line not in body:
         updated["body"] = f"{body} {notice_line}".strip()
     payload["chat_response"] = _chat_response_with_render_profile(

--- a/src/wrapper/localized_copy.py
+++ b/src/wrapper/localized_copy.py
@@ -569,3 +569,89 @@ def skill_picker_body(
         )
     lines.extend(["", family_heading, *family_lines])
     return "\n".join(lines)
+
+
+# The consolidation notice is one sentence appended to whatever card the router
+# chose, and that card's copy is already in the reader's language. An English
+# suffix on a Korean body reads as a glitch, so the sentence and its reason
+# phrases localize through the same locale the card used.
+_CONSOLIDATION_NOTICE_SENTENCES = {
+    "en": "Memory tidy-up is pending ({summary}). Ask me to review and consolidate memory.",
+    "ko": "기억 정리가 밀려 있습니다 ({summary}). 기억을 검토하고 정리해 달라고 말씀해 주세요.",
+    "ja": "メモリ整理が保留中です（{summary}）。メモリの確認と整理を依頼してください。",
+    "zh": "记忆整理待处理（{summary}）。请让我审查并整理记忆。",
+    "es": "La consolidación de memoria está pendiente ({summary}). Pídeme revisar y consolidar la memoria.",
+}
+
+_CONSOLIDATION_REASON_PHRASES = {
+    "headroom_below_floor": {
+        "en": "memory is nearly full",
+        "ko": "기억이 거의 가득 참",
+        "ja": "メモリがほぼ満杯",
+        "zh": "记忆几乎已满",
+        "es": "la memoria está casi llena",
+    },
+    "turn_interval_reached": {
+        "en": "several turns since the last tidy-up",
+        "ko": "마지막 정리 후 여러 턴 경과",
+        "ja": "前回の整理から数ターン経過",
+        "zh": "距上次整理已过多轮",
+        "es": "varios turnos desde la última consolidación",
+    },
+    "session_ending_with_unconsolidated_turns": {
+        "en": "a session ended with work not yet consolidated",
+        "ko": "정리되지 않은 작업을 남긴 채 세션 종료",
+        "ja": "未整理の作業を残してセッションが終了",
+        "zh": "会话结束时仍有未整理的内容",
+        "es": "una sesión terminó con trabajo sin consolidar",
+    },
+    "context_compaction_observed": {
+        "en": "context was compacted",
+        "ko": "컨텍스트가 압축됨",
+        "ja": "コンテキストが圧縮された",
+        "zh": "上下文已压缩",
+        "es": "el contexto fue compactado",
+    },
+    "duplicate_records": {
+        "en": "duplicate memories were detected",
+        "ko": "중복 기억 발견",
+        "ja": "重複した記憶を検出",
+        "zh": "检测到重复记忆",
+        "es": "se detectaron memorias duplicadas",
+    },
+    "expiring_records": {
+        "en": "some memories are expiring",
+        "ko": "일부 기억이 만료 예정",
+        "ja": "一部の記憶が期限切れ間近",
+        "zh": "部分记忆即将过期",
+        "es": "algunas memorias están por expirar",
+    },
+}
+
+_CONSOLIDATION_FALLBACK_SUMMARY = {
+    "en": "a consolidation brief is waiting",
+    "ko": "정리 안내가 대기 중",
+    "ja": "整理の案内が待機中",
+    "zh": "整理提示等待处理",
+    "es": "hay un aviso de consolidación en espera",
+}
+
+
+def consolidation_notice_line(locale: str, reasons: list[str]) -> str:
+    """The pending-consolidation sentence in the card's language.
+
+    ``reasons`` are the scheduler's own strings (``headroom_below_floor:289<=300``);
+    the value suffix is detail for wrappers, so only the family selects a phrase
+    and an unknown family simply contributes nothing.
+    """
+    resolved = _normalize_locale(locale)
+    if resolved not in _CONSOLIDATION_NOTICE_SENTENCES:
+        resolved = "en"
+    phrases: list[str] = []
+    for reason in reasons:
+        family = reason.split(":", 1)[0]
+        phrase = _CONSOLIDATION_REASON_PHRASES.get(family, {}).get(resolved)
+        if phrase and phrase not in phrases:
+            phrases.append(phrase)
+    summary = "; ".join(phrases) if phrases else _CONSOLIDATION_FALLBACK_SUMMARY[resolved]
+    return _CONSOLIDATION_NOTICE_SENTENCES[resolved].format(summary=summary)

--- a/tests/test_memory_provider.py
+++ b/tests/test_memory_provider.py
@@ -1034,9 +1034,16 @@ class ChatNoticeOnEveryMessengerTests(unittest.TestCase):
     did not exist. The notice attaches at the one seam every chat surface passes
     through, so covering the seam covers Slack, Telegram, Discord, CLI, and
     desktop at once.
+
+    The review pass on the first version confirmed two failures by execution:
+    a schema-valid brief whose ``reasons`` was an int crashed every chat turn,
+    and nothing ever retired a brief, so the notice suffixed every reply
+    forever. Both are pinned here now.
     """
 
-    NOTICE_LINE = "Memory tidy-up is pending"
+    NOTICE_KO = "기억 정리가 밀려 있습니다"
+    NOTICE_EN = "Memory tidy-up is pending"
+    KO_MESSAGE = "이 레포에 기능 하나 안전하게 추가하고 싶어"
 
     def _due_paths(self, root: Path):
         from omh.paths import resolve_paths
@@ -1046,29 +1053,42 @@ class ChatNoticeOnEveryMessengerTests(unittest.TestCase):
         (memories / "MEMORY.md").write_text("x" * 2100, encoding="utf-8")
         provider = OmhMemoryProvider(root / ".omh")
         provider.initialize("s", hermes_home=str(root / ".hermes"), agent_context="primary")
-        return resolve_paths(root / ".omh", root / ".hermes")
+        return provider, resolve_paths(root / ".omh", root / ".hermes")
 
-    def _payload(self, paths, source: str) -> dict:
+    def _payload(self, paths, source: str, message: str | None = None) -> dict:
         from omh.wrapper.contract import build_chat_interaction_payload
 
-        return build_chat_interaction_payload("이 레포에 기능 하나 안전하게 추가하고 싶어", source=source, paths=paths)
+        return build_chat_interaction_payload(message or self.KO_MESSAGE, source=source, paths=paths)
 
     def test_every_chat_source_carries_the_notice_in_its_rendered_body(self) -> None:
         from omh.ingress import CHAT_SOURCES
 
         with TemporaryDirectory() as tmp:
-            paths = self._due_paths(Path(tmp))
+            _, paths = self._due_paths(Path(tmp))
             for source in sorted(CHAT_SOURCES):
                 with self.subTest(source=source):
                     payload = self._payload(paths, source)
                     notice = payload.get("memory_consolidation_notice")
                     self.assertIsInstance(notice, dict)
                     self.assertIn("not evidence", str(notice["claim_boundary"]))
-                    body = str(payload["chat_response"]["body"])
-                    self.assertIn(self.NOTICE_LINE, body)
-                    rendering = payload["chat_response"].get("messenger_rendering")
-                    if isinstance(rendering, dict):
-                        self.assertIn(self.NOTICE_LINE, str(rendering.get("body_text", "")))
+                    self.assertTrue(notice["raised_at"])
+                    self.assertIn(self.NOTICE_KO, str(payload["chat_response"]["body"]))
+                    # Unconditional on purpose: a vacuous isinstance guard here
+                    # is exactly the regression this assertion exists to catch.
+                    rendering = payload["chat_response"]["messenger_rendering"]
+                    self.assertIn(self.NOTICE_KO, str(rendering["body_text"]))
+
+    def test_the_notice_speaks_the_language_of_the_card(self) -> None:
+        # The routed card's copy is localized; an English suffix on a Korean
+        # body reads as a glitch. Same brief, two messages, two languages.
+        with TemporaryDirectory() as tmp:
+            _, paths = self._due_paths(Path(tmp))
+            korean = str(self._payload(paths, "slack")["chat_response"]["body"])
+            english = str(self._payload(paths, "slack", "I want to add a feature safely")["chat_response"]["body"])
+            self.assertIn(self.NOTICE_KO, korean)
+            self.assertNotIn(self.NOTICE_EN, korean)
+            self.assertIn(self.NOTICE_EN, english)
+            self.assertNotIn(self.NOTICE_KO, english)
 
     def test_the_routed_card_is_not_displaced(self) -> None:
         # Additive means additive: same kind, same headline, one extra sentence.
@@ -1078,7 +1098,8 @@ class ChatNoticeOnEveryMessengerTests(unittest.TestCase):
 
             clean = resolve_paths(root / ".clean-omh", root / ".clean-hermes")
             control = self._payload(clean, "slack")["chat_response"]
-            noticed = self._payload(self._due_paths(root), "slack")["chat_response"]
+            _, paths = self._due_paths(root)
+            noticed = self._payload(paths, "slack")["chat_response"]
             self.assertEqual(noticed["kind"], control["kind"])
             self.assertEqual(noticed["headline"], control["headline"])
             self.assertTrue(str(noticed["body"]).startswith(str(control["body"])))
@@ -1090,29 +1111,87 @@ class ChatNoticeOnEveryMessengerTests(unittest.TestCase):
             paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
             payload = self._payload(paths, "telegram")
             self.assertNotIn("memory_consolidation_notice", payload)
-            self.assertNotIn(self.NOTICE_LINE, str(payload["chat_response"]["body"]))
+            self.assertNotIn(self.NOTICE_KO, str(payload["chat_response"]["body"]))
 
-    def test_an_unreadable_brief_degrades_to_no_notice(self) -> None:
+    def test_a_malformed_brief_never_takes_down_a_turn(self) -> None:
+        # The first version crashed here: valid JSON, right schema string,
+        # reasons an int -- and the TypeError escaped through every messenger.
+        cases = (
+            {"schema_version": "omh_memory_consolidation_handoff/v1", "due": True, "reasons": 5},
+            {"schema_version": "omh_memory_consolidation_handoff/v1", "due": True, "reasons": None},
+            {"schema_version": "omh_memory_consolidation_handoff/v1", "due": True, "reasons": "headroom"},
+            {"schema_version": "omh_memory_consolidation_handoff/v1", "due": True, "reasons": {"a": 1}},
+            "{not json",
+        )
+        for case in cases:
+            with self.subTest(case=str(case)[:40]), TemporaryDirectory() as tmp:
+                from omh.paths import resolve_paths
+
+                root = Path(tmp)
+                broken = root / ".omh" / "memory" / "consolidation.json"
+                broken.parent.mkdir(parents=True, exist_ok=True)
+                broken.write_text(case if isinstance(case, str) else json.dumps(case), encoding="utf-8")
+                payload = self._payload(resolve_paths(root / ".omh", root / ".hermes"), "slack")
+                self.assertNotIn("memory_consolidation_notice", payload)
+
+    def test_the_notice_retires_once_consolidation_is_observed(self) -> None:
+        # A Hermes memory write is what an actual consolidation looks like from
+        # here. Before: the brief was never rewritten, so the notice suffixed
+        # every reply forever, including after the user complied.
         with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            provider, paths = self._due_paths(root)
+            self.assertIn("memory_consolidation_notice", self._payload(paths, "slack"))
+
+            (root / ".hermes" / "memories" / "MEMORY.md").write_text("short note", encoding="utf-8")
+            provider.on_memory_write("replace", "memory", "short note")
+
+            payload = self._payload(paths, "slack")
+            self.assertNotIn("memory_consolidation_notice", payload)
+            self.assertNotIn(self.NOTICE_KO, str(payload["chat_response"]["body"]))
+            brief = json.loads((root / ".omh" / "memory" / "consolidation.json").read_text(encoding="utf-8"))
+            self.assertFalse(brief["due"])
+            self.assertEqual(brief["superseded_by_trigger"], "memory_write")
+
+    def test_the_notice_persists_while_the_condition_still_holds(self) -> None:
+        # Suppression (#700) stops repeated briefs; it must not retire one. A
+        # memory write that does NOT clear the pressure keeps the notice alive.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            provider, paths = self._due_paths(root)
+            provider.on_turn_start(1, "hi")
+            provider.on_memory_write("add", "memory", "still full")
+            self.assertIn("memory_consolidation_notice", self._payload(paths, "slack"))
+
+    def test_an_interval_brief_survives_the_turn_after_it_fired(self) -> None:
+        # Event reasons clear themselves by firing -- the counter resets -- so
+        # "nothing standing" one turn later is not evidence anyone consolidated.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
             from omh.paths import resolve_paths
 
-            root = Path(tmp)
-            broken = root / ".omh" / "memory" / "consolidation.json"
-            broken.parent.mkdir(parents=True, exist_ok=True)
-            broken.write_text("{not json", encoding="utf-8")
-            payload = self._payload(resolve_paths(root / ".omh", root / ".hermes"), "slack")
-            self.assertNotIn("memory_consolidation_notice", payload)
+            memories = root / ".hermes" / "memories"
+            memories.mkdir(parents=True, exist_ok=True)
+            (memories / "MEMORY.md").write_text("plenty of headroom", encoding="utf-8")
+            provider = OmhMemoryProvider(root / ".omh")
+            provider.initialize("s", hermes_home=str(root / ".hermes"), agent_context="primary")
+            for turn in range(1, DEFAULT_TURN_INTERVAL + 2):
+                provider.on_turn_start(turn, "hi")
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            self.assertIn("memory_consolidation_notice", self._payload(paths, "slack"))
 
     def test_messenger_copy_carries_no_filesystem_paths(self) -> None:
         # A Slack channel is a shared surface; a local path in the body leaks
-        # the operator's machine layout to everyone in it.
+        # the operator's machine layout to everyone in it. The structured
+        # notice is wrapper-facing and equally shared, so it is scanned too.
         with TemporaryDirectory() as tmp:
             root = Path(tmp)
-            payload = self._payload(self._due_paths(root), "slack")
-            body = str(payload["chat_response"]["body"])
-            self.assertNotIn(str(root), body)
-            self.assertNotIn("/Users/", body)
-            self.assertNotIn(".omh", body)
+            _, paths = self._due_paths(root)
+            payload = self._payload(paths, "slack")
+            for surface in (str(payload["chat_response"]["body"]), json.dumps(payload["memory_consolidation_notice"])):
+                self.assertNotIn(str(root), surface)
+                self.assertNotIn("/Users/", surface)
+                self.assertNotIn(".omh", surface)
 
     def test_the_cached_pathless_call_stays_notice_free(self) -> None:
         # The cache key excludes any OMH home, so a cached payload must never
@@ -1143,7 +1222,7 @@ class ChatNoticeOnEveryMessengerTests(unittest.TestCase):
                             )
                         )
                         self.assertIn("memory_consolidation_notice", out)
-                        self.assertIn(self.NOTICE_LINE, str(out["chat_response"]["body"]))
+                        self.assertIn(self.NOTICE_KO, str(out["chat_response"]["body"]))
 
 
 class BlockBudgetDefaultTests(unittest.TestCase):


### PR DESCRIPTION
## Feature Report

### What Changed

Closes the two HIGH findings the adversarial review pass confirmed by execution on #702, plus the MEDIUM/LOW items underneath:

1. **Crash-proofed the brief reader.** `read_latest_consolidation` now normalizes every field it returns (`due`→bool, `reasons`→list of strings, `trigger`/`raised_at`→strings). Before: `{"due": true, "reasons": 5}` — valid JSON, right schema string — raised `TypeError` inside `build_chat_interaction_payload`, taking down every reply on every messenger from one malformed local file.
2. **The notice now retires.** Nothing ever cleared `consolidation.json`, so the suffix repeated forever, including after the user consolidated. A Hermes memory write is the only observable consolidation signal — its memory tool is the only thing that edits the store — so `on_memory_write` re-evaluates, and when no standing condition remains, rewrites the brief `due: false` with `superseded_at`/`superseded_by_trigger`.
3. **The line speaks the card's language.** en/ko/ja/zh/es through the same locale table as the rest of the chat copy; the English-suffix-on-Korean-card glitch the review reproduced is pinned by test in both directions.
4. Smaller findings: `raised_at` is now the brief's own timestamp (not `last_consolidated_at`, which is when the *previous* brief fired); the structured notice attaches only when a usable `chat_response` exists; the wrapper runbook documents the new envelope field; the `messenger_rendering` assertion is unconditional; the no-filesystem-paths scan covers the structured notice.

### Why This Exists

The /ultragoal final quality gate ran an independent code review on the merged #702. Verdict: REQUEST_CHANGES on two HIGHs, both reproduced by execution, neither a design objection. Ultragoal recorded them as blocker story G004; this resolves it.

### How It Works — the subtle part

Retirement is **gated to the `memory_write` trigger**, and that took one real design catch: my first version retired whenever standing conditions were empty, which is wrong — event reasons clear themselves by firing (the turn counter resets), so an interval-raised brief always looks "no longer standing" one turn later, and every notice would have been erased before anyone could act on it.

The fix splits the two questions explicitly: `consolidation_reasons(suppress=False)` answers *"is anything still true"*, the default keeps answering *"should a new brief fire"*, and only the first — observed at the one moment consolidation can actually have happened — may decide retirement.

Lifecycle, verified end to end:

| Step | Result |
| --- | --- |
| Brief due (memory 2100/2200) | Korean card gets `기억 정리가 밀려 있습니다 (기억이 거의 가득 참)…`, real `raised_at` |
| Suppressed re-evaluation, still full | Notice **persists** |
| Hermes consolidates (memory write, headroom freed) | Brief rewritten `due: false`, notice gone from every payload |
| Brief with `reasons: 5 / None / "str" / {}` or raw bytes | No crash, no notice |

### Files And Contracts Touched

- `src/plugin_bundle/omh/memory_dreaming.py` — normalized reader, `raised_at` field, `suppress` parameter.
- `src/plugin_bundle/omh/memory_provider.py` — retirement path, `on_memory_write` evaluation.
- `src/wrapper/contract.py`, `src/wrapper/localized_copy.py` — localized sentence, response-first attach order.
- `src/maintenance/doctor.py` — timestamp source; inherits the hardened reader.
- `docs/HERMES_AGENT_INTEGRATION_RUNBOOK.md` — envelope field documented.
- Contract note: `omh_memory_consolidation_handoff/v1` gains `raised_at`; retirement adds `superseded_at`/`superseded_by_trigger`. Additive.

## Validation

- [x] `uv run --group lint ruff check src tests` — All checks passed
- [x] `python3 -m unittest discover -s tests` — **2208 passed**, 1 skipped
- [x] `python3 -m compileall src`
- [x] `python3 -m omh.cli docs workflows --check`, `docs roles --check`, `docs capability-families --check`
- [x] `python3 -m omh.cli harness validate`
- [x] `git diff --check`
- [x] Full lifecycle scenario run end to end (table above)
- [ ] Manual Hermes/TUI check — ja/zh/es lines are table-verified but not exercised by a fixture message; live channel rendering remains unobserved.

## Risk

Medium. The provider now writes a retirement record from a hook, and `consolidation_reasons` gained a parameter (default preserves existing behaviour — every pre-existing call is unchanged). The retirement signal is deliberately conservative: only an observed memory write, never a timer, a read, or an inference.

## Release / Claims

- [x] Release-channel impact considered — `local`; no version change.
- [x] Claims marked observed vs not — lifecycle observed in tests; live messenger rendering not observed.
- [x] Known manual Hermes checks listed.

## Follow-Up

- A user who consolidates outside Hermes' memory tool (hand-editing MEMORY.md) produces no `on_memory_write`, so their notice persists until the next Hermes-mediated write. Documented behaviour, acceptable for now.
