### PR TITLE
fix: let a consolidation restart the turn clock it is named after

### DIFF
--- a/src/plugin_bundle/omh/memory_dreaming.py
+++ b/src/plugin_bundle/omh/memory_dreaming.py
@@ -126,6 +126,26 @@ def record_memory_write(state: dict[str, Any]) -> dict[str, object]:
     return updated
 
 
+def record_consolidation_observed(state: dict[str, Any]) -> dict[str, object]:
+    """A consolidation-shaped write happened; the clock restarts here.
+
+    `turns_since_consolidation` reset only when a BRIEF fired, never when the
+    consolidation itself did -- despite the name. Observed live: a session
+    whose only work was consolidating memory still ended with turns > 0, so
+    `session_ending_with_unconsolidated_turns` raised a fresh brief at the
+    exit of the very session that had just consolidated. Every tidy-up ended
+    by requesting the next one.
+
+    A replace/remove from Hermes' memory tool is the consolidation the counter
+    is named after, so it zeroes the turn count and lowers the compaction
+    flag: both describe work waiting to be consolidated, and it just was.
+    """
+    updated = dict(state)
+    updated["turns_since_consolidation"] = 0
+    updated["compaction_pending"] = False
+    return updated
+
+
 def clear_after_consolidation(state: dict[str, Any], *, at: str, reasons: list[str]) -> dict[str, object]:
     updated = dict(state)
     updated["turns_since_consolidation"] = 0

--- a/src/plugin_bundle/omh/memory_provider.py
+++ b/src/plugin_bundle/omh/memory_provider.py
@@ -58,6 +58,7 @@ from .memory_dreaming import (
     read_dreaming_state,
     read_latest_consolidation,
     record_compaction,
+    record_consolidation_observed,
     record_memory_write,
     record_turn,
     write_dreaming_state,
@@ -188,8 +189,16 @@ class OmhMemoryProvider(_MemoryProviderBase):
         # Hermes documents the action vocabulary as add/replace/remove:
         # an 'add' appends new material and consolidates nothing; 'replace' and
         # 'remove' are what a merge or prune actually emits.
-        if action in ("replace", "remove") and not self._standing_reasons():
-            self._retire_stale_brief("memory_write")
+        if action in ("replace", "remove"):
+            # The consolidation the turn counter is named after just happened,
+            # so the clock restarts BEFORE the standing check. Observed live
+            # without this: the counter survived the consolidation, so the very
+            # session that tidied memory raised a fresh
+            # `session_ending_with_unconsolidated_turns` brief at its own exit,
+            # and every tidy-up ended by requesting the next one.
+            self._mutate_state(record_consolidation_observed)
+            if not self._standing_reasons():
+                self._retire_stale_brief("memory_write")
 
     def on_session_end(self, messages: list[dict[str, Any]] | None = None) -> None:
         self._evaluate_if_due("session_end")

--- a/tests/test_memory_provider.py
+++ b/tests/test_memory_provider.py
@@ -1319,6 +1319,76 @@ class RetirementSignalTests(unittest.TestCase):
             self.assertEqual(handoff["raised_at"], "")
 
 
+class ConsolidationResetsTheClockTests(unittest.TestCase):
+    """A session whose work WAS the consolidation must end quiet.
+
+    Observed live: Hermes consolidated MEMORY.md (six removes, two adds,
+    1921 -> 1122 chars), the headroom brief retired mid-session -- and then the
+    session ended and raised `session_ending_with_unconsolidated_turns:1`,
+    because `turns_since_consolidation` reset only when a BRIEF fired, never
+    when the consolidation itself did. Every tidy-up ended by requesting the
+    next one.
+    """
+
+    def _consolidating_session(self, root: Path) -> OmhMemoryProvider:
+        memories = root / ".hermes" / "memories"
+        memories.mkdir(parents=True, exist_ok=True)
+        (memories / "MEMORY.md").write_text("x" * 2100, encoding="utf-8")
+        provider = OmhMemoryProvider(root / ".omh")
+        provider.initialize("s", hermes_home=str(root / ".hermes"), agent_context="primary")
+        provider.on_turn_start(1, "기억 정리해줘")
+        (memories / "MEMORY.md").write_text("consolidated" * 20, encoding="utf-8")
+        for _ in range(3):
+            provider.on_memory_write("remove", "memory", "")
+        provider.on_memory_write("add", "memory", "merged summary")
+        return provider
+
+    def test_a_consolidating_write_restarts_the_turn_clock(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._consolidating_session(root)
+            state = read_dreaming_state(root / ".omh")
+            self.assertEqual(state["turns_since_consolidation"], 0)
+            self.assertFalse(state["compaction_pending"])
+
+    def test_the_session_that_consolidated_ends_without_raising(self) -> None:
+        # The live failure: retirement worked mid-session, then the session's
+        # own exit re-raised. Both halves are asserted.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            provider = self._consolidating_session(root)
+            self.assertFalse(read_latest_consolidation(root / ".omh")["due"])
+            provider.on_session_end([])
+            self.assertFalse(read_latest_consolidation(root / ".omh")["due"])
+
+    def test_a_session_that_did_not_consolidate_still_raises_at_exit(self) -> None:
+        # Loss prevention is the reason the session-ending bar exists; a plain
+        # append is not a consolidation and must not silence it.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / ".hermes" / "memories").mkdir(parents=True)
+            (root / ".hermes" / "memories" / "MEMORY.md").write_text("small", encoding="utf-8")
+            provider = OmhMemoryProvider(root / ".omh")
+            provider.initialize("s", hermes_home=str(root / ".hermes"), agent_context="primary")
+            provider.on_turn_start(1, "hi")
+            provider.on_memory_write("add", "memory", "a new fact")
+            provider.on_session_end([])
+            brief = read_latest_consolidation(root / ".omh")
+            self.assertTrue(brief["due"])
+            self.assertIn("session_ending_with_unconsolidated_turns:1", brief["reasons"])
+
+    def test_turns_after_the_consolidation_count_from_zero(self) -> None:
+        # The interval restarts at the consolidation, not at the last brief.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            provider = self._consolidating_session(root)
+            for turn in range(2, DEFAULT_TURN_INTERVAL + 1):
+                provider.on_turn_start(turn, "hi")
+            self.assertFalse(read_latest_consolidation(root / ".omh")["due"])
+            provider.on_turn_start(DEFAULT_TURN_INTERVAL + 1, "hi")
+            self.assertTrue(read_latest_consolidation(root / ".omh")["due"])
+
+
 class NoticeLocaleCoverageTests(unittest.TestCase):
     """The notice speaks every locale the copy system supports, gated."""
 


### PR DESCRIPTION
## Feature Report

### What Changed

A consolidation-shaped memory write (`replace`/`remove` from Hermes' memory tool) now resets `turns_since_consolidation` to zero and lowers `compaction_pending`, before the retirement check runs.

### Why This Exists

Found by doing what the feature asks for. 케이홉 told Hermes to tidy its memory. Hermes did — six removes, two adds, MEMORY.md 1921 → 1122 chars. The headroom brief retired mid-session exactly as designed. **And then the session ended and raised `session_ending_with_unconsolidated_turns:1`** — the notice came back at the exit of the very session that had just consolidated.

The cause: `turns_since_consolidation` reset only when a *brief fired*, never when a *consolidation happened*, despite the name. A session whose only work was consolidating still ended with turns > 0, and the session-ending bar (one unconsolidated turn, there for loss prevention) re-raised. Every tidy-up ended by requesting the next one.

### How It Works

The reset rides the same observed signal that already gates retirement — a `replace`/`remove` emitted by Hermes' own memory tool — never a timer or an assumption about what a session meant. Replayed against the recorded live sequence:

| Step | Before | After |
| --- | --- | --- |
| Consolidating writes land | brief retired ✓ | brief retired ✓, clock → 0 |
| That session ends | **new brief raised** | **quiet** |
| Next interval | counts from last brief | counts from the consolidation |
| Control: append-only session ends | raises at exit | still raises at exit |

### Files And Contracts Touched

- `src/plugin_bundle/omh/memory_dreaming.py` — `record_consolidation_observed`.
- `src/plugin_bundle/omh/memory_provider.py` — wired before the retirement check.
- `tests/test_memory_provider.py` — 4 new cases.
- No schema change.

## Validation

- [x] `uv run --group lint ruff check src tests` — All checks passed
- [x] `python3 -m unittest discover -s tests` — **2219 passed**, 1 skipped
- [x] `python3 -m compileall src`
- [x] `python3 -m omh.cli docs workflows --check`, `docs roles --check`, `docs capability-families --check`
- [x] `python3 -m omh.cli harness validate`
- [x] `git diff --check`
- [x] The exact live failure sequence replayed before/after (table above)
- [ ] Live re-run against the installed bundle — happens after merge; the replay uses the recorded live sequence, not a second live session.

## Risk

Low. One state mutation on a signal that already gates retirement; sessions without consolidating writes behave byte-identically, pinned by the control test.

## Release / Claims

- [x] `local` channel; no version change.
- [x] Observed vs not marked — the failure was observed live; the fix is verified by replay, with the live re-run to follow post-merge.
