### PR TITLE
fix: close the six goal/handoff failures one live Slack session surfaced

### DIFF
--- a/src/coding/coding_delegation.py
+++ b/src/coding/coding_delegation.py
@@ -76,6 +76,32 @@ SCHEMA_VERSION = "coding_delegation/v1"
 DELEGATION_ACTIONS = ("delegate", "clarify", "fallback")
 MESSAGE_CONTEXT_SCHEMA_VERSION = "coding_delegation_message_context/v1"
 MESSAGE_CONTEXT_MODES = ("full", "bounded")
+# Four rules pinned from one live Slack session where a chat wrapper went wrong in front of a user:
+# (a) after a context compaction it said "승인 받았어" (I received approval) and dispatched to Codex —
+#     no approving user message existed, the compaction resume was mistaken for approval;
+# (b) its status copy never named which executor/model actually ran, so nobody could tell;
+# (c) it proposed retrying "with a working model (gpt-5.1-codex 등)", inventing a model name from stale
+#     memory; and (d) it read `which codex` plus an existing ~/.codex/auth.json as "Codex ready", dispatched,
+#     and the run then failed — a binary on PATH and an auth file are not run evidence.
+# These travel on the shared payload (not copied into each per-target handoff builder) so every executor
+# target — codex, claude-code, hermes, generic, or a future one — carries the same guardrail text.
+APPROVAL_EVIDENCE_RULE = (
+    "Approval is a quoted user message visible in the current context. A compaction or session resume "
+    "is never approval. If the approving message is not visible after compaction, re-ask before dispatching."
+)
+EXECUTOR_IDENTITY_RULE = (
+    "State the executor and model exactly as configured or observed (e.g. from the runtime record or CLI "
+    "config), in parentheses after status lines. If the model is not observed, say the model is unconfirmed."
+)
+MODEL_NAMING_RULE = (
+    "Never name a concrete model from memory. Model names come only from observed config, runtime records, "
+    "or the executor CLI's own output; otherwise ask or say unknown."
+)
+READINESS_EVIDENCE_RULE = (
+    "A binary on PATH and an auth file are not run evidence. Before claiming an executor is ready, observe "
+    "it execute — a --version or no-op invocation — and read its configured model from its own config or "
+    "output. Readiness claimed from file existence alone must be labeled prepared, not observed."
+)
 _CATALOG_INTENT_RETAINED_WORKFLOWS = set(catalog_intent_delegation_skill_names())
 _RETAINED_HERMES_WORKFLOWS = set(retained_delegation_skill_names())
 _LOCAL_CAPABILITY_STRATEGY_SCHEMA_VERSION = "executor_local_capability_strategy/v1"
@@ -317,6 +343,10 @@ def build_coding_delegation_payload(
         "source": source,
         "delegation": delegation.to_dict(),
         "recommendations": recommendations,
+        "approval_evidence_rule": APPROVAL_EVIDENCE_RULE,
+        "executor_identity_rule": EXECUTOR_IDENTITY_RULE,
+        "model_naming_rule": MODEL_NAMING_RULE,
+        "readiness_evidence_rule": READINESS_EVIDENCE_RULE,
     }
     selection = executor_selection_for_target(executor_target, action=delegation.action)
     isolation_plan = (
@@ -1214,7 +1244,8 @@ def _codex_session_observation_contract() -> dict[str, object]:
         ),
         "approval_rule": (
             "Approval or user-input waits are blockers until an explicit observed approval, rejection, or input "
-            "is recorded; never auto-approve from a prepared handoff."
+            "is recorded; never auto-approve from a prepared handoff. A compaction or session resume is never "
+            "that observed approval."
         ),
         "event_filter_rule": "Observe only events for the matching thread and turn identifiers.",
         "observed_state_owner": [
@@ -1260,7 +1291,8 @@ def _claude_code_session_observation_contract() -> dict[str, object]:
         ),
         "approval_rule": (
             "Approval or user-input waits are blockers until an explicit observed approval, rejection, or input "
-            "is recorded; never auto-approve from a prepared handoff."
+            "is recorded; never auto-approve from a prepared handoff. A compaction or session resume is never "
+            "that observed approval."
         ),
         "event_filter_rule": "Observe only events for the matching Claude Code session and turn identifiers.",
         "observed_state_owner": [

--- a/src/routing/candidate_handoff.py
+++ b/src/routing/candidate_handoff.py
@@ -27,9 +27,29 @@ import hashlib
 import json
 
 from .input_language import SUPPORT_MODEL_SELECTION_REQUIRED
+from ..skills.catalog import routable_definitions
+from ..workflows.hermes_planning import is_coding_shaped_task
 
 
 CANDIDATE_HANDOFF_SCHEMA_VERSION = "model_selection_candidates/v1"
+
+# The workflows that actually deliver implementation work. Observed live: an
+# implementation-shaped request ("...백엔드 구현해줘") reached model selection
+# carrying instinct-ledger, materials-package, and memory-new at score 3 --
+# decomposed-token noise -- while the picker in the same session offered
+# idea-to-deploy and planning flows. The engines that do the work (ultraprocess,
+# team, ultragoal) never surfaced, because nothing connected "this is coding"
+# to "these are the coding candidates".
+CODING_LANE_CANDIDATES = (
+    ("ultraprocess", "prepare_coding_handoff"),
+    ("team", "prepare_coding_handoff"),
+    ("ultragoal", "prepare_goal_ledger"),
+    ("executor-runtime-readiness", "check_executor_readiness"),
+)
+
+# Matches the router's own specific-capability minimum: below this, a match is
+# decomposition noise, not a signal worth showing over the coding lane.
+CODING_LANE_SCORE_FLOOR = 6
 
 # Below this score gap the scorer is not discriminating between the top two
 # candidates, it is picking one arbitrarily. Measured ties (gap 0) and near-ties
@@ -76,6 +96,47 @@ def candidate_handoff_reasons(route: dict[str, object]) -> tuple[str, ...]:
     return tuple(reasons)
 
 
+def _coding_lane_applies(candidates: list[dict[str, object]], message: str) -> bool:
+    """Should the coding lane replace what scoring found?
+
+    Only when the message is implementation-shaped AND every scored candidate
+    is below the floor. A strong match -- memory-sync at 31, ultraprocess at a
+    real trigger score -- keeps its shortlist; the lane replaces noise, never
+    signal.
+    """
+    if not message or not is_coding_shaped_task(message):
+        return False
+    return all(int(candidate.get("score", 0) or 0) < CODING_LANE_SCORE_FLOOR for candidate in candidates)
+
+
+def _coding_lane() -> list[dict[str, object]]:
+    definitions = {definition.name: definition for definition in routable_definitions()}
+    lane: list[dict[str, object]] = []
+    for name, next_action in CODING_LANE_CANDIDATES:
+        definition = definitions.get(name)
+        if definition is None:
+            continue
+        lane.append(
+            {
+                "skill": definition.name,
+                "description": definition.description,
+                "why_it_matched": (
+                    "The request is implementation-shaped; this is one of the workflows that "
+                    "actually delivers coding work."
+                ),
+                "matched": ["coding_shaped_task"],
+                "score": 0,
+                "confidence": "low",
+                "next_action": next_action,
+                "evidence_boundary": (
+                    "A candidate is routing input only; nothing has been planned, dispatched, "
+                    "implemented, or verified."
+                ),
+            }
+        )
+    return lane[:MAX_CANDIDATES]
+
+
 def _candidate(recommendation: dict[str, object]) -> dict[str, object]:
     return {
         "skill": recommendation.get("skill"),
@@ -104,7 +165,7 @@ def candidate_handoff_digest(candidates: list[dict[str, object]], reasons: tuple
     return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
 
 
-def build_candidate_handoff(route: dict[str, object]) -> dict[str, object] | None:
+def build_candidate_handoff(route: dict[str, object], message: str = "") -> dict[str, object] | None:
     """Build the model-selection handoff, or None when the route is decidable."""
     reasons = candidate_handoff_reasons(route)
     if not reasons:
@@ -112,6 +173,10 @@ def build_candidate_handoff(route: dict[str, object]) -> dict[str, object] | Non
 
     recommendations = [item for item in route.get("recommendations", []) if isinstance(item, dict)]
     candidates = [_candidate(recommendation) for recommendation in recommendations[:MAX_CANDIDATES]]
+
+    if _coding_lane_applies(candidates, message):
+        candidates = _coding_lane()
+        reasons = (*reasons, "implementation_shaped_request")
 
     payload: dict[str, object] = {
         "schema_version": CANDIDATE_HANDOFF_SCHEMA_VERSION,
@@ -123,7 +188,13 @@ def build_candidate_handoff(route: dict[str, object]) -> dict[str, object] | Non
         "claim_boundary": CLAIM_BOUNDARY,
     }
 
-    if candidates:
+    if "implementation_shaped_request" in reasons:
+        payload["question"] = (
+            "The request is implementation-shaped but no workflow matched strongly. These are "
+            "the coding-delivery workflows; choose the one that fits the delivery grain, or ask "
+            "one clarifying question. Do not route implementation work to planning-only flows."
+        )
+    elif candidates:
         payload["question"] = (
             "Which of these workflows fits the request? Choose one, say why in one line, "
             "and carry its evidence boundary forward. If none fit, ask one clarifying question."

--- a/src/routing/chat.py
+++ b/src/routing/chat.py
@@ -1357,7 +1357,7 @@ def route_chat_message(
     route["input_language"] = routing_input_language(message)
     # An undecidable route carries its shortlist forward for model selection
     # instead of stopping at a picker or a bare fallback.
-    candidate_handoff = build_candidate_handoff(route)
+    candidate_handoff = build_candidate_handoff(route, message)
     if candidate_handoff:
         route["candidate_handoff"] = candidate_handoff
     return _apply_skill_governance(route, skill_policy)

--- a/src/workflows/goal_ledger.py
+++ b/src/workflows/goal_ledger.py
@@ -475,6 +475,28 @@ def build_goal_continuation(paths: OmhPaths, goal_id: str) -> dict[str, Any]:
     }
 
 
+def _checkpoint_id_short(checkpoint_id: str) -> str:
+    # The trailing token from _new_item_id (secrets.token_hex(3)) is short,
+    # stable, and unique enough to reference a checkpoint in a status line.
+    segment = checkpoint_id.rsplit("-", 1)[-1]
+    return segment or checkpoint_id[:8]
+
+
+def _checkpoint_lines(checkpoints: list[dict[str, Any]]) -> list[str]:
+    # Pre-rendered as dash lines, not left to the caller's judgment: a live
+    # Slack session once rendered this same data as a markdown table, which
+    # messenger surfaces (Slack, Telegram) silently drop. Handing back the
+    # exact lines to print removes that choice entirely.
+    lines = []
+    for checkpoint in checkpoints:
+        evidence = "observed" if checkpoint.get("evidence_refs") else "prepared"
+        lines.append(
+            f"- {_checkpoint_id_short(checkpoint['checkpoint_id'])}: "
+            f"{checkpoint['summary']} — {checkpoint['status']}, {evidence}"
+        )
+    return lines
+
+
 def build_goal_status_card(paths: OmhPaths, goal_id: str) -> dict[str, Any]:
     goal = read_goal_ledger(paths, goal_id)
     gate = build_goal_completion_gate(paths, goal_id)
@@ -492,6 +514,11 @@ def build_goal_status_card(paths: OmhPaths, goal_id: str) -> dict[str, Any]:
         "allowed_actions": _allowed_goal_actions(gate),
         "safe_copy": _goal_safe_copy(goal, gate, progress),
         "completion_gate": gate,
+        "checkpoint_lines": _checkpoint_lines(goal["checkpoints"]),
+        "render_guidance": (
+            "Render checkpoints as the provided dash lines, one per line. "
+            "Never render a markdown table: messenger surfaces (Slack, Telegram) drop tables."
+        ),
     }
 
 
@@ -607,6 +634,9 @@ def _goal_safe_copy(goal: dict[str, Any], gate: dict[str, Any], progress: dict[s
         "headline": f"Goal {goal['goal_id']} is {goal['status']}.",
         "progress": f"{progress['required_satisfied']}/{progress['required_total']} required criteria satisfied.",
         "next_step": next_step,
+        # A live Slack session rendered checkpoints as a markdown table, which
+        # messenger surfaces drop; this hint steers callers back to bullets.
+        "checkpoint_format": "- cpN: summary — status, evidence",
     }
 
 

--- a/tests/test_candidate_handoff.py
+++ b/tests/test_candidate_handoff.py
@@ -97,5 +97,55 @@ class CandidateHandoffTests(unittest.TestCase):
         self.assertIn("not a routing decision", route["candidate_handoff"]["claim_boundary"])
 
 
+class CodingLaneTests(unittest.TestCase):
+    """An implementation-shaped request gets the coding lane, not scorer noise.
+
+    Observed live: "...백엔드 구현해줘" reached model selection carrying
+    instinct-ledger, materials-package, and memory-new at score 3 -- decomposed
+    -token noise -- while the engines that deliver coding work (ultraprocess,
+    team, ultragoal) never surfaced. The same session's picker offered
+    idea-to-deploy and planning flows for what was an implementation ask.
+    """
+
+    LANE = ["ultraprocess", "team", "ultragoal", "executor-runtime-readiness"]
+
+    def _handoff(self, message: str) -> dict:
+        from omh.routing.chat import route_chat_message
+
+        return route_chat_message(message, source="slack").get("candidate_handoff") or {}
+
+    def test_the_observed_failure_now_yields_the_coding_lane(self) -> None:
+        handoff = self._handoff(
+            "document-harness에서 프로젝트 링크만 주면 observer 결과를 자동 조회하게 백엔드 구현해줘"
+        )
+        self.assertEqual([c["skill"] for c in handoff["candidates"]], self.LANE)
+        self.assertIn("implementation_shaped_request", handoff["reasons"])
+        self.assertIn("Do not route implementation work to planning-only flows", handoff["question"])
+
+    def test_english_implementation_asks_get_the_same_lane(self) -> None:
+        handoff = self._handoff("implement the backend for observer lookup")
+        self.assertEqual([c["skill"] for c in handoff["candidates"]], self.LANE)
+
+    def test_a_strong_match_keeps_its_own_shortlist(self) -> None:
+        # The lane replaces noise, never signal: a real trigger match must not
+        # be displaced by generic coding candidates.
+        from omh.routing.chat import route_chat_message
+
+        route = route_chat_message("기억이 잘못 저장된 것 같아 확인해줘", source="slack")
+        self.assertEqual(route["action"], "dispatch")
+        self.assertNotIn("candidate_handoff", route)
+
+    def test_non_coding_weak_requests_do_not_get_the_lane(self) -> None:
+        handoff = self._handoff("점심 뭐 먹을까 추천해줘")
+        skills = [c["skill"] for c in handoff.get("candidates", [])]
+        self.assertNotEqual(skills, self.LANE)
+        self.assertNotIn("implementation_shaped_request", handoff.get("reasons", []))
+
+    def test_lane_candidates_carry_the_routing_only_boundary(self) -> None:
+        handoff = self._handoff("implement the backend for observer lookup")
+        for candidate in handoff["candidates"]:
+            self.assertIn("routing input only", candidate["evidence_boundary"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_goal_ledger.py
+++ b/tests/test_goal_ledger.py
@@ -264,5 +264,64 @@ class GoalLedgerTests(unittest.TestCase):
         self.assertIn("objective_storage must be sha256", validation["errors"])
 
 
+class GoalStatusCardCheckpointRenderingTests(unittest.TestCase):
+    # A live Slack session once rendered goal checkpoints as a markdown
+    # table (| ID | 이름 | 상태 | 증거 |), which messenger surfaces (Slack,
+    # Telegram) silently drop. These tests pin the fix: the status card
+    # pre-renders dash lines and tells the caller never to use a table.
+    def test_checkpoint_lines_are_pre_rendered_dash_bullets(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            create_goal_ledger(
+                paths,
+                "Finish the durable goal",
+                ["Criterion one"],
+                goal_id="goal-checkpoint-lines",
+            )
+            record_goal_checkpoint(paths, "goal-checkpoint-lines", "Wrote the ledger module", evidence_refs=["unit"])
+            record_goal_checkpoint(paths, "goal-checkpoint-lines", "Drafted the design notes")
+
+            status_card = build_goal_status_card(paths, "goal-checkpoint-lines")
+            lines = status_card["checkpoint_lines"]
+
+            self.assertEqual(len(lines), 2)
+            self.assertRegex(lines[0], r"^- [0-9a-f]+: Wrote the ledger module — done, observed$")
+            self.assertRegex(lines[1], r"^- [0-9a-f]+: Drafted the design notes — done, prepared$")
+            self.assertIn("Never render a markdown table", status_card["render_guidance"])
+            self.assertIn("messenger surfaces", status_card["render_guidance"])
+
+    def test_checkpoint_lines_is_empty_list_not_missing_key_when_no_checkpoints(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            create_goal_ledger(
+                paths,
+                "Finish the durable goal",
+                ["Criterion one"],
+                goal_id="goal-no-checkpoints",
+            )
+
+            status_card = build_goal_status_card(paths, "goal-no-checkpoints")
+
+            self.assertIn("checkpoint_lines", status_card)
+            self.assertEqual(status_card["checkpoint_lines"], [])
+
+    def test_safe_copy_carries_checkpoint_format_hint(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            create_goal_ledger(
+                paths,
+                "Finish the durable goal",
+                ["Criterion one"],
+                goal_id="goal-format-hint",
+            )
+
+            status_card = build_goal_status_card(paths, "goal-format-hint")
+
+            self.assertEqual(
+                status_card["safe_copy"]["checkpoint_format"],
+                "- cpN: summary — status, evidence",
+            )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_prepared_runtime_run_executor_matrix.py
+++ b/tests/test_prepared_runtime_run_executor_matrix.py
@@ -8,7 +8,14 @@ from tempfile import TemporaryDirectory
 from _local_package import load_local_package
 
 load_local_package()
-from omh.coding_delegation import build_coding_delegation_payload, coding_delegation_record_payload
+from omh.coding_delegation import (
+    APPROVAL_EVIDENCE_RULE,
+    EXECUTOR_IDENTITY_RULE,
+    MODEL_NAMING_RULE,
+    READINESS_EVIDENCE_RULE,
+    build_coding_delegation_payload,
+    coding_delegation_record_payload,
+)
 from omh.executors import (
     CODING_EXECUTOR_HANDOFF_TARGETS,
     CODING_RUNTIME_HANDOFF_TARGETS,
@@ -203,6 +210,44 @@ class PreparedRuntimeRunExecutorMatrixTests(unittest.TestCase):
             self.assertEqual(coding["executor_handoff"]["status"], "prepared_not_observed")
             self.assertFalse((run_dir / "delegation.json").exists())
             self.assertFalse((run_dir / "wrapper.json").exists())
+
+
+class CodingDelegationGuidanceRulesTests(unittest.TestCase):
+    """Pin the shared guardrail fields added after one live Slack session went wrong three ways in a
+    row, plus a fourth failure caught the same session: a compaction resume was read as approval, status
+    copy never named which executor/model ran, a retry suggestion invented a model name from memory, and
+    `which codex` plus an auth file on disk were read as "ready" for a run that then failed. The fields
+    must live once on the shared payload (not copied per executor-target handoff builder) so every
+    executor target carries the identical guardrail text."""
+
+    def test_all_four_rules_are_present_on_every_executor_targets_payload(self) -> None:
+        for profile in EXECUTOR_PROFILES:
+            with self.subTest(profile=profile):
+                payload = build_coding_delegation_payload(MESSAGE, source="discord", executor_target=profile)
+
+                self.assertEqual(payload["approval_evidence_rule"], APPROVAL_EVIDENCE_RULE)
+                self.assertEqual(payload["executor_identity_rule"], EXECUTOR_IDENTITY_RULE)
+                self.assertEqual(payload["model_naming_rule"], MODEL_NAMING_RULE)
+                self.assertEqual(payload["readiness_evidence_rule"], READINESS_EVIDENCE_RULE)
+
+    def test_approval_evidence_rule_names_compaction_as_never_approval(self) -> None:
+        self.assertIn("compaction", APPROVAL_EVIDENCE_RULE)
+        self.assertIn("is never approval", APPROVAL_EVIDENCE_RULE)
+
+    def test_model_naming_rule_forbids_naming_a_model_from_memory(self) -> None:
+        self.assertIn("Never name a concrete model from memory", MODEL_NAMING_RULE)
+
+    def test_readiness_evidence_rule_rejects_path_and_auth_file_as_run_evidence(self) -> None:
+        self.assertIn("PATH", READINESS_EVIDENCE_RULE)
+        self.assertIn("auth file", READINESS_EVIDENCE_RULE)
+        self.assertIn("are not run evidence", READINESS_EVIDENCE_RULE)
+
+    def test_approval_rule_in_session_observation_contracts_names_compaction(self) -> None:
+        codex_handoff = build_coding_delegation_payload(MESSAGE, source="discord", executor_target="codex")["executor_handoff"]
+        claude_code_handoff = build_coding_delegation_payload(MESSAGE, source="discord", executor_target="claude-code")["prompt_handoff"]
+
+        self.assertIn("compaction", codex_handoff["session_observation_contract"]["approval_rule"])
+        self.assertIn("compaction", claude_code_handoff["session_observation_contract"]["approval_rule"])
 
 
 def _prepare_linked_codex_session(paths) -> tuple[str, str]:


### PR DESCRIPTION
## Feature Report

### What Changed

One live Slack session drove a goal from ralplan to a Codex handoff and hit six distinct failures. All six live on the goal/coding-handoff chat surface, so they ship as one goal:

| # | Observed live | Fix |
| --- | --- | --- |
| 1 | Checkpoints rendered as a markdown table (messengers drop tables) | `goal_status_card/v1` pre-renders `checkpoint_lines` (`- {id}: {summary} — {status}, {observed\|prepared}`) + `render_guidance` forbidding tables |
| 2 | Implementation ask surfaced planning flows + score-3 scorer noise; ultraprocess/team/ultragoal never appeared | Coding-shaped requests with every candidate under the router's own floor now get the coding lane (ultraprocess, team, ultragoal, executor-runtime-readiness) as the model-selection shortlist |
| 3 | "승인 받았어" straight after context compaction — no approving message existed | `approval_evidence_rule` in every delegation payload: approval is a quoted user message visible in current context; compaction/resume is never approval; re-ask |
| 4 | No output said which model ran | `executor_identity_rule`: state executor+model as configured/observed, `(…)` after status lines; say unconfirmed otherwise |
| 5 | Retry option proposed "gpt-5.1-codex" — invented from stale memory | `model_naming_rule`: model names only from observed config, runtime records, or the CLI's own output |
| 6 | "Codex 준비됨" claimed from `which codex` + auth-file existence; the run then failed | `readiness_evidence_rule`: PATH + auth file ≠ run evidence; observe a `--version`/no-op execution and read the configured model first |

### How It Works

- **#1**: the model invented the table because the card carried structure and no format. Pre-rendered lines remove the choice.
- **#2**: `is_coding_shaped_task` already recognized the message; nothing connected "this is coding" to "these are the coding candidates". The lane fires only when every scored candidate is below the specific-capability floor (6) — **it replaces noise, never signal**, pinned by a strong-match control (memory-sync keeps its shortlist) and a non-coding control (lunch advice gets no lane).
- **#3–#6**: four rules land once at the shared payload level in `build_coding_delegation_payload`, so codex, claude-code, hermes, generic, and the omx/omo/omc runtime targets carry identical text. The approval sentence is also woven into the codex and claude-code session-observation contracts' existing `approval_rule`.

### Files And Contracts Touched

- `src/workflows/goal_ledger.py` — card fields (additive).
- `src/routing/candidate_handoff.py`, `src/routing/chat.py` — coding lane; handoff gains the `implementation_shaped_request` reason.
- `src/coding/coding_delegation.py` — four rule constants + payload fields (additive).
- Tests: `test_goal_ledger` (+3), `test_candidate_handoff` (+5), `test_prepared_runtime_run_executor_matrix` (+4).
- No schema version changed shape; no trigger phrases added (frozen Korean tables untouched).

## Validation

- [x] `uv run --group lint ruff check src tests` — All checks passed
- [x] `python3 -m unittest discover -s tests` — **2238 passed**, 1 skipped
- [x] `python3 -m compileall src`
- [x] `python3 -m omh.cli docs workflows --check`, `docs roles --check`, `docs capability-families --check`
- [x] `python3 -m omh.cli harness validate`
- [x] `git diff --check`
- [x] The observed #2 failure re-run before/after: noise candidates → coding lane, with positive and negative controls
- [ ] Manual Hermes/TUI check — **not run.** No second live Slack session has replayed the six scenarios; rules 3–6 are guidance the model reads, and whether it obeys in a live turn is unobserved until the next real session.

## Risk

Low-to-medium. The candidate handoff conditionally replaces a shortlist (bounded by the floor + coding-shape gate, both tested); everything else is additive fields. Honest limit: 3–6 constrain what the model is told, not what it can do — they raise the evidence bar, they cannot enforce it.

## Release / Claims

- [x] `local` channel; no version change.
- [x] Observed vs not marked throughout.
