### PR TITLE
feat: research role routes read-only investigation lanes by scope

### DIFF
--- a/docs/FANOUT.md
+++ b/docs/FANOUT.md
@@ -89,7 +89,11 @@ goal to Hermes in chat; these commands are the backend surface.
   observed evidence, and the fix is a one-line data edit in
   `DISPATCH_COMMAND_TEMPLATES`.
 - **Model routing.** A unit may declare `model`, `reasoning_effort`, and/or
-  `role` (brain, implementation, design_visual, review, docs). Prepare embeds
+  `role` (brain, implementation, design_visual, review, docs, research —
+  research is the read-only investigation lane: its chain default is the
+  fast-tier cheap sweep, and a deep multi-system investigation escalates
+  model tier or effort explicitly on the unit, since requested values
+  always win). Prepare embeds
   the resolved `coding_model_route/v2` in the unit handoff, and dispatch
   turns it into argv fragments (`codex --model … --config
   model_reasoning_effort=…`; `claude --model … --effort …`). Resolution is a

--- a/src/coding/model_inventory.py
+++ b/src/coding/model_inventory.py
@@ -97,6 +97,9 @@ OMO_CATEGORY_ROLE_SOURCES: Final[dict[str, tuple[str, ...]]] = {
     "design_visual": ("visual-engineering", "artistry"),
     "review": ("unspecified-high", "deep"),
     "docs": ("writing", "quick"),
+    # Read-only investigation lanes default to the cheap sweep; deep
+    # investigations escalate explicitly on the unit.
+    "research": ("quick", "unspecified-low"),
 }
 
 _OMO_AGENT_CONFIG_RELATIVE: Final[str] = ".config/opencode/oh-my-openagent.json"

--- a/src/coding/model_routing.py
+++ b/src/coding/model_routing.py
@@ -41,6 +41,11 @@ MODEL_ROLES: Final[tuple[str, ...]] = (
     "design_visual",
     "review",
     "docs",
+    # Read-only investigation lanes. The chain default is the cheap sweep;
+    # a deep multi-system investigation escalates model/effort EXPLICITLY on
+    # the unit (requested values always win) — scope is the caller's dial,
+    # never an inferred one.
+    "research",
 )
 
 MODEL_ROUTE_STATUSES: Final[tuple[str, ...]] = (
@@ -110,7 +115,7 @@ EXECUTOR_MODEL_OPTIONS: Final[dict[str, tuple[dict[str, object], ...]]] = {
             "model_id": "gpt-5",
             "label": "General frontier model",
             "tier": "standard",
-            "recommended_roles": ("implementation", "docs", "review"),
+            "recommended_roles": ("implementation", "docs", "review", "research"),
             "reasoning_efforts": ("low", "medium", "high", "xhigh"),
         },
     ),
@@ -133,7 +138,7 @@ EXECUTOR_MODEL_OPTIONS: Final[dict[str, tuple[dict[str, object], ...]]] = {
             "model_id": "haiku",
             "label": "Claude fast tier alias",
             "tier": "fast",
-            "recommended_roles": ("docs",),
+            "recommended_roles": ("docs", "research"),
             "reasoning_efforts": ("low", "medium", "high", "xhigh", "max"),
         },
     ),
@@ -165,6 +170,10 @@ ROLE_MODEL_CHAINS: Final[dict[str, dict[str, tuple[dict[str, str], ...]]]] = {
         "docs": (
             {"model_id": "gpt-5", "reasoning_effort": ""},
         ),
+        "research": (
+            {"model_id": "gpt-5", "reasoning_effort": "low"},
+            {"model_id": "gpt-5-codex", "reasoning_effort": ""},
+        ),
     },
     "claude-code": {
         "brain": (
@@ -184,6 +193,10 @@ ROLE_MODEL_CHAINS: Final[dict[str, dict[str, tuple[dict[str, str], ...]]]] = {
             {"model_id": "sonnet", "reasoning_effort": ""},
         ),
         "docs": (
+            {"model_id": "haiku", "reasoning_effort": ""},
+            {"model_id": "sonnet", "reasoning_effort": ""},
+        ),
+        "research": (
             {"model_id": "haiku", "reasoning_effort": ""},
             {"model_id": "sonnet", "reasoning_effort": ""},
         ),

--- a/src/commands/coding.py
+++ b/src/commands/coding.py
@@ -1324,7 +1324,7 @@ def _add_coding_commands(sub) -> None:
     )
     model_route.add_argument("--model", default=None, help="Explicit model id; always passes through unvalidated.")
     model_route.add_argument("--effort", default=None, help="Reasoning effort for profiles that support one.")
-    model_route.add_argument("--role", default=None, help="Subagent role: brain, implementation, design_visual, review, docs.")
+    model_route.add_argument("--role", default=None, help="Subagent role: brain, implementation, design_visual, review, docs, research.")
     model_route.add_argument(
         "--explain",
         action="store_true",

--- a/tests/test_model_routing.py
+++ b/tests/test_model_routing.py
@@ -28,6 +28,27 @@ from omh.coding.model_routing import (  # noqa: E402
 )
 
 
+class ResearchRoleTests(unittest.TestCase):
+    def test_research_defaults_to_the_cheap_sweep(self) -> None:
+        """Read-only investigation lanes route to the fast tier by default;
+        depth is the caller's explicit dial, never an inferred one."""
+        codex = resolve_model_route("codex", role="research")
+        self.assertEqual(codex["selected_model"], "gpt-5")
+        self.assertEqual(codex["selected_reasoning_effort"], "low")
+        self.assertEqual(codex["provenance"], "role_chain_head")
+        claude = resolve_model_route("claude-code", role="research")
+        self.assertEqual(claude["selected_model"], "haiku")
+        self.assertEqual(claude["selected_reasoning_effort"], "")
+
+    def test_deep_research_escalates_only_explicitly(self) -> None:
+        route = resolve_model_route(
+            "claude-code", role="research", requested_model="opus", requested_effort="high"
+        )
+        self.assertEqual(route["provenance"], "request_named_model")
+        self.assertEqual(route["selected_model"], "opus")
+        self.assertEqual(route["selected_reasoning_effort"], "high")
+
+
 class FamilyPrefixParityTests(unittest.TestCase):
     def test_family_prefixes_match_dynamic_workflow_target_prefixes(self) -> None:
         """The two prefix lists must name families the same way; drift between
@@ -313,7 +334,10 @@ class ModelRouteResolverTests(unittest.TestCase):
         self.assertIn("never retries or switches", route["claim_boundary"])
 
     def test_model_roles_vocabulary_is_stable(self) -> None:
-        self.assertEqual(MODEL_ROLES, ("brain", "implementation", "design_visual", "review", "docs"))
+        self.assertEqual(
+            MODEL_ROLES,
+            ("brain", "implementation", "design_visual", "review", "docs", "research"),
+        )
 
 
 class RouteVocabularyPolicyTests(unittest.TestCase):


### PR DESCRIPTION
## Capability

Read-only investigation lanes — the parallel research subagents a wrapper spins up before any coding starts — get a first-class routing role. A fanout unit (or `omh coding model-route --role research`) now resolves:

- **codex**: `gpt-5` at `low` effort → `gpt-5-codex` next-candidate
- **claude-code**: `haiku` → `sonnet` next-candidate
- **omo-runtime (inventory-derived)**: sourced from the user's own `quick` / `unspecified-low` omo categories

The default is deliberately the cheap sweep. Depth is the **caller's explicit dial**: a deep multi-system investigation escalates model tier or effort on the unit itself, and requested values always win — scope is never inferred from text (overroute risk stays zero).

## Motivation

User steering on a live session running parallel Hermes research lanes: investigators should route by investigation scope instead of inheriting the parent model blindly. This closes the role-vocabulary gap (`research` was the one lane shape with no chain).

## Surface

`MODEL_ROLES` += research (exact-tuple test updated same commit); chains for both built-in profiles; `recommended_roles` on `gpt-5`/`haiku`; `OMO_CATEGORY_ROLE_SOURCES` mapping; `--role` help text; `docs/FANOUT.md`. The bidirectional catalog↔chain parity gates and the prompt-budget worst-case loop pick up the new role automatically.

## Verification (observed)

Full suite OK; docs workflows/roles/capability-families `--check`; ruff; `git diff --check`. Resolver tests: cheap-sweep defaults on both profiles, explicit escalation via requested model+effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)