### PR TITLE
fix: remove the pre-relabel skill directory once its replacement is installed

### DIFF
--- a/src/install/installer.py
+++ b/src/install/installer.py
@@ -142,15 +142,72 @@ def install_skill_pack(
         {template.name for template in all_templates},
         force=force,
     )
+    relabelled = _prune_relabelled_skill_directories(
+        paths.skills_dir,
+        manifest,
+        {template.name for template in all_templates},
+        force=force,
+    )
     records = skill_records(paths.skills_dir, source)
     manifest_data = new_manifest(source, paths.skills_dir, records)
     manifest_data["skill_profile"] = profile
     if context_cost_warning is not None:
         manifest_data["context_cost_warning"] = context_cost_warning
     manifest_data["pruned_skills"] = pruned_skills
+    manifest_data["relabelled_skills_removed"] = relabelled["removed"]
+    manifest_data["relabelled_skills_retained"] = relabelled["retained"]
     manifest_data["skill_profile_state"] = skill_profile_state(paths.skills_dir, manifest_data)
     write_manifest(paths.manifest_path, manifest_data)
     return manifest_data
+
+
+def _prune_relabelled_skill_directories(
+    skills_dir: Path,
+    manifest: dict | None,
+    catalog_names: set[str],
+    *,
+    force: bool,
+) -> dict[str, list[str]]:
+    """Drop the pre-relabel directory once its labelled replacement is in place.
+
+    Skills moved from `skills/<canonical>/` to `skills/<label>/`. Installs are
+    non-destructive, so the first install after that change wrote the new
+    directories and left the old ones beside them: an observed machine went from
+    92 skills to 184, doubling the per-turn context weight of the pack, and the
+    manifest then reported every vanished old path as a local modification.
+
+    The safety rules match `_prune_orphaned_skills`: remove only a directory that
+    is (a) named after a catalog skill whose label differs, (b) recorded in the
+    prior manifest, (c) already replaced by a labelled directory holding a
+    SKILL.md, and (d) byte-identical to what the manifest recorded. Anything a
+    user edited is kept and reported instead, unless ``force``.
+    """
+    if not manifest:
+        return {"removed": [], "retained": []}
+    modified = set(local_modifications(manifest, skills_dir))
+    recorded = {str(record.get("name")) for record in manifest.get("skills", []) if record.get("name")}
+    recorded_paths = {
+        str(record.get("name")): str(record.get("path", "")) for record in manifest.get("skills", [])
+    }
+    removed: list[str] = []
+    retained: list[str] = []
+    for name in sorted(catalog_names):
+        label = skill_directory_name(name)
+        if label == name or name not in recorded:
+            continue
+        old_dir = skills_dir / name
+        if not old_dir.is_dir() or old_dir.is_symlink():
+            continue
+        if not (skills_dir / label / "SKILL.md").is_file():
+            # Nothing to fall back on yet; never leave the skill uninstalled.
+            retained.append(name)
+            continue
+        if recorded_paths.get(name, "") in modified and not force:
+            retained.append(name)
+            continue
+        shutil.rmtree(old_dir)
+        removed.append(name)
+    return {"removed": removed, "retained": retained}
 
 
 def _installed_skill_names(skills_dir: Path) -> set[str]:

--- a/tests/test_installer_skill_profile.py
+++ b/tests/test_installer_skill_profile.py
@@ -13,11 +13,16 @@ load_local_package()
 from _cli_harness import run_cli
 from omh.core.errors import OmhError
 from omh.hashutil import sha256_file
-from omh.installer import install_skill_pack, skill_directory_name, reconcile_skill_profile, skill_profile_report
+from omh.installer import install_skill_pack, reconcile_skill_profile, skill_directory_name, skill_profile_report
 from omh.maintenance.doctor import run_doctor
-from omh.manifest import read_manifest, write_manifest
+from omh.manifest import new_manifest, read_manifest, skill_records, write_manifest
 from omh.paths import resolve_paths
-from omh.skill_pack import CORE_PROFILE_SKILLS, CORE_SKILLS, builtin_skill_templates
+from omh.skill_pack import (
+    CORE_PROFILE_SKILLS,
+    CORE_SKILLS,
+    builtin_skill_templates,
+    installable_skill_names,
+)
 
 
 def _installed_names(paths) -> set[str]:
@@ -25,6 +30,77 @@ def _installed_names(paths) -> set[str]:
 
 
 class InstallerSkillProfileTests(unittest.TestCase):
+    def test_installing_over_a_pre_relabel_pack_removes_the_old_directories(self) -> None:
+        """The relabel must not leave both layouts installed.
+
+        Skills moved from `skills/<canonical>/` to `skills/<label>/`. Installs are
+        non-destructive, so the first install after that change wrote the new
+        directories and left the old ones beside them: an observed machine went
+        from 92 skills to 184, doubling the pack's per-turn context weight, and
+        the manifest then reported every vanished old path as a local
+        modification.
+        """
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            install_skill_pack(paths, profile="full")
+            labelled = _installed_names(paths)
+
+            # Recreate the pre-relabel layout: every skill also present under its
+            # canonical directory, recorded in the manifest.
+            relabelled = [
+                name for name in installable_skill_names() if skill_directory_name(name) != name
+            ]
+            self.assertTrue(relabelled, "fixture needs at least one relabelled skill")
+            for name in relabelled:
+                legacy = paths.skills_dir / name
+                legacy.mkdir(parents=True, exist_ok=True)
+                (legacy / "SKILL.md").write_text(
+                    (paths.skills_dir / skill_directory_name(name) / "SKILL.md").read_text(encoding="utf-8"),
+                    encoding="utf-8",
+                )
+            manifest = new_manifest("builtin", paths.skills_dir, skill_records(paths.skills_dir, "builtin"))
+            write_manifest(paths.manifest_path, manifest)
+            self.assertEqual(len(_installed_names(paths)), len(labelled) + len(relabelled))
+
+            result = install_skill_pack(paths, profile="full", force=True)
+
+            self.assertEqual(_installed_names(paths), labelled)
+            self.assertEqual(sorted(result["relabelled_skills_removed"]), sorted(relabelled))
+            self.assertEqual(result["relabelled_skills_retained"], [])
+
+    def test_a_locally_edited_pre_relabel_directory_blocks_the_install(self) -> None:
+        """The migration never gets to delete an edit; the existing guard stops first.
+
+        `install_skill_pack` refuses outright when a managed file differs from the
+        manifest, so an edited pre-relabel directory makes the install ask the user
+        to resolve it rather than being quietly cleaned up. `--force` is the
+        explicit way through, and it does remove the directory.
+        """
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            install_skill_pack(paths, profile="full")
+            victim = next(
+                name for name in sorted(installable_skill_names()) if skill_directory_name(name) != name
+            )
+            legacy = paths.skills_dir / victim
+            legacy.mkdir(parents=True, exist_ok=True)
+            (legacy / "SKILL.md").write_text("recorded content\n", encoding="utf-8")
+            write_manifest(
+                paths.manifest_path,
+                new_manifest("builtin", paths.skills_dir, skill_records(paths.skills_dir, "builtin")),
+            )
+            (legacy / "SKILL.md").write_text("edited after the manifest\n", encoding="utf-8")
+
+            with self.assertRaises(OmhError) as refused:
+                install_skill_pack(paths, profile="full")
+            self.assertIn(f"{victim}/SKILL.md", str(refused.exception))
+            self.assertTrue((legacy / "SKILL.md").is_file())
+
+            result = install_skill_pack(paths, profile="full", force=True)
+
+            self.assertFalse(legacy.exists())
+            self.assertIn(victim, result["relabelled_skills_removed"])
+
     def test_a_core_refresh_updates_full_only_skills_already_on_disk(self) -> None:
         """`omh update` must leave nothing stale, whatever profile is recorded.
 


### PR DESCRIPTION
## Feature Report

### What Changed

`install_skill_pack` now removes the pre-relabel skill directory once its labelled replacement is installed, and reports what it removed.

### Why This Exists

#705 moved skills from `skills/<canonical>/` to `skills/<label>/`. Installs are non-destructive, so the first install after it wrote the new directories and **left the old ones beside them**. On a real machine:

```
omh update  →  OMH workflows: 184 ready       ← was 92
omh doctor  →  local_modifications: changed managed files:
               accessibility-audit/SKILL.md, achievements/SKILL.md, … (all 92)
```

Two separate harms: the pack's per-turn context weight doubled, and the manifest still recorded the old paths so every vanished file read as a local edit. Repairing it took a manual directory sweep plus `omh install --force` — not something a user should have to work out.

### User / Operator Impact

One `omh update` now lands the new layout and leaves nothing behind. The removals appear in the install payload as `relabelled_skills_removed` / `relabelled_skills_retained` rather than happening silently.

### How It Works

This deletes files, so the safety rules copy `_prune_orphaned_skills` exactly. A directory goes **only** when all four hold:

1. it is named after a catalog skill whose label differs from its canonical name,
2. it was recorded in the prior manifest (so it is managed, not the user's own),
3. a labelled directory holding a `SKILL.md` already replaced it,
4. it is byte-identical to what the manifest recorded.

Condition 3 is what makes a mid-install failure safe: the replacement must already be on disk, so nothing can end up uninstalled.

**A locally edited pre-relabel directory never reaches this code.** The existing `local_modifications` guard refuses the install first and names the file, so the edit is protected and `--force` stays the explicit way through. The second test pins that, because the interesting question about a migration that deletes things is what it *refuses* to delete.

### Files And Contracts Touched

- `src/install/installer.py` — `_prune_relabelled_skill_directories()`, wired after the orphan prune and before the manifest is rebuilt; two new manifest keys.
- `tests/test_installer_skill_profile.py` — two tests.

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `python3 -m unittest discover -s tests` — 2210 passed, 1 skipped
- [x] `python3 -m compileall src`
- [x] `python3 -m omh.cli docs workflows --check` (also `docs roles`, `docs capability-families`)
- [x] `python3 -m omh.cli release drift` — 12 checks, no drift
- [ ] `python3 -m omh.cli harness validate` — not rerun; no harness contract touched
- [ ] `python3 -m omh.cli release checklist --json` — not rerun
- [ ] `python3 -m omh.cli release hermes-smoke` — not rerun
- [x] `omh --help`
- [ ] `omh --omh-home … release hermes-smoke --include-command-smoke` — not rerun
- [ ] Relevant workflow-learning review queue smoke — not applicable
- [x] Relevant dry-run or smoke command: a full install plus a reconstructed pre-relabel layout goes from 184 directories back to 92 with every removal reported
- [ ] **Manual Hermes/TUI check — not run.** The reporting user's machine was repaired by hand before this existed, so no real install exercised the automatic path.

**Both tests fail when the migration is disabled** — verified by stubbing it out and re-running.

## Risk

- **This deletes directories.** Bounded to catalog skills whose label differs from their canonical name, requires the replacement to exist, and honors the same modification guard as every other managed write.
- A user who had *added files* inside a pre-relabel managed directory without touching `SKILL.md` would lose those extra files, since the guard keys on recorded managed paths. That matches how `_prune_orphaned_skills` already behaves; calling it out because it is the sharpest edge here.

## Compatibility / Rollout

- No CLI, schema, or routing change. Machines already on the new layout see no removals; machines on the old layout converge on the next install.

## Release / Claims

- [x] Release-channel impact considered (`stable`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Known manual Hermes checks are listed

## Follow-Up

- `omh update` reports counts, not the migration. Surfacing `relabelled_skills_removed` in the human summary would make the one-time cleanup visible to the person running it — a small change to the update output, separate from this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
