### PR TITLE
fix: serialize per-unit git worktree creation in fanout dispatch

### DIFF
--- a/src/coding/worktree_creator.py
+++ b/src/coding/worktree_creator.py
@@ -17,12 +17,15 @@ from __future__ import annotations
 import json
 from pathlib import Path
 import subprocess
+import threading
 from typing import Any, Callable
 
 from ..local_store import ensure_dir, ensure_file, file_lock, read_jsonl_objects, utc_now
 from ..paths import OmhPaths, expand_path
 
 WORKTREE_OBSERVATION_SCHEMA_VERSION = "omh_worktree_observation/v1"
+
+_WORKTREE_ADD_LOCK = threading.Lock()
 
 WORKTREE_CLAIM_BOUNDARY = (
     "An observed Git worktree is workspace-isolation evidence only. "
@@ -109,13 +112,19 @@ def ensure_fanout_unit_worktree(
         _append_worktree_record(paths, _observation_record(result))
         return result
     try:
-        completed = runner(
-            ["git", "worktree", "add", str(worktree_path), "-b", branch, base_sha],
-            cwd=str(repo_root),
-            text=True,
-            capture_output=True,
-            timeout=120,
-        )
+        # Dispatch creates unit worktrees from a thread pool, and concurrent
+        # `git worktree add` calls against one repository contend on shared
+        # repo-level lock files (packed-refs/config), which fails
+        # intermittently on slow filesystems. Creation is cheap relative to
+        # the agent run, so it is serialized process-wide.
+        with _WORKTREE_ADD_LOCK:
+            completed = runner(
+                ["git", "worktree", "add", str(worktree_path), "-b", branch, base_sha],
+                cwd=str(repo_root),
+                text=True,
+                capture_output=True,
+                timeout=120,
+            )
     except (OSError, subprocess.TimeoutExpired) as exc:
         result["reason"] = f"git worktree add failed to run: {exc}"
         _append_worktree_record(paths, _observation_record(result))


### PR DESCRIPTION
## What changed
`ensure_fanout_unit_worktree` now serializes the `git worktree add` subprocess behind a process-wide lock. Everything else about the fanout dispatch bridge (readiness gate, per-unit worktrees, observation ledger, agent-run concurrency) is unchanged.

## Why
Main went red on run 30261914506: `test_missing_cli_maps_to_exit_127` reported `worktree_failed` instead of `failed`/127, on a commit (#709) that only touched routing. Dispatch creates unit worktrees from a `ThreadPoolExecutor`, and concurrent `git worktree add` calls against one repository contend on shared repo-level lock files (packed-refs/config). On slow CI filesystems that contention intermittently fails one of the adds, which the summary faithfully reports as `worktree_failed` — a false negative that also blocks the unit's dependents.

## What you can do after this change
Fanout dispatch results on CI (and any slower filesystem) no longer intermittently report worktree failures for healthy repos; the flaky main signal disappears at its root instead of via retries.

## Implementation at the boundary
- `src/coding/worktree_creator.py`: module-level `threading.Lock` around the `git worktree add` runner call only. Creation is milliseconds next to the agent run it isolates, so real dispatch concurrency (the spawned agent CLIs) is unaffected. In-process locking is sufficient because the racing calls all come from one dispatch process's thread pool.

## Verification observed
- `PYTHONPATH=tests uv run python -m unittest tests.test_fanout_dispatch` — 14 tests OK.
- `uv run python -m compileall -q src` clean.
- Local stress: 25/25 runs of the failing test pass at latest main (race not reproducible on fast local SSD — consistent with a CI-filesystem-timing race).
- Rerun of the failed main run was triggered separately to confirm flakiness.

## Risks / follow-up
- The race was not reproduced locally, so this is a root-cause-shaped fix validated by reasoning about git's shared lock files plus the CI evidence; if the rerun of main also fails deterministically, something else is wrong and this PR should not be treated as the full story.
- No behavior change for single-unit or sequential dispatches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A4YNe8BB4KPWbgfEiZyfpC