### PR TITLE
fix: detect the omo runtime host CLI instead of hardcoding senpi

### DIFF
--- a/docs/FANOUT.md
+++ b/docs/FANOUT.md
@@ -43,8 +43,13 @@ goal to Hermes in chat; these commands are the backend surface.
 - **Spawnability is data.** `DISPATCH_COMMAND_TEMPLATES` in
   `src/coding/fanout_dispatch.py` maps profiles with a local headless CLI to
   fixed argv templates — currently codex (`codex exec`), claude-code
-  (`claude -p`), and omo-runtime (`senpi --print`, since omo ships as an
-  extension of the senpi host CLI; readiness probes `senpi` accordingly).
+  (`claude -p`), and omo-runtime. The omo runtime's host CLI is DETECTED at
+  dispatch/readiness time in a fixed order (`pi`, then its `senpi`
+  distribution, then `opencode`) — first on PATH wins, no personal stack is
+  hardcoded, and the selected host is visible in the planned argv and the
+  probed command. The pi-family surface was validated in a live bridge
+  dispatch; the opencode template is prepared from its verified flags and
+  validates on first live dispatch (claude-template precedent).
   Profiles without a template (hermes, omx/omc runtimes, generic,
   unassigned) are reported `unsupported_for_local_dispatch` with the unit
   handoff as a prepared-prompt fallback — no profile is privileged.
@@ -77,8 +82,8 @@ goal to Hermes in chat; these commands are the backend surface.
   alone let the agent create files but blocked the requested `git commit`,
   so the template additionally grants `--allowedTools
   "Bash(git add:*),Bash(git commit:*)"` — exactly those two git verbs,
-  nothing broader. The senpi template was validated in a live bridge
-  dispatch (2026-07): a routed unit spawned non-interactively via
+  nothing broader. The pi-family template was validated in a live bridge
+  dispatch (2026-07, senpi distribution): a routed unit spawned non-interactively via
   `--print --no-session`, the `workspace` permission preset allowed file
   creation plus the exact `git add`/`git commit` the unit prompt asks for
   (the unit completed with a real commit inside its isolated worktree, no

--- a/src/coding/executor_auth_signals.py
+++ b/src/coding/executor_auth_signals.py
@@ -25,10 +25,15 @@ AUTH_MARKER_STATES: Final[tuple[str, ...]] = ("present", "absent", "unknown")
 _CLAUDE_CONFIG_RELATIVE: Final[str] = ".claude.json"
 _CLAUDE_LOGIN_KEY: Final[str] = "oauthAccount"
 _CODEX_AUTH_RELATIVE: Final[str] = ".codex/auth.json"
-# senpi hosts the omo runtime locally; its credential store is a JSON object
-# keyed by provider name. Presence of at least one key is the marker — key
-# names and values are never read into state.
-_SENPI_AUTH_RELATIVE: Final[str] = ".senpi/agent/auth.json"
+# A pi-family host CLI carries the omo runtime locally; its credential
+# store is a JSON object keyed by provider name. Presence of at least one
+# key in the first store found (fixed order: pi, then its senpi
+# distribution) is the marker — key names and values are never read into
+# state, and an absent marker never vetoes.
+_PI_FAMILY_AUTH_RELATIVES: Final[tuple[str, ...]] = (
+    ".pi/agent/auth.json",
+    ".senpi/agent/auth.json",
+)
 
 AUTH_SIGNAL_PROFILES: Final[tuple[str, ...]] = ("codex", "claude-code", "omo-runtime")
 
@@ -126,16 +131,18 @@ def _claude_marker(home: Path) -> str:
 
 
 def _senpi_marker(home: Path) -> str:
-    auth_path = home / _SENPI_AUTH_RELATIVE
-    try:
+    for relative in _PI_FAMILY_AUTH_RELATIVES:
+        auth_path = home / relative
         if not auth_path.is_file():
-            return "absent"
-        parsed = json.loads(auth_path.read_text(encoding="utf-8"))
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
-        return "unknown"
-    if not isinstance(parsed, dict):
-        return "unknown"
-    return "present" if parsed else "absent"
+            continue
+        try:
+            parsed = json.loads(auth_path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+            return "unknown"
+        if not isinstance(parsed, dict):
+            return "unknown"
+        return "present" if parsed else "absent"
+    return "absent"
 
 
 def _codex_marker(home: Path) -> str:

--- a/src/coding/executor_readiness.py
+++ b/src/coding/executor_readiness.py
@@ -39,13 +39,12 @@ _COMMANDS: dict[str, tuple[str, tuple[str, ...]]] = {
     "codex": ("codex", ("--version",)),
     "claude-code": ("claude", ("--version",)),
     "omx-runtime": ("omx", ("--version",)),
-    # omo ships as an extension of a host agent CLI, not as its own binary;
-    # the locally-dispatchable host surface is the senpi CLI (observed
-    # 2026-07: non-interactive --print completes, workspace permission
-    # preset allows file edits plus git add/commit). An opencode-hosted omo
-    # install without senpi reads `missing` here — that is a truthful
-    # bridge-readiness answer, and the runtime prompt-handoff path never
-    # needed a local CLI.
+    # omo ships as an extension of a host agent CLI, not as its own binary.
+    # The probed command is the DETECTED host (usually `pi`; `senpi` is a pi
+    # distribution; opencode hosts omo as a plugin) — see
+    # `omo_runtime_host` in fanout_dispatch. No host on PATH probes the
+    # first candidate and truthfully reads `missing`; the runtime
+    # prompt-handoff path never needed a local CLI.
     "omo-runtime": ("senpi", ("--version",)),
     "omc-runtime": ("omc", ("--version",)),
 }
@@ -73,7 +72,7 @@ def _executor_readiness_contract_cached(normalized: str) -> dict[str, object]:
             },
             "claim_boundary": "Executor readiness is not dispatch, execution, verification, review, CI, or merge evidence.",
         }
-    command, args = _COMMANDS.get(normalized, ("", ()))
+    command, args = _resolved_command(normalized) or ("", ())
     probe_kind = "local_command" if command else "wrapper_observed_profile"
     return {
         "schema_version": EXECUTOR_READINESS_SCHEMA_VERSION,
@@ -260,6 +259,16 @@ def _resolution_report(command: str, args: list[str]) -> list[dict[str, str]]:
         {"path": path, "observed_version": _observed_version(path, args)}
         for path in _path_resolutions(command)[:_MAX_OBSERVED_RESOLUTIONS]
     ]
+
+
+def _resolved_command(profile: str) -> tuple[str, tuple[str, ...]] | None:
+    entry = _COMMANDS.get(profile)
+    if profile == "omo-runtime":
+        from .fanout_dispatch import OMO_RUNTIME_HOST_CANDIDATES, omo_runtime_host
+
+        host = omo_runtime_host()
+        return ((host, ("--version",)) if host else (OMO_RUNTIME_HOST_CANDIDATES[0], ("--version",)))
+    return entry
 
 
 def _run_probe(contract: dict[str, object]) -> dict[str, object]:

--- a/src/coding/fanout_dispatch.py
+++ b/src/coding/fanout_dispatch.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+import shutil
 import subprocess
 import time
 from typing import Any, Callable, Iterable, Mapping, Sequence
@@ -64,13 +65,19 @@ DISPATCH_COMMAND_TEMPLATES: dict[str, tuple[str, ...]] = {
         "--allowedTools",
         "Bash(git add:*),Bash(git commit:*)",
     ),
-    # omo runs as an extension of the senpi host CLI. Validated live
-    # (2026-07): `--print --no-session` completes non-interactively with a
-    # clean exit code on failure (missing API key, plan 402), and the
-    # `workspace` permission preset allowed file creation plus the exact
-    # `git add`/`git commit` the unit prompt asks for — no interactive
-    # prompt, no broader grant. `--no-session` keeps the dispatch ephemeral
-    # so no session state accumulates outside the worktree.
+    # omo ships as an extension of a pi-family host CLI (usually `pi`;
+    # `senpi` is a distribution of it with the same headless surface) or of
+    # opencode. The host is DETECTED at dispatch time in a fixed order —
+    # see OMO_RUNTIME_HOST_CANDIDATES — and the placeholder below is
+    # replaced by the detected host's template; no personal stack is
+    # hardcoded. The pi/senpi surface was validated in a live bridge
+    # dispatch (2026-07, senpi): `--print --no-session` completes
+    # non-interactively with clean exit codes on failure, and the
+    # `workspace` permission preset allowed file creation plus exactly the
+    # `git add`/`git commit` the unit prompt asks for. The opencode
+    # template is prepared from `opencode run --help` (model/variant flags
+    # verified locally); its permission behavior validates on first live
+    # dispatch, claude-template precedent.
     "omo-runtime": (
         "senpi",
         "--print",
@@ -80,6 +87,47 @@ DISPATCH_COMMAND_TEMPLATES: dict[str, tuple[str, ...]] = {
         "{prompt}",
     ),
 }
+
+# Fixed detection order for the omo runtime's local host CLI: first on PATH
+# wins ("usually pi" — user-stated common case; senpi is a pi distribution;
+# opencode hosts omo as a plugin). Detection is presence-only and recorded
+# implicitly by argv[0]/probe command.
+OMO_RUNTIME_HOST_CANDIDATES: tuple[str, ...] = ("pi", "senpi", "opencode")
+
+_OMO_HOST_TEMPLATES: dict[str, dict[str, tuple[str, ...] | int | None]] = {
+    "pi": {
+        "argv": ("pi", "--print", "--no-session", "--permission-preset", "workspace", "{prompt}"),
+        "model": ("--model", "{model}"),
+        "effort": ("--thinking", "{effort}"),
+        "insert": 5,
+    },
+    "senpi": {
+        "argv": ("senpi", "--print", "--no-session", "--permission-preset", "workspace", "{prompt}"),
+        "model": ("--model", "{model}"),
+        "effort": ("--thinking", "{effort}"),
+        "insert": 5,
+    },
+    "opencode": {
+        "argv": ("opencode", "run", "{prompt}"),
+        "model": ("--model", "{model}"),
+        "effort": ("--variant", "{effort}"),
+        "insert": 2,
+    },
+}
+
+
+def omo_runtime_host(which: Callable[[str], str | None] | None = None) -> str | None:
+    """Return the first omo host CLI present on PATH, or None.
+
+    The default resolves `shutil.which` at CALL time (a def-time default
+    would freeze the binding and make the probe untestable/unpatchable).
+    """
+    resolved_which = shutil.which if which is None else which
+    for candidate in OMO_RUNTIME_HOST_CANDIDATES:
+        if resolved_which(candidate):
+            return candidate
+    return None
+
 
 # Model routing is prepared metadata on the unit handoff; these fragments turn
 # it into argv only at dispatch time. Codex takes options before the prompt
@@ -116,7 +164,20 @@ def build_dispatch_argv(
     Without a model route the argv is byte-identical to the base template; a
     routed model/effort inserts the per-owner option fragments only.
     """
-    template = DISPATCH_COMMAND_TEMPLATES.get(owner)
+    if owner == "omo-runtime":
+        host = omo_runtime_host()
+        if host is None:
+            return None
+        host_table = _OMO_HOST_TEMPLATES[host]
+        template = host_table["argv"]
+        model_template = host_table["model"]
+        effort_template = host_table["effort"]
+        insert_index = host_table["insert"]
+    else:
+        template = DISPATCH_COMMAND_TEMPLATES.get(owner)
+        model_template = DISPATCH_MODEL_OPTION_TEMPLATES.get(owner, ())
+        effort_template = DISPATCH_REASONING_OPTION_TEMPLATES.get(owner, ())
+        insert_index = _DISPATCH_OPTION_INSERT_INDEX.get(owner)
     if template is None:
         return None
     argv = [part.replace("{prompt}", prompt) for part in template]
@@ -125,12 +186,12 @@ def build_dispatch_argv(
     model = str(route.get("selected_model", "") or "")
     effort = str(route.get("selected_reasoning_effort", "") or "")
     if model:
-        options.extend(part.replace("{model}", model) for part in DISPATCH_MODEL_OPTION_TEMPLATES.get(owner, ()))
+        options.extend(part.replace("{model}", model) for part in model_template)
     if effort:
-        options.extend(part.replace("{effort}", effort) for part in DISPATCH_REASONING_OPTION_TEMPLATES.get(owner, ()))
+        options.extend(part.replace("{effort}", effort) for part in effort_template)
     if not options:
         return argv
-    insert_at = _DISPATCH_OPTION_INSERT_INDEX.get(owner)
+    insert_at = insert_index
     if insert_at is None:
         return argv + options
     return argv[:insert_at] + options + argv[insert_at:]

--- a/src/coding/model_inventory.py
+++ b/src/coding/model_inventory.py
@@ -52,6 +52,7 @@ CLI_PRESENCE_COMMANDS: Final[tuple[str, ...]] = (
     "codex",
     "claude",
     "opencode",
+    "pi",
     "senpi",
     "gemini",
     "grok",
@@ -108,6 +109,7 @@ OMO_CATEGORY_ROLE_SOURCES: Final[dict[str, tuple[str, ...]]] = {
 _OMO_AGENT_CONFIG_RELATIVE: Final[str] = ".config/opencode/oh-my-openagent.json"
 _OPENCODE_CONFIG_RELATIVE: Final[str] = ".config/opencode/opencode.json"
 _OPENCODE_AUTH_RELATIVE: Final[str] = ".local/share/opencode/auth.json"
+_PI_AUTH_RELATIVE: Final[str] = ".pi/agent/auth.json"
 _SENPI_AUTH_RELATIVE: Final[str] = ".senpi/agent/auth.json"
 
 # Narrow by design (mirrors `_claude_marker`): a failure to read or parse a
@@ -123,6 +125,7 @@ def local_model_inventory(home: Path | None = None) -> dict[str, object]:
     provider_source = _top_level_key_source(base / _OPENCODE_CONFIG_RELATIVE, section="provider")
     auth_source = _top_level_key_source(base / _OPENCODE_AUTH_RELATIVE, section="")
     senpi_auth_source = _top_level_key_source(base / _SENPI_AUTH_RELATIVE, section="")
+    pi_auth_source = _top_level_key_source(base / _PI_AUTH_RELATIVE, section="")
     auth_signals = executor_auth_signals(base)
     signal_profiles = auth_signals.get("profiles", {})
     login_markers = {
@@ -143,6 +146,7 @@ def local_model_inventory(home: Path | None = None) -> dict[str, object]:
             "omo_agent_config": omo_source,
             "opencode_config_providers": provider_source,
             "opencode_auth_providers": auth_source,
+            "pi_auth_providers": pi_auth_source,
             "senpi_auth_providers": senpi_auth_source,
             "executor_auth_signals": {"status": "present", "login_markers": login_markers},
         },

--- a/tests/test_model_inventory.py
+++ b/tests/test_model_inventory.py
@@ -196,7 +196,7 @@ class ModelInventoryTests(unittest.TestCase):
     def test_cli_presence_table_is_fixed_vocabulary(self) -> None:
         self.assertEqual(
             CLI_PRESENCE_COMMANDS,
-            ("codex", "claude", "opencode", "senpi", "gemini", "grok", "qwen"),
+            ("codex", "claude", "opencode", "pi", "senpi", "gemini", "grok", "qwen"),
         )
 
     def test_senpi_auth_provider_names_are_presence_only(self) -> None:

--- a/tests/test_model_routing.py
+++ b/tests/test_model_routing.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import re
 from tempfile import TemporaryDirectory
 import unittest
+from unittest import mock
 
 from _local_package import load_local_package
 
@@ -597,7 +598,8 @@ class DispatchArgvTests(unittest.TestCase):
         claude = build_dispatch_argv("claude-code", "do the work")
         self.assertEqual(claude[0:3], ["claude", "-p", "do the work"])
         self.assertNotIn("--model", claude)
-        senpi = build_dispatch_argv("omo-runtime", "do the work")
+        with mock.patch("omh.coding.fanout_dispatch.shutil.which", lambda name: "/x/senpi" if name == "senpi" else None):
+            senpi = build_dispatch_argv("omo-runtime", "do the work")
         self.assertEqual(
             senpi,
             ["senpi", "--print", "--no-session", "--permission-preset", "workspace", "do the work"],
@@ -613,7 +615,8 @@ class DispatchArgvTests(unittest.TestCase):
             "selected_model": "kimi-coding/k3",
             "selected_reasoning_effort": "high",
         }
-        argv = build_dispatch_argv("omo-runtime", "do the work", route)
+        with mock.patch("omh.coding.fanout_dispatch.shutil.which", lambda name: "/x/senpi" if name == "senpi" else None):
+            argv = build_dispatch_argv("omo-runtime", "do the work", route)
         self.assertEqual(
             argv,
             [
@@ -683,6 +686,38 @@ class DispatchArgvTests(unittest.TestCase):
         self.assertIn("model_reasoning_effort=max", build_dispatch_argv("codex", "p", old_shape_route))
         new_route = resolve_model_route("codex", requested_model="gpt-5-codex", requested_effort="max")
         self.assertIn("model_reasoning_effort=xhigh", build_dispatch_argv("codex", "p", new_route))
+
+
+class OmoHostDetectionTests(unittest.TestCase):
+    def test_detection_order_prefers_pi_then_senpi_then_opencode(self) -> None:
+        """The usual host is `pi`; senpi is its distribution; opencode hosts
+        omo as a plugin. First on PATH wins, deterministically."""
+        from omh.coding.fanout_dispatch import OMO_RUNTIME_HOST_CANDIDATES, omo_runtime_host
+
+        self.assertEqual(OMO_RUNTIME_HOST_CANDIDATES, ("pi", "senpi", "opencode"))
+        both = lambda name: f"/x/{name}" if name in ("pi", "senpi") else None
+        self.assertEqual(omo_runtime_host(both), "pi")
+        self.assertEqual(omo_runtime_host(lambda name: "/x/senpi" if name == "senpi" else None), "senpi")
+        self.assertEqual(omo_runtime_host(lambda name: "/x/opencode" if name == "opencode" else None), "opencode")
+        self.assertIsNone(omo_runtime_host(lambda name: None))
+
+    def test_pi_and_opencode_hosts_shape_the_argv(self) -> None:
+        route = {
+            "schema_version": CODING_MODEL_ROUTE_SCHEMA_VERSION,
+            "selected_model": "zai/glm-5.2",
+            "selected_reasoning_effort": "high",
+        }
+        with mock.patch("omh.coding.fanout_dispatch.shutil.which", lambda name: "/x/pi" if name == "pi" else None):
+            pi_argv = build_dispatch_argv("omo-runtime", "work", route)
+        self.assertEqual(pi_argv[0], "pi")
+        self.assertEqual(pi_argv[5:9], ["--model", "zai/glm-5.2", "--thinking", "high"])
+        with mock.patch("omh.coding.fanout_dispatch.shutil.which", lambda name: "/x/opencode" if name == "opencode" else None):
+            oc_argv = build_dispatch_argv("omo-runtime", "work", route)
+        self.assertEqual(oc_argv, ["opencode", "run", "--model", "zai/glm-5.2", "--variant", "high", "work"])
+
+    def test_no_host_on_path_means_no_argv(self) -> None:
+        with mock.patch("omh.coding.fanout_dispatch.shutil.which", lambda name: None):
+            self.assertIsNone(build_dispatch_argv("omo-runtime", "work"))
 
 
 class UnitModelRouteTests(unittest.TestCase):


### PR DESCRIPTION
## What / why

User challenge on the dispatch-surface change: **omh should not "know" senpi.** Correct — the senpi entries encoded a machine-specific fact (this machine's omo runs on the senpi distribution) as product data, and FANOUT.md stated it universally. The usual host is **`pi`**; senpi is a distribution of it; opencode hosts omo as a plugin.

The omo runtime's host CLI is now **detected, not hardcoded**: `OMO_RUNTIME_HOST_CANDIDATES = ("pi", "senpi", "opencode")`, first on PATH wins at dispatch/readiness time, selected host visible in the planned argv and probed command. No host → argv `None` (`unsupported_for_local_dispatch`) and readiness truthfully reads `missing`. Per-host templates: pi/senpi share the live-validated pi-family surface (`--print --no-session --permission-preset workspace`, `--model`/`--thinking`); opencode uses `run`/`--model`/`--variant` (prepared from verified flags; permissions validate on first live dispatch — claude-template precedent). Auth marker walks `.pi/agent/auth.json` then `.senpi/agent/auth.json`, presence-only; inventory gains `pi` presence + `pi_auth_providers`.

Also fixes a latent testability bug caught while writing the host tests: the detection default bound `shutil.which` at def time, freezing the binding against patching — now resolved at call time.

## Verification

Full suite OK; all byte gates; ruff; `git diff --check`. New tests: detection order (pi > senpi > opencode), per-host argv shapes, no-host → None — all with mocked PATH so CI (no hosts installed) stays green. Live evidence unchanged: the pi-family surface was validated end-to-end via the senpi distribution (#729); a real `pi` or opencode host was not available on this machine — divergence surfaces as a clean observed exit failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)