### PR TITLE
fix: migrate pre-relabel installs and keep renamed skill labels resolvable

### DIFF
--- a/docs/ADDING-A-SKILL.md
+++ b/docs/ADDING-A-SKILL.md
@@ -64,7 +64,7 @@ uv run python -m omh.cli cases demo --all --json > examples/use-cases/g1-g10-dem
 
 Every added skill grows the always-loaded prompt body of a `full` install.
 Check what it cost, and keep shared policy in
-`skills/oh-my-hermes/references/skill-common-rail.md` instead of a new
+`skills/omh-routing/references/skill-common-rail.md` instead of a new
 repeated section in `workflow_skill`:
 
 ```sh

--- a/docs/APPLICATION_CASES.md
+++ b/docs/APPLICATION_CASES.md
@@ -131,7 +131,7 @@ Install the Hermes skill pack through Hermes' native skill surface:
 
 ```sh
 hermes skills tap add rlaope/oh-my-hermes
-hermes skills install rlaope/oh-my-hermes/skills/oh-my-hermes --yes
+hermes skills install rlaope/oh-my-hermes/skills/omh-routing --yes
 ```
 
 If the deployment needs the managed bootstrap path, install and verify the same
@@ -212,8 +212,8 @@ Confirm the skill pack is installed through Hermes or registered through the
 OMH bootstrap path:
 
 ```sh
-hermes skills install deep-interview
-hermes skills install ralplan
+hermes skills install ulw-interview
+hermes skills install ulw-plan
 omh setup
 omh doctor
 ```
@@ -283,7 +283,7 @@ config that `omh apply` updated when using the bootstrap path:
 
 ```sh
 hermes skills tap add rlaope/oh-my-hermes
-hermes skills install rlaope/oh-my-hermes/skills/oh-my-hermes --yes
+hermes skills install rlaope/oh-my-hermes/skills/omh-routing --yes
 omh setup
 omh doctor
 ```
@@ -635,7 +635,7 @@ Before using these cases as public release evidence, verify:
 
 - The one-command installer still works.
 - `hermes skills tap add rlaope/oh-my-hermes` and
-  `hermes skills install rlaope/oh-my-hermes/skills/oh-my-hermes --yes`
+  `hermes skills install rlaope/oh-my-hermes/skills/omh-routing --yes`
   are documented as the primary install path when Hermes taps are available.
 - `omh setup` reports the managed skill directory, equivalent Hermes install
   intent, and Hermes config registration clearly.

--- a/docs/CHAT_WRAPPER_EXAMPLES.md
+++ b/docs/CHAT_WRAPPER_EXAMPLES.md
@@ -294,7 +294,7 @@ Example plan effect:
 
 ```text
 Hermes Agent  BOT
-[omh] ralplan - I routed this to `omh-ralplan` because it needs a safe plan first.
+[omh] ralplan - I routed this to `ulw-plan` because it needs a safe plan first.
 
 Accept or revise the plan first; the handoff button stays disabled until
 acceptance. A draft plan is still only planning evidence.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -372,10 +372,10 @@ ambiguity in current Hermes CLI releases while installing the same
 Install additional workflow skills when you want direct Hermes skill surfaces:
 
 ```sh
-hermes skills install deep-interview
-hermes skills install ralplan
-hermes skills install web-research
-hermes skills install code-review
+hermes skills install ulw-interview
+hermes skills install ulw-plan
+hermes skills install ulw-research
+hermes skills install omh-code-review
 ```
 
 This path reads the tap-compatible skill pack under `skills/` in this
@@ -1211,7 +1211,7 @@ omh docs skill-context-cost --json   # omh_skill_context_cost/v1
 Repetition is derived, not hand-classified: for each `##` heading the report
 counts occurrences, distinct bodies, and the duplicate bytes an install pays
 for the second and later copies. Policy shared by every generated workflow
-skill lives once in `skills/oh-my-hermes/references/skill-common-rail.md`
+skill lives once in `skills/omh-routing/references/skill-common-rail.md`
 (progressive disclosure, loaded on demand) rather than inside each body; that
 reference ships with the always-installed `oh-my-hermes` skill, so both
 profiles resolve it. Reference bytes are reported separately from the

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -16,7 +16,7 @@ Hermes-native skill install:
 
 ```sh
 hermes skills tap add rlaope/oh-my-hermes
-hermes skills install rlaope/oh-my-hermes/skills/oh-my-hermes --yes
+hermes skills install rlaope/oh-my-hermes/skills/omh-routing --yes
 ```
 
 Pinned stable install:
@@ -385,7 +385,7 @@ The live smoke runs the selected Hermes install path plus:
 hermes skills tap list
 hermes skills list --enabled-only
 hermes skills check oh-my-hermes
-hermes skills inspect rlaope/oh-my-hermes/skills/oh-my-hermes
+hermes skills inspect rlaope/oh-my-hermes/skills/omh-routing
 ```
 
 Passing the tap smoke means Hermes CLI install/list/check/inspect commands

--- a/skills/omh-routing/references/wrapper-routing.md
+++ b/skills/omh-routing/references/wrapper-routing.md
@@ -20,11 +20,11 @@ Bare `./omh`, `/omh`, `./skills`, or `/skills` opens the workflow picker. A lead
 
 ## Skill Name Display Prefix
 
-Installed OMH skills render an `omh-` prefixed frontmatter `name` so the host status line reads `Reading skill omh-ultrawork` instead of a label indistinguishable from a Hermes built-in. The router skill renders as `omh-routing`.
+Installed OMH skills render a prefixed frontmatter `name` so the host status line is distinguishable from a Hermes built-in: domain skills carry `omh-` and the workflow-engine skills carry `ulw-` (for example `Reading skill ulw-work` for `ultrawork`, `ulw-plan` for `ralplan`, `ulw-goal` for `ultragoal`). The router skill renders as `omh-routing`.
 
-That label is a display identifier only. The canonical catalog name still owns the `skills/<name>/` directory, the install manifest, the tap URL, routing keys, and every `omh` CLI argument, so `omh recommend`, `omh runtime record --skill <name>`, and trigger strings keep using unprefixed names.
+That label names the installed `skills/<label>/` directory and the host status line only. The canonical catalog name still owns the install manifest `name`, routing keys, and every `omh` CLI argument, so `omh recommend`, `omh runtime record --skill <name>`, and trigger strings keep using canonical names. Earlier label eras (`omh-ultrawork`, `ulw-ultrawork`) remain accepted as routing aliases of the same workflow, so text echoed from a stale install still resolves — but always render the current label.
 
-Two host-side consequences follow, both accepted. Host slash commands derive from the same frontmatter `name`, so an explicit invocation is `/omh-ultrawork`, not `/ultrawork`. And because every installed skill now shares the `omh-` stem, a bare `/omh` is an ambiguous multi-candidate command on hosts that complete slash commands by prefix; treat it as the picker alias described above rather than as a single resolved skill, and disambiguate by completing the full `omh-<name>` form.
+Two host-side consequences follow, both accepted. Host slash commands derive from the same frontmatter `name`, so an explicit invocation is `/ulw-work` or `/omh-visual-qa`, never the bare canonical form. And because installed skills share the `omh-`/`ulw-` stems, a bare `/omh` is an ambiguous multi-candidate command on hosts that complete slash commands by prefix; treat it as the picker alias described above rather than as a single resolved skill, and disambiguate by completing the full label.
 
 ## Coding Delegation
 

--- a/src/install/installer.py
+++ b/src/install/installer.py
@@ -104,7 +104,16 @@ def install_skill_pack(
         refreshable = {
             template.name
             for template in all_templates
-            if template.name in CORE_PROFILE_SKILLS or skill_directory_name(template.name) in installed
+            if template.name in CORE_PROFILE_SKILLS
+            or skill_directory_name(template.name) in installed
+            # A pre-relabel install has the CANONICAL directory on disk and the
+            # labelled one absent, so matching only the label dropped the skill
+            # from refresh entirely: the labelled replacement was never
+            # written, the relabel pruner then kept the old directory ("no
+            # replacement yet"), and the host kept serving the stale pre-label
+            # SKILL.md forever. The canonical name keeps it refreshable so one
+            # update writes the labelled directory and prunes the old one.
+            or template.name in installed
         }
         templates = [template for template in all_templates if template.name in refreshable]
         reference_templates = [

--- a/src/plugin_bundle/omh/awareness.py
+++ b/src/plugin_bundle/omh/awareness.py
@@ -5627,10 +5627,17 @@ def _canonical_workflow_by_display_name() -> dict[str, str]:
         ("ulw-qa", "ultraqa"),
         ("ulw-work", "ultrawork"),
     ):
-        mapping.pop(f"omh-{workflow}", None)
-        mapping.pop(f"ulw-{workflow}", None)
         if workflow in workflows:
             mapping[display] = workflow
+            # Earlier releases rendered `omh-<workflow>` (pre-ulw era) and the
+            # mechanical `ulw-<workflow>`; stale agents still echo both, so
+            # they stay resolvable as historical aliases of the same workflow
+            # instead of being dropped. Mirrors
+            # `skills/catalog_types.historical_skill_display_names`.
+            mapping.setdefault(f"omh-{workflow}", workflow)
+        else:
+            mapping.pop(f"omh-{workflow}", None)
+            mapping.pop(f"ulw-{workflow}", None)
     return mapping
 
 

--- a/src/routing/chat.py
+++ b/src/routing/chat.py
@@ -53,6 +53,7 @@ from ..quality.skill_governance import build_skill_governance_policy, resolve_sk
 from ..surfaces.evidence_copy import not_evidence_action_suffix, not_evidence_reply_suffix
 from ..skills.catalog import (
     SkillDefinition,
+    historical_skill_display_names,
     omh_skill_display_name,
     primary_harness_for_skill,
     routable_definitions,
@@ -1405,8 +1406,18 @@ def public_chat_route_payload(
 
 @lru_cache(maxsize=1)
 def _canonical_skill_by_display_name() -> dict[str, str]:
-    """Map every rendered `omh-` label back to the catalog name that owns routing."""
-    return {omh_skill_display_name(definition.name): definition.name for definition in routable_definitions()}
+    """Map every rendered `omh-`/`ulw-` label back to the catalog name that owns routing.
+
+    Historical labels earlier releases rendered (`omh-ultragoal`,
+    `ulw-ultrawork`) resolve too: stale agents, memories, and docs still echo
+    them, and a silent miss on a rename is how one workflow ends up addressed
+    by three names. Current labels always win a collision.
+    """
+    mapping = {omh_skill_display_name(definition.name): definition.name for definition in routable_definitions()}
+    for definition in routable_definitions():
+        for alias in historical_skill_display_names(definition.name):
+            mapping.setdefault(alias, definition.name)
+    return mapping
 
 
 def _with_canonical_display_names(routing_message: str) -> str:

--- a/src/skills/catalog.py
+++ b/src/skills/catalog.py
@@ -92,6 +92,7 @@ from .catalog_types import (
     _CODING_INTENT_BY_SKILL,
     _feature_surface_skill,
     canonical_hermes_role,
+    historical_skill_display_names,
     omh_description,
     omh_skill_display_name,
 )

--- a/src/skills/catalog_types.py
+++ b/src/skills/catalog_types.py
@@ -86,9 +86,10 @@ ULW_ENGINE_SKILL_NAMES = frozenset(
 def omh_skill_display_name(name: str) -> str:
     """Return the rendered frontmatter label for a canonical catalog name.
 
-    This is a display identifier only. The canonical `SkillDefinition.name` still
-    owns the `skills/<name>/` directory, the install manifest, the tap URL,
-    routing keys, and every CLI argument.
+    This is a display identifier that, since the relabel, also names the
+    `skills/<label>/` install directory. The canonical `SkillDefinition.name`
+    still owns the install manifest `name`, routing keys, and every CLI
+    argument.
     """
     text = name.strip()
     override = OMH_SKILL_DISPLAY_NAME_OVERRIDES.get(text)
@@ -98,6 +99,24 @@ def omh_skill_display_name(name: str) -> str:
     if text.startswith(prefix):
         return text
     return f"{prefix}{text}"
+
+
+def historical_skill_display_names(name: str) -> tuple[str, ...]:
+    """Return display labels earlier releases rendered for this canonical name.
+
+    Two label eras shipped before the current one: `omh-<name>` for every
+    skill, then `ulw-<name>` for the workflow engines before their labels were
+    shortened (`ulw-ultrawork` → `ulw-work`). Stale agents, memories, and docs
+    still echo those forms, so routing accepts them as aliases of the current
+    label instead of letting them silently miss. Current labels always win a
+    collision; a rename here is deliberately additive.
+    """
+    text = name.strip()
+    current = omh_skill_display_name(text)
+    candidates = [f"{OMH_SKILL_NAME_PREFIX}{text}"]
+    if text in ULW_ENGINE_SKILL_NAMES:
+        candidates.append(f"{ULW_SKILL_NAME_PREFIX}{text}")
+    return tuple(candidate for candidate in candidates if candidate != current)
 
 
 _ROLE_BY_CATEGORY = {

--- a/src/skills/render.py
+++ b/src/skills/render.py
@@ -599,11 +599,11 @@ Bare `./omh`, `/omh`, `./skills`, or `/skills` opens the workflow picker. A lead
 
 ## Skill Name Display Prefix
 
-Installed OMH skills render an `omh-` prefixed frontmatter `name` so the host status line reads `Reading skill omh-ultrawork` instead of a label indistinguishable from a Hermes built-in. The router skill renders as `omh-routing`.
+Installed OMH skills render a prefixed frontmatter `name` so the host status line is distinguishable from a Hermes built-in: domain skills carry `omh-` and the workflow-engine skills carry `ulw-` (for example `Reading skill ulw-work` for `ultrawork`, `ulw-plan` for `ralplan`, `ulw-goal` for `ultragoal`). The router skill renders as `omh-routing`.
 
-That label is a display identifier only. The canonical catalog name still owns the `skills/<name>/` directory, the install manifest, the tap URL, routing keys, and every `omh` CLI argument, so `omh recommend`, `omh runtime record --skill <name>`, and trigger strings keep using unprefixed names.
+That label names the installed `skills/<label>/` directory and the host status line only. The canonical catalog name still owns the install manifest `name`, routing keys, and every `omh` CLI argument, so `omh recommend`, `omh runtime record --skill <name>`, and trigger strings keep using canonical names. Earlier label eras (`omh-ultrawork`, `ulw-ultrawork`) remain accepted as routing aliases of the same workflow, so text echoed from a stale install still resolves — but always render the current label.
 
-Two host-side consequences follow, both accepted. Host slash commands derive from the same frontmatter `name`, so an explicit invocation is `/omh-ultrawork`, not `/ultrawork`. And because every installed skill now shares the `omh-` stem, a bare `/omh` is an ambiguous multi-candidate command on hosts that complete slash commands by prefix; treat it as the picker alias described above rather than as a single resolved skill, and disambiguate by completing the full `omh-<name>` form.
+Two host-side consequences follow, both accepted. Host slash commands derive from the same frontmatter `name`, so an explicit invocation is `/ulw-work` or `/omh-visual-qa`, never the bare canonical form. And because installed skills share the `omh-`/`ulw-` stems, a bare `/omh` is an ambiguous multi-candidate command on hosts that complete slash commands by prefix; treat it as the picker alias described above rather than as a single resolved skill, and disambiguate by completing the full label.
 
 ## Coding Delegation
 

--- a/tests/test_display_names.py
+++ b/tests/test_display_names.py
@@ -22,7 +22,7 @@ from omh.plugin_bundle.omh.awareness import awareness_route_hint
 from omh.plugin_bundle.omh.degradation import DEGRADATION_CHAT_NOTE
 from omh.routing.chat import route_chat_message
 from omh.routing.display_names import canonical_display_mentions
-from omh.skills.catalog import installable_skill_definitions, omh_skill_display_name
+from omh.skills.catalog import historical_skill_display_names, installable_skill_definitions, omh_skill_display_name
 from omh.wrapper.contract import build_chat_interaction_payload
 from omh.wrapper.route_hints import build_chat_route_hint_payload
 
@@ -229,7 +229,38 @@ class DisplayNameEchoBackRoutingTests(unittest.TestCase):
         self.assertEqual(mapping["omh-routing"], "oh-my-hermes")
         for display, canonical in mapping.items():
             with self.subTest(display=display):
-                self.assertEqual(omh_skill_display_name(canonical), display)
+                allowed = (omh_skill_display_name(canonical), *historical_skill_display_names(canonical))
+                self.assertIn(display, allowed)
+        # The current label always wins its slot; historical aliases only ever
+        # add entries, never replace one.
+        for display, canonical in mapping.items():
+            if display == omh_skill_display_name(canonical):
+                continue
+            with self.subTest(alias=display):
+                self.assertIn(omh_skill_display_name(canonical), mapping)
+
+
+class HistoricalLabelAliasTests(unittest.TestCase):
+    """Renamed labels stay resolvable: stale agents echo the era they installed."""
+
+    def test_historical_labels_resolve_to_the_same_workflow_as_current_ones(self) -> None:
+        for old, canonical in (
+            ("omh-ultragoal", "ultragoal"),
+            ("omh-ultrawork", "ultrawork"),
+            ("omh-ralplan", "ralplan"),
+            ("ulw-ultrawork", "ultrawork"),
+            ("omh-strategy-brief", "strategy-brief"),
+        ):
+            with self.subTest(old=old):
+                route = route_chat_message(f"use {old} for this", source="discord")
+                current = route_chat_message(f"use {omh_skill_display_name(canonical)} for this", source="discord")
+                self.assertEqual(route["selected_skill"], current["selected_skill"], old)
+
+    def test_awareness_map_carries_the_pre_ulw_labels(self) -> None:
+        mapping = awareness_module._canonical_workflow_by_display_name()
+        self.assertEqual(mapping.get("omh-ultragoal"), "ultragoal")
+        self.assertEqual(mapping.get("ulw-ultrawork"), "ultrawork")
+        self.assertEqual(mapping.get("ulw-goal"), "ultragoal")
 
 
 class DisplayNamesLeaveDegradationRenderingAloneTests(unittest.TestCase):

--- a/tests/test_installer_skill_profile.py
+++ b/tests/test_installer_skill_profile.py
@@ -68,6 +68,43 @@ class InstallerSkillProfileTests(unittest.TestCase):
             self.assertEqual(sorted(result["relabelled_skills_removed"]), sorted(relabelled))
             self.assertEqual(result["relabelled_skills_retained"], [])
 
+    def test_a_core_refresh_migrates_a_pre_relabel_only_directory(self) -> None:
+        """The refresh gate must accept the pre-relabel directory name.
+
+        A pre-relabel install has only `skills/<canonical>/` on disk. Matching the
+        refresh gate on the labelled name alone dropped such a skill from refresh
+        entirely: the labelled replacement was never written, the relabel pruner
+        then kept the old directory ("no replacement yet"), and the host kept
+        serving the stale pre-label SKILL.md forever — the observed
+        `Reading skill ultragoal` long after the catalog moved to `ulw-goal`.
+        """
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            install_skill_pack(paths, profile="core")
+            victim = next(
+                name
+                for name in sorted(installable_skill_names())
+                if skill_directory_name(name) != name and name not in CORE_PROFILE_SKILLS
+            )
+            legacy = paths.skills_dir / victim
+            legacy.mkdir(parents=True, exist_ok=True)
+            (legacy / "SKILL.md").write_text(f"---\nname: {victim}\n---\nstale pre-relabel render\n", encoding="utf-8")
+            write_manifest(
+                paths.manifest_path,
+                new_manifest("builtin", paths.skills_dir, skill_records(paths.skills_dir, "builtin")),
+            )
+
+            result = install_skill_pack(paths, profile="core", force=True)
+
+            labelled = paths.skills_dir / skill_directory_name(victim)
+            self.assertTrue((labelled / "SKILL.md").is_file(), "labelled replacement was not written")
+            self.assertFalse(legacy.exists(), "pre-relabel directory survived the refresh")
+            self.assertIn(victim, result["relabelled_skills_removed"])
+            self.assertIn(
+                f"name: {skill_directory_name(victim)}",
+                (labelled / "SKILL.md").read_text(encoding="utf-8"),
+            )
+
     def test_a_locally_edited_pre_relabel_directory_blocks_the_install(self) -> None:
         """The migration never gets to delete an edit; the existing guard stops first.
 


### PR DESCRIPTION
## Capability

Renamed skills stop stranding stale installs and stale agents. After this PR: (1) one `omh update`/`omh setup` on a pre-relabel machine actually writes the labelled skill directory (`ulw-goal`, `ulw-plan`, …) and removes the old canonical one in the same pass, so hosts stop announcing `Reading skill ultragoal` from a stale render; (2) labels from earlier eras (`omh-ultragoal`, `omh-ralplan`, `ulw-ultrawork`, `omh-strategy-brief`) keep resolving to the same workflow in chat routing and the plugin-bundle awareness copy, so agents/memories/docs that echo an old label route correctly instead of silently missing; (3) the generated wrapper-routing reference and the public docs stop teaching the pre-relabel world.

## Motivation

Field report (2026-07-27, mikument-harness incident follow-up): a Hermes host still displayed `Reading skill ultragoal` and an agent still routed `ralplan`, unaware of `ulw-plan`. Root causes found:

- **Installer refresh-gate bug** (`src/install/installer.py`): the core-profile refresh gate matched only the labelled directory name. A pre-relabel install has only the canonical directory on disk, so the skill fell out of the refresh set entirely — the labelled replacement was never written, the relabel pruner then *kept* the old directory (its safety rule: never delete without a replacement), and the stale pre-label SKILL.md was served forever. The gate's own comment even named this exact failure.
- **No rename aliases anywhere**: the display-name maps were built from current labels only, and the awareness copy explicitly popped the historical forms.
- **Stale generated + hand-written text**: the wrapper-routing reference asserted `Reading skill omh-ultrawork`, `/omh-ultrawork`, a single `omh-` stem, and canonical-owned directories — all false since the relabel; INSTALLATION/APPLICATION_CASES/RELEASE/CHAT_WRAPPER_EXAMPLES installed or referenced now-nonexistent tap paths (`hermes skills install ralplan`, `skills/oh-my-hermes`).

## Implementation at the boundary

- `src/install/installer.py`: refresh gate additionally accepts the canonical (pre-relabel) directory name, making migration a one-update act.
- `src/skills/catalog_types.py`: new derived `historical_skill_display_names()` (mechanical `omh-<name>` / `ulw-<name>` forms that differ from the current label) — no hand-maintained table; also corrects the stale `omh_skill_display_name` docstring (label owns the install directory since the relabel).
- `src/routing/chat.py`: `_canonical_skill_by_display_name()` merges historical aliases (current labels win collisions).
- `src/plugin_bundle/omh/awareness.py`: the catalog-free copy keeps mechanical historical entries and adds the pre-ulw `omh-<workflow>` forms instead of popping them; the display-map lock test now pins exactly this rule.
- `src/skills/render.py` + regenerated `skills/omh-routing/references/wrapper-routing.md`: two-stem reality (`omh-`/`ulw-`), label-owned directories, `/ulw-work`-style invocations, and an explicit note that historical labels stay accepted as aliases but current labels are what gets rendered.
- Docs sweep: `docs/INSTALLATION.md`, `docs/APPLICATION_CASES.md`, `docs/RELEASE.md`, `docs/ADDING-A-SKILL.md`, `docs/CHAT_WRAPPER_EXAMPLES.md` now name the labelled tap paths.

## Verification observed

- New regression test reproduces the stranded-install shape: core profile + pre-relabel-only directory → after refresh, labelled dir written with the current `name:`, old dir pruned, listed in `relabelled_skills_removed`.
- New alias tests assert `use omh-ultragoal` / `ulw-ultrawork` / `omh-ralplan` route to the same workflow as the current label, end-to-end through `route_chat_message`, and that the awareness map carries the same entries.
- Full suite: 2241 tests OK (1 pre-existing skip); `docs workflows/roles/capability-families --check` OK (tap-skills 104/104 after regeneration); ruff clean; `git diff --check` clean; DCO verified.

## Risks / notes

- The refresh set widens only to skills whose canonical-named directory is already on disk — fresh installs and healthy labelled installs are byte-identical to before.
- Aliases are resolution-only: nothing renders a historical label into new output, so the alias set cannot grow the visible vocabulary.
- The mikument host itself still needs `omh update` (or `omh setup`) once this merges — the fix makes that single update sufficient, it cannot reach out to stale machines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A4YNe8BB4KPWbgfEiZyfpC