### PR TITLE
fix: stop reading punctuation and bare syllables as workflow intent

### DIFF
--- a/src/routing/chat.py
+++ b/src/routing/chat.py
@@ -1428,6 +1428,13 @@ def _route_chat_message_cached(
     min_confidence: str,
 ) -> dict[str, object]:
     routing_message = _with_canonical_display_names(scrub_diagnostic_status_text(message))
+    trivial_decision = _trivial_message_fast_path_decision(
+        routing_message,
+        source=source,
+        min_confidence=min_confidence,
+    )
+    if trivial_decision is not None:
+        return trivial_decision.to_dict()
     fast_omh_help_decision = _omh_help_fast_path_decision(
         message,
         routing_message=routing_message,
@@ -4901,6 +4908,64 @@ def _fast_path_compact(value: str) -> str:
     return re.sub(r"[\s\?\!\.,;:~…？]+", "", value)
 
 
+def _trivial_message_fast_path_decision(
+    routing_message: str,
+    *,
+    source: str,
+    min_confidence: str,
+) -> ChatRouteDecision | None:
+    """A message with no routable content can never carry workflow intent.
+
+    Observed live on Slack, mid document-harness conversation: a bare "?" got
+    an OMH catalog menu, because nothing guarded messages whose entire content
+    is punctuation. Worse, "뭐" alone DISPATCHED agent-ops-review at score 18
+    -- multi-word Korean triggers decompose into single-syllable scorer tokens,
+    and the existing direct-answer guard applies only at candidate_score <= 4,
+    so the very noise it exists to stop is what disarmed it. This guard runs
+    before any scoring, because no score derived from one syllable or a
+    question mark is evidence of anything.
+
+    A named skill is exempt: "wiki" or "/ask" is a routable one-word message,
+    and `explicit_skill_invocation` already knows every name and alias.
+    """
+    text = routing_message.strip()
+    if not text:
+        return None
+    if explicit_skill_invocation(text) is not None:
+        return None
+    # A leading @mention is addressing, not content: on Slack the observed bug
+    # message was literally "@mikument-harness?".
+    core = _MENTION_PREFIX.sub("", text).strip()
+    if len(core) > 12:
+        return None
+    # A message that IS a curated trigger, whole, is deliberate shorthand --
+    # "뭔일임?" is agent-ops slang someone chose to put in the catalog. Only
+    # sub-trigger fragments are noise; the whole trigger is the signal.
+    if normalized_phrase(core.rstrip("?？!！.。")) in _whole_trigger_phrases():
+        return None
+    content = [character for character in core if character.isalnum()]
+    if len(content) <= 2:
+        return _direct_answer_decision(text, source=source, min_confidence=min_confidence)
+    # "그래서?" -- a single questioning token is a conversational beat, not a
+    # workflow request. Imperatives ("리뷰해") do not end in a question mark and
+    # keep routing.
+    if " " not in core and core.endswith(("?", "？")) and len(content) <= 4:
+        return _direct_answer_decision(text, source=source, min_confidence=min_confidence)
+    return None
+
+
+@lru_cache(maxsize=1)
+def _whole_trigger_phrases() -> frozenset[str]:
+    return frozenset(
+        normalized_phrase(trigger)
+        for definition in routable_definitions()
+        for trigger in definition.triggers
+    )
+
+
+_MENTION_PREFIX = re.compile(r"^(?:@\S+\s*)+")
+
+
 def _direct_answer_fast_path_decision(
     message: str,
     *,
@@ -4912,6 +4977,15 @@ def _direct_answer_fast_path_decision(
         return None
     if not _is_fast_plain_direct_answer_question(routing_message):
         return None
+    return _direct_answer_decision(message, source=source, min_confidence=min_confidence)
+
+
+def _direct_answer_decision(
+    message: str,
+    *,
+    source: str,
+    min_confidence: str,
+) -> ChatRouteDecision:
     selected_harness = primary_harness_for_skill(_ROUTER_SKILL)
     reason = DIRECT_ANSWER_REASON
     return ChatRouteDecision(

--- a/tests/test_routing_precision.py
+++ b/tests/test_routing_precision.py
@@ -387,5 +387,59 @@ class RoutingPrecisionTests(unittest.TestCase):
         self.assertEqual(payload["summary"]["missed_intervention_count"], 0)
 
 
+class TrivialMessageGuardTests(unittest.TestCase):
+    """A message with no routable content never reaches trigger scoring.
+
+    Observed live on Slack, mid document-harness conversation: the user sent
+    the bot a bare "?" and got an OMH catalog menu back, and "뭐" alone
+    DISPATCHED agent-ops-review at score 18. Multi-word Korean triggers
+    decompose into single-syllable scorer tokens, and the pre-existing
+    direct-answer guard applied only at candidate_score <= 4 -- so the noise
+    it exists to stop was exactly what disarmed it. The guard now runs before
+    any scoring.
+    """
+
+    TRIVIAL = ("?", "??", "@mikument-harness?", "뭐", "응?", "그래서?", "네", "ok", "왜?", "뭐지?")
+
+    def test_trivial_messages_fall_back_to_a_direct_answer(self) -> None:
+        from omh.routing.chat import DIRECT_ANSWER_REASON, route_chat_message
+
+        for message in self.TRIVIAL:
+            with self.subTest(message=message):
+                route = route_chat_message(message, source="slack")
+                self.assertEqual(route["action"], "fallback")
+                self.assertEqual(route["reason"], DIRECT_ANSWER_REASON)
+
+    def test_a_bare_syllable_never_dispatches_a_workflow(self) -> None:
+        # The exact live failure: one syllable, high-confidence dispatch.
+        from omh.routing.chat import route_chat_message
+
+        route = route_chat_message("뭐", source="slack")
+        self.assertNotEqual(route["action"], "dispatch")
+        self.assertNotEqual(route["selected_skill"], "agent-ops-review")
+
+    def test_named_skills_stay_routable_as_one_word_messages(self) -> None:
+        # `explicit_skill_invocation` knows every name and alias, and a named
+        # skill is the one legitimate one-word message.
+        from omh.routing.chat import DIRECT_ANSWER_REASON, route_chat_message
+
+        for message, expected in (("wiki", "wiki"), ("/wiki", "wiki"), ("ask", "ask"), ("team", "team")):
+            with self.subTest(message=message):
+                route = route_chat_message(message, source="slack")
+                self.assertEqual(route["action"], "dispatch")
+                self.assertEqual(route["selected_skill"], expected)
+                self.assertNotEqual(route["reason"], DIRECT_ANSWER_REASON)
+
+    def test_short_imperatives_and_real_requests_keep_routing(self) -> None:
+        # An imperative does not end in a question mark; a spaced request has
+        # content. Neither belongs to this guard.
+        from omh.routing.chat import DIRECT_ANSWER_REASON, route_chat_message
+
+        for message in ("리뷰해", "배포해줘", "상태 보여줘", "왜 빌드가 깨졌어", "이거 기억해둬", "omh doctor"):
+            with self.subTest(message=message):
+                route = route_chat_message(message, source="slack")
+                self.assertNotEqual(route["reason"], DIRECT_ANSWER_REASON)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

A trivial-message guard now runs before any trigger scoring: a message whose content (after stripping a leading @mention) is at most two characters, or a single questioning token of at most four, falls back to "answer directly in chat" instead of reaching the workflow scorer or the router-clarify fallback.

Three measured exemptions: named skills (`wiki`, `/ask`), whole curated triggers (`뭔일임?`), and imperatives (`리뷰해`).

### Why This Exists

Observed live on Slack, mid document-harness conversation: 케이홉 sent the bot `?` and got an OMH catalog menu back — the bot's own words: *"내가 '?' 받고 그걸 OMH 카탈로그 질문으로 착각하고"*. Reproducing locally found worse: **`뭐` alone dispatched `agent-ops-review` at score 18, high confidence.**

Both share one mechanic. Multi-word Korean triggers decompose into single-syllable scorer tokens (`지금 뭐 하고 있어` donates a bare `뭐`), and short messages match triggers by containment, so one syllable collects score from every trigger containing it. The existing direct-answer guard applied only at `candidate_score <= 4` — **the noise it exists to stop was what disarmed it.** And bare `?` had no guard at all: it fell to the router-clarify fallback, whose reason tells the model to clarify *which workflow* — how a punctuation mark became a catalog menu mid-project.

### How It Works

| Message | Before | After |
| --- | --- | --- |
| `?`, `??`, `@bot ?` | router-clarify → OMH menu | direct answer |
| `뭐` | **dispatch agent-ops-review (18)** | direct answer |
| `응?` `그래서?` `네` `ok` `왜?` | mixed | direct answer |
| `뭔일임?` (curated trigger) | dispatch agent-ops-review | **unchanged** — whole-trigger exemption |
| `wiki` `/wiki` `ask` `team` | dispatch | unchanged |
| `리뷰해` `배포해줘` `상태 보여줘` | routes | unchanged |

The whole-trigger exemption exists because the precision corpus caught the first version of this guard eating `뭔일임?` — only sub-trigger *fragments* are noise; the whole trigger is the signal someone deliberately curated.

### What This Does Not Fix

The model keeping OMH salient after a session-start "load OMH" request is model behaviour, not routing — OMH can stop feeding it wrong routes (this PR) but cannot un-prime the conversation. The containment-scoring root cause remains the deliberately-deferred c52f4b6b territory.

### Files And Contracts Touched

- `src/routing/chat.py` — `_trivial_message_fast_path_decision`, `_whole_trigger_phrases`, shared `_direct_answer_decision` extraction.
- `tests/test_routing_precision.py` — 4 new guard tests.
- No trigger phrases added; frozen Korean trigger counts untouched.

## Validation

- [x] `uv run --group lint ruff check src tests` — All checks passed
- [x] `python3 -m unittest discover -s tests` — **2225 passed**, 1 skipped
- [x] Routing-precision demo gate — 56/56 negative controls, 129/129 interventions
- [x] `python3 -m compileall src`; docs workflows/roles/capability-families `--check`; harness validate; `git diff --check`
- [x] Sweep: 10/10 trivial forms guarded, 14/14 short-but-real messages untouched
- [ ] Manual Hermes/TUI check — **not run.** The Slack gateway's own mention-stripping is unobserved; the guard handles both the raw `@bot ?` form and a pre-stripped `?`, so either lands in the same place.

## Risk

Low. The guard touches only messages whose stripped content is ≤4 characters; everything longer is untouched by construction. The one behavioural trade-off: a genuinely intentful 1–2 character message that is neither a skill name nor a curated trigger now gets a direct answer instead of a workflow — which is the failure direction the precision corpus prefers.

## Release / Claims

- [x] `local` channel; no version change.
- [x] Observed vs not marked — the Slack failure was observed live; the fix is verified by reproduction and corpus, not a second live Slack round-trip.
