### PR TITLE
fix: retire only on consolidation-shaped writes, and localize from the message

### DIFF
--- a/src/plugin_bundle/omh/memory_provider.py
+++ b/src/plugin_bundle/omh/memory_provider.py
@@ -177,11 +177,19 @@ class OmhMemoryProvider(_MemoryProviderBase):
             return
         self._append_write_journal(action, target, content, metadata)
         self._mutate_state(record_memory_write)
-        # A Hermes memory write is what an actual consolidation looks like from
-        # here -- its memory tool is the only thing that edits the store. This
-        # is the promptest moment a standing brief can be found no longer true
-        # and retired, instead of waiting for the next turn or session edge.
-        self._evaluate_if_due("memory_write")
+        # Retirement only, and only for consolidation-shaped writes. The first
+        # version routed this through the full evaluation, which had two
+        # measured consequences: every write below the headroom floor re-raised
+        # a brief (the embedded value changes, so suppression never held) and
+        # reset the turn counter, starving the interval trigger and growing the
+        # journal one record per write. And gating on the trigger alone was not
+        # enough either -- an interval-raised brief has its counters cleared at
+        # birth, so ANY 'add' write one moment later looked like consolidation.
+        # Hermes documents the action vocabulary as add/replace/remove:
+        # an 'add' appends new material and consolidates nothing; 'replace' and
+        # 'remove' are what a merge or prune actually emits.
+        if action in ("replace", "remove") and not self._standing_reasons():
+            self._retire_stale_brief("memory_write")
 
     def on_session_end(self, messages: list[dict[str, Any]] | None = None) -> None:
         self._evaluate_if_due("session_end")
@@ -217,25 +225,8 @@ class OmhMemoryProvider(_MemoryProviderBase):
         weighed, not only the ones that fired.
         """
         state = read_dreaming_state(self._omh_home)
-        reading = self._memory_reading()
-        headroom = reading.headroom_chars if reading is not None else None
-        plan = (
-            build_eviction_plan(reading.entries, cap=reading.cap, cap_source=reading.cap_source)
-            if reading is not None
-            else {}
-        )
-        # Two different questions, one evaluation. `reasons` (suppressed) asks
-        # "should a new brief fire now"; `standing` asks "is anything still
-        # true at all". A suppressed standing condition returns [] for the
-        # first while remaining true for the second, and only the second may
-        # decide retirement.
-        reason_kwargs = {
-            "headroom_chars": headroom,
-            "duplicate_count": len(plan.get("duplicate_clusters", []) or []),
-            "session_ending": trigger in _SESSION_ENDING_TRIGGERS,
-        }
+        plan, reason_kwargs = self._evaluation_inputs(trigger)
         reasons = consolidation_reasons(state, **reason_kwargs)
-        standing = consolidation_reasons(state, suppress=False, **reason_kwargs)
         handoff = build_consolidation_handoff(
             reasons,
             block_summaries=[block.to_summary() for block in read_memory_blocks(self._omh_home)],
@@ -243,7 +234,9 @@ class OmhMemoryProvider(_MemoryProviderBase):
             trigger=trigger,
             messages_at_risk=messages_at_risk,
             session_id=self._session_id,
-            raised_at=_utc_now(),
+            # Only a brief that actually fires was raised; stamping the not-due
+            # inspection object gave it a raise time for a raise that never was.
+            raised_at=_utc_now() if reasons else "",
         )
         if reasons:
             self._write_handoff(handoff)
@@ -251,9 +244,31 @@ class OmhMemoryProvider(_MemoryProviderBase):
                 self._omh_home,
                 clear_after_consolidation(state, at=_utc_now(), reasons=reasons),
             )
-        elif not standing and trigger == "memory_write":
-            self._retire_stale_brief(trigger)
         return handoff
+
+    def _evaluation_inputs(self, trigger: str) -> tuple[dict[str, object], dict[str, object]]:
+        """The eviction plan and reason kwargs for one evaluation, no writes."""
+        reading = self._memory_reading()
+        plan = (
+            build_eviction_plan(reading.entries, cap=reading.cap, cap_source=reading.cap_source)
+            if reading is not None
+            else {}
+        )
+        return plan, {
+            "headroom_chars": reading.headroom_chars if reading is not None else None,
+            "duplicate_count": len(plan.get("duplicate_clusters", []) or []),
+            "session_ending": trigger in _SESSION_ENDING_TRIGGERS,
+        }
+
+    def _standing_reasons(self) -> list[str]:
+        """Is anything still true at all? Read-only, suppression bypassed.
+
+        A suppressed standing condition returns [] from the default evaluation
+        while remaining true; retirement must see through that, or it would
+        clear a notice whose fact had not cleared.
+        """
+        _, reason_kwargs = self._evaluation_inputs("memory_write")
+        return consolidation_reasons(read_dreaming_state(self._omh_home), suppress=False, **reason_kwargs)
 
     def _retire_stale_brief(self, trigger: str) -> None:
         """Mark the on-disk brief not-due once consolidation was observed.
@@ -263,13 +278,12 @@ class OmhMemoryProvider(_MemoryProviderBase):
         and every messenger's chat notice repeated forever -- including after
         the user actually consolidated.
 
-        Retirement is gated on the `memory_write` trigger on purpose. A Hermes
-        memory write is what an actual consolidation looks like from here, and
-        it is the only observable signal of one. An empty standing set alone is
-        not enough: event reasons clear themselves the moment they fire -- the
-        turn counter resets -- so an interval-raised brief always looks
-        "no longer standing" one turn later, and retiring on that would erase
-        every notice before anyone could act on it.
+        The only caller is the consolidation-shaped branch of
+        `on_memory_write`: a 'replace' or 'remove' from Hermes' memory tool is
+        what a merge or prune actually emits, and it is the one observable
+        signal that consolidation happened. Timers, reads, and other triggers
+        never retire -- event reasons clear their own counters by firing, so
+        anything looser erases a brief before anyone could act on it.
         """
         brief = read_latest_consolidation(self._omh_home)
         if not brief or not brief.get("due"):

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -2983,7 +2983,7 @@ def build_chat_interaction_payload(
     # cached branch above never reaches this: it requires `paths is None`, and
     # without an OMH home there is no brief to read.
     if paths is not None:
-        payload = _with_memory_consolidation_notice(payload, paths)
+        payload = _with_memory_consolidation_notice(payload, paths, message)
     return payload
 
 
@@ -6090,7 +6090,9 @@ def _chat_response_with_goal_quality_coaching(
 MEMORY_CONSOLIDATION_NOTICE_SCHEMA_VERSION = "omh_memory_consolidation_notice/v1"
 
 
-def _with_memory_consolidation_notice(payload: dict[str, object], paths: OmhPaths) -> dict[str, object]:
+def _with_memory_consolidation_notice(
+    payload: dict[str, object], paths: OmhPaths, message: str = ""
+) -> dict[str, object]:
     """Carry a pending consolidation brief into the chat card, on every surface.
 
     The scheduler's decision used to reach an operator only through
@@ -6138,8 +6140,14 @@ def _with_memory_consolidation_notice(payload: dict[str, object], paths: OmhPath
     state["memory_consolidation"] = {"due": True, "next_action": "ask_hermes_to_consolidate_memory"}
     updated["state"] = state
     body = str(updated.get("body", ""))
+    # The locale comes from the user's message through the same detector the
+    # card copy used, not from the rendered card text. Re-deriving from the
+    # card was exact for CJK scripts but lossy for Latin ones: the detector's
+    # Latin-script hints are user-question phrases ("quiero", "peux-tu"), which
+    # declarative card copy does not contain, so es/fr/de cards read as English
+    # and got an English suffix -- the exact glitch this line exists to avoid.
     notice_line = consolidation_notice_line(
-        detect_copy_locale(f"{updated.get('headline', '')} {body}"), reasons
+        detect_copy_locale(message or f"{updated.get('headline', '')} {body}"), reasons
     )
     if notice_line not in body:
         updated["body"] = f"{body} {notice_line}".strip()

--- a/src/wrapper/localized_copy.py
+++ b/src/wrapper/localized_copy.py
@@ -581,6 +581,8 @@ _CONSOLIDATION_NOTICE_SENTENCES = {
     "ja": "メモリ整理が保留中です（{summary}）。メモリの確認と整理を依頼してください。",
     "zh": "记忆整理待处理（{summary}）。请让我审查并整理记忆。",
     "es": "La consolidación de memoria está pendiente ({summary}). Pídeme revisar y consolidar la memoria.",
+    "fr": "Le rangement de la mémoire est en attente ({summary}). Demandez-moi de revoir et consolider la mémoire.",
+    "de": "Das Aufräumen des Gedächtnisses steht aus ({summary}). Bitte mich, das Gedächtnis zu prüfen und zu konsolidieren.",
 }
 
 _CONSOLIDATION_REASON_PHRASES = {
@@ -590,6 +592,8 @@ _CONSOLIDATION_REASON_PHRASES = {
         "ja": "メモリがほぼ満杯",
         "zh": "记忆几乎已满",
         "es": "la memoria está casi llena",
+        "fr": "la mémoire est presque pleine",
+        "de": "der Speicher ist fast voll",
     },
     "turn_interval_reached": {
         "en": "several turns since the last tidy-up",
@@ -597,6 +601,8 @@ _CONSOLIDATION_REASON_PHRASES = {
         "ja": "前回の整理から数ターン経過",
         "zh": "距上次整理已过多轮",
         "es": "varios turnos desde la última consolidación",
+        "fr": "plusieurs tours depuis le dernier rangement",
+        "de": "mehrere Züge seit dem letzten Aufräumen",
     },
     "session_ending_with_unconsolidated_turns": {
         "en": "a session ended with work not yet consolidated",
@@ -604,6 +610,8 @@ _CONSOLIDATION_REASON_PHRASES = {
         "ja": "未整理の作業を残してセッションが終了",
         "zh": "会话结束时仍有未整理的内容",
         "es": "una sesión terminó con trabajo sin consolidar",
+        "fr": "une session s'est terminée avec du travail non consolidé",
+        "de": "eine Sitzung endete mit nicht konsolidierter Arbeit",
     },
     "context_compaction_observed": {
         "en": "context was compacted",
@@ -611,6 +619,8 @@ _CONSOLIDATION_REASON_PHRASES = {
         "ja": "コンテキストが圧縮された",
         "zh": "上下文已压缩",
         "es": "el contexto fue compactado",
+        "fr": "le contexte a été compacté",
+        "de": "der Kontext wurde komprimiert",
     },
     "duplicate_records": {
         "en": "duplicate memories were detected",
@@ -618,6 +628,8 @@ _CONSOLIDATION_REASON_PHRASES = {
         "ja": "重複した記憶を検出",
         "zh": "检测到重复记忆",
         "es": "se detectaron memorias duplicadas",
+        "fr": "des souvenirs en double ont été détectés",
+        "de": "doppelte Erinnerungen erkannt",
     },
     "expiring_records": {
         "en": "some memories are expiring",
@@ -625,6 +637,8 @@ _CONSOLIDATION_REASON_PHRASES = {
         "ja": "一部の記憶が期限切れ間近",
         "zh": "部分记忆即将过期",
         "es": "algunas memorias están por expirar",
+        "fr": "certains souvenirs arrivent à expiration",
+        "de": "einige Erinnerungen laufen ab",
     },
 }
 
@@ -634,6 +648,8 @@ _CONSOLIDATION_FALLBACK_SUMMARY = {
     "ja": "整理の案内が待機中",
     "zh": "整理提示等待处理",
     "es": "hay un aviso de consolidación en espera",
+    "fr": "un avis de consolidation est en attente",
+    "de": "ein Konsolidierungshinweis wartet",
 }
 
 

--- a/tests/test_memory_provider.py
+++ b/tests/test_memory_provider.py
@@ -1225,6 +1225,146 @@ class ChatNoticeOnEveryMessengerTests(unittest.TestCase):
                         self.assertIn(self.NOTICE_KO, str(out["chat_response"]["body"]))
 
 
+class RetirementSignalTests(unittest.TestCase):
+    """Only a consolidation-shaped write may retire a brief.
+
+    The re-review reproduced the gap: an interval-raised brief has its counters
+    cleared at birth, so under trigger-only gating ANY memory write one moment
+    later looked like consolidation and erased the notice before anyone could
+    act. Hermes documents its write actions as add/replace/remove; an 'add'
+    appends new material and consolidates nothing, while 'replace' and 'remove'
+    are what a merge or prune actually emits.
+    """
+
+    def _interval_brief(self, root: Path) -> OmhMemoryProvider:
+        memories = root / ".hermes" / "memories"
+        memories.mkdir(parents=True, exist_ok=True)
+        (memories / "MEMORY.md").write_text("plenty of headroom", encoding="utf-8")
+        provider = OmhMemoryProvider(root / ".omh")
+        provider.initialize("s", hermes_home=str(root / ".hermes"), agent_context="primary")
+        for turn in range(1, DEFAULT_TURN_INTERVAL + 1):
+            provider.on_turn_start(turn, "hi")
+        return provider
+
+    def _due(self, root: Path) -> bool:
+        brief = read_latest_consolidation(root / ".omh")
+        return bool(brief and brief["due"])
+
+    def test_an_unrelated_add_write_never_retires_a_brief(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            provider = self._interval_brief(root)
+            self.assertTrue(self._due(root))
+            provider.on_memory_write("add", "memory", "an unrelated single fact")
+            self.assertTrue(self._due(root))
+
+    def test_a_consolidating_write_retires_when_nothing_stands(self) -> None:
+        with TemporaryDirectory() as tmp:
+            for action in ("replace", "remove"):
+                with self.subTest(action=action):
+                    root = Path(tmp) / action
+                    provider = self._interval_brief(root)
+                    provider.on_memory_write(action, "memory", "merged entries")
+                    self.assertFalse(self._due(root))
+                    brief = read_latest_consolidation(root / ".omh")
+                    self.assertEqual(brief["superseded_by_trigger"], "memory_write")
+
+    def test_a_consolidating_write_does_not_retire_while_pressure_remains(self) -> None:
+        # A 'replace' that fails to clear the condition is not a consolidation
+        # worth retiring over -- the store is still full.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            memories = root / ".hermes" / "memories"
+            memories.mkdir(parents=True, exist_ok=True)
+            (memories / "MEMORY.md").write_text("x" * 2100, encoding="utf-8")
+            provider = OmhMemoryProvider(root / ".omh")
+            provider.initialize("s", hermes_home=str(root / ".hermes"), agent_context="primary")
+            provider.on_memory_write("replace", "memory", "still full afterwards")
+            self.assertTrue(self._due(root))
+
+    def test_writes_do_not_reraise_briefs_or_reset_the_turn_counter(self) -> None:
+        # The first retirement path routed writes through the full evaluation:
+        # every write below the headroom floor re-raised a brief (the embedded
+        # value changes, so suppression never held) and reset the turn counter,
+        # starving the interval trigger and growing the journal per write.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            memories = root / ".hermes" / "memories"
+            memories.mkdir(parents=True, exist_ok=True)
+            (memories / "MEMORY.md").write_text("x" * 2100, encoding="utf-8")
+            provider = OmhMemoryProvider(root / ".omh")
+            provider.initialize("s", hermes_home=str(root / ".hermes"), agent_context="primary")
+            for turn in range(1, 4):
+                provider.on_turn_start(turn, "hi")
+            journal = root / ".omh" / "memory" / "consolidation.jsonl"
+            turns_before = read_dreaming_state(root / ".omh")["turns_since_consolidation"]
+            records_before = len(journal.read_text(encoding="utf-8").splitlines())
+
+            for index in range(5):
+                (memories / "MEMORY.md").write_text("x" * (2100 + index), encoding="utf-8")
+                provider.on_memory_write("add", "memory", f"fact {index}")
+
+            self.assertEqual(read_dreaming_state(root / ".omh")["turns_since_consolidation"], turns_before)
+            self.assertEqual(len(journal.read_text(encoding="utf-8").splitlines()), records_before)
+
+    def test_a_not_due_inspection_carries_no_raised_at(self) -> None:
+        # Stamping the inspection object gave it a raise time for a raise that
+        # never happened.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            provider = OmhMemoryProvider(root / ".omh")
+            provider.initialize("s", hermes_home=str(root / ".hermes"), agent_context="primary")
+            handoff = provider.consolidation_due()
+            self.assertFalse(handoff["due"])
+            self.assertEqual(handoff["raised_at"], "")
+
+
+class NoticeLocaleCoverageTests(unittest.TestCase):
+    """The notice speaks every locale the copy system supports, gated."""
+
+    def test_the_notice_tables_cover_every_supported_locale(self) -> None:
+        # This repo gates parallel tables so a new locale cannot silently
+        # regress the notice to English; this is that gate.
+        from omh.wrapper.localized_copy import (
+            _CONSOLIDATION_FALLBACK_SUMMARY,
+            _CONSOLIDATION_NOTICE_SENTENCES,
+            _CONSOLIDATION_REASON_PHRASES,
+            SUPPORTED_COPY_LOCALES,
+        )
+
+        expected = set(SUPPORTED_COPY_LOCALES)
+        self.assertEqual(set(_CONSOLIDATION_NOTICE_SENTENCES), expected)
+        self.assertEqual(set(_CONSOLIDATION_FALLBACK_SUMMARY), expected)
+        for family, phrases in _CONSOLIDATION_REASON_PHRASES.items():
+            self.assertEqual(set(phrases), expected, family)
+
+    def test_latin_script_messages_get_their_own_sentence(self) -> None:
+        # The re-review round-tripped every card body through the detector and
+        # found es/fr/de all fell back to English: the Latin-script hints are
+        # user-question phrases that declarative card copy never contains. The
+        # locale now comes from the user's message -- the same input the card
+        # copy itself localized from.
+        from omh.paths import resolve_paths
+        from omh.wrapper.contract import build_chat_interaction_payload
+
+        cases = (
+            ("¿Puedes ayudarme? quiero añadir una función", "La consolidación de memoria está pendiente"),
+            ("Peux-tu m'aider à ajouter une fonctionnalité ?", "Le rangement de la mémoire est en attente"),
+            ("Kannst du mir helfen, eine Funktion hinzuzufügen?", "Das Aufräumen des Gedächtnisses steht aus"),
+        )
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            memories = root / ".hermes" / "memories"
+            memories.mkdir(parents=True, exist_ok=True)
+            (memories / "MEMORY.md").write_text("x" * 2100, encoding="utf-8")
+            OmhMemoryProvider(root / ".omh").initialize("s", hermes_home=str(root / ".hermes"), agent_context="primary")
+            paths = resolve_paths(root / ".omh", root / ".hermes")
+            for message, marker in cases:
+                with self.subTest(message=message[:24]):
+                    payload = build_chat_interaction_payload(message, source="slack", paths=paths)
+                    self.assertIn(marker, str(payload["chat_response"]["body"]))
+
+
 class BlockBudgetDefaultTests(unittest.TestCase):
     def test_the_default_block_limit_fits_beside_hermes_own_cap(self) -> None:
         # A block that alone exceeded Hermes' 2200-char memory file would make


### PR DESCRIPTION
## Feature Report

### What Changed

Closes the three MEDIUMs (plus two LOWs) the re-review of #703 confirmed by execution. The reviewer's one substantive ask was that #703's gating claim be made true or corrected — this makes it true.

1. **Retirement requires a consolidation-shaped write.** Trigger gating narrowed *when* retirement ran but not *whether* the write was a consolidation: an interval-raised brief has its counters cleared at birth, so any `add` one moment later erased the notice. Hermes documents its write actions as `add`/`replace`/`remove` — an `add` appends and consolidates nothing; `replace`/`remove` are what a merge or prune actually emits. Retirement now requires both a consolidation-shaped action **and** no standing condition.
2. **`on_memory_write` no longer re-raises briefs or resets counters.** Routing writes through the full evaluation raised a fresh brief per write below the headroom floor (the embedded value changes, so suppression never held), reset the turn counter, and grew the journal per write — measured 1→5 records over five writes. The hook now asks one read-only question (`_standing_reasons()`) and either retires or does nothing. Re-measured: turns 3→3, journal 1→1.
3. **es/fr/de get their own sentence.** The re-review measured 9–10 of 11 es/fr/de card bodies misdetecting as English: the detector's Latin-script hints are user-question phrases that declarative card copy never contains. The locale now comes from the **user's message** — the same input the card copy itself localized from — and the missing fr/de table rows are filled in.
4. LOWs: a not-due inspection handoff carries no `raised_at`; a gate test pins every notice table to `SUPPORTED_COPY_LOCALES`.

### How It Works

| Scenario (reviewer's reproductions) | Before | After |
| --- | --- | --- |
| Interval brief, then unrelated `add` write | notice erased | **notice survives** |
| Interval brief, then consolidating `replace` | — | retired, `superseded_by_trigger: memory_write` |
| `replace` while store still full | — | **not** retired |
| 5 writes below headroom floor | turns 3→0, journal 1→5 | turns 3→3, journal 1→1 |
| Spanish/French/German message | English suffix | own-language sentence |

### Files And Contracts Touched

- `src/plugin_bundle/omh/memory_provider.py` — action-gated retirement, `_standing_reasons()`, `_evaluation_inputs()` extraction, conditional `raised_at`.
- `src/wrapper/contract.py` — locale from the entry-point message.
- `src/wrapper/localized_copy.py` — fr/de rows in all three tables.
- `tests/test_memory_provider.py` — 7 new cases.
- No schema change.

## Validation

- [x] `uv run --group lint ruff check src tests` — All checks passed
- [x] `python3 -m unittest discover -s tests` — **2215 passed**, 1 skipped
- [x] `python3 -m compileall src`
- [x] `python3 -m omh.cli docs workflows --check`, `docs roles --check`, `docs capability-families --check`
- [x] `python3 -m omh.cli harness validate`
- [x] `git diff --check`
- [x] All three reviewer reproduction scenarios re-run against the fix (table above)
- [ ] Manual Hermes/TUI check — **not run.** The `add`/`replace`/`remove` vocabulary is taken from Hermes' `MemoryProvider` ABC docstring, not observed from a live consolidation; an unknown fourth action would neither retire nor crash.

## Risk

Low. `on_memory_write` now does strictly less than before, and the notice locale source changes only for Latin-script messages — where it was measurably wrong.

## Release / Claims

- [x] Release-channel impact considered — `local`; no version change.
- [x] Claims marked observed vs not — reproduction scenarios observed in tests; live consolidation action vocabulary not observed.
- [x] Known manual Hermes checks listed.
