### PR TITLE
fix: name a same-topic sibling when the recall budget cuts one side

### DIFF
--- a/src/workflows/memory.py
+++ b/src/workflows/memory.py
@@ -133,7 +133,7 @@ _PROJECT_MEMORY_RECALL_ITEM_KEYS = {
     "staleness",
     "score",
 }
-_PROJECT_MEMORY_EXCLUDED_KEYS = {"record_id", "reason", "staleness"}
+_PROJECT_MEMORY_EXCLUDED_KEYS = {"record_id", "reason", "staleness", "sibling_included"}
 _PROJECT_MEMORY_TASK_REF_KEYS = {"sha256", "length", "query_supplied"}
 _HANDOFF_CONTEXT_PACK_KEYS = {
     "schema_version",
@@ -467,13 +467,22 @@ def build_project_memory_recall_pack(
             over_chars = max_chars is not None and kept_chars + summary_chars > max_chars
             budget_exhausted = over_records or over_chars
         if budget_exhausted:
-            excluded.append(
-                {
-                    "record_id": str(item.get("record_id", "")),
-                    "reason": "over_budget",
-                    "staleness": item.get("staleness", {"state": "not_checked"}),
-                }
-            )
+            entry = {
+                "record_id": str(item.get("record_id", "")),
+                "reason": "over_budget",
+                "staleness": item.get("staleness", {"state": "not_checked"}),
+            }
+            # A cut record that shares a tag with a KEPT record may be the
+            # other side of a same-topic disagreement; without this hint the
+            # surviving record silently "wins" until curation runs. The hint
+            # names the sibling only -- it never re-adds the record past the
+            # budget and never guesses which side is right.
+            cut_tags = {str(tag) for tag in item.get("tags", []) or []}
+            for kept_item in kept:
+                if cut_tags & {str(tag) for tag in kept_item.get("tags", []) or []}:
+                    entry["sibling_included"] = str(kept_item.get("record_id", ""))
+                    break
+            excluded.append(entry)
             continue
         kept.append(item)
         kept_chars += summary_chars

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -247,6 +247,37 @@ class MemoryContractTests(unittest.TestCase):
 
             self.assertEqual(sorted(p.name for p in records_dir.glob("*.json")), names_before)
             self.assertEqual({p.name: p.lstat().st_mtime_ns for p in records_dir.glob("*.json")}, mtimes_before)
+    def test_over_budget_cut_names_a_same_topic_sibling(self) -> None:
+        """A cut record sharing a tag with a kept record gets a sibling hint,
+        so a same-topic disagreement cannot vanish silently; unrelated cuts
+        carry no hint (issue #740)."""
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            write_setup_profile(paths, memory_mode="auto-safe")
+            for idx in range(3):
+                capture_project_memory_candidate(
+                    paths,
+                    f"Deploy policy variant {idx} for release tests",
+                    record_type="procedure",
+                    tags=["release", "tests"],
+                )
+            capture_project_memory_candidate(
+                paths,
+                "Unrelated onboarding note for docs",
+                record_type="procedure",
+                tags=["onboarding"],
+            )
+            pack = build_project_memory_recall_pack(paths, "release tests deploy policy", limit=2)
+            self.assertTrue(pack["truncated"])
+            kept_ids = {str(item["record_id"]) for item in pack["included_records"]}
+            cut = [item for item in pack["excluded_records"] if item["reason"] == "over_budget"]
+            self.assertTrue(cut)
+            tagged_cut = [item for item in cut if "sibling_included" in item]
+            self.assertTrue(tagged_cut)
+            for item in tagged_cut:
+                self.assertIn(item["sibling_included"], kept_ids)
+            self.assertEqual(validate_project_memory_recall_pack(pack), [])
+
     def test_project_memory_recall_pack_budget_marks_truncation(self) -> None:
         with TemporaryDirectory() as tmp:
             paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")


### PR DESCRIPTION
Closes #740. An `over_budget` exclusion sharing a tag with a kept record now carries `sibling_included: <record_id>` — a same-topic disagreement can no longer vanish silently on a budget cut. Hint only: never re-adds past the budget, never adjudicates. Validator allowlist extended. Full suite OK, byte gates, ruff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)