### PR TITLE
feat: research depth dial - standard default, declared shallow/deep chains

### DIFF
--- a/docs/FANOUT.md
+++ b/docs/FANOUT.md
@@ -90,10 +90,14 @@ goal to Hermes in chat; these commands are the backend surface.
   `DISPATCH_COMMAND_TEMPLATES`.
 - **Model routing.** A unit may declare `model`, `reasoning_effort`, and/or
   `role` (brain, implementation, design_visual, review, docs, research —
-  research is the read-only investigation lane: its chain default is the
-  fast-tier cheap sweep, and a deep multi-system investigation escalates
-  model tier or effort explicitly on the unit, since requested values
-  always win). Prepare embeds
+  research is the read-only investigation lane). Research units may also
+  declare `depth` (shallow | standard | deep) — an explicit dial, never
+  inferred from text, matching the surveyed autorouting consensus:
+  standard is the default chain, shallow swaps in the declared fast-tier
+  sweep, deep swaps in the declared frontier-tier chain (locally-derived
+  catalogs source these from the user's own quick and deep/ultrabrain
+  categories), and the swap (or the reason none happened) is recorded in
+  `attempted[]`. Requested model/effort still always win. Prepare embeds
   the resolved `coding_model_route/v2` in the unit handoff, and dispatch
   turns it into argv fragments (`codex --model … --config
   model_reasoning_effort=…`; `claude --model … --effort …`). Resolution is a

--- a/src/coding/fanout.py
+++ b/src/coding/fanout.py
@@ -183,6 +183,7 @@ def _normalized_unit(unit: Mapping[str, object], index: int) -> dict[str, object
         "reasoning_effort": str(unit.get("reasoning_effort", "") or "").strip(),
         "role": str(unit.get("role", "") or "").strip(),
         "domain": str(unit.get("domain", "") or "").strip(),
+        "depth": str(unit.get("depth", "") or "").strip(),
     }
 
 

--- a/src/coding/model_inventory.py
+++ b/src/coding/model_inventory.py
@@ -97,9 +97,12 @@ OMO_CATEGORY_ROLE_SOURCES: Final[dict[str, tuple[str, ...]]] = {
     "design_visual": ("visual-engineering", "artistry"),
     "review": ("unspecified-high", "deep"),
     "docs": ("writing", "quick"),
-    # Read-only investigation lanes default to the cheap sweep; deep
-    # investigations escalate explicitly on the unit.
-    "research": ("quick", "unspecified-low"),
+    # Read-only investigation lanes: standard depth is the default; the
+    # shallow/deep entries resolve only when the unit DECLARES that depth
+    # (autorouting survey consensus: depth is a dial, never inferred).
+    "research": ("unspecified-low", "quick"),
+    "research:shallow": ("quick",),
+    "research:deep": ("deep", "ultrabrain"),
 }
 
 _OMO_AGENT_CONFIG_RELATIVE: Final[str] = ".config/opencode/oh-my-openagent.json"

--- a/src/coding/model_routing.py
+++ b/src/coding/model_routing.py
@@ -171,7 +171,7 @@ ROLE_MODEL_CHAINS: Final[dict[str, dict[str, tuple[dict[str, str], ...]]]] = {
             {"model_id": "gpt-5", "reasoning_effort": ""},
         ),
         "research": (
-            {"model_id": "gpt-5", "reasoning_effort": "low"},
+            {"model_id": "gpt-5", "reasoning_effort": "medium"},
             {"model_id": "gpt-5-codex", "reasoning_effort": ""},
         ),
     },
@@ -197,8 +197,35 @@ ROLE_MODEL_CHAINS: Final[dict[str, dict[str, tuple[dict[str, str], ...]]]] = {
             {"model_id": "sonnet", "reasoning_effort": ""},
         ),
         "research": (
-            {"model_id": "haiku", "reasoning_effort": ""},
             {"model_id": "sonnet", "reasoning_effort": ""},
+            {"model_id": "haiku", "reasoning_effort": ""},
+        ),
+    },
+}
+
+# Explicit research-depth dial (surveyed autorouting consensus: depth is a
+# DECLARED dial, never inferred from text; standard is the default, shallow
+# is the declared saving, deep is the declared escalation). `standard` has
+# no entry here on purpose: it IS the role chain above.
+RESEARCH_DEPTHS: Final[tuple[str, ...]] = ("shallow", "standard", "deep")
+
+RESEARCH_DEPTH_CHAINS: Final[dict[str, dict[str, tuple[dict[str, str], ...]]]] = {
+    "codex": {
+        "shallow": (
+            {"model_id": "gpt-5", "reasoning_effort": "low"},
+        ),
+        "deep": (
+            {"model_id": "gpt-5-codex", "reasoning_effort": "xhigh"},
+            {"model_id": "gpt-5", "reasoning_effort": "high"},
+        ),
+    },
+    "claude-code": {
+        "shallow": (
+            {"model_id": "haiku", "reasoning_effort": ""},
+        ),
+        "deep": (
+            {"model_id": "opus", "reasoning_effort": "high"},
+            {"model_id": "sonnet", "reasoning_effort": "high"},
         ),
     },
 }
@@ -248,6 +275,7 @@ def resolve_model_route(
     requested_effort: str = "",
     role: str = "",
     requested_domain: str = "",
+    requested_depth: str = "",
     chains: Mapping[str, Mapping[str, tuple[Mapping[str, str], ...]]] | None = None,
     local_catalog: Mapping[str, object] | None = None,
 ) -> dict[str, object]:
@@ -278,6 +306,12 @@ def resolve_model_route(
     to the front — an advisory reorder recorded in `attempted[]`, never a
     veto: every entry stays in the chain and a requested model still wins.
     Outside a local catalog the domain is recorded and explicitly skipped.
+
+    `requested_depth` is the research-lane dial (shallow|standard|deep) —
+    explicit unit data, never inferred. It applies only to `role="research"`:
+    shallow/deep swap in their declared depth chain, standard (or no depth)
+    keeps the role chain. On other roles or unknown vocabulary the depth is
+    recorded and explicitly skipped.
     """
     profile = str(executor_profile or "").strip().casefold()
     raw_role = str(role or "").strip()
@@ -323,6 +357,11 @@ def resolve_model_route(
         chain_table = ROLE_MODEL_CHAINS if chains is None else chains
         role_chain = tuple(chain_table.get(profile, {}).get(normalized_role, ())) if normalized_role else ()
     attempted: list[dict[str, str]] = []
+    depth = str(requested_depth or "").strip().casefold()
+    if depth:
+        role_chain = _depth_selected_chain(
+            depth, normalized_role, profile, role_chain, local_chains if catalog_kind == "local_inventory" else None, attempted
+        )
     domain = str(requested_domain or "").strip().casefold().replace("-", "_")
     if domain:
         role_chain = _domain_ordered_chain(
@@ -350,6 +389,7 @@ def resolve_model_route(
             catalog_kind=catalog_kind,
             catalog_fingerprint=catalog_fingerprint,
             domain=domain,
+            depth=depth,
             chain=_chain_payload(options, role_chain, selected_model=""),
             attempted=attempted,
             candidates=candidates,
@@ -377,6 +417,7 @@ def resolve_model_route(
             catalog_kind=catalog_kind,
             catalog_fingerprint=catalog_fingerprint,
             domain=domain,
+            depth=depth,
             chain=[],
             attempted=attempted,
             candidates=[],
@@ -408,6 +449,7 @@ def resolve_model_route(
                 catalog_kind=catalog_kind,
                 catalog_fingerprint=catalog_fingerprint,
                 domain=domain,
+                depth=depth,
                 chain=_chain_payload(options, role_chain, selected_model=selected),
                 attempted=attempted,
                 candidates=candidates,
@@ -436,6 +478,7 @@ def resolve_model_route(
             catalog_kind=catalog_kind,
             catalog_fingerprint=catalog_fingerprint,
             domain=domain,
+            depth=depth,
             chain=[],
             attempted=attempted,
             candidates=candidates,
@@ -468,6 +511,7 @@ def resolve_model_route(
         catalog_kind=catalog_kind,
         catalog_fingerprint=catalog_fingerprint,
         domain=domain,
+        depth=depth,
         chain=[],
         attempted=attempted,
         candidates=candidates,
@@ -498,6 +542,7 @@ def model_route_for_unit(
         requested_effort=effort,
         role=role,
         requested_domain=str(unit.get("domain", "") or "").strip(),
+        requested_depth=str(unit.get("depth", "") or "").strip(),
         local_catalog=local_catalog,
     )
 
@@ -530,6 +575,82 @@ def route_provenance(route: Mapping[str, object] | object) -> tuple[str, str]:
 def _normalized_role(role: str) -> str:
     normalized = str(role or "").strip().casefold().replace("-", "_")
     return normalized if normalized in MODEL_ROLES else ""
+
+
+def _depth_selected_chain(
+    depth: str,
+    normalized_role: str,
+    profile: str,
+    role_chain: tuple[Mapping[str, str], ...],
+    local_chains: Mapping[str, object] | None,
+    attempted: list[dict[str, str]],
+) -> tuple[Mapping[str, str], ...]:
+    """Swap in the declared research-depth chain, recording the outcome.
+
+    Depth never infers: unknown vocabulary and non-research roles keep the
+    chain untouched with a named skip, and `standard` is the role chain by
+    definition.
+    """
+    if normalized_role != "research":
+        attempted.append(
+            {
+                "stage": "research_depth",
+                "outcome": "skipped",
+                "reason": f"depth `{depth}` recorded; the depth dial applies to the research role only",
+            }
+        )
+        return role_chain
+    if depth not in RESEARCH_DEPTHS:
+        attempted.append(
+            {
+                "stage": "research_depth",
+                "outcome": "unknown_depth",
+                "reason": f"depth `{depth}` is not in ({', '.join(RESEARCH_DEPTHS)}); standard chain kept",
+            }
+        )
+        return role_chain
+    if depth == "standard":
+        attempted.append(
+            {"stage": "research_depth", "outcome": "standard", "reason": "standard is the role chain"}
+        )
+        return role_chain
+    if local_chains is not None:
+        depth_chain = local_chains.get(f"research:{depth}")
+        if isinstance(depth_chain, (list, tuple)) and depth_chain:
+            attempted.append(
+                {
+                    "stage": "research_depth",
+                    "outcome": "applied",
+                    "reason": f"declared `{depth}` research depth uses its locally-derived chain",
+                }
+            )
+            return tuple(entry for entry in depth_chain if isinstance(entry, Mapping))
+        attempted.append(
+            {
+                "stage": "research_depth",
+                "outcome": "no_depth_chain",
+                "reason": f"the local catalog derives no `{depth}` research chain; standard chain kept",
+            }
+        )
+        return role_chain
+    depth_chain = RESEARCH_DEPTH_CHAINS.get(profile, {}).get(depth, ())
+    if depth_chain:
+        attempted.append(
+            {
+                "stage": "research_depth",
+                "outcome": "applied",
+                "reason": f"declared `{depth}` research depth uses its declared chain",
+            }
+        )
+        return tuple(depth_chain)
+    attempted.append(
+        {
+            "stage": "research_depth",
+            "outcome": "no_depth_chain",
+            "reason": f"no `{depth}` research chain is declared for `{profile}`; standard chain kept",
+        }
+    )
+    return role_chain
 
 
 def _domain_ordered_chain(
@@ -748,6 +869,7 @@ def _route_payload(
     catalog_kind: str = MODEL_CATALOG_KIND,
     catalog_fingerprint: dict[str, object] | None = None,
     domain: str = "",
+    depth: str = "",
 ) -> dict[str, object]:
     payload: dict[str, object] = {
         "schema_version": CODING_MODEL_ROUTE_SCHEMA_VERSION,
@@ -778,6 +900,8 @@ def _route_payload(
         # Present only when the unit declared a domain: existing payloads
         # stay byte-identical.
         payload["domain"] = domain
+    if depth:
+        payload["depth"] = depth
     if catalog_fingerprint is not None:
         payload["catalog_fingerprint"] = catalog_fingerprint
     if effort_change is not None:

--- a/src/commands/coding.py
+++ b/src/commands/coding.py
@@ -666,6 +666,7 @@ def cmd_coding_model_route(args: argparse.Namespace) -> int:
         requested_effort=args.effort or "",
         role=args.role or "",
         requested_domain=getattr(args, "domain", None) or "",
+        requested_depth=getattr(args, "depth", None) or "",
         local_catalog=local_catalog,
     )
     if _wants_json(args):
@@ -1337,6 +1338,11 @@ def _add_coding_commands(sub) -> None:
             "Declared work domain (for example x_platform_data); advisorily reorders a "
             "locally-derived chain toward affine families, recorded in the route, never a veto."
         ),
+    )
+    model_route.add_argument(
+        "--depth",
+        default=None,
+        help="Research-lane depth dial: shallow, standard, or deep (explicit, never inferred).",
     )
     model_route.add_argument(
         "--from-inventory",

--- a/tests/test_model_routing.py
+++ b/tests/test_model_routing.py
@@ -29,16 +29,59 @@ from omh.coding.model_routing import (  # noqa: E402
 
 
 class ResearchRoleTests(unittest.TestCase):
-    def test_research_defaults_to_the_cheap_sweep(self) -> None:
-        """Read-only investigation lanes route to the fast tier by default;
-        depth is the caller's explicit dial, never an inferred one."""
+    def test_research_defaults_to_standard_depth(self) -> None:
+        """Autorouting survey consensus: standard is the default; shallow is
+        the declared saving, deep the declared escalation — never inferred."""
         codex = resolve_model_route("codex", role="research")
         self.assertEqual(codex["selected_model"], "gpt-5")
-        self.assertEqual(codex["selected_reasoning_effort"], "low")
+        self.assertEqual(codex["selected_reasoning_effort"], "medium")
         self.assertEqual(codex["provenance"], "role_chain_head")
+        self.assertNotIn("depth", codex)
         claude = resolve_model_route("claude-code", role="research")
-        self.assertEqual(claude["selected_model"], "haiku")
+        self.assertEqual(claude["selected_model"], "sonnet")
         self.assertEqual(claude["selected_reasoning_effort"], "")
+
+    def test_declared_depth_swaps_the_chain(self) -> None:
+        shallow = resolve_model_route("claude-code", role="research", requested_depth="shallow")
+        self.assertEqual(shallow["selected_model"], "haiku")
+        self.assertEqual(shallow["depth"], "shallow")
+        deep = resolve_model_route("claude-code", role="research", requested_depth="deep")
+        self.assertEqual(deep["selected_model"], "opus")
+        self.assertEqual(deep["selected_reasoning_effort"], "high")
+        deep_codex = resolve_model_route("codex", role="research", requested_depth="deep")
+        self.assertEqual(deep_codex["selected_model"], "gpt-5-codex")
+        self.assertEqual(deep_codex["selected_reasoning_effort"], "xhigh")
+        outcomes = {entry["stage"]: entry["outcome"] for entry in deep["attempted"]}
+        self.assertEqual(outcomes["research_depth"], "applied")
+
+    def test_standard_and_unknown_depths_keep_the_role_chain(self) -> None:
+        standard = resolve_model_route("codex", role="research", requested_depth="standard")
+        self.assertEqual(standard["selected_model"], "gpt-5")
+        self.assertEqual(standard["depth"], "standard")
+        unknown = resolve_model_route("codex", role="research", requested_depth="bottomless")
+        self.assertEqual(unknown["selected_model"], "gpt-5")
+        outcomes = {entry["stage"]: entry["outcome"] for entry in unknown["attempted"]}
+        self.assertEqual(outcomes["research_depth"], "unknown_depth")
+
+    def test_depth_on_non_research_role_is_recorded_and_skipped(self) -> None:
+        baseline = resolve_model_route("codex", role="brain")
+        route = resolve_model_route("codex", role="brain", requested_depth="deep")
+        self.assertEqual(route["selected_model"], baseline["selected_model"])
+        self.assertEqual(route["chain"], baseline["chain"])
+        self.assertEqual(route["depth"], "deep")
+        outcomes = {entry["stage"]: entry["outcome"] for entry in route["attempted"]}
+        self.assertEqual(outcomes["research_depth"], "skipped")
+
+    def test_depth_chain_models_stay_inside_the_catalog(self) -> None:
+        from omh.coding.model_routing import RESEARCH_DEPTH_CHAINS, RESEARCH_DEPTHS
+
+        self.assertEqual(RESEARCH_DEPTHS, ("shallow", "standard", "deep"))
+        for profile, depths in RESEARCH_DEPTH_CHAINS.items():
+            catalog_ids = {str(o["model_id"]) for o in EXECUTOR_MODEL_OPTIONS[profile]}
+            self.assertEqual(set(depths), {"shallow", "deep"}, profile)
+            for depth, chain in depths.items():
+                for entry in chain:
+                    self.assertIn(entry["model_id"], catalog_ids, f"{profile}:{depth}")
 
     def test_deep_research_escalates_only_explicitly(self) -> None:
         route = resolve_model_route(


### PR DESCRIPTION
## Capability

Follow-through on the user's reconsideration: research lanes sometimes need HIGH-cost models, not just the cheap sweep. A web survey of open autorouting designs (RouteLLM, LiteLLM Router, Aider's main/weak/editor split, Not Diamond/OpenRouter auto, Claude Code's subagent thoroughness, oh-my-openagent's category system) found every no-classifier system converges on one shape: **depth is a declared dial resolved by deterministic config, defaulting to standard — and nobody infers research depth from text** (systems that do use trained classifiers, unavailable to a no-LLM layer).

So the research role gains an explicit `depth` dial:

| depth | codex | claude-code | omo-derived (from the user's own categories) |
|---|---|---|---|
| `shallow` (declared saving) | gpt-5 **low** | **haiku** | `quick` |
| `standard` (**default**) | gpt-5 **medium** | **sonnet** | `unspecified-low` → `quick` |
| `deep` (declared escalation) | **gpt-5-codex xhigh** | **opus high** | `deep` → `ultrabrain` |

- Declared on the unit (`"depth": "deep"`) or `omh coding model-route --role research --depth deep`. Never inferred.
- The swap — or the exact reason none happened (`standard`, `unknown_depth`, non-research role, no depth chain) — is recorded in `attempted[]`; `depth` rides the frozen payload only when declared.
- Requested model/effort still always win; the domain-affinity reorder acts on whatever chain depth selected; depth-chain models are test-gated inside the profile catalog.
- This also corrects #732's default: the previous cheap-first head made economy the silent default — the survey (Aider, oMo) says cheap must be the *declared* choice.

## Alternatives rejected (from the survey)

- Separate `deep-research` role — duplicates the role surface; one role × three depths is orthogonal.
- Escalate-only-from-cheap — wastes a full cheap pass on tasks the caller already knows are deep; the chain's next-candidates already carry escalation advice for free.
- Budget caps — govern spend, not capability need; unobservable at resolve time in a no-network layer.

## Verification (observed)

Full suite OK; docs workflows/roles/capability-families `--check`; ruff; `git diff --check`. Depth tests: default-standard, declared shallow/deep swaps on both profiles, standard/unknown-depth keep the role chain with named outcomes, non-research depth recorded+skipped, catalog containment gate.

Survey sources are linked in the research report recorded with this change (RouteLLM blog/repo, LiteLLM routing + tag docs, Aider options, OpenRouter auto-router notes, oMo agent-model-matching).

🤖 Generated with [Claude Code](https://claude.com/claude-code)