### PR TITLE
feat: local dispatch surface for the OMO runtime via the senpi host CLI

### DIFF
--- a/docs/FANOUT.md
+++ b/docs/FANOUT.md
@@ -42,10 +42,12 @@ goal to Hermes in chat; these commands are the backend surface.
 
 - **Spawnability is data.** `DISPATCH_COMMAND_TEMPLATES` in
   `src/coding/fanout_dispatch.py` maps profiles with a local headless CLI to
-  fixed argv templates. Profiles without a template (hermes, omx/omo/omc
-  runtimes, generic, unassigned) are reported
-  `unsupported_for_local_dispatch` with the unit handoff as a prepared-prompt
-  fallback — no profile is privileged.
+  fixed argv templates — currently codex (`codex exec`), claude-code
+  (`claude -p`), and omo-runtime (`senpi --print`, since omo ships as an
+  extension of the senpi host CLI; readiness probes `senpi` accordingly).
+  Profiles without a template (hermes, omx/omc runtimes, generic,
+  unassigned) are reported `unsupported_for_local_dispatch` with the unit
+  handoff as a prepared-prompt fallback — no profile is privileged.
 - **Bridge dispatch is a separate axis from chat prompt-handoff.** Chat
   surfaces keep their prompt-only semantics for prompt-only profiles; the
   bridge is an operator-invoked command on a different surface.
@@ -75,9 +77,17 @@ goal to Hermes in chat; these commands are the backend surface.
   alone let the agent create files but blocked the requested `git commit`,
   so the template additionally grants `--allowedTools
   "Bash(git add:*),Bash(git commit:*)"` — exactly those two git verbs,
-  nothing broader. Template drift in either CLI surfaces as a clean
-  readiness or exit-code failure recorded as observed evidence, and the fix
-  is a one-line data edit in `DISPATCH_COMMAND_TEMPLATES`.
+  nothing broader. The senpi template was validated in a live bridge
+  dispatch (2026-07): a routed unit spawned non-interactively via
+  `--print --no-session`, the `workspace` permission preset allowed file
+  creation plus the exact `git add`/`git commit` the unit prompt asks for
+  (the unit completed with a real commit inside its isolated worktree, no
+  interactive prompt), and a missing provider key and an inactive plan each
+  surfaced as a clean exit-1 failure with bounded output (feeding the usual
+  limit-signal path). Template drift
+  in any CLI surfaces as a clean readiness or exit-code failure recorded as
+  observed evidence, and the fix is a one-line data edit in
+  `DISPATCH_COMMAND_TEMPLATES`.
 - **Model routing.** A unit may declare `model`, `reasoning_effort`, and/or
   `role` (brain, implementation, design_visual, review, docs). Prepare embeds
   the resolved `coding_model_route/v2` in the unit handoff, and dispatch

--- a/src/coding/executor_auth_signals.py
+++ b/src/coding/executor_auth_signals.py
@@ -25,8 +25,12 @@ AUTH_MARKER_STATES: Final[tuple[str, ...]] = ("present", "absent", "unknown")
 _CLAUDE_CONFIG_RELATIVE: Final[str] = ".claude.json"
 _CLAUDE_LOGIN_KEY: Final[str] = "oauthAccount"
 _CODEX_AUTH_RELATIVE: Final[str] = ".codex/auth.json"
+# senpi hosts the omo runtime locally; its credential store is a JSON object
+# keyed by provider name. Presence of at least one key is the marker — key
+# names and values are never read into state.
+_SENPI_AUTH_RELATIVE: Final[str] = ".senpi/agent/auth.json"
 
-AUTH_SIGNAL_PROFILES: Final[tuple[str, ...]] = ("codex", "claude-code")
+AUTH_SIGNAL_PROFILES: Final[tuple[str, ...]] = ("codex", "claude-code", "omo-runtime")
 
 
 def executor_auth_signals(home: Path | None = None) -> dict[str, object]:
@@ -38,6 +42,7 @@ def executor_auth_signals(home: Path | None = None) -> dict[str, object]:
         "profiles": {
             "codex": _marker_payload(_codex_marker(base), marker_kind="local_auth_file"),
             "claude-code": _marker_payload(_claude_marker(base), marker_kind="local_config_login_key"),
+            "omo-runtime": _marker_payload(_senpi_marker(base), marker_kind="local_auth_file"),
         },
         "claim_boundary": EXECUTOR_AUTH_SIGNALS_CLAIM_BOUNDARY,
     }
@@ -61,6 +66,8 @@ def auth_signal_for_profile(profile: str, home: Path | None = None) -> dict[str,
     base = home if home is not None else Path.home()
     if normalized == "codex":
         entry = _marker_payload(_codex_marker(base), marker_kind="local_auth_file")
+    elif normalized == "omo-runtime":
+        entry = _marker_payload(_senpi_marker(base), marker_kind="local_auth_file")
     else:
         entry = _marker_payload(_claude_marker(base), marker_kind="local_config_login_key")
     entry["claim_boundary"] = EXECUTOR_AUTH_SIGNALS_CLAIM_BOUNDARY
@@ -116,6 +123,19 @@ def _claude_marker(home: Path) -> str:
     if not isinstance(parsed, dict):
         return "unknown"
     return "present" if _CLAUDE_LOGIN_KEY in parsed else "absent"
+
+
+def _senpi_marker(home: Path) -> str:
+    auth_path = home / _SENPI_AUTH_RELATIVE
+    try:
+        if not auth_path.is_file():
+            return "absent"
+        parsed = json.loads(auth_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return "unknown"
+    if not isinstance(parsed, dict):
+        return "unknown"
+    return "present" if parsed else "absent"
 
 
 def _codex_marker(home: Path) -> str:

--- a/src/coding/executor_readiness.py
+++ b/src/coding/executor_readiness.py
@@ -39,7 +39,14 @@ _COMMANDS: dict[str, tuple[str, tuple[str, ...]]] = {
     "codex": ("codex", ("--version",)),
     "claude-code": ("claude", ("--version",)),
     "omx-runtime": ("omx", ("--version",)),
-    "omo-runtime": ("omo", ("--version",)),
+    # omo ships as an extension of a host agent CLI, not as its own binary;
+    # the locally-dispatchable host surface is the senpi CLI (observed
+    # 2026-07: non-interactive --print completes, workspace permission
+    # preset allows file edits plus git add/commit). An opencode-hosted omo
+    # install without senpi reads `missing` here — that is a truthful
+    # bridge-readiness answer, and the runtime prompt-handoff path never
+    # needed a local CLI.
+    "omo-runtime": ("senpi", ("--version",)),
     "omc-runtime": ("omc", ("--version",)),
 }
 
@@ -336,7 +343,11 @@ def _run_probe(contract: dict[str, object]) -> dict[str, object]:
     return result
 
 
-EXECUTOR_CHOICE_CONTEXT_PROFILES = ("codex", "claude-code")
+# CLI-backed candidates for the choose-executor question: profiles with a
+# locally probeable agent CLI. omo-runtime joined when the senpi host CLI
+# gained a validated dispatch template — the choice card should offer every
+# surface the user can actually run.
+EXECUTOR_CHOICE_CONTEXT_PROFILES = ("codex", "claude-code", "omo-runtime")
 EXECUTOR_CHOICE_CONTEXT_CLAIM_BOUNDARY = (
     "Choice context ranks locally-installed executor candidates from cached readiness and local "
     "markers only. It is not provider quota, entitlement, or login truth, and it never removes a "

--- a/src/coding/fanout_dispatch.py
+++ b/src/coding/fanout_dispatch.py
@@ -64,6 +64,21 @@ DISPATCH_COMMAND_TEMPLATES: dict[str, tuple[str, ...]] = {
         "--allowedTools",
         "Bash(git add:*),Bash(git commit:*)",
     ),
+    # omo runs as an extension of the senpi host CLI. Validated live
+    # (2026-07): `--print --no-session` completes non-interactively with a
+    # clean exit code on failure (missing API key, plan 402), and the
+    # `workspace` permission preset allowed file creation plus the exact
+    # `git add`/`git commit` the unit prompt asks for — no interactive
+    # prompt, no broader grant. `--no-session` keeps the dispatch ephemeral
+    # so no session state accumulates outside the worktree.
+    "omo-runtime": (
+        "senpi",
+        "--print",
+        "--no-session",
+        "--permission-preset",
+        "workspace",
+        "{prompt}",
+    ),
 }
 
 # Model routing is prepared metadata on the unit handoff; these fragments turn
@@ -73,14 +88,22 @@ DISPATCH_COMMAND_TEMPLATES: dict[str, tuple[str, ...]] = {
 DISPATCH_MODEL_OPTION_TEMPLATES: dict[str, tuple[str, ...]] = {
     "codex": ("--model", "{model}"),
     "claude-code": ("--model", "{model}"),
+    # senpi takes `provider/model` ids — exactly the form inventory-derived
+    # routes carry.
+    "omo-runtime": ("--model", "{model}"),
 }
 DISPATCH_REASONING_OPTION_TEMPLATES: dict[str, tuple[str, ...]] = {
     # `-c` values parse as TOML with a raw-string fallback, so a bare effort
     # level is accepted verbatim (verified against `codex exec --help`).
     "codex": ("--config", "model_reasoning_effort={effort}"),
     "claude-code": ("--effort", "{effort}"),
+    # senpi's thinking levels (off|minimal|low|medium|high|xhigh|max) are a
+    # superset of the effort ladder, so routed efforts map verbatim.
+    "omo-runtime": ("--thinking", "{effort}"),
 }
-_DISPATCH_OPTION_INSERT_INDEX: dict[str, int | None] = {"codex": 2, "claude-code": None}
+# senpi treats trailing tokens as message positionals, so options insert
+# before the prompt like codex; claude accepts them anywhere and appends.
+_DISPATCH_OPTION_INSERT_INDEX: dict[str, int | None] = {"codex": 2, "claude-code": None, "omo-runtime": 5}
 
 
 def build_dispatch_argv(

--- a/src/coding/model_inventory.py
+++ b/src/coding/model_inventory.py
@@ -52,6 +52,7 @@ CLI_PRESENCE_COMMANDS: Final[tuple[str, ...]] = (
     "codex",
     "claude",
     "opencode",
+    "senpi",
     "gemini",
     "grok",
     "qwen",
@@ -101,6 +102,7 @@ OMO_CATEGORY_ROLE_SOURCES: Final[dict[str, tuple[str, ...]]] = {
 _OMO_AGENT_CONFIG_RELATIVE: Final[str] = ".config/opencode/oh-my-openagent.json"
 _OPENCODE_CONFIG_RELATIVE: Final[str] = ".config/opencode/opencode.json"
 _OPENCODE_AUTH_RELATIVE: Final[str] = ".local/share/opencode/auth.json"
+_SENPI_AUTH_RELATIVE: Final[str] = ".senpi/agent/auth.json"
 
 # Narrow by design (mirrors `_claude_marker`): a failure to read or parse a
 # config marks the source `unreadable` and nothing else — no broad except.
@@ -114,6 +116,7 @@ def local_model_inventory(home: Path | None = None) -> dict[str, object]:
     omo_source, omo_models, category_chains = _omo_agent_config_source(base / _OMO_AGENT_CONFIG_RELATIVE)
     provider_source = _top_level_key_source(base / _OPENCODE_CONFIG_RELATIVE, section="provider")
     auth_source = _top_level_key_source(base / _OPENCODE_AUTH_RELATIVE, section="")
+    senpi_auth_source = _top_level_key_source(base / _SENPI_AUTH_RELATIVE, section="")
     auth_signals = executor_auth_signals(base)
     signal_profiles = auth_signals.get("profiles", {})
     login_markers = {
@@ -134,6 +137,7 @@ def local_model_inventory(home: Path | None = None) -> dict[str, object]:
             "omo_agent_config": omo_source,
             "opencode_config_providers": provider_source,
             "opencode_auth_providers": auth_source,
+            "senpi_auth_providers": senpi_auth_source,
             "executor_auth_signals": {"status": "present", "login_markers": login_markers},
         },
         "available_models": available_models,

--- a/tests/test_executor_auth_signals.py
+++ b/tests/test_executor_auth_signals.py
@@ -59,6 +59,26 @@ class AuthSignalMarkerTests(unittest.TestCase):
         entry = auth_signal_for_profile("hermes")
         self.assertEqual(entry["login_marker"], "not_applicable")
 
+    def test_senpi_marker_is_presence_only(self) -> None:
+        """omo-runtime's marker is the senpi credential store: present iff a
+        non-empty JSON object exists; provider names and values never read."""
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            self.assertEqual(executor_auth_signals(home=home)["profiles"]["omo-runtime"]["login_marker"], "absent")
+            senpi_dir = home / ".senpi" / "agent"
+            senpi_dir.mkdir(parents=True)
+            (senpi_dir / "auth.json").write_text("{}", encoding="utf-8")
+            self.assertEqual(executor_auth_signals(home=home)["profiles"]["omo-runtime"]["login_marker"], "absent")
+            (senpi_dir / "auth.json").write_text(
+                json.dumps({"kimi-coding": {"key": "sk-SECRET-VALUE-12345"}}), encoding="utf-8"
+            )
+            signals = executor_auth_signals(home=home)
+            self.assertEqual(signals["profiles"]["omo-runtime"]["login_marker"], "present")
+            self.assertNotIn("sk-SECRET-VALUE-12345", json.dumps(signals))
+            self.assertNotIn("kimi-coding", json.dumps(signals))
+            (senpi_dir / "auth.json").write_text("not json {", encoding="utf-8")
+            self.assertEqual(executor_auth_signals(home=home)["profiles"]["omo-runtime"]["login_marker"], "unknown")
+
 
 class LimitSignalReadTests(unittest.TestCase):
     def test_missing_state_reads_as_empty(self) -> None:
@@ -134,13 +154,15 @@ class ReadinessAdvisoryFreshnessTests(unittest.TestCase):
 
 
 class ExecutorChoiceContextTests(unittest.TestCase):
-    def test_choice_context_lists_both_cli_candidates_without_probing(self) -> None:
+    def test_choice_context_lists_every_cli_candidate_without_probing(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)
             paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
             context = executor_choice_context(paths)
             profiles = [entry["profile"] for entry in context["candidates"]]
-            self.assertEqual(profiles, ["codex", "claude-code"])
+            # Ranking may reorder by live local login markers; membership and
+            # count are the contract.
+            self.assertEqual(sorted(profiles), ["claude-code", "codex", "omo-runtime"])
             for entry in context["candidates"]:
                 self.assertEqual(entry["readiness_status"], "not_observed")
                 self.assertIn("auth_signal", entry)

--- a/tests/test_model_inventory.py
+++ b/tests/test_model_inventory.py
@@ -195,8 +195,23 @@ class ModelInventoryTests(unittest.TestCase):
 
     def test_cli_presence_table_is_fixed_vocabulary(self) -> None:
         self.assertEqual(
-            CLI_PRESENCE_COMMANDS, ("codex", "claude", "opencode", "gemini", "grok", "qwen")
+            CLI_PRESENCE_COMMANDS,
+            ("codex", "claude", "opencode", "senpi", "gemini", "grok", "qwen"),
         )
+
+    def test_senpi_auth_provider_names_are_presence_only(self) -> None:
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            senpi_dir = home / ".senpi" / "agent"
+            senpi_dir.mkdir(parents=True)
+            (senpi_dir / "auth.json").write_text(
+                json.dumps({"kimi-coding": {"type": "api", "key": _SECRET}}), encoding="utf-8"
+            )
+            inventory = local_model_inventory(home)
+        source = inventory["sources"]["senpi_auth_providers"]
+        self.assertEqual(source["status"], "present")
+        self.assertEqual(source["providers"], ["kimi-coding"])
+        self.assertNotIn(_SECRET, json.dumps(inventory))
 
 
 class InventoryModelCatalogTests(unittest.TestCase):

--- a/tests/test_model_routing.py
+++ b/tests/test_model_routing.py
@@ -530,6 +530,38 @@ class DispatchArgvTests(unittest.TestCase):
         claude = build_dispatch_argv("claude-code", "do the work")
         self.assertEqual(claude[0:3], ["claude", "-p", "do the work"])
         self.assertNotIn("--model", claude)
+        senpi = build_dispatch_argv("omo-runtime", "do the work")
+        self.assertEqual(
+            senpi,
+            ["senpi", "--print", "--no-session", "--permission-preset", "workspace", "do the work"],
+        )
+
+    def test_omo_runtime_model_and_thinking_insert_before_prompt(self) -> None:
+        """The senpi host treats trailing tokens as message positionals, so
+        routed options must land before the prompt — validated live: --print
+        completes non-interactively and the workspace preset allowed file
+        edits plus git add/commit."""
+        route = {
+            "schema_version": CODING_MODEL_ROUTE_SCHEMA_VERSION,
+            "selected_model": "kimi-coding/k3",
+            "selected_reasoning_effort": "high",
+        }
+        argv = build_dispatch_argv("omo-runtime", "do the work", route)
+        self.assertEqual(
+            argv,
+            [
+                "senpi",
+                "--print",
+                "--no-session",
+                "--permission-preset",
+                "workspace",
+                "--model",
+                "kimi-coding/k3",
+                "--thinking",
+                "high",
+                "do the work",
+            ],
+        )
 
     def test_codex_model_and_effort_insert_before_prompt(self) -> None:
         route = resolve_model_route("codex", requested_model="gpt-5-codex", requested_effort="xhigh")


### PR DESCRIPTION
## Capability

Closes #721 — the last blocked follow-up in the model-distribution line. Models the user activates through the omo ecosystem (kimi/glm/gemini-style providers) are now **locally dispatchable**: `omh coding fanout dispatch` can spawn the **senpi host CLI** for `omo-runtime`-owned units, carrying the frozen route's `provider/model` and thinking level on the argv.

```
senpi --print --no-session --permission-preset workspace [--model <provider/model>] [--thinking <effort>] <unit prompt>
```

## Why senpi (alternatives analysis from the issue)

- omo ships as an **extension of a host agent CLI**, not its own binary. On the reference machine the host is senpi (the omo-senpi components are live in its output); opencode reported **0 credentials**, making its success path unobservable — the issue's own bar ("observe before templating") ruled it out for now.
- A new `senpi`/`opencode` executor profile was rejected: ~30 registry crossings (most untested, per the earlier adversarial review), token collisions, and no capability the existing `omo-runtime` profile cannot carry. Bridge dispatch is a separate axis from lanes (claude-code precedent), so **no EXECUTOR_PROFILES/lane/matrix change** was needed.

## Observed evidence (the point of this PR)

All live, in isolated scratch homes/repos:

1. **Success path**: `senpi --print --no-session --model anthropic/claude-haiku-4-5` → exit 0, exact requested reply. No hang non-interactively.
2. **Permission path** (where the claude template previously failed until observed): `--permission-preset workspace` allowed file creation **plus the exact `git add`/`git commit`** the unit prompt requires — no interactive prompt, no broader grant.
3. **Failure paths**: missing provider key ("No API key found") and an inactive plan (402) each surfaced as clean **exit-1 observed failures** with bounded output — feeding the existing limit-signal machinery.
4. **Full live bridge dispatch**: a frozen contract's `omo-runtime` unit (routed `anthropic/claude-haiku-4-5`) spawned through `omh coding fanout dispatch`, created `docs/PROBE_NOTE.md` **inside its isolated worktree on `agent/note`, committed it, respected the file-scope boundary**, and reported `completed` with exit 0 and the model recorded.

## Surface changes

- `DISPATCH_COMMAND_TEMPLATES`/model/reasoning/insert-index tables gain `omo-runtime` (senpi's thinking levels are a superset of the effort ladder — routed efforts map verbatim; `--no-session` keeps dispatches ephemeral).
- Readiness: `omo-runtime` probes `senpi --version` (an opencode-hosted install without senpi truthfully reads `missing` for the bridge; the runtime prompt-handoff path never needed a CLI).
- Auth signals: `omo-runtime` marker = senpi credential store presence (non-empty JSON object; provider names/values never read — secret-plant tested).
- Choose-executor context gains `omo-runtime` as a third CLI-backed candidate (membership/count is the test contract).
- Inventory: `senpi` joins CLI presence; new `senpi_auth_providers` source reports provider key **names** only.
- `docs/FANOUT.md` updated (spawnability list + first-use validation notes).

## Verification

Full suite **2378 tests OK**; docs workflows/roles/capability-families `--check`, `ruff`, `git diff --check` green. Live evidence above.

## Risks / notes

- GLM-family live run not yet observed (provider unauthenticated on the reference machine) — the same template carries it the moment `zai`/`alibaba` auth exists; a missing key today is a clean observed failure, exactly as designed.
- Readiness probe command change for `omo-runtime` (`omo` → `senpi`) is a behavior change for anyone who had an `omo` binary on PATH; documented in the module and FANOUT.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)