### PR TITLE
feat: composer-model calibrations and mandatory delegation observability

### DIFF
--- a/docs/FANOUT.md
+++ b/docs/FANOUT.md
@@ -155,6 +155,15 @@ goal to Hermes in chat; these commands are the backend surface.
   stays in the chain, built-in chains are never reordered (a domain there is
   recorded and explicitly skipped), a requested model still wins, and no
   text matching ever infers a domain.
+- **Composer calibration.** The MAIN agent composing the split runs on
+  whatever model the user configured (a claude-family fable/opus, a
+  gpt-family sol/terra, a gemini, a kimi, ...), and each family fails
+  composition differently. `omh coding composition-guide --model <id>`
+  returns the discipline that agent applies to ITSELF while writing the
+  split, the unit prompts, and the briefings — same family key set as the
+  subagent calibrations (parity-gated), generic fallback for unmet
+  families, selected by the composer's own model id (provider prefixes
+  welcome).
 - **Unit prompt protocol.** Every dispatched unit prompt carries a fixed
   verification discipline (`src/coding/unit_prompt_protocol.py`): the
   subagent first echoes the goal, its deliverable, and the numbered
@@ -206,6 +215,7 @@ omh coding fanout dispatch <fanout-id> --goal-file goal.txt \
   [--unit <id> ...] [--dry-run]
 omh coding model-route [--executor <profile>] [--role <role>] [--model <id>] [--effort <level>] [--domain <name>] [--explain] [--from-inventory] [--json]
 omh coding model-inventory [--json]
+omh coding composition-guide [--model <id>] [--json]
 ```
 
 `--units` and `--goal-file` accept `-` for stdin. `--dry-run` resolves

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -5786,6 +5786,9 @@ Route implementation requests through scoped context, edit discipline, tests, re
   - When an explicit project root is supplied, attach only conflict-free project_governance_profile/v1 metadata; existing project rules override advisory defaults and a declined default stays non-blocking.
   - Use product_family_template/v1 for prepared web, mobile, desktop, or API quality guidance without implying installed tools, execution, or observed QA.
   - Report coding progress from lifecycle evidence, not from the existence of a prepared prompt.
+  - Name every delegated or parallel lane's model and reasoning effort inline as `(model effort)` in status and briefing lines — including runtime-native subagents; write the literal `unknown` when the host does not expose a value, never empty parentheses, and carry token and elapsed figures the same way.
+  - When the user asks mid-run which models are working or how many tokens are spent, answer immediately with one line per lane in that same format plus a one-line total; a steering question never waits for lane completion.
+  - When delegating, show the composed delegate prompt in a fenced code block in the status message; truncate a long prompt to a bounded preview ending with `... [truncated, N chars total]` — the user must see WHAT was asked, not just that something was.
 - Inputs:
   - task statement
   - repo context
@@ -5829,7 +5832,7 @@ Route implementation requests through scoped context, edit discipline, tests, re
   - `run_started`
   - `coding_delegation_recorded`
   - `verification_recorded`
-- Delegation expectation: Consult omh coding model-inventory before proposing which executor or model owns the work, and propose only from what the user actually has locally. Record prepared coding delegation with omh coding delegate; record observed execution only when Hermes exposes a separate coding, review, or verification lane.
+- Delegation expectation: Consult omh coding model-inventory before proposing which executor or model owns the work, and propose only from what the user actually has locally; when composing a split or unit prompts, apply your own model family's discipline from omh coding composition-guide --model <your model>. Record prepared coding delegation with omh coding delegate; record observed execution only when Hermes exposes a separate coding, review, or verification lane.
 - Privacy default: `metadata_only`
 - Overclaim guards:
   - A prepared coding_delegation.json is not implementation evidence.

--- a/src/coding/unit_prompt_protocol.py
+++ b/src/coding/unit_prompt_protocol.py
@@ -106,6 +106,73 @@ HIGH_EFFORT_CALIBRATIONS: Final[dict[str, str]] = {
 }
 
 
+# Calibration for the MAIN agent — the one COMPOSING the split, the unit
+# prompts, and the briefings — keyed by ITS OWN model family. The user picks
+# what Hermes runs on (a claude-family fable/opus, a gpt-family sol/terra, a
+# gemini, a kimi, ...), and each family fails composition differently: the
+# guidance counters the composer's own defaults, never the subagents'.
+# Same key set as HIGH_EFFORT_CALIBRATIONS (parity-tested) so no family gets
+# subagent discipline without composer discipline, and "generic" stays the
+# mandatory fallback for families the table has not met.
+MAIN_AGENT_COMPOSITION_CALIBRATIONS: Final[dict[str, str]] = {
+    "gpt": (
+        "Composition calibration: compose outcome-first, but never compress the contract away — "
+        "every unit prompt keeps its declared boundary, dependencies, numbered criteria, and the "
+        "one-pass verification floor spelled out. A tighter prompt that drops a stated invariant is "
+        "a worse prompt."
+    ),
+    "claude": (
+        "Composition calibration: split only what the goal requires — do not grow the fanout with "
+        "speculative units, and never spawn a subagent to double-check your own composition. The "
+        "criteria you write are a closed checklist: state them once, completely, and freeze."
+    ),
+    "gemini": (
+        "Composition calibration: compose from tool-verified facts, not recall — run the inventory "
+        "and readiness commands before naming owners or models, and never describe a unit as "
+        "prepared until the actual prepare command produced its artifact. A split narrated without "
+        "the commands behind it is not a split."
+    ),
+    "kimi": (
+        "Composition calibration: partitioning work is mostly low-entropy — decide the split once, "
+        "freeze it, and reserve deep reasoning for boundary overlaps and dependency cycles. Do not "
+        "enumerate alternative splits nobody asked for; if two partitions both satisfy the "
+        "boundaries, take the first and move."
+    ),
+    "glm": (
+        "Composition calibration: fill the contract fields literally — every unit carries its "
+        "owner, boundary, and (when known) model, role, and domain; 'every' means every. Sufficient "
+        "context beats complete context: once boundaries are clean and dependencies acyclic, freeze "
+        "the smallest split that covers the goal."
+    ),
+    "grok": (
+        "Composition calibration: speed never skips freeze-time validation — run the overlap and "
+        "cycle checks before recording the contract, not after dispatch fails. Pick the partition "
+        "once by the stated boundaries and dispatch; re-querying for a better split is re-verifying "
+        "a settled decision."
+    ),
+    "generic": (
+        "Composition calibration: compose the contract fields exactly, validate the split once with "
+        "the validation command, and stop — composing is preparing evidence, and a prepared "
+        "contract is the only proof a split exists."
+    ),
+}
+
+
+def composition_calibration_for_model(model_id: str) -> str:
+    """Return the main-agent composition calibration for the composer's own model.
+
+    Family comes from `model_family()` (provider-prefixed ids welcome);
+    unknown or blank families get the generic block — a composer never goes
+    without discipline just because the table has not met its model.
+    """
+    from .model_routing import model_family
+
+    family = model_family(str(model_id or ""))
+    return MAIN_AGENT_COMPOSITION_CALIBRATIONS.get(
+        family, MAIN_AGENT_COMPOSITION_CALIBRATIONS["generic"]
+    )
+
+
 def completion_criteria_for_unit(unit: Mapping[str, Any]) -> list[str]:
     """Return the pre-declared, numbered 'done means' criteria for one unit.
 

--- a/src/commands/coding.py
+++ b/src/commands/coding.py
@@ -765,6 +765,41 @@ def _local_model_catalogs() -> dict[str, dict[str, object]]:
     return {str(catalog.get("executor_profile", "")): catalog}
 
 
+def cmd_coding_composition_guide(args: argparse.Namespace) -> int:
+    from ..coding.model_routing import model_family
+    from ..coding.unit_prompt_protocol import (
+        MAIN_AGENT_COMPOSITION_CALIBRATIONS,
+        composition_calibration_for_model,
+    )
+
+    model = str(args.model or "").strip()
+    if model:
+        payload: dict[str, object] = {
+            "schema_version": "composition_guide/v1",
+            "model_id": model,
+            "family": model_family(model) or "unknown",
+            "calibration": composition_calibration_for_model(model),
+        }
+        if _wants_json(args):
+            _print_json(payload)
+            return 0
+        print(f"Composition guidance for `{model}` ({payload['family']} family):")
+        print(str(payload["calibration"]))
+        return 0
+    payload = {
+        "schema_version": "composition_guide/v1",
+        "calibrations": dict(MAIN_AGENT_COMPOSITION_CALIBRATIONS),
+    }
+    if _wants_json(args):
+        _print_json(payload)
+        return 0
+    lines = ["Main-agent composition calibrations by model family:"]
+    for family, block in MAIN_AGENT_COMPOSITION_CALIBRATIONS.items():
+        lines.append(f"- {family}: {block}")
+    print("\n".join(lines))
+    return 0
+
+
 def cmd_coding_fanout_prepare(args: argparse.Namespace) -> int:
     from ..coding.fanout import build_fanout_contract, is_degenerate_single_unit, single_unit_redirect
     from ..coding.fanout_artifacts import write_fanout_contract
@@ -1321,6 +1356,18 @@ def _add_coding_commands(sub) -> None:
     )
     model_inventory.add_argument("--json", action="store_true", help="Emit the machine payload instead of plain text.")
     model_inventory.set_defaults(func=cmd_coding_model_inventory)
+
+    composition_guide = coding_sub.add_parser(
+        "composition-guide",
+        help="Composition calibration for the MAIN agent's own model family (how to compose splits and unit prompts).",
+    )
+    composition_guide.add_argument(
+        "--model",
+        default=None,
+        help="The main agent's own model id (for example claude-fable-5, gpt-5.6-sol, kimi-k3); omit to list all families.",
+    )
+    composition_guide.add_argument("--json", action="store_true", help="Emit the machine payload instead of plain text.")
+    composition_guide.set_defaults(func=cmd_coding_composition_guide)
 
     delegate = coding_sub.add_parser("delegate")
     delegate.add_argument("message", nargs="*", help="Coding task description to prepare for executor delegation.")

--- a/src/skills/catalog_harnesses.py
+++ b/src/skills/catalog_harnesses.py
@@ -71,7 +71,7 @@ _HARNESSES = [
         ("run the smallest relevant tests", "inspect generated skill output when routing changed"),
         "If the request is underspecified, ask one concise clarification question before editing.",
         ("run_started", "coding_delegation_recorded", "verification_recorded"),
-        "Consult omh coding model-inventory before proposing which executor or model owns the work, and propose only from what the user actually has locally. Record prepared coding delegation with omh coding delegate; record observed execution only when Hermes exposes a separate coding, review, or verification lane.",
+        "Consult omh coding model-inventory before proposing which executor or model owns the work, and propose only from what the user actually has locally; when composing a split or unit prompts, apply your own model family's discipline from omh coding composition-guide --model <your model>. Record prepared coding delegation with omh coding delegate; record observed execution only when Hermes exposes a separate coding, review, or verification lane.",
         "metadata_only",
         quality_tier="handoff-gated",
         quality_bar=(
@@ -81,6 +81,9 @@ _HARNESSES = [
             "When an explicit project root is supplied, attach only conflict-free project_governance_profile/v1 metadata; existing project rules override advisory defaults and a declined default stays non-blocking.",
             "Use product_family_template/v1 for prepared web, mobile, desktop, or API quality guidance without implying installed tools, execution, or observed QA.",
             "Report coding progress from lifecycle evidence, not from the existence of a prepared prompt.",
+            "Name every delegated or parallel lane's model and reasoning effort inline as `(model effort)` in status and briefing lines — including runtime-native subagents; write the literal `unknown` when the host does not expose a value, never empty parentheses, and carry token and elapsed figures the same way.",
+            "When the user asks mid-run which models are working or how many tokens are spent, answer immediately with one line per lane in that same format plus a one-line total; a steering question never waits for lane completion.",
+            "When delegating, show the composed delegate prompt in a fenced code block in the status message; truncate a long prompt to a bounded preview ending with `... [truncated, N chars total]` — the user must see WHAT was asked, not just that something was.",
         ),
         evidence_ladder=(
             "coding_delegation_prepared",

--- a/tests/test_unit_prompt_protocol.py
+++ b/tests/test_unit_prompt_protocol.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import unittest
 
 from _local_package import load_local_package
@@ -9,15 +10,18 @@ load_local_package()
 from omh.coding.fanout import build_fanout_contract  # noqa: E402
 from omh.coding.fanout_dispatch import build_unit_prompt  # noqa: E402
 from omh.coding.model_routing import EXECUTOR_MODEL_OPTIONS, MODEL_ROLES  # noqa: E402
+from _cli_harness import run_cli  # noqa: E402
 from omh.coding.unit_prompt_protocol import (  # noqa: E402
     GOAL_ECHO_PROTOCOL,
     HIGH_EFFORT_CALIBRATIONS,
     HIGH_EFFORT_TIER,
+    MAIN_AGENT_COMPOSITION_CALIBRATIONS,
     REVIEW_ROLE_PROTOCOL,
     UNIT_PROMPT_MAX_BYTES,
     VERIFICATION_STOP_PROTOCOL,
     calibration_for_route,
     completion_criteria_for_unit,
+    composition_calibration_for_model,
     unit_protocol_lines,
 )
 
@@ -141,6 +145,56 @@ class CalibrationSelectionTests(unittest.TestCase):
         self.assertIn("generic", HIGH_EFFORT_CALIBRATIONS)
         for family, block in HIGH_EFFORT_CALIBRATIONS.items():
             self.assertTrue(block.startswith("High-effort calibration:"), family)
+
+
+class CompositionCalibrationTests(unittest.TestCase):
+    def test_composer_families_mirror_subagent_families(self) -> None:
+        """No family gets subagent discipline without composer discipline:
+        the two calibration tables share one key set, generic included."""
+        self.assertEqual(
+            set(MAIN_AGENT_COMPOSITION_CALIBRATIONS), set(HIGH_EFFORT_CALIBRATIONS)
+        )
+        for family, block in MAIN_AGENT_COMPOSITION_CALIBRATIONS.items():
+            self.assertTrue(block.startswith("Composition calibration:"), family)
+
+    def test_selection_follows_the_composers_own_model(self) -> None:
+        # The user's own examples: fable5 -> claude family, sol -> gpt,
+        # gemini -> gemini, kimi -> kimi; provider prefixes welcome.
+        cases = {
+            "claude-fable-5": "claude",
+            "gpt-5.6-sol": "gpt",
+            "gemini-3.1-pro": "gemini",
+            "kimi-k3": "kimi",
+            "opencode/glm-5": "glm",
+            "grok-code-fast-1": "grok",
+        }
+        for model_id, family in cases.items():
+            self.assertEqual(
+                composition_calibration_for_model(model_id),
+                MAIN_AGENT_COMPOSITION_CALIBRATIONS[family],
+                model_id,
+            )
+        self.assertEqual(
+            composition_calibration_for_model("mystery-model-9"),
+            MAIN_AGENT_COMPOSITION_CALIBRATIONS["generic"],
+        )
+        self.assertEqual(
+            composition_calibration_for_model(""),
+            MAIN_AGENT_COMPOSITION_CALIBRATIONS["generic"],
+        )
+
+    def test_cli_guide_plain_default_and_json(self) -> None:
+        status, stdout, _stderr = run_cli(
+            ["coding", "composition-guide", "--model", "claude-fable-5"], output_json=False
+        )
+        self.assertEqual(status, 0)
+        self.assertIn("claude family", stdout)
+        self.assertIn("Composition calibration:", stdout)
+        status, stdout, _stderr = run_cli(["coding", "composition-guide", "--json"])
+        self.assertEqual(status, 0)
+        payload = json.loads(stdout)
+        self.assertEqual(payload["schema_version"], "composition_guide/v1")
+        self.assertEqual(set(payload["calibrations"]), set(MAIN_AGENT_COMPOSITION_CALIBRATIONS))
 
 
 class PromptBudgetPolicyTests(unittest.TestCase):


### PR DESCRIPTION
## Capability

Two halves of one goal — the MAIN agent composes delegated work under its own model's discipline, and everything it delegates stays observable:

1. **Composer calibrations by the main agent's own model family.** The user decides what Hermes runs on (fable/opus → claude family, sol/terra → gpt, gemini, kimi, glm, grok); each family fails composition differently (scope growth, tool-free narration, over-analysis of mechanical splits, ...). `omh coding composition-guide --model <id>` returns the discipline that agent applies to itself while writing splits, unit prompts, and briefings. Same family key set as the subagent calibrations — parity-tested, generic floor mandatory.
2. **Delegation observability is now contract, not courtesy.** Observed live in a real briefing: parallel research lanes rendered with empty parentheses where the model label belonged — those lanes were runtime-native subagents, which never pass through `omh coding fanout brief` (the surface that already carries `(model effort)` labels). The coding-handling guidance now requires, for EVERY delegated or parallel lane including runtime-native ones: `(model effort)` inline (literal `unknown` when the host hides it — never empty parentheses), token + elapsed figures the same way, immediate per-lane answers to mid-run steering questions ("which model? how many tokens?") with a one-line total, and the composed delegate prompt shown in a fenced code block (bounded preview + `[truncated, N chars total]` marker for long prompts).

## Why

User steering on a live session: the parallel-agent briefing was good but hid which reasoning-level model each lane ran on, and asked for (a) that never happening again, (b) clean mid-run answers about models/tokens, (c) the delegate prompt itself being visible. The fanout brief already discloses labels structurally; the gap was the runtime-native path, which only guidance reaches.

## Verification (observed)

Full suite OK, all byte gates (workflows/roles/capability-families), ruff, `git diff --check`. Live CLI: `composition-guide --model claude-fable-5` → claude-family block; `--json` lists all families.

## Notes

- Guidance/pure-data only; OMH still observes nothing it cannot observe — undisclosed host values stay the literal `unknown`.
- Structured token/session capture for dispatched units remains the recorded follow-up from the fanout deferral; a `research` role for scope-matched investigation-lane routing lands separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)