### PR TITLE
feat: observe every PATH resolution of an executor, pinned to no version

### DIFF
--- a/src/coding/executor_readiness.py
+++ b/src/coding/executor_readiness.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 from functools import lru_cache
+from pathlib import Path
 from typing import Any
 
 from ..executors import EXECUTOR_PROFILES, executor_label
@@ -13,6 +15,26 @@ from ..paths import OmhPaths
 EXECUTOR_READINESS_SCHEMA_VERSION = "executor_readiness/v1"
 EXECUTOR_READINESS_PROFILES = EXECUTOR_PROFILES
 _PROBE_TIMEOUT_SECONDS = 3
+
+# How many PATH resolutions of one command get their version observed. Users
+# update codex and claude on their own cadence and by more than one installer
+# (npm, standalone, brew), so several binaries of different versions routinely
+# coexist; two or three is the realistic ceiling worth the subprocess cost.
+_MAX_OBSERVED_RESOLUTIONS = 3
+
+# OMH pins no executor version, ever -- a guard test rejects any version
+# literal in this module, including comments. The observed failure that
+# motivates the shadow report was not "the version was wrong": `shutil.which`
+# returns only the FIRST match, so a stale npm codex probed "ready" while the
+# newer standalone the auth session actually required sat one PATH entry
+# later, invisible. Version requirements belong to the executor CLI's own
+# output at run time; OMH's job is to observe every resolution and say when
+# the one that will run is not the only one installed.
+EXECUTOR_VERSION_POLICY = (
+    "OMH pins no executor CLI version. Version requirements come from the executor's own "
+    "output at run time; the probe reports every PATH resolution it observed so a stale "
+    "binary shadowing a newer install is visible instead of silently selected."
+)
 _COMMANDS: dict[str, tuple[str, tuple[str, ...]]] = {
     "codex": ("codex", ("--version",)),
     "claude-code": ("claude", ("--version",)),
@@ -183,6 +205,56 @@ def _with_advisory_signals(paths: OmhPaths, profile: str, result: dict[str, obje
     return result
 
 
+def _path_resolutions(command: str) -> list[str]:
+    """Every distinct binary this command resolves to, in PATH order.
+
+    `shutil.which` answers "what will run"; this answers "what else could".
+    Deduplicated by real path so a symlink chain to the same binary does not
+    read as a conflict.
+    """
+    resolutions: list[str] = []
+    seen: set[str] = set()
+    for directory in os.environ.get("PATH", "").split(os.pathsep):
+        if not directory:
+            continue
+        candidate = Path(directory) / command
+        try:
+            if not candidate.is_file() or not os.access(candidate, os.X_OK):
+                continue
+            real = str(candidate.resolve())
+        except OSError:
+            continue
+        if real in seen:
+            continue
+        seen.add(real)
+        resolutions.append(str(candidate))
+    return resolutions
+
+
+def _observed_version(binary: str, args: list[str]) -> str:
+    """The binary's own version line, or the failure it printed instead."""
+    try:
+        completed = subprocess.run(
+            [binary, *args],
+            text=True,
+            capture_output=True,
+            timeout=_PROBE_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return f"probe failed: {exc}"[:200]
+    output = (completed.stdout or completed.stderr or "").strip().splitlines()
+    return output[0][:200] if output else f"exited with {completed.returncode}"
+
+
+def _resolution_report(command: str, args: list[str]) -> list[dict[str, str]]:
+    """One row per distinct PATH resolution, each with its observed version."""
+    return [
+        {"path": path, "observed_version": _observed_version(path, args)}
+        for path in _path_resolutions(command)[:_MAX_OBSERVED_RESOLUTIONS]
+    ]
+
+
 def _run_probe(contract: dict[str, object]) -> dict[str, object]:
     result = dict(contract)
     probe = result.get("probe")
@@ -234,6 +306,15 @@ def _run_probe(contract: dict[str, object]) -> dict[str, object]:
         )
         return result
     output = (completed.stdout or completed.stderr or "").strip().splitlines()
+    summary = output[0][:200] if output else f"`{command}` exited with {completed.returncode}."
+    resolutions = _resolution_report(command, args)
+    versions = {row["observed_version"] for row in resolutions}
+    shadowed = len(resolutions) > 1 and len(versions) > 1
+    if shadowed:
+        others = "; ".join(
+            f"{row['path']} ({row['observed_version']})" for row in resolutions[1:]
+        )
+        summary = f"{summary} — PATH also resolves: {others}"[:400]
     result.update(
         {
             "status": "ready" if completed.returncode == 0 else "blocked",
@@ -241,7 +322,14 @@ def _run_probe(contract: dict[str, object]) -> dict[str, object]:
             "observed_once": True,
             "exit_code": completed.returncode,
             "command_path": resolved,
-            "summary": output[0][:200] if output else f"`{command}` exited with {completed.returncode}.",
+            "path_resolutions": resolutions,
+            # Shadowed means: more than one distinct binary, with differing
+            # observed versions. The first is what will run and status reflects
+            # it honestly; the flag exists so a stale binary hiding a newer
+            # install is a stated fact, not a mid-dispatch surprise.
+            "shadowed": shadowed,
+            "version_policy": EXECUTOR_VERSION_POLICY,
+            "summary": summary,
             "next_action": _ready_action(str(result.get("profile", ""))) if completed.returncode == 0 else "choose_executor_or_configure_path",
         }
     )

--- a/tests/test_executor_readiness_resolutions.py
+++ b/tests/test_executor_readiness_resolutions.py
@@ -1,0 +1,112 @@
+"""The readiness probe reports every PATH resolution, pinned to no version.
+
+Users update codex and claude on their own cadence and through more than one
+installer, so binaries of different versions routinely coexist on PATH.
+Observed live: a stale npm codex 0.144.5 resolved first and probed "ready"
+while the standalone 0.145.0 the auth session actually required sat one PATH
+entry later -- `shutil.which` answers only "what will run", so the newer
+install was invisible and the dispatch failed mid-flight.
+
+The structural rule these pin: OMH never compares an executor version against
+an expectation of its own. It observes what each resolution prints and says
+when the binary that will run is not the only one installed.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.coding.executor_readiness import (
+    EXECUTOR_VERSION_POLICY,
+    _run_probe,
+    executor_readiness_contract,
+)
+
+
+def _fake_binary(directory: str, name: str, version: str) -> Path:
+    path = Path(directory) / name
+    path.write_text(f"#!/bin/sh\necho 'codex-cli {version}'\n", encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IEXEC)
+    return path
+
+
+class PathResolutionReportTests(unittest.TestCase):
+    def _probe(self, path_value: str) -> dict:
+        with patch.dict(os.environ, {"PATH": path_value}):
+            return _run_probe(dict(executor_readiness_contract("codex")))
+
+    def test_a_stale_binary_shadowing_a_newer_one_is_reported(self) -> None:
+        # The live failure, reproduced: first-on-PATH is old, newer sits behind.
+        with TemporaryDirectory() as first, TemporaryDirectory() as second:
+            _fake_binary(first, "codex", "0.144.5")
+            _fake_binary(second, "codex", "0.145.0")
+            result = self._probe(os.pathsep.join([first, second]))
+
+            self.assertTrue(result["shadowed"])
+            versions = [row["observed_version"] for row in result["path_resolutions"]]
+            self.assertEqual(versions, ["codex-cli 0.144.5", "codex-cli 0.145.0"])
+            # The stale one is still what runs, so status stays honest...
+            self.assertEqual(result["status"], "ready")
+            # ...and the summary names the alternative instead of hiding it.
+            self.assertIn("0.145.0", result["summary"])
+            self.assertIn("PATH also resolves", result["summary"])
+
+    def test_a_single_binary_reports_no_shadow(self) -> None:
+        with TemporaryDirectory() as only:
+            _fake_binary(only, "codex", "0.145.0")
+            result = self._probe(only)
+            self.assertFalse(result["shadowed"])
+            self.assertEqual(len(result["path_resolutions"]), 1)
+            self.assertNotIn("PATH also resolves", result["summary"])
+
+    def test_a_symlink_to_the_same_binary_is_not_a_conflict(self) -> None:
+        # Dedup is by real path: standalone installs symlink through a
+        # `current` pointer, and a chain to one binary is one binary.
+        with TemporaryDirectory() as real_dir, TemporaryDirectory() as link_dir:
+            real = _fake_binary(real_dir, "codex", "0.145.0")
+            (Path(link_dir) / "codex").symlink_to(real)
+            result = self._probe(os.pathsep.join([link_dir, real_dir]))
+            self.assertFalse(result["shadowed"])
+            self.assertEqual(len(result["path_resolutions"]), 1)
+
+    def test_same_version_in_two_places_is_not_flagged_as_shadowed(self) -> None:
+        # Two distinct binaries printing the same version disagree about
+        # nothing a user must resolve; flagging them would train people to
+        # ignore the flag.
+        with TemporaryDirectory() as first, TemporaryDirectory() as second:
+            _fake_binary(first, "codex", "0.145.0")
+            _fake_binary(second, "codex", "0.145.0")
+            result = self._probe(os.pathsep.join([first, second]))
+            self.assertFalse(result["shadowed"])
+
+    def test_the_probe_carries_the_no_pinned_version_policy(self) -> None:
+        with TemporaryDirectory() as only:
+            _fake_binary(only, "codex", "9.9.9")
+            result = self._probe(only)
+            self.assertEqual(result["version_policy"], EXECUTOR_VERSION_POLICY)
+            # A future version OMH has never seen probes ready: nothing in the
+            # contract encodes an expected version to fall behind.
+            self.assertEqual(result["status"], "ready")
+
+    def test_no_source_line_hardcodes_an_executor_version(self) -> None:
+        # The guard for the structural rule itself: the module may print
+        # versions it observed, never carry one of its own.
+        import inspect
+
+        import omh.coding.executor_readiness as module
+
+        source = inspect.getsource(module)
+        for literal in ("0.144", "0.145", "2.1.2"):
+            self.assertNotIn(literal, source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

The executor readiness probe now enumerates **every distinct PATH resolution** of the executor command (deduplicated by real path), observes what each prints for `--version`, and reports three additive fields: `path_resolutions`, `shadowed`, and `version_policy`. OMH pins no executor version anywhere — and a guard test rejects any version literal in the module, comments included.

### Why This Exists

Observed live: a stale npm codex resolved first on PATH and the readiness probe reported "ready", while the newer standalone the auth session actually required sat one PATH entry later. `shutil.which` answers only "what will run" — the newer install was invisible, the dispatch went out on the stale binary, and the run failed mid-flight.

케이홉 fixed that machine's PATH by hand, then asked the structural question: users update codex and claude dynamically, through more than one installer — OMH must work whatever version is installed. The failure mode wasn't "wrong version"; it was **shadowing OMH couldn't see**.

### How It Works

| Scenario | `shadowed` | Probe says |
| --- | --- | --- |
| Stale binary first, newer behind (the live failure) | **true** | `codex-cli 0.144.5 — PATH also resolves: …/codex (codex-cli 0.145.0)` |
| One binary | false | version line only |
| Symlink chain to same binary (standalone `current` pointer) | false | one resolution |
| Same version installed twice | false | not a user problem; flagging it trains people to ignore the flag |
| A version OMH has never seen | — | probes **ready** — nothing encodes an expectation to fall behind |

Status stays derived from the first resolution because that is what will actually run; the flag turns stale-shadows-newer into a stated fact instead of a mid-dispatch surprise. Cost is bounded: ≤3 version subprocesses, probes remain first-use cached.

The guard test caught its own first draft — the module comment named the observed versions, which is exactly the rot the rule forbids.

### Files And Contracts Touched

- `src/coding/executor_readiness.py` — `_path_resolutions`, `_observed_version`, `_resolution_report`, `EXECUTOR_VERSION_POLICY`; wired into `_run_probe`.
- `tests/test_executor_readiness_resolutions.py` — 6 new tests.
- `executor_readiness/v1` gains three additive keys; no schema shape changed.

## Validation

- [x] `python3 -m unittest discover -s tests` — **2298 passed**, 1 skipped
- [x] `ruff`, `compileall`, docs workflows/roles/capability-families `--check`, harness validate, `git diff --check`
- [x] Live-failure fixture (stale-first/newer-second) plus 4 controls
- [x] Real machine: codex → single resolution 0.145.0, claude → 2.1.220, both `shadowed=False` after cleanup
- [ ] No live dispatch has run against a shadowed PATH since the change — verified by fixture.

## Risk

Low. Additive fields; existing consumers reading known keys are unaffected. Rejected alternatives are recorded in the commit: pinning minimum versions (rots as users update), preferring the newest resolution (reports a binary PATH won't run), flagging same-version duplicates (cries wolf).
