### PR TITLE
feat: budget recall packs and say when records were cut

### DIFF
--- a/src/commands/memory.py
+++ b/src/commands/memory.py
@@ -126,6 +126,7 @@ def cmd_memory_recall(args: argparse.Namespace) -> int:
             scope_kind=args.scope_kind,
             scope_ref=args.scope_ref,
             limit=_optional_positive_int(args.limit, "--limit") or 6,
+            max_chars=_optional_positive_int(args.max_chars, "--max-chars"),
             include_stale=args.include_stale,
         )
     except (OSError, ValueError) as exc:

--- a/src/commands/memory_parser.py
+++ b/src/commands/memory_parser.py
@@ -50,6 +50,12 @@ def add_memory_commands(sub: argparse._SubParsersAction[argparse.ArgumentParser]
     recall.add_argument("--scope-kind", choices=("project", "target", "thread", "run"), default=None)
     recall.add_argument("--scope-ref", default=None)
     recall.add_argument("--limit", type=int, default=6)
+    recall.add_argument(
+        "--max-chars",
+        type=int,
+        default=None,
+        help="Optional summary-character budget; records cut by it are marked over_budget and the pack says truncated.",
+    )
     recall.add_argument("--include-stale", action="store_true")
     recall.set_defaults(func=memory.cmd_memory_recall)
 

--- a/src/runtime/records.py
+++ b/src/runtime/records.py
@@ -1553,6 +1553,7 @@ def _compact_memory_recall_pack(value: Any) -> dict[str, Any]:
         "included_records": [],
         "excluded_records": [],
         "record_count": len(value.get("included_records", [])) if isinstance(value.get("included_records"), list) else 0,
+        "truncated": bool(value.get("truncated", False)),
         "redaction_policy": str(value.get("redaction_policy", "")),
         "claim_boundary": str(value.get("claim_boundary", "")),
     }

--- a/src/workflows/memory.py
+++ b/src/workflows/memory.py
@@ -100,6 +100,7 @@ _PROJECT_MEMORY_RECALL_PACK_KEYS = {
     "included_records",
     "excluded_records",
     "record_count",
+    "truncated",
     "redaction_policy",
     "claim_boundary",
 }
@@ -386,6 +387,7 @@ def build_project_memory_recall_pack(
     scope_kind: str | None = None,
     scope_ref: str | None = None,
     limit: int = 6,
+    max_chars: int | None = None,
     include_stale: bool = False,
 ) -> dict[str, object]:
     policy = read_project_memory_policy(paths)
@@ -423,7 +425,32 @@ def build_project_memory_recall_pack(
             continue
         included.append(_recall_item(record, score=score, staleness=staleness))
     included.sort(key=lambda item: (-int(item.get("score", 0)), str(item.get("record_id", ""))))
-    included = included[: max(limit, 0)]
+    # Budget cut follows the priority ladder above: once either budget is
+    # crossed, everything after that point is cut, so a lower-priority record
+    # never displaces a higher-priority one. Cut records are recorded as
+    # over_budget rather than dropped silently -- the pack must be able to say
+    # "this is not everything".
+    kept: list[dict[str, object]] = []
+    kept_chars = 0
+    budget_exhausted = False
+    for item in included:
+        summary_chars = len(str(item.get("summary", "")))
+        if not budget_exhausted:
+            over_records = len(kept) >= max(limit, 0)
+            over_chars = max_chars is not None and kept_chars + summary_chars > max_chars
+            budget_exhausted = over_records or over_chars
+        if budget_exhausted:
+            excluded.append(
+                {
+                    "record_id": str(item.get("record_id", "")),
+                    "reason": "over_budget",
+                    "staleness": item.get("staleness", {"state": "not_checked"}),
+                }
+            )
+            continue
+        kept.append(item)
+        kept_chars += summary_chars
+    included = kept
     return {
         "schema_version": PROJECT_MEMORY_RECALL_PACK_SCHEMA_VERSION,
         "enabled": True,
@@ -435,6 +462,7 @@ def build_project_memory_recall_pack(
         "included_records": included,
         "excluded_records": excluded,
         "record_count": len(included),
+        "truncated": budget_exhausted,
         "redaction_policy": "metadata_only",
         "claim_boundary": (
             "Memory recall packs contain reviewed OMH project summaries only; "
@@ -690,6 +718,8 @@ def validate_project_memory_recall_pack(value: Any, *, label: str = "memory_reca
     _validate_context_list(value.get("included_records"), _PROJECT_MEMORY_RECALL_ITEM_KEYS, errors, f"{label}.included_records", scope_key="scope")
     _validate_context_list(value.get("excluded_records"), _PROJECT_MEMORY_EXCLUDED_KEYS, errors, f"{label}.excluded_records")
     _validate_context_map(value.get("task_ref"), _PROJECT_MEMORY_TASK_REF_KEYS, errors, f"{label}.task_ref")
+    if not isinstance(value.get("truncated"), bool):
+        errors.append(f"{label}.truncated must be a boolean")
     if not isinstance(value.get("policy"), dict):
         errors.append(f"{label}.policy must be an object")
     if value.get("redaction_policy") != "metadata_only":
@@ -826,6 +856,7 @@ def _empty_recall_pack(
         "included_records": [],
         "excluded_records": [{"record_id": "", "reason": reason, "staleness": {"state": "not_checked"}}],
         "record_count": 0,
+        "truncated": False,
         "redaction_policy": "metadata_only",
         "claim_boundary": "Memory recall is disabled or empty; no execution, review, CI, merge, or Hermes internal-memory evidence is produced.",
     }

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -23,6 +23,7 @@ from omh.memory import (
     memory_recall_pack_for_handoff,
     read_handoff_context_pack_file,
     reject_project_memory_candidate,
+    validate_project_memory_recall_pack,
 )
 from omh.paths import resolve_paths
 from omh.profiles.setup import write_setup_profile
@@ -106,6 +107,43 @@ class MemoryContractTests(unittest.TestCase):
             self.assertTrue(captured["auto_approved"])
             self.assertEqual(captured["record"]["schema_version"], "project_memory_record/v1")
             self.assertEqual(build_project_memory_status(paths)["counts"]["approved_records"], 1)
+
+    def test_project_memory_recall_pack_budget_marks_truncation(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            write_setup_profile(paths, memory_mode="auto-safe")
+            for idx in range(4):
+                capture_project_memory_candidate(
+                    paths,
+                    f"Release tests procedure variant {idx} keeps workflow docs verified",
+                    record_type="procedure",
+                    tags=["release", "tests"],
+                )
+
+            untouched = build_project_memory_recall_pack(paths, "release tests")
+            self.assertEqual(untouched["record_count"], 4)
+            self.assertFalse(untouched["truncated"])
+            self.assertEqual(validate_project_memory_recall_pack(untouched), [])
+
+            by_records = build_project_memory_recall_pack(paths, "release tests", limit=2)
+            self.assertTrue(by_records["truncated"])
+            self.assertEqual(by_records["record_count"], 2)
+            over_budget = [item for item in by_records["excluded_records"] if item["reason"] == "over_budget"]
+            self.assertEqual(len(over_budget), 2)
+            included_ids = {item["record_id"] for item in by_records["included_records"]}
+            self.assertFalse(included_ids & {item["record_id"] for item in over_budget})
+            self.assertEqual(included_ids, {item["record_id"] for item in untouched["included_records"][:2]})
+            self.assertEqual(validate_project_memory_recall_pack(by_records), [])
+
+            summary_chars = len(str(untouched["included_records"][0]["summary"]))
+            by_chars = build_project_memory_recall_pack(paths, "release tests", max_chars=summary_chars * 2)
+            self.assertTrue(by_chars["truncated"])
+            self.assertEqual(by_chars["record_count"], 2)
+            self.assertEqual(
+                sum(1 for item in by_chars["excluded_records"] if item["reason"] == "over_budget"),
+                2,
+            )
+            self.assertEqual(validate_project_memory_recall_pack(by_chars), [])
 
     def test_project_memory_recall_pack_feeds_coding_handoff_when_enabled(self) -> None:
         with TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Feature Report

### What Changed

- `memory_recall_pack/v1` gains an explicit truncation contract: recall now takes an optional `--max-chars` summary-character budget alongside the existing `--limit` record budget, cuts strictly along the existing priority ladder, records every cut record in `excluded_records` with `reason: "over_budget"`, and carries a top-level `truncated` boolean.
- `omh memory recall` grows the `--max-chars` flag (validated as a positive int, default off).
- Compact lifecycle copies of the pack (`_compact_memory_recall_pack` in `src/runtime/records.py`) preserve the `truncated` flag, so persisted coding-delegation records keep the signal.

### Why This Exists

- A recall pack cut by the record limit dropped the cut records silently: they appeared in neither `included_records` nor `excluded_records`, so a consumer (or the selected coding owner reading a handoff) could not distinguish a complete pack from a truncated one.
- The store grows over time while handoff context budgets do not; operators need a character-level budget knob and an honest marker when it bites. Making truncation explicit matches the repo's prepared-vs-observed philosophy: the pack states "this is not everything" instead of implying completeness.

### User / Operator Impact

- Before: `omh memory recall --limit N` silently discarded everything past N.
- After: any record cut by either budget is visible as an `over_budget` exclusion, `truncated: true` says the pack is partial, and `--max-chars` lets an operator or wrapper bound the summary payload for handoffs. When nothing is cut, `truncated: false` and the pack is unchanged for existing consumers.

### How It Works

- `build_project_memory_recall_pack` (`src/workflows/memory.py`) sorts by the existing score ladder, then applies a prefix cut: once either budget (record count or cumulative summary chars) is crossed, that record and everything after it becomes an `over_budget` exclusion, so a lower-priority record can never displace a higher-priority one (first-fit packing was rejected for exactly that reason).
- `validate_project_memory_recall_pack` requires `truncated` to be a boolean and allows the new key; `_empty_recall_pack` emits `truncated: false`.
- Schema stays `project_memory_recall_pack/v1`: the change is additive and every producer in-tree now emits the field.

### Files And Contracts Touched

- `src/workflows/memory.py` — builder, empty pack, validator, allowed-key set.
- `src/commands/memory.py`, `src/commands/memory_parser.py` — `--max-chars` CLI surface.
- `src/runtime/records.py` — compaction keeps `truncated` (lifecycle records revalidate the compacted pack; dropping the field there fails every delegation write).
- `tests/test_memory.py` — budget contract test (untruncated, record-budget, char-budget cases, validator round-trip).

## Validation

- [x] `uv run --group lint ruff check src tests` — clean
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests` — 2339 tests OK (1 pre-existing skip)
- [x] `uv run python -m compileall -q src tests` — clean
- [x] New test captured failing first (`KeyError: 'truncated'`) before the production change, green after
- [x] CLI smoke on a temp OMH home: 3 approved records, `memory recall --limit 1` → `truncated: true` + 2 `over_budget` exclusions; `--max-chars 80` → 1 included, 2 cut
- [x] `git diff --check` — clean
- [ ] Manual Hermes/TUI check: not run — the change is a data-contract + CLI surface; no chat-rendered output changed

## Risk

- Additive field under an allowed-key validator: any out-of-tree producer of `memory_recall_pack/v1` that does not emit `truncated` will now fail validation. In-tree producers are updated; the field defaults to `false` semantics everywhere.
- Follow-up candidate (not in this PR): dedupe of near-identical records — over_budget exclusion logs now make the duplication measurable first.
