### PR TITLE
feat: inventory-derived routing with a fingerprint-recorded basis

### DIFF
--- a/docs/FANOUT.md
+++ b/docs/FANOUT.md
@@ -115,11 +115,28 @@ goal to Hermes in chat; these commands are the backend surface.
   favors the grok family) under their own claim boundary: editorial
   defaults, not observed capability, no routing effect. The inventory never
   enters a model route, a frozen contract, or persisted state — it is
-  read-time advisory context for the operator or wrapper proposing a split,
-  and routing consumption is a recorded follow-up. A compact hint (families
-  present, model count, the full-report command) rides the choose-executor
-  context automatically, so Hermes proposes owners from what the user
-  actually has instead of asking blind.
+  read-time advisory context for the operator or wrapper proposing a split.
+  A compact hint (families present, model count, the full-report command)
+  rides the choose-executor context automatically, so Hermes proposes owners
+  from what the user actually has instead of asking blind.
+- **Inventory-derived routing (fingerprint-recorded).** For profiles without
+  a built-in model catalog, the command layer derives a
+  `local_model_catalog/v1` from the observed inventory — today that means
+  the OMO runtime, whose role chains come from the user's own omo category
+  config (ordered category→role sources declared as data). Built-in
+  catalogs always win; the derived catalog applies only to the profile it
+  names; and it never gains effort authority (observed config variants are
+  evidence of use, not of a model's effort vocabulary, so requested ladder
+  efforts pass through untouched). A route resolved this way records
+  `catalog_kind: "local_inventory"` plus a `catalog_fingerprint` (model-set
+  digest, per-source statuses, observation time) so the frozen contract
+  names the exact basis it was resolved from. At dispatch, units carrying a
+  fingerprint gain an advisory `inventory_fingerprint` note comparing the
+  frozen digest against the current one — a mismatch never blocks (the
+  frozen contract stays the instruction; provider truth adjudicates), it
+  only makes prepare-vs-dispatch skew visible. `omh coding model-route
+  --from-inventory` previews these routes; fanout prepare consults the
+  derived catalog automatically.
 - **Unit prompt protocol.** Every dispatched unit prompt carries a fixed
   verification discipline (`src/coding/unit_prompt_protocol.py`): the
   subagent first echoes the goal, its deliverable, and the numbered
@@ -169,7 +186,7 @@ omh coding fanout brief [<fanout-id>] [--json]
 omh coding fanout dispatch <fanout-id> --goal-file goal.txt \
   [--repo-root .] [--base-ref HEAD] [--concurrency 2] [--timeout 1800] \
   [--unit <id> ...] [--dry-run]
-omh coding model-route [--executor <profile>] [--role <role>] [--model <id>] [--effort <level>] [--explain] [--json]
+omh coding model-route [--executor <profile>] [--role <role>] [--model <id>] [--effort <level>] [--explain] [--from-inventory] [--json]
 omh coding model-inventory [--json]
 ```
 

--- a/src/coding/fanout.py
+++ b/src/coding/fanout.py
@@ -24,6 +24,7 @@ def build_fanout_contract(
     *,
     source: str = "generic",
     source_metadata: Mapping[str, object] | None = None,
+    local_catalogs: Mapping[str, Mapping[str, object]] | None = None,
 ) -> dict[str, object]:
     normalized_goal = " ".join(goal.split())
     if not normalized_goal:
@@ -36,7 +37,12 @@ def build_fanout_contract(
     fanout_id = f"fanout-{digest[:12]}"
     unit_ids = [str(unit["unit_id"]) for unit in normalized_units]
     contract_units = [
-        _contract_unit(unit, sibling_scopes=_sibling_scopes(normalized_units, str(unit["unit_id"])), fanout_id=fanout_id)
+        _contract_unit(
+            unit,
+            sibling_scopes=_sibling_scopes(normalized_units, str(unit["unit_id"])),
+            fanout_id=fanout_id,
+            local_catalogs=local_catalogs,
+        )
         for unit in normalized_units
     ]
     return {
@@ -188,11 +194,18 @@ def _sibling_scopes(units: Sequence[Mapping[str, object]], unit_id: str) -> list
     return sorted(scopes)
 
 
-def _contract_unit(unit: Mapping[str, object], *, sibling_scopes: list[str], fanout_id: str) -> dict[str, object]:
+def _contract_unit(
+    unit: Mapping[str, object],
+    *,
+    sibling_scopes: list[str],
+    fanout_id: str,
+    local_catalogs: Mapping[str, Mapping[str, object]] | None = None,
+) -> dict[str, object]:
     unit_id = str(unit["unit_id"])
     own_scope = set(str(path) for path in unit.get("file_scope", []))
     executor_target = str(unit.get("owner")) if unit.get("owner") else "choose"
-    model_route = model_route_for_unit(unit, executor_target)
+    local_catalog = (local_catalogs or {}).get(executor_target)
+    model_route = model_route_for_unit(unit, executor_target, local_catalog)
     handoff: dict[str, object] = {
         "schema_version": "fanout_unit_handoff/v1",
         "executor_target": executor_target,

--- a/src/coding/fanout_dispatch.py
+++ b/src/coding/fanout_dispatch.py
@@ -4,7 +4,7 @@ from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 import subprocess
 import time
-from typing import Any, Callable, Mapping, Sequence
+from typing import Any, Callable, Iterable, Mapping, Sequence
 
 from ..runtime.artifacts import append_journal_observation, create_run, show_run
 from ..system.local_store import atomic_write_json, locked_json_update, utc_now
@@ -168,6 +168,7 @@ def dispatch_fanout(
     verify_goal_matches_contract(contract, goal_text)
     units = {str(unit["unit_id"]): unit for unit in contract.get("units", []) if isinstance(unit, Mapping)}
     order = [str(unit_id) for unit_id in contract.get("merge_plan", {}).get("merge_order", [])]
+    current_catalog_digest = _current_catalog_digest(units.values())
     selected = set(only_units) if only_units else set(order)
     results: dict[str, dict[str, Any]] = {}
 
@@ -217,6 +218,7 @@ def dispatch_fanout(
                     dry_run=dry_run,
                     runner=runner,
                     readiness=readiness,
+                    current_catalog_digest=current_catalog_digest,
                 )
                 for unit_id in ready
             }
@@ -290,6 +292,26 @@ def _merged_dispatch_summary(summary_path: Path, summary: dict[str, Any]) -> dic
     return merged
 
 
+def _current_catalog_digest(units: Iterable[Mapping[str, Any]]) -> str:
+    """Observe the current local-catalog digest once per dispatch, and only
+    when some unit's frozen route actually carries a catalog fingerprint —
+    contracts routed purely from built-in catalogs never trigger the read."""
+    for unit in units:
+        handoff = unit.get("handoff", {}) if isinstance(unit.get("handoff"), Mapping) else {}
+        route = handoff.get("model_route")
+        if isinstance(route, Mapping) and isinstance(route.get("catalog_fingerprint"), Mapping):
+            break
+    else:
+        return ""
+    from .model_inventory import inventory_model_catalog, local_model_inventory
+
+    catalog = inventory_model_catalog(local_model_inventory())
+    if not isinstance(catalog, Mapping):
+        return ""
+    fingerprint = catalog.get("fingerprint")
+    return str(fingerprint.get("digest", "") or "") if isinstance(fingerprint, Mapping) else ""
+
+
 def _dispatch_unit(
     paths: OmhPaths,
     unit: Mapping[str, Any],
@@ -301,7 +323,10 @@ def _dispatch_unit(
     dry_run: bool,
     runner: Callable[..., Any],
     readiness: Callable[..., dict[str, object]],
+    current_catalog_digest: str = "",
 ) -> dict[str, Any]:
+    from .model_inventory import catalog_fingerprint_note
+
     unit_id = str(unit["unit_id"])
     run_ref = str(unit.get("run_ref", unit_id))
     handoff = unit.get("handoff", {}) if isinstance(unit.get("handoff"), Mapping) else {}
@@ -309,6 +334,7 @@ def _dispatch_unit(
     model_route = handoff.get("model_route") if isinstance(handoff.get("model_route"), Mapping) else None
     routed_model = str(model_route.get("selected_model", "") or "") if model_route else ""
     routed_effort = str(model_route.get("selected_reasoning_effort", "") or "") if model_route else ""
+    fingerprint_note = catalog_fingerprint_note(model_route, current_catalog_digest)
     if DISPATCH_COMMAND_TEMPLATES.get(owner) is None:
         return {
             "unit_id": unit_id,
@@ -332,7 +358,7 @@ def _dispatch_unit(
     argv = build_dispatch_argv(owner, prompt, model_route)
     worktree = _worktree_path(repo_root, unit_id)
     if dry_run:
-        return {
+        planned: dict[str, Any] = {
             "unit_id": unit_id,
             "run_ref": run_ref,
             "owner": owner,
@@ -342,6 +368,9 @@ def _dispatch_unit(
             "worktree_path": str(worktree),
             "merge_ready": False,
         }
+        if fingerprint_note is not None:
+            planned["inventory_fingerprint"] = fingerprint_note
+        return planned
     from .worktree_creator import ensure_fanout_unit_worktree
 
     worktree_record = ensure_fanout_unit_worktree(
@@ -434,6 +463,8 @@ def _dispatch_unit(
         "finished_at": finished_at,
         "duration_seconds": duration_seconds,
     }
+    if fingerprint_note is not None:
+        result["inventory_fingerprint"] = fingerprint_note
     if limit_label:
         result["limit_shaped"] = True
         result["limit_pattern"] = limit_label

--- a/src/coding/model_inventory.py
+++ b/src/coding/model_inventory.py
@@ -24,6 +24,7 @@ Boundaries, in order of importance:
 
 from __future__ import annotations
 
+from hashlib import sha256
 import json
 from pathlib import Path
 import shutil
@@ -74,6 +75,27 @@ MODEL_DOMAIN_AFFINITY_CLAIM_BOUNDARY: Final[str] = (
     "rank an option; the user's explicit choice always wins."
 )
 
+# The executor profile a locally-derived catalog belongs to: omo ships as an
+# opencode plugin, so models named by its config run under the OMO runtime
+# surface, never under codex/claude-code (whose catalogs stay built-in).
+MODEL_INVENTORY_CATALOG_PROFILE: Final[str] = "omo-runtime"
+
+LOCAL_MODEL_CATALOG_SCHEMA_VERSION: Final[str] = "local_model_catalog/v1"
+
+# Ordered category sources per role: deterministic data, not inference. The
+# omo config's semantic categories map onto the fanout roles; where several
+# categories serve one role, the order below decides chain concatenation and
+# ties break toward the stronger-signal category. Review deliberately reuses
+# the high-capability categories — reviewer-vs-author separation is advisory
+# handoff text, not a catalog property.
+OMO_CATEGORY_ROLE_SOURCES: Final[dict[str, tuple[str, ...]]] = {
+    "brain": ("ultrabrain", "deep", "unspecified-high"),
+    "implementation": ("unspecified-high", "unspecified-low"),
+    "design_visual": ("visual-engineering", "artistry"),
+    "review": ("unspecified-high", "deep"),
+    "docs": ("writing", "quick"),
+}
+
 _OMO_AGENT_CONFIG_RELATIVE: Final[str] = ".config/opencode/oh-my-openagent.json"
 _OPENCODE_CONFIG_RELATIVE: Final[str] = ".config/opencode/opencode.json"
 _OPENCODE_AUTH_RELATIVE: Final[str] = ".local/share/opencode/auth.json"
@@ -87,7 +109,7 @@ def local_model_inventory(home: Path | None = None) -> dict[str, object]:
     """Return the metadata-only inventory of locally-activated coding models."""
     base = home if home is not None else Path.home()
     cli_presence = {command: shutil.which(command) is not None for command in CLI_PRESENCE_COMMANDS}
-    omo_source, omo_models = _omo_agent_config_source(base / _OMO_AGENT_CONFIG_RELATIVE)
+    omo_source, omo_models, category_chains = _omo_agent_config_source(base / _OMO_AGENT_CONFIG_RELATIVE)
     provider_source = _top_level_key_source(base / _OPENCODE_CONFIG_RELATIVE, section="provider")
     auth_source = _top_level_key_source(base / _OPENCODE_AUTH_RELATIVE, section="")
     auth_signals = executor_auth_signals(base)
@@ -114,6 +136,7 @@ def local_model_inventory(home: Path | None = None) -> dict[str, object]:
         },
         "available_models": available_models,
         "families_present": families,
+        "omo_category_chains": {name: list(chain) for name, chain in sorted(category_chains.items())},
         "domain_affinity_notes": [
             {
                 "domain": domain,
@@ -127,24 +150,38 @@ def local_model_inventory(home: Path | None = None) -> dict[str, object]:
     }
 
 
-def _omo_agent_config_source(path: Path) -> tuple[dict[str, object], list[tuple[str, str, str]]]:
-    """Read (source payload, [(provider, model_id, variant), ...]) from the omo config."""
+def _omo_agent_config_source(
+    path: Path,
+) -> tuple[dict[str, object], list[tuple[str, str, str]], dict[str, list[dict[str, str]]]]:
+    """Read (source payload, model entries, per-category ordered chains).
+
+    Model entries are `(provider, model_id, variant)` tuples from both agents
+    and categories. Category chains keep the config's own primary-then-
+    fallback order per category name so a local catalog can derive role
+    chains from them deterministically.
+    """
     parsed = _read_json(path)
     if parsed is None:
-        return {"status": "absent" if not path.is_file() else "unreadable", "model_count": 0, "rejected": 0}, []
+        return (
+            {"status": "absent" if not path.is_file() else "unreadable", "model_count": 0, "rejected": 0},
+            [],
+            {},
+        )
     entries: list[tuple[str, str, str]] = []
+    category_chains: dict[str, list[dict[str, str]]] = {}
     rejected = 0
     for section in ("agents", "categories"):
         table = parsed.get(section)
         if not isinstance(table, Mapping):
             continue
-        for spec in table.values():
+        for name, spec in table.items():
             if not isinstance(spec, Mapping):
                 continue
             candidates = [spec]
             fallbacks = spec.get("fallback_models")
             if isinstance(fallbacks, list):
                 candidates.extend(entry for entry in fallbacks if isinstance(entry, Mapping))
+            accepted_chain: list[dict[str, str]] = []
             for candidate in candidates:
                 if "model" not in candidate:
                     continue
@@ -154,7 +191,18 @@ def _omo_agent_config_source(path: Path) -> tuple[dict[str, object], list[tuple[
                     rejected += 1
                 else:
                     entries.append(accepted)
-    return {"status": "present", "model_count": len(entries), "rejected": rejected}, entries
+                    provider, model_id, variant = accepted
+                    accepted_chain.append(
+                        {"model_id": f"{provider}/{model_id}", "reasoning_effort": variant}
+                    )
+            if section == "categories" and accepted_chain:
+                try:
+                    category = require_opaque_metadata_ref(name, field="category")
+                except ValueError:
+                    rejected += 1
+                    continue
+                category_chains[category] = accepted_chain
+    return {"status": "present", "model_count": len(entries), "rejected": rejected}, entries, category_chains
 
 
 def _accepted_model_entry(candidate: Mapping[str, object]) -> tuple[str, str, str] | None:
@@ -202,6 +250,121 @@ def _read_json(path: Path) -> dict[str, object] | None:
     except _READ_ERRORS:
         return None
     return parsed if isinstance(parsed, dict) else None
+
+
+def inventory_model_catalog(inventory: Mapping[str, object]) -> dict[str, object] | None:
+    """Derive the local model catalog for the OMO runtime from an inventory payload.
+
+    Pure data transform (no I/O): callers observe the inventory once and pass
+    it in, so the route resolver stays free of filesystem reads. Returns None
+    when the inventory names no models — a missing catalog must read as
+    "nothing configured", never as an empty-but-authoritative catalog.
+
+    The fingerprint is the reproducibility anchor for any route frozen from
+    this catalog: digest of the sorted model ids plus per-source statuses and
+    the observation time. `reasoning_efforts` stays empty on every option —
+    observed config variants are evidence of use, not of a model's effort
+    vocabulary, so this catalog never gains effort authority.
+    """
+    models = inventory.get("available_models", [])
+    if not isinstance(models, list) or not models:
+        return None
+    option_ids: list[str] = []
+    options: list[dict[str, object]] = []
+    for entry in models:
+        if not isinstance(entry, Mapping):
+            continue
+        model_id = f"{entry.get('provider')}/{entry.get('model_id')}"
+        option_ids.append(model_id)
+        options.append(
+            {
+                "model_id": model_id,
+                "label": f"{entry.get('family') or 'unknown'} family via {entry.get('provider')}",
+                "tier": "",
+                "recommended_roles": (),
+                "reasoning_efforts": (),
+            }
+        )
+    category_chains = inventory.get("omo_category_chains", {})
+    chains: dict[str, tuple[dict[str, str], ...]] = {}
+    if isinstance(category_chains, Mapping):
+        for role, categories in OMO_CATEGORY_ROLE_SOURCES.items():
+            merged: list[dict[str, str]] = []
+            seen: set[tuple[str, str]] = set()
+            for category in categories:
+                chain = category_chains.get(category)
+                if not isinstance(chain, list):
+                    continue
+                for entry in chain:
+                    if not isinstance(entry, Mapping):
+                        continue
+                    key = (str(entry.get("model_id", "")), str(entry.get("reasoning_effort", "")))
+                    if key in seen or not key[0]:
+                        continue
+                    seen.add(key)
+                    merged.append({"model_id": key[0], "reasoning_effort": key[1]})
+            if merged:
+                chains[role] = tuple(merged)
+    sources = inventory.get("sources", {})
+    source_statuses = (
+        {name: str(entry.get("status", "unknown")) for name, entry in sources.items() if isinstance(entry, Mapping)}
+        if isinstance(sources, Mapping)
+        else {}
+    )
+    # The digest anchors the derived ARTIFACT, not just the input model set:
+    # reassigning a category (and with it a role chain) to an already-present
+    # model is exactly the drift the fingerprint exists to make visible, so
+    # the chains participate in the digest alongside the option ids.
+    canonical = json.dumps(
+        {
+            "options": sorted(option_ids),
+            "chains": {
+                role: [[entry["model_id"], entry["reasoning_effort"]] for entry in chain]
+                for role, chain in sorted(chains.items())
+            },
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    digest = sha256(canonical.encode("utf-8")).hexdigest()[:16]
+    return {
+        "schema_version": LOCAL_MODEL_CATALOG_SCHEMA_VERSION,
+        "executor_profile": MODEL_INVENTORY_CATALOG_PROFILE,
+        "catalog_kind": "local_inventory",
+        "options": options,
+        "chains": chains,
+        "fingerprint": {
+            "digest": digest,
+            "sources": source_statuses,
+            "observed_at": str(inventory.get("observed_at", "")),
+        },
+    }
+
+
+def catalog_fingerprint_note(
+    model_route: Mapping[str, object] | None, current_digest: str
+) -> dict[str, object] | None:
+    """Advisory prepare-vs-dispatch skew record for a frozen route.
+
+    A route resolved from a local catalog froze that catalog's fingerprint;
+    the local config may have changed between prepare and dispatch. The note
+    names both digests and whether they match — advisory only: a mismatch
+    never blocks dispatch (the frozen contract stays the explicit instruction
+    and provider truth adjudicates the model), it only makes the skew visible.
+    Returns None for routes without a fingerprint.
+    """
+    if not isinstance(model_route, Mapping):
+        return None
+    fingerprint = model_route.get("catalog_fingerprint")
+    if not isinstance(fingerprint, Mapping):
+        return None
+    frozen = str(fingerprint.get("digest", "") or "")
+    current = str(current_digest or "")
+    return {
+        "frozen_digest": frozen,
+        "current_digest": current,
+        "match": bool(frozen) and frozen == current,
+    }
 
 
 def _aggregated_models(entries: list[tuple[str, str, str]]) -> list[dict[str, object]]:

--- a/src/coding/model_routing.py
+++ b/src/coding/model_routing.py
@@ -91,6 +91,12 @@ CODING_MODEL_ROUTE_CLAIM_BOUNDARY: Final[str] = (
 # the catalog is a default candidate list, not an allowlist.
 MODEL_CATALOG_KIND: Final[str] = "built_in_defaults"
 
+# Closed vocabulary for a route's catalog basis. `local_inventory` marks a
+# catalog derived from the user's own local configuration at observation time;
+# such routes additionally carry `catalog_fingerprint` so a frozen record
+# names the exact basis it was resolved from.
+MODEL_CATALOG_KINDS: Final[tuple[str, ...]] = ("built_in_defaults", "local_inventory")
+
 EXECUTOR_MODEL_OPTIONS: Final[dict[str, tuple[dict[str, object], ...]]] = {
     "codex": (
         {
@@ -209,6 +215,11 @@ def model_family(model_id: str) -> str:
     normalized = str(model_id or "").strip().casefold()
     if not normalized:
         return ""
+    # Provider-prefixed ids (`opencode/kimi-k3`, `anthropic/claude-opus-5`)
+    # classify by the model segment: the provider names where it runs, the
+    # family names what it is.
+    if "/" in normalized:
+        normalized = normalized.rsplit("/", 1)[1]
     if normalized in _CLAUDE_TIER_ALIASES:
         return "claude"
     for prefix, family in _MODEL_FAMILY_PREFIXES:
@@ -224,6 +235,7 @@ def resolve_model_route(
     requested_effort: str = "",
     role: str = "",
     chains: Mapping[str, Mapping[str, tuple[Mapping[str, str], ...]]] | None = None,
+    local_catalog: Mapping[str, object] | None = None,
 ) -> dict[str, object]:
     """Return the deterministic prepared model route for one executor profile.
 
@@ -232,8 +244,19 @@ def resolve_model_route(
     to its chain head; a role whose chain is missing is an explicit choice;
     no data leaves the executor CLI default in place as a named outcome.
 
-    `chains` is injectable for tests only; production callers always use
-    `ROLE_MODEL_CHAINS`.
+    Injection precedence — the two parameters never apply to the same profile:
+    `chains` (tests only) overrides role chains for profiles WITH a built-in
+    catalog; `local_catalog` (a `local_model_catalog/v1` payload derived by
+    the caller from an observed inventory — I/O stays in the caller, this
+    function remains pure) is consulted ONLY when the profile has no built-in
+    catalog and the payload names this profile. A route resolved from a local
+    catalog records `catalog_kind: "local_inventory"` plus the catalog's
+    `fingerprint` so the frozen record names its exact basis, and a local
+    catalog never gains effort authority — observed config variants are
+    evidence of use, not of a model's effort vocabulary. An absent
+    `catalog_fingerprint` on any route means "no local basis was consulted",
+    never "unknown basis" — v1 routes and built-in-catalog routes correctly
+    carry none.
     """
     profile = str(executor_profile or "").strip().casefold()
     raw_role = str(role or "").strip()
@@ -249,16 +272,44 @@ def resolve_model_route(
     model = str(requested_model or "").strip()
     effort = str(requested_effort or "").strip().casefold()
     options = EXECUTOR_MODEL_OPTIONS.get(profile, ())
+    catalog_kind = MODEL_CATALOG_KIND
+    catalog_fingerprint: dict[str, object] | None = None
+    effort_authoritative = True
+    local_chains: Mapping[str, tuple[Mapping[str, str], ...]] = {}
+    if not options and _local_catalog_applies(profile, local_catalog):
+        raw_options = local_catalog.get("options", []) if isinstance(local_catalog, Mapping) else []
+        resolved_options = tuple(option for option in raw_options if isinstance(option, Mapping))
+        if resolved_options:
+            # The local basis is claimed only once it demonstrably exists: an
+            # empty or corrupt payload must fall through to the executor
+            # default WITHOUT a fingerprint, or the frozen record would name
+            # a basis that never adjudicated anything.
+            options = resolved_options
+            raw_chains = local_catalog.get("chains", {}) if isinstance(local_catalog, Mapping) else {}
+            local_chains = raw_chains if isinstance(raw_chains, Mapping) else {}
+            raw_fingerprint = local_catalog.get("fingerprint") if isinstance(local_catalog, Mapping) else None
+            catalog_fingerprint = dict(raw_fingerprint) if isinstance(raw_fingerprint, Mapping) else None
+            catalog_kind = "local_inventory"
+            effort_authoritative = False
+        else:
+            role_reasons.append(
+                "A local model catalog was offered but carried no usable options; it was not consulted."
+            )
     candidates = [dict(option) for option in options]
-    chain_table = ROLE_MODEL_CHAINS if chains is None else chains
-    role_chain = tuple(chain_table.get(profile, {}).get(normalized_role, ())) if normalized_role else ()
+    if catalog_kind == "local_inventory":
+        role_chain = tuple(local_chains.get(normalized_role, ())) if normalized_role else ()
+    else:
+        chain_table = ROLE_MODEL_CHAINS if chains is None else chains
+        role_chain = tuple(chain_table.get(profile, {}).get(normalized_role, ())) if normalized_role else ()
     attempted: list[dict[str, str]] = []
 
     if model:
         attempted.append(
             {"stage": "requested_model", "outcome": "selected", "reason": f"request names `{model}`"}
         )
-        selected_effort, effort_change = _selected_effort(profile, effort, "", model)
+        selected_effort, effort_change = _selected_effort(
+            options, effort, "", model, authoritative=effort_authoritative
+        )
         return _route_payload(
             profile,
             status="routed",
@@ -267,7 +318,9 @@ def resolve_model_route(
             selected_model=model,
             selected_reasoning_effort=selected_effort,
             effort_change=effort_change,
-            chain=_chain_payload(profile, role_chain, selected_model=""),
+            catalog_kind=catalog_kind,
+            catalog_fingerprint=catalog_fingerprint,
+            chain=_chain_payload(options, role_chain, selected_model=""),
             attempted=attempted,
             candidates=candidates,
             reasons=role_reasons + [f"The request names `{model}` directly, so the catalog is advisory only."],
@@ -281,7 +334,9 @@ def resolve_model_route(
         attempted.append(
             {"stage": "executor_default", "outcome": "selected", "reason": "no catalog; executor CLI default applies"}
         )
-        selected_effort, effort_change = _selected_effort(profile, effort, "", "")
+        selected_effort, effort_change = _selected_effort(
+            options, effort, "", "", authoritative=effort_authoritative
+        )
         return _route_payload(
             profile,
             status="no_model_catalog",
@@ -289,6 +344,8 @@ def resolve_model_route(
             role=normalized_role,
             selected_reasoning_effort=selected_effort,
             effort_change=effort_change,
+            catalog_kind=catalog_kind,
+            catalog_fingerprint=catalog_fingerprint,
             chain=[],
             attempted=attempted,
             candidates=[],
@@ -306,7 +363,8 @@ def resolve_model_route(
                 {"stage": "role_chain", "outcome": "selected", "reason": f"chain head `{selected}` for role `{normalized_role}`"}
             )
             selected_effort, effort_change = _selected_effort(
-                profile, effort, str(head.get("reasoning_effort", "") or ""), selected
+                options, effort, str(head.get("reasoning_effort", "") or ""), selected,
+                authoritative=effort_authoritative,
             )
             return _route_payload(
                 profile,
@@ -316,7 +374,9 @@ def resolve_model_route(
                 selected_model=selected,
                 selected_reasoning_effort=selected_effort,
                 effort_change=effort_change,
-                chain=_chain_payload(profile, role_chain, selected_model=selected),
+                catalog_kind=catalog_kind,
+                catalog_fingerprint=catalog_fingerprint,
+                chain=_chain_payload(options, role_chain, selected_model=selected),
                 attempted=attempted,
                 candidates=candidates,
                 reasons=role_reasons
@@ -331,7 +391,9 @@ def resolve_model_route(
         attempted.append(
             {"stage": "role_chain", "outcome": "unavailable", "reason": f"no chain declared for role `{normalized_role}`"}
         )
-        selected_effort, effort_change = _selected_effort(profile, effort, "", "")
+        selected_effort, effort_change = _selected_effort(
+            options, effort, "", "", authoritative=effort_authoritative
+        )
         return _route_payload(
             profile,
             status="choice_required",
@@ -339,6 +401,8 @@ def resolve_model_route(
             role=normalized_role,
             selected_reasoning_effort=selected_effort,
             effort_change=effort_change,
+            catalog_kind=catalog_kind,
+            catalog_fingerprint=catalog_fingerprint,
             chain=[],
             attempted=attempted,
             candidates=candidates,
@@ -358,7 +422,9 @@ def resolve_model_route(
         if not raw_role
         else "No usable model or role remained, so the executor CLI default model applies."
     )
-    selected_effort, effort_change = _selected_effort(profile, effort, "", "")
+    selected_effort, effort_change = _selected_effort(
+        options, effort, "", "", authoritative=effort_authoritative
+    )
     return _route_payload(
         profile,
         status="model_unrouted",
@@ -366,6 +432,8 @@ def resolve_model_route(
         role=normalized_role,
         selected_reasoning_effort=selected_effort,
         effort_change=effort_change,
+        catalog_kind=catalog_kind,
+        catalog_fingerprint=catalog_fingerprint,
         chain=[],
         attempted=attempted,
         candidates=candidates,
@@ -373,8 +441,16 @@ def resolve_model_route(
     )
 
 
-def model_route_for_unit(unit: Mapping[str, object], executor_target: str) -> dict[str, object] | None:
-    """Return the prepared model route for a fanout unit, or None when unrouted."""
+def model_route_for_unit(
+    unit: Mapping[str, object],
+    executor_target: str,
+    local_catalog: Mapping[str, object] | None = None,
+) -> dict[str, object] | None:
+    """Return the prepared model route for a fanout unit, or None when unrouted.
+
+    `local_catalog` is passed through verbatim; this function stays pure and
+    the resolver's precedence rules decide whether it applies.
+    """
     model = str(unit.get("model", "") or "").strip()
     effort = str(unit.get("reasoning_effort", "") or "").strip()
     role = str(unit.get("role", "") or "").strip()
@@ -385,6 +461,7 @@ def model_route_for_unit(unit: Mapping[str, object], executor_target: str) -> di
         requested_model=model,
         requested_effort=effort,
         role=role,
+        local_catalog=local_catalog,
     )
 
 
@@ -418,20 +495,31 @@ def _normalized_role(role: str) -> str:
     return normalized if normalized in MODEL_ROLES else ""
 
 
-def _supported_efforts(profile: str, model_id: str) -> tuple[tuple[str, ...], str]:
+def _local_catalog_applies(profile: str, local_catalog: Mapping[str, object] | None) -> bool:
+    """A local catalog applies only to the profile it names — never to a
+    profile with a built-in catalog (the caller gate) and never to a payload
+    resolved for some other executor."""
+    if not isinstance(local_catalog, Mapping):
+        return False
+    return str(local_catalog.get("executor_profile", "") or "").strip().casefold() == profile
+
+
+def _supported_efforts(
+    options: tuple[Mapping[str, object], ...], model_id: str
+) -> tuple[tuple[str, ...], str]:
     """Return (efforts, authority) with authority "exact_model" | "profile_union".
 
     Only an exact catalog match grants the catalog authority over a model's
     effort vocabulary. The union fallback exists so a requested effort is never
     silently dropped for a model the catalog has not met — the catalog
     disclaims authority there, so its answer is advisory, never adjudicating.
-    A profile absent from the catalog returns ((), "profile_union").
+    An empty options tuple returns ((), "profile_union").
     """
-    for option in EXECUTOR_MODEL_OPTIONS.get(profile, ()):
+    for option in options:
         if str(option.get("model_id", "")).casefold() == str(model_id or "").casefold():
             return tuple(str(value) for value in option.get("reasoning_efforts", ())), "exact_model"
     union: list[str] = []
-    for option in EXECUTOR_MODEL_OPTIONS.get(profile, ()):
+    for option in options:
         for value in option.get("reasoning_efforts", ()):
             if str(value) not in union:
                 union.append(str(value))
@@ -451,20 +539,25 @@ _EFFORT_SHAPE_CHARSET: Final[frozenset[str]] = frozenset("abcdefghijklmnopqrstuv
 
 
 def _selected_effort(
-    profile: str,
+    options: tuple[Mapping[str, object], ...],
     requested_effort: str,
     chain_effort: str,
     model_id: str,
+    *,
+    authoritative: bool = True,
 ) -> tuple[str, dict[str, str] | None]:
     """Resolve the effort and its typed change record.
 
     Precedence: requested > chain-entry > none. The change record exists only
     when the user requested an effort; chain-supplied efforts never appear in
     it. The ladder downgrades only under exact-model catalog authority — the
-    catalog never adjudicates a model it has not met.
+    catalog never adjudicates a model it has not met, and a non-authoritative
+    catalog (local inventory) never adjudicates at all.
     """
     if requested_effort:
-        supported, authority = _supported_efforts(profile, model_id)
+        supported, authority = _supported_efforts(options, model_id)
+        if not authoritative:
+            authority = "profile_union"
         if requested_effort in supported:
             return requested_effort, _effort_change(requested_effort, requested_effort, "unchanged", "supported as requested")
         if requested_effort in _EFFORT_LADDER and authority == "exact_model":
@@ -505,13 +598,13 @@ def _effort_change(requested: str, selected: str, kind: str, reason: str) -> dic
 
 
 def _chain_payload(
-    profile: str,
+    options: tuple[Mapping[str, object], ...],
     role_chain: tuple[Mapping[str, str], ...],
     *,
     selected_model: str,
 ) -> list[dict[str, object]]:
-    by_model: dict[str, dict[str, object]] = {
-        str(option.get("model_id", "")): option for option in EXECUTOR_MODEL_OPTIONS.get(profile, ())
+    by_model: dict[str, Mapping[str, object]] = {
+        str(option.get("model_id", "")): option for option in options
     }
     payload: list[dict[str, object]] = []
     for position, entry in enumerate(role_chain):
@@ -543,6 +636,8 @@ def _route_payload(
     selected_model: str = "",
     selected_reasoning_effort: str = "",
     effort_change: dict[str, str] | None = None,
+    catalog_kind: str = MODEL_CATALOG_KIND,
+    catalog_fingerprint: dict[str, object] | None = None,
 ) -> dict[str, object]:
     payload: dict[str, object] = {
         "schema_version": CODING_MODEL_ROUTE_SCHEMA_VERSION,
@@ -565,10 +660,12 @@ def _route_payload(
             }
             for option in candidates
         ],
-        "catalog_kind": MODEL_CATALOG_KIND,
+        "catalog_kind": catalog_kind,
         "reasons": list(reasons),
         "claim_boundary": CODING_MODEL_ROUTE_CLAIM_BOUNDARY,
     }
+    if catalog_fingerprint is not None:
+        payload["catalog_fingerprint"] = catalog_fingerprint
     if effort_change is not None:
         payload["effort_change"] = effort_change
     return payload

--- a/src/commands/coding.py
+++ b/src/commands/coding.py
@@ -657,11 +657,15 @@ def cmd_coding_model_route(args: argparse.Namespace) -> int:
 
     if not args.executor:
         raise OmhError("--executor is required unless --explain is given")
+    local_catalog = None
+    if getattr(args, "from_inventory", False):
+        local_catalog = _local_model_catalogs().get(str(args.executor or "").strip().casefold())
     route = resolve_model_route(
         args.executor,
         requested_model=args.model or "",
         requested_effort=args.effort or "",
         role=args.role or "",
+        local_catalog=local_catalog,
     )
     if _wants_json(args):
         _print_json(route)
@@ -746,21 +750,46 @@ def cmd_coding_model_inventory(args: argparse.Namespace) -> int:
     return 0
 
 
+def _local_model_catalogs() -> dict[str, dict[str, object]]:
+    """Observe the local inventory once and key its derived catalog by profile.
+
+    The I/O boundary lives here in the command layer: the route resolver and
+    contract builder receive the catalog as data and stay pure.
+    """
+    from ..coding.model_inventory import inventory_model_catalog, local_model_inventory
+
+    catalog = inventory_model_catalog(local_model_inventory())
+    if catalog is None:
+        return {}
+    return {str(catalog.get("executor_profile", "")): catalog}
+
+
 def cmd_coding_fanout_prepare(args: argparse.Namespace) -> int:
     from ..coding.fanout import build_fanout_contract, is_degenerate_single_unit, single_unit_redirect
     from ..coding.fanout_artifacts import write_fanout_contract
     from ..coding.fanout_contracts import FanoutContractError
+    from ..coding.model_routing import EXECUTOR_MODEL_OPTIONS
 
     units = _read_fanout_units(args.units)
     if is_degenerate_single_unit(units):
         _print_json(single_unit_redirect(units))
         return 0
+    # The inventory is observed only when some unit names a profile without a
+    # built-in catalog — a codex/claude-only contract must stay byte-identical
+    # across machines regardless of what local config exists.
+    needs_inventory = any(
+        isinstance(unit, dict)
+        and str(unit.get("owner", "") or "")
+        and str(unit.get("owner", "") or "") not in EXECUTOR_MODEL_OPTIONS
+        for unit in units
+    )
     try:
         contract = build_fanout_contract(
             " ".join(args.goal).strip(),
             units,
             source=args.source,
             source_metadata=_explicit_source_metadata(args),
+            local_catalogs=_local_model_catalogs() if needs_inventory else {},
         )
     except FanoutContractError as exc:
         raise OmhError(str(exc)) from exc
@@ -1264,6 +1293,15 @@ def _add_coding_commands(sub) -> None:
         "--explain",
         action="store_true",
         help="Render the effective profile x role resolution matrix with full chains and provenance.",
+    )
+    model_route.add_argument(
+        "--from-inventory",
+        action="store_true",
+        dest="from_inventory",
+        help=(
+            "Consult the locally-derived model catalog (fingerprint-recorded) for profiles without "
+            "a built-in catalog; built-in catalogs always win."
+        ),
     )
     model_route.add_argument("--json", action="store_true", help="Emit the machine payload instead of plain text.")
     model_route.set_defaults(func=cmd_coding_model_route)

--- a/tests/test_model_inventory.py
+++ b/tests/test_model_inventory.py
@@ -13,9 +13,14 @@ load_local_package()
 from _cli_harness import run_cli  # noqa: E402
 from omh.coding.model_inventory import (  # noqa: E402
     CLI_PRESENCE_COMMANDS,
+    LOCAL_MODEL_CATALOG_SCHEMA_VERSION,
     MODEL_DOMAIN_AFFINITIES,
     MODEL_DOMAIN_AFFINITY_CLAIM_BOUNDARY,
+    MODEL_INVENTORY_CATALOG_PROFILE,
     MODEL_INVENTORY_SCHEMA_VERSION,
+    OMO_CATEGORY_ROLE_SOURCES,
+    catalog_fingerprint_note,
+    inventory_model_catalog,
     local_model_inventory,
 )
 
@@ -192,7 +197,170 @@ class ModelInventoryTests(unittest.TestCase):
         )
 
 
+class InventoryModelCatalogTests(unittest.TestCase):
+    def _catalog(self) -> dict:
+        with TemporaryDirectory() as tmp:
+            inventory = local_model_inventory(_write_home(tmp, omo_config=_OMO_FIXTURE))
+        catalog = inventory_model_catalog(inventory)
+        assert catalog is not None
+        return catalog
+
+    def test_catalog_targets_the_omo_runtime_profile(self) -> None:
+        catalog = self._catalog()
+        self.assertEqual(catalog["schema_version"], LOCAL_MODEL_CATALOG_SCHEMA_VERSION)
+        self.assertEqual(catalog["executor_profile"], MODEL_INVENTORY_CATALOG_PROFILE)
+        self.assertEqual(catalog["catalog_kind"], "local_inventory")
+
+    def test_chains_derive_from_category_role_sources_in_config_order(self) -> None:
+        catalog = self._catalog()
+        chains = catalog["chains"]
+        # The fixture declares only visual-engineering; only roles sourcing it
+        # gain a chain, in the config's own primary-then-fallback order.
+        self.assertEqual(
+            [entry["model_id"] for entry in chains["design_visual"]],
+            ["opencode/gemini-3.1-pro", "anthropic/claude-opus-5"],
+        )
+        self.assertEqual(chains["design_visual"][0]["reasoning_effort"], "high")
+        self.assertNotIn("brain", chains)
+        self.assertIn("design_visual", OMO_CATEGORY_ROLE_SOURCES)
+
+    def test_options_never_carry_effort_authority(self) -> None:
+        catalog = self._catalog()
+        for option in catalog["options"]:
+            self.assertEqual(option["reasoning_efforts"], ())
+
+    def test_fingerprint_is_deterministic_for_an_unchanged_config(self) -> None:
+        first = self._catalog()
+        second = self._catalog()
+        self.assertEqual(first["fingerprint"]["digest"], second["fingerprint"]["digest"])
+        self.assertIn("omo_agent_config", first["fingerprint"]["sources"])
+
+    def test_fingerprint_changes_when_chains_move_across_the_same_models(self) -> None:
+        """The digest anchors the derived artifact: reassigning a category to
+        an already-present model must change the digest even though the model
+        SET is identical — that reassignment is exactly the drift the
+        fingerprint exists to make visible."""
+        base = {
+            "categories": {
+                "ultrabrain": {"model": "opencode/glm-5"},
+                "quick": {"model": "opencode/gemini-3-flash"},
+            }
+        }
+        swapped = {
+            "categories": {
+                "ultrabrain": {"model": "opencode/gemini-3-flash"},
+                "quick": {"model": "opencode/glm-5"},
+            }
+        }
+        digests = []
+        for config in (base, swapped):
+            with TemporaryDirectory() as tmp:
+                inventory = local_model_inventory(_write_home(tmp, omo_config=config))
+            catalog = inventory_model_catalog(inventory)
+            assert catalog is not None
+            digests.append(catalog["fingerprint"]["digest"])
+        self.assertNotEqual(digests[0], digests[1])
+
+    def test_empty_inventory_yields_no_catalog(self) -> None:
+        with TemporaryDirectory() as tmp:
+            inventory = local_model_inventory(Path(tmp))
+        self.assertIsNone(inventory_model_catalog(inventory))
+
+    def test_fingerprint_note_reports_skew_advisorily(self) -> None:
+        route = {"catalog_fingerprint": {"digest": "abc123"}}
+        note = catalog_fingerprint_note(route, "abc123")
+        self.assertEqual(note, {"frozen_digest": "abc123", "current_digest": "abc123", "match": True})
+        drifted = catalog_fingerprint_note(route, "def456")
+        self.assertFalse(drifted["match"])
+        self.assertIsNone(catalog_fingerprint_note({"selected_model": "x"}, "abc123"))
+        self.assertIsNone(catalog_fingerprint_note(None, "abc123"))
+
+
 class ModelInventoryCliTests(unittest.TestCase):
+    def test_fanout_prepare_freezes_local_route_with_fingerprint(self) -> None:
+        """A unit owned by the OMO runtime with a declared role freezes a
+        route resolved from the user's own config — catalog_kind plus the
+        inventory fingerprint land in the contract so the basis is named."""
+        units = json.dumps(
+            [
+                {
+                    "unit_id": "visual",
+                    "title": "Visual work",
+                    "owner": "omo-runtime",
+                    "file_scope": ["src/ui/"],
+                    "role": "design_visual",
+                },
+                {
+                    "unit_id": "aux",
+                    "title": "Aux",
+                    "owner": "codex",
+                    "file_scope": ["docs/"],
+                },
+            ]
+        )
+        with TemporaryDirectory() as tmp:
+            home = _write_home(tmp, omo_config=_OMO_FIXTURE)
+            with mock.patch.dict("os.environ", {"HOME": str(home)}):
+                status, stdout, _stderr = run_cli(
+                    ["coding", "fanout", "prepare", "--goal", "ship", "the", "feature", "--units", "-"],
+                    stdin_text=units,
+                )
+        self.assertEqual(status, 0)
+        contract = json.loads(stdout)
+        by_id = {unit["unit_id"]: unit for unit in contract["units"]}
+        route = by_id["visual"]["handoff"]["model_route"]
+        self.assertEqual(route["catalog_kind"], "local_inventory")
+        self.assertEqual(route["selected_model"], "opencode/gemini-3.1-pro")
+        self.assertTrue(route["catalog_fingerprint"]["digest"])
+        # Built-in-catalog owners stay on built-in resolution, untouched.
+        self.assertNotIn("model_route", by_id["aux"]["handoff"])
+
+    def test_prepare_without_catalogless_owners_is_home_independent(self) -> None:
+        """A codex/claude-only contract must stay byte-identical across
+        machines: prepare consults the inventory only when a unit names a
+        profile without a built-in catalog, so whatever local config exists
+        must not leak into the contract."""
+        units = json.dumps(
+            [
+                {"unit_id": "core", "title": "Core", "owner": "codex", "file_scope": ["src/a/"], "role": "brain"},
+                {"unit_id": "aux", "title": "Aux", "owner": "claude-code", "file_scope": ["docs/"], "role": "docs"},
+            ]
+        )
+        outputs = []
+        for config in (_OMO_FIXTURE, None):
+            with TemporaryDirectory() as tmp:
+                home = _write_home(tmp, omo_config=config) if config else Path(tmp)
+                with mock.patch.dict("os.environ", {"HOME": str(home)}):
+                    status, stdout, _stderr = run_cli(
+                        ["coding", "fanout", "prepare", "--goal", "ship", "it", "--units", "-"],
+                        stdin_text=units,
+                    )
+            self.assertEqual(status, 0)
+            outputs.append(stdout)
+        self.assertEqual(outputs[0], outputs[1])
+
+    def test_model_route_cli_from_inventory_flag(self) -> None:
+        with TemporaryDirectory() as tmp:
+            home = _write_home(tmp, omo_config=_OMO_FIXTURE)
+            with mock.patch.dict("os.environ", {"HOME": str(home)}):
+                status, stdout, _stderr = run_cli(
+                    [
+                        "coding",
+                        "model-route",
+                        "--executor",
+                        "omo-runtime",
+                        "--role",
+                        "design_visual",
+                        "--from-inventory",
+                        "--json",
+                    ]
+                )
+        self.assertEqual(status, 0)
+        route = json.loads(stdout)
+        self.assertEqual(route["status"], "routed")
+        self.assertEqual(route["catalog_kind"], "local_inventory")
+        self.assertEqual(route["selected_model"], "opencode/gemini-3.1-pro")
+
     def test_cli_plain_text_default_and_json_optin(self) -> None:
         with TemporaryDirectory() as tmp:
             home = _write_home(tmp, omo_config=_OMO_FIXTURE)

--- a/tests/test_model_routing.py
+++ b/tests/test_model_routing.py
@@ -44,6 +44,113 @@ class FamilyPrefixParityTests(unittest.TestCase):
     def test_grok_family_is_recognized(self) -> None:
         self.assertEqual(model_family("grok-code-fast-1"), "grok")
 
+    def test_provider_prefixed_ids_classify_by_model_segment(self) -> None:
+        self.assertEqual(model_family("opencode/kimi-k3"), "kimi")
+        self.assertEqual(model_family("anthropic/claude-opus-5"), "claude")
+        self.assertEqual(model_family("openai/gpt-5.6-sol"), "gpt")
+        self.assertEqual(model_family("opencode/big-pickle"), "unknown")
+
+
+_LOCAL_CATALOG = {
+    "schema_version": "local_model_catalog/v1",
+    "executor_profile": "omo-runtime",
+    "catalog_kind": "local_inventory",
+    "options": (
+        {
+            "model_id": "opencode/kimi-k3",
+            "label": "kimi family via opencode",
+            "tier": "",
+            "recommended_roles": (),
+            "reasoning_efforts": (),
+        },
+        {
+            "model_id": "opencode/gemini-3.1-pro",
+            "label": "gemini family via opencode",
+            "tier": "",
+            "recommended_roles": (),
+            "reasoning_efforts": (),
+        },
+    ),
+    "chains": {
+        "brain": (
+            {"model_id": "opencode/kimi-k3", "reasoning_effort": "high"},
+            {"model_id": "opencode/gemini-3.1-pro", "reasoning_effort": ""},
+        ),
+    },
+    "fingerprint": {"digest": "cafe1234beef5678", "sources": {"omo_agent_config": "present"}, "observed_at": "t"},
+}
+
+
+class LocalCatalogRouteTests(unittest.TestCase):
+    def test_catalogless_profile_routes_from_local_catalog_with_fingerprint(self) -> None:
+        route = resolve_model_route("omo-runtime", role="brain", local_catalog=_LOCAL_CATALOG)
+        self.assertEqual(route["status"], "routed")
+        self.assertEqual(route["provenance"], "role_chain_head")
+        self.assertEqual(route["selected_model"], "opencode/kimi-k3")
+        self.assertEqual(route["selected_reasoning_effort"], "high")
+        self.assertEqual(route["model_family"], "kimi")
+        self.assertEqual(route["catalog_kind"], "local_inventory")
+        self.assertEqual(route["catalog_fingerprint"]["digest"], "cafe1234beef5678")
+        self.assertEqual(len(route["chain"]), 2)
+
+    def test_local_catalog_never_applies_to_built_in_profiles(self) -> None:
+        """Built-in catalogs always win: a local catalog naming codex (or
+        handed to a codex resolution) must change nothing, byte for byte."""
+        hostile = dict(_LOCAL_CATALOG)
+        hostile["executor_profile"] = "codex"
+        baseline = resolve_model_route("codex", role="brain")
+        self.assertEqual(resolve_model_route("codex", role="brain", local_catalog=hostile), baseline)
+        self.assertEqual(resolve_model_route("codex", role="brain", local_catalog=_LOCAL_CATALOG), baseline)
+
+    def test_local_catalog_for_other_profile_is_ignored(self) -> None:
+        route = resolve_model_route("hermes", role="brain", local_catalog=_LOCAL_CATALOG)
+        self.assertEqual(route["status"], "no_model_catalog")
+        self.assertEqual(route["catalog_kind"], "built_in_defaults")
+        self.assertNotIn("catalog_fingerprint", route)
+
+    def test_local_catalog_never_gains_effort_authority(self) -> None:
+        """Observed config variants are evidence of use, not vocabulary: a
+        requested ladder effort passes through untouched, never downgraded."""
+        route = resolve_model_route(
+            "omo-runtime", role="brain", requested_effort="max", local_catalog=_LOCAL_CATALOG
+        )
+        self.assertEqual(route["selected_reasoning_effort"], "max")
+        self.assertEqual(route["effort_change"]["kind"], "catalog_no_authority_passthrough")
+
+    def test_requested_model_still_wins_over_local_chain(self) -> None:
+        route = resolve_model_route(
+            "omo-runtime",
+            role="brain",
+            requested_model="opencode/glm-5",
+            local_catalog=_LOCAL_CATALOG,
+        )
+        self.assertEqual(route["provenance"], "request_named_model")
+        self.assertEqual(route["selected_model"], "opencode/glm-5")
+        self.assertEqual(route["model_family"], "glm")
+        self.assertEqual(route["catalog_kind"], "local_inventory")
+
+    def test_unchained_role_on_local_catalog_is_explicit_choice(self) -> None:
+        route = resolve_model_route("omo-runtime", role="docs", local_catalog=_LOCAL_CATALOG)
+        self.assertEqual(route["status"], "choice_required")
+        self.assertEqual(route["provenance"], "role_unchained")
+        self.assertEqual(route["catalog_kind"], "local_inventory")
+
+    def test_empty_or_corrupt_local_catalog_claims_no_basis(self) -> None:
+        """A frozen record must never name a basis that adjudicated nothing:
+        an offered catalog with no usable options falls through to the
+        executor default WITHOUT catalog_kind/fingerprint, and says so."""
+        for hostile_options in ([], ["not-a-mapping", 42]):
+            hostile = dict(_LOCAL_CATALOG)
+            hostile["options"] = hostile_options
+            route = resolve_model_route("omo-runtime", role="brain", local_catalog=hostile)
+            self.assertEqual(route["status"], "no_model_catalog")
+            self.assertEqual(route["catalog_kind"], "built_in_defaults")
+            self.assertNotIn("catalog_fingerprint", route)
+            self.assertTrue(
+                any("no usable options" in reason for reason in route["reasons"]),
+                route["reasons"],
+            )
+
 
 class ModelRouteResolverTests(unittest.TestCase):
     def test_requested_model_always_wins_and_passes_through_unvalidated(self) -> None:


### PR DESCRIPTION
## Capability

Closes #722. Routing now consumes the model inventory (#720/#725) — the "route on what the user actually has" half of the feature line, done without breaking the frozen-contract evidence discipline.

For executor profiles **without a built-in model catalog** (today: the OMO runtime, whose models arrive via opencode providers), the command layer derives a `local_model_catalog/v1` from the observed inventory. Role chains come from the **user's own omo category config**: ordered category→role source data (`ultrabrain`/`deep`/`unspecified-high` → brain, `visual-engineering`/`artistry` → design_visual, `writing`/`quick` → docs, …) merges the config's primary-then-fallback entries per role, deterministically.

Live on this machine: `omh coding model-route --executor omo-runtime --role brain --from-inventory` routes to `openai/gpt-5.6-sol xhigh` with a 12-entry prepared fallback chain — entirely from the user's real config.

## The evidence contract (the hard part)

A route resolved from a user-mutable config must name its basis, or the frozen record becomes an unverifiable assertion:

- Every local-catalog route records `catalog_kind: "local_inventory"` plus a **`catalog_fingerprint`**: a digest over the derived artifact (**options AND chains** — reassigning a category to an already-present model changes the digest; negative-tested with a constructed counterexample), per-source statuses, and the observation time.
- An **empty or corrupt catalog payload claims no basis**: it falls through to the executor default with a named reason and no fingerprint — a frozen record never says something that never happened.
- Absent `catalog_fingerprint` means "no local basis was consulted", never "unknown basis" (v1 routes and built-in-catalog routes correctly carry none; documented invariant).
- **Prepare-vs-dispatch skew**: dispatched units whose route carries a fingerprint gain an advisory `inventory_fingerprint {frozen_digest, current_digest, match}` — a mismatch never blocks (the frozen contract stays the instruction; provider truth adjudicates), it makes the skew visible. The current-inventory read happens once per dispatch and only when some unit actually carries a fingerprint.

## Guardrails

- **Built-in catalogs always win, byte-for-byte** — a local catalog naming codex changes nothing (tested against baseline equality).
- Requested models still pass through unvalidated; a local catalog **never gains effort authority** (observed config variants are evidence of use, not vocabulary — requested ladder efforts pass through as `catalog_no_authority_passthrough`).
- `fanout prepare` consults the inventory **only when a unit names a catalogless profile**: codex/claude-only contracts are byte-identical across machines regardless of local config (guard-tested under two HOMEs). `model-route --from-inventory` is opt-in.
- Resolver purity intact: all I/O lives in the command layer; `_supported_efforts`/`_chain_payload` take the options table as parameters.
- `model_family` now classifies provider-prefixed ids by the model segment (`opencode/kimi-k3` → kimi, selecting the kimi calibration block) — write-time only, frozen records untouched.

## Consensus process

Adversarial critic review of the diff: ITERATE with three majors, all fixed with their own regression tests — (1) the empty-catalog branch fabricated a basis (now claims none), (2) the digest covered only the model set and missed chain-reassignment drift (now digests the derived artifact; critic demonstrated the collision empirically), (3) prepare read the inventory unconditionally, one fixture away from machine-dependent contracts (now gated + HOME-independence guard test). Critic also verified: no strict-key validator breaks on the new optional fields, `model_family` is write-time-only so frozen records are safe, no companion accessor needed for the fingerprint, and the suite is green under empty/rich-fake/real HOME states.

## Verification (observed)

- Full suite **2370 tests OK**; docs workflows/roles/capability-families `--check`, `ruff`, `git diff --check`, `compileall` all green.
- Live smoke on the reference machine (above). Critic independently ran the suite under three HOME states: identical results.

## Risks / follow-ups

- Dispatch consuming these routes end-to-end is blocked on opencode provider auth (observations recorded on #721: non-interactive exits cleanly, failures exit 1; success-path permission behavior unobservable at 0 credentials).
- "Local inventory" is currently a synonym for the OMO runtime profile (deliberate; stated in FANOUT.md) — a future profile must bring its own derivation, not inherit this one.
- #723 (affinity ranking) remains, now unblocked by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)