### PR TITLE
feat: surface skill triggers to the host picker and fix selection levers

### DIFF
--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -925,7 +925,7 @@ These surfaces are generated command references, not installed Hermes workflow s
 
 ### strategy-brief
 
-[omh] Hermes Strategy Brief workflow: options, tradeoffs, recommendation, and decision notes.
+[omh] Decide between options: tradeoffs, a recommendation, and a decision note you can act on.
 
 - Category: `strategy`
 - Phase: `brief`

--- a/skills/omh-accessibility-audit/SKILL.md
+++ b/skills/omh-accessibility-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-accessibility-audit
-description: [omh] Hermes Accessibility Audit workflow: prepare WCAG, keyboard, focus, screen-reader, target-size, and reflow evidence gates for UI surfaces.
+description: [omh] Hermes Accessibility Audit workflow: prepare WCAG, keyboard, focus, screen-reader, target-size, and reflow evidence gates for UI surfaces. Use when the user says: accessibility-audit, accessibility audit, a11y audit, a11y architect, wcag audit, wcag 2.2, wcag 2.2 aa, accessibility pass.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, accessibility]

--- a/skills/omh-achievements/SKILL.md
+++ b/skills/omh-achievements/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-achievements
-description: [omh] Hermes achievements observation workflow: summarize hermes-achievements badges, tiers, recent unlocks, and progress from local plugin artifacts.
+description: [omh] Hermes achievements observation workflow: summarize hermes-achievements badges, tiers, recent unlocks, and progress from local plugin artifacts. Use when the user says: achievements, achievement, badges, badge, my badges, show achievements, achievement summary, unlocked badges.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, observability]

--- a/skills/omh-agent-board/SKILL.md
+++ b/skills/omh-agent-board/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-agent-board
-description: [omh] Hermes agent board workflow: coordinate multiple Hermes profiles or agents with task, handoff, heartbeat, blocker, and completion states.
+description: [omh] Hermes agent board workflow: coordinate multiple Hermes profiles or agents with task, handoff, heartbeat, blocker, and completion states. Use when the user says: agent-board, agent board, kanban, multi-agent, multi agent, multi agent board, multiple hermes agents, multiple hermes profiles.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, agent-coordination]

--- a/skills/omh-agent-debug/SKILL.md
+++ b/skills/omh-agent-debug/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-agent-debug
-description: [omh] Agent Debug workflow: capture a stuck, looping, drifting, or repeatedly failing agent run, diagnose the likely failure pattern, and prepare the smallest safe recovery action.
+description: [omh] Agent Debug workflow: capture a stuck, looping, drifting, or repeatedly failing agent run, diagnose the likely failure pattern, and prepare the smallest safe recovery action. Use when the user says: agent-debug, agent debug, agent debugging, agent introspection, agent self-debug, self-debug, self debugging, looping agent.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, operations]

--- a/skills/omh-agent-evaluation/SKILL.md
+++ b/skills/omh-agent-evaluation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-agent-evaluation
-description: [omh] Hermes Agent Evaluation workflow: compare executor or agent choices on reproducible tasks using quality, cost, time, tool, and evidence metrics.
+description: [omh] Hermes Agent Evaluation workflow: compare executor or agent choices on reproducible tasks using quality, cost, time, tool, and evidence metrics. Use when the user says: agent-evaluation, agent evaluation, agent eval, agent benchmark, executor evaluation, executor benchmark, compare agents, compare codex claude.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, operations]

--- a/skills/omh-agent-ops-review/SKILL.md
+++ b/skills/omh-agent-ops-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-agent-ops-review
-description: [omh] Hermes agent ops review workflow: help managers inspect AI-agent progress, blockers, quality gates, and throughput levers.
+description: [omh] Hermes agent ops review workflow: help managers inspect AI-agent progress, blockers, quality gates, and throughput levers. Use when the user says: agent-ops-review, agent ops review, agent productivity, operator productivity, manager view, quality dashboard, throughput review, agent work quality.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, operator]

--- a/skills/omh-ai-slop-cleaner/SKILL.md
+++ b/skills/omh-ai-slop-cleaner/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-ai-slop-cleaner
-description: [omh] Hermes AI slop cleaner workflow: delete AI-generated slop, dead code, and duplication while observable behavior stays identical.
+description: [omh] Hermes AI slop cleaner workflow: delete AI-generated slop, dead code, and duplication while observable behavior stays identical. Use when the user says: ai-slop-cleaner, cleanup, deslop, refactor, risky, behavior-preserving refactor, risk analysis, refactor workflow.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, maintenance]

--- a/skills/omh-ask/SKILL.md
+++ b/skills/omh-ask/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-ask
-description: [omh] Hermes adaptation for consulting an external advisor when configured.
+description: [omh] Hermes adaptation for consulting an external advisor when configured. Use when the user says: ask, external advisor, claude, gemini, ask claude, ask gemini, consult claude, consult gemini.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, review]

--- a/skills/omh-automation-blueprint/SKILL.md
+++ b/skills/omh-automation-blueprint/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-automation-blueprint
-description: [omh] Hermes Scheduled Ops Blueprint workflow: design recurring Hermes operations with schedule, delivery, silence policy, context chain, and prepared-vs-observed status.
+description: [omh] Hermes Scheduled Ops Blueprint workflow: design recurring Hermes operations with schedule, delivery, silence policy, context chain, and prepared-vs-observed status. Use when the user says: automation-blueprint, scheduled ops, scheduled operation, scheduled operations, automation blueprint, cron blueprint, cron-ready, recurring ops.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, operations]

--- a/skills/omh-autoresearch-goal/SKILL.md
+++ b/skills/omh-autoresearch-goal/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-autoresearch-goal
-description: [omh] Hermes adaptation for durable research-goal execution.
+description: [omh] Hermes adaptation for durable research-goal execution. Use when the user says: autoresearch-goal, research goal, durable research, critic research.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, research]

--- a/skills/omh-best-practice-research/SKILL.md
+++ b/skills/omh-best-practice-research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-best-practice-research
-description: [omh] Hermes adaptation for bounded official/upstream best-practice research.
+description: [omh] Hermes adaptation for bounded official/upstream best-practice research. Use when the user says: best-practice-research, best practice, official docs, upstream guidance, what do the docs say, check the docs.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, research]

--- a/skills/omh-browser-operator/SKILL.md
+++ b/skills/omh-browser-operator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-browser-operator
-description: [omh] Hermes browser operator workflow: scope URL opening, page interaction, login/form boundaries, observations, and destructive confirmation gates.
+description: [omh] Hermes browser operator workflow: scope URL opening, page interaction, login/form boundaries, observations, and destructive confirmation gates. Use when the user says: browser-operator, browser operator, browser task, browser operation, browser automation, browser session, webpage operation, web page operation.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, browser]

--- a/skills/omh-build-failure-triage/SKILL.md
+++ b/skills/omh-build-failure-triage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-build-failure-triage
-description: [omh] Hermes Build Failure Triage workflow: classify build, typecheck, lint, test, CI, and DCO failures into minimal safe fix handoffs.
+description: [omh] Hermes Build Failure Triage workflow: classify build, typecheck, lint, test, CI, and DCO failures into minimal safe fix handoffs. Use when the user says: build-failure-triage, build failure triage, build failure, build-failure, build fix, build failed, build failing, compile error.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, verification]

--- a/skills/omh-cancel/SKILL.md
+++ b/skills/omh-cancel/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-cancel
-description: [omh] Hermes adaptation for ending active workflow state cleanly.
+description: [omh] Hermes adaptation for ending active workflow state cleanly. Use when the user says: cancel, stop the workflow, abort the run, cancel the loop.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, operator]

--- a/skills/omh-code-review/SKILL.md
+++ b/skills/omh-code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-code-review
-description: [omh] Hermes Code Review workflow: bug-first review with evidence.
+description: [omh] Hermes Code Review workflow: bug-first review with evidence. Use when the user says: code-review, review, audit, find bugs, release gate, claim audit, evidence audit, README claim.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, review]

--- a/skills/omh-codebase-onboarding/SKILL.md
+++ b/skills/omh-codebase-onboarding/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-codebase-onboarding
-description: [omh] Hermes Codebase Onboarding workflow: create a repo map, reading path, glossary, risk map, and first-task runway for unfamiliar codebases.
+description: [omh] Hermes Codebase Onboarding workflow: create a repo map, reading path, glossary, risk map, and first-task runway for unfamiliar codebases. Use when the user says: codebase-onboarding, codebase onboarding, repo onboarding, repository onboarding, codebase tour, code tour, new repo orientation, understand this repo.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, planning]

--- a/skills/omh-codegraph-refresh/SKILL.md
+++ b/skills/omh-codegraph-refresh/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-codegraph-refresh
-description: [omh] Hermes Codegraph Refresh workflow: refresh local code intelligence, summarize repo structure, and prepare task-scoped codegraph handoff context without overclaiming execution.
+description: [omh] Hermes Codegraph Refresh workflow: refresh local code intelligence, summarize repo structure, and prepare task-scoped codegraph handoff context without overclaiming execution. Use when the user says: codegraph-refresh, codegraph refresh, refresh codegraph, update codegraph, codegraph stale, stale codegraph, codegraph handoff, codegraph summary.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, planning]

--- a/skills/omh-command-operator/SKILL.md
+++ b/skills/omh-command-operator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-command-operator
-description: [omh] Hermes command operator workflow: scope terminal, shell, CLI, package-manager, and test commands with cwd, environment, safety, and result-evidence gates.
+description: [omh] Hermes command operator workflow: scope terminal, shell, CLI, package-manager, and test commands with cwd, environment, safety, and result-evidence gates. Use when the user says: command-operator, command operator, terminal command, terminal task, shell command, shell task, cli command, command execution.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, command]

--- a/skills/omh-connector-operator/SKILL.md
+++ b/skills/omh-connector-operator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-connector-operator
-description: [omh] Hermes connector operator workflow: scope external app actions across email, Slack, Discord, Notion, Linear, Jira, CRM, and similar providers with auth, payload, confirmation, and result-evidence gates.
+description: [omh] Hermes connector operator workflow: scope external app actions across email, Slack, Discord, Notion, Linear, Jira, CRM, and similar providers with auth, payload, confirmation, and result-evidence gates. Use when the user says: connector-operator, connector operator, external app action, external connector action, saas action, api action, send email, email customer.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, connector]

--- a/skills/omh-content-operator/SKILL.md
+++ b/skills/omh-content-operator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-content-operator
-description: [omh] Hermes content operator workflow: scope publish-ready writing, rewriting, summarization, translation, release-note, newsletter, customer-copy, social-copy, README-copy, and email-draft work with audience, tone, style, source, review, and hallucination gates.
+description: [omh] Hermes content operator workflow: scope publish-ready writing, rewriting, summarization, translation, release-note, newsletter, customer-copy, social-copy, README-copy, and email-draft work with audience, tone, style, source, review, and hallucination gates. Use when the user says: content-operator, content operator, content workflow, writing workflow, publish-ready writing, publish ready writing, release notes, release note draft.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, content]

--- a/skills/omh-context-budget-review/SKILL.md
+++ b/skills/omh-context-budget-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-context-budget-review
-description: [omh] Hermes Context Budget Review workflow: plan compact context, token/cost budgets, summarization checkpoints, and overflow recovery before long agent work.
+description: [omh] Hermes Context Budget Review workflow: plan compact context, token/cost budgets, summarization checkpoints, and overflow recovery before long agent work. Use when the user says: context-budget-review, context budget review, context budget, token budget review, token budget, prompt budget, context compaction, compact context.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, observability]

--- a/skills/omh-cto-loop/SKILL.md
+++ b/skills/omh-cto-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-cto-loop
-description: [omh] Hermes CTO Loop workflow: roadmap, PM, technical tradeoffs, risk, delivery, release, and follow-up operating cadence.
+description: [omh] Hermes CTO Loop workflow: roadmap, PM, technical tradeoffs, risk, delivery, release, and follow-up operating cadence. Use when the user says: cto-loop, cto loop, cto, cto pm, pm dev qa security ops, roadmap technical tradeoffs, technical tradeoff, delivery risk.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, leadership]

--- a/skills/omh-data-analysis/SKILL.md
+++ b/skills/omh-data-analysis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-data-analysis
-description: [omh] Hermes data analysis workflow: scope supplied data with provenance, causal-claim, and hallucination guards.
+description: [omh] Hermes data analysis workflow: scope supplied data with provenance, causal-claim, and hallucination guards. Use when the user says: data-analysis, data analysis, dataset analysis, csv analysis, json analysis, log analysis, table analysis, analyze csv.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, analysis]

--- a/skills/omh-decide/SKILL.md
+++ b/skills/omh-decide/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-decide
-description: [omh] Hermes Strategy Brief workflow: options, tradeoffs, recommendation, and decision notes.
+description: [omh] Decide between options: tradeoffs, a recommendation, and a decision note you can act on. Use when the user says: strategy-brief, strategy brief, strategy memo, product strategy, strategic options, decision note, leadership strategy, next strategy.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, strategy]

--- a/skills/omh-decision-recall/SKILL.md
+++ b/skills/omh-decision-recall/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-decision-recall
-description: [omh] Recall scoped reviewed rejected decisions without elevating them to approved memory.
+description: [omh] Recall scoped reviewed rejected decisions without elevating them to approved memory. Use when the user says: decision-recall, rejected decision recall, rejected decisions, why was this rejected, previously rejected alternative, 거절된 결정, 기각된 대안.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, memory]

--- a/skills/omh-deliverable-package/SKILL.md
+++ b/skills/omh-deliverable-package/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-deliverable-package
-description: [omh] Hermes deliverable package workflow: track PPT, PDF, XLSX, DOCX, HWP, Markdown, and attachments through prepared, generated, QA, approved, and attached states.
+description: [omh] Hermes deliverable package workflow: track PPT, PDF, XLSX, DOCX, HWP, Markdown, and attachments through prepared, generated, QA, approved, and attached states. Use when the user says: deliverable-package, deliverable mode, file attachment, attach file, attachment status, file delivery, file deliverable status, generated file.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, deliverables]

--- a/skills/omh-deploy-and-monitor/SKILL.md
+++ b/skills/omh-deploy-and-monitor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-deploy-and-monitor
-description: [omh] Hermes Deploy-and-Monitor workflow: release checklist, deploy decision, health signals, rollback gate, and post-deploy status.
+description: [omh] Hermes Deploy-and-Monitor workflow: release checklist, deploy decision, health signals, rollback gate, and post-deploy status. Use when the user says: deploy-and-monitor, deploy and monitor, deploy monitor, deployment monitoring, release monitor, post deploy, post-deploy, rollback.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, monitoring]

--- a/skills/omh-design-orchestration/SKILL.md
+++ b/skills/omh-design-orchestration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-design-orchestration
-description: [omh] Hermes design orchestration workflow: prepare a bounded design direction, existing-lane composition, and executor-neutral handoff.
+description: [omh] Hermes design orchestration workflow: prepare a bounded design direction, existing-lane composition, and executor-neutral handoff. Use when the user says: design-orchestration, design orchestration, design ownership, handle this product design, take on the design, 디자인 맡겨, 디자인 맡겨줘, 디자인 전체 맡겨.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, materials]

--- a/skills/omh-design-quality-gate/SKILL.md
+++ b/skills/omh-design-quality-gate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-design-quality-gate
-description: [omh] Hermes Design Quality Gate workflow: enforce superior content, design, layout, publishing, and visual QA gates.
+description: [omh] Hermes Design Quality Gate workflow: enforce superior content, design, layout, publishing, and visual QA gates. Use when the user says: design-quality-gate, design quality gate, ui ux pro max, design pro max, frontend pro max, visual qa pro, premium design, high quality design.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, materials]

--- a/skills/omh-doctor/SKILL.md
+++ b/skills/omh-doctor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-doctor
-description: [omh] Hermes adaptation for diagnosing oh-my-hermes installation health.
+description: [omh] Hermes adaptation for diagnosing oh-my-hermes installation health. Use when the user says: doctor, diagnose omh, installation health.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, operator]

--- a/skills/omh-executor-runtime-readiness/SKILL.md
+++ b/skills/omh-executor-runtime-readiness/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-executor-runtime-readiness
-description: [omh] Hermes executor runtime readiness workflow: compare Codex, Claude Code, Hermes coding, and oh-my runtimes by available tools, missing tools, and handoff mode.
+description: [omh] Hermes executor runtime readiness workflow: compare Codex, Claude Code, Hermes coding, and oh-my runtimes by available tools, missing tools, and handoff mode. Use when the user says: executor-runtime-readiness, executor readiness, runtime readiness, codex readiness, claude code readiness, hermes coding readiness, executor tools, missing tools.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, executor-readiness]

--- a/skills/omh-external-connector-readiness/SKILL.md
+++ b/skills/omh-external-connector-readiness/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-external-connector-readiness
-description: [omh] Hermes external connector readiness workflow: decide whether a candidate plugin, connector, API, data provider, or multimodal route is safe, affordable, fresh, and observable enough to adopt, route, or trial.
+description: [omh] Hermes external connector readiness workflow: decide whether a candidate plugin, connector, API, data provider, or multimodal route is safe, affordable, fresh, and observable enough to adopt, route, or trial. Use when the user says: external-connector-readiness, external connector readiness, connector readiness matrix, plugin readiness matrix, provider readiness, api readiness, connector adoption, external plugin adoption.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, connector]

--- a/skills/omh-failure-signal-audit/SKILL.md
+++ b/skills/omh-failure-signal-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-failure-signal-audit
-description: [omh] Failure Signal Audit workflow: find swallowed errors, unsafe fallbacks, hidden UI/runtime failures, and missing propagation before they become false green status.
+description: [omh] Failure Signal Audit workflow: find swallowed errors, unsafe fallbacks, hidden UI/runtime failures, and missing propagation before they become false green status. Use when the user says: failure-signal-audit, failure signal audit, silent failure, silent failures, silent failure hunter, swallowed error, swallowed errors, empty catch.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, review]

--- a/skills/omh-feedback-triage/SKILL.md
+++ b/skills/omh-feedback-triage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-feedback-triage
-description: [omh] Hermes Feedback Triage workflow: cluster customer signals and choose the next workflow.
+description: [omh] Hermes Feedback Triage workflow: cluster customer signals and choose the next workflow. Use when the user says: feedback-triage, customer-feedback-triage, feedback triage, customer feedback, feedback cluster, bug or feature, feature request triage, payment failure feedback.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, triage]

--- a/skills/omh-frontend/SKILL.md
+++ b/skills/omh-frontend/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-frontend
-description: [omh] Hermes frontend workflow: prepare design-system-driven web UI creation, redesign, polish, accessibility, performance, and visual QA handoffs.
+description: [omh] Hermes frontend workflow: prepare design-system-driven web UI creation, redesign, polish, accessibility, performance, and visual QA handoffs. Use when the user says: frontend, front-end, front end, frontend skill, web ui, ui ux, landing page, web app layout.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, materials]

--- a/skills/omh-gateway-intent-card/SKILL.md
+++ b/skills/omh-gateway-intent-card/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-gateway-intent-card
-description: [omh] Hermes gateway intent workflow: normalize Discord, Slack, Telegram, and other gateway sessions into origin, thread, delivery, silent, attachment, and status-update policy.
+description: [omh] Hermes gateway intent workflow: normalize Discord, Slack, Telegram, and other gateway sessions into origin, thread, delivery, silent, attachment, and status-update policy. Use when the user says: gateway-intent-card, gateway intent, discord thread, slack thread, telegram delivery, discord delivery policy, slack delivery policy, telegram delivery policy.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, gateway]

--- a/skills/omh-github-event-ops/SKILL.md
+++ b/skills/omh-github-event-ops/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-github-event-ops
-description: [omh] Hermes GitHub event operations workflow: route PR, issue, CI, and review webhook events into triage, review, or fix handoff cards.
+description: [omh] Hermes GitHub event operations workflow: route PR, issue, CI, and review webhook events into triage, review, or fix handoff cards. Use when the user says: github-event-ops, github event ops, github ops, github triage, github pr, github review, github action, github actions.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, github-ops]

--- a/skills/omh-harness-session-inventory/SKILL.md
+++ b/skills/omh-harness-session-inventory/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-harness-session-inventory
-description: [omh] Hermes harness session inventory workflow: normalize Codex, Claude Code, Hermes, OpenCode, Cursor, MCP host, worktree, and wrapper session metadata into one drift-aware inventory.
+description: [omh] Hermes harness session inventory workflow: normalize Codex, Claude Code, Hermes, OpenCode, Cursor, MCP host, worktree, and wrapper session metadata into one drift-aware inventory. Use when the user says: harness-session-inventory, harness session inventory, session inventory, session adapter, session adapters, harness sessions, mcp inventory, mcp config inventory.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, observability]

--- a/skills/omh-idea-to-deploy/SKILL.md
+++ b/skills/omh-idea-to-deploy/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-idea-to-deploy
-description: [omh] Hermes Idea-to-Deploy workflow: shape an app idea into decisions, delivery handoff, verification, release, and monitoring status.
+description: [omh] Hermes Idea-to-Deploy workflow: shape an app idea into decisions, delivery handoff, verification, release, and monitoring status. Use when the user says: idea-to-deploy, idea to deploy, from idea to deploy, plan to deploy, idea to launch, ship this idea, ship this feature, launch this feature.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, delivery]

--- a/skills/omh-img-summary/SKILL.md
+++ b/skills/omh-img-summary/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-img-summary
-description: [omh] Hermes img-summary workflow: turn meetings, reports, PRs, issues, research, and releases into domain-aware image prompt cards.
+description: [omh] Hermes img-summary workflow: turn meetings, reports, PRs, issues, research, and releases into domain-aware image prompt cards. Use when the user says: img-summary, img summary, visual prompt card, image card, image generation, image edit, edit this image, remove the background.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, materials]

--- a/skills/omh-instinct-ledger/SKILL.md
+++ b/skills/omh-instinct-ledger/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-instinct-ledger
-description: [omh] Instinct Ledger workflow: turn repeated project or cross-project lessons into atomic, confidence-scored instinct candidates with scoped promotion and export boundaries.
+description: [omh] Instinct Ledger workflow: turn repeated project or cross-project lessons into atomic, confidence-scored instinct candidates with scoped promotion and export boundaries. Use when the user says: instinct-ledger, instinct ledger, project instincts, project-scoped instincts, project scoped instincts, global instincts, instinct review, instinct candidate.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, optimization]

--- a/skills/omh-live-info-operator/SKILL.md
+++ b/skills/omh-live-info-operator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-live-info-operator
-description: [omh] Hermes live information workflow: scope read-only weather, finance, sports, map, place, exchange-rate, and time-zone lookups with provider, freshness, units, source-quality, and result-evidence gates.
+description: [omh] Hermes live information workflow: scope read-only weather, finance, sports, map, place, exchange-rate, and time-zone lookups with provider, freshness, units, source-quality, and result-evidence gates. Use when the user says: live-info-operator, live info operator, live information, real time information, real-time information, weather today, current weather, weather forecast.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, live-info]

--- a/skills/omh-materials-package/SKILL.md
+++ b/skills/omh-materials-package/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-materials-package
-description: [omh] Hermes Materials Package workflow: decks, PDFs, spreadsheets, documents, HWP, Markdown, and binary export handoffs.
+description: [omh] Hermes Materials Package workflow: decks, PDFs, spreadsheets, documents, HWP, Markdown, and binary export handoffs. Use when the user says: materials-package, material package, materials package, document package, deck file, binary export, file export, render qa.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, materials]

--- a/skills/omh-media-input-operator/SKILL.md
+++ b/skills/omh-media-input-operator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-media-input-operator
-description: [omh] Hermes media input workflow: scope audio, video, YouTube, screenshot, receipt image, OCR, meeting recording, transcript, timestamp, and clip-summary requests with source, permission, extraction, transcription, and hallucination gates.
+description: [omh] Hermes media input workflow: scope audio, video, YouTube, screenshot, receipt image, OCR, meeting recording, transcript, timestamp, and clip-summary requests with source, permission, extraction, transcription, and hallucination gates. Use when the user says: media-input-operator, media input operator, media input, audio transcription, audio transcript, transcribe audio, transcribe this audio, meeting recording.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, media]

--- a/skills/omh-meeting-brief/SKILL.md
+++ b/skills/omh-meeting-brief/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-meeting-brief
-description: [omh] Hermes Meeting Brief workflow: agenda, prompts, decisions, and record template.
+description: [omh] Hermes Meeting Brief workflow: agenda, prompts, decisions, and record template. Use when the user says: meeting-brief, meeting brief, meeting agenda, agenda, discussion prompts, decisions needed, record template, meeting topics.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, meeting]

--- a/skills/omh-memory-new/SKILL.md
+++ b/skills/omh-memory-new/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-memory-new
-description: [omh] Hermes new-memory capture workflow: add reviewed project, product, or durable context candidates through capture, review, and approve actions.
+description: [omh] Hermes new-memory capture workflow: add reviewed project, product, or durable context candidates through capture, review, and approve actions. Use when the user says: memory-new, new memory, project memory, product memory, remember this project, remember this product, memory capture, capture memory.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, memory]

--- a/skills/omh-memory-sync/SKILL.md
+++ b/skills/omh-memory-sync/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-memory-sync
-description: [omh] Hermes existing-memory curation workflow: review stale, conflicting, duplicate, overgeneralized, or risky USER.md, MEMORY.md, and skill memories through approve/reject/update actions.
+description: [omh] Hermes existing-memory curation workflow: review stale, conflicting, duplicate, overgeneralized, or risky USER.md, MEMORY.md, and skill memories through approve/reject/update actions. Use when the user says: memory-sync, memory curation, memory review, memory inspect, memory check, memory update, context cleanup, curate memory.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, memory]

--- a/skills/omh-model-setup/SKILL.md
+++ b/skills/omh-model-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-model-setup
-description: [omh] Hermes Model Setup workflow: diagnose role-slot model configuration, guide provider connection, and apply changes only after diff approval.
+description: [omh] Hermes Model Setup workflow: diagnose role-slot model configuration, guide provider connection, and apply changes only after diff approval. Use when the user says: model-setup, hermes model setup, set up my models, set up my model, configure my models, configure model provider, connect my model provider, set up model role slots.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, hermes-setup]

--- a/skills/omh-morning-brief/SKILL.md
+++ b/skills/omh-morning-brief/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-morning-brief
-description: [omh] Hermes Morning Brief setup workflow: diagnose mail and calendar MCP connection, guide read/draft-only access, and apply changes only after diff approval.
+description: [omh] Hermes Morning Brief setup workflow: diagnose mail and calendar MCP connection, guide read/draft-only access, and apply changes only after diff approval. Use when the user says: morning-brief, morning brief, connect my email for a morning brief, set up morning brief, configure morning brief, connect mail for morning brief, connect calendar for morning brief, set up my morning brief.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, hermes-setup]

--- a/skills/omh-operating-rhythm/SKILL.md
+++ b/skills/omh-operating-rhythm/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-operating-rhythm
-description: [omh] Hermes Operating Rhythm workflow: meeting minutes, scrum/sprint records, retros, decisions, and follow-up history.
+description: [omh] Hermes Operating Rhythm workflow: meeting minutes, scrum/sprint records, retros, decisions, and follow-up history. Use when the user says: operating-rhythm, operating rhythm, meeting minutes, meeting history, scrum record, sprint planning, sprint review, sprint retrospective.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, operations]

--- a/skills/omh-ops-observability-card/SKILL.md
+++ b/skills/omh-ops-observability-card/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-ops-observability-card
-description: [omh] Hermes ops observability workflow: prepare an operations command-board for wrapper-safe token, cost, latency, run history, queue, failure-mode, external metric-provider, and service-quality evidence boundaries.
+description: [omh] Hermes ops observability workflow: prepare an operations command-board for wrapper-safe token, cost, latency, run history, queue, failure-mode, external metric-provider, and service-quality evidence boundaries. Use when the user says: ops-observability-card, observability card, operations command board, ops command board, service quality board, service quality, external metric provider, metric provider.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, observability]

--- a/skills/omh-ops-review/SKILL.md
+++ b/skills/omh-ops-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-ops-review
-description: [omh] Hermes Ops Review workflow: status, risks, blockers, priorities, and follow-ups.
+description: [omh] Hermes Ops Review workflow: status, risks, blockers, priorities, and follow-ups. Use when the user says: ops-review, ops review, weekly ops review, status review, operating review, release risks, risks and blockers, priorities.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, operations]

--- a/skills/omh-paper-learning/SKILL.md
+++ b/skills/omh-paper-learning/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-paper-learning
-description: [omh] Hermes Paper Learning workflow: explain a supplied paper or paper/PDF at a selected level while preserving full section coverage and source evidence boundaries.
+description: [omh] Hermes Paper Learning workflow: explain a supplied paper or paper/PDF at a selected level while preserving full section coverage and source evidence boundaries. Use when the user says: paper-learning, paper learning, paper-explainer, paper explainer, paper explanation, explain this paper, explain this arxiv paper, paper walkthrough.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, research]

--- a/skills/omh-parallel-tools/SKILL.md
+++ b/skills/omh-parallel-tools/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-parallel-tools
-description: [omh] Hermes Parallel Tools workflow: check version currency and parallel-tool capability status, then apply an update only after diff approval.
+description: [omh] Hermes Parallel Tools workflow: check version currency and parallel-tool capability status, then apply an update only after diff approval. Use when the user says: parallel-tools, parallel tools, hermes parallel tools setup, update hermes for parallel tools, check parallel tool support, enable parallel tool calls, verify parallel tools capability, check hermes version for parallel tools.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, hermes-setup]

--- a/skills/omh-performance-goal/SKILL.md
+++ b/skills/omh-performance-goal/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-performance-goal
-description: [omh] Hermes adaptation for measurable performance-goal execution.
+description: [omh] Hermes adaptation for measurable performance-goal execution. Use when the user says: performance-goal, performance goal, latency, throughput, benchmark.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, optimization]

--- a/skills/omh-physical-device-readiness/SKILL.md
+++ b/skills/omh-physical-device-readiness/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-physical-device-readiness
-description: [omh] Hermes readiness workflow for robots, 3D printers, IoT relays, sensors, and lab hardware before hardware trials.
+description: [omh] Hermes readiness workflow for robots, 3D printers, IoT relays, sensors, and lab hardware before hardware trials. Use when the user says: physical-device-readiness, physical device readiness, device safety readiness, physical device safety, hardware safety gate, 3d printer readiness, 3D printer safety, snapmaker printer safety.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, operations]

--- a/skills/omh-plan/SKILL.md
+++ b/skills/omh-plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-plan
-description: [omh] Hermes Plan workflow: structured planning before execution.
+description: [omh] Hermes Plan workflow: structured planning before execution. Use when the user says: plan, implementation plan, task breakdown, safe feature, safely add a feature, add a feature, feature request, new feature.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, planning]

--- a/skills/omh-production-audit/SKILL.md
+++ b/skills/omh-production-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-production-audit
-description: [omh] Hermes Production Audit workflow: evaluate release, deploy, security, observability, rollback, docs, and support readiness without claiming production access.
+description: [omh] Hermes Production Audit workflow: evaluate release, deploy, security, observability, rollback, docs, and support readiness without claiming production access. Use when the user says: production-audit, production audit, production readiness, prod audit, prod readiness, ready for production, ready to ship, ship readiness.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, review]

--- a/skills/omh-prompt-import-readiness/SKILL.md
+++ b/skills/omh-prompt-import-readiness/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-prompt-import-readiness
-description: [omh] Hermes prompt import readiness workflow: decide whether external CLI-agent prompt files can be safely reviewed, normalized, and offered as Hermes slash-command candidates without mutating prompts or command registries.
+description: [omh] Hermes prompt import readiness workflow: decide whether external CLI-agent prompt files can be safely reviewed, normalized, and offered as Hermes slash-command candidates without mutating prompts or command registries. Use when the user says: prompt-import-readiness, prompt import readiness, slash prompt import, slash prompts import, slash command prompt import, prompt library import, prompt folder import, prompt directory import.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, prompt]

--- a/skills/omh-provider-profile-posture/SKILL.md
+++ b/skills/omh-provider-profile-posture/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-provider-profile-posture
-description: [omh] Prepare provider-profile metadata without reading secrets or calling providers.
+description: [omh] Prepare provider-profile metadata without reading secrets or calling providers. Use when the user says: provider-profile-posture, provider profile posture, provider profile readiness, secret presence confirmation, connector profile posture, 공급자 프로필 상태, 시크릿 존재 확인, 커넥터 준비 상태.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, operations]

--- a/skills/omh-reliability-review/SKILL.md
+++ b/skills/omh-reliability-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-reliability-review
-description: [omh] Hermes Reliability Review workflow: postmortems, SLOs, error budgets, incident follow-ups, and service reliability evidence.
+description: [omh] Hermes Reliability Review workflow: postmortems, SLOs, error budgets, incident follow-ups, and service reliability evidence. Use when the user says: reliability-review, reliability review, incident review, incident postmortem, postmortem, post-mortem, slo review, slo.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, reliability]

--- a/skills/omh-report-package/SKILL.md
+++ b/skills/omh-report-package/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-report-package
-description: [omh] Hermes Report Package workflow: weekly/monthly reports, executive briefs, PPT-ready outlines, and upload packages.
+description: [omh] Hermes Report Package workflow: weekly/monthly reports, executive briefs, PPT-ready outlines, and upload packages. Use when the user says: report-package, report package, weekly report, monthly report, executive report, exec brief, leadership deck, status package.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, reporting]

--- a/skills/omh-research-brief/SKILL.md
+++ b/skills/omh-research-brief/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-research-brief
-description: [omh] Hermes Research Brief workflow: source-backed business research without pretending evidence was fetched.
+description: [omh] Hermes Research Brief workflow: source-backed business research without pretending evidence was fetched. Use when the user says: research-brief, business-research, business research, research brief, source-backed business research, customer feedback trends, feedback trends, market evidence.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, research]

--- a/skills/omh-research-department/SKILL.md
+++ b/skills/omh-research-department/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-research-department
-description: [omh] Hermes Research Department workflow pack: prepare Scout, Analyst, and Briefer research operations with source inbox and briefing status boundaries.
+description: [omh] Hermes Research Department workflow pack: prepare Scout, Analyst, and Briefer research operations with source inbox and briefing status boundaries. Use when the user says: research-department, research department, research ops department, research operations department, scout analyst briefer, scout analyst brief, daily research department, competitor research department.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, research]

--- a/skills/omh-routing/references/catalog-index.md
+++ b/skills/omh-routing/references/catalog-index.md
@@ -6,95 +6,95 @@ Trigger phrases and the role registry live in `references/workflow-registry.md`;
 
 ## Skills
 
-- `accessibility-audit`: [omh] Hermes Accessibility Audit workflow: prepare WCAG, keyboard, focus, screen-reader, target-size, and reflow evidence gates for UI surfaces.
-- `achievements`: [omh] Hermes achievements observation workflow: summarize hermes-achievements badges, tiers, recent unlocks, and progress from local plugin artifacts.
-- `agent-board`: [omh] Hermes agent board workflow: coordinate multiple Hermes profiles or agents with task, handoff, heartbeat, blocker, and completion states.
-- `agent-debug`: [omh] Agent Debug workflow: capture a stuck, looping, drifting, or repeatedly failing agent run, diagnose the likely failure pattern, and prepare the smallest safe recovery action.
-- `agent-evaluation`: [omh] Hermes Agent Evaluation workflow: compare executor or agent choices on reproducible tasks using quality, cost, time, tool, and evidence metrics.
-- `agent-ops-review`: [omh] Hermes agent ops review workflow: help managers inspect AI-agent progress, blockers, quality gates, and throughput levers.
-- `ai-slop-cleaner`: [omh] Hermes AI slop cleaner workflow: delete AI-generated slop, dead code, and duplication while observable behavior stays identical.
-- `ask`: [omh] Hermes adaptation for consulting an external advisor when configured.
-- `automation-blueprint`: [omh] Hermes Scheduled Ops Blueprint workflow: design recurring Hermes operations with schedule, delivery, silence policy, context chain, and prepared-vs-observed status.
-- `autoresearch-goal`: [omh] Hermes adaptation for durable research-goal execution.
-- `best-practice-research`: [omh] Hermes adaptation for bounded official/upstream best-practice research.
-- `browser-operator`: [omh] Hermes browser operator workflow: scope URL opening, page interaction, login/form boundaries, observations, and destructive confirmation gates.
-- `build-failure-triage`: [omh] Hermes Build Failure Triage workflow: classify build, typecheck, lint, test, CI, and DCO failures into minimal safe fix handoffs.
-- `cancel`: [omh] Hermes adaptation for ending active workflow state cleanly.
-- `code-review`: [omh] Hermes Code Review workflow: bug-first review with evidence.
-- `codebase-onboarding`: [omh] Hermes Codebase Onboarding workflow: create a repo map, reading path, glossary, risk map, and first-task runway for unfamiliar codebases.
-- `codegraph-refresh`: [omh] Hermes Codegraph Refresh workflow: refresh local code intelligence, summarize repo structure, and prepare task-scoped codegraph handoff context without overclaiming execution.
-- `command-operator`: [omh] Hermes command operator workflow: scope terminal, shell, CLI, package-manager, and test commands with cwd, environment, safety, and result-evidence gates.
-- `connector-operator`: [omh] Hermes connector operator workflow: scope external app actions across email, Slack, Discord, Notion, Linear, Jira, CRM, and similar providers with auth, payload, confirmation, and result-evidence gates.
-- `content-operator`: [omh] Hermes content operator workflow: scope publish-ready writing, rewriting, summarization, translation, release-note, newsletter, customer-copy, social-copy, README-copy, and email-draft work with audience, tone, style, source, review, and hallucination gates.
-- `context-budget-review`: [omh] Hermes Context Budget Review workflow: plan compact context, token/cost budgets, summarization checkpoints, and overflow recovery before long agent work.
-- `cto-loop`: [omh] Hermes CTO Loop workflow: roadmap, PM, technical tradeoffs, risk, delivery, release, and follow-up operating cadence.
-- `data-analysis`: [omh] Hermes data analysis workflow: scope supplied data with provenance, causal-claim, and hallucination guards.
-- `decision-recall`: [omh] Recall scoped reviewed rejected decisions without elevating them to approved memory.
-- `deep-interview`: [omh] Hermes Deep Interview workflow: one-question-at-a-time clarification.
-- `deliverable-package`: [omh] Hermes deliverable package workflow: track PPT, PDF, XLSX, DOCX, HWP, Markdown, and attachments through prepared, generated, QA, approved, and attached states.
-- `deploy-and-monitor`: [omh] Hermes Deploy-and-Monitor workflow: release checklist, deploy decision, health signals, rollback gate, and post-deploy status.
-- `design-orchestration`: [omh] Hermes design orchestration workflow: prepare a bounded design direction, existing-lane composition, and executor-neutral handoff.
-- `design-quality-gate`: [omh] Hermes Design Quality Gate workflow: enforce superior content, design, layout, publishing, and visual QA gates.
-- `doctor`: [omh] Hermes adaptation for diagnosing oh-my-hermes installation health.
-- `executor-runtime-readiness`: [omh] Hermes executor runtime readiness workflow: compare Codex, Claude Code, Hermes coding, and oh-my runtimes by available tools, missing tools, and handoff mode.
-- `external-connector-readiness`: [omh] Hermes external connector readiness workflow: decide whether a candidate plugin, connector, API, data provider, or multimodal route is safe, affordable, fresh, and observable enough to adopt, route, or trial.
-- `failure-signal-audit`: [omh] Failure Signal Audit workflow: find swallowed errors, unsafe fallbacks, hidden UI/runtime failures, and missing propagation before they become false green status.
-- `feedback-triage`: [omh] Hermes Feedback Triage workflow: cluster customer signals and choose the next workflow.
-- `frontend`: [omh] Hermes frontend workflow: prepare design-system-driven web UI creation, redesign, polish, accessibility, performance, and visual QA handoffs.
-- `gateway-intent-card`: [omh] Hermes gateway intent workflow: normalize Discord, Slack, Telegram, and other gateway sessions into origin, thread, delivery, silent, attachment, and status-update policy.
-- `github-event-ops`: [omh] Hermes GitHub event operations workflow: route PR, issue, CI, and review webhook events into triage, review, or fix handoff cards.
-- `harness-session-inventory`: [omh] Hermes harness session inventory workflow: normalize Codex, Claude Code, Hermes, OpenCode, Cursor, MCP host, worktree, and wrapper session metadata into one drift-aware inventory.
-- `idea-to-deploy`: [omh] Hermes Idea-to-Deploy workflow: shape an app idea into decisions, delivery handoff, verification, release, and monitoring status.
-- `img-summary`: [omh] Hermes img-summary workflow: turn meetings, reports, PRs, issues, research, and releases into domain-aware image prompt cards.
-- `instinct-ledger`: [omh] Instinct Ledger workflow: turn repeated project or cross-project lessons into atomic, confidence-scored instinct candidates with scoped promotion and export boundaries.
-- `live-info-operator`: [omh] Hermes live information workflow: scope read-only weather, finance, sports, map, place, exchange-rate, and time-zone lookups with provider, freshness, units, source-quality, and result-evidence gates.
-- `loop`: [omh] Hermes Loop workflow: agentic interviewer -> planner -> researcher -> builder -> reviewer cycles until a real gate.
-- `materials-package`: [omh] Hermes Materials Package workflow: decks, PDFs, spreadsheets, documents, HWP, Markdown, and binary export handoffs.
-- `media-input-operator`: [omh] Hermes media input workflow: scope audio, video, YouTube, screenshot, receipt image, OCR, meeting recording, transcript, timestamp, and clip-summary requests with source, permission, extraction, transcription, and hallucination gates.
-- `meeting-brief`: [omh] Hermes Meeting Brief workflow: agenda, prompts, decisions, and record template.
-- `memory-new`: [omh] Hermes new-memory capture workflow: add reviewed project, product, or durable context candidates through capture, review, and approve actions.
-- `memory-sync`: [omh] Hermes existing-memory curation workflow: review stale, conflicting, duplicate, overgeneralized, or risky USER.md, MEMORY.md, and skill memories through approve/reject/update actions.
-- `meta-router`: [omh] Meta-routing guidance for a leading /omh command: reason over the imperative task, consult the live workflow catalog, and select or chain the right workflow(s).
-- `model-setup`: [omh] Hermes Model Setup workflow: diagnose role-slot model configuration, guide provider connection, and apply changes only after diff approval.
-- `morning-brief`: [omh] Hermes Morning Brief setup workflow: diagnose mail and calendar MCP connection, guide read/draft-only access, and apply changes only after diff approval.
-- `oh-my-hermes`: [omh] Router guidance for using oh-my-hermes workflow skills inside Hermes Agent.
-- `operating-rhythm`: [omh] Hermes Operating Rhythm workflow: meeting minutes, scrum/sprint records, retros, decisions, and follow-up history.
-- `ops-observability-card`: [omh] Hermes ops observability workflow: prepare an operations command-board for wrapper-safe token, cost, latency, run history, queue, failure-mode, external metric-provider, and service-quality evidence boundaries.
-- `ops-review`: [omh] Hermes Ops Review workflow: status, risks, blockers, priorities, and follow-ups.
-- `paper-learning`: [omh] Hermes Paper Learning workflow: explain a supplied paper or paper/PDF at a selected level while preserving full section coverage and source evidence boundaries.
-- `parallel-tools`: [omh] Hermes Parallel Tools workflow: check version currency and parallel-tool capability status, then apply an update only after diff approval.
-- `performance-goal`: [omh] Hermes adaptation for measurable performance-goal execution.
-- `physical-device-readiness`: [omh] Hermes readiness workflow for robots, 3D printers, IoT relays, sensors, and lab hardware before hardware trials.
-- `plan`: [omh] Hermes Plan workflow: structured planning before execution.
-- `production-audit`: [omh] Hermes Production Audit workflow: evaluate release, deploy, security, observability, rollback, docs, and support readiness without claiming production access.
-- `prompt-import-readiness`: [omh] Hermes prompt import readiness workflow: decide whether external CLI-agent prompt files can be safely reviewed, normalized, and offered as Hermes slash-command candidates without mutating prompts or command registries.
-- `provider-profile-posture`: [omh] Prepare provider-profile metadata without reading secrets or calling providers.
-- `ralph`: [omh] Hermes Ralph workflow: persistent execution with verification and review.
-- `ralplan`: [omh] Hermes Ralplan workflow: consensus planning with review gates.
-- `reliability-review`: [omh] Hermes Reliability Review workflow: postmortems, SLOs, error budgets, incident follow-ups, and service reliability evidence.
-- `report-package`: [omh] Hermes Report Package workflow: weekly/monthly reports, executive briefs, PPT-ready outlines, and upload packages.
-- `research-brief`: [omh] Hermes Research Brief workflow: source-backed business research without pretending evidence was fetched.
-- `research-department`: [omh] Hermes Research Department workflow pack: prepare Scout, Analyst, and Briefer research operations with source inbox and briefing status boundaries.
-- `rules-distill`: [omh] Hermes Rules Distill workflow: extract repeated principles from skills, prompts, traces, reviews, and failures into reviewed rule candidates without auto-mutating guidance.
-- `run-efficiency`: [omh] Report supplied local run efficiency while provider and host data stay unobserved.
-- `security-safety-review`: [omh] Hermes Security Safety Review workflow: review prompt, tool, secret, dependency, destructive-action, and explicit local plugin risks before agent or code execution.
-- `skill`: [omh] Hermes adaptation for managing local skills.
-- `skill-health`: [omh] Skill Health workflow: prepare a metadata-only OMH skill portfolio dashboard with stale surfaces, observed failure signals, pending amendments, and top actions.
-- `skill-scout`: [omh] Skill Scout workflow: prepare a metadata-only search-before-creation report for local, marketplace, GitHub, and web skill candidates with risk review and adoption options.
-- `source-finder`: [omh] Hermes Source Finder workflow: prepare typed source candidates and acquisition status before downstream work.
-- `strategy-brief`: [omh] Hermes Strategy Brief workflow: options, tradeoffs, recommendation, and decision notes.
-- `team`: [omh] Hermes Team workflow: coordinated parallel or sequential work lanes.
-- `toolbelt-readiness`: [omh] Hermes toolbelt readiness workflow: check which MCP servers, CLIs, APIs, credentials, and connectors a workflow needs before claiming it can run.
-- `ultragoal`: [omh] Hermes Ultragoal workflow: file-backed durable goal ledgers.
-- `ultraprocess`: [omh] Ultra Process - Research - Ralplan - Ultragoal - Code Review - Sync Circle: one PR-ready delivery cycle.
-- `ultraqa`: [omh] Hermes UltraQA workflow: adversarial QA and fix loops.
-- `ultrawork`: [omh] Hermes Ultrawork compatibility workflow: bounded parallel delivery guidance.
-- `verification-gate`: [omh] Hermes Verification Gate workflow: define and record build, lint, typecheck, test, security, docs, generated-output, and CI evidence before completion or merge.
-- `visual-qa`: [omh] Hermes visual-qa workflow: prepare observed-only rendered QA gates for web, frontend, image, document, and TUI surfaces.
-- `voice-operator`: [omh] Hermes voice operator workflow: turn short voice or mobile commands into clarify, plan, status, handoff, or confirmation actions.
-- `web-research`: [omh] Hermes Web Research workflow: source-backed current information gathering.
-- `websearch-setup`: [omh] Hermes Web Search Setup workflow: diagnose scraper and auxiliary extract-model configuration, guide account setup, and apply each change as its own diff approval.
-- `wiki`: [omh] Hermes adaptation for wiki construction blueprints and retained knowledge capture with destination-aware external knowledge connection guidance.
-- `workflow-learning`: [omh] Hermes workflow learning workflow: classify and review self-improvement store routes as an auxiliary review lane before durable writes, then record workflow attempts as metadata-only traces, evals, review queues, patch proposals, regression cases, audits, indexes, and exports.
-- `workspace-audit`: [omh] Hermes Workspace Audit workflow: map repository, skill, prompt, plugin, MCP, hook, config, and runtime surfaces before strengthening or operating OMH.
-- `workspace-file-operator`: [omh] Hermes workspace file operator workflow: scope local file/folder listing, search, organize, copy, move, rename, and delete tasks with path and destructive-action gates.
+- `omh-accessibility-audit`: [omh] Hermes Accessibility Audit workflow: prepare WCAG, keyboard, focus, screen-reader, target-size, and reflow evidence gates for UI surfaces.
+- `omh-achievements`: [omh] Hermes achievements observation workflow: summarize hermes-achievements badges, tiers, recent unlocks, and progress from local plugin artifacts.
+- `omh-agent-board`: [omh] Hermes agent board workflow: coordinate multiple Hermes profiles or agents with task, handoff, heartbeat, blocker, and completion states.
+- `omh-agent-debug`: [omh] Agent Debug workflow: capture a stuck, looping, drifting, or repeatedly failing agent run, diagnose the likely failure pattern, and prepare the smallest safe recovery action.
+- `omh-agent-evaluation`: [omh] Hermes Agent Evaluation workflow: compare executor or agent choices on reproducible tasks using quality, cost, time, tool, and evidence metrics.
+- `omh-agent-ops-review`: [omh] Hermes agent ops review workflow: help managers inspect AI-agent progress, blockers, quality gates, and throughput levers.
+- `omh-ai-slop-cleaner`: [omh] Hermes AI slop cleaner workflow: delete AI-generated slop, dead code, and duplication while observable behavior stays identical.
+- `omh-ask`: [omh] Hermes adaptation for consulting an external advisor when configured.
+- `omh-automation-blueprint`: [omh] Hermes Scheduled Ops Blueprint workflow: design recurring Hermes operations with schedule, delivery, silence policy, context chain, and prepared-vs-observed status.
+- `omh-autoresearch-goal`: [omh] Hermes adaptation for durable research-goal execution.
+- `omh-best-practice-research`: [omh] Hermes adaptation for bounded official/upstream best-practice research.
+- `omh-browser-operator`: [omh] Hermes browser operator workflow: scope URL opening, page interaction, login/form boundaries, observations, and destructive confirmation gates.
+- `omh-build-failure-triage`: [omh] Hermes Build Failure Triage workflow: classify build, typecheck, lint, test, CI, and DCO failures into minimal safe fix handoffs.
+- `omh-cancel`: [omh] Hermes adaptation for ending active workflow state cleanly.
+- `omh-code-review`: [omh] Hermes Code Review workflow: bug-first review with evidence.
+- `omh-codebase-onboarding`: [omh] Hermes Codebase Onboarding workflow: create a repo map, reading path, glossary, risk map, and first-task runway for unfamiliar codebases.
+- `omh-codegraph-refresh`: [omh] Hermes Codegraph Refresh workflow: refresh local code intelligence, summarize repo structure, and prepare task-scoped codegraph handoff context without overclaiming execution.
+- `omh-command-operator`: [omh] Hermes command operator workflow: scope terminal, shell, CLI, package-manager, and test commands with cwd, environment, safety, and result-evidence gates.
+- `omh-connector-operator`: [omh] Hermes connector operator workflow: scope external app actions across email, Slack, Discord, Notion, Linear, Jira, CRM, and similar providers with auth, payload, confirmation, and result-evidence gates.
+- `omh-content-operator`: [omh] Hermes content operator workflow: scope publish-ready writing, rewriting, summarization, translation, release-note, newsletter, customer-copy, social-copy, README-copy, and email-draft work with audience, tone, style, source, review, and hallucination gates.
+- `omh-context-budget-review`: [omh] Hermes Context Budget Review workflow: plan compact context, token/cost budgets, summarization checkpoints, and overflow recovery before long agent work.
+- `omh-cto-loop`: [omh] Hermes CTO Loop workflow: roadmap, PM, technical tradeoffs, risk, delivery, release, and follow-up operating cadence.
+- `omh-data-analysis`: [omh] Hermes data analysis workflow: scope supplied data with provenance, causal-claim, and hallucination guards.
+- `omh-decision-recall`: [omh] Recall scoped reviewed rejected decisions without elevating them to approved memory.
+- `ulw-interview`: [omh] Hermes Deep Interview workflow: one-question-at-a-time clarification.
+- `omh-deliverable-package`: [omh] Hermes deliverable package workflow: track PPT, PDF, XLSX, DOCX, HWP, Markdown, and attachments through prepared, generated, QA, approved, and attached states.
+- `omh-deploy-and-monitor`: [omh] Hermes Deploy-and-Monitor workflow: release checklist, deploy decision, health signals, rollback gate, and post-deploy status.
+- `omh-design-orchestration`: [omh] Hermes design orchestration workflow: prepare a bounded design direction, existing-lane composition, and executor-neutral handoff.
+- `omh-design-quality-gate`: [omh] Hermes Design Quality Gate workflow: enforce superior content, design, layout, publishing, and visual QA gates.
+- `omh-doctor`: [omh] Hermes adaptation for diagnosing oh-my-hermes installation health.
+- `omh-executor-runtime-readiness`: [omh] Hermes executor runtime readiness workflow: compare Codex, Claude Code, Hermes coding, and oh-my runtimes by available tools, missing tools, and handoff mode.
+- `omh-external-connector-readiness`: [omh] Hermes external connector readiness workflow: decide whether a candidate plugin, connector, API, data provider, or multimodal route is safe, affordable, fresh, and observable enough to adopt, route, or trial.
+- `omh-failure-signal-audit`: [omh] Failure Signal Audit workflow: find swallowed errors, unsafe fallbacks, hidden UI/runtime failures, and missing propagation before they become false green status.
+- `omh-feedback-triage`: [omh] Hermes Feedback Triage workflow: cluster customer signals and choose the next workflow.
+- `omh-frontend`: [omh] Hermes frontend workflow: prepare design-system-driven web UI creation, redesign, polish, accessibility, performance, and visual QA handoffs.
+- `omh-gateway-intent-card`: [omh] Hermes gateway intent workflow: normalize Discord, Slack, Telegram, and other gateway sessions into origin, thread, delivery, silent, attachment, and status-update policy.
+- `omh-github-event-ops`: [omh] Hermes GitHub event operations workflow: route PR, issue, CI, and review webhook events into triage, review, or fix handoff cards.
+- `omh-harness-session-inventory`: [omh] Hermes harness session inventory workflow: normalize Codex, Claude Code, Hermes, OpenCode, Cursor, MCP host, worktree, and wrapper session metadata into one drift-aware inventory.
+- `omh-idea-to-deploy`: [omh] Hermes Idea-to-Deploy workflow: shape an app idea into decisions, delivery handoff, verification, release, and monitoring status.
+- `omh-img-summary`: [omh] Hermes img-summary workflow: turn meetings, reports, PRs, issues, research, and releases into domain-aware image prompt cards.
+- `omh-instinct-ledger`: [omh] Instinct Ledger workflow: turn repeated project or cross-project lessons into atomic, confidence-scored instinct candidates with scoped promotion and export boundaries.
+- `omh-live-info-operator`: [omh] Hermes live information workflow: scope read-only weather, finance, sports, map, place, exchange-rate, and time-zone lookups with provider, freshness, units, source-quality, and result-evidence gates.
+- `ulw-loop`: [omh] Hermes Loop workflow: agentic interviewer -> planner -> researcher -> builder -> reviewer cycles until a real gate.
+- `omh-materials-package`: [omh] Hermes Materials Package workflow: decks, PDFs, spreadsheets, documents, HWP, Markdown, and binary export handoffs.
+- `omh-media-input-operator`: [omh] Hermes media input workflow: scope audio, video, YouTube, screenshot, receipt image, OCR, meeting recording, transcript, timestamp, and clip-summary requests with source, permission, extraction, transcription, and hallucination gates.
+- `omh-meeting-brief`: [omh] Hermes Meeting Brief workflow: agenda, prompts, decisions, and record template.
+- `omh-memory-new`: [omh] Hermes new-memory capture workflow: add reviewed project, product, or durable context candidates through capture, review, and approve actions.
+- `omh-memory-sync`: [omh] Hermes existing-memory curation workflow: review stale, conflicting, duplicate, overgeneralized, or risky USER.md, MEMORY.md, and skill memories through approve/reject/update actions.
+- `omh-meta-router`: [omh] Meta-routing guidance for a leading /omh command: reason over the imperative task, consult the live workflow catalog, and select or chain the right workflow(s).
+- `omh-model-setup`: [omh] Hermes Model Setup workflow: diagnose role-slot model configuration, guide provider connection, and apply changes only after diff approval.
+- `omh-morning-brief`: [omh] Hermes Morning Brief setup workflow: diagnose mail and calendar MCP connection, guide read/draft-only access, and apply changes only after diff approval.
+- `omh-routing`: [omh] Router guidance for using oh-my-hermes workflow skills inside Hermes Agent.
+- `omh-operating-rhythm`: [omh] Hermes Operating Rhythm workflow: meeting minutes, scrum/sprint records, retros, decisions, and follow-up history.
+- `omh-ops-observability-card`: [omh] Hermes ops observability workflow: prepare an operations command-board for wrapper-safe token, cost, latency, run history, queue, failure-mode, external metric-provider, and service-quality evidence boundaries.
+- `omh-ops-review`: [omh] Hermes Ops Review workflow: status, risks, blockers, priorities, and follow-ups.
+- `omh-paper-learning`: [omh] Hermes Paper Learning workflow: explain a supplied paper or paper/PDF at a selected level while preserving full section coverage and source evidence boundaries.
+- `omh-parallel-tools`: [omh] Hermes Parallel Tools workflow: check version currency and parallel-tool capability status, then apply an update only after diff approval.
+- `omh-performance-goal`: [omh] Hermes adaptation for measurable performance-goal execution.
+- `omh-physical-device-readiness`: [omh] Hermes readiness workflow for robots, 3D printers, IoT relays, sensors, and lab hardware before hardware trials.
+- `omh-plan`: [omh] Hermes Plan workflow: structured planning before execution.
+- `omh-production-audit`: [omh] Hermes Production Audit workflow: evaluate release, deploy, security, observability, rollback, docs, and support readiness without claiming production access.
+- `omh-prompt-import-readiness`: [omh] Hermes prompt import readiness workflow: decide whether external CLI-agent prompt files can be safely reviewed, normalized, and offered as Hermes slash-command candidates without mutating prompts or command registries.
+- `omh-provider-profile-posture`: [omh] Prepare provider-profile metadata without reading secrets or calling providers.
+- `ulw-ralph`: [omh] Hermes Ralph workflow: persistent execution with verification and review.
+- `ulw-plan`: [omh] Hermes Ralplan workflow: consensus planning with review gates.
+- `omh-reliability-review`: [omh] Hermes Reliability Review workflow: postmortems, SLOs, error budgets, incident follow-ups, and service reliability evidence.
+- `omh-report-package`: [omh] Hermes Report Package workflow: weekly/monthly reports, executive briefs, PPT-ready outlines, and upload packages.
+- `omh-research-brief`: [omh] Hermes Research Brief workflow: source-backed business research without pretending evidence was fetched.
+- `omh-research-department`: [omh] Hermes Research Department workflow pack: prepare Scout, Analyst, and Briefer research operations with source inbox and briefing status boundaries.
+- `omh-rules-distill`: [omh] Hermes Rules Distill workflow: extract repeated principles from skills, prompts, traces, reviews, and failures into reviewed rule candidates without auto-mutating guidance.
+- `omh-run-efficiency`: [omh] Report supplied local run efficiency while provider and host data stay unobserved.
+- `omh-security-safety-review`: [omh] Hermes Security Safety Review workflow: review prompt, tool, secret, dependency, destructive-action, and explicit local plugin risks before agent or code execution.
+- `omh-skill`: [omh] Hermes adaptation for managing local skills.
+- `omh-skill-health`: [omh] Skill Health workflow: prepare a metadata-only OMH skill portfolio dashboard with stale surfaces, observed failure signals, pending amendments, and top actions.
+- `omh-skill-scout`: [omh] Skill Scout workflow: prepare a metadata-only search-before-creation report for local, marketplace, GitHub, and web skill candidates with risk review and adoption options.
+- `omh-source-finder`: [omh] Hermes Source Finder workflow: prepare typed source candidates and acquisition status before downstream work.
+- `omh-decide`: [omh] Decide between options: tradeoffs, a recommendation, and a decision note you can act on.
+- `ulw-team`: [omh] Hermes Team workflow: coordinated parallel or sequential work lanes.
+- `omh-toolbelt-readiness`: [omh] Hermes toolbelt readiness workflow: check which MCP servers, CLIs, APIs, credentials, and connectors a workflow needs before claiming it can run.
+- `ulw-goal`: [omh] Hermes Ultragoal workflow: file-backed durable goal ledgers.
+- `ulw-process`: [omh] Ultra Process - Research - Ralplan - Ultragoal - Code Review - Sync Circle: one PR-ready delivery cycle.
+- `ulw-qa`: [omh] Hermes UltraQA workflow: adversarial QA and fix loops.
+- `ulw-work`: [omh] Hermes Ultrawork compatibility workflow: bounded parallel delivery guidance.
+- `omh-verification-gate`: [omh] Hermes Verification Gate workflow: define and record build, lint, typecheck, test, security, docs, generated-output, and CI evidence before completion or merge.
+- `omh-visual-qa`: [omh] Hermes visual-qa workflow: prepare observed-only rendered QA gates for web, frontend, image, document, and TUI surfaces.
+- `omh-voice-operator`: [omh] Hermes voice operator workflow: turn short voice or mobile commands into clarify, plan, status, handoff, or confirmation actions.
+- `ulw-research`: [omh] Hermes Web Research workflow: source-backed current information gathering.
+- `omh-websearch-setup`: [omh] Hermes Web Search Setup workflow: diagnose scraper and auxiliary extract-model configuration, guide account setup, and apply each change as its own diff approval.
+- `omh-wiki`: [omh] Hermes adaptation for wiki construction blueprints and retained knowledge capture with destination-aware external knowledge connection guidance.
+- `omh-workflow-learning`: [omh] Hermes workflow learning workflow: classify and review self-improvement store routes as an auxiliary review lane before durable writes, then record workflow attempts as metadata-only traces, evals, review queues, patch proposals, regression cases, audits, indexes, and exports.
+- `omh-workspace-audit`: [omh] Hermes Workspace Audit workflow: map repository, skill, prompt, plugin, MCP, hook, config, and runtime surfaces before strengthening or operating OMH.
+- `omh-workspace-file-operator`: [omh] Hermes workspace file operator workflow: scope local file/folder listing, search, organize, copy, move, rename, and delete tasks with path and destructive-action gates.

--- a/skills/omh-rules-distill/SKILL.md
+++ b/skills/omh-rules-distill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-rules-distill
-description: [omh] Hermes Rules Distill workflow: extract repeated principles from skills, prompts, traces, reviews, and failures into reviewed rule candidates without auto-mutating guidance.
+description: [omh] Hermes Rules Distill workflow: extract repeated principles from skills, prompts, traces, reviews, and failures into reviewed rule candidates without auto-mutating guidance. Use when the user says: rules-distill, rules distill, distill rules, rule distillation, principle distill, skill principles, extract agent rules, turn traces into rules.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, knowledge]

--- a/skills/omh-run-efficiency/SKILL.md
+++ b/skills/omh-run-efficiency/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-run-efficiency
-description: [omh] Report supplied local run efficiency while provider and host data stay unobserved.
+description: [omh] Report supplied local run efficiency while provider and host data stay unobserved. Use when the user says: run-efficiency, run efficiency report, local run efficiency, context utilization, tool duration report, 실행 효율 리포트, 컨텍스트 사용량, 도구 지연 시간.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, observability]

--- a/skills/omh-security-safety-review/SKILL.md
+++ b/skills/omh-security-safety-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-security-safety-review
-description: [omh] Hermes Security Safety Review workflow: review prompt, tool, secret, dependency, destructive-action, and explicit local plugin risks before agent or code execution.
+description: [omh] Hermes Security Safety Review workflow: review prompt, tool, secret, dependency, destructive-action, and explicit local plugin risks before agent or code execution. Use when the user says: security-safety-review, security safety review, ai coding safety, agent safety review, prompt injection review, tool permission review, secret exposure review, destructive action review.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, review]

--- a/skills/omh-skill-health/SKILL.md
+++ b/skills/omh-skill-health/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-skill-health
-description: [omh] Skill Health workflow: prepare a metadata-only OMH skill portfolio dashboard with stale surfaces, observed failure signals, pending amendments, and top actions.
+description: [omh] Skill Health workflow: prepare a metadata-only OMH skill portfolio dashboard with stale surfaces, observed failure signals, pending amendments, and top actions. Use when the user says: skill-health, skill health, skill portfolio health, skill dashboard, skill health dashboard, skill failure pattern dashboard, skill failure patterns, pending skill amendments.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, operations]

--- a/skills/omh-skill-scout/SKILL.md
+++ b/skills/omh-skill-scout/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-skill-scout
-description: [omh] Skill Scout workflow: prepare a metadata-only search-before-creation report for local, marketplace, GitHub, and web skill candidates with risk review and adoption options.
+description: [omh] Skill Scout workflow: prepare a metadata-only search-before-creation report for local, marketplace, GitHub, and web skill candidates with risk review and adoption options. Use when the user says: skill-scout, skill scout, skill candidate, skill candidate search, skill discovery, find a skill, find skills, top skills.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, operations]

--- a/skills/omh-skill/SKILL.md
+++ b/skills/omh-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-skill
-description: [omh] Hermes adaptation for managing local skills.
+description: [omh] Hermes adaptation for managing local skills. Use when the user says: skill, skills, manage skills.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, operator]

--- a/skills/omh-source-finder/SKILL.md
+++ b/skills/omh-source-finder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-source-finder
-description: [omh] Hermes Source Finder workflow: prepare typed source candidates and acquisition status before downstream work.
+description: [omh] Hermes Source Finder workflow: prepare typed source candidates and acquisition status before downstream work. Use when the user says: source-finder, source finder, source acquisition, source intake, find papers and datasets, find datasets and repos, find papers, find arxiv link.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, research]

--- a/skills/omh-toolbelt-readiness/SKILL.md
+++ b/skills/omh-toolbelt-readiness/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-toolbelt-readiness
-description: [omh] Hermes toolbelt readiness workflow: check which MCP servers, CLIs, APIs, credentials, and connectors a workflow needs before claiming it can run.
+description: [omh] Hermes toolbelt readiness workflow: check which MCP servers, CLIs, APIs, credentials, and connectors a workflow needs before claiming it can run. Use when the user says: toolbelt-readiness, mcp readiness, tool readiness, plugin readiness, connector readiness, needed mcp, api credential, missing cli.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, tools]

--- a/skills/omh-verification-gate/SKILL.md
+++ b/skills/omh-verification-gate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-verification-gate
-description: [omh] Hermes Verification Gate workflow: define and record build, lint, typecheck, test, security, docs, generated-output, and CI evidence before completion or merge.
+description: [omh] Hermes Verification Gate workflow: define and record build, lint, typecheck, test, security, docs, generated-output, and CI evidence before completion or merge. Use when the user says: verification-gate, verification gate, quality gate, release gate, test gate, build lint test, lint typecheck tests, verify before merge.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, verification]

--- a/skills/omh-visual-qa/SKILL.md
+++ b/skills/omh-visual-qa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-visual-qa
-description: [omh] Hermes visual-qa workflow: prepare observed-only rendered QA gates for web, frontend, image, document, and TUI surfaces.
+description: [omh] Hermes visual-qa workflow: prepare observed-only rendered QA gates for web, frontend, image, document, and TUI surfaces. Use when the user says: visual-qa, visual qa, visual QA, visual quality assurance, visual check, web qa, web visual qa, screenshot qa.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, materials]

--- a/skills/omh-voice-operator/SKILL.md
+++ b/skills/omh-voice-operator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-voice-operator
-description: [omh] Hermes voice operator workflow: turn short voice or mobile commands into clarify, plan, status, handoff, or confirmation actions.
+description: [omh] Hermes voice operator workflow: turn short voice or mobile commands into clarify, plan, status, handoff, or confirmation actions. Use when the user says: voice-operator, voice operator, voice-first, voice command, mobile command, short command, dictated command, dictated request.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, accessibility]

--- a/skills/omh-websearch-setup/SKILL.md
+++ b/skills/omh-websearch-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-websearch-setup
-description: [omh] Hermes Web Search Setup workflow: diagnose scraper and auxiliary extract-model configuration, guide account setup, and apply each change as its own diff approval.
+description: [omh] Hermes Web Search Setup workflow: diagnose scraper and auxiliary extract-model configuration, guide account setup, and apply each change as its own diff approval. Use when the user says: websearch-setup, web search setup, make web search cheaper, set up web search, configure web search, reduce web search cost, connect scraper api key, set up auxiliary web-extract model.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, hermes-setup]

--- a/skills/omh-wiki/SKILL.md
+++ b/skills/omh-wiki/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-wiki
-description: [omh] Hermes adaptation for wiki construction blueprints and retained knowledge capture with destination-aware external knowledge connection guidance.
+description: [omh] Hermes adaptation for wiki construction blueprints and retained knowledge capture with destination-aware external knowledge connection guidance. Use when the user says: wiki, project wiki, build a wiki, start a wiki, organize my notes, external knowledge store, knowledge base, Obsidian.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, knowledge]

--- a/skills/omh-workflow-learning/SKILL.md
+++ b/skills/omh-workflow-learning/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-workflow-learning
-description: [omh] Hermes workflow learning workflow: classify and review self-improvement store routes as an auxiliary review lane before durable writes, then record workflow attempts as metadata-only traces, evals, review queues, patch proposals, regression cases, audits, indexes, and exports.
+description: [omh] Hermes workflow learning workflow: classify and review self-improvement store routes as an auxiliary review lane before durable writes, then record workflow attempts as metadata-only traces, evals, review queues, patch proposals, regression cases, audits, indexes, and exports. Use when the user says: workflow-learning, workflow learning, route-signal, self-improvement store routing, store route review, memory skill wiki routing, learning trace, learning audit.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, optimization]

--- a/skills/omh-workspace-audit/SKILL.md
+++ b/skills/omh-workspace-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-workspace-audit
-description: [omh] Hermes Workspace Audit workflow: map repository, skill, prompt, plugin, MCP, hook, config, and runtime surfaces before strengthening or operating OMH.
+description: [omh] Hermes Workspace Audit workflow: map repository, skill, prompt, plugin, MCP, hook, config, and runtime surfaces before strengthening or operating OMH. Use when the user says: workspace-audit, workspace audit, repo surface audit, repository surface audit, workspace surface audit, repo inventory, surface inventory, skill inventory.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, operations]

--- a/skills/omh-workspace-file-operator/SKILL.md
+++ b/skills/omh-workspace-file-operator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-workspace-file-operator
-description: [omh] Hermes workspace file operator workflow: scope local file/folder listing, search, organize, copy, move, rename, and delete tasks with path and destructive-action gates.
+description: [omh] Hermes workspace file operator workflow: scope local file/folder listing, search, organize, copy, move, rename, and delete tasks with path and destructive-action gates. Use when the user says: workspace-file-operator, workspace file operator, file operator, file operation, file operations, filesystem task, filesystem operation, file system task.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, filesystem]

--- a/skills/ulw-goal/SKILL.md
+++ b/skills/ulw-goal/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ulw-goal
-description: [omh] Hermes Ultragoal workflow: file-backed durable goal ledgers.
+description: [omh] Hermes Ultragoal workflow: file-backed durable goal ledgers. Use when the user says: ultragoal, durable goal, multi-goal, goal ledger, long running goal, 완료조건까지 계속, keep working until acceptance criteria pass, 장기 목표.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, execution]

--- a/skills/ulw-interview/SKILL.md
+++ b/skills/ulw-interview/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ulw-interview
-description: [omh] Hermes Deep Interview workflow: one-question-at-a-time clarification.
+description: [omh] Hermes Deep Interview workflow: one-question-at-a-time clarification. Use when the user says: deep-interview, interview, clarify, feature shaping, ambiguous product request, one question, 온보딩, 부드럽게.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, clarification]

--- a/skills/ulw-loop/SKILL.md
+++ b/skills/ulw-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ulw-loop
-description: [omh] Hermes Loop workflow: agentic interviewer -> planner -> researcher -> builder -> reviewer cycles until a real gate.
+description: [omh] Hermes Loop workflow: agentic interviewer -> planner -> researcher -> builder -> reviewer cycles until a real gate. Use when the user says: loop, goal loop, long horizon goal, never stop, research plan ultragoal feedback, token exhaustion resume, permission profile, star 10k.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, goal-loop]

--- a/skills/ulw-plan/SKILL.md
+++ b/skills/ulw-plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ulw-plan
-description: [omh] Hermes Ralplan workflow: consensus planning with review gates.
+description: [omh] Hermes Ralplan workflow: consensus planning with review gates. Use when the user says: ralplan, consensus plan, reviewed plan, issue to PR, acceptance criteria, verification command, reviewable PR, risky planning.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, planning]

--- a/skills/ulw-process/SKILL.md
+++ b/skills/ulw-process/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ulw-process
-description: [omh] Ultra Process - Research - Ralplan - Ultragoal - Code Review - Sync Circle: one PR-ready delivery cycle.
+description: [omh] Ultra Process - Research - Ralplan - Ultragoal - Code Review - Sync Circle: one PR-ready delivery cycle. Use when the user says: ultraprocess, single-cycle delivery, one-cycle delivery, end-to-end process, delivery process, research plan implement review docs pr, plan implement review docs pr, ralplan ultragoal code-review.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, process]

--- a/skills/ulw-qa/SKILL.md
+++ b/skills/ulw-qa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ulw-qa
-description: [omh] Hermes UltraQA workflow: adversarial QA and fix loops.
+description: [omh] Hermes UltraQA workflow: adversarial QA and fix loops. Use when the user says: ultraqa, adversarial qa, hostile scenarios, e2e qa, real-world qa, qa scenario, release qa, 장애 상황.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, verification]

--- a/skills/ulw-ralph/SKILL.md
+++ b/skills/ulw-ralph/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ulw-ralph
-description: [omh] Hermes Ralph workflow: persistent execution with verification and review.
+description: [omh] Hermes Ralph workflow: persistent execution with verification and review. Use when the user says: ralph, finish until done, persistent execution, self-referential loop.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, execution]

--- a/skills/ulw-research/SKILL.md
+++ b/skills/ulw-research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ulw-research
-description: [omh] Hermes Web Research workflow: source-backed current information gathering.
+description: [omh] Hermes Web Research workflow: source-backed current information gathering. Use when the user says: web-research, web research, web search, search the web, internet search, fresh sources, current sources, current web evidence.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, research]

--- a/skills/ulw-team/SKILL.md
+++ b/skills/ulw-team/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ulw-team
-description: [omh] Hermes Team workflow: coordinated parallel or sequential work lanes.
+description: [omh] Hermes Team workflow: coordinated parallel or sequential work lanes. Use when the user says: team, swarm, parallel agents, coordinated workers.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, execution]

--- a/skills/ulw-work/SKILL.md
+++ b/skills/ulw-work/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ulw-work
-description: [omh] Hermes Ultrawork compatibility workflow: bounded parallel delivery guidance.
+description: [omh] Hermes Ultrawork compatibility workflow: bounded parallel delivery guidance. Use when the user says: ultrawork, ulw, parallel work, parallel implementation, high throughput.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, execution]

--- a/src/plugin_bundle/omh/awareness.py
+++ b/src/plugin_bundle/omh/awareness.py
@@ -5330,6 +5330,15 @@ def awareness_primer_context() -> str:
                 "briefings, coding handoffs, status -- and tracks prepared against observed."
             ),
             str(payload["first_turn_rule"]),
+            # Collision rule, previously reachable only inside the omh-routing
+            # skill body — a document the model must have already chosen to
+            # load before reading the rule that influences choosing. The
+            # always-on rail is the only surface that reliably arrives before
+            # selection, so the one-sentence version lives here.
+            (
+                "On a collision, prefer the OMH workflow when the result should persist or carry "
+                "evidence; natives win one-shot lookups."
+            ),
             "Use message-specific route hints when present; they should outrank this always-on rail.",
             "Boundary: " + str(payload["evidence_boundary"]),
             # `tool_hints` in the context brief is not this rail: `pre_llm_call`

--- a/src/skills/catalog_definitions.py
+++ b/src/skills/catalog_definitions.py
@@ -1049,7 +1049,9 @@ _DEFINITIONS = [
     ),
     SkillDefinition(
         "strategy-brief",
-        "Hermes Strategy Brief workflow: options, tradeoffs, recommendation, and decision notes.",
+        # Installed label is `omh-decide`; the description must lead with the
+        # word the label promises or the picker sees a self-contradiction.
+        "Decide between options: tradeoffs, a recommendation, and a decision note you can act on.",
         (
             "strategy-brief",
             "strategy brief",

--- a/src/skills/render.py
+++ b/src/skills/render.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from functools import lru_cache
+import re
 
 from .catalog import (
     DEEP_INTERVIEW_MAX_ROUNDS,
@@ -198,6 +199,34 @@ def _definitions_by_name() -> dict[str, SkillDefinition]:
     return {definition.name: definition for definition in builtin_definitions()}
 
 
+# A host's skill picker reads frontmatter `name` + `description` only — the
+# curated trigger phrases rendered into skill BODIES are invisible at
+# selection time (measured live: `ulw` routes because the token is in the
+# NAME; body-only triggers, Korean ones included, never influenced a pick).
+# The description therefore carries the top trigger phrases itself. Only
+# plain-scalar-safe phrases are surfaced so the unquoted YAML stays valid;
+# sigil/path aliases (`$ulw`, `./x`, `/x`) duplicate a bare form anyway.
+_FRONTMATTER_TRIGGER_LIMIT = 8
+_FRONTMATTER_SAFE_TRIGGER = re.compile(r"^[0-9A-Za-z가-힣][0-9A-Za-z가-힣 _.-]*$")
+
+
+def _frontmatter_trigger_tail(definition: SkillDefinition | None) -> str:
+    if definition is None:
+        return ""
+    # The router describes plumbing, not an intent; surfacing its `omh`
+    # tokens would also collide with the substring-trap detectors.
+    if definition.name == "oh-my-hermes":
+        return ""
+    safe = [
+        trigger
+        for trigger in definition.triggers
+        if _FRONTMATTER_SAFE_TRIGGER.fullmatch(trigger)
+    ]
+    if not safe:
+        return ""
+    return " Use when the user says: " + ", ".join(safe[:_FRONTMATTER_TRIGGER_LIMIT]) + "."
+
+
 def _frontmatter(name: str, description: str) -> str:
     # `name` is the CANONICAL catalog name and is used as the lookup key below.
     # The display prefix is applied after the lookup, never at the call sites:
@@ -206,7 +235,7 @@ def _frontmatter(name: str, description: str) -> str:
     definition = _definitions_by_name().get(name)
     category = definition.category if definition else "workflow"
     phase = definition.phase if definition else "general"
-    description = omh_description(description)
+    description = omh_description(description) + _frontmatter_trigger_tail(definition)
     display_name = omh_skill_display_name(name)
     return (
         f"---\nname: {display_name}\ndescription: {description}\nmetadata:\n"
@@ -491,8 +520,11 @@ preparation, not execution, review, CI, merge-readiness, or merge evidence.
 
 
 def _router_catalog_index_reference() -> str:
+    # The shortlist must name skills by the label a host can actually invoke
+    # (`ulw-work`, `omh-plan`), not the canonical catalog key — a shortlist
+    # entry the host cannot type is a dead recommendation.
     lines = "\n".join(
-        f"- `{definition.name}`: {definition.description}"
+        f"- `{omh_skill_display_name(definition.name)}`: {definition.description}"
         for definition in sorted(routable_definitions(), key=lambda definition: definition.name)
     )
     return f"""# OMH Skill Catalog Index

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -143,7 +143,14 @@ class RouterContentTests(unittest.TestCase):
 
         skill_lines = [line for line in rendered.splitlines() if line.startswith("- `")]
         names = [line.split("`")[1] for line in skill_lines]
-        expected = sorted(definition.name for definition in routable_definitions())
+        # The shortlist names skills by the label a host can actually invoke
+        # (the installed directory / slash-command name), never the internal
+        # canonical key — a shortlist entry the host cannot type is a dead
+        # recommendation.
+        expected = [
+            omh_skill_display_name(definition.name)
+            for definition in sorted(routable_definitions(), key=lambda definition: definition.name)
+        ]
         self.assertEqual(names, expected)
         self.assertEqual(len(names), len(set(names)))
 


### PR DESCRIPTION
## Capability

Makes omh skills actually competitive in a Hermes host's skill picker. Two parallel research lanes converged on one structural cause: **a host picks skills from frontmatter `name` + `description` only, and every curated trigger phrase (~1,900, Korean included) lived in skill BODIES — invisible at selection time.** `ulw` routes well precisely because its token is in the NAME; everything else competed on `[omh] Hermes <X> workflow:` boilerplate and lost to native skills.

What changes:

1. **Triggers reach the picker.** Every generated SKILL.md description now ends with `Use when the user says: <top trigger phrases>` — e.g. `ulw-work`: `... Use when the user says: ultrawork, ulw, parallel work, parallel implementation, high throughput.` Only plain-scalar-safe phrases surface (unquoted YAML stays valid); sigil/path aliases are dropped as duplicates; the router skill is excluded (its `omh` tokens are plumbing and collide with the substring-trap detectors). 91 files regenerated.
2. **The collision rule arrives BEFORE selection.** The "prefer OMH when..." guidance lived only inside the 12KB `omh-routing` body — a document the host must have already chosen to load before reading the rule about choosing (the in-code precedent notes a hint outside the injected rail reached the model zero times). The always-on primer now carries the one-line rule; primer stays within its 900-char efficiency contract at 897.
3. **The router's shortlist names invocable labels** (`ulw-work`, `omh-plan`) instead of internal canonical keys — a recommendation the host cannot type is dead. Test contract updated to pin the new rule.
4. **`omh-decide` contradiction fixed** — its description led with "Strategy Brief" after the label rename; the picker saw a label/description mismatch.

## Verification (observed)

- Full suite OK; docs workflows/roles/capability-families `--check`; `release skill-content-smoke` **Status: ok** (primer 897/900, router body back under the 12,000-byte budget, capability payload within caps); ruff; `git diff --check`.
- Routing-precision negative controls (56) and intervention cases (129) all green — description trigger tails add lexical score only where the trigger already matched.
- Honest limit: the live selection-rate change on a real Hermes host is unobservable from this repo.

## Follow-ups (issue to be filed)

The research audit also produced: a top-10 description rewrite table (kill the `Hermes <X> workflow:` stems, lead with the user's words + Korean phrases), an `aliases` field to replicate the ulw name-token win (`ulp`/`ulg`/`ulr`), dedup of the 4-way research / 3-way memory / 8-way operator description clusters, reframing ~8 native-unwinnable operator skills as policy overlays, a native-competition routing gate, and reclaiming ~200KB of duplicated always-loaded rail text to widen the 9-skill default profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)