### PR TITLE
docs: add community links callout

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,10 @@
 > [!TIP]
 > Be with us!
 >
-> | [<img alt="X link" src="https://img.shields.io/badge/Follow-%40rlaope-00CED1?style=flat-square&logo=x&labelColor=black" width="156px" />](https://x.com/rlaope) | Follow [@rlaope](https://x.com/rlaope) on X for project updates. |
+> | [<img alt="X link" src="https://img.shields.io/badge/Follow-%40rlaope-00CED1?style=flat-square&logo=x&labelColor=black" width="112px" style="min-width: 96px" />](https://x.com/rlaope) | Follow [@rlaope](https://x.com/rlaope) on X. |
 > | :-----| :----- |
-> | [<img alt="GitHub Follow" src="https://img.shields.io/github/followers/rlaope?style=flat-square&logo=github&labelColor=black&color=24292f" width="156px" />](https://github.com/rlaope) | Follow [@rlaope](https://github.com/rlaope) on GitHub for more projects. |
-> | [<img alt="AI agent collaborators" src="https://img.shields.io/badge/With-AI%20agents%3A%20Friren%20%2B%20Killua-6f42c1?style=flat-square&labelColor=black" width="156px" />](https://github.com/rlaope/oh-my-hermes/graphs/contributors) | Built with AI agents **Friren** and **Killua**, collaborators helping ship `oh-my-hermes`. |
+> | [<img alt="GitHub Follow" src="https://img.shields.io/github/followers/rlaope?style=flat-square&logo=github&labelColor=black&color=24292f" width="112px" style="min-width: 96px" />](https://github.com/rlaope) | Follow [@rlaope](https://github.com/rlaope) on GitHub. |
+> | [<img alt="AI agent collaborators" src="https://img.shields.io/badge/With-AI%20agents%3A%20Friren%20%2B%20Killua-6f42c1?style=flat-square&labelColor=black" width="112px" style="min-width: 96px" />](https://github.com/rlaope/oh-my-hermes/graphs/contributors) | With AI agents **Friren** + **Killua**. |
 
 [Website](https://rlaope.github.io/oh-my-hermes/) ·
 [Documentation](docs/README.md) ·

--- a/README.md
+++ b/README.md
@@ -80,15 +80,19 @@
 > <table>
 >   <tr>
 >     <td width="124"><a href="https://x.com/rlaope"><img alt="X link" src="https://img.shields.io/badge/Follow-%40rlaope-00CED1?style=flat-square&logo=x&labelColor=black" width="112" /></a></td>
->     <td>Follow <a href="https://x.com/rlaope">@rlaope</a> on X.</td>
+>     <td>Updates for <code>oh-my-hermes</code> are shared on <a href="https://x.com/rlaope">@rlaope</a> on X, alongside release notes and project news.</td>
 >   </tr>
 >   <tr>
 >     <td width="124"><a href="https://github.com/rlaope"><img alt="GitHub Follow" src="https://img.shields.io/github/followers/rlaope?style=flat-square&logo=github&labelColor=black&color=24292f" width="112" /></a></td>
->     <td>Follow <a href="https://github.com/rlaope">@rlaope</a> on GitHub.</td>
+>     <td>Follow <a href="https://github.com/rlaope">@rlaope</a> on GitHub for more projects, releases, and ongoing work.</td>
 >   </tr>
 >   <tr>
 >     <td width="124"><a href="https://github.com/rlaope/oh-my-hermes/graphs/contributors"><img alt="AI agent collaborators" src="https://img.shields.io/badge/With-AI%20agents-6f42c1?style=flat-square&labelColor=black" width="112" /></a></td>
->     <td>With AI agents <a href="https://github.com/frirne-ai"><strong>Friren</strong></a> + <a href="https://github.com/sionic-khope"><strong>Killua</strong></a>.</td>
+>     <td>Built with AI agents <a href="https://github.com/frirne-ai"><strong>Friren</strong></a> and <a href="https://github.com/sionic-khope"><strong>Killua</strong></a>, collaborators helping ship <code>oh-my-hermes</code>.</td>
+>   </tr>
+>   <tr>
+>     <td width="124"><a href="https://nousresearch.com/"><img alt="Thanks to Nous Research" src="https://img.shields.io/badge/Thanks-Nous%20Research-4B2E83?style=flat-square&labelColor=black" width="112" /></a></td>
+>     <td>Thank you to <a href="https://nousresearch.com/">Nous Research</a> for creating Hermes Agent.</td>
 >   </tr>
 > </table>
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@
 >   </tr>
 >   <tr>
 >     <td width="124"><a href="https://github.com/rlaope/oh-my-hermes/graphs/contributors"><img alt="AI agent collaborators" src="https://img.shields.io/badge/With-AI%20agents-6f42c1?style=flat-square&labelColor=black" width="112" /></a></td>
->     <td>With AI agents <strong>Friren</strong> + <strong>Killua</strong>.</td>
+>     <td>With AI agents <a href="https://github.com/frirne-ai"><strong>Friren</strong></a> + <a href="https://github.com/sionic-khope"><strong>Killua</strong></a>.</td>
 >   </tr>
 > </table>
 

--- a/README.md
+++ b/README.md
@@ -77,10 +77,20 @@
 > [!TIP]
 > Be with us!
 >
-> | [<img alt="X link" src="https://img.shields.io/badge/Follow-%40rlaope-00CED1?style=flat-square&logo=x&labelColor=black" width="112px" style="min-width: 96px" />](https://x.com/rlaope) | Follow [@rlaope](https://x.com/rlaope) on X. |
-> | :-----| :----- |
-> | [<img alt="GitHub Follow" src="https://img.shields.io/github/followers/rlaope?style=flat-square&logo=github&labelColor=black&color=24292f" width="112px" style="min-width: 96px" />](https://github.com/rlaope) | Follow [@rlaope](https://github.com/rlaope) on GitHub. |
-> | [<img alt="AI agent collaborators" src="https://img.shields.io/badge/With-AI%20agents%3A%20Friren%20%2B%20Killua-6f42c1?style=flat-square&labelColor=black" width="112px" style="min-width: 96px" />](https://github.com/rlaope/oh-my-hermes/graphs/contributors) | With AI agents **Friren** + **Killua**. |
+> <table>
+>   <tr>
+>     <td width="124"><a href="https://x.com/rlaope"><img alt="X link" src="https://img.shields.io/badge/Follow-%40rlaope-00CED1?style=flat-square&logo=x&labelColor=black" width="112px" /></a></td>
+>     <td>Follow <a href="https://x.com/rlaope">@rlaope</a> on X.</td>
+>   </tr>
+>   <tr>
+>     <td width="124"><a href="https://github.com/rlaope"><img alt="GitHub Follow" src="https://img.shields.io/github/followers/rlaope?style=flat-square&logo=github&labelColor=black&color=24292f" width="112px" /></a></td>
+>     <td>Follow <a href="https://github.com/rlaope">@rlaope</a> on GitHub.</td>
+>   </tr>
+>   <tr>
+>     <td width="124"><a href="https://github.com/rlaope/oh-my-hermes/graphs/contributors"><img alt="AI agent collaborators" src="https://img.shields.io/badge/With-AI%20agents%3A%20Friren%20%2B%20Killua-6f42c1?style=flat-square&labelColor=black" width="112px" /></a></td>
+>     <td>With AI agents <strong>Friren</strong> + <strong>Killua</strong>.</td>
+>   </tr>
+> </table>
 
 [Website](https://rlaope.github.io/oh-my-hermes/) ·
 [Documentation](docs/README.md) ·

--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@
   owners.
 </p>
 
+> [!TIP]
+> Be with us!
+>
+> | [<img alt="X link" src="https://img.shields.io/badge/Follow-%40rlaope-00CED1?style=flat-square&logo=x&labelColor=black" width="156px" />](https://x.com/rlaope) | Follow [@rlaope](https://x.com/rlaope) on X for project updates. |
+> | :-----| :----- |
+> | [<img alt="GitHub Follow" src="https://img.shields.io/github/followers/rlaope?style=flat-square&logo=github&labelColor=black&color=24292f" width="156px" />](https://github.com/rlaope) | Follow [@rlaope](https://github.com/rlaope) on GitHub for more projects. |
+> | [<img alt="AI agent collaborators" src="https://img.shields.io/badge/With-AI%20agents%3A%20Friren%20%2B%20Killua-6f42c1?style=flat-square&labelColor=black" width="156px" />](https://github.com/rlaope/oh-my-hermes/graphs/contributors) | Built with AI agents **Friren** and **Killua**, collaborators helping ship `oh-my-hermes`. |
+
 [Website](https://rlaope.github.io/oh-my-hermes/) ·
 [Documentation](docs/README.md) ·
 [Installation](docs/INSTALLATION.md) ·

--- a/README.md
+++ b/README.md
@@ -74,6 +74,26 @@
   owners.
 </p>
 
+[Website](https://rlaope.github.io/oh-my-hermes/) ·
+[Documentation](docs/README.md) ·
+[Installation](docs/INSTALLATION.md) ·
+[Capabilities](docs/CAPABILITIES.md) ·
+[Capability Impact](docs/CAPABILITY_IMPACT.md) ·
+[Agent Install](INSTALL_FOR_AGENTS.md) ·
+[GitHub Pages site](site/index.html)
+
+> [!NOTE]
+> OMH keeps Hermes as the natural-language surface and adds a professional
+> operating layer with explicit evidence boundaries.
+>
+> <p align="center">
+>   <img src="assets/hermes-omh-terminal-orchestration.png" alt="Hermes Agent and OH-MY-HERMES working side by side" width="1080">
+> </p>
+>
+> <p align="center">
+>   <img src="assets/friren-agent-omh-callout.png" alt="Friren Agent explaining OMH in Art&Engine" width="720">
+> </p>
+
 > [!TIP]
 > Be with us!
 >
@@ -95,26 +115,6 @@
 >     <td>Thank you to <a href="https://nousresearch.com/">Nous Research</a> for creating Hermes Agent.</td>
 >   </tr>
 > </table>
-
-[Website](https://rlaope.github.io/oh-my-hermes/) ·
-[Documentation](docs/README.md) ·
-[Installation](docs/INSTALLATION.md) ·
-[Capabilities](docs/CAPABILITIES.md) ·
-[Capability Impact](docs/CAPABILITY_IMPACT.md) ·
-[Agent Install](INSTALL_FOR_AGENTS.md) ·
-[GitHub Pages site](site/index.html)
-
-> [!NOTE]
-> OMH keeps Hermes as the natural-language surface and adds a professional
-> operating layer with explicit evidence boundaries.
->
-> <p align="center">
->   <img src="assets/hermes-omh-terminal-orchestration.png" alt="Hermes Agent and OH-MY-HERMES working side by side" width="1080">
-> </p>
->
-> <p align="center">
->   <img src="assets/friren-agent-omh-callout.png" alt="Friren Agent explaining OMH in Art&Engine" width="720">
-> </p>
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -79,15 +79,15 @@
 >
 > <table>
 >   <tr>
->     <td width="124"><a href="https://x.com/rlaope"><img alt="X link" src="https://img.shields.io/badge/Follow-%40rlaope-00CED1?style=flat-square&logo=x&labelColor=black" width="112px" /></a></td>
+>     <td width="124"><a href="https://x.com/rlaope"><img alt="X link" src="https://img.shields.io/badge/Follow-%40rlaope-00CED1?style=flat-square&logo=x&labelColor=black" width="112" /></a></td>
 >     <td>Follow <a href="https://x.com/rlaope">@rlaope</a> on X.</td>
 >   </tr>
 >   <tr>
->     <td width="124"><a href="https://github.com/rlaope"><img alt="GitHub Follow" src="https://img.shields.io/github/followers/rlaope?style=flat-square&logo=github&labelColor=black&color=24292f" width="112px" /></a></td>
+>     <td width="124"><a href="https://github.com/rlaope"><img alt="GitHub Follow" src="https://img.shields.io/github/followers/rlaope?style=flat-square&logo=github&labelColor=black&color=24292f" width="112" /></a></td>
 >     <td>Follow <a href="https://github.com/rlaope">@rlaope</a> on GitHub.</td>
 >   </tr>
 >   <tr>
->     <td width="124"><a href="https://github.com/rlaope/oh-my-hermes/graphs/contributors"><img alt="AI agent collaborators" src="https://img.shields.io/badge/With-AI%20agents%3A%20Friren%20%2B%20Killua-6f42c1?style=flat-square&labelColor=black" width="112px" /></a></td>
+>     <td width="124"><a href="https://github.com/rlaope/oh-my-hermes/graphs/contributors"><img alt="AI agent collaborators" src="https://img.shields.io/badge/With-AI%20agents-6f42c1?style=flat-square&labelColor=black" width="112" /></a></td>
 >     <td>With AI agents <strong>Friren</strong> + <strong>Killua</strong>.</td>
 >   </tr>
 > </table>


### PR DESCRIPTION
## Feature Report

### What Changed

- Added a GitHub `TIP` callout after the complete root README `NOTE` block and its two images.
- Added fuller X and GitHub community descriptions for `rlaope`.
- Linked each AI-agent name individually: Friren → `github.com/frirne-ai`; Killua → `github.com/sionic-khope`.
- Added a linked Nous Research badge and the acknowledgement: “Thank you to Nous Research for creating Hermes Agent.”
- Omitted the Discord row as requested.
- Used a GitHub-rendered two-column HTML table inside the alert so the badge column remains intact on narrow screens.

### Why This Exists

Readers need clear destinations for project updates, the people and agents who help ship the project, and acknowledgement of the Hermes Agent origin without crowding the primary introduction.

### User / Operator Impact

The README now places the four-row community section after the blue `NOTE` callout and both supporting images, preserving the product introduction while making project links and acknowledgements easy to find.

### How It Works

- The `NOTE` closes before the independent `TIP` begins; GitHub rendering confirms the TIP is not nested in the NOTE.
- X links only to `https://x.com/rlaope`; GitHub links to `https://github.com/rlaope`.
- Friren and Killua are separate text links to their requested GitHub profiles.
- The Nous Research badge and acknowledgement link to `https://nousresearch.com/`.

### Files And Contracts Touched

- `README.md` adds and positions the presentation-only community callout.
- No runtime, CLI, dependency, generated-skill, routing, or catalog contract changes.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests.test_router_content -q` — 74 tests passed.
- [x] `git diff --check`
- [x] GitHub-rendered README inspected for commit `3d6ae086f33ba0b2904c325f455d21c3b99d1b99`: the NOTE ends before the TIP (`inNote: false`), and the TIP begins directly below the two NOTE images.
- [x] GitHub CI passed for `3d6ae086f33ba0b2904c325f455d21c3b99d1b99`: Python 3.11, Python 3.12, and DCO.

## Risk

- The callout is documentation-only and does not assert runtime integration or provider availability.
- GitHub’s README sanitizer controls final rendering, so the callout uses supported alert, table, link, and image primitives.

## Compatibility / Rollout

- No behavior or installation compatibility impact.
- Existing README content and external destinations remain unchanged; Discord is intentionally not added.

## Release / Claims

- [x] Release-channel impact considered: none; README-only change.
- [x] No runtime/native/provider capability claim is added.
- [x] Latest CI passed.

## Follow-Up

- Keep this PR as a Draft for review; do not merge without explicit instruction.