### PR TITLE
feat: goal echo-back and bounded verification discipline in unit prompts

### DIFF
--- a/docs/FANOUT.md
+++ b/docs/FANOUT.md
@@ -101,6 +101,23 @@ goal to Hermes in chat; these commands are the backend surface.
   resolution matrix with chains and provenance. Contracts frozen before the
   v2 bump may embed `coding_model_route/v1` routes — they are read verbatim
   (the brief annotates them `[schema v1]`), never rewritten.
+- **Unit prompt protocol.** Every dispatched unit prompt carries a fixed
+  verification discipline (`src/coding/unit_prompt_protocol.py`): the
+  subagent first echoes the goal, its deliverable, and the numbered
+  completion criteria back before any tool use (and stops to report a
+  conflict instead of guessing); "done" is pre-declared as numbered
+  criteria derived from the frozen contract (boundary confinement, the
+  unit's integration checks, committed work); and verification is
+  mandatory-but-bounded — exactly one full pass is the floor, a finding
+  blocks only when it violates a stated criterion, passing criteria are
+  never re-verified, and a still-failing criterion is reported after two
+  fix-and-verify cycles instead of looping. Review-role units add
+  criterion-bound review with a two-round re-review cap. High-effort
+  routes (high/xhigh/max) append a per-family calibration block countering
+  over-verification inertia; unknown families get the generic block so no
+  vendor carries richer guidance than another. Prompts are subprocess
+  argv, so the assembled worst case is policy-gated under
+  `UNIT_PROMPT_MAX_BYTES` in tests rather than trimmed at runtime.
 - **Telemetry.** Each dispatched unit records `started_at`, `finished_at`,
   and `duration_seconds`, and the full dispatch summary persists to
   `~/.omh/coding/fanout/<id>/dispatch_summary.json` (latest wins,

--- a/src/coding/fanout_dispatch.py
+++ b/src/coding/fanout_dispatch.py
@@ -12,6 +12,7 @@ from ..system.metadata_safety import redact_metadata_text
 from ..system.paths import OmhPaths
 from .executor_readiness import probe_executor_readiness
 from .fanout_contracts import FANOUT_CLAIM_BOUNDARY
+from .unit_prompt_protocol import unit_protocol_lines
 
 FANOUT_DISPATCH_SCHEMA_VERSION = "fanout_dispatch_summary/v1"
 DISPATCH_CLAIM_BOUNDARY = (
@@ -116,7 +117,6 @@ def build_unit_prompt(unit: Mapping[str, Any], goal_text: str) -> str:
     boundary = unit.get("boundary", {}) if isinstance(unit.get("boundary"), Mapping) else {}
     file_scope = ", ".join(str(path) for path in boundary.get("file_scope", []))
     do_not_touch = ", ".join(str(path) for path in boundary.get("do_not_touch", []))
-    checks = "; ".join(str(check) for check in unit.get("integration_checks", []))
     lines = [
         f"Work unit: {unit.get('title', unit.get('unit_id'))}",
         f"Overall goal: {goal_text.strip()}",
@@ -125,8 +125,10 @@ def build_unit_prompt(unit: Mapping[str, Any], goal_text: str) -> str:
     if do_not_touch:
         lines.append(f"Do not touch: {do_not_touch} (owned by sibling units).")
     lines.append(f"Work on branch {unit.get('branch_suggestion', '')} in the current worktree.")
-    if checks:
-        lines.append(f"Before finishing: {checks}.")
+    # Goal echo-back, pre-declared completion criteria (absorbing the unit's
+    # integration checks), bounded verification discipline, and — on
+    # high-effort routes — the per-family over-verification calibration.
+    lines.extend(unit_protocol_lines(unit))
     lines.append("Commit your work; do not merge or push other branches.")
     return "\n".join(lines)
 

--- a/src/coding/unit_prompt_protocol.py
+++ b/src/coding/unit_prompt_protocol.py
@@ -1,0 +1,134 @@
+"""Verification discipline for prepared fanout unit prompts.
+
+Three deterministic text blocks ride every dispatched unit prompt:
+
+1. **Goal echo-back** — before any tool use the subagent restates the goal,
+   its own deliverable, and the completion criteria, and stops to report (not
+   guess) if its reading conflicts with the declared boundary.
+2. **Pre-declared completion criteria** — "done" is defined BEFORE work
+   starts, as a numbered list derived from the unit contract, so completion
+   is a check against stated criteria rather than a feeling.
+3. **Verification stop conditions** — verification is mandatory (exactly one
+   full pass is the floor, never skipped) and bounded (after the criteria
+   pass, re-verifying is forbidden; on failure, at most two fix-and-verify
+   cycles before reporting the failing criterion instead of looping).
+
+High-effort routes additionally get a per-family calibration block that
+counters the known over-verification inertia of strong reasoning models.
+Calibration is keyed by model family and selected only when the routed
+reasoning effort is in the high tier; families the table has not met get the
+generic block — no family carries richer guidance than another without a
+stated reason, and no vendor is privileged.
+
+Everything here is pure data and pure functions: the blocks land in prepared
+prompts (subprocess argv), so the total prompt size is policy-gated by
+`UNIT_PROMPT_MAX_BYTES` in tests rather than trimmed at runtime.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Final, Mapping
+
+# Policy ceiling for a fully-assembled unit prompt (bytes of UTF-8). The
+# worst-case combination across roles, owners, and calibration blocks is
+# asserted under this in tests; runtime never truncates.
+UNIT_PROMPT_MAX_BYTES: Final[int] = 8000
+
+# Reasoning efforts that mark a route as high-effort for calibration purposes.
+HIGH_EFFORT_TIER: Final[frozenset[str]] = frozenset({"high", "xhigh", "max"})
+
+GOAL_ECHO_PROTOCOL: Final[str] = (
+    "Before your first tool use, restate in your own words: (1) the overall goal in one sentence, "
+    "(2) this unit's deliverable, and (3) the numbered completion criteria below. If your restatement "
+    "conflicts with the declared boundary or criteria, stop and report the conflict instead of guessing."
+)
+
+VERIFICATION_STOP_PROTOCOL: Final[str] = (
+    "Verification discipline: run exactly ONE full verification pass against the numbered criteria after "
+    "finishing the work — verification is never skipped. A check failure blocks completion only when it "
+    "violates a stated criterion; note anything else as an observation and move on. Once every criterion "
+    "has passed, STOP: do not re-verify, do not add a just-to-be-sure pass, and do not restart verification "
+    "after edits that no criterion covers. If a criterion still fails after two fix-and-verify cycles, "
+    "commit what passes and report the failing criterion with its output instead of looping."
+)
+
+REVIEW_ROLE_PROTOCOL: Final[str] = (
+    "Review discipline: a finding blocks only when it violates a stated success criterion of the reviewed "
+    "work; list every other finding as non-blocking. Cap re-review at two rounds — after that, report the "
+    "remaining criterion-cited blockers rather than starting another round."
+)
+
+# Per-family counters to the over-verification inertia of high-effort routes.
+# Keyed by `model_family()` output; "generic" is the mandatory fallback so an
+# unknown family never gets weaker discipline than a known one.
+HIGH_EFFORT_CALIBRATIONS: Final[dict[str, str]] = {
+    "gpt": (
+        "High-effort calibration: your reasoning depth is for the hard parts of THIS unit, not for "
+        "re-deriving settled facts. Once the decisive fact is in view, act on it; once a criterion has "
+        "passed, it is settled evidence — reopen it only when new output contradicts it, never to "
+        "reassure yourself."
+    ),
+    "claude": (
+        "High-effort calibration: follow the numbered criteria as the complete checklist — do not grow "
+        "the checklist mid-run. Deliberate deeply only where correctness is genuinely at risk; for "
+        "mechanical steps, act directly and let the single verification pass prove them."
+    ),
+    "generic": (
+        "High-effort calibration: reserve extended reasoning for genuine ambiguity with materially "
+        "different outcomes. Decide once, act, verify once against the criteria, and stop — speed is "
+        "never a reason to skip the verification pass, and thoroughness is never a reason to repeat it."
+    ),
+}
+
+
+def completion_criteria_for_unit(unit: Mapping[str, Any]) -> list[str]:
+    """Return the pre-declared, numbered 'done means' criteria for one unit.
+
+    Derived deterministically from the frozen unit contract: boundary
+    confinement and committed work are always criteria; the contract's
+    integration checks become the unit-specific ones.
+    """
+    boundary = unit.get("boundary", {}) if isinstance(unit.get("boundary"), Mapping) else {}
+    file_scope = ", ".join(str(path) for path in boundary.get("file_scope", []))
+    criteria = [f"Every edit stays inside: {file_scope}." if file_scope else "Every edit stays inside the declared file scope."]
+    for check in unit.get("integration_checks", []) or []:
+        text = str(check).strip()
+        if text:
+            criteria.append(text[0].upper() + text[1:] if text[0].islower() else text)
+    criteria.append("The work is committed on the unit branch; nothing else is merged or pushed.")
+    return criteria
+
+
+def calibration_for_route(model_route: Mapping[str, Any] | None) -> str:
+    """Return the high-effort calibration block for a routed unit, or ''.
+
+    Selected only when the route's effective reasoning effort is in the high
+    tier; family comes from the already-recorded `model_family` (falling back
+    to generic for unknown/blank families).
+    """
+    if not isinstance(model_route, Mapping):
+        return ""
+    effort = str(model_route.get("selected_reasoning_effort", "") or "").casefold()
+    if effort not in HIGH_EFFORT_TIER:
+        return ""
+    family = str(model_route.get("model_family", "") or "").casefold()
+    return HIGH_EFFORT_CALIBRATIONS.get(family, HIGH_EFFORT_CALIBRATIONS["generic"])
+
+
+def unit_protocol_lines(unit: Mapping[str, Any]) -> list[str]:
+    """Return the ordered protocol lines appended to a unit prompt."""
+    criteria = completion_criteria_for_unit(unit)
+    lines = [GOAL_ECHO_PROTOCOL, "Done means, and only means:"]
+    lines.extend(f"{index}. {criterion}" for index, criterion in enumerate(criteria, start=1))
+    lines.append(VERIFICATION_STOP_PROTOCOL)
+    handoff = unit.get("handoff", {}) if isinstance(unit.get("handoff"), Mapping) else {}
+    model_route = handoff.get("model_route") if isinstance(handoff.get("model_route"), Mapping) else None
+    # Contract units carry the declared role inside the recorded route, not as
+    # a top-level key; accept both so pre-contract unit dicts behave the same.
+    role = str(unit.get("role", "") or "") or (str(model_route.get("role", "") or "") if model_route else "")
+    if role == "review":
+        lines.append(REVIEW_ROLE_PROTOCOL)
+    calibration = calibration_for_route(model_route)
+    if calibration:
+        lines.append(calibration)
+    return lines

--- a/tests/test_unit_prompt_protocol.py
+++ b/tests/test_unit_prompt_protocol.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import unittest
+
+from _local_package import load_local_package
+
+load_local_package()
+
+from omh.coding.fanout import build_fanout_contract  # noqa: E402
+from omh.coding.fanout_dispatch import build_unit_prompt  # noqa: E402
+from omh.coding.model_routing import EXECUTOR_MODEL_OPTIONS, MODEL_ROLES  # noqa: E402
+from omh.coding.unit_prompt_protocol import (  # noqa: E402
+    GOAL_ECHO_PROTOCOL,
+    HIGH_EFFORT_CALIBRATIONS,
+    HIGH_EFFORT_TIER,
+    REVIEW_ROLE_PROTOCOL,
+    UNIT_PROMPT_MAX_BYTES,
+    VERIFICATION_STOP_PROTOCOL,
+    calibration_for_route,
+    completion_criteria_for_unit,
+    unit_protocol_lines,
+)
+
+_GOAL = "build the virtual dashboard feature across subagents"
+
+
+def _contract_unit(units: list[dict], unit_id: str) -> dict:
+    contract = build_fanout_contract(_GOAL, units)
+    return {unit["unit_id"]: unit for unit in contract["units"]}[unit_id]
+
+
+class ProtocolContentTests(unittest.TestCase):
+    def test_prompt_carries_echo_criteria_and_stop_protocol(self) -> None:
+        unit = _contract_unit(
+            [
+                {"unit_id": "impl", "title": "Impl", "owner": "codex", "file_scope": ["src/core/"]},
+                {"unit_id": "aux", "title": "Aux", "owner": "claude-code", "file_scope": ["docs/"]},
+            ],
+            "impl",
+        )
+        prompt = build_unit_prompt(unit, _GOAL)
+        self.assertIn(GOAL_ECHO_PROTOCOL, prompt)
+        self.assertIn("Done means, and only means:", prompt)
+        self.assertIn(VERIFICATION_STOP_PROTOCOL, prompt)
+        # Verification stays mandatory: the discipline bounds it, never skips it.
+        self.assertIn("verification is never skipped", prompt)
+        self.assertIn("Commit your work; do not merge or push other branches.", prompt)
+
+    def test_integration_checks_become_numbered_criteria(self) -> None:
+        unit = _contract_unit(
+            [
+                {"unit_id": "impl", "title": "Impl", "owner": "codex", "file_scope": ["src/core/"]},
+                {"unit_id": "aux", "title": "Aux", "owner": "claude-code", "file_scope": ["docs/"]},
+            ],
+            "impl",
+        )
+        prompt = build_unit_prompt(unit, _GOAL)
+        self.assertNotIn("Before finishing:", prompt)
+        criteria = completion_criteria_for_unit(unit)
+        self.assertGreaterEqual(len(criteria), 3)
+        for index, criterion in enumerate(criteria, start=1):
+            self.assertIn(f"{index}. {criterion}", prompt)
+        # Boundary confinement and committed work are always declared criteria.
+        self.assertTrue(any("src/core/" in criterion for criterion in criteria))
+        self.assertTrue(any("committed" in criterion for criterion in criteria))
+
+    def test_review_role_gets_criterion_bound_review_protocol(self) -> None:
+        review = _contract_unit(
+            [
+                {"unit_id": "review", "title": "Review", "owner": "codex", "file_scope": ["src/r/"], "role": "review"},
+                {"unit_id": "aux", "title": "Aux", "owner": "claude-code", "file_scope": ["docs/"]},
+            ],
+            "review",
+        )
+        self.assertIn(REVIEW_ROLE_PROTOCOL, build_unit_prompt(review, _GOAL))
+        aux = _contract_unit(
+            [
+                {"unit_id": "review", "title": "Review", "owner": "codex", "file_scope": ["src/r/"], "role": "review"},
+                {"unit_id": "aux", "title": "Aux", "owner": "claude-code", "file_scope": ["docs/"]},
+            ],
+            "aux",
+        )
+        self.assertNotIn(REVIEW_ROLE_PROTOCOL, build_unit_prompt(aux, _GOAL))
+
+
+class CalibrationSelectionTests(unittest.TestCase):
+    def test_high_effort_codex_brain_gets_gpt_calibration(self) -> None:
+        unit = _contract_unit(
+            [
+                {"unit_id": "brain", "title": "Brain", "owner": "codex", "file_scope": ["src/d/"], "role": "brain"},
+                {"unit_id": "aux", "title": "Aux", "owner": "claude-code", "file_scope": ["docs/"]},
+            ],
+            "brain",
+        )
+        prompt = build_unit_prompt(unit, _GOAL)
+        self.assertIn(HIGH_EFFORT_CALIBRATIONS["gpt"], prompt)
+
+    def test_high_effort_claude_brain_gets_claude_calibration(self) -> None:
+        unit = _contract_unit(
+            [
+                {"unit_id": "brain", "title": "Brain", "owner": "claude-code", "file_scope": ["src/d/"], "role": "brain"},
+                {"unit_id": "aux", "title": "Aux", "owner": "codex", "file_scope": ["docs/"]},
+            ],
+            "brain",
+        )
+        prompt = build_unit_prompt(unit, _GOAL)
+        self.assertIn(HIGH_EFFORT_CALIBRATIONS["claude"], prompt)
+
+    def test_low_or_absent_effort_gets_no_calibration(self) -> None:
+        unit = _contract_unit(
+            [
+                {"unit_id": "docs", "title": "Docs", "owner": "codex", "file_scope": ["docs/a/"], "role": "docs"},
+                {"unit_id": "aux", "title": "Aux", "owner": "claude-code", "file_scope": ["docs/b/"]},
+            ],
+            "docs",
+        )
+        prompt = build_unit_prompt(unit, _GOAL)
+        for block in HIGH_EFFORT_CALIBRATIONS.values():
+            self.assertNotIn(block, prompt)
+
+    def test_unknown_family_high_effort_falls_back_to_generic(self) -> None:
+        route = {"selected_reasoning_effort": "xhigh", "model_family": "unknown"}
+        self.assertEqual(calibration_for_route(route), HIGH_EFFORT_CALIBRATIONS["generic"])
+        route = {"selected_reasoning_effort": "xhigh", "model_family": "kimi"}
+        self.assertEqual(calibration_for_route(route), HIGH_EFFORT_CALIBRATIONS["generic"])
+
+    def test_no_route_means_no_calibration(self) -> None:
+        self.assertEqual(calibration_for_route(None), "")
+
+    def test_generic_fallback_exists_and_no_family_lacks_discipline(self) -> None:
+        # Executor neutrality: the generic block is mandatory so an unknown
+        # family never gets weaker discipline than a known one, and every
+        # declared block carries the same core stop rule.
+        self.assertIn("generic", HIGH_EFFORT_CALIBRATIONS)
+        for family, block in HIGH_EFFORT_CALIBRATIONS.items():
+            self.assertTrue(block.startswith("High-effort calibration:"), family)
+
+
+class PromptBudgetPolicyTests(unittest.TestCase):
+    def test_worst_case_prompt_stays_under_budget(self) -> None:
+        """Unit prompts become subprocess argv; the ceiling is policy-gated
+        here rather than trimmed at runtime. Exercises every profile x role
+        combination plus a wide sibling boundary."""
+        wide_scope = [f"src/area{i}/" for i in range(12)]
+        worst = 0
+        for profile in EXECUTOR_MODEL_OPTIONS:
+            for role in MODEL_ROLES:
+                units = [
+                    {
+                        "unit_id": "target",
+                        "title": "A deliberately verbose unit title for budget measurement",
+                        "owner": profile,
+                        "file_scope": ["src/target/"],
+                        "role": role,
+                        "reasoning_effort": "max",
+                    },
+                    {"unit_id": "sibling", "title": "Sibling", "owner": profile, "file_scope": wide_scope},
+                ]
+                unit = _contract_unit(units, "target")
+                prompt = build_unit_prompt(unit, _GOAL * 3)
+                worst = max(worst, len(prompt.encode("utf-8")))
+        self.assertLess(worst, UNIT_PROMPT_MAX_BYTES, f"worst-case unit prompt {worst}B")
+
+    def test_protocol_lines_are_deterministic(self) -> None:
+        unit = _contract_unit(
+            [
+                {"unit_id": "brain", "title": "Brain", "owner": "codex", "file_scope": ["src/d/"], "role": "brain"},
+                {"unit_id": "aux", "title": "Aux", "owner": "claude-code", "file_scope": ["docs/"]},
+            ],
+            "brain",
+        )
+        self.assertEqual(unit_protocol_lines(unit), unit_protocol_lines(unit))
+        self.assertEqual(build_unit_prompt(unit, _GOAL), build_unit_prompt(unit, _GOAL))
+
+    def test_high_effort_tier_vocabulary(self) -> None:
+        self.assertEqual(HIGH_EFFORT_TIER, frozenset({"high", "xhigh", "max"}))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Stacked on #717** (model-distribution v2) — calibration selection reads the v2 route's `model_family`/effort. Merge #717 first; this PR's base is that branch and should be retargeted to `main` after #717 lands.

## Capability

Every dispatched fanout unit prompt now carries a deterministic verification protocol (`src/coding/unit_prompt_protocol.py`), adapting the stop-condition techniques from the oh-my-openagent research (terminal-condition rules, criterion-bound blocking, capped re-review) that keep high-effort models (GPT Sol/Terra at high/xhigh, opus at max) from looping verify → re-produce → re-verify:

1. **복명복창 (goal echo-back)** — before any tool use the subagent restates the overall goal, its own deliverable, and the numbered completion criteria; a conflict with the declared boundary is reported, never guessed around.
2. **Pre-declared completion criteria** — "done" is defined *before* work starts as numbered criteria derived from the frozen contract (boundary confinement + the unit's integration checks + committed work). Completion becomes a check against stated criteria, not a feeling.
3. **Bounded-but-mandatory verification** — per 케이홉's explicit constraint, verification is never removed: exactly one full pass is the floor. Then it is bounded: a finding blocks only when it violates a stated criterion; passed criteria are settled evidence, never re-verified, no just-to-be-sure passes; a still-failing criterion is reported with its output after two fix-and-verify cycles instead of looping. Review-role units additionally get criterion-bound review with a two-round re-review cap.
4. **High-effort calibration blocks (data, not free text)** — routes at high/xhigh/max effort append a per-family counter to over-verification inertia (gpt: settled facts stay settled; claude: the checklist does not grow mid-run), selected by the route's recorded `model_family`. A mandatory **generic** fallback covers unknown families so no vendor carries richer guidance than another (executor-neutrality preserved).

## The deferral blocker, resolved first

The consensus plan deferred calibration blocks because `build_unit_prompt` output becomes subprocess argv with no size budget. This PR adds `UNIT_PROMPT_MAX_BYTES` (8000) as a **policy gate**: the worst-case assembled prompt across every profile × role × max-effort combination (wide sibling boundaries, long goals) is asserted under the ceiling in tests. Runtime never truncates — silent loss was rejected.

## Follow-up filed

Extensible model families (Kimi K3, GLM 5.2) and custom-variant tier registration: **#718** — blocked on an executor surface for those families; the reference category semantics (ultrabrain/deep/unspecified-low/high/visual-engineering) are recorded there as design context, not as a setup instruction.

## Verification observed

- Full suite on the stacked branch: **2332 tests OK (1 pre-existing skip)** — includes the new `tests/test_unit_prompt_protocol.py` (12 tests: block presence per role/effort/family, generic fallback, no-calibration cases, integration-checks absorption, determinism, worst-case byte budget).
- Byte gates (workflows/roles/capability-families) OK; ruff clean; `git diff --check` clean; DCO verified.
- `docs/FANOUT.md` documents the protocol under dispatch semantics.

## Risks

- Changes the prepared prompt text every dispatched unit receives; boundary/branch/commit instructions are unchanged and the old `Before finishing:` line is absorbed into the numbered criteria (asserted by test).
- Live subagent *compliance* with the protocol is executor truth omh does not observe — the prompt content is what this PR pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A4YNe8BB4KPWbgfEiZyfpC
