### PR TITLE
fix: dispatch fails closed on a frozen choice_required model route

### DIFF
--- a/docs/FANOUT.md
+++ b/docs/FANOUT.md
@@ -70,8 +70,11 @@ goal to Hermes in chat; these commands are the backend surface.
 - **Dependency bar.** A satisfied dependency means only that the owner agent
   process exited 0. It is not verified, reviewed, or correct work. Failed
   units block their dependents, never their independents.
-- **Blocked-by-design cascades.** An `unsupported_for_local_dispatch` or
-  `executor_not_ready` dependency also blocks its dependents — dependents must
+- **Blocked-by-design cascades.** An `unsupported_for_local_dispatch`,
+  `executor_not_ready`, or `model_choice_required` dependency (a frozen
+  route that reserves the model choice is never dispatched on the silent
+  executor default — re-prepare the unit with a declared model or a
+  resolvable role) also blocks its dependents — dependents must
   never build on an unstarted base. Recovery: complete that unit manually (or
   via its owner's own tooling), record its observed result on the unit's
   `run_ref` run, then re-run `dispatch --unit <dependent>`; completed units

--- a/src/coding/fanout_dispatch.py
+++ b/src/coding/fanout_dispatch.py
@@ -419,6 +419,24 @@ def _dispatch_unit(
     routed_model = str(model_route.get("selected_model", "") or "") if model_route else ""
     routed_effort = str(model_route.get("selected_reasoning_effort", "") or "") if model_route else ""
     fingerprint_note = catalog_fingerprint_note(model_route, current_catalog_digest)
+    if model_route is not None and str(model_route.get("status", "")) == "choice_required":
+        # A frozen choice_required route means the contract explicitly says
+        # "a human or wrapper must pick the model". Spawning anyway would
+        # silently substitute the executor CLI default for a choice the
+        # contract reserved — fail closed and name the unresolved choice
+        # instead. Recovery: re-prepare the unit with an explicit `model`
+        # (or a role that resolves), then re-run dispatch for this unit.
+        return {
+            "unit_id": unit_id,
+            "run_ref": run_ref,
+            "owner": owner,
+            "status": "model_choice_required",
+            "merge_ready": False,
+            "reason": (
+                "the frozen route requires an explicit model choice; re-prepare the unit with a "
+                "declared model or resolvable role, then re-dispatch"
+            ),
+        }
     if DISPATCH_COMMAND_TEMPLATES.get(owner) is None:
         return {
             "unit_id": unit_id,

--- a/tests/test_fanout_dispatch.py
+++ b/tests/test_fanout_dispatch.py
@@ -83,6 +83,40 @@ class FanoutDispatchEngineTests(unittest.TestCase):
         contract = write_fanout_contract(paths, build_fanout_contract(_GOAL, _UNITS))
         return paths, repo, sha, contract
 
+    def test_choice_required_route_blocks_the_unit_fail_closed(self) -> None:
+        """A frozen choice_required route must never dispatch on the silent
+        executor default: the unit reports model_choice_required, stays
+        un-merge-ready, and its dependents block (issue #716, option 2)."""
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            for unit in contract["units"]:
+                if unit["unit_id"] == "core":
+                    unit["handoff"]["model_route"] = {
+                        "schema_version": "coding_model_route/v2",
+                        "status": "choice_required",
+                        "provenance": "role_unchained",
+                        "selected_model": "",
+                        "selected_reasoning_effort": "",
+                    }
+            summary = dispatch_fanout(
+                paths,
+                contract,
+                goal_text=_GOAL,
+                repo_root=repo,
+                base_sha=sha,
+                runner=_agent_runner(),
+                readiness=_ready,
+            )
+            by_unit = {entry["unit_id"]: entry for entry in summary["units"]}
+            self.assertEqual(by_unit["core"]["status"], "model_choice_required")
+            self.assertFalse(by_unit["core"]["merge_ready"])
+            self.assertIn("re-prepare", by_unit["core"]["reason"])
+            self.assertNotIn("core", summary["merge_ready_units"])
+            # The dependent of the blocked unit must not build on an
+            # unstarted base; the independent unit still completes.
+            self.assertNotEqual(by_unit["tests"]["status"], "completed")
+            self.assertEqual(by_unit["docs"]["status"], "completed")
+
     def test_happy_path_dispatches_units_and_records_observed_evidence(self) -> None:
         with TemporaryDirectory() as tmp:
             paths, repo, sha, contract = self._setup(tmp)


### PR DESCRIPTION
Closes #716 (option 2). A unit whose frozen route says `choice_required` no longer dispatches on the silent executor default: it reports `model_choice_required` with a named recovery, stays un-merge-ready, the wave continues, and dependents block. Docs note added to the blocked-cascade list. Full suite OK; byte gates; ruff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)