### PR TITLE
feat: declared-domain affinity advisorily reorders locally-derived chains

### DIFF
--- a/docs/FANOUT.md
+++ b/docs/FANOUT.md
@@ -136,7 +136,15 @@ goal to Hermes in chat; these commands are the backend surface.
   frozen contract stays the instruction; provider truth adjudicates), it
   only makes prepare-vs-dispatch skew visible. `omh coding model-route
   --from-inventory` previews these routes; fanout prepare consults the
-  derived catalog automatically.
+  derived catalog automatically. A unit may additionally declare an explicit
+  work `domain` (closed vocabulary riding the catalog payload — for example
+  `x_platform_data`, whose affine family is grok): affine-family entries are
+  stably moved to the front of the locally-derived chain, the reorder (or
+  the reason none happened) is recorded in the route's `attempted[]` trail,
+  and the declared domain rides the frozen route. Never a veto: every entry
+  stays in the chain, built-in chains are never reordered (a domain there is
+  recorded and explicitly skipped), a requested model still wins, and no
+  text matching ever infers a domain.
 - **Unit prompt protocol.** Every dispatched unit prompt carries a fixed
   verification discipline (`src/coding/unit_prompt_protocol.py`): the
   subagent first echoes the goal, its deliverable, and the numbered
@@ -186,7 +194,7 @@ omh coding fanout brief [<fanout-id>] [--json]
 omh coding fanout dispatch <fanout-id> --goal-file goal.txt \
   [--repo-root .] [--base-ref HEAD] [--concurrency 2] [--timeout 1800] \
   [--unit <id> ...] [--dry-run]
-omh coding model-route [--executor <profile>] [--role <role>] [--model <id>] [--effort <level>] [--explain] [--from-inventory] [--json]
+omh coding model-route [--executor <profile>] [--role <role>] [--model <id>] [--effort <level>] [--domain <name>] [--explain] [--from-inventory] [--json]
 omh coding model-inventory [--json]
 ```
 

--- a/src/coding/fanout.py
+++ b/src/coding/fanout.py
@@ -182,6 +182,7 @@ def _normalized_unit(unit: Mapping[str, object], index: int) -> dict[str, object
         "model": str(unit.get("model", "") or "").strip(),
         "reasoning_effort": str(unit.get("reasoning_effort", "") or "").strip(),
         "role": str(unit.get("role", "") or "").strip(),
+        "domain": str(unit.get("domain", "") or "").strip(),
     }
 
 

--- a/src/coding/model_inventory.py
+++ b/src/coding/model_inventory.py
@@ -71,8 +71,10 @@ MODEL_DOMAIN_AFFINITIES: Final[dict[str, tuple[str, ...]]] = {
 
 MODEL_DOMAIN_AFFINITY_CLAIM_BOUNDARY: Final[str] = (
     "Domain affinity notes are static editorial defaults, not observed, benchmarked, or measured "
-    "capability — OMH never evaluates a model. They carry no routing effect and never remove or "
-    "rank an option; the user's explicit choice always wins."
+    "capability — OMH never evaluates a model. When a unit explicitly declares a domain, they may "
+    "advisorily reorder a locally-derived chain with the reorder recorded in the route's attempted "
+    "trail; they are never a veto, never remove an option, and the user's explicit model choice "
+    "always wins."
 )
 
 # The executor profile a locally-derived catalog belongs to: omo ships as an
@@ -333,6 +335,10 @@ def inventory_model_catalog(inventory: Mapping[str, object]) -> dict[str, object
         "catalog_kind": "local_inventory",
         "options": options,
         "chains": chains,
+        # The affinity vocabulary rides the catalog payload so the resolver
+        # consumes it as data — routing never imports this module, and the
+        # reorder scope stays exactly the locally-derived chains.
+        "domain_affinities": {domain: affine for domain, affine in sorted(MODEL_DOMAIN_AFFINITIES.items())},
         "fingerprint": {
             "digest": digest,
             "sources": source_statuses,

--- a/src/coding/model_routing.py
+++ b/src/coding/model_routing.py
@@ -234,6 +234,7 @@ def resolve_model_route(
     requested_model: str = "",
     requested_effort: str = "",
     role: str = "",
+    requested_domain: str = "",
     chains: Mapping[str, Mapping[str, tuple[Mapping[str, str], ...]]] | None = None,
     local_catalog: Mapping[str, object] | None = None,
 ) -> dict[str, object]:
@@ -257,6 +258,13 @@ def resolve_model_route(
     `catalog_fingerprint` on any route means "no local basis was consulted",
     never "unknown basis" — v1 routes and built-in-catalog routes correctly
     carry none.
+
+    `requested_domain` is explicit unit data (never inferred from text). When
+    a locally-derived chain resolves and the catalog's affinity vocabulary
+    knows the domain, chain entries from affine families are stably reordered
+    to the front — an advisory reorder recorded in `attempted[]`, never a
+    veto: every entry stays in the chain and a requested model still wins.
+    Outside a local catalog the domain is recorded and explicitly skipped.
     """
     profile = str(executor_profile or "").strip().casefold()
     raw_role = str(role or "").strip()
@@ -302,6 +310,14 @@ def resolve_model_route(
         chain_table = ROLE_MODEL_CHAINS if chains is None else chains
         role_chain = tuple(chain_table.get(profile, {}).get(normalized_role, ())) if normalized_role else ()
     attempted: list[dict[str, str]] = []
+    domain = str(requested_domain or "").strip().casefold().replace("-", "_")
+    if domain:
+        role_chain = _domain_ordered_chain(
+            domain,
+            role_chain,
+            local_catalog if catalog_kind == "local_inventory" else None,
+            attempted,
+        )
 
     if model:
         attempted.append(
@@ -320,6 +336,7 @@ def resolve_model_route(
             effort_change=effort_change,
             catalog_kind=catalog_kind,
             catalog_fingerprint=catalog_fingerprint,
+            domain=domain,
             chain=_chain_payload(options, role_chain, selected_model=""),
             attempted=attempted,
             candidates=candidates,
@@ -346,6 +363,7 @@ def resolve_model_route(
             effort_change=effort_change,
             catalog_kind=catalog_kind,
             catalog_fingerprint=catalog_fingerprint,
+            domain=domain,
             chain=[],
             attempted=attempted,
             candidates=[],
@@ -376,6 +394,7 @@ def resolve_model_route(
                 effort_change=effort_change,
                 catalog_kind=catalog_kind,
                 catalog_fingerprint=catalog_fingerprint,
+                domain=domain,
                 chain=_chain_payload(options, role_chain, selected_model=selected),
                 attempted=attempted,
                 candidates=candidates,
@@ -403,6 +422,7 @@ def resolve_model_route(
             effort_change=effort_change,
             catalog_kind=catalog_kind,
             catalog_fingerprint=catalog_fingerprint,
+            domain=domain,
             chain=[],
             attempted=attempted,
             candidates=candidates,
@@ -434,6 +454,7 @@ def resolve_model_route(
         effort_change=effort_change,
         catalog_kind=catalog_kind,
         catalog_fingerprint=catalog_fingerprint,
+        domain=domain,
         chain=[],
         attempted=attempted,
         candidates=candidates,
@@ -455,12 +476,15 @@ def model_route_for_unit(
     effort = str(unit.get("reasoning_effort", "") or "").strip()
     role = str(unit.get("role", "") or "").strip()
     if not model and not effort and not role:
+        # A declared domain alone never triggers routing: it advises chain
+        # order, it does not request a model.
         return None
     return resolve_model_route(
         executor_target,
         requested_model=model,
         requested_effort=effort,
         role=role,
+        requested_domain=str(unit.get("domain", "") or "").strip(),
         local_catalog=local_catalog,
     )
 
@@ -493,6 +517,78 @@ def route_provenance(route: Mapping[str, object] | object) -> tuple[str, str]:
 def _normalized_role(role: str) -> str:
     normalized = str(role or "").strip().casefold().replace("-", "_")
     return normalized if normalized in MODEL_ROLES else ""
+
+
+def _domain_ordered_chain(
+    domain: str,
+    role_chain: tuple[Mapping[str, str], ...],
+    local_catalog: Mapping[str, object] | None,
+    attempted: list[dict[str, str]],
+) -> tuple[Mapping[str, str], ...]:
+    """Stably move affine-family chain entries to the front for a declared domain.
+
+    Advisory only: every entry stays in the chain, the reorder (or the reason
+    none happened) is recorded in `attempted[]`, and outside a locally-derived
+    catalog the domain is explicitly skipped — built-in chains stay curated.
+    """
+    if local_catalog is None:
+        attempted.append(
+            {
+                "stage": "domain_affinity",
+                "outcome": "skipped",
+                "reason": f"domain `{domain}` recorded; affinity reordering applies to locally-derived chains only",
+            }
+        )
+        return role_chain
+    affinities = local_catalog.get("domain_affinities", {})
+    affine = (
+        tuple(str(family) for family in affinities.get(domain, ()))
+        if isinstance(affinities, Mapping)
+        else ()
+    )
+    if not affine:
+        attempted.append(
+            {
+                "stage": "domain_affinity",
+                "outcome": "unknown_domain",
+                "reason": f"domain `{domain}` is not in the catalog's affinity vocabulary; chain order unchanged",
+            }
+        )
+        return role_chain
+    if not role_chain:
+        attempted.append(
+            {"stage": "domain_affinity", "outcome": "skipped", "reason": "no chain to reorder"}
+        )
+        return role_chain
+    front = tuple(entry for entry in role_chain if model_family(str(entry.get("model_id", ""))) in affine)
+    rest = tuple(entry for entry in role_chain if model_family(str(entry.get("model_id", ""))) not in affine)
+    if not front:
+        attempted.append(
+            {
+                "stage": "domain_affinity",
+                "outcome": "no_affine_candidate",
+                "reason": f"no chain entry belongs to an affine family ({', '.join(affine)}) for domain `{domain}`",
+            }
+        )
+        return role_chain
+    reordered = front + rest
+    if reordered == role_chain:
+        attempted.append(
+            {
+                "stage": "domain_affinity",
+                "outcome": "already_ordered",
+                "reason": f"affine families ({', '.join(affine)}) already lead the chain for domain `{domain}`",
+            }
+        )
+        return role_chain
+    attempted.append(
+        {
+            "stage": "domain_affinity",
+            "outcome": "reordered",
+            "reason": f"affine families ({', '.join(affine)}) moved ahead for domain `{domain}`; no entry removed",
+        }
+    )
+    return reordered
 
 
 def _local_catalog_applies(profile: str, local_catalog: Mapping[str, object] | None) -> bool:
@@ -638,6 +734,7 @@ def _route_payload(
     effort_change: dict[str, str] | None = None,
     catalog_kind: str = MODEL_CATALOG_KIND,
     catalog_fingerprint: dict[str, object] | None = None,
+    domain: str = "",
 ) -> dict[str, object]:
     payload: dict[str, object] = {
         "schema_version": CODING_MODEL_ROUTE_SCHEMA_VERSION,
@@ -664,6 +761,10 @@ def _route_payload(
         "reasons": list(reasons),
         "claim_boundary": CODING_MODEL_ROUTE_CLAIM_BOUNDARY,
     }
+    if domain:
+        # Present only when the unit declared a domain: existing payloads
+        # stay byte-identical.
+        payload["domain"] = domain
     if catalog_fingerprint is not None:
         payload["catalog_fingerprint"] = catalog_fingerprint
     if effort_change is not None:

--- a/src/commands/coding.py
+++ b/src/commands/coding.py
@@ -665,6 +665,7 @@ def cmd_coding_model_route(args: argparse.Namespace) -> int:
         requested_model=args.model or "",
         requested_effort=args.effort or "",
         role=args.role or "",
+        requested_domain=getattr(args, "domain", None) or "",
         local_catalog=local_catalog,
     )
     if _wants_json(args):
@@ -1293,6 +1294,14 @@ def _add_coding_commands(sub) -> None:
         "--explain",
         action="store_true",
         help="Render the effective profile x role resolution matrix with full chains and provenance.",
+    )
+    model_route.add_argument(
+        "--domain",
+        default=None,
+        help=(
+            "Declared work domain (for example x_platform_data); advisorily reorders a "
+            "locally-derived chain toward affine families, recorded in the route, never a veto."
+        ),
     )
     model_route.add_argument(
         "--from-inventory",

--- a/tests/test_model_inventory.py
+++ b/tests/test_model_inventory.py
@@ -171,12 +171,14 @@ class ModelInventoryTests(unittest.TestCase):
         # The affinity table is an editorial default, not a capability claim:
         # its own boundary rides the payload (critic-mandated condition).
         self.assertEqual(inventory["domain_affinity_claim_boundary"], MODEL_DOMAIN_AFFINITY_CLAIM_BOUNDARY)
-        self.assertIn("no routing effect", MODEL_DOMAIN_AFFINITY_CLAIM_BOUNDARY)
+        self.assertIn("never a veto", MODEL_DOMAIN_AFFINITY_CLAIM_BOUNDARY)
+        self.assertIn("explicit model choice", MODEL_DOMAIN_AFFINITY_CLAIM_BOUNDARY)
 
-    def test_affinity_vocabulary_stays_out_of_routing_and_dispatch(self) -> None:
-        """No downstream payload builder consumes the affinity table: the
-        domain vocabulary must not appear in routing, dispatch, or contract
-        modules, so the notes stay report-only by construction."""
+    def test_affinity_vocabulary_reaches_routing_only_as_catalog_data(self) -> None:
+        """Routing consumes domain affinities exclusively via the local
+        catalog payload: the vocabulary constants and domain literals never
+        appear in routing, dispatch, or contract module SOURCE, so built-in
+        chains cannot grow a hidden affinity dependency."""
         src = Path(__file__).resolve().parent.parent / "src" / "coding"
         for module in ("model_routing.py", "fanout_dispatch.py", "fanout.py", "fanout_contracts.py"):
             source = (src / module).read_text(encoding="utf-8")
@@ -210,6 +212,9 @@ class InventoryModelCatalogTests(unittest.TestCase):
         self.assertEqual(catalog["schema_version"], LOCAL_MODEL_CATALOG_SCHEMA_VERSION)
         self.assertEqual(catalog["executor_profile"], MODEL_INVENTORY_CATALOG_PROFILE)
         self.assertEqual(catalog["catalog_kind"], "local_inventory")
+        # The affinity vocabulary rides the catalog so routing consumes it as
+        # data, never as an import.
+        self.assertEqual(catalog["domain_affinities"], MODEL_DOMAIN_AFFINITIES)
 
     def test_chains_derive_from_category_role_sources_in_config_order(self) -> None:
         catalog = self._catalog()
@@ -289,6 +294,7 @@ class ModelInventoryCliTests(unittest.TestCase):
                     "owner": "omo-runtime",
                     "file_scope": ["src/ui/"],
                     "role": "design_visual",
+                    "domain": "multimodal_vision",
                 },
                 {
                     "unit_id": "aux",
@@ -312,6 +318,9 @@ class ModelInventoryCliTests(unittest.TestCase):
         self.assertEqual(route["catalog_kind"], "local_inventory")
         self.assertEqual(route["selected_model"], "opencode/gemini-3.1-pro")
         self.assertTrue(route["catalog_fingerprint"]["digest"])
+        # The declared domain rides the frozen route with its attempted trail.
+        self.assertEqual(route["domain"], "multimodal_vision")
+        self.assertIn("domain_affinity", [entry["stage"] for entry in route["attempted"]])
         # Built-in-catalog owners stay on built-in resolution, untouched.
         self.assertNotIn("model_route", by_id["aux"]["handoff"])
 

--- a/tests/test_model_routing.py
+++ b/tests/test_model_routing.py
@@ -75,9 +75,11 @@ _LOCAL_CATALOG = {
         "brain": (
             {"model_id": "opencode/kimi-k3", "reasoning_effort": "high"},
             {"model_id": "opencode/gemini-3.1-pro", "reasoning_effort": ""},
+            {"model_id": "opencode/grok-code-fast", "reasoning_effort": ""},
         ),
     },
     "fingerprint": {"digest": "cafe1234beef5678", "sources": {"omo_agent_config": "present"}, "observed_at": "t"},
+    "domain_affinities": {"x_platform_data": ("grok",), "multimodal_vision": ("gemini", "gpt", "claude")},
 }
 
 
@@ -91,7 +93,7 @@ class LocalCatalogRouteTests(unittest.TestCase):
         self.assertEqual(route["model_family"], "kimi")
         self.assertEqual(route["catalog_kind"], "local_inventory")
         self.assertEqual(route["catalog_fingerprint"]["digest"], "cafe1234beef5678")
-        self.assertEqual(len(route["chain"]), 2)
+        self.assertEqual(len(route["chain"]), 3)
 
     def test_local_catalog_never_applies_to_built_in_profiles(self) -> None:
         """Built-in catalogs always win: a local catalog naming codex (or
@@ -134,6 +136,58 @@ class LocalCatalogRouteTests(unittest.TestCase):
         self.assertEqual(route["status"], "choice_required")
         self.assertEqual(route["provenance"], "role_unchained")
         self.assertEqual(route["catalog_kind"], "local_inventory")
+
+    def test_declared_domain_reorders_local_chain_without_removal(self) -> None:
+        """The user's example made concrete: X-platform data work declared on
+        the unit moves the grok-family entry to the chain head — a stable
+        reorder recorded in attempted[], with every entry kept."""
+        route = resolve_model_route(
+            "omo-runtime", role="brain", requested_domain="x_platform_data", local_catalog=_LOCAL_CATALOG
+        )
+        self.assertEqual(route["selected_model"], "opencode/grok-code-fast")
+        self.assertEqual(route["domain"], "x_platform_data")
+        self.assertEqual(
+            [entry["model_id"] for entry in route["chain"]],
+            ["opencode/grok-code-fast", "opencode/kimi-k3", "opencode/gemini-3.1-pro"],
+        )
+        outcomes = {entry["stage"]: entry["outcome"] for entry in route["attempted"]}
+        self.assertEqual(outcomes["domain_affinity"], "reordered")
+
+    def test_unknown_domain_is_recorded_and_ignored(self) -> None:
+        route = resolve_model_route(
+            "omo-runtime", role="brain", requested_domain="nonsense", local_catalog=_LOCAL_CATALOG
+        )
+        self.assertEqual(route["selected_model"], "opencode/kimi-k3")
+        self.assertEqual(route["domain"], "nonsense")
+        outcomes = {entry["stage"]: entry["outcome"] for entry in route["attempted"]}
+        self.assertEqual(outcomes["domain_affinity"], "unknown_domain")
+
+    def test_no_domain_means_no_domain_key(self) -> None:
+        route = resolve_model_route("omo-runtime", role="brain", local_catalog=_LOCAL_CATALOG)
+        self.assertNotIn("domain", route)
+        self.assertNotIn("domain_affinity", [entry["stage"] for entry in route["attempted"]])
+
+    def test_domain_on_built_in_profile_is_recorded_and_skipped(self) -> None:
+        """Built-in chains stay curated: a declared domain on codex changes
+        no selection, only records itself and the explicit skip."""
+        baseline = resolve_model_route("codex", role="brain")
+        route = resolve_model_route("codex", role="brain", requested_domain="x_platform_data")
+        self.assertEqual(route["selected_model"], baseline["selected_model"])
+        self.assertEqual(route["chain"], baseline["chain"])
+        self.assertEqual(route["domain"], "x_platform_data")
+        outcomes = {entry["stage"]: entry["outcome"] for entry in route["attempted"]}
+        self.assertEqual(outcomes["domain_affinity"], "skipped")
+
+    def test_requested_model_wins_over_domain(self) -> None:
+        route = resolve_model_route(
+            "omo-runtime",
+            role="brain",
+            requested_model="opencode/glm-5",
+            requested_domain="x_platform_data",
+            local_catalog=_LOCAL_CATALOG,
+        )
+        self.assertEqual(route["provenance"], "request_named_model")
+        self.assertEqual(route["selected_model"], "opencode/glm-5")
 
     def test_empty_or_corrupt_local_catalog_claims_no_basis(self) -> None:
         """A frozen record must never name a basis that adjudicated nothing:


### PR DESCRIPTION
## Capability

Closes #723 — the last piece of the model-distribution follow-up chain. The user's example, made concrete: a fanout unit that declares `"domain": "x_platform_data"` gets its locally-derived chain stably reordered so **grok-family** entries lead; `multimodal_vision` leans toward gemini/gpt/claude. The reorder — or the exact reason none happened — is recorded in the route's `attempted[]` trail, and the declared domain rides the frozen route.

## How it stays safe

- **Advisory, never a veto**: every entry stays in the chain. Outcomes are a closed set (`reordered` / `already_ordered` / `no_affine_candidate` / `unknown_domain` / `skipped`), each with a named reason.
- **Built-in chains are never reordered** — curated per profile; a domain declared on a codex/claude unit is recorded and explicitly skipped (selection byte-identical to baseline; tested).
- **A requested model still wins**; a domain alone never triggers routing; **no text matching** ever infers a domain — it is explicit unit data, so overroute risk is zero by construction.
- The vocabulary travels **inside the `local_model_catalog/v1` payload** (`domain_affinities`), so routing consumes it as data and never imports the inventory module — the guard test now pins exactly that invariant (vocabulary literals stay out of routing/dispatch/contract source).
- Routes without a declared domain are **byte-identical** to before (the `domain` key exists only when declared; tested).
- `MODEL_DOMAIN_AFFINITY_CLAIM_BOUNDARY` updated to say what is now true: the notes may advisorily reorder a locally-derived chain, recorded in the route; still not observed/benchmarked capability, still never removing an option, user's explicit choice always wins.

## Surface

- `resolve_model_route(requested_domain=...)` + `_domain_ordered_chain` (pure, stable partition by `model_family`).
- Fanout units carry `domain`; prepare freezes it with the route (CLI-tested end to end).
- `omh coding model-route --domain <name>` for previews.
- `docs/FANOUT.md` updated.

## Verification (observed)

- Full suite **2375 tests OK**; docs workflows/roles/capability-families `--check`, `ruff`, `git diff --check` green.
- Live smoke on the reference machine — the honest case: the real config has **no grok model**, so `--domain x_platform_data` records `no_affine_candidate` ("no chain entry belongs to an affine family (grok)") and leaves the chain untouched. Exactly the intended never-fabricate behavior.

## Follow-ups

- #721 (dispatch surface for opencode-hosted models) remains blocked on the success-path permission observation (`opencode auth login` needed; probes recorded on the issue).
- Extending the domain vocabulary is a data edit in `MODEL_DOMAIN_AFFINITIES` under the same claim boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)