### PR TITLE
feat: model-routed, limit-aware, briefable coding delegation orchestration

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -657,6 +657,8 @@ Runtime artifacts are local JSON/JSONL files under `.omh/runtime/`.
   targets.json
   runtime/
     state.json
+    executor-readiness.json
+    executor-limit-signals.json
     runs/
       <run-id>/
         run.json
@@ -671,6 +673,11 @@ Runtime artifacts are local JSON/JSONL files under `.omh/runtime/`.
         session.json
         events.jsonl
 ```
+
+`executor-limit-signals.json` keeps, per executor profile, the last observed
+limit-shaped dispatch failure (timestamp, run ref, pattern label only — never
+matched text). It is advisory ranking metadata for executor choice, not
+provider quota truth.
 
 `targets.json` records observed Hermes target topology for setup drift, including
 single-to-multi and multi-to-single changes. `state.json` records install,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -674,7 +674,7 @@ Runtime artifacts are local JSON/JSONL files under `.omh/runtime/`.
         events.jsonl
 ```
 
-`executor-limit-signals.json` keeps, per executor profile, the last observed
+`executor-limit-signals.json` (written under a transient `.lock` sibling) keeps, per executor profile, the last observed
 limit-shaped dispatch failure (timestamp, run ref, pattern label only — never
 matched text). It is advisory ranking metadata for executor choice, not
 provider quota truth.

--- a/docs/FANOUT.md
+++ b/docs/FANOUT.md
@@ -21,6 +21,15 @@ goal to Hermes in chat; these commands are the backend surface.
    history, so repeated checks cost the same context instead of growing with
    the run. `--limit N` changes the tail; `--full` reads everything and is
    expensive for agent context.
+   For user-facing briefings, `omh coding fanout brief <id>` emits one
+   `fanout_briefing/v1` row per unit (owner, routed model, session ref,
+   status, elapsed seconds, token count, last observed summary) joined from
+   the contract, the persisted dispatch summary, and a one-event journal
+   tail; unknown fields stay the literal string `unknown` rather than being
+   inferred. Without an id it lists known fanouts. Session refs and token
+   counts are `unknown` until a structured-output dispatch contract lands
+   (deliberate deferral — the current templates keep executor stdout as
+   opaque bounded text).
 5. **Merge (human/agent-gated)** — dispatch never merges. The summary lists
    merge-ready units in the contract's `merge_order`; merging and the final
    integration gate remain the operator's or reviewing agent's job.
@@ -65,10 +74,32 @@ goal to Hermes in chat; these commands are the backend surface.
   nothing broader. Template drift in either CLI surfaces as a clean
   readiness or exit-code failure recorded as observed evidence, and the fix
   is a one-line data edit in `DISPATCH_COMMAND_TEMPLATES`.
+- **Model routing.** A unit may declare `model`, `reasoning_effort`, and/or
+  `role` (brain, implementation, design_visual, review, docs). Prepare embeds
+  the resolved `coding_model_route/v1` in the unit handoff, and dispatch
+  turns it into argv fragments (`codex --model … --config
+  model_reasoning_effort=…`; `claude --model … --effort …`). No route means
+  the argv stays byte-identical to the base template and the executor CLI
+  default model applies. Model availability and entitlement are provider
+  truth; a routed model that the CLI rejects surfaces as a normal observed
+  exit failure. `omh coding model-route` previews routes standalone.
+- **Telemetry.** Each dispatched unit records `started_at`, `finished_at`,
+  and `duration_seconds`, and the full dispatch summary persists to
+  `~/.omh/coding/fanout/<id>/dispatch_summary.json` (latest wins,
+  metadata only, skipped on `--dry-run`).
+- **Limit signals.** A failed spawn whose bounded output matches a fixed
+  limit-shape pattern (rate limit, usage limit, quota, 429, credits) is
+  flagged `limit_shaped` with a pattern label; the last such failure per
+  executor persists to `~/.omh/runtime/executor-limit-signals.json` and
+  surfaces as an advisory in `omh coding executor-readiness` and the
+  choose-executor context. Only the boolean and label persist — never the
+  matched text, and stderr is matched in memory only.
 - **Resume.** Re-running dispatch skips units whose runs already carry an
   observed successful result. `--unit <id>` selects subsets.
 - **Never**: auto-merge, default-on execution, network calls by omh itself,
-  raw-prompt persistence under `.omh`.
+  raw-prompt persistence under `.omh`, Hermes-inline coding (coding-shaped
+  work that cannot resolve an executor becomes an explicit user choice, not
+  retained Hermes implementation).
 
 ## Command reference
 
@@ -76,9 +107,11 @@ goal to Hermes in chat; these commands are the backend surface.
 omh coding fanout prepare --goal <words...> --units units.json [--record] [--source discord]
 omh coding fanout validate --units units.json
 omh coding fanout show <fanout-id> [--limit 20] [--full]
+omh coding fanout brief [<fanout-id>]
 omh coding fanout dispatch <fanout-id> --goal-file goal.txt \
   [--repo-root .] [--base-ref HEAD] [--concurrency 2] [--timeout 1800] \
   [--unit <id> ...] [--dry-run]
+omh coding model-route --executor <profile> [--role <role>] [--model <id>] [--effort <level>]
 ```
 
 `--units` and `--goal-file` accept `-` for stdin. `--dry-run` resolves

--- a/docs/FANOUT.md
+++ b/docs/FANOUT.md
@@ -21,15 +21,19 @@ goal to Hermes in chat; these commands are the backend surface.
    history, so repeated checks cost the same context instead of growing with
    the run. `--limit N` changes the tail; `--full` reads everything and is
    expensive for agent context.
-   For user-facing briefings, `omh coding fanout brief <id>` emits one
-   `fanout_briefing/v1` row per unit (owner, routed model, session ref,
-   status, elapsed seconds, token count, last observed summary) joined from
-   the contract, the persisted dispatch summary, and a one-event journal
-   tail; unknown fields stay the literal string `unknown` rather than being
-   inferred. Without an id it lists known fanouts. Session refs and token
-   counts are `unknown` until a structured-output dispatch contract lands
-   (deliberate deferral — the current templates keep executor stdout as
-   opaque bounded text).
+   For user-facing briefings, `omh coding fanout brief <id>` renders one
+   line per unit in merge-plan order — unit, owner, `(model effort)` label
+   (for example `(gpt-5-codex xhigh)`), status, elapsed seconds, token
+   count, session ref, last observed summary — as plain text by default
+   with `--json` for the `fanout_briefing/v1` payload. It joins the
+   contract, the persisted dispatch summary, and a one-event journal tail;
+   unknown fields stay the literal `unknown` rather than being inferred,
+   and never-dispatched units keep `prepared_not_observed`. Without an id
+   it lists known fanouts. Session refs and token counts are `unknown`
+   until a structured-output dispatch contract lands (deliberate deferral
+   — the current templates keep executor stdout as opaque bounded text);
+   executor-progress bindings for `omh runtime progress-status` are
+   deferred with that same follow-up.
 5. **Merge (human/agent-gated)** — dispatch never merges. The summary lists
    merge-ready units in the contract's `merge_order`; merging and the final
    integration gate remain the operator's or reviewing agent's job.
@@ -87,13 +91,17 @@ goal to Hermes in chat; these commands are the backend surface.
   and `duration_seconds`, and the full dispatch summary persists to
   `~/.omh/coding/fanout/<id>/dispatch_summary.json` (latest wins,
   metadata only, skipped on `--dry-run`).
-- **Limit signals.** A failed spawn whose bounded output matches a fixed
-  limit-shape pattern (rate limit, usage limit, quota, 429, credits) is
-  flagged `limit_shaped` with a pattern label; the last such failure per
-  executor persists to `~/.omh/runtime/executor-limit-signals.json` and
-  surfaces as an advisory in `omh coding executor-readiness` and the
-  choose-executor context. Only the boolean and label persist — never the
-  matched text, and stderr is matched in memory only.
+- **Limit signals.** A failed spawn whose bounded output matches a fixed,
+  context-anchored limit-shape pattern (rate limit, usage limit, quota
+  exceeded, HTTP 429, credits) is flagged `limit_shaped` with a pattern
+  label; the last such failure per executor persists to
+  `~/.omh/runtime/executor-limit-signals.json` (plus its transient `.lock`
+  sibling) and surfaces as an advisory — with read-time `age_seconds` and
+  a 6-hour `stale` marker — in `omh coding executor-readiness` and the
+  choose-executor context, where candidates rank logged-in/no-fresh-limit
+  first without ever removing an option. A later successful dispatch to
+  the same executor clears its signal. Only the boolean and label persist
+  — never the matched text, and stderr is matched in memory only.
 - **Resume.** Re-running dispatch skips units whose runs already carry an
   observed successful result. `--unit <id>` selects subsets.
 - **Never**: auto-merge, default-on execution, network calls by omh itself,
@@ -107,11 +115,11 @@ goal to Hermes in chat; these commands are the backend surface.
 omh coding fanout prepare --goal <words...> --units units.json [--record] [--source discord]
 omh coding fanout validate --units units.json
 omh coding fanout show <fanout-id> [--limit 20] [--full]
-omh coding fanout brief [<fanout-id>]
+omh coding fanout brief [<fanout-id>] [--json]
 omh coding fanout dispatch <fanout-id> --goal-file goal.txt \
   [--repo-root .] [--base-ref HEAD] [--concurrency 2] [--timeout 1800] \
   [--unit <id> ...] [--dry-run]
-omh coding model-route --executor <profile> [--role <role>] [--model <id>] [--effort <level>]
+omh coding model-route --executor <profile> [--role <role>] [--model <id>] [--effort <level>] [--json]
 ```
 
 `--units` and `--goal-file` accept `-` for stdin. `--dry-run` resolves

--- a/src/coding/coding_delegation.py
+++ b/src/coding/coding_delegation.py
@@ -355,7 +355,9 @@ def build_coding_delegation_payload(
     )
     if isolation_plan:
         payload["isolation_plan"] = isolation_plan
-    if _inline_coding_policy_applies(delegation.intent, delegation.action, selection.choice_required):
+    if _inline_coding_policy_applies(
+        message.lower(), delegation.intent, delegation.action, selection.choice_required
+    ):
         payload["delegation_policy"] = inline_coding_policy_payload()
     if selection.selected_executor_profile == "codex" and delegation.action == "delegate":
         payload["executor_handoff"] = _executor_handoff(executor_target, delegation, isolation_plan=isolation_plan)
@@ -596,14 +598,31 @@ def inline_coding_policy_payload() -> dict[str, object]:
     }
 
 
-def _inline_coding_policy_applies(intent: str, action: str, choice_required: bool) -> bool:
+# Cues that mark a message as coding-shaped for the prohibition even when
+# scoring produced no intent (score 0 → "unknown" → fallback is exactly the
+# path a bare "코딩 해줘" takes). Extends the catalog's coding terms with the
+# bare activity words the catalog reserves for stronger signals; matched with
+# the same substring rule `_intent_for` already uses for these terms.
+_INLINE_CODING_POLICY_EXTRA_TERMS = ("coding", "코딩", "패치", "patch ", " 짜줘", "코드 좀")
+
+
+def _message_is_coding_shaped(lowered_message: str, intent: str) -> bool:
+    if intent in {"coding", "review"}:
+        return True
+    if _has_any(lowered_message, coding_terms_for_intent("coding")):
+        return True
+    return _has_any(lowered_message, _INLINE_CODING_POLICY_EXTRA_TERMS)
+
+
+def _inline_coding_policy_applies(lowered_message: str, intent: str, action: str, choice_required: bool) -> bool:
     # The prohibition is product-wide; the block rides every payload where a
     # wrapper could otherwise read "Hermes keeps it" into coding-shaped work:
-    # clarify/fallback outcomes and unresolved-owner delegations, including
-    # retained workflows. Wrappers read it from the payload; retained-workflow
-    # chat cards keep their contractually executor-free copy and never render
-    # it into user-facing text.
-    if intent not in {"coding", "review"}:
+    # clarify/fallback outcomes (including score-0 fallbacks like a bare
+    # "코딩 해줘") and unresolved-owner delegations, including retained
+    # workflows. Wrappers read it from the payload; retained-workflow chat
+    # cards keep their contractually executor-free copy and never render it
+    # into user-facing text.
+    if not _message_is_coding_shaped(lowered_message, intent):
         return False
     return action != "delegate" or choice_required
 

--- a/src/coding/coding_delegation.py
+++ b/src/coding/coding_delegation.py
@@ -74,6 +74,12 @@ from ..skills.catalog import (
 
 SCHEMA_VERSION = "coding_delegation/v1"
 DELEGATION_ACTIONS = ("delegate", "clarify", "fallback")
+DELEGATION_POLICY_SCHEMA_VERSION = "coding_delegation_policy/v1"
+INLINE_CODING_POLICY_STATEMENT = (
+    "Hermes never implements main coding work inline. Coding-shaped work always becomes a prepared "
+    "handoff owned by a selected coding executor; when no executor is resolvable, ask the user which "
+    "coding agent should own the work instead of retaining it."
+)
 MESSAGE_CONTEXT_SCHEMA_VERSION = "coding_delegation_message_context/v1"
 MESSAGE_CONTEXT_MODES = ("full", "bounded")
 _CATALOG_INTENT_RETAINED_WORKFLOWS = set(catalog_intent_delegation_skill_names())
@@ -349,6 +355,8 @@ def build_coding_delegation_payload(
     )
     if isolation_plan:
         payload["isolation_plan"] = isolation_plan
+    if _inline_coding_policy_applies(delegation.intent, delegation.action, selection.choice_required):
+        payload["delegation_policy"] = inline_coding_policy_payload()
     if selection.selected_executor_profile == "codex" and delegation.action == "delegate":
         payload["executor_handoff"] = _executor_handoff(executor_target, delegation, isolation_plan=isolation_plan)
         _attach_context_pack(payload["executor_handoff"], context_pack)
@@ -573,6 +581,31 @@ def coding_delegation_record_payload(
     if isinstance(payload.get("plan_artifact"), dict):
         record["plan_artifact"] = payload["plan_artifact"]
     return record
+
+
+def inline_coding_policy_payload() -> dict[str, object]:
+    """Return the delegation-mandatory policy block for coding-shaped requests."""
+    return {
+        "schema_version": DELEGATION_POLICY_SCHEMA_VERSION,
+        "inline_coding_prohibited": True,
+        "policy": INLINE_CODING_POLICY_STATEMENT,
+        "ask_user_shape": (
+            "Ask which coding agent should own the work — for example Claude Code or Codex — "
+            "before any implementation starts."
+        ),
+    }
+
+
+def _inline_coding_policy_applies(intent: str, action: str, choice_required: bool) -> bool:
+    # The prohibition is product-wide; the block rides every payload where a
+    # wrapper could otherwise read "Hermes keeps it" into coding-shaped work:
+    # clarify/fallback outcomes and unresolved-owner delegations, including
+    # retained workflows. Wrappers read it from the payload; retained-workflow
+    # chat cards keep their contractually executor-free copy and never render
+    # it into user-facing text.
+    if intent not in {"coding", "review"}:
+        return False
+    return action != "delegate" or choice_required
 
 
 def _intent_for(message: str, workflow: str, score: int) -> str:

--- a/src/coding/context_safety.py
+++ b/src/coding/context_safety.py
@@ -293,7 +293,7 @@ def coding_progress_policy_enforcement() -> dict[str, object]:
     return {
         "schema_version": CODING_PROGRESS_POLICY_ENFORCEMENT_SCHEMA_VERSION,
         "mechanism": "bounded_tail_plus_run_context_budget_ledger",
-        "bounded_surfaces": ["omh runtime show", "omh coding fanout show"],
+        "bounded_surfaces": ["omh runtime show", "omh coding fanout show", "omh coding fanout brief"],
         "default_history_limit": MAX_RUN_HISTORY_EVENTS,
         "run_context_budget_bytes": RUN_CONTEXT_BUDGET_BYTES,
         "degraded_output": "summary_only_with_artifact_pointers",

--- a/src/coding/executor_auth_signals.py
+++ b/src/coding/executor_auth_signals.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
 import json
 from pathlib import Path
 from typing import Final
@@ -43,7 +44,12 @@ def executor_auth_signals(home: Path | None = None) -> dict[str, object]:
 
 
 def auth_signal_for_profile(profile: str, home: Path | None = None) -> dict[str, object]:
-    """Return the auth-signal entry for one profile; non-CLI profiles are not_applicable."""
+    """Return the auth-signal entry for one profile; non-CLI profiles are not_applicable.
+
+    Probes only the requested profile's marker file — readiness calls this once
+    per dispatch unit, so probing both files here would multiply reads of the
+    potentially large `~/.claude.json` for no signal gain.
+    """
     normalized = str(profile or "").strip().casefold()
     if normalized not in AUTH_SIGNAL_PROFILES:
         return {
@@ -52,15 +58,26 @@ def auth_signal_for_profile(profile: str, home: Path | None = None) -> dict[str,
             "observed_at": utc_now(),
             "claim_boundary": EXECUTOR_AUTH_SIGNALS_CLAIM_BOUNDARY,
         }
-    signals = executor_auth_signals(home)
-    profiles = signals.get("profiles")
-    entry = dict(profiles[normalized]) if isinstance(profiles, dict) and normalized in profiles else {}
+    base = home if home is not None else Path.home()
+    if normalized == "codex":
+        entry = _marker_payload(_codex_marker(base), marker_kind="local_auth_file")
+    else:
+        entry = _marker_payload(_claude_marker(base), marker_kind="local_config_login_key")
     entry["claim_boundary"] = EXECUTOR_AUTH_SIGNALS_CLAIM_BOUNDARY
     return entry
 
 
+# Past this horizon a limit signal is advisory history, not current state: the
+# provider windows that produce limit-shaped failures reset within hours.
+LIMIT_SIGNAL_STALE_AFTER_SECONDS: Final[int] = 6 * 60 * 60
+
+
 def last_limit_signal_for_profile(paths: OmhPaths, profile: str) -> dict[str, object]:
-    """Return the last observed limit-shaped dispatch failure for one profile, if any."""
+    """Return the last observed limit-shaped dispatch failure for one profile, if any.
+
+    The entry gains `age_seconds` and `stale` computed at read time so a
+    consumer can never mistake an old observation for current provider state.
+    """
     state, error = read_json_object_result(paths.executor_limit_signals_path)
     if error or not isinstance(state, dict):
         return {}
@@ -70,7 +87,22 @@ def last_limit_signal_for_profile(paths: OmhPaths, profile: str) -> dict[str, ob
     entry = profiles.get(str(profile or "").strip().casefold())
     if not isinstance(entry, dict):
         return {}
-    return {str(key): value for key, value in entry.items()}
+    payload = {str(key): value for key, value in entry.items()}
+    age = _age_seconds(str(payload.get("last_limit_shaped_at", "") or ""))
+    if age is not None:
+        payload["age_seconds"] = age
+        payload["stale"] = age > LIMIT_SIGNAL_STALE_AFTER_SECONDS
+    return payload
+
+
+def _age_seconds(observed_at: str) -> int | None:
+    if not observed_at:
+        return None
+    try:
+        observed = datetime.fromisoformat(observed_at.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return max(0, int((datetime.now(timezone.utc) - observed).total_seconds()))
 
 
 def _claude_marker(home: Path) -> str:

--- a/src/coding/executor_auth_signals.py
+++ b/src/coding/executor_auth_signals.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Final
+
+from ..system.local_store import read_json_object_result, utc_now
+from ..system.paths import OmhPaths
+
+EXECUTOR_AUTH_SIGNALS_SCHEMA_VERSION: Final[str] = "executor_auth_signals/v1"
+
+EXECUTOR_AUTH_SIGNALS_CLAIM_BOUNDARY: Final[str] = (
+    "An auth signal is a local file-presence marker only. It is not subscription tier, quota, "
+    "entitlement, or login truth — the provider owns those — and no secret value is ever read "
+    "into omh state."
+)
+
+AUTH_MARKER_STATES: Final[tuple[str, ...]] = ("present", "absent", "unknown")
+
+# Marker sources are local config files the agent CLIs write after login.
+# Only presence/shape is observed; values are never copied. API-key or
+# environment-token installs legitimately show `absent` while working —
+# markers rank candidates, they never veto one.
+_CLAUDE_CONFIG_RELATIVE: Final[str] = ".claude.json"
+_CLAUDE_LOGIN_KEY: Final[str] = "oauthAccount"
+_CODEX_AUTH_RELATIVE: Final[str] = ".codex/auth.json"
+
+AUTH_SIGNAL_PROFILES: Final[tuple[str, ...]] = ("codex", "claude-code")
+
+
+def executor_auth_signals(home: Path | None = None) -> dict[str, object]:
+    """Return metadata-only login markers for the locally-installed agent CLIs."""
+    base = home if home is not None else Path.home()
+    return {
+        "schema_version": EXECUTOR_AUTH_SIGNALS_SCHEMA_VERSION,
+        "observed_at": utc_now(),
+        "profiles": {
+            "codex": _marker_payload(_codex_marker(base), marker_kind="local_auth_file"),
+            "claude-code": _marker_payload(_claude_marker(base), marker_kind="local_config_login_key"),
+        },
+        "claim_boundary": EXECUTOR_AUTH_SIGNALS_CLAIM_BOUNDARY,
+    }
+
+
+def auth_signal_for_profile(profile: str, home: Path | None = None) -> dict[str, object]:
+    """Return the auth-signal entry for one profile; non-CLI profiles are not_applicable."""
+    normalized = str(profile or "").strip().casefold()
+    if normalized not in AUTH_SIGNAL_PROFILES:
+        return {
+            "login_marker": "not_applicable",
+            "marker_kind": "",
+            "observed_at": utc_now(),
+            "claim_boundary": EXECUTOR_AUTH_SIGNALS_CLAIM_BOUNDARY,
+        }
+    signals = executor_auth_signals(home)
+    profiles = signals.get("profiles")
+    entry = dict(profiles[normalized]) if isinstance(profiles, dict) and normalized in profiles else {}
+    entry["claim_boundary"] = EXECUTOR_AUTH_SIGNALS_CLAIM_BOUNDARY
+    return entry
+
+
+def last_limit_signal_for_profile(paths: OmhPaths, profile: str) -> dict[str, object]:
+    """Return the last observed limit-shaped dispatch failure for one profile, if any."""
+    state, error = read_json_object_result(paths.executor_limit_signals_path)
+    if error or not isinstance(state, dict):
+        return {}
+    profiles = state.get("profiles")
+    if not isinstance(profiles, dict):
+        return {}
+    entry = profiles.get(str(profile or "").strip().casefold())
+    if not isinstance(entry, dict):
+        return {}
+    return {str(key): value for key, value in entry.items()}
+
+
+def _claude_marker(home: Path) -> str:
+    config_path = home / _CLAUDE_CONFIG_RELATIVE
+    try:
+        if not config_path.is_file():
+            return "absent"
+        parsed = json.loads(config_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return "unknown"
+    if not isinstance(parsed, dict):
+        return "unknown"
+    return "present" if _CLAUDE_LOGIN_KEY in parsed else "absent"
+
+
+def _codex_marker(home: Path) -> str:
+    auth_path = home / _CODEX_AUTH_RELATIVE
+    try:
+        if not auth_path.is_file():
+            return "absent"
+        return "present" if auth_path.stat().st_size > 0 else "absent"
+    except OSError:
+        return "unknown"
+
+
+def _marker_payload(marker: str, *, marker_kind: str) -> dict[str, object]:
+    return {
+        "login_marker": marker,
+        "marker_kind": marker_kind,
+        "observed_at": utc_now(),
+    }

--- a/src/coding/executor_readiness.py
+++ b/src/coding/executor_readiness.py
@@ -152,7 +152,7 @@ def probe_executor_readiness(
         result["cache_status"] = "cached"
         result["first_use_skipped"] = True
         result["claim_boundary"] = contract["claim_boundary"]
-        return result
+        return _with_advisory_signals(paths, normalized, result)
     if dry_run:
         result = dict(contract)
         result.update(
@@ -163,9 +163,23 @@ def probe_executor_readiness(
                 "state_error": state_error or "",
             }
         )
-        return result
+        return _with_advisory_signals(paths, normalized, result)
     result = _run_probe(contract)
     _write_state(paths, state, normalized, result)
+    return _with_advisory_signals(paths, normalized, result)
+
+
+def _with_advisory_signals(paths: OmhPaths, profile: str, result: dict[str, object]) -> dict[str, object]:
+    """Attach live advisory markers outside the observed_once cache.
+
+    Login and limit markers change whenever the user logs in/out or a dispatch
+    hits a provider limit, so they are recomputed on every call and never
+    persisted with the cached probe (which would freeze them at first use).
+    """
+    from .executor_auth_signals import auth_signal_for_profile, last_limit_signal_for_profile
+
+    result["auth_signal"] = auth_signal_for_profile(profile)
+    result["last_limit_signal"] = last_limit_signal_for_profile(paths, profile)
     return result
 
 
@@ -234,6 +248,41 @@ def _run_probe(contract: dict[str, object]) -> dict[str, object]:
     return result
 
 
+EXECUTOR_CHOICE_CONTEXT_PROFILES = ("codex", "claude-code")
+EXECUTOR_CHOICE_CONTEXT_CLAIM_BOUNDARY = (
+    "Choice context ranks locally-installed executor candidates from cached readiness and local "
+    "markers only. It is not provider quota, entitlement, or login truth, and it never removes a "
+    "candidate the user may still pick."
+)
+
+
+def executor_choice_context(paths: OmhPaths) -> dict[str, object]:
+    """Return per-candidate readiness/auth context for the choose-executor question.
+
+    Reads cached readiness state and cheap local markers only — no subprocess
+    runs — so wrapper cards can embed it as deterministic data.
+    """
+    from .executor_auth_signals import auth_signal_for_profile, last_limit_signal_for_profile
+
+    state, _ = _read_state(paths)
+    candidates: list[dict[str, object]] = []
+    for profile in EXECUTOR_CHOICE_CONTEXT_PROFILES:
+        cached = _cached_profile(state, profile) or {}
+        candidates.append(
+            {
+                "profile": profile,
+                "label": executor_label(profile),
+                "readiness_status": str(cached.get("status", "not_observed")),
+                "auth_signal": auth_signal_for_profile(profile),
+                "last_limit_signal": last_limit_signal_for_profile(paths, profile),
+            }
+        )
+    return {
+        "candidates": candidates,
+        "claim_boundary": EXECUTOR_CHOICE_CONTEXT_CLAIM_BOUNDARY,
+    }
+
+
 def _ready_action(profile: str) -> str:
     if profile == "codex":
         return "send_to_executor"
@@ -281,6 +330,10 @@ def _write_state(paths: OmhPaths, state: dict[str, Any], profile: str, result: d
     if not isinstance(profiles, dict):
         profiles = {}
     stored = dict(result)
+    # Advisory markers are recomputed per call; persisting them would freeze
+    # login/limit state at first probe (see _with_advisory_signals).
+    stored.pop("auth_signal", None)
+    stored.pop("last_limit_signal", None)
     stored["updated_at"] = utc_now()
     profiles[profile] = stored
     state.update(

--- a/src/coding/executor_readiness.py
+++ b/src/coding/executor_readiness.py
@@ -277,10 +277,25 @@ def executor_choice_context(paths: OmhPaths) -> dict[str, object]:
                 "last_limit_signal": last_limit_signal_for_profile(paths, profile),
             }
         )
+    # Advisory ranking, never a veto: logged-in first, then no fresh limit
+    # signal, then cached-ready, with the fixed profile order as tiebreak so
+    # equal candidates stay deterministic.
+    candidates.sort(key=_choice_context_rank)
     return {
         "candidates": candidates,
+        "ranked_by": ("login_marker", "fresh_limit_signal_absent", "readiness_status"),
         "claim_boundary": EXECUTOR_CHOICE_CONTEXT_CLAIM_BOUNDARY,
     }
+
+
+def _choice_context_rank(candidate: dict[str, object]) -> tuple[int, int, int, int]:
+    auth = candidate.get("auth_signal")
+    login = str(auth.get("login_marker", "")) if isinstance(auth, dict) else ""
+    limit = candidate.get("last_limit_signal")
+    fresh_limit = isinstance(limit, dict) and bool(limit) and not limit.get("stale", False)
+    ready = str(candidate.get("readiness_status", "")) == "ready"
+    original = EXECUTOR_CHOICE_CONTEXT_PROFILES.index(str(candidate.get("profile", "")))
+    return (0 if login == "present" else 1, 1 if fresh_limit else 0, 0 if ready else 1, original)
 
 
 def _ready_action(profile: str) -> str:

--- a/src/coding/fanout.py
+++ b/src/coding/fanout.py
@@ -13,6 +13,7 @@ from .fanout_contracts import (
     FanoutContractError,
     PREPARED_NOT_OBSERVED,
 )
+from .model_routing import model_route_for_unit
 
 _UNIT_ID_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}$")
 
@@ -172,6 +173,9 @@ def _normalized_unit(unit: Mapping[str, object], index: int) -> dict[str, object
         "owner": str(owner) if owner is not None and str(owner).strip() else None,
         "file_scope": sorted(set(file_scope)),
         "depends_on": sorted(set(depends_on)),
+        "model": str(unit.get("model", "") or "").strip(),
+        "reasoning_effort": str(unit.get("reasoning_effort", "") or "").strip(),
+        "role": str(unit.get("role", "") or "").strip(),
     }
 
 
@@ -187,6 +191,20 @@ def _sibling_scopes(units: Sequence[Mapping[str, object]], unit_id: str) -> list
 def _contract_unit(unit: Mapping[str, object], *, sibling_scopes: list[str], fanout_id: str) -> dict[str, object]:
     unit_id = str(unit["unit_id"])
     own_scope = set(str(path) for path in unit.get("file_scope", []))
+    executor_target = str(unit.get("owner")) if unit.get("owner") else "choose"
+    model_route = model_route_for_unit(unit, executor_target)
+    handoff: dict[str, object] = {
+        "schema_version": "fanout_unit_handoff/v1",
+        "executor_target": executor_target,
+        "dispatch_policy": "prepare_only",
+        "status": PREPARED_NOT_OBSERVED,
+        "claim_boundary": (
+            "This per-unit handoff is prepared guidance only; record observed evidence on a run named by "
+            "run_ref before any dispatch, verification, review, CI, or merge claim."
+        ),
+    }
+    if model_route is not None:
+        handoff["model_route"] = model_route
     return {
         "unit_id": unit_id,
         "title": str(unit.get("title") or unit_id),
@@ -198,16 +216,7 @@ def _contract_unit(unit: Mapping[str, object], *, sibling_scopes: list[str], fan
         "branch_suggestion": f"agent/{unit_id}",
         "depends_on": list(unit.get("depends_on", [])),
         "run_ref": f"{fanout_id}-{unit_id}",
-        "handoff": {
-            "schema_version": "fanout_unit_handoff/v1",
-            "executor_target": str(unit.get("owner")) if unit.get("owner") else "choose",
-            "dispatch_policy": "prepare_only",
-            "status": PREPARED_NOT_OBSERVED,
-            "claim_boundary": (
-                "This per-unit handoff is prepared guidance only; record observed evidence on a run named by "
-                "run_ref before any dispatch, verification, review, CI, or merge claim."
-            ),
-        },
+        "handoff": handoff,
         "integration_checks": [
             "unit tests covering the unit's file_scope pass",
             "no edits outside boundary.file_scope",

--- a/src/coding/fanout_artifacts.py
+++ b/src/coding/fanout_artifacts.py
@@ -25,6 +25,11 @@ def write_fanout_contract(paths: OmhPaths, contract: dict[str, object]) -> dict[
     return payload
 
 
+def fanout_dispatch_summary_path(paths: OmhPaths, fanout_id: str) -> Path:
+    """Validated dispatch-summary path for one fanout (id pattern + containment)."""
+    return _managed_fanout_dir(paths, _validated_fanout_id(fanout_id)) / "dispatch_summary.json"
+
+
 def read_fanout_contract(paths: OmhPaths, fanout_id: str) -> dict[str, object]:
     import json
 

--- a/src/coding/fanout_dispatch.py
+++ b/src/coding/fanout_dispatch.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 import subprocess
+import time
 from typing import Any, Callable, Mapping, Sequence
 
 from ..runtime.artifacts import append_journal_observation, create_run, show_run
+from ..system.local_store import atomic_write_json, locked_json_update, utc_now
 from ..system.paths import OmhPaths
 from .executor_readiness import probe_executor_readiness
 from .fanout_contracts import FANOUT_CLAIM_BOUNDARY
@@ -14,6 +16,25 @@ FANOUT_DISPATCH_SCHEMA_VERSION = "fanout_dispatch_summary/v1"
 DISPATCH_CLAIM_BOUNDARY = (
     "A dispatch summary records observed local subprocess activity only. It is not verification, review, CI, "
     "merge-readiness, or merge evidence, and omh never merges unit branches itself."
+)
+EXECUTOR_LIMIT_SIGNALS_SCHEMA_VERSION = "executor_limit_signals/v1"
+EXECUTOR_LIMIT_SIGNALS_CLAIM_BOUNDARY = (
+    "A limit signal records that one observed local dispatch failure matched a rate/usage-limit shape. "
+    "It is not provider quota truth, not an entitlement statement, and it expires as evidence the moment "
+    "the provider state changes."
+)
+
+# Deterministic limit-shape patterns, matched case-insensitively over the
+# in-memory stdout/stderr tails of a FAILED spawn only. Only the boolean and
+# the matched label are persisted — never the matched text itself.
+_LIMIT_SHAPED_PATTERNS: tuple[tuple[str, str], ...] = (
+    ("rate_limit", "rate limit"),
+    ("usage_limit", "usage limit"),
+    ("quota", "quota"),
+    ("http_429", "429"),
+    ("credit", "insufficient credit"),
+    ("credit", "out of credits"),
+    ("limit_reached", "limit reached"),
 )
 
 # Spawnability is a data property: profiles listed here have a local headless
@@ -34,6 +55,52 @@ DISPATCH_COMMAND_TEMPLATES: dict[str, tuple[str, ...]] = {
         "Bash(git add:*),Bash(git commit:*)",
     ),
 }
+
+# Model routing is prepared metadata on the unit handoff; these fragments turn
+# it into argv only at dispatch time. Codex takes options before the prompt
+# positional; claude accepts them anywhere, so they append after the pinned
+# base argv to keep the no-route argv byte-identical to the template.
+DISPATCH_MODEL_OPTION_TEMPLATES: dict[str, tuple[str, ...]] = {
+    "codex": ("--model", "{model}"),
+    "claude-code": ("--model", "{model}"),
+}
+DISPATCH_REASONING_OPTION_TEMPLATES: dict[str, tuple[str, ...]] = {
+    # `-c` values parse as TOML with a raw-string fallback, so a bare effort
+    # level is accepted verbatim (verified against `codex exec --help`).
+    "codex": ("--config", "model_reasoning_effort={effort}"),
+    "claude-code": ("--effort", "{effort}"),
+}
+_DISPATCH_OPTION_INSERT_INDEX: dict[str, int | None] = {"codex": 2, "claude-code": None}
+
+
+def build_dispatch_argv(
+    owner: str,
+    prompt: str,
+    model_route: Mapping[str, Any] | None = None,
+) -> list[str] | None:
+    """Return the spawn argv for one owner, or None when the owner has no template.
+
+    Without a model route the argv is byte-identical to the base template; a
+    routed model/effort inserts the per-owner option fragments only.
+    """
+    template = DISPATCH_COMMAND_TEMPLATES.get(owner)
+    if template is None:
+        return None
+    argv = [part.replace("{prompt}", prompt) for part in template]
+    route = model_route or {}
+    options: list[str] = []
+    model = str(route.get("selected_model", "") or "")
+    effort = str(route.get("selected_reasoning_effort", "") or "")
+    if model:
+        options.extend(part.replace("{model}", model) for part in DISPATCH_MODEL_OPTION_TEMPLATES.get(owner, ()))
+    if effort:
+        options.extend(part.replace("{effort}", effort) for part in DISPATCH_REASONING_OPTION_TEMPLATES.get(owner, ()))
+    if not options:
+        return argv
+    insert_at = _DISPATCH_OPTION_INSERT_INDEX.get(owner)
+    if insert_at is None:
+        return argv + options
+    return argv[:insert_at] + options + argv[insert_at:]
 
 
 def build_unit_prompt(unit: Mapping[str, Any], goal_text: str) -> str:
@@ -147,10 +214,11 @@ def dispatch_fanout(
                 pending.remove(unit_id)
 
     summary_units = [results[unit_id] for unit_id in order]
-    return {
+    summary = {
         "schema_version": FANOUT_DISPATCH_SCHEMA_VERSION,
         "fanout_id": contract.get("fanout_id", ""),
         "dry_run": dry_run,
+        "observed_at": utc_now(),
         "merge_order": order,
         "units": summary_units,
         "merge_ready_units": [entry["unit_id"] for entry in summary_units if entry.get("merge_ready")],
@@ -162,6 +230,12 @@ def dispatch_fanout(
         "base_sha": base_sha,
         "claim_boundary": f"{DISPATCH_CLAIM_BOUNDARY} {FANOUT_CLAIM_BOUNDARY}",
     }
+    fanout_id = str(contract.get("fanout_id", "") or "")
+    if not dry_run and fanout_id:
+        # Latest-wins metadata-only persistence so `omh coding fanout brief`
+        # can join observed telemetry without replaying the journal.
+        atomic_write_json(paths.fanout_dispatch_summary_path(fanout_id), summary, private=True)
+    return summary
 
 
 def _dispatch_unit(
@@ -178,9 +252,11 @@ def _dispatch_unit(
 ) -> dict[str, Any]:
     unit_id = str(unit["unit_id"])
     run_ref = str(unit.get("run_ref", unit_id))
-    owner = str(unit.get("handoff", {}).get("executor_target", "choose"))
-    template = DISPATCH_COMMAND_TEMPLATES.get(owner)
-    if template is None:
+    handoff = unit.get("handoff", {}) if isinstance(unit.get("handoff"), Mapping) else {}
+    owner = str(handoff.get("executor_target", "choose"))
+    model_route = handoff.get("model_route") if isinstance(handoff.get("model_route"), Mapping) else None
+    routed_model = str(model_route.get("selected_model", "") or "") if model_route else ""
+    if DISPATCH_COMMAND_TEMPLATES.get(owner) is None:
         return {
             "unit_id": unit_id,
             "run_ref": run_ref,
@@ -200,13 +276,14 @@ def _dispatch_unit(
             "merge_ready": False,
         }
     prompt = build_unit_prompt(unit, goal_text)
-    argv = [part.replace("{prompt}", prompt) for part in template]
+    argv = build_dispatch_argv(owner, prompt, model_route)
     worktree = _worktree_path(repo_root, unit_id)
     if dry_run:
         return {
             "unit_id": unit_id,
             "run_ref": run_ref,
             "owner": owner,
+            "model": routed_model,
             "status": "dry_run_planned",
             "planned_argv": [part if part != prompt else "<unit prompt>" for part in argv],
             "worktree_path": str(worktree),
@@ -246,17 +323,29 @@ def _dispatch_unit(
             "worktree_ref": str(worktree),
         },
     )
+    started_at = utc_now()
+    started_clock = time.monotonic()
+    stderr_tail = ""
     try:
         completed = runner(argv, cwd=str(worktree), text=True, capture_output=True, timeout=timeout)
         exit_code = int(getattr(completed, "returncode", 1))
         output_tail = str(getattr(completed, "stdout", "") or "")[-2000:]
+        stderr_tail = str(getattr(completed, "stderr", "") or "")[-2000:]
     except FileNotFoundError:
         exit_code, output_tail = 127, f"{argv[0]} not found on PATH"
     except subprocess.TimeoutExpired:
         exit_code, output_tail = 124, f"unit timed out after {timeout}s"
     except OSError as exc:
         exit_code, output_tail = 1, f"spawn failed: {exc}"
+    finished_at = utc_now()
+    duration_seconds = round(time.monotonic() - started_clock, 3)
+    limit_label = _limit_shaped_label(output_tail, stderr_tail) if exit_code != 0 else ""
+    if limit_label:
+        _record_limit_signal(paths, owner, run_ref=run_ref, unit_id=unit_id, pattern_label=limit_label)
     status = "observed" if exit_code == 0 else "failed"
+    summary = f"unit {unit_id} exit {exit_code} after {duration_seconds}s: {output_tail[-300:]}"
+    if limit_label:
+        summary = f"limit-shaped failure ({limit_label}); {summary}"
     append_journal_observation(
         paths,
         {
@@ -265,20 +354,28 @@ def _dispatch_unit(
             "run_id": run_ref,
             "event": "worker_result",
             "status": status,
-            "summary": f"unit {unit_id} exit {exit_code}: {output_tail[-300:]}",
+            "summary": summary,
             "worker_ref": unit_id,
             "worktree_ref": str(worktree),
         },
     )
-    return {
+    result = {
         "unit_id": unit_id,
         "run_ref": run_ref,
         "owner": owner,
+        "model": routed_model,
         "status": "completed" if exit_code == 0 else "failed",
         "exit_code": exit_code,
         "worktree_path": str(worktree),
         "merge_ready": exit_code == 0,
+        "started_at": started_at,
+        "finished_at": finished_at,
+        "duration_seconds": duration_seconds,
     }
+    if limit_label:
+        result["limit_shaped"] = True
+        result["limit_pattern"] = limit_label
+    return result
 
 
 def _ensure_unit_run(paths: OmhPaths, unit: Mapping[str, Any], owner: str) -> None:
@@ -365,3 +462,27 @@ def _skipped(unit: Mapping[str, Any], status: str, *, merge_ready: bool = False)
 
 def _worktree_path(repo_root: Path, unit_id: str) -> Path:
     return repo_root.parent / f"{repo_root.name}-fanout-{unit_id}"
+
+
+def _limit_shaped_label(output_tail: str, stderr_tail: str) -> str:
+    haystack = f"{output_tail}\n{stderr_tail}".casefold()
+    for label, pattern in _LIMIT_SHAPED_PATTERNS:
+        if pattern in haystack:
+            return label
+    return ""
+
+
+def _record_limit_signal(paths: OmhPaths, owner: str, *, run_ref: str, unit_id: str, pattern_label: str) -> None:
+    def _update(state: dict[str, Any]) -> dict[str, Any]:
+        state["schema_version"] = EXECUTOR_LIMIT_SIGNALS_SCHEMA_VERSION
+        profiles = state.setdefault("profiles", {})
+        profiles[owner] = {
+            "last_limit_shaped_at": utc_now(),
+            "run_ref": run_ref,
+            "unit_id": unit_id,
+            "pattern_label": pattern_label,
+        }
+        state["claim_boundary"] = EXECUTOR_LIMIT_SIGNALS_CLAIM_BOUNDARY
+        return state
+
+    locked_json_update(paths.executor_limit_signals_path, _update, private=True)

--- a/src/coding/fanout_dispatch.py
+++ b/src/coding/fanout_dispatch.py
@@ -8,6 +8,7 @@ from typing import Any, Callable, Mapping, Sequence
 
 from ..runtime.artifacts import append_journal_observation, create_run, show_run
 from ..system.local_store import atomic_write_json, locked_json_update, utc_now
+from ..system.metadata_safety import redact_metadata_text
 from ..system.paths import OmhPaths
 from .executor_readiness import probe_executor_readiness
 from .fanout_contracts import FANOUT_CLAIM_BOUNDARY
@@ -26,12 +27,20 @@ EXECUTOR_LIMIT_SIGNALS_CLAIM_BOUNDARY = (
 
 # Deterministic limit-shape patterns, matched case-insensitively over the
 # in-memory stdout/stderr tails of a FAILED spawn only. Only the boolean and
-# the matched label are persisted — never the matched text itself.
+# the matched label are persisted — never the matched text itself. Every
+# pattern is anchored to limit context: bare "429" or "quota" would match a
+# stack-trace line number or a disk-quota message and fabricate provider
+# evidence from unrelated text.
 _LIMIT_SHAPED_PATTERNS: tuple[tuple[str, str], ...] = (
     ("rate_limit", "rate limit"),
     ("usage_limit", "usage limit"),
-    ("quota", "quota"),
-    ("http_429", "429"),
+    ("quota_exceeded", "quota exceed"),
+    ("quota_exceeded", "quota exhaust"),
+    ("quota_exceeded", "api quota"),
+    ("http_429", "status 429"),
+    ("http_429", "error 429"),
+    ("http_429", "http 429"),
+    ("http_429", "429 too many"),
     ("credit", "insufficient credit"),
     ("credit", "out of credits"),
     ("limit_reached", "limit reached"),
@@ -232,10 +241,51 @@ def dispatch_fanout(
     }
     fanout_id = str(contract.get("fanout_id", "") or "")
     if not dry_run and fanout_id:
-        # Latest-wins metadata-only persistence so `omh coding fanout brief`
-        # can join observed telemetry without replaying the journal.
-        atomic_write_json(paths.fanout_dispatch_summary_path(fanout_id), summary, private=True)
+        from .fanout_artifacts import fanout_dispatch_summary_path
+
+        # Metadata-only persistence so `omh coding fanout brief` can join
+        # observed telemetry without replaying the journal. The validated
+        # helper re-checks the id pattern and containment because this
+        # fanout_id comes from the contract body, not the CLI argument.
+        # Per-unit entries merge with the stored summary so a partial
+        # re-dispatch (`--unit b`) does not erase unit a's observed telemetry
+        # with a skipped placeholder.
+        summary_path = fanout_dispatch_summary_path(paths, fanout_id)
+        stored = _merged_dispatch_summary(summary_path, summary)
+        atomic_write_json(summary_path, stored, private=True)
     return summary
+
+
+_DISPATCH_SKIP_STATUSES = frozenset({"already_completed", "not_selected"})
+
+
+def _merged_dispatch_summary(summary_path: Path, summary: dict[str, Any]) -> dict[str, Any]:
+    from ..system.local_store import read_json_object_result
+
+    previous, _error = read_json_object_result(summary_path)
+    previous_units = {
+        str(entry.get("unit_id", "")): entry
+        for entry in (previous or {}).get("units", [])
+        if isinstance(entry, dict)
+    }
+    merged_units = []
+    for entry in summary.get("units", []):
+        if not isinstance(entry, dict):
+            continue
+        unit_id = str(entry.get("unit_id", ""))
+        earlier = previous_units.get(unit_id)
+        if entry.get("status") in _DISPATCH_SKIP_STATUSES and isinstance(earlier, dict):
+            # A skipped unit carries no telemetry; the earlier observed entry
+            # is the richer record and stays.
+            merged_units.append(earlier)
+        else:
+            merged_units.append(entry)
+    merged = dict(summary)
+    merged["units"] = merged_units
+    merged["merge_ready_units"] = [
+        str(entry.get("unit_id")) for entry in merged_units if isinstance(entry, dict) and entry.get("merge_ready")
+    ]
+    return merged
 
 
 def _dispatch_unit(
@@ -256,6 +306,7 @@ def _dispatch_unit(
     owner = str(handoff.get("executor_target", "choose"))
     model_route = handoff.get("model_route") if isinstance(handoff.get("model_route"), Mapping) else None
     routed_model = str(model_route.get("selected_model", "") or "") if model_route else ""
+    routed_effort = str(model_route.get("selected_reasoning_effort", "") or "") if model_route else ""
     if DISPATCH_COMMAND_TEMPLATES.get(owner) is None:
         return {
             "unit_id": unit_id,
@@ -342,8 +393,16 @@ def _dispatch_unit(
     limit_label = _limit_shaped_label(output_tail, stderr_tail) if exit_code != 0 else ""
     if limit_label:
         _record_limit_signal(paths, owner, run_ref=run_ref, unit_id=unit_id, pattern_label=limit_label)
+    elif exit_code == 0:
+        # A successful dispatch to this executor is the freshest evidence the
+        # provider is serving it again; a stale limit signal must not keep
+        # down-ranking the executor forever.
+        _clear_limit_signal(paths, owner)
     status = "observed" if exit_code == 0 else "failed"
-    summary = f"unit {unit_id} exit {exit_code} after {duration_seconds}s: {output_tail[-300:]}"
+    summary = (
+        f"unit {unit_id} exit {exit_code} after {duration_seconds}s: "
+        f"{redact_metadata_text(output_tail[-300:], limit=300)}"
+    )
     if limit_label:
         summary = f"limit-shaped failure ({limit_label}); {summary}"
     append_journal_observation(
@@ -364,6 +423,7 @@ def _dispatch_unit(
         "run_ref": run_ref,
         "owner": owner,
         "model": routed_model,
+        "reasoning_effort": routed_effort,
         "status": "completed" if exit_code == 0 else "failed",
         "exit_code": exit_code,
         "worktree_path": str(worktree),
@@ -485,4 +545,26 @@ def _record_limit_signal(paths: OmhPaths, owner: str, *, run_ref: str, unit_id: 
         state["claim_boundary"] = EXECUTOR_LIMIT_SIGNALS_CLAIM_BOUNDARY
         return state
 
-    locked_json_update(paths.executor_limit_signals_path, _update, private=True)
+    try:
+        locked_json_update(paths.executor_limit_signals_path, _update, private=True)
+    except (OSError, TimeoutError):
+        # An advisory that cannot be written must never abort the dispatch —
+        # losing the whole summary over a lock timeout would be worse than
+        # missing one ranking hint.
+        pass
+
+
+def _clear_limit_signal(paths: OmhPaths, owner: str) -> None:
+    if not paths.executor_limit_signals_path.exists():
+        return
+
+    def _update(state: dict[str, Any]) -> dict[str, Any]:
+        profiles = state.get("profiles")
+        if isinstance(profiles, dict):
+            profiles.pop(owner, None)
+        return state
+
+    try:
+        locked_json_update(paths.executor_limit_signals_path, _update, private=True)
+    except (OSError, TimeoutError):
+        pass

--- a/src/coding/model_routing.py
+++ b/src/coding/model_routing.py
@@ -55,7 +55,10 @@ EXECUTOR_MODEL_OPTIONS: Final[dict[str, tuple[dict[str, object], ...]]] = {
             "model_id": "gpt-5",
             "label": "General frontier model",
             "tier": "standard",
-            "recommended_roles": ("implementation", "docs"),
+            # `review` appears on both codex options on purpose: a review unit
+            # can be run frontier or standard, so the role resolves to an
+            # explicit choice rather than a silent default.
+            "recommended_roles": ("implementation", "docs", "review"),
             "reasoning_efforts": ("low", "medium", "high", "xhigh"),
         },
     ),
@@ -65,21 +68,21 @@ EXECUTOR_MODEL_OPTIONS: Final[dict[str, tuple[dict[str, object], ...]]] = {
             "label": "Claude frontier tier alias",
             "tier": "frontier",
             "recommended_roles": ("brain", "review", "design_visual"),
-            "reasoning_efforts": ("low", "medium", "high"),
+            "reasoning_efforts": ("low", "medium", "high", "xhigh", "max"),
         },
         {
             "model_id": "sonnet",
             "label": "Claude standard tier alias",
             "tier": "standard",
             "recommended_roles": ("implementation",),
-            "reasoning_efforts": ("low", "medium", "high"),
+            "reasoning_efforts": ("low", "medium", "high", "xhigh", "max"),
         },
         {
             "model_id": "haiku",
             "label": "Claude fast tier alias",
             "tier": "fast",
             "recommended_roles": ("docs",),
-            "reasoning_efforts": ("low", "medium", "high"),
+            "reasoning_efforts": ("low", "medium", "high", "xhigh", "max"),
         },
     ),
 }
@@ -137,7 +140,16 @@ def resolve_model_route(
     executor CLI default in place as a named outcome rather than a guess.
     """
     profile = str(executor_profile or "").strip().casefold()
-    normalized_role = _normalized_role(role)
+    raw_role = str(role or "").strip()
+    normalized_role = _normalized_role(raw_role)
+    role_reasons: list[str] = []
+    if raw_role and not normalized_role:
+        # A declared role that fails to normalize must be named, not erased:
+        # this reason lands in frozen contracts, so "no role was requested"
+        # would be a false statement about the request.
+        role_reasons.append(
+            f"Role {raw_role!r} is not a known role ({', '.join(MODEL_ROLES)}); it was ignored."
+        )
     model = str(requested_model or "").strip()
     effort = str(requested_effort or "").strip().casefold()
     options = EXECUTOR_MODEL_OPTIONS.get(profile, ())
@@ -149,8 +161,10 @@ def resolve_model_route(
             status="no_model_catalog",
             source="no_catalog",
             role=normalized_role,
+            selected_reasoning_effort=_selected_effort(profile, effort, normalized_role, ""),
             candidates=[],
-            reasons=[
+            reasons=role_reasons
+            + [
                 f"No built-in model catalog exists for `{profile or 'unknown'}`; the executor CLI default applies.",
             ],
         )
@@ -164,7 +178,7 @@ def resolve_model_route(
             selected_model=model,
             selected_reasoning_effort=_selected_effort(profile, effort, normalized_role, model),
             candidates=candidates,
-            reasons=[f"The request names `{model}` directly, so the catalog is advisory only."],
+            reasons=role_reasons + [f"The request names `{model}` directly, so the catalog is advisory only."],
         )
 
     if normalized_role:
@@ -179,22 +193,36 @@ def resolve_model_route(
                 selected_model=selected,
                 selected_reasoning_effort=_selected_effort(profile, effort, normalized_role, selected),
                 candidates=candidates,
-                reasons=[
+                reasons=role_reasons
+                + [
                     f"Role `{normalized_role}` has exactly one built-in candidate for `{profile}`.",
                 ],
+            )
+        if matched:
+            reason = (
+                f"Role `{normalized_role}` matches {len(matched)} candidates for `{profile}`; "
+                "the caller picks one or names a model."
+            )
+        else:
+            reason = (
+                f"Role `{normalized_role}` matches no built-in candidate for `{profile}`; "
+                f"pick one of the {len(candidates)} catalog options or name a model."
             )
         return _route_payload(
             profile,
             status="choice_required",
             source="role_catalog_candidates",
             role=normalized_role,
+            selected_reasoning_effort=_selected_effort(profile, effort, normalized_role, ""),
             candidates=matched or candidates,
-            reasons=[
-                f"Role `{normalized_role}` matches {len(matched) or len(candidates)} candidates for `{profile}`; "
-                "the caller picks one or names a model.",
-            ],
+            reasons=role_reasons + [reason],
         )
 
+    unrouted_reason = (
+        "No model or role was requested, so the executor CLI default model applies."
+        if not raw_role
+        else "No usable model or role remained, so the executor CLI default model applies."
+    )
     return _route_payload(
         profile,
         status="model_unrouted",
@@ -202,7 +230,7 @@ def resolve_model_route(
         role=normalized_role,
         selected_reasoning_effort=_selected_effort(profile, effort, normalized_role, ""),
         candidates=candidates,
-        reasons=["No model or role was requested, so the executor CLI default model applies."],
+        reasons=role_reasons + [unrouted_reason],
     )
 
 
@@ -240,11 +268,23 @@ def _supported_efforts(profile: str, model_id: str) -> tuple[str, ...]:
     return tuple(union)
 
 
+# Efforts are a closed vocabulary shape, unlike model ids: an effort value is
+# embedded into a codex `--config key=value` composite, so free text here would
+# lean on the third-party TOML parser for containment. Off-catalog efforts are
+# accepted only in this shape; anything else falls back to the CLI default.
+_EFFORT_SHAPE_CHARSET: Final[frozenset[str]] = frozenset("abcdefghijklmnopqrstuvwxyz0123456789-")
+
+
 def _selected_effort(profile: str, requested_effort: str, role: str, model_id: str) -> str:
     if requested_effort:
-        # Requested efforts pass through even off-catalog; the executor CLI is
-        # the authority on what it accepts, same rule as requested models.
-        return requested_effort
+        supported = _supported_efforts(profile, model_id)
+        if requested_effort in supported:
+            return requested_effort
+        if set(requested_effort) <= _EFFORT_SHAPE_CHARSET:
+            # Unknown-but-effort-shaped values still pass through so a newer
+            # CLI vocabulary is not blocked by a stale catalog.
+            return requested_effort
+        return ""
     if role in _HIGH_EFFORT_ROLES and _HIGH_EFFORT_DEFAULT in _supported_efforts(profile, model_id):
         return _HIGH_EFFORT_DEFAULT
     return ""

--- a/src/coding/model_routing.py
+++ b/src/coding/model_routing.py
@@ -1,0 +1,286 @@
+from __future__ import annotations
+
+from typing import Final, Mapping
+
+CODING_MODEL_ROUTE_SCHEMA_VERSION: Final[str] = "coding_model_route/v1"
+
+# Roles are the subagent shapes a fanout/handoff unit can declare. They name the
+# kind of work, never a vendor, so per-role defaults stay executor-neutral.
+MODEL_ROLES: Final[tuple[str, ...]] = (
+    "brain",
+    "implementation",
+    "design_visual",
+    "review",
+    "docs",
+)
+
+MODEL_ROUTE_STATUSES: Final[tuple[str, ...]] = (
+    "routed",
+    "choice_required",
+    "model_unrouted",
+    "no_model_catalog",
+)
+
+MODEL_ROUTE_SOURCES: Final[tuple[str, ...]] = (
+    "request_named_model",
+    "role_catalog_default",
+    "role_catalog_candidates",
+    "executor_default",
+    "no_catalog",
+)
+
+CODING_MODEL_ROUTE_CLAIM_BOUNDARY: Final[str] = (
+    "A model route is prepared metadata for a coding handoff or dispatch argv. Model availability, "
+    "entitlement, pricing, and quota are provider truth omh does not observe, and a routed model is "
+    "not execution, verification, review, CI, or merge evidence."
+)
+
+# Built-in default candidates per dispatchable/prompt-handoff executor profile.
+# Claude Code accepts stable tier aliases that track the newest model in each
+# tier; Codex takes vendor model ids. Both CLIs also accept ids this catalog
+# has never heard of, so requested models always pass through unvalidated —
+# the catalog is a default candidate list, not an allowlist.
+MODEL_CATALOG_KIND: Final[str] = "built_in_defaults"
+
+EXECUTOR_MODEL_OPTIONS: Final[dict[str, tuple[dict[str, object], ...]]] = {
+    "codex": (
+        {
+            "model_id": "gpt-5-codex",
+            "label": "Codex frontier coding model",
+            "tier": "frontier",
+            "recommended_roles": ("brain", "review", "design_visual"),
+            "reasoning_efforts": ("low", "medium", "high", "xhigh"),
+        },
+        {
+            "model_id": "gpt-5",
+            "label": "General frontier model",
+            "tier": "standard",
+            "recommended_roles": ("implementation", "docs"),
+            "reasoning_efforts": ("low", "medium", "high", "xhigh"),
+        },
+    ),
+    "claude-code": (
+        {
+            "model_id": "opus",
+            "label": "Claude frontier tier alias",
+            "tier": "frontier",
+            "recommended_roles": ("brain", "review", "design_visual"),
+            "reasoning_efforts": ("low", "medium", "high"),
+        },
+        {
+            "model_id": "sonnet",
+            "label": "Claude standard tier alias",
+            "tier": "standard",
+            "recommended_roles": ("implementation",),
+            "reasoning_efforts": ("low", "medium", "high"),
+        },
+        {
+            "model_id": "haiku",
+            "label": "Claude fast tier alias",
+            "tier": "fast",
+            "recommended_roles": ("docs",),
+            "reasoning_efforts": ("low", "medium", "high"),
+        },
+    ),
+}
+
+# Model-family prefixes mirror the dynamic-workflow target classifier so both
+# surfaces name families the same way; bare Claude tier aliases fold into the
+# claude family because the claude CLI resolves them to concrete claude models.
+_MODEL_FAMILY_PREFIXES: Final[tuple[tuple[str, str], ...]] = (
+    ("gpt-", "gpt"),
+    ("glm-", "glm"),
+    ("claude-", "claude"),
+    ("openai-", "openai"),
+    ("anthropic-", "anthropic"),
+    ("gemini-", "gemini"),
+    ("qwen-", "qwen"),
+    ("kimi-", "kimi"),
+    ("mistral-", "mistral"),
+    ("llama-", "llama"),
+    ("deepseek-", "deepseek"),
+    ("codestral-", "codestral"),
+)
+_CLAUDE_TIER_ALIASES: Final[frozenset[str]] = frozenset({"opus", "sonnet", "haiku"})
+
+# Role-based reasoning-effort default: deep planning/architecture units get a
+# high-effort default when the profile supports efforts and no effort was
+# requested; every other role leaves the executor CLI default in place.
+_HIGH_EFFORT_ROLES: Final[frozenset[str]] = frozenset({"brain"})
+_HIGH_EFFORT_DEFAULT: Final[str] = "high"
+
+
+def model_family(model_id: str) -> str:
+    normalized = str(model_id or "").strip().casefold()
+    if not normalized:
+        return ""
+    if normalized in _CLAUDE_TIER_ALIASES:
+        return "claude"
+    for prefix, family in _MODEL_FAMILY_PREFIXES:
+        if normalized.startswith(prefix):
+            return family
+    return "unknown"
+
+
+def resolve_model_route(
+    executor_profile: str,
+    *,
+    requested_model: str = "",
+    requested_effort: str = "",
+    role: str = "",
+) -> dict[str, object]:
+    """Return the deterministic prepared model route for one executor profile.
+
+    Precedence: an explicitly requested model always wins (passthrough, never
+    rejected); otherwise a role with exactly one catalog candidate routes to
+    it; several candidates become an explicit choice; no data leaves the
+    executor CLI default in place as a named outcome rather than a guess.
+    """
+    profile = str(executor_profile or "").strip().casefold()
+    normalized_role = _normalized_role(role)
+    model = str(requested_model or "").strip()
+    effort = str(requested_effort or "").strip().casefold()
+    options = EXECUTOR_MODEL_OPTIONS.get(profile, ())
+    candidates = [dict(option) for option in options]
+
+    if not options and not model:
+        return _route_payload(
+            profile,
+            status="no_model_catalog",
+            source="no_catalog",
+            role=normalized_role,
+            candidates=[],
+            reasons=[
+                f"No built-in model catalog exists for `{profile or 'unknown'}`; the executor CLI default applies.",
+            ],
+        )
+
+    if model:
+        return _route_payload(
+            profile,
+            status="routed",
+            source="request_named_model",
+            role=normalized_role,
+            selected_model=model,
+            selected_reasoning_effort=_selected_effort(profile, effort, normalized_role, model),
+            candidates=candidates,
+            reasons=[f"The request names `{model}` directly, so the catalog is advisory only."],
+        )
+
+    if normalized_role:
+        matched = [option for option in candidates if normalized_role in tuple(option.get("recommended_roles", ()))]
+        if len(matched) == 1:
+            selected = str(matched[0]["model_id"])
+            return _route_payload(
+                profile,
+                status="routed",
+                source="role_catalog_default",
+                role=normalized_role,
+                selected_model=selected,
+                selected_reasoning_effort=_selected_effort(profile, effort, normalized_role, selected),
+                candidates=candidates,
+                reasons=[
+                    f"Role `{normalized_role}` has exactly one built-in candidate for `{profile}`.",
+                ],
+            )
+        return _route_payload(
+            profile,
+            status="choice_required",
+            source="role_catalog_candidates",
+            role=normalized_role,
+            candidates=matched or candidates,
+            reasons=[
+                f"Role `{normalized_role}` matches {len(matched) or len(candidates)} candidates for `{profile}`; "
+                "the caller picks one or names a model.",
+            ],
+        )
+
+    return _route_payload(
+        profile,
+        status="model_unrouted",
+        source="executor_default",
+        role=normalized_role,
+        selected_reasoning_effort=_selected_effort(profile, effort, normalized_role, ""),
+        candidates=candidates,
+        reasons=["No model or role was requested, so the executor CLI default model applies."],
+    )
+
+
+def model_route_for_unit(unit: Mapping[str, object], executor_target: str) -> dict[str, object] | None:
+    """Return the prepared model route for a fanout unit, or None when unrouted."""
+    model = str(unit.get("model", "") or "").strip()
+    effort = str(unit.get("reasoning_effort", "") or "").strip()
+    role = str(unit.get("role", "") or "").strip()
+    if not model and not effort and not role:
+        return None
+    return resolve_model_route(
+        executor_target,
+        requested_model=model,
+        requested_effort=effort,
+        role=role,
+    )
+
+
+def _normalized_role(role: str) -> str:
+    normalized = str(role or "").strip().casefold().replace("-", "_")
+    return normalized if normalized in MODEL_ROLES else ""
+
+
+def _supported_efforts(profile: str, model_id: str) -> tuple[str, ...]:
+    for option in EXECUTOR_MODEL_OPTIONS.get(profile, ()):
+        if str(option.get("model_id", "")).casefold() == str(model_id or "").casefold():
+            return tuple(str(value) for value in option.get("reasoning_efforts", ()))
+    # Unknown/passthrough models keep the profile-level union so a requested
+    # effort is never silently dropped for a model the catalog has not met.
+    union: list[str] = []
+    for option in EXECUTOR_MODEL_OPTIONS.get(profile, ()):
+        for value in option.get("reasoning_efforts", ()):
+            if str(value) not in union:
+                union.append(str(value))
+    return tuple(union)
+
+
+def _selected_effort(profile: str, requested_effort: str, role: str, model_id: str) -> str:
+    if requested_effort:
+        # Requested efforts pass through even off-catalog; the executor CLI is
+        # the authority on what it accepts, same rule as requested models.
+        return requested_effort
+    if role in _HIGH_EFFORT_ROLES and _HIGH_EFFORT_DEFAULT in _supported_efforts(profile, model_id):
+        return _HIGH_EFFORT_DEFAULT
+    return ""
+
+
+def _route_payload(
+    profile: str,
+    *,
+    status: str,
+    source: str,
+    role: str,
+    candidates: list[dict[str, object]],
+    reasons: list[str],
+    selected_model: str = "",
+    selected_reasoning_effort: str = "",
+) -> dict[str, object]:
+    return {
+        "schema_version": CODING_MODEL_ROUTE_SCHEMA_VERSION,
+        "executor_profile": profile,
+        "status": status,
+        "source": source,
+        "role": role,
+        "selected_model": selected_model,
+        "selected_reasoning_effort": selected_reasoning_effort,
+        "model_family": model_family(selected_model),
+        "candidates": [
+            {
+                "model_id": str(option.get("model_id", "")),
+                "label": str(option.get("label", "")),
+                "tier": str(option.get("tier", "")),
+                "recommended_roles": list(option.get("recommended_roles", ())),
+                "reasoning_efforts": list(option.get("reasoning_efforts", ())),
+            }
+            for option in candidates
+        ],
+        "catalog_kind": MODEL_CATALOG_KIND,
+        "reasons": list(reasons),
+        "claim_boundary": CODING_MODEL_ROUTE_CLAIM_BOUNDARY,
+    }

--- a/src/commands/coding.py
+++ b/src/commands/coding.py
@@ -103,6 +103,10 @@ def cmd_coding_delegate(args: argparse.Namespace) -> int:
         )
         if plan_artifact:
             _apply_plan_handoff_source(payload)
+        if payload.get("delegation_policy") or _payload_choice_required(payload):
+            from ..executor_readiness import executor_choice_context
+
+            payload["executor_choice_context"] = executor_choice_context(paths)
         runtime_skip_reason = ""
         if args.record:
             runtime_skip_reason = _coding_delegate_record_readiness_skip_reason(
@@ -575,6 +579,25 @@ def cmd_coding_quality_harness_show(args: argparse.Namespace) -> int:
     return 0
 
 
+def _payload_choice_required(payload: dict[str, object]) -> bool:
+    selection = payload.get("executor_selection")
+    return isinstance(selection, dict) and bool(selection.get("choice_required"))
+
+
+def cmd_coding_model_route(args: argparse.Namespace) -> int:
+    from ..coding.model_routing import resolve_model_route
+
+    _print_json(
+        resolve_model_route(
+            args.executor,
+            requested_model=args.model or "",
+            requested_effort=args.effort or "",
+            role=args.role or "",
+        )
+    )
+    return 0
+
+
 def cmd_coding_fanout_prepare(args: argparse.Namespace) -> int:
     from ..coding.fanout import build_fanout_contract, is_degenerate_single_unit, single_unit_redirect
     from ..coding.fanout_artifacts import write_fanout_contract
@@ -709,6 +732,125 @@ def cmd_coding_fanout_show(args: argparse.Namespace) -> int:
     _print_json(payload)
     _record_fanout_board_emission(paths, watched_runs, payload, fingerprint)
     return 0
+
+
+_FANOUT_BRIEF_SUMMARY_LIMIT = 200
+_FANOUT_BRIEF_CLAIM_BOUNDARY = (
+    "A fanout briefing joins the frozen contract with observed dispatch and journal metadata only. "
+    "It is not verification, review, CI, merge-readiness, or merge evidence; unknown fields stay "
+    "unknown rather than being inferred."
+)
+
+
+def cmd_coding_fanout_brief(args: argparse.Namespace) -> int:
+    from ..coding.fanout_artifacts import read_fanout_contract
+    from ..local_store import read_json_object_result
+    from ..runtime.artifacts import show_run
+
+    paths = _paths(args)
+    fanout_id = getattr(args, "fanout_id", None)
+    if not fanout_id:
+        _print_json(_fanout_brief_listing(paths))
+        return 0
+    try:
+        contract = read_fanout_contract(paths, fanout_id)
+    except (OSError, ValueError) as exc:
+        raise OmhError(f"fanout contract not found: {exc}") from exc
+    dispatch_summary, _ = read_json_object_result(paths.fanout_dispatch_summary_path(str(fanout_id)))
+    dispatched_units = {
+        str(entry.get("unit_id", "")): entry
+        for entry in (dispatch_summary or {}).get("units", [])
+        if isinstance(entry, dict)
+    }
+    units = []
+    watched_runs: list[str] = []
+    for unit in contract.get("units", []):
+        if not isinstance(unit, dict):
+            continue
+        unit_id = str(unit.get("unit_id", ""))
+        handoff = unit.get("handoff", {}) if isinstance(unit.get("handoff"), dict) else {}
+        model_route = handoff.get("model_route", {}) if isinstance(handoff.get("model_route"), dict) else {}
+        dispatched = dispatched_units.get(unit_id, {})
+        run_ref = str(unit.get("run_ref", ""))
+        latest_summary = ""
+        observed_status = "not_observed"
+        if run_ref and (paths.runtime_runs_dir / run_ref / "run.json").exists():
+            try:
+                shown = show_run(paths, run_ref, history_limit=1)
+            except (OSError, ValueError, KeyError):
+                shown = None
+            if isinstance(shown, dict):
+                watched_runs.append(run_ref)
+                events = [event for event in shown.get("journal_events", []) or [] if isinstance(event, dict)]
+                if events:
+                    latest_summary = str(events[-1].get("summary", ""))[:_FANOUT_BRIEF_SUMMARY_LIMIT]
+                    observed_status = str(events[-1].get("status", "not_observed"))
+                else:
+                    observed_status = "run_recorded_no_observations"
+        status = str(dispatched.get("status", "") or "") or str(unit.get("status", "prepared"))
+        units.append(
+            {
+                "unit_id": unit_id,
+                "owner": str(handoff.get("executor_target", "choose")),
+                "model": str(model_route.get("selected_model", "") or "") or "executor_default",
+                "session_ref": str(dispatched.get("session_ref", "") or "") or "unknown",
+                "status": status,
+                "observed_run_status": observed_status,
+                "elapsed_seconds": dispatched.get("duration_seconds", "unknown"),
+                "tokens_total": dispatched.get("tokens_total", "unknown"),
+                "limit_shaped": bool(dispatched.get("limit_shaped", False)),
+                "summary": latest_summary,
+            }
+        )
+    payload = {
+        "schema_version": "fanout_briefing/v1",
+        "fanout_id": contract.get("fanout_id"),
+        "merge_order": contract.get("merge_plan", {}).get("merge_order", []),
+        "dispatch_observed_at": (dispatch_summary or {}).get("observed_at", ""),
+        "units": units,
+        "generated_from": ["fanout_contract", "dispatch_summary", "run_journal"],
+        "claim_boundary": _FANOUT_BRIEF_CLAIM_BOUNDARY,
+    }
+    _print_json(payload)
+    _record_fanout_brief_emission(paths, watched_runs, payload)
+    return 0
+
+
+def _record_fanout_brief_emission(paths, watched_runs: list[str], payload: dict) -> None:
+    from ..runtime.context_budget import record_context_emission
+
+    if not watched_runs:
+        return
+    per_run = len(json.dumps(payload, sort_keys=True)) // len(watched_runs)
+    for run_ref in watched_runs:
+        record_context_emission(paths, run_ref, surface="fanout_brief", byte_count=per_run)
+
+
+def _fanout_brief_listing(paths) -> dict[str, object]:
+    from ..local_store import read_json_object_result
+
+    entries = []
+    contracts_dir = paths.fanout_contracts_dir
+    if contracts_dir.is_dir():
+        for child in sorted(contracts_dir.iterdir()):
+            contract_path = child / "fanout_contract.json"
+            if not contract_path.is_file():
+                continue
+            contract, _ = read_json_object_result(contract_path)
+            summary, _ = read_json_object_result(paths.fanout_dispatch_summary_path(child.name))
+            entries.append(
+                {
+                    "fanout_id": child.name,
+                    "unit_count": len((contract or {}).get("units", [])),
+                    "last_dispatch_observed_at": (summary or {}).get("observed_at", ""),
+                }
+            )
+    return {
+        "schema_version": "fanout_briefing_listing/v1",
+        "fanouts": entries,
+        "next_action": "run `omh coding fanout brief <fanout-id>` for one fanout's unit briefing",
+        "claim_boundary": _FANOUT_BRIEF_CLAIM_BOUNDARY,
+    }
 
 
 def _fanout_board_unchanged(paths, watched_runs: list[str], fingerprint: str) -> bool:
@@ -854,6 +996,23 @@ def _add_coding_commands(sub) -> None:
     fanout_dispatch.add_argument("--unit", action="append", default=None, help="Dispatch only these unit ids (repeatable).")
     fanout_dispatch.add_argument("--dry-run", action="store_true", help="Resolve readiness, argv, and worktree paths; spawn nothing.")
     fanout_dispatch.set_defaults(func=cmd_coding_fanout_dispatch)
+
+    fanout_brief = fanout_sub.add_parser(
+        "brief",
+        help="Join the frozen contract with observed dispatch/journal metadata into one per-unit briefing.",
+    )
+    fanout_brief.add_argument("fanout_id", nargs="?", default=None, help="Fanout id; omit to list known fanouts.")
+    fanout_brief.set_defaults(func=cmd_coding_fanout_brief)
+
+    model_route = coding_sub.add_parser(
+        "model-route",
+        help="Resolve the prepared model route for one executor profile (metadata only, never invocation).",
+    )
+    model_route.add_argument("--executor", required=True, help="Executor profile, for example codex or claude-code.")
+    model_route.add_argument("--model", default=None, help="Explicit model id; always passes through unvalidated.")
+    model_route.add_argument("--effort", default=None, help="Reasoning effort for profiles that support one.")
+    model_route.add_argument("--role", default=None, help="Subagent role: brain, implementation, design_visual, review, docs.")
+    model_route.set_defaults(func=cmd_coding_model_route)
 
     delegate = coding_sub.add_parser("delegate")
     delegate.add_argument("message", nargs="*", help="Coding task description to prepare for executor delegation.")

--- a/src/commands/coding.py
+++ b/src/commands/coding.py
@@ -38,7 +38,7 @@ from ..wrapper.lifecycle import (
     report_codex_delegation_lifecycle,
     start_codex_delegation_lifecycle,
 )
-from .common import _chat_input_and_metadata, _explicit_source_metadata, _paths, _print_json, _resolved_executor
+from .common import _chat_input_and_metadata, _explicit_source_metadata, _paths, _print_json, _resolved_executor, _wants_json
 from .dynamic_workflow import _add_dynamic_workflow_command, cmd_coding_dynamic_workflow
 
 
@@ -587,14 +587,28 @@ def _payload_choice_required(payload: dict[str, object]) -> bool:
 def cmd_coding_model_route(args: argparse.Namespace) -> int:
     from ..coding.model_routing import resolve_model_route
 
-    _print_json(
-        resolve_model_route(
-            args.executor,
-            requested_model=args.model or "",
-            requested_effort=args.effort or "",
-            role=args.role or "",
-        )
+    route = resolve_model_route(
+        args.executor,
+        requested_model=args.model or "",
+        requested_effort=args.effort or "",
+        role=args.role or "",
     )
+    if _wants_json(args):
+        _print_json(route)
+        return 0
+    selected = str(route.get("selected_model", "") or "")
+    effort = str(route.get("selected_reasoning_effort", "") or "")
+    selected_label = " ".join(part for part in (selected, effort) if part) or "executor default"
+    lines = [
+        f"Model route for {route['executor_profile']}: {selected_label} ({route['status']}, {route['source']})",
+    ]
+    for candidate in route.get("candidates", []):
+        roles = ", ".join(str(role) for role in candidate.get("recommended_roles", []))
+        lines.append(f"- candidate {candidate.get('model_id')} [{candidate.get('tier')}] roles: {roles or 'any'}")
+    for reason in route.get("reasons", []):
+        lines.append(f"note: {reason}")
+    lines.append(str(route.get("claim_boundary", "")))
+    print("\n".join(lines))
     return 0
 
 
@@ -743,20 +757,26 @@ _FANOUT_BRIEF_CLAIM_BOUNDARY = (
 
 
 def cmd_coding_fanout_brief(args: argparse.Namespace) -> int:
-    from ..coding.fanout_artifacts import read_fanout_contract
+    from ..coding.fanout_artifacts import fanout_dispatch_summary_path, read_fanout_contract
+    from ..coding.fanout_contracts import PREPARED_NOT_OBSERVED
     from ..local_store import read_json_object_result
     from ..runtime.artifacts import show_run
+    from ..system.metadata_safety import redact_metadata_text
 
     paths = _paths(args)
     fanout_id = getattr(args, "fanout_id", None)
     if not fanout_id:
-        _print_json(_fanout_brief_listing(paths))
+        listing = _fanout_brief_listing(paths)
+        if _wants_json(args):
+            _print_json(listing)
+        else:
+            print(_render_fanout_brief_listing_text(listing))
         return 0
     try:
         contract = read_fanout_contract(paths, fanout_id)
     except (OSError, ValueError) as exc:
         raise OmhError(f"fanout contract not found: {exc}") from exc
-    dispatch_summary, _ = read_json_object_result(paths.fanout_dispatch_summary_path(str(fanout_id)))
+    dispatch_summary, summary_error = read_json_object_result(fanout_dispatch_summary_path(paths, str(fanout_id)))
     dispatched_units = {
         str(entry.get("unit_id", "")): entry
         for entry in (dispatch_summary or {}).get("units", [])
@@ -764,9 +784,14 @@ def cmd_coding_fanout_brief(args: argparse.Namespace) -> int:
     }
     units = []
     watched_runs: list[str] = []
-    for unit in contract.get("units", []):
-        if not isinstance(unit, dict):
-            continue
+    merge_plan = contract.get("merge_plan", {}) if isinstance(contract.get("merge_plan"), dict) else {}
+    merge_order = [str(unit_id) for unit_id in merge_plan.get("merge_order", [])]
+    contract_units = [unit for unit in contract.get("units", []) if isinstance(unit, dict)]
+    # Brief follows the merge plan like the dispatch wavefront does; contract
+    # units missing from the plan (defensive only) keep their contract order.
+    order_index = {unit_id: index for index, unit_id in enumerate(merge_order)}
+    contract_units.sort(key=lambda unit: order_index.get(str(unit.get("unit_id", "")), len(order_index)))
+    for unit in contract_units:
         unit_id = str(unit.get("unit_id", ""))
         handoff = unit.get("handoff", {}) if isinstance(unit.get("handoff"), dict) else {}
         model_route = handoff.get("model_route", {}) if isinstance(handoff.get("model_route"), dict) else {}
@@ -783,16 +808,28 @@ def cmd_coding_fanout_brief(args: argparse.Namespace) -> int:
                 watched_runs.append(run_ref)
                 events = [event for event in shown.get("journal_events", []) or [] if isinstance(event, dict)]
                 if events:
-                    latest_summary = str(events[-1].get("summary", ""))[:_FANOUT_BRIEF_SUMMARY_LIMIT]
+                    # Journal summaries written before the write-site redaction
+                    # landed may still carry raw output; redact again at this
+                    # egress so the briefing never re-exports it.
+                    latest_summary = redact_metadata_text(
+                        str(events[-1].get("summary", "")), limit=_FANOUT_BRIEF_SUMMARY_LIMIT
+                    )
                     observed_status = str(events[-1].get("status", "not_observed"))
                 else:
                     observed_status = "run_recorded_no_observations"
-        status = str(dispatched.get("status", "") or "") or str(unit.get("status", "prepared"))
+        status = str(dispatched.get("status", "") or "") or PREPARED_NOT_OBSERVED
+        model_id = str(model_route.get("selected_model", "") or "")
+        effort = str(model_route.get("selected_reasoning_effort", "") or "")
+        # One human-readable label per subagent, e.g. "gpt-5-codex xhigh" —
+        # what a briefing renders next to the unit without joining two fields.
+        model_label = " ".join(part for part in (model_id, effort) if part) or "executor default"
         units.append(
             {
                 "unit_id": unit_id,
                 "owner": str(handoff.get("executor_target", "choose")),
-                "model": str(model_route.get("selected_model", "") or "") or "executor_default",
+                "model": model_id or "executor_default",
+                "reasoning_effort": effort,
+                "model_label": model_label,
                 "session_ref": str(dispatched.get("session_ref", "") or "") or "unknown",
                 "status": status,
                 "observed_run_status": observed_status,
@@ -805,15 +842,59 @@ def cmd_coding_fanout_brief(args: argparse.Namespace) -> int:
     payload = {
         "schema_version": "fanout_briefing/v1",
         "fanout_id": contract.get("fanout_id"),
-        "merge_order": contract.get("merge_plan", {}).get("merge_order", []),
+        "merge_order": merge_order,
         "dispatch_observed_at": (dispatch_summary or {}).get("observed_at", ""),
         "units": units,
         "generated_from": ["fanout_contract", "dispatch_summary", "run_journal"],
         "claim_boundary": _FANOUT_BRIEF_CLAIM_BOUNDARY,
     }
-    _print_json(payload)
+    if summary_error:
+        payload["summary_error"] = str(summary_error)
+    if _wants_json(args):
+        _print_json(payload)
+    else:
+        print(_render_fanout_brief_text(payload))
     _record_fanout_brief_emission(paths, watched_runs, payload)
     return 0
+
+
+def _render_fanout_brief_text(payload: dict) -> str:
+    lines = [f"Fanout {payload.get('fanout_id')} briefing:"]
+    for unit in payload.get("units", []):
+        elapsed = unit.get("elapsed_seconds", "unknown")
+        elapsed_text = f"{elapsed}s" if isinstance(elapsed, (int, float)) else "elapsed unknown"
+        tokens = unit.get("tokens_total", "unknown")
+        tokens_text = f"{tokens} tokens" if isinstance(tokens, (int, float)) else "tokens unknown"
+        parts = [
+            str(unit.get("unit_id", "")),
+            str(unit.get("owner", "")),
+            f"({unit.get('model_label', 'executor default')})",
+            str(unit.get("status", "")),
+            elapsed_text,
+            tokens_text,
+            f"session {unit.get('session_ref', 'unknown')}",
+        ]
+        line = "- " + " — ".join(parts)
+        summary = str(unit.get("summary", "") or "")
+        if summary:
+            line += f" — {summary}"
+        lines.append(line)
+    if payload.get("summary_error"):
+        lines.append(f"warning: dispatch summary unreadable ({payload['summary_error']})")
+    lines.append(str(payload.get("claim_boundary", "")))
+    return "\n".join(lines)
+
+
+def _render_fanout_brief_listing_text(listing: dict) -> str:
+    fanouts = listing.get("fanouts", [])
+    if not fanouts:
+        return "No fanout contracts recorded."
+    lines = ["Known fanouts:"]
+    for entry in fanouts:
+        observed = entry.get("last_dispatch_observed_at") or "never dispatched"
+        lines.append(f"- {entry.get('fanout_id')} — {entry.get('unit_count')} units — last dispatch: {observed}")
+    lines.append(str(listing.get("next_action", "")))
+    return "\n".join(lines)
 
 
 def _record_fanout_brief_emission(paths, watched_runs: list[str], payload: dict) -> None:
@@ -827,6 +908,7 @@ def _record_fanout_brief_emission(paths, watched_runs: list[str], payload: dict)
 
 
 def _fanout_brief_listing(paths) -> dict[str, object]:
+    from ..coding.fanout_artifacts import fanout_dispatch_summary_path
     from ..local_store import read_json_object_result
 
     entries = []
@@ -836,8 +918,14 @@ def _fanout_brief_listing(paths) -> dict[str, object]:
             contract_path = child / "fanout_contract.json"
             if not contract_path.is_file():
                 continue
+            try:
+                summary_path = fanout_dispatch_summary_path(paths, child.name)
+            except ValueError:
+                # A stray directory that does not match the fanout id pattern
+                # is not a managed contract; skip it rather than guessing.
+                continue
             contract, _ = read_json_object_result(contract_path)
-            summary, _ = read_json_object_result(paths.fanout_dispatch_summary_path(child.name))
+            summary, _ = read_json_object_result(summary_path)
             entries.append(
                 {
                     "fanout_id": child.name,
@@ -1002,6 +1090,7 @@ def _add_coding_commands(sub) -> None:
         help="Join the frozen contract with observed dispatch/journal metadata into one per-unit briefing.",
     )
     fanout_brief.add_argument("fanout_id", nargs="?", default=None, help="Fanout id; omit to list known fanouts.")
+    fanout_brief.add_argument("--json", action="store_true", help="Emit the machine payload instead of plain text.")
     fanout_brief.set_defaults(func=cmd_coding_fanout_brief)
 
     model_route = coding_sub.add_parser(
@@ -1012,6 +1101,7 @@ def _add_coding_commands(sub) -> None:
     model_route.add_argument("--model", default=None, help="Explicit model id; always passes through unvalidated.")
     model_route.add_argument("--effort", default=None, help="Reasoning effort for profiles that support one.")
     model_route.add_argument("--role", default=None, help="Subagent role: brain, implementation, design_visual, review, docs.")
+    model_route.add_argument("--json", action="store_true", help="Emit the machine payload instead of plain text.")
     model_route.set_defaults(func=cmd_coding_model_route)
 
     delegate = coding_sub.add_parser("delegate")

--- a/src/system/paths.py
+++ b/src/system/paths.py
@@ -180,6 +180,13 @@ class OmhPaths:
         return self.runtime_dir / "executor-readiness.json"
 
     @property
+    def executor_limit_signals_path(self) -> Path:
+        return self.runtime_dir / "executor-limit-signals.json"
+
+    def fanout_dispatch_summary_path(self, fanout_id: str) -> Path:
+        return self.fanout_contracts_dir / fanout_id / "dispatch_summary.json"
+
+    @property
     def dynamic_coding_workflows_dir(self) -> Path:
         return self.omh_home / "coding" / "dynamic-workflows"
 

--- a/src/system/paths.py
+++ b/src/system/paths.py
@@ -183,9 +183,6 @@ class OmhPaths:
     def executor_limit_signals_path(self) -> Path:
         return self.runtime_dir / "executor-limit-signals.json"
 
-    def fanout_dispatch_summary_path(self, fanout_id: str) -> Path:
-        return self.fanout_contracts_dir / fanout_id / "dispatch_summary.json"
-
     @property
     def dynamic_coding_workflows_dir(self) -> Path:
         return self.omh_home / "coding" / "dynamic-workflows"

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -5478,10 +5478,12 @@ def build_chat_response_from_delegation(delegation_payload: dict[str, object], *
                 "prepared_handoff_boundary": "Coding-agent choice is not dispatch or implementation evidence.",
                 "executor_readiness": delegation_payload.get("executor_readiness", {}),
                 "executor_resolution": executor_resolution,
+                **_delegation_policy_state(delegation_payload),
             },
         )
     if action == "clarify":
         workflow = str(delegation.get("recommended_workflow", ""))
+        policy_state = _delegation_policy_state(delegation_payload)
         if workflow in _RETAINED_DELEGATION_SKILLS:
             return _chat_response(
                 kind="clarification",
@@ -5507,7 +5509,11 @@ def build_chat_response_from_delegation(delegation_payload: dict[str, object], *
             thread_key=thread_key,
             actions=[_action("answer:clarify", "Answer clarification", "primary"), _action("cancel", "Cancel", "secondary")],
             claim_boundary="No executor handoff is dispatchable.",
-            extra_state={"delegation_action": action, "intent": delegation.get("intent", "unknown")},
+            extra_state={
+                "delegation_action": action,
+                "intent": delegation.get("intent", "unknown"),
+                **policy_state,
+            },
         )
     return _chat_response(
         kind="clarification",
@@ -5520,6 +5526,14 @@ def build_chat_response_from_delegation(delegation_payload: dict[str, object], *
         claim_boundary="No executor handoff is dispatchable.",
         extra_state={"delegation_action": action, "intent": delegation.get("intent", "unknown")},
     )
+
+
+def _delegation_policy_state(delegation_payload: dict[str, Any]) -> dict[str, object]:
+    """Pass the delegation-mandatory policy block through to card state when present."""
+    policy = delegation_payload.get("delegation_policy")
+    if not isinstance(policy, dict) or not policy.get("inline_coding_prohibited"):
+        return {}
+    return {"delegation_policy": dict(policy)}
 
 
 def build_chat_response_from_status(status_payload: dict[str, Any], *, thread_key: str = "") -> dict[str, object]:

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -3582,6 +3582,7 @@ def _build_chat_interaction_payload_uncached(
         delegation["executor_resolution"] = executor_resolution
         coding_route_decision = _coding_route_decision_for_delegation(message, executor_resolution)
         delegation["coding_route_decision"] = coding_route_decision
+        _attach_executor_choice_context(delegation, paths)
         base["delegation"] = delegation
         base["executor_resolution"] = executor_resolution
         base["coding_route_decision"] = coding_route_decision
@@ -3754,6 +3755,7 @@ def _attach_coding_owner_handoff(
     }
     coding_route_decision = _coding_route_decision_for_delegation(message, executor_resolution)
     delegation["coding_route_decision"] = coding_route_decision
+    _attach_executor_choice_context(delegation, paths)
     agentic_playbook = delegation.get("agentic_playbook")
     if isinstance(agentic_playbook, dict):
         base["agentic_playbook"] = agentic_playbook
@@ -3763,6 +3765,22 @@ def _attach_coding_owner_handoff(
     base["next_action"] = _delegation_next_action(delegation)
     base["chat_response"] = build_chat_response_from_delegation(delegation, thread_key=str(base["thread_key"]))
     return base
+
+
+def _attach_executor_choice_context(delegation: dict[str, object], paths: OmhPaths | None) -> None:
+    """Attach cached per-candidate readiness/auth/limit context where a choice is live.
+
+    Only cached readiness state and cheap local markers are read — no
+    subprocess runs — so the chat lane stays as deterministic as the CLI lane
+    that already attaches the same block.
+    """
+    if paths is None:
+        return
+    if not (delegation.get("delegation_policy") or _nested(delegation, "executor_selection").get("choice_required")):
+        return
+    from ..coding.executor_readiness import executor_choice_context
+
+    delegation["executor_choice_context"] = executor_choice_context(paths)
 
 
 def _coding_route_decision_for_delegation(
@@ -4790,6 +4808,13 @@ def build_chat_response_from_route(
                     "blockers": status_card.get("blockers", []),
                     "throughput_levers": card.get("throughput_levers", []),
                     "evidence_not_observed": card.get("not_evidence_until_observed", []),
+                    # The card itself is projection-only; these are the live
+                    # observed-evidence surfaces a briefing should be read
+                    # from before narrating in-flight subagent work.
+                    "live_status_sources": [
+                        "omh coding fanout brief",
+                        "omh runtime progress-status",
+                    ],
                 },
             )
         if selected == "workflow-learning":
@@ -5453,10 +5478,25 @@ def build_chat_response_from_delegation(delegation_payload: dict[str, object], *
             },
         )
     if action == "delegate" and _nested(delegation_payload, "executor_selection").get("choice_required"):
+        policy_state = _delegation_policy_state(delegation_payload)
+        body = (
+            "Keep this in Hermes, hand it to Claude Code, hand it to Codex or an oh-my runtime path, "
+            "or split it across several agents in parallel before this becomes a prepared coding handoff."
+        )
+        if policy_state:
+            # Coding-shaped work never opens with "keep this in Hermes": the
+            # choice is which coding agent owns it, not whether to delegate.
+            # Hermes is still named first — as orchestrator, not owner — so the
+            # card stays executor-neutral with no vendor presented as default.
+            body = (
+                "Hermes keeps orchestration and status only — choose the coding agent that owns this "
+                "work: Claude Code, Codex, an oh-my runtime path, or split it across several agents "
+                "in parallel. Main coding stays delegated."
+            )
         return _chat_response(
             kind="handoff",
             headline="Choose the coding agent.",
-            body="Keep this in Hermes, hand it to Claude Code, hand it to Codex or an oh-my runtime path, or split it across several agents in parallel before this becomes a prepared coding handoff.",
+            body=body,
             phase="executor_choice_required",
             next_action="choose_executor",
             thread_key=thread_key,
@@ -5477,8 +5517,9 @@ def build_chat_response_from_delegation(delegation_payload: dict[str, object], *
                 "executor_options": _nested(delegation_payload, "executor_selection").get("options", []),
                 "prepared_handoff_boundary": "Coding-agent choice is not dispatch or implementation evidence.",
                 "executor_readiness": delegation_payload.get("executor_readiness", {}),
+                "executor_choice_context": delegation_payload.get("executor_choice_context", {}),
                 "executor_resolution": executor_resolution,
-                **_delegation_policy_state(delegation_payload),
+                **policy_state,
             },
         )
     if action == "clarify":
@@ -5524,7 +5565,11 @@ def build_chat_response_from_delegation(delegation_payload: dict[str, object], *
         thread_key=thread_key,
         actions=[_action("answer:clarify", "Answer clarification", "primary"), _action("cancel", "Cancel", "secondary")],
         claim_boundary="No executor handoff is dispatchable.",
-        extra_state={"delegation_action": action, "intent": delegation.get("intent", "unknown")},
+        extra_state={
+            "delegation_action": action,
+            "intent": delegation.get("intent", "unknown"),
+            **_delegation_policy_state(delegation_payload),
+        },
     )
 
 

--- a/tests/test_delegation_mandatory_policy.py
+++ b/tests/test_delegation_mandatory_policy.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import json
+import unittest
+
+from _local_package import load_local_package
+
+load_local_package()
+
+from omh.coding.coding_delegation import (  # noqa: E402
+    DELEGATION_POLICY_SCHEMA_VERSION,
+    build_coding_delegation_payload,
+)
+from omh.coding.executors import executor_selection_for_target  # noqa: E402
+from omh.routing.coding_route_actions import resolve_coding_route_decision  # noqa: E402
+from omh.skills.catalog import retained_delegation_skill_names  # noqa: E402
+from omh.wrapper.contract import build_chat_response_from_delegation  # noqa: E402
+
+_RETAINED = set(retained_delegation_skill_names())
+
+# Coding-shaped requests that historically could fall into clarify/fallback
+# (low score, no file reference, retained top workflow) — the exact paths where
+# "Hermes keeps it" must never read as "Hermes codes it".
+_CODING_SHAPED_MESSAGES = (
+    "fix the bug",
+    "implement the new login feature in src/auth/login.py with tests",
+    "refactor this code",
+    "리팩토링 해줘",
+    "write code for the parser and fix the failing tests",
+)
+
+_NON_CODING_MESSAGES = (
+    "what skills do you have",
+    "research the best database for this workload",
+)
+
+
+class InlineCodingProhibitionTests(unittest.TestCase):
+    def test_coding_shaped_messages_never_present_hermes_as_coding_owner(self) -> None:
+        exercised_policy = False
+        for message in _CODING_SHAPED_MESSAGES:
+            with self.subTest(message=message):
+                payload = build_coding_delegation_payload(message)
+                delegation = payload["delegation"]
+                intent = str(delegation["intent"])
+                action = str(delegation["action"])
+                if intent not in {"coding", "review"}:
+                    continue
+                if action != "delegate" or payload["executor_selection"]["choice_required"]:
+                    policy = payload.get("delegation_policy")
+                    self.assertIsInstance(policy, dict, f"{message!r} lacks the delegation policy block")
+                    self.assertTrue(policy["inline_coding_prohibited"])
+                    self.assertEqual(policy["schema_version"], DELEGATION_POLICY_SCHEMA_VERSION)
+                    self.assertIn("never implements main coding work inline", policy["policy"])
+                    exercised_policy = True
+                if action == "delegate" and not payload["executor_selection"]["choice_required"]:
+                    self.assertNotEqual(payload["work_owner_mode"], "retained_hermes")
+        self.assertTrue(exercised_policy, "no coding-shaped message exercised the policy block")
+
+    def test_non_coding_messages_do_not_carry_the_policy_block(self) -> None:
+        for message in _NON_CODING_MESSAGES:
+            with self.subTest(message=message):
+                payload = build_coding_delegation_payload(message)
+                if str(payload["delegation"]["intent"]) in {"coding", "review"}:
+                    continue
+                self.assertNotIn("delegation_policy", payload)
+
+    def test_retained_hermes_selection_is_never_dispatchable_and_never_delegate(self) -> None:
+        selection = executor_selection_for_target("codex", action="clarify")
+        self.assertEqual(selection.work_owner_mode, "retained_hermes")
+        self.assertFalse(selection.dispatchable)
+        for target in ("codex", "claude-code", "hermes", "generic", "choose"):
+            with self.subTest(target=target):
+                delegate_selection = executor_selection_for_target(target, action="delegate")
+                self.assertNotEqual(delegate_selection.work_owner_mode, "retained_hermes")
+
+    def test_unresolved_owner_with_no_setup_requires_user_choice(self) -> None:
+        decision = resolve_coding_route_decision("fix the login bug please")
+        self.assertTrue(decision.choice_required)
+        self.assertEqual(decision.next_action, "choose_executor")
+        self.assertEqual(decision.selected_owner, "")
+
+    def test_hermes_is_never_auto_selected_without_explicit_naming(self) -> None:
+        for query in ("fix the login bug", "refactor the parser", "write tests for src/x.py"):
+            with self.subTest(query=query):
+                decision = resolve_coding_route_decision(query)
+                self.assertNotEqual(decision.selected_owner, "hermes")
+
+
+class PolicyCardStateTests(unittest.TestCase):
+    def test_retained_workflow_clarify_card_omits_policy_while_payload_carries_it(self) -> None:
+        # "fix the bug" → coding intent, clarify, retained build-failure-triage:
+        # the payload must carry the prohibition for wrappers, while the
+        # retained chat card keeps its existing copy (its body never renders
+        # the policy text — retained cards own their own wording contract).
+        payload = build_coding_delegation_payload("fix the bug")
+        delegation = payload["delegation"]
+        self.assertEqual(str(delegation["action"]), "clarify")
+        self.assertIn(str(delegation["recommended_workflow"]), _RETAINED)
+        self.assertIn("delegation_policy", payload)
+        response = build_chat_response_from_delegation(payload)
+        self.assertNotIn("delegation_policy", response["state"])
+        self.assertNotIn("never implements main coding work inline", json.dumps(response))
+
+    def test_non_retained_clarify_card_carries_the_policy_block(self) -> None:
+        payload = build_coding_delegation_payload("코드 고쳐줘")
+        delegation = payload["delegation"]
+        self.assertEqual(str(delegation["action"]), "clarify")
+        self.assertNotIn(str(delegation["recommended_workflow"]), _RETAINED)
+        self.assertIn("delegation_policy", payload)
+        response = build_chat_response_from_delegation(payload)
+        self.assertIn("delegation_policy", response["state"])
+        self.assertTrue(response["state"]["delegation_policy"]["inline_coding_prohibited"])
+
+    def test_choice_required_delegate_carries_the_policy_block(self) -> None:
+        payload = build_coding_delegation_payload(
+            "implement pagination in src/api/list.py and run the tests",
+            executor_target="choose",
+        )
+        delegation = payload["delegation"]
+        self.assertEqual(str(delegation["action"]), "delegate")
+        self.assertTrue(payload["executor_selection"]["choice_required"])
+        self.assertIn("delegation_policy", payload)
+        response = build_chat_response_from_delegation(payload)
+        self.assertIn("delegation_policy", response["state"])
+        self.assertTrue(response["state"]["delegation_policy"]["inline_coding_prohibited"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_delegation_mandatory_policy.py
+++ b/tests/test_delegation_mandatory_policy.py
@@ -19,14 +19,19 @@ from omh.wrapper.contract import build_chat_response_from_delegation  # noqa: E4
 _RETAINED = set(retained_delegation_skill_names())
 
 # Coding-shaped requests that historically could fall into clarify/fallback
-# (low score, no file reference, retained top workflow) — the exact paths where
-# "Hermes keeps it" must never read as "Hermes codes it".
+# (low score, no file reference, retained top workflow, score-0 fallbacks) —
+# the exact paths where "Hermes keeps it" must never read as "Hermes codes it".
 _CODING_SHAPED_MESSAGES = (
     "fix the bug",
     "implement the new login feature in src/auth/login.py with tests",
     "refactor this code",
     "리팩토링 해줘",
     "write code for the parser and fix the failing tests",
+    "코딩 해줘",
+    "깡으로 코딩해줘",
+    "패치 좀",
+    "write it",
+    "너가 직접 구현해",
 )
 
 _NON_CODING_MESSAGES = (
@@ -37,25 +42,36 @@ _NON_CODING_MESSAGES = (
 
 class InlineCodingProhibitionTests(unittest.TestCase):
     def test_coding_shaped_messages_never_present_hermes_as_coding_owner(self) -> None:
-        exercised_policy = False
+        # The invariant, asserted from the spec side rather than from the
+        # implementation's own gate: whenever a coding-shaped message resolves
+        # to retained_hermes (or an unresolved-owner delegate), the payload
+        # MUST carry the prohibition — including score-0 fallbacks like a bare
+        # "코딩 해줘", the exact shape the user banned.
         for message in _CODING_SHAPED_MESSAGES:
             with self.subTest(message=message):
                 payload = build_coding_delegation_payload(message)
                 delegation = payload["delegation"]
-                intent = str(delegation["intent"])
                 action = str(delegation["action"])
-                if intent not in {"coding", "review"}:
-                    continue
-                if action != "delegate" or payload["executor_selection"]["choice_required"]:
+                if payload["work_owner_mode"] == "retained_hermes" or (
+                    action == "delegate" and payload["executor_selection"]["choice_required"]
+                ):
                     policy = payload.get("delegation_policy")
                     self.assertIsInstance(policy, dict, f"{message!r} lacks the delegation policy block")
                     self.assertTrue(policy["inline_coding_prohibited"])
                     self.assertEqual(policy["schema_version"], DELEGATION_POLICY_SCHEMA_VERSION)
                     self.assertIn("never implements main coding work inline", policy["policy"])
-                    exercised_policy = True
                 if action == "delegate" and not payload["executor_selection"]["choice_required"]:
                     self.assertNotEqual(payload["work_owner_mode"], "retained_hermes")
-        self.assertTrue(exercised_policy, "no coding-shaped message exercised the policy block")
+
+    def test_score_zero_fallback_carries_policy_and_fallback_card_state(self) -> None:
+        payload = build_coding_delegation_payload("깡으로 코딩해줘")
+        delegation = payload["delegation"]
+        self.assertEqual(str(delegation["action"]), "fallback")
+        self.assertEqual(payload["work_owner_mode"], "retained_hermes")
+        self.assertIn("delegation_policy", payload)
+        response = build_chat_response_from_delegation(payload)
+        self.assertIn("delegation_policy", response["state"])
+        self.assertTrue(response["state"]["delegation_policy"]["inline_coding_prohibited"])
 
     def test_non_coding_messages_do_not_carry_the_policy_block(self) -> None:
         for message in _NON_CODING_MESSAGES:
@@ -112,7 +128,7 @@ class PolicyCardStateTests(unittest.TestCase):
         self.assertIn("delegation_policy", response["state"])
         self.assertTrue(response["state"]["delegation_policy"]["inline_coding_prohibited"])
 
-    def test_choice_required_delegate_carries_the_policy_block(self) -> None:
+    def test_choice_required_delegate_carries_policy_context_and_delegation_first_copy(self) -> None:
         payload = build_coding_delegation_payload(
             "implement pagination in src/api/list.py and run the tests",
             executor_target="choose",
@@ -121,9 +137,21 @@ class PolicyCardStateTests(unittest.TestCase):
         self.assertEqual(str(delegation["action"]), "delegate")
         self.assertTrue(payload["executor_selection"]["choice_required"])
         self.assertIn("delegation_policy", payload)
+        # The wrapper lane attaches this from cached readiness state; the card
+        # must pass it through untouched.
+        payload["executor_choice_context"] = {
+            "candidates": [{"profile": "codex", "readiness_status": "ready"}],
+            "claim_boundary": "test",
+        }
         response = build_chat_response_from_delegation(payload)
-        self.assertIn("delegation_policy", response["state"])
-        self.assertTrue(response["state"]["delegation_policy"]["inline_coding_prohibited"])
+        state = response["state"]
+        self.assertIn("delegation_policy", state)
+        self.assertTrue(state["delegation_policy"]["inline_coding_prohibited"])
+        self.assertEqual(state["executor_choice_context"]["candidates"][0]["profile"], "codex")
+        # Coding-shaped choice cards never lead with keeping the work in
+        # Hermes; delegation is the premise, the choice is only who owns it.
+        self.assertNotIn("Keep this in Hermes", str(response["body"]))
+        self.assertIn("stays delegated", str(response["body"]))
 
 
 if __name__ == "__main__":

--- a/tests/test_executor_auth_signals.py
+++ b/tests/test_executor_auth_signals.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+
+from _local_package import load_local_package
+
+load_local_package()
+
+from omh.coding.executor_auth_signals import (  # noqa: E402
+    EXECUTOR_AUTH_SIGNALS_SCHEMA_VERSION,
+    auth_signal_for_profile,
+    executor_auth_signals,
+    last_limit_signal_for_profile,
+)
+from omh.coding.executor_readiness import executor_choice_context, probe_executor_readiness  # noqa: E402
+from omh.system.local_store import atomic_write_json  # noqa: E402
+from omh.system.paths import OmhPaths  # noqa: E402
+
+
+class AuthSignalMarkerTests(unittest.TestCase):
+    def test_absent_markers_when_nothing_is_installed(self) -> None:
+        with TemporaryDirectory() as tmp:
+            signals = executor_auth_signals(home=Path(tmp))
+            self.assertEqual(signals["schema_version"], EXECUTOR_AUTH_SIGNALS_SCHEMA_VERSION)
+            self.assertEqual(signals["profiles"]["codex"]["login_marker"], "absent")
+            self.assertEqual(signals["profiles"]["claude-code"]["login_marker"], "absent")
+            self.assertIn("not subscription tier", signals["claim_boundary"])
+
+    def test_present_markers_read_shape_only(self) -> None:
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            (home / ".claude.json").write_text(json.dumps({"oauthAccount": {"x": 1}}), encoding="utf-8")
+            (home / ".codex").mkdir()
+            (home / ".codex" / "auth.json").write_text("{\"tokens\": \"sk-SECRET-VALUE-12345\"}", encoding="utf-8")
+            signals = executor_auth_signals(home=home)
+            self.assertEqual(signals["profiles"]["claude-code"]["login_marker"], "present")
+            self.assertEqual(signals["profiles"]["codex"]["login_marker"], "present")
+            # No credential value may appear anywhere in the payload.
+            self.assertNotIn("sk-SECRET-VALUE-12345", json.dumps(signals))
+
+    def test_unreadable_claude_config_is_unknown(self) -> None:
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            (home / ".claude.json").write_text("not json at all {", encoding="utf-8")
+            signals = executor_auth_signals(home=home)
+            self.assertEqual(signals["profiles"]["claude-code"]["login_marker"], "unknown")
+
+    def test_claude_config_without_login_key_is_absent(self) -> None:
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            (home / ".claude.json").write_text(json.dumps({"projects": {}}), encoding="utf-8")
+            signals = executor_auth_signals(home=home)
+            self.assertEqual(signals["profiles"]["claude-code"]["login_marker"], "absent")
+
+    def test_non_cli_profile_is_not_applicable(self) -> None:
+        entry = auth_signal_for_profile("hermes")
+        self.assertEqual(entry["login_marker"], "not_applicable")
+
+
+class LimitSignalReadTests(unittest.TestCase):
+    def test_missing_state_reads_as_empty(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+            self.assertEqual(last_limit_signal_for_profile(paths, "codex"), {})
+
+    def test_recorded_signal_round_trips(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+            atomic_write_json(
+                paths.executor_limit_signals_path,
+                {
+                    "schema_version": "executor_limit_signals/v1",
+                    "profiles": {"codex": {"last_limit_shaped_at": "2026-07-27T00:00:00Z", "pattern_label": "rate_limit"}},
+                },
+                private=True,
+            )
+            entry = last_limit_signal_for_profile(paths, "codex")
+            self.assertEqual(entry["pattern_label"], "rate_limit")
+
+
+class ReadinessAdvisoryFreshnessTests(unittest.TestCase):
+    def test_advisories_refresh_while_probe_stays_cached(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+            # Seed a cached observed_once probe result so no subprocess runs.
+            atomic_write_json(
+                paths.executor_readiness_path,
+                {
+                    "schema_version": "executor_readiness_cache/v1",
+                    "profiles": {
+                        "codex": {
+                            "schema_version": "executor_readiness/v1",
+                            "profile": "codex",
+                            "status": "ready",
+                            "observed_once": True,
+                        }
+                    },
+                },
+                private=True,
+            )
+            first = probe_executor_readiness(paths, "codex")
+            self.assertEqual(first["cache_status"], "cached")
+            self.assertIn("auth_signal", first)
+            self.assertEqual(first["last_limit_signal"], {})
+            # A limit signal lands later; the cached probe must surface it
+            # without --force.
+            atomic_write_json(
+                paths.executor_limit_signals_path,
+                {
+                    "schema_version": "executor_limit_signals/v1",
+                    "profiles": {"codex": {"pattern_label": "quota"}},
+                },
+                private=True,
+            )
+            second = probe_executor_readiness(paths, "codex")
+            self.assertEqual(second["cache_status"], "cached")
+            self.assertEqual(second["last_limit_signal"]["pattern_label"], "quota")
+
+    def test_advisories_are_not_persisted_into_the_cache(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+            probe_executor_readiness(paths, "omx-runtime", force=True)
+            stored = json.loads(paths.executor_readiness_path.read_text(encoding="utf-8"))
+            profile_entry = stored["profiles"]["omx-runtime"]
+            self.assertNotIn("auth_signal", profile_entry)
+            self.assertNotIn("last_limit_signal", profile_entry)
+
+
+class ExecutorChoiceContextTests(unittest.TestCase):
+    def test_choice_context_lists_both_cli_candidates_without_probing(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+            context = executor_choice_context(paths)
+            profiles = [entry["profile"] for entry in context["candidates"]]
+            self.assertEqual(profiles, ["codex", "claude-code"])
+            for entry in context["candidates"]:
+                self.assertEqual(entry["readiness_status"], "not_observed")
+                self.assertIn("auth_signal", entry)
+                self.assertIn("last_limit_signal", entry)
+            self.assertIn("never removes a candidate", context["claim_boundary"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_fanout_dispatch.py
+++ b/tests/test_fanout_dispatch.py
@@ -455,5 +455,173 @@ class FanoutDispatchCliTests(unittest.TestCase):
             self.assertIn("does not match the digest", stderr)
 
 
+class FanoutDispatchTelemetryTests(unittest.TestCase):
+    def _setup(self, tmp: str, units=None):
+        root = Path(tmp)
+        paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+        repo, sha = _make_repo(root)
+        contract = write_fanout_contract(paths, build_fanout_contract(_GOAL, units or _UNITS))
+        return paths, repo, sha, contract
+
+    def test_observed_units_record_timestamps_and_duration(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            summary = dispatch_fanout(
+                paths, contract, goal_text=_GOAL, repo_root=repo, base_sha=sha,
+                runner=_agent_runner(), readiness=_ready,
+            )
+            core = {entry["unit_id"]: entry for entry in summary["units"]}["core"]
+            self.assertTrue(str(core["started_at"]).endswith("Z"))
+            self.assertTrue(str(core["finished_at"]).endswith("Z"))
+            self.assertGreaterEqual(float(core["duration_seconds"]), 0.0)
+
+    def test_dispatch_summary_is_persisted_metadata_only(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            dispatch_fanout(
+                paths, contract, goal_text=_GOAL, repo_root=repo, base_sha=sha,
+                runner=_agent_runner(), readiness=_ready,
+            )
+            stored_path = paths.fanout_dispatch_summary_path(str(contract["fanout_id"]))
+            self.assertTrue(stored_path.is_file())
+            stored = json.loads(stored_path.read_text(encoding="utf-8"))
+            self.assertEqual(stored["schema_version"], "fanout_dispatch_summary/v1")
+            # Persisted state stays metadata-only: no raw agent output fields.
+            for entry in stored["units"]:
+                self.assertNotIn("stdout", entry)
+                self.assertNotIn("output_tail", entry)
+                self.assertNotIn("planned_argv", entry)
+
+    def test_dry_run_does_not_persist_a_summary(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            dispatch_fanout(
+                paths, contract, goal_text=_GOAL, repo_root=repo, base_sha=sha,
+                dry_run=True, runner=_agent_runner(), readiness=_ready,
+            )
+            self.assertFalse(paths.fanout_dispatch_summary_path(str(contract["fanout_id"])).exists())
+
+    def test_limit_shaped_failure_is_classified_and_recorded(self) -> None:
+        with TemporaryDirectory() as tmp:
+            units = [
+                {"unit_id": "core", "title": "Core", "owner": "codex", "file_scope": ["src/core/"]},
+            ]
+            other = [
+                {"unit_id": "docs", "title": "Docs", "owner": "claude-code", "file_scope": ["docs/"]},
+            ]
+            paths, repo, sha, contract = self._setup(tmp, units=units + other)
+
+            def runner(argv, **kwargs):
+                if argv[0] == "git":
+                    return subprocess.run(argv, **kwargs)
+                if argv[0] == "codex":
+                    return _FakeCompleted(1, "Error: You have hit your usage limit. Try again later.")
+                return _FakeCompleted(0, "done")
+
+            summary = dispatch_fanout(
+                paths, contract, goal_text=_GOAL, repo_root=repo, base_sha=sha,
+                runner=runner, readiness=_ready,
+            )
+            by_unit = {entry["unit_id"]: entry for entry in summary["units"]}
+            self.assertTrue(by_unit["core"]["limit_shaped"])
+            self.assertEqual(by_unit["core"]["limit_pattern"], "usage_limit")
+            self.assertNotIn("limit_shaped", by_unit["docs"])
+            stored = json.loads(paths.executor_limit_signals_path.read_text(encoding="utf-8"))
+            self.assertEqual(stored["profiles"]["codex"]["pattern_label"], "usage_limit")
+            self.assertNotIn("claude-code", stored["profiles"])
+            # Journal summary names the shape without dumping extra raw text.
+            shown = show_run(paths, by_unit["core"]["run_ref"])
+            result_events = [e for e in shown["journal_events"] if e["event"] == "executor_result_observed"]
+            self.assertIn("limit-shaped failure (usage_limit)", result_events[-1]["summary"])
+
+    def test_successful_exit_is_never_limit_shaped(self) -> None:
+        with TemporaryDirectory() as tmp:
+            units = [{"unit_id": "core", "title": "Core", "owner": "codex", "file_scope": ["src/core/"]}]
+            paths, repo, sha, contract = self._setup(tmp, units=units + [
+                {"unit_id": "docs", "title": "Docs", "owner": "claude-code", "file_scope": ["docs/"]},
+            ])
+
+            def runner(argv, **kwargs):
+                if argv[0] == "git":
+                    return subprocess.run(argv, **kwargs)
+                return _FakeCompleted(0, "quota discussion in output but exit 0")
+
+            summary = dispatch_fanout(
+                paths, contract, goal_text=_GOAL, repo_root=repo, base_sha=sha,
+                runner=runner, readiness=_ready,
+            )
+            for entry in summary["units"]:
+                self.assertNotIn("limit_shaped", entry)
+            self.assertFalse(paths.executor_limit_signals_path.exists())
+
+    def test_routed_model_reaches_spawn_argv(self) -> None:
+        with TemporaryDirectory() as tmp:
+            units = [
+                {"unit_id": "brain", "title": "Brain", "owner": "codex", "file_scope": ["src/a/"], "role": "brain"},
+                {"unit_id": "ui", "title": "UI", "owner": "claude-code", "file_scope": ["src/b/"], "model": "opus"},
+            ]
+            paths, repo, sha, contract = self._setup(tmp, units=units)
+            runner = _agent_runner()
+            summary = dispatch_fanout(
+                paths, contract, goal_text=_GOAL, repo_root=repo, base_sha=sha,
+                runner=runner, readiness=_ready,
+            )
+            spawned = {argv[0]: argv for argv in runner.spawned}
+            self.assertIn("--config", spawned["codex"])
+            self.assertIn("model_reasoning_effort=high", spawned["codex"])
+            self.assertIn("--model", spawned["claude"])
+            self.assertIn("opus", spawned["claude"])
+            by_unit = {entry["unit_id"]: entry for entry in summary["units"]}
+            self.assertEqual(by_unit["ui"]["model"], "opus")
+
+
+class FanoutBriefCliTests(unittest.TestCase):
+    def test_brief_joins_contract_journal_and_dispatch_summary(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+            repo, sha = _make_repo(root)
+            units = [
+                {"unit_id": "core", "title": "Core", "owner": "codex", "file_scope": ["src/core/"], "role": "brain"},
+                {"unit_id": "manual", "title": "Manual", "owner": "hermes", "file_scope": ["notes/"]},
+            ]
+            contract = write_fanout_contract(paths, build_fanout_contract(_GOAL, units))
+            dispatch_fanout(
+                paths, contract, goal_text=_GOAL, repo_root=repo, base_sha=sha,
+                runner=_agent_runner(), readiness=_ready,
+            )
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+            status, stdout, stderr = run_cli(base + ["coding", "fanout", "brief", str(contract["fanout_id"])])
+            self.assertEqual(status, 0, stderr)
+            brief = json.loads(stdout)
+            self.assertEqual(brief["schema_version"], "fanout_briefing/v1")
+            by_unit = {entry["unit_id"]: entry for entry in brief["units"]}
+            core = by_unit["core"]
+            self.assertEqual(core["owner"], "codex")
+            self.assertEqual(core["model"], "gpt-5-codex")
+            self.assertEqual(core["status"], "completed")
+            self.assertEqual(core["session_ref"], "unknown")
+            self.assertEqual(core["tokens_total"], "unknown")
+            self.assertGreaterEqual(float(core["elapsed_seconds"]), 0.0)
+            # A never-dispatched unit keeps its prepared-vs-observed shape.
+            manual = by_unit["manual"]
+            self.assertEqual(manual["status"], "unsupported_for_local_dispatch")
+            self.assertEqual(manual["observed_run_status"], "not_observed")
+            self.assertIn("unknown fields stay", brief["claim_boundary"])
+
+    def test_brief_without_id_lists_known_fanouts(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+            contract = write_fanout_contract(paths, build_fanout_contract(_GOAL, _UNITS))
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+            status, stdout, stderr = run_cli(base + ["coding", "fanout", "brief"])
+            self.assertEqual(status, 0, stderr)
+            listing = json.loads(stdout)
+            self.assertEqual(listing["schema_version"], "fanout_briefing_listing/v1")
+            self.assertEqual(listing["fanouts"][0]["fanout_id"], contract["fanout_id"])
+            self.assertEqual(listing["fanouts"][0]["unit_count"], 3)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_fanout_dispatch.py
+++ b/tests/test_fanout_dispatch.py
@@ -14,6 +14,7 @@ from _cli_harness import run_cli  # noqa: E402
 
 from omh.coding.fanout import build_fanout_contract  # noqa: E402
 from omh.coding.fanout_artifacts import write_fanout_contract  # noqa: E402
+from omh.coding.fanout_artifacts import fanout_dispatch_summary_path  # noqa: E402
 from omh.coding.fanout_dispatch import dispatch_fanout, verify_goal_matches_contract  # noqa: E402
 from omh.runtime.artifacts import show_run  # noqa: E402
 from omh.system.paths import OmhPaths  # noqa: E402
@@ -482,7 +483,7 @@ class FanoutDispatchTelemetryTests(unittest.TestCase):
                 paths, contract, goal_text=_GOAL, repo_root=repo, base_sha=sha,
                 runner=_agent_runner(), readiness=_ready,
             )
-            stored_path = paths.fanout_dispatch_summary_path(str(contract["fanout_id"]))
+            stored_path = fanout_dispatch_summary_path(paths, str(contract["fanout_id"]))
             self.assertTrue(stored_path.is_file())
             stored = json.loads(stored_path.read_text(encoding="utf-8"))
             self.assertEqual(stored["schema_version"], "fanout_dispatch_summary/v1")
@@ -499,7 +500,7 @@ class FanoutDispatchTelemetryTests(unittest.TestCase):
                 paths, contract, goal_text=_GOAL, repo_root=repo, base_sha=sha,
                 dry_run=True, runner=_agent_runner(), readiness=_ready,
             )
-            self.assertFalse(paths.fanout_dispatch_summary_path(str(contract["fanout_id"])).exists())
+            self.assertFalse(fanout_dispatch_summary_path(paths, str(contract["fanout_id"])).exists())
 
     def test_limit_shaped_failure_is_classified_and_recorded(self) -> None:
         with TemporaryDirectory() as tmp:
@@ -533,6 +534,54 @@ class FanoutDispatchTelemetryTests(unittest.TestCase):
             shown = show_run(paths, by_unit["core"]["run_ref"])
             result_events = [e for e in shown["journal_events"] if e["event"] == "executor_result_observed"]
             self.assertIn("limit-shaped failure (usage_limit)", result_events[-1]["summary"])
+
+    def test_unrelated_429_and_disk_quota_text_are_not_limit_shaped(self) -> None:
+        with TemporaryDirectory() as tmp:
+            units = [
+                {"unit_id": "core", "title": "Core", "owner": "codex", "file_scope": ["src/core/"]},
+                {"unit_id": "docs", "title": "Docs", "owner": "claude-code", "file_scope": ["docs/"]},
+            ]
+            paths, repo, sha, contract = self._setup(tmp, units=units)
+
+            def runner(argv, **kwargs):
+                if argv[0] == "git":
+                    return subprocess.run(argv, **kwargs)
+                if argv[0] == "codex":
+                    return _FakeCompleted(1, 'Traceback: File "src/foo.py", line 429, in bar\nAssertionError')
+                completed = _FakeCompleted(1, "tests failed")
+                completed.stderr = "error: disk quota check skipped"
+                return completed
+
+            summary = dispatch_fanout(
+                paths, contract, goal_text=_GOAL, repo_root=repo, base_sha=sha,
+                runner=runner, readiness=_ready,
+            )
+            for entry in summary["units"]:
+                self.assertNotIn("limit_shaped", entry, entry["unit_id"])
+            self.assertFalse(paths.executor_limit_signals_path.exists())
+
+    def test_successful_dispatch_clears_a_prior_limit_signal(self) -> None:
+        with TemporaryDirectory() as tmp:
+            units = [{"unit_id": "core", "title": "Core", "owner": "codex", "file_scope": ["src/core/"]}]
+            paths, repo, sha, contract = self._setup(tmp, units=units + [
+                {"unit_id": "docs", "title": "Docs", "owner": "claude-code", "file_scope": ["docs/"]},
+            ])
+            from omh.system.local_store import atomic_write_json
+
+            atomic_write_json(
+                paths.executor_limit_signals_path,
+                {
+                    "schema_version": "executor_limit_signals/v1",
+                    "profiles": {"codex": {"pattern_label": "usage_limit"}},
+                },
+                private=True,
+            )
+            dispatch_fanout(
+                paths, contract, goal_text=_GOAL, repo_root=repo, base_sha=sha,
+                runner=_agent_runner(), readiness=_ready,
+            )
+            stored = json.loads(paths.executor_limit_signals_path.read_text(encoding="utf-8"))
+            self.assertNotIn("codex", stored.get("profiles", {}))
 
     def test_successful_exit_is_never_limit_shaped(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_model_routing.py
+++ b/tests/test_model_routing.py
@@ -47,12 +47,29 @@ class ModelRouteResolverTests(unittest.TestCase):
         self.assertEqual(route["source"], "role_catalog_default")
         self.assertEqual(route["selected_model"], "sonnet")
 
-    def test_role_with_many_candidates_requires_choice(self) -> None:
-        route = resolve_model_route("codex", role="implementation")
-        # codex catalog maps implementation+docs to gpt-5 only; brain has one too.
-        self.assertIn(route["status"], {"routed", "choice_required"})
-        if route["status"] == "choice_required":
-            self.assertTrue(route["candidates"])
+    def test_review_role_on_codex_requires_an_explicit_choice(self) -> None:
+        # `review` is recommended on both codex options by design, so the role
+        # resolves to a choice instead of a silent default.
+        route = resolve_model_route("codex", role="review")
+        self.assertEqual(route["status"], "choice_required")
+        self.assertEqual(route["source"], "role_catalog_candidates")
+        self.assertEqual(len(route["candidates"]), 2)
+        self.assertEqual(route["selected_model"], "")
+
+    def test_unknown_role_is_named_in_reasons_not_erased(self) -> None:
+        route = resolve_model_route("codex", role="tester")
+        self.assertEqual(route["status"], "model_unrouted")
+        self.assertTrue(any("tester" in reason for reason in route["reasons"]))
+        self.assertFalse(any("No model or role was requested" in reason for reason in route["reasons"]))
+
+    def test_effort_survives_profiles_without_catalog(self) -> None:
+        route = resolve_model_route("gemini-runtime", requested_effort="high")
+        self.assertEqual(route["status"], "no_model_catalog")
+        self.assertEqual(route["selected_reasoning_effort"], "high")
+
+    def test_unsafe_effort_shape_falls_back_to_cli_default(self) -> None:
+        route = resolve_model_route("codex", requested_model="gpt-5", requested_effort='high\nsandbox_mode = "danger"')
+        self.assertEqual(route["selected_reasoning_effort"], "")
 
     def test_brain_role_gets_high_effort_default(self) -> None:
         route = resolve_model_route("codex", role="brain")

--- a/tests/test_model_routing.py
+++ b/tests/test_model_routing.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+
+from _local_package import load_local_package
+
+load_local_package()
+
+from _cli_harness import run_cli  # noqa: E402
+
+from omh.coding.fanout import build_fanout_contract  # noqa: E402
+from omh.coding.fanout_dispatch import build_dispatch_argv  # noqa: E402
+from omh.coding.model_routing import (  # noqa: E402
+    CODING_MODEL_ROUTE_SCHEMA_VERSION,
+    MODEL_ROLES,
+    model_family,
+    model_route_for_unit,
+    resolve_model_route,
+)
+
+
+class ModelRouteResolverTests(unittest.TestCase):
+    def test_requested_model_always_wins_and_passes_through_unvalidated(self) -> None:
+        route = resolve_model_route("codex", requested_model="gpt-6-terra", requested_effort="xhigh", role="brain")
+        self.assertEqual(route["schema_version"], CODING_MODEL_ROUTE_SCHEMA_VERSION)
+        self.assertEqual(route["status"], "routed")
+        self.assertEqual(route["source"], "request_named_model")
+        self.assertEqual(route["selected_model"], "gpt-6-terra")
+        self.assertEqual(route["selected_reasoning_effort"], "xhigh")
+        self.assertEqual(route["model_family"], "gpt")
+
+    def test_unknown_family_is_named_not_rejected(self) -> None:
+        route = resolve_model_route("claude-code", requested_model="luna-5.5")
+        self.assertEqual(route["status"], "routed")
+        self.assertEqual(route["model_family"], "unknown")
+
+    def test_claude_tier_aliases_fold_into_claude_family(self) -> None:
+        self.assertEqual(model_family("opus"), "claude")
+        self.assertEqual(model_family("claude-opus-5"), "claude")
+
+    def test_role_with_single_candidate_routes_deterministically(self) -> None:
+        route = resolve_model_route("claude-code", role="implementation")
+        self.assertEqual(route["status"], "routed")
+        self.assertEqual(route["source"], "role_catalog_default")
+        self.assertEqual(route["selected_model"], "sonnet")
+
+    def test_role_with_many_candidates_requires_choice(self) -> None:
+        route = resolve_model_route("codex", role="implementation")
+        # codex catalog maps implementation+docs to gpt-5 only; brain has one too.
+        self.assertIn(route["status"], {"routed", "choice_required"})
+        if route["status"] == "choice_required":
+            self.assertTrue(route["candidates"])
+
+    def test_brain_role_gets_high_effort_default(self) -> None:
+        route = resolve_model_route("codex", role="brain")
+        self.assertEqual(route["selected_reasoning_effort"], "high")
+
+    def test_no_request_is_an_explicit_executor_default_outcome(self) -> None:
+        route = resolve_model_route("codex")
+        self.assertEqual(route["status"], "model_unrouted")
+        self.assertEqual(route["source"], "executor_default")
+        self.assertEqual(route["selected_model"], "")
+
+    def test_profile_without_catalog_is_named(self) -> None:
+        route = resolve_model_route("hermes")
+        self.assertEqual(route["status"], "no_model_catalog")
+
+    def test_claim_boundary_disclaims_provider_truth(self) -> None:
+        route = resolve_model_route("codex", requested_model="gpt-5")
+        self.assertIn("provider truth", route["claim_boundary"])
+
+    def test_model_roles_vocabulary_is_stable(self) -> None:
+        self.assertEqual(MODEL_ROLES, ("brain", "implementation", "design_visual", "review", "docs"))
+
+
+class DispatchArgvTests(unittest.TestCase):
+    def test_no_route_keeps_argv_byte_identical(self) -> None:
+        argv = build_dispatch_argv("codex", "do the work")
+        self.assertEqual(argv, ["codex", "exec", "do the work"])
+        claude = build_dispatch_argv("claude-code", "do the work")
+        self.assertEqual(claude[0:3], ["claude", "-p", "do the work"])
+        self.assertNotIn("--model", claude)
+
+    def test_codex_model_and_effort_insert_before_prompt(self) -> None:
+        route = resolve_model_route("codex", requested_model="gpt-5-codex", requested_effort="xhigh")
+        argv = build_dispatch_argv("codex", "do the work", route)
+        self.assertEqual(
+            argv,
+            [
+                "codex",
+                "exec",
+                "--model",
+                "gpt-5-codex",
+                "--config",
+                "model_reasoning_effort=xhigh",
+                "do the work",
+            ],
+        )
+
+    def test_claude_model_options_append_after_base_argv(self) -> None:
+        route = resolve_model_route("claude-code", requested_model="opus", requested_effort="high")
+        argv = build_dispatch_argv("claude-code", "do the work", route)
+        self.assertEqual(argv[-4:], ["--model", "opus", "--effort", "high"])
+        self.assertEqual(argv[1], "-p")
+
+    def test_unknown_owner_has_no_argv(self) -> None:
+        self.assertIsNone(build_dispatch_argv("hermes", "do the work"))
+
+
+class UnitModelRouteTests(unittest.TestCase):
+    def test_unit_without_model_fields_stays_unrouted(self) -> None:
+        self.assertIsNone(model_route_for_unit({"unit_id": "core"}, "codex"))
+
+    def test_contract_embeds_model_route_when_unit_names_one(self) -> None:
+        contract = build_fanout_contract(
+            "split the sample feature across agents",
+            [
+                {"unit_id": "brain", "owner": "codex", "file_scope": ["src/a/"], "role": "brain"},
+                {"unit_id": "ui", "owner": "claude-code", "file_scope": ["src/b/"], "model": "opus"},
+                {"unit_id": "plain", "owner": "codex", "file_scope": ["src/c/"]},
+            ],
+        )
+        units = {unit["unit_id"]: unit for unit in contract["units"]}
+        brain_route = units["brain"]["handoff"]["model_route"]
+        self.assertEqual(brain_route["selected_reasoning_effort"], "high")
+        ui_route = units["ui"]["handoff"]["model_route"]
+        self.assertEqual(ui_route["selected_model"], "opus")
+        self.assertNotIn("model_route", units["plain"]["handoff"])
+
+
+class ModelRouteCliTests(unittest.TestCase):
+    def test_cli_resolves_route_json(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+            status, stdout, stderr = run_cli(
+                base + ["coding", "model-route", "--executor", "codex", "--role", "brain"]
+            )
+            self.assertEqual(status, 0, stderr)
+            route = json.loads(stdout)
+            self.assertEqual(route["schema_version"], CODING_MODEL_ROUTE_SCHEMA_VERSION)
+            self.assertEqual(route["selected_reasoning_effort"], "high")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Capability

Hermes-side coding delegation orchestration gains four deterministic capabilities in one goal PR. All of them stay inside the product boundaries: core omh makes no LLM/API/network calls, prepared-vs-observed evidence is preserved everywhere, and persisted state stays metadata-only.

1. **Model routing** — new `coding_model_route/v1` catalog + resolver (`src/coding/model_routing.py`) with a `omh coding model-route` preview command. Fanout units may declare `model`, `reasoning_effort`, and/or `role` (brain / implementation / design_visual / review / docs); `fanout prepare` embeds the resolved route in the unit handoff, and the opt-in dispatch bridge renders it into argv (`codex --model … --config model_reasoning_effort=…`, `claude --model … --effort …`, flags verified against the local CLIs). Requested models always pass through unvalidated (availability/entitlement is provider truth); no route keeps the argv byte-identical to today (pinned by a regression test).
2. **Subscription/limit awareness** — new `executor_auth_signals/v1` (`src/coding/executor_auth_signals.py`) reads local login markers only (`~/.claude.json` login key presence, `~/.codex/auth.json` presence — shape only, never values), and failed dispatches matching fixed limit shapes (rate limit / usage limit / quota / 429 / credits) persist `executor_limit_signals/v1` under a file lock. Both surface as per-call advisories on `omh coding executor-readiness` — computed outside the observed_once cache so they never freeze at first probe — and in the new `executor_choice_context` embedded in choose-executor payloads.
3. **Delegation-mandatory ask-first policy** — coding-shaped clarify/fallback and unresolved-owner delegate payloads now carry `coding_delegation_policy/v1` with `inline_coding_prohibited: true`, closing the path where a low-score or retained-workflow coding request could read as "Hermes keeps it → Hermes codes it". When no executor is resolvable the outcome is an explicit user choice with per-candidate readiness + auth + limit context. Retained-workflow chat cards keep their contractually executor-free copy (the policy rides the payload there); non-retained clarify and choose-executor cards render the block into card state.
4. **Subagent briefing** — dispatch now records per-unit `started_at`/`finished_at`/`duration_seconds` and persists a metadata-only dispatch summary under the fanout contract dir. New `omh coding fanout brief [<id>]` joins contract + dispatch summary + a one-event journal tail into `fanout_briefing/v1`: per unit owner, routed model, session ref, status (preserving prepared-vs-observed vocabulary), elapsed seconds, token count, and last observed summary — unknowns stay the literal `unknown`. Without an id it lists known fanouts so Hermes can answer "브리핑해줘" without knowing ids. The command is registered in the bounded-surfaces enforcement with emission metering.

## Motivation

The user goal: Hermes should orchestrate coding delegation like a real conductor — route models per subagent role, know whether the user's claude/codex CLIs are installed/logged-in/limit-blocked before deciding, absolutely never fall back to Hermes-inline coding (ask "클로드/코덱스 중 어디에 위임할까요?" instead), and brief the user on running subagents (ids, progress, tokens, elapsed) in messenger surfaces. Before this PR: dispatch had no model dimension at all, there was zero auth/limit awareness (a logged-out CLI still probed `ready`), the retained-workflow clarify path could silently keep coding-shaped work in Hermes, and dispatch persisted no session/duration/token telemetry.

## Implementation at the boundary

- `src/coding/model_routing.py` (new), `src/coding/fanout.py` (`_normalized_unit`/`_contract_unit`), `src/coding/fanout_dispatch.py` (`build_dispatch_argv`, option-fragment tables, telemetry, limit classification, summary persistence), `src/coding/executor_auth_signals.py` (new), `src/coding/executor_readiness.py` (per-call advisories + `executor_choice_context`), `src/coding/coding_delegation.py` (policy block), `src/wrapper/contract.py` (policy passthrough on non-retained clarify + choose cards), `src/commands/coding.py` (`model-route`, `fanout brief`, choice-context attach), `src/system/paths.py` (2 new path properties), `src/coding/context_safety.py` (bounded surface), docs (FANOUT.md, ARCHITECTURE.md).
- New state files: `~/.omh/runtime/executor-limit-signals.json` (locked read-modify-write; label/ids/timestamps only), `~/.omh/coding/fanout/<id>/dispatch_summary.json` (latest-wins, skipped on --dry-run).

## Verification observed

- Full suite on the rebased branch: `PYTHONPATH=tests uv run python -m unittest discover -s tests` — **2268 tests, OK (1 pre-existing skip)**.
- Byte gates: `docs workflows --check`, `docs roles --check`, `docs capability-families --check` — all ok (no catalog change, no skill added).
- `uv run --group lint ruff check src tests` — clean; `git diff --check` — clean; DCO signoff verified per commit.
- New tests: `tests/test_model_routing.py` (resolver precedence, argv byte-identity, contract embedding, CLI), `tests/test_executor_auth_signals.py` (markers incl. secret-leak assert, cache-freshness of advisories), `tests/test_delegation_mandatory_policy.py` (payload policy, retained-card copy, choose-card state, no auto-hermes), extended `tests/test_fanout_dispatch.py` (telemetry, limit classification + locked persistence, summary persistence, routed argv reaching spawn, `fanout brief` join + listing).
- CLI flags for model/effort verified against local `codex exec --help` / `claude --help` (no network).
- A concurrently-run architect/security/code-review validation pass is in flight; findings, if any, will land as review-fix commits on this PR.

## Risks / deferrals / follow-ups

- **Deferred (deliberate):** per-unit session ids and token counts report `unknown` — capturing them needs structured-output dispatch templates (`codex exec --json`, `claude --output-format json`), which would persist raw model output into the journal and violate the metadata-only rule as-is. That lands as a follow-up PR with a proper structured-output contract and hidden-key redaction (independent rollback boundary). Executor-progress binding wiring for `omh runtime progress-status` is deferred with it.
- Built-in model catalog ids will age; requested-model passthrough covers drift, and the catalog is marked `built_in_defaults` with a provider-truth claim boundary.
- API-key/env-token installs legitimately show `login_marker: absent` while functional — markers rank candidates and never veto one (documented in the schema's claim boundary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A4YNe8BB4KPWbgfEiZyfpC