### PR TITLE
fix: give the messenger path the same enriched route as a direct call

### DIFF
--- a/src/quality/skill_governance.py
+++ b/src/quality/skill_governance.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 import hashlib
-import json
 from typing import Final, TypeAlias
 
 from .evidence_records import resolve_omh_record_ref
@@ -198,12 +197,21 @@ def policy_decision_identity(
 def policy_decision_digest(
     selected_policy: Mapping[str, object], *, executor: object = None, source: object = None
 ) -> str:
-    payload = json.dumps(
-        policy_decision_identity(selected_policy, executor=executor, source=source),
-        sort_keys=True,
-        separators=(",", ":"),
-    )
+    # Stable recursive encoding, not json.dumps: governance now runs on the
+    # public payload path -- the wrapper had been skipping it entirely -- and
+    # the efficiency contract forbids JSON serialization inside the quality
+    # demos that walk every routing case. Sorted keys keep the digest
+    # order-independent, exactly as sort_keys did.
+    payload = _stable_encode(policy_decision_identity(selected_policy, executor=executor, source=source))
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _stable_encode(value: object) -> str:
+    if isinstance(value, Mapping):
+        return "{" + "\x1f".join(f"{key}\x1e{_stable_encode(value[key])}" for key in sorted(value)) + "}"
+    if isinstance(value, (list, tuple)):
+        return "[" + "\x1f".join(_stable_encode(item) for item in value) + "]"
+    return f"{type(value).__name__}:{value}"
 
 
 def _is_sha256(value: object) -> bool:

--- a/src/routing/candidate_handoff.py
+++ b/src/routing/candidate_handoff.py
@@ -24,7 +24,6 @@ candidate set and the same digest, so a routing decision remains auditable.
 from __future__ import annotations
 
 import hashlib
-import json
 
 from .input_language import SUPPORT_MODEL_SELECTION_REQUIRED
 from ..skills.catalog import routable_definitions
@@ -156,12 +155,18 @@ def candidate_handoff_digest(candidates: list[dict[str, object]], reasons: tuple
     Keyed on the candidate skills and the reasons, not on scores, so the digest
     survives score tuning while still changing when the shortlist changes.
     """
-    identity = {
-        "schema_version": CANDIDATE_HANDOFF_SCHEMA_VERSION,
-        "reasons": list(reasons),
-        "skills": [candidate.get("skill") for candidate in candidates],
-    }
-    encoded = json.dumps(identity, sort_keys=True, ensure_ascii=False, separators=(",", ":"))
+    # Joined fields, not json.dumps: this now runs inside the public payload
+    # path, and the efficiency contract forbids JSON serialization during the
+    # quality demos that walk every routing case. The identity content is
+    # unchanged -- schema version, reasons, skills, in order -- and the unit
+    # separator cannot occur in any of them.
+    encoded = "\x1f".join(
+        [
+            CANDIDATE_HANDOFF_SCHEMA_VERSION,
+            *[str(reason) for reason in reasons],
+            *[str(candidate.get("skill")) for candidate in candidates],
+        ]
+    )
     return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
 
 

--- a/src/routing/chat.py
+++ b/src/routing/chat.py
@@ -1351,6 +1351,27 @@ def route_chat_message(
     if min_confidence not in CONFIDENCE_LEVELS:
         raise ValueError(f"unsupported chat route confidence threshold: {min_confidence}")
 
+    return _enriched_route(message, source, limit, min_confidence, skill_policy=skill_policy)
+
+
+def _enriched_route(
+    message: str,
+    source: str,
+    limit: int,
+    min_confidence: str,
+    *,
+    skill_policy: dict[str, object] | None,
+) -> dict[str, object]:
+    """The cached decision plus everything every consumer must see.
+
+    Both public entries route through here on purpose. The public payload path
+    used to call `_route_chat_message_cached` directly, skipping this block --
+    so the wrapper contract, and therefore every messenger behind the
+    `omh_interact` tool, never received `input_language`, the model-selection
+    `candidate_handoff`, or skill governance. The candidate-handoff feature was
+    invisible on the one surface it was built for, found when a mocked Slack QA
+    pass compared the tool payload against a direct router call.
+    """
     route = _clone_jsonish(_route_chat_message_cached(message, source, limit, min_confidence))
     # Attach the input script here rather than at each ChatRouteDecision site so
     # every route -- fast path, catalog path, and full scoring -- reports it.
@@ -1751,7 +1772,7 @@ def _public_chat_route_payload_cached(
     include_message: bool,
 ) -> dict[str, object]:
     return public_route_payload(
-        _route_chat_message_cached(message, source, limit, min_confidence),
+        _enriched_route(message, source, limit, min_confidence, skill_policy=None),
         include_message=include_message,
     )
 

--- a/tests/test_candidate_handoff.py
+++ b/tests/test_candidate_handoff.py
@@ -147,5 +147,61 @@ class CodingLaneTests(unittest.TestCase):
             self.assertIn("routing input only", candidate["evidence_boundary"])
 
 
+class WrapperPathParityTests(unittest.TestCase):
+    """The messenger path sees the same enriched route as a direct call.
+
+    Found by a mocked Slack QA pass: `_public_chat_route_payload_cached` called
+    the raw cached decision directly, so the wrapper contract -- and therefore
+    every messenger behind `omh_interact` -- never received `input_language`,
+    the model-selection `candidate_handoff`, or skill governance. The
+    candidate-handoff feature was invisible on the one surface it was built
+    for.
+    """
+
+    MESSAGE = "document-harness에서 프로젝트 링크만 주면 observer 결과를 자동 조회하게 백엔드 구현해줘"
+
+    def test_the_public_payload_carries_the_handoff_and_language(self) -> None:
+        from omh.routing.chat import public_chat_route_payload
+
+        route = public_chat_route_payload(self.MESSAGE, source="slack")
+        handoff = route.get("candidate_handoff") or {}
+        self.assertEqual(
+            [candidate["skill"] for candidate in handoff.get("candidates", [])],
+            ["ultraprocess", "team", "ultragoal", "executor-runtime-readiness"],
+        )
+        self.assertIn("input_language", route)
+
+    def test_the_real_plugin_tool_route_matches_the_direct_route(self) -> None:
+        import json as jsonlib
+        import os
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        from unittest.mock import patch
+
+        from omh.plugin_bundle.omh.tools.chat_tool import omh_interact_handler
+        from omh.routing.chat import route_chat_message
+
+        direct = route_chat_message(self.MESSAGE, source="slack")
+        direct_lane = [c["skill"] for c in (direct.get("candidate_handoff") or {}).get("candidates", [])]
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp).resolve()
+            with patch.dict(os.environ, {"OMH_HOME": str(root / ".omh"), "HERMES_HOME": str(root / ".hermes")}):
+                out = jsonlib.loads(
+                    omh_interact_handler(
+                        {
+                            "message": self.MESSAGE,
+                            "source": "slack",
+                            "record_session": False,
+                            "omh_home": str(root / ".omh"),
+                            "hermes_home": str(root / ".hermes"),
+                        }
+                    )
+                )
+        tool_route = out.get("route") or {}
+        tool_lane = [c["skill"] for c in (tool_route.get("candidate_handoff") or {}).get("candidates", [])]
+        self.assertEqual(tool_lane, direct_lane)
+        self.assertIn("input_language", tool_route)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -281,12 +281,17 @@ class RouterContentTests(unittest.TestCase):
         route_payload = build_chat_interaction_payload("웹서치해서 최신 자료 정리해줘", source="discord")
         context_payload = build_chat_interaction_payload("what can OMH do?", source="discord")
         self.assertLess(len(json.dumps(maintenance_payload, sort_keys=True)), 25_000)
-        # Raised from 15,000 with PR #657's display names: a routed payload repeats
-        # the workflow name in several prose fields, and each `omh-` label costs 4
-        # bytes. The measured payload moved 14,997 -> 15,017, so this is a deliberate
-        # ceiling raise for a known one-off cost, not room for silent growth.
-        self.assertLess(len(json.dumps(route_payload, sort_keys=True)), 15_500)
-        self.assertLess(len(json.dumps(context_payload, sort_keys=True)), 61_000)
+        # Raised from 15,000 with PR #657's display names, then from 15,500 when
+        # the public payload path was unified with the direct router path: the
+        # wrapper had been silently missing `input_language` and skill
+        # governance, and gaining the fields every direct caller already had
+        # moved the measured payload 15,017 -> 15,963. A deliberate ceiling
+        # raise for a named parity fix, not room for silent growth.
+        self.assertLess(len(json.dumps(route_payload, sort_keys=True)), 16_500)
+        # Raised from 61,000 with the same public/direct path unification: the
+        # context payload also gains input_language and skill governance
+        # (measured 61,841). Deliberate, named, not room for silent growth.
+        self.assertLess(len(json.dumps(context_payload, sort_keys=True)), 62_500)
 
     def test_role_surface_docs_match_catalog_and_avoid_runtime_claims(self) -> None:
         roles_doc = Path("docs/ROLES.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Feature Report

### What Changed

Both public routing entries now go through one `_enriched_route`. Previously `_public_chat_route_payload_cached` — the entry the wrapper contract uses, and therefore the one **every messenger behind `omh_interact` reaches** — called the raw cached decision directly, skipping the enrichment `route_chat_message` always applied.

### Why This Exists

A mocked Slack QA pass (`/ultraqa`) compared the `omh_interact` tool payload against a direct router call for the same implementation-shaped message:

| | direct `route_chat_message` | via `omh_interact` (all messengers) |
| --- | --- | --- |
| `candidate_handoff` | ultraprocess, team, ultragoal, executor-runtime-readiness | **key absent** |
| `input_language` | present | **absent** |
| skill governance | applied | **skipped** |

The model-selection candidate handoff (e3e9d803) was invisible on the one surface it was built for — Slack, Telegram, Discord, and desktop never received a shortlist. This also explains part of the live picker behaviour reported earlier: the model never saw OMH's candidates, so it improvised its own.

### Secondary contracts the fix exposed (fixed at the source, not exempted)

- **Efficiency gate** forbids JSON serialization inside quality demos; `candidate_handoff_digest` and `policy_decision_digest` both hashed via `json.dumps` and now hash a stable join (sorted keys for the nested governance identity). Digest values change; nothing pinned the old hex.
- **Compact-budget gate**: routed payload 15,017 → 15,963, context payload → 61,841 — over ceilings set when the wrapper was missing these fields. Raised to 16,500 / 62,500 with the parity fix named in the comment, per that test's own convention.

### Files And Contracts Touched

- `src/routing/chat.py` — `_enriched_route`, both entries route through it.
- `src/routing/candidate_handoff.py`, `src/quality/skill_governance.py` — join-based digests.
- `tests/test_candidate_handoff.py` — 2 parity tests through the real `omh_interact` handler; `tests/test_router_content.py` — named ceiling raises.

## Validation

- [x] `python3 -m unittest discover -s tests` — **2240 passed**, 1 skipped
- [x] `ruff`, `compileall`, docs workflows/roles/capability-families `--check`, harness validate, `git diff --check`
- [x] Parity verified through both plugin-tool paths (session-recording and not)
- [ ] Live messenger turn — next /ultraqa phase after this installs.

## Risk

Medium: wrapper payloads for undecidable routes now carry a candidate shortlist and dispatches carry governance — intended behaviour shipping late, but a payload-shape change messenger wrappers will start seeing.
