### PR TITLE
fix: carry the delegation protocol to runtime-native delegate prompts

### DIFF
--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -5789,6 +5789,7 @@ Route implementation requests through scoped context, edit discipline, tests, re
   - Name every delegated or parallel lane's model and reasoning effort inline as `(model effort)` in status and briefing lines — including runtime-native subagents; write the literal `unknown` when the host does not expose a value, never empty parentheses, and carry token and elapsed figures the same way.
   - When the user asks mid-run which models are working or how many tokens are spent, answer immediately with one line per lane in that same format plus a one-line total; a steering question never waits for lane completion.
   - When delegating, show the composed delegate prompt in a fenced code block in the status message; truncate a long prompt to a bounded preview ending with `... [truncated, N chars total]` — the user must see WHAT was asked, not just that something was.
+  - Embed the delegation protocol (omh coding composition-guide) into EVERY delegated or reviewer prompt — runtime-native spawns included: goal echo-back before tool use, numbered pre-declared done criteria, exactly one mandatory verification pass with a two fix-and-verify cycle cap, and a two-round re-review cap — after two review rounds, stop and report the criterion-cited blockers instead of starting another reviewer.
 - Inputs:
   - task statement
   - repo context

--- a/src/commands/coding.py
+++ b/src/commands/coding.py
@@ -769,9 +769,22 @@ def _local_model_catalogs() -> dict[str, dict[str, object]]:
 def cmd_coding_composition_guide(args: argparse.Namespace) -> int:
     from ..coding.model_routing import model_family
     from ..coding.unit_prompt_protocol import (
+        GOAL_ECHO_PROTOCOL,
         MAIN_AGENT_COMPOSITION_CALIBRATIONS,
+        REVIEW_ROLE_PROTOCOL,
+        VERIFICATION_STOP_PROTOCOL,
         composition_calibration_for_model,
     )
+
+    delegation_protocol = {
+        "goal_echo": GOAL_ECHO_PROTOCOL,
+        "verification_stop": VERIFICATION_STOP_PROTOCOL,
+        "review_cap": REVIEW_ROLE_PROTOCOL,
+        "applies_to": (
+            "EVERY delegated or reviewer prompt the main agent composes — runtime-native "
+            "spawns included, not only bridge-dispatched fanout units."
+        ),
+    }
 
     model = str(args.model or "").strip()
     if model:
@@ -780,16 +793,22 @@ def cmd_coding_composition_guide(args: argparse.Namespace) -> int:
             "model_id": model,
             "family": model_family(model) or "unknown",
             "calibration": composition_calibration_for_model(model),
+            "delegation_protocol": delegation_protocol,
         }
         if _wants_json(args):
             _print_json(payload)
             return 0
         print(f"Composition guidance for `{model}` ({payload['family']} family):")
         print(str(payload["calibration"]))
+        print("Delegation protocol (embed in every delegated or reviewer prompt, runtime-native included):")
+        print(f"- {GOAL_ECHO_PROTOCOL}")
+        print(f"- {VERIFICATION_STOP_PROTOCOL}")
+        print(f"- {REVIEW_ROLE_PROTOCOL}")
         return 0
     payload = {
         "schema_version": "composition_guide/v1",
         "calibrations": dict(MAIN_AGENT_COMPOSITION_CALIBRATIONS),
+        "delegation_protocol": delegation_protocol,
     }
     if _wants_json(args):
         _print_json(payload)

--- a/src/skills/catalog_harnesses.py
+++ b/src/skills/catalog_harnesses.py
@@ -84,6 +84,7 @@ _HARNESSES = [
             "Name every delegated or parallel lane's model and reasoning effort inline as `(model effort)` in status and briefing lines — including runtime-native subagents; write the literal `unknown` when the host does not expose a value, never empty parentheses, and carry token and elapsed figures the same way.",
             "When the user asks mid-run which models are working or how many tokens are spent, answer immediately with one line per lane in that same format plus a one-line total; a steering question never waits for lane completion.",
             "When delegating, show the composed delegate prompt in a fenced code block in the status message; truncate a long prompt to a bounded preview ending with `... [truncated, N chars total]` — the user must see WHAT was asked, not just that something was.",
+            "Embed the delegation protocol (omh coding composition-guide) into EVERY delegated or reviewer prompt — runtime-native spawns included: goal echo-back before tool use, numbered pre-declared done criteria, exactly one mandatory verification pass with a two fix-and-verify cycle cap, and a two-round re-review cap — after two review rounds, stop and report the criterion-cited blockers instead of starting another reviewer.",
         ),
         evidence_ladder=(
             "coding_delegation_prepared",


### PR DESCRIPTION
## What / why

Live transcript from the user's Hermes (a security-fix loop): the main agent composed **raw runtime-native delegate/reviewer prompts**, bypassing the goal-echo + bounded-verification discipline that ships only in fanout unit prompts (#719). Observed consequences: no 복명복창 restatement in delegate outputs, two 60-turn max-turns exits on one fix owner, and a **third** fresh-reviewer round being planned where the shipped cap is **two rounds → report criterion-cited blockers**.

Fix, on the surfaces that reach the composer before it writes prompts:

- `omh coding composition-guide` now returns/prints a `delegation_protocol` block — goal echo-back, numbered pre-declared done criteria, exactly one mandatory verification pass + two fix-and-verify cycle cap, two-round re-review cap — with an explicit **applies-to: every delegated or reviewer prompt, runtime-native spawns included**. Reuses the exact `unit_prompt_protocol` constants: one vocabulary, zero drift between bridge and native paths.
- coding-handling guidance adds the matching contract line ("after two review rounds, stop and report the criterion-cited blockers instead of starting another reviewer").

## Verification

Full suite OK; all byte gates; ruff; `git diff --check`. Live host adoption is wrapper-side and observable only in future runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)