### PR TITLE
feat: rewrite the top-10 skill descriptions to win the host picker

### DIFF
--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -150,7 +150,7 @@ These surfaces are generated command references, not installed Hermes workflow s
 
 ### ralph
 
-[omh] Hermes Ralph workflow: persistent execution with verification and review.
+[omh] Ralph - one owner drives a concrete task to done: implement, verify, review, repeat until the gate passes; prefer over one-shot delegation when the task needs a verification loop.
 
 - Category: `execution`
 - Phase: `completion`
@@ -206,7 +206,7 @@ These surfaces are generated command references, not installed Hermes workflow s
 
 ### ultragoal
 
-[omh] Hermes Ultragoal workflow: file-backed durable goal ledgers.
+[omh] Ultragoal - durable multi-session goal tracking: a checkpointed ledger survives context loss and resumes exactly where work stopped, with a final completion gate.
 
 - Category: `execution`
 - Phase: `durable-goals`
@@ -224,7 +224,7 @@ These surfaces are generated command references, not installed Hermes workflow s
   - The request is a single-turn answer, quick diagnosis, or small edit that does not need a durable ledger.
   - Acceptance criteria, current checkpoint, and final gate expectations are too vague to make a goal inspectable.
   - The user expects hidden Hermes code execution rather than explicit executor handoff and observed verification evidence.
-- Strong routing signals: `ultragoal`, `$ultragoal`, `durable goal`, `multi-goal`, `goal ledger`, `long running goal`, `완료조건까지 계속`, `keep working until acceptance criteria pass`, `장기 목표`, `오래 실행`, `완료 조건까지 계속`
+- Strong routing signals: `ultragoal`, `$ultragoal`, `ulg`, `$ulg`, `durable goal`, `multi-goal`, `goal ledger`, `long running goal`, `완료조건까지 계속`, `keep working until acceptance criteria pass`, `장기 목표`, `오래 실행`, `완료 조건까지 계속`
 - Good example:
   - Prompt: $ultragoal turn OMH skill quality into a durable goal with rubrics, generated skill sync, tests, and a PR gate.
   - Expected behavior: Create or update a goal ledger, split the story into verifiable checkpoints, and close only after generated docs, skills, and tests match.
@@ -366,7 +366,7 @@ These surfaces are generated command references, not installed Hermes workflow s
 
 ### ultraprocess
 
-[omh] Ultra Process - Research - Ralplan - Ultragoal - Code Review - Sync Circle: one PR-ready delivery cycle.
+[omh] Ultraprocess - one full task-to-PR cycle: codebase research, reviewed plan, coding handoff to the selected executor, code review, docs sync, and PR, tracked end to end.
 
 - Category: `process`
 - Phase: `single-cycle-plan-to-pr`
@@ -385,7 +385,7 @@ These surfaces are generated command references, not installed Hermes workflow s
   - The task is still ambiguous enough that a deep interview is required before planning.
   - No repo, product, or delivery surface is available to support a plan-to-PR cycle.
   - The goal is removing existing slop or duplication with identical observable behavior rather than delivering new or changed behavior; use `ai-slop-cleaner`.
-- Strong routing signals: `ultraprocess`, `$ultraprocess`, `./ultraprocess`, `/ultraprocess`, `single-cycle delivery`, `one-cycle delivery`, `end-to-end process`, `delivery process`, `research plan implement review docs pr`, `plan implement review docs pr`, `ralplan ultragoal code-review`, `codebase source research planning implementation review docs sync pr`, `docs sync`, `pr-ready`, `prepare a pr`, `sync docs and prepare a pr`, `code-review sync docs and prepare a pr`, `delegate to codex`, `send to codex`, `codex implement`, `codex progress tracking`, `codex session tracking`, `make a pr`, `open a pr`, `끝까지 해줘`, `PR까지`, `계획 구현 리뷰 문서 PR`, `기획 구현 리뷰 문서 PR`, `코드베이스 조사 웹리서치 계획 구현 리뷰 문서 최신화 PR`, `codex로 구현`, `코덱스로 구현`, `codex에게 맡기`, `codex로 맡기`, `코덱스에게 맡기`, `코딩 에이전트에게 맡기`, `구현하게 맡기고 진행상태 추적`, `진행상태 추적`, `진행 상태 추적`, `문서 최신화 PR`, `test driven development`, `write tests first`, `tests first`, `tdd implementation`, `테스트부터 작성`, `테스트 먼저 작성`, `테스트 우선 구현`, `TDD로 구현`
+- Strong routing signals: `ultraprocess`, `$ultraprocess`, `ulp`, `$ulp`, `./ultraprocess`, `/ultraprocess`, `single-cycle delivery`, `one-cycle delivery`, `end-to-end process`, `delivery process`, `research plan implement review docs pr`, `plan implement review docs pr`, `ralplan ultragoal code-review`, `codebase source research planning implementation review docs sync pr`, `docs sync`, `pr-ready`, `prepare a pr`, `sync docs and prepare a pr`, `code-review sync docs and prepare a pr`, `delegate to codex`, `send to codex`, `codex implement`, `codex progress tracking`, `codex session tracking`, `make a pr`, `open a pr`, `끝까지 해줘`, `PR까지`, `계획 구현 리뷰 문서 PR`, `기획 구현 리뷰 문서 PR`, `코드베이스 조사 웹리서치 계획 구현 리뷰 문서 최신화 PR`, `codex로 구현`, `코덱스로 구현`, `codex에게 맡기`, `codex로 맡기`, `코덱스에게 맡기`, `코딩 에이전트에게 맡기`, `구현하게 맡기고 진행상태 추적`, `진행상태 추적`, `진행 상태 추적`, `문서 최신화 PR`, `test driven development`, `write tests first`, `tests first`, `tdd implementation`, `테스트부터 작성`, `테스트 먼저 작성`, `테스트 우선 구현`, `TDD로 구현`
 - Good example:
   - Prompt: $ultraprocess research this setup bug, plan the fix, implement, review, sync docs, and prepare a PR.
   - Expected behavior: Run exactly one delivery cycle and report which stages are observed, prepared, or blocked.
@@ -491,7 +491,7 @@ These surfaces are generated command references, not installed Hermes workflow s
 
 ### team
 
-[omh] Hermes Team workflow: coordinated parallel or sequential work lanes.
+[omh] Team - run N coordinated workers on one shared task list with explicit lane ownership and merged verification; choose over raw subagents when lanes must not collide.
 
 - Category: `execution`
 - Phase: `coordination`
@@ -547,7 +547,7 @@ These surfaces are generated command references, not installed Hermes workflow s
 
 ### ultrawork
 
-[omh] Hermes Ultrawork compatibility workflow: bounded parallel delivery guidance.
+[omh] Ultrawork - split an accepted plan into disjoint parallel lanes with per-lane acceptance criteria, verification commands, and owners; prevents two lanes editing the same file.
 
 - Category: `execution`
 - Phase: `parallel-delivery`
@@ -606,7 +606,7 @@ These surfaces are generated command references, not installed Hermes workflow s
 
 ### web-research
 
-[omh] Hermes Web Research workflow: source-backed current information gathering.
+[omh] Web research with citation discipline on top of native search - every claim carries a live URL, sources are diversity-checked, and anything not fetched is marked not observed instead of guessed.
 
 - Category: `research`
 - Phase: `current-evidence`
@@ -739,7 +739,7 @@ These surfaces are generated command references, not installed Hermes workflow s
 
 ### research-brief
 
-[omh] Hermes Research Brief workflow: source-backed business research without pretending evidence was fetched.
+[omh] Business research brief - turns a market, competitor, pricing, or customer question into a structured brief with an explicit evidence-vs-inference split; for raw link gathering use ulw-research.
 
 - Category: `research`
 - Phase: `business-brief`
@@ -3673,7 +3673,7 @@ These surfaces are generated command references, not installed Hermes workflow s
 
 ### morning-brief
 
-[omh] Hermes Morning Brief setup workflow: diagnose mail and calendar MCP connection, guide read/draft-only access, and apply changes only after diff approval.
+[omh] Morning brief SETUP (one-time) - connects mail and calendar MCP with read-and-draft-only scope and diff approval; produces the configuration, not the daily brief itself.
 
 - Category: `hermes-setup`
 - Phase: `setup`
@@ -3900,7 +3900,7 @@ These surfaces are generated command references, not installed Hermes workflow s
 
 ### memory-new
 
-[omh] Hermes new-memory capture workflow: add reviewed project, product, or durable context candidates through capture, review, and approve actions.
+[omh] Save a new durable project or product fact - captures a candidate, shows it for review, and writes only on approval; for auditing memories that already exist use omh-memory-sync.
 
 - Category: `memory`
 - Phase: `candidate-capture`
@@ -3959,7 +3959,7 @@ These surfaces are generated command references, not installed Hermes workflow s
 
 ### memory-sync
 
-[omh] Hermes existing-memory curation workflow: review stale, conflicting, duplicate, overgeneralized, or risky USER.md, MEMORY.md, and skill memories through approve/reject/update actions.
+[omh] Audit what Hermes already remembers - walks USER.md, MEMORY.md, and skill memories claim by claim, flags stale, conflicting, duplicate, or overgeneralized entries, and rewrites only after an approved diff.
 
 - Category: `memory`
 - Phase: `curation-review`

--- a/skills/omh-memory-new/SKILL.md
+++ b/skills/omh-memory-new/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-memory-new
-description: [omh] Hermes new-memory capture workflow: add reviewed project, product, or durable context candidates through capture, review, and approve actions. Use when the user says: memory-new, new memory, project memory, product memory, remember this project, remember this product, memory capture, capture memory.
+description: [omh] Save a new durable project or product fact - captures a candidate, shows it for review, and writes only on approval; for auditing memories that already exist use omh-memory-sync. Use when the user says: memory-new, new memory, project memory, product memory, remember this project, remember this product, memory capture, capture memory.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, memory]

--- a/skills/omh-memory-sync/SKILL.md
+++ b/skills/omh-memory-sync/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-memory-sync
-description: [omh] Hermes existing-memory curation workflow: review stale, conflicting, duplicate, overgeneralized, or risky USER.md, MEMORY.md, and skill memories through approve/reject/update actions. Use when the user says: memory-sync, memory curation, memory review, memory inspect, memory check, memory update, context cleanup, curate memory.
+description: [omh] Audit what Hermes already remembers - walks USER.md, MEMORY.md, and skill memories claim by claim, flags stale, conflicting, duplicate, or overgeneralized entries, and rewrites only after an approved diff. Use when the user says: memory-sync, memory curation, memory review, memory inspect, memory check, memory update, context cleanup, curate memory.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, memory]

--- a/skills/omh-morning-brief/SKILL.md
+++ b/skills/omh-morning-brief/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-morning-brief
-description: [omh] Hermes Morning Brief setup workflow: diagnose mail and calendar MCP connection, guide read/draft-only access, and apply changes only after diff approval. Use when the user says: morning-brief, morning brief, connect my email for a morning brief, set up morning brief, configure morning brief, connect mail for morning brief, connect calendar for morning brief, set up my morning brief.
+description: [omh] Morning brief SETUP (one-time) - connects mail and calendar MCP with read-and-draft-only scope and diff approval; produces the configuration, not the daily brief itself. Use when the user says: morning-brief, morning brief, connect my email for a morning brief, set up morning brief, configure morning brief, connect mail for morning brief, connect calendar for morning brief, set up my morning brief.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, hermes-setup]

--- a/skills/omh-research-brief/SKILL.md
+++ b/skills/omh-research-brief/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-research-brief
-description: [omh] Hermes Research Brief workflow: source-backed business research without pretending evidence was fetched. Use when the user says: research-brief, business-research, business research, research brief, source-backed business research, customer feedback trends, feedback trends, market evidence.
+description: [omh] Business research brief - turns a market, competitor, pricing, or customer question into a structured brief with an explicit evidence-vs-inference split; for raw link gathering use ulw-research. Use when the user says: research-brief, business-research, business research, research brief, source-backed business research, customer feedback trends, feedback trends, market evidence.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, research]

--- a/skills/omh-routing/references/catalog-index.md
+++ b/skills/omh-routing/references/catalog-index.md
@@ -52,11 +52,11 @@ Trigger phrases and the role registry live in `references/workflow-registry.md`;
 - `omh-materials-package`: [omh] Hermes Materials Package workflow: decks, PDFs, spreadsheets, documents, HWP, Markdown, and binary export handoffs.
 - `omh-media-input-operator`: [omh] Hermes media input workflow: scope audio, video, YouTube, screenshot, receipt image, OCR, meeting recording, transcript, timestamp, and clip-summary requests with source, permission, extraction, transcription, and hallucination gates.
 - `omh-meeting-brief`: [omh] Hermes Meeting Brief workflow: agenda, prompts, decisions, and record template.
-- `omh-memory-new`: [omh] Hermes new-memory capture workflow: add reviewed project, product, or durable context candidates through capture, review, and approve actions.
-- `omh-memory-sync`: [omh] Hermes existing-memory curation workflow: review stale, conflicting, duplicate, overgeneralized, or risky USER.md, MEMORY.md, and skill memories through approve/reject/update actions.
+- `omh-memory-new`: [omh] Save a new durable project or product fact - captures a candidate, shows it for review, and writes only on approval; for auditing memories that already exist use omh-memory-sync.
+- `omh-memory-sync`: [omh] Audit what Hermes already remembers - walks USER.md, MEMORY.md, and skill memories claim by claim, flags stale, conflicting, duplicate, or overgeneralized entries, and rewrites only after an approved diff.
 - `omh-meta-router`: [omh] Meta-routing guidance for a leading /omh command: reason over the imperative task, consult the live workflow catalog, and select or chain the right workflow(s).
 - `omh-model-setup`: [omh] Hermes Model Setup workflow: diagnose role-slot model configuration, guide provider connection, and apply changes only after diff approval.
-- `omh-morning-brief`: [omh] Hermes Morning Brief setup workflow: diagnose mail and calendar MCP connection, guide read/draft-only access, and apply changes only after diff approval.
+- `omh-morning-brief`: [omh] Morning brief SETUP (one-time) - connects mail and calendar MCP with read-and-draft-only scope and diff approval; produces the configuration, not the daily brief itself.
 - `omh-routing`: [omh] Router guidance for using oh-my-hermes workflow skills inside Hermes Agent.
 - `omh-operating-rhythm`: [omh] Hermes Operating Rhythm workflow: meeting minutes, scrum/sprint records, retros, decisions, and follow-up history.
 - `omh-ops-observability-card`: [omh] Hermes ops observability workflow: prepare an operations command-board for wrapper-safe token, cost, latency, run history, queue, failure-mode, external metric-provider, and service-quality evidence boundaries.
@@ -69,11 +69,11 @@ Trigger phrases and the role registry live in `references/workflow-registry.md`;
 - `omh-production-audit`: [omh] Hermes Production Audit workflow: evaluate release, deploy, security, observability, rollback, docs, and support readiness without claiming production access.
 - `omh-prompt-import-readiness`: [omh] Hermes prompt import readiness workflow: decide whether external CLI-agent prompt files can be safely reviewed, normalized, and offered as Hermes slash-command candidates without mutating prompts or command registries.
 - `omh-provider-profile-posture`: [omh] Prepare provider-profile metadata without reading secrets or calling providers.
-- `ulw-ralph`: [omh] Hermes Ralph workflow: persistent execution with verification and review.
+- `ulw-ralph`: [omh] Ralph - one owner drives a concrete task to done: implement, verify, review, repeat until the gate passes; prefer over one-shot delegation when the task needs a verification loop.
 - `ulw-plan`: [omh] Hermes Ralplan workflow: consensus planning with review gates.
 - `omh-reliability-review`: [omh] Hermes Reliability Review workflow: postmortems, SLOs, error budgets, incident follow-ups, and service reliability evidence.
 - `omh-report-package`: [omh] Hermes Report Package workflow: weekly/monthly reports, executive briefs, PPT-ready outlines, and upload packages.
-- `omh-research-brief`: [omh] Hermes Research Brief workflow: source-backed business research without pretending evidence was fetched.
+- `omh-research-brief`: [omh] Business research brief - turns a market, competitor, pricing, or customer question into a structured brief with an explicit evidence-vs-inference split; for raw link gathering use ulw-research.
 - `omh-research-department`: [omh] Hermes Research Department workflow pack: prepare Scout, Analyst, and Briefer research operations with source inbox and briefing status boundaries.
 - `omh-rules-distill`: [omh] Hermes Rules Distill workflow: extract repeated principles from skills, prompts, traces, reviews, and failures into reviewed rule candidates without auto-mutating guidance.
 - `omh-run-efficiency`: [omh] Report supplied local run efficiency while provider and host data stay unobserved.
@@ -83,16 +83,16 @@ Trigger phrases and the role registry live in `references/workflow-registry.md`;
 - `omh-skill-scout`: [omh] Skill Scout workflow: prepare a metadata-only search-before-creation report for local, marketplace, GitHub, and web skill candidates with risk review and adoption options.
 - `omh-source-finder`: [omh] Hermes Source Finder workflow: prepare typed source candidates and acquisition status before downstream work.
 - `omh-decide`: [omh] Decide between options: tradeoffs, a recommendation, and a decision note you can act on.
-- `ulw-team`: [omh] Hermes Team workflow: coordinated parallel or sequential work lanes.
+- `ulw-team`: [omh] Team - run N coordinated workers on one shared task list with explicit lane ownership and merged verification; choose over raw subagents when lanes must not collide.
 - `omh-toolbelt-readiness`: [omh] Hermes toolbelt readiness workflow: check which MCP servers, CLIs, APIs, credentials, and connectors a workflow needs before claiming it can run.
-- `ulw-goal`: [omh] Hermes Ultragoal workflow: file-backed durable goal ledgers.
-- `ulw-process`: [omh] Ultra Process - Research - Ralplan - Ultragoal - Code Review - Sync Circle: one PR-ready delivery cycle.
+- `ulw-goal`: [omh] Ultragoal - durable multi-session goal tracking: a checkpointed ledger survives context loss and resumes exactly where work stopped, with a final completion gate.
+- `ulw-process`: [omh] Ultraprocess - one full task-to-PR cycle: codebase research, reviewed plan, coding handoff to the selected executor, code review, docs sync, and PR, tracked end to end.
 - `ulw-qa`: [omh] Hermes UltraQA workflow: adversarial QA and fix loops.
-- `ulw-work`: [omh] Hermes Ultrawork compatibility workflow: bounded parallel delivery guidance.
+- `ulw-work`: [omh] Ultrawork - split an accepted plan into disjoint parallel lanes with per-lane acceptance criteria, verification commands, and owners; prevents two lanes editing the same file.
 - `omh-verification-gate`: [omh] Hermes Verification Gate workflow: define and record build, lint, typecheck, test, security, docs, generated-output, and CI evidence before completion or merge.
 - `omh-visual-qa`: [omh] Hermes visual-qa workflow: prepare observed-only rendered QA gates for web, frontend, image, document, and TUI surfaces.
 - `omh-voice-operator`: [omh] Hermes voice operator workflow: turn short voice or mobile commands into clarify, plan, status, handoff, or confirmation actions.
-- `ulw-research`: [omh] Hermes Web Research workflow: source-backed current information gathering.
+- `ulw-research`: [omh] Web research with citation discipline on top of native search - every claim carries a live URL, sources are diversity-checked, and anything not fetched is marked not observed instead of guessed.
 - `omh-websearch-setup`: [omh] Hermes Web Search Setup workflow: diagnose scraper and auxiliary extract-model configuration, guide account setup, and apply each change as its own diff approval.
 - `omh-wiki`: [omh] Hermes adaptation for wiki construction blueprints and retained knowledge capture with destination-aware external knowledge connection guidance.
 - `omh-workflow-learning`: [omh] Hermes workflow learning workflow: classify and review self-improvement store routes as an auxiliary review lane before durable writes, then record workflow attempts as metadata-only traces, evals, review queues, patch proposals, regression cases, audits, indexes, and exports.

--- a/skills/omh-routing/references/workflow-registry.md
+++ b/skills/omh-routing/references/workflow-registry.md
@@ -38,9 +38,9 @@ When Hermes exposes installed skill descriptions to the model, use this registry
 
 - `meta-router`: `/omh`, `./omh`
 - `ralph`: `ralph`, `$ralph`, `finish until done`, `persistent execution`, `self-referential loop`
-- `ultragoal`: `ultragoal`, `$ultragoal`, `durable goal`, `multi-goal`, `goal ledger`, `long running goal`, `완료조건까지 계속`, `keep working until acceptance criteria pass`, `장기 목표`
+- `ultragoal`: `ultragoal`, `$ultragoal`, `ulg`, `$ulg`, `durable goal`, `multi-goal`, `goal ledger`, `long running goal`, `완료조건까지 계속`
 - `loop`: `loop`, `./loop`, `$loop`, `goal loop`, `long horizon goal`, `never stop`, `research plan ultragoal feedback`, `token exhaustion resume`, `permission profile`
-- `ultraprocess`: `ultraprocess`, `$ultraprocess`, `./ultraprocess`, `/ultraprocess`, `single-cycle delivery`, `one-cycle delivery`, `end-to-end process`, `delivery process`, `research plan implement review docs pr`
+- `ultraprocess`: `ultraprocess`, `$ultraprocess`, `ulp`, `$ulp`, `./ultraprocess`, `/ultraprocess`, `single-cycle delivery`, `one-cycle delivery`, `end-to-end process`
 - `deep-interview`: `deep-interview`, `$deep-interview`, `interview`, `don't assume`, `clarify`, `feature shaping`, `ambiguous product request`, `one question`, `온보딩`
 - `team`: `team`, `$team`, `swarm`, `parallel agents`, `coordinated workers`
 - `ultrawork`: `ultrawork`, `$ultrawork`, `ulw`, `$ulw`, `parallel work`, `parallel implementation`, `high throughput`

--- a/skills/ulw-goal/SKILL.md
+++ b/skills/ulw-goal/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ulw-goal
-description: [omh] Hermes Ultragoal workflow: file-backed durable goal ledgers. Use when the user says: ultragoal, durable goal, multi-goal, goal ledger, long running goal, 완료조건까지 계속, keep working until acceptance criteria pass, 장기 목표.
+description: [omh] Ultragoal - durable multi-session goal tracking: a checkpointed ledger survives context loss and resumes exactly where work stopped, with a final completion gate. Use when the user says: ultragoal, ulg, durable goal, multi-goal, goal ledger, long running goal, 완료조건까지 계속, keep working until acceptance criteria pass.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, execution]
@@ -70,7 +70,7 @@ Bad example:
 
 Use when work needs durable goal artifacts, checkpointed progress, and final quality gates.
 
-    Strong routing signals: `ultragoal`, `$ultragoal`, `durable goal`, `multi-goal`, `goal ledger`, `long running goal`, `완료조건까지 계속`, `keep working until acceptance criteria pass`, `장기 목표`, `오래 실행`, `완료 조건까지 계속`
+    Strong routing signals: `ultragoal`, `$ultragoal`, `ulg`, `$ulg`, `durable goal`, `multi-goal`, `goal ledger`, `long running goal`, `완료조건까지 계속`, `keep working until acceptance criteria pass`, `장기 목표`, `오래 실행`, `완료 조건까지 계속`
 
 ## Catalog Metadata
 

--- a/skills/ulw-process/SKILL.md
+++ b/skills/ulw-process/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ulw-process
-description: [omh] Ultra Process - Research - Ralplan - Ultragoal - Code Review - Sync Circle: one PR-ready delivery cycle. Use when the user says: ultraprocess, single-cycle delivery, one-cycle delivery, end-to-end process, delivery process, research plan implement review docs pr, plan implement review docs pr, ralplan ultragoal code-review.
+description: [omh] Ultraprocess - one full task-to-PR cycle: codebase research, reviewed plan, coding handoff to the selected executor, code review, docs sync, and PR, tracked end to end. Use when the user says: ultraprocess, ulp, single-cycle delivery, one-cycle delivery, end-to-end process, delivery process, research plan implement review docs pr, plan implement review docs pr.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, process]
@@ -70,7 +70,7 @@ Bad example:
 
 Use when the user asks Hermes to take a concrete task through one full delivery cycle: research/codebase context, reviewed plan, selected implementation handoff, code review, docs sync when needed, and PR preparation.
 
-    Strong routing signals: `ultraprocess`, `$ultraprocess`, `./ultraprocess`, `/ultraprocess`, `single-cycle delivery`, `one-cycle delivery`, `end-to-end process`, `delivery process`, `research plan implement review docs pr`, `plan implement review docs pr`, `ralplan ultragoal code-review`, `codebase source research planning implementation review docs sync pr`, `docs sync`, `pr-ready`, `prepare a pr`, `sync docs and prepare a pr`, `code-review sync docs and prepare a pr`, `delegate to codex`, `send to codex`, `codex implement`, `codex progress tracking`, `codex session tracking`, `make a pr`, `open a pr`, `끝까지 해줘`, `PR까지`, `계획 구현 리뷰 문서 PR`, `기획 구현 리뷰 문서 PR`, `코드베이스 조사 웹리서치 계획 구현 리뷰 문서 최신화 PR`, `codex로 구현`, `코덱스로 구현`, `codex에게 맡기`, `codex로 맡기`, `코덱스에게 맡기`, `코딩 에이전트에게 맡기`, `구현하게 맡기고 진행상태 추적`, `진행상태 추적`, `진행 상태 추적`, `문서 최신화 PR`, `test driven development`, `write tests first`, `tests first`, `tdd implementation`, `테스트부터 작성`, `테스트 먼저 작성`, `테스트 우선 구현`, `TDD로 구현`
+    Strong routing signals: `ultraprocess`, `$ultraprocess`, `ulp`, `$ulp`, `./ultraprocess`, `/ultraprocess`, `single-cycle delivery`, `one-cycle delivery`, `end-to-end process`, `delivery process`, `research plan implement review docs pr`, `plan implement review docs pr`, `ralplan ultragoal code-review`, `codebase source research planning implementation review docs sync pr`, `docs sync`, `pr-ready`, `prepare a pr`, `sync docs and prepare a pr`, `code-review sync docs and prepare a pr`, `delegate to codex`, `send to codex`, `codex implement`, `codex progress tracking`, `codex session tracking`, `make a pr`, `open a pr`, `끝까지 해줘`, `PR까지`, `계획 구현 리뷰 문서 PR`, `기획 구현 리뷰 문서 PR`, `코드베이스 조사 웹리서치 계획 구현 리뷰 문서 최신화 PR`, `codex로 구현`, `코덱스로 구현`, `codex에게 맡기`, `codex로 맡기`, `코덱스에게 맡기`, `코딩 에이전트에게 맡기`, `구현하게 맡기고 진행상태 추적`, `진행상태 추적`, `진행 상태 추적`, `문서 최신화 PR`, `test driven development`, `write tests first`, `tests first`, `tdd implementation`, `테스트부터 작성`, `테스트 먼저 작성`, `테스트 우선 구현`, `TDD로 구현`
 
 ## Catalog Metadata
 

--- a/skills/ulw-ralph/SKILL.md
+++ b/skills/ulw-ralph/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ulw-ralph
-description: [omh] Hermes Ralph workflow: persistent execution with verification and review. Use when the user says: ralph, finish until done, persistent execution, self-referential loop.
+description: [omh] Ralph - one owner drives a concrete task to done: implement, verify, review, repeat until the gate passes; prefer over one-shot delegation when the task needs a verification loop. Use when the user says: ralph, finish until done, persistent execution, self-referential loop.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, execution]

--- a/skills/ulw-research/SKILL.md
+++ b/skills/ulw-research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ulw-research
-description: [omh] Hermes Web Research workflow: source-backed current information gathering. Use when the user says: web-research, web research, web search, search the web, internet search, fresh sources, current sources, current web evidence.
+description: [omh] Web research with citation discipline on top of native search - every claim carries a live URL, sources are diversity-checked, and anything not fetched is marked not observed instead of guessed. Use when the user says: web-research, web research, web search, search the web, internet search, fresh sources, current sources, current web evidence.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, research]

--- a/skills/ulw-team/SKILL.md
+++ b/skills/ulw-team/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ulw-team
-description: [omh] Hermes Team workflow: coordinated parallel or sequential work lanes. Use when the user says: team, swarm, parallel agents, coordinated workers.
+description: [omh] Team - run N coordinated workers on one shared task list with explicit lane ownership and merged verification; choose over raw subagents when lanes must not collide. Use when the user says: team, swarm, parallel agents, coordinated workers.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, execution]

--- a/skills/ulw-work/SKILL.md
+++ b/skills/ulw-work/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ulw-work
-description: [omh] Hermes Ultrawork compatibility workflow: bounded parallel delivery guidance. Use when the user says: ultrawork, ulw, parallel work, parallel implementation, high throughput.
+description: [omh] Ultrawork - split an accepted plan into disjoint parallel lanes with per-lane acceptance criteria, verification commands, and owners; prevents two lanes editing the same file. Use when the user says: ultrawork, ulw, parallel work, parallel implementation, high throughput.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, execution]

--- a/src/skills/catalog_definitions.py
+++ b/src/skills/catalog_definitions.py
@@ -175,7 +175,7 @@ _DEFINITIONS = [
     ),
     SkillDefinition(
         "ralph",
-        "Hermes Ralph workflow: persistent execution with verification and review.",
+        "Ralph - one owner drives a concrete task to done: implement, verify, review, repeat until the gate passes; prefer over one-shot delegation when the task needs a verification loop.",
         ("ralph", "$ralph", "finish until done", "persistent execution", "self-referential loop"),
         "Use after scope is concrete and the user wants one owner to continue through implementation and verification.",
         category="execution",
@@ -194,10 +194,12 @@ _DEFINITIONS = [
     ),
     SkillDefinition(
         "ultragoal",
-        "Hermes Ultragoal workflow: file-backed durable goal ledgers.",
+        "Ultragoal - durable multi-session goal tracking: a checkpointed ledger survives context loss and resumes exactly where work stopped, with a final completion gate.",
         (
             "ultragoal",
             "$ultragoal",
+            "ulg",
+            "$ulg",
             "durable goal",
             "multi-goal",
             "goal ledger",
@@ -349,10 +351,12 @@ _DEFINITIONS = [
     ),
     SkillDefinition(
         "ultraprocess",
-        "Ultra Process - Research - Ralplan - Ultragoal - Code Review - Sync Circle: one PR-ready delivery cycle.",
+        "Ultraprocess - one full task-to-PR cycle: codebase research, reviewed plan, coding handoff to the selected executor, code review, docs sync, and PR, tracked end to end.",
         (
             "ultraprocess",
             "$ultraprocess",
+            "ulp",
+            "$ulp",
             "./ultraprocess",
             "/ultraprocess",
             "single-cycle delivery",
@@ -517,7 +521,7 @@ _DEFINITIONS = [
     ),
     SkillDefinition(
         "team",
-        "Hermes Team workflow: coordinated parallel or sequential work lanes.",
+        "Team - run N coordinated workers on one shared task list with explicit lane ownership and merged verification; choose over raw subagents when lanes must not collide.",
         ("team", "$team", "swarm", "parallel agents", "coordinated workers"),
         "Use when multiple independent lanes materially improve throughput or verification.",
         category="execution",
@@ -552,7 +556,7 @@ _DEFINITIONS = [
     ),
     SkillDefinition(
         "ultrawork",
-        "Hermes Ultrawork compatibility workflow: bounded parallel delivery guidance.",
+        "Ultrawork - split an accepted plan into disjoint parallel lanes with per-lane acceptance criteria, verification commands, and owners; prevents two lanes editing the same file.",
         ("ultrawork", "$ultrawork", "ulw", "$ulw", "parallel work", "parallel implementation", "high throughput"),
         "Use when an accepted implementation plan can be split into independent, reviewable work lanes.",
         category="execution",
@@ -604,7 +608,7 @@ _DEFINITIONS = [
     ),
     SkillDefinition(
         "web-research",
-        "Hermes Web Research workflow: source-backed current information gathering.",
+        "Web research with citation discipline on top of native search - every claim carries a live URL, sources are diversity-checked, and anything not fetched is marked not observed instead of guessed.",
         (
             "web-research",
             "web research",
@@ -805,7 +809,7 @@ _DEFINITIONS = [
     ),
     SkillDefinition(
         "research-brief",
-        "Hermes Research Brief workflow: source-backed business research without pretending evidence was fetched.",
+        "Business research brief - turns a market, competitor, pricing, or customer question into a structured brief with an explicit evidence-vs-inference split; for raw link gathering use ulw-research.",
         (
             "research-brief",
             "business-research",
@@ -4292,7 +4296,7 @@ _DEFINITIONS = [
     ),
     SkillDefinition(
         "morning-brief",
-        "Hermes Morning Brief setup workflow: diagnose mail and calendar MCP connection, guide read/draft-only access, and apply changes only after diff approval.",
+        "Morning brief SETUP (one-time) - connects mail and calendar MCP with read-and-draft-only scope and diff approval; produces the configuration, not the daily brief itself.",
         (
             "morning-brief",
             "morning brief",

--- a/src/skills/catalog_feature_surfaces.py
+++ b/src/skills/catalog_feature_surfaces.py
@@ -116,7 +116,7 @@ _FEATURE_SURFACE_SKILLS = (
     ),
     _feature_surface_skill(
         "memory-new",
-        "Hermes new-memory capture workflow: add reviewed project, product, or durable context candidates through capture, review, and approve actions.",
+        "Save a new durable project or product fact - captures a candidate, shows it for review, and writes only on approval; for auditing memories that already exist use omh-memory-sync.",
         (
             "memory-new",
             "new memory",
@@ -163,7 +163,7 @@ _FEATURE_SURFACE_SKILLS = (
     ),
     _feature_surface_skill(
         "memory-sync",
-        "Hermes existing-memory curation workflow: review stale, conflicting, duplicate, overgeneralized, or risky USER.md, MEMORY.md, and skill memories through approve/reject/update actions.",
+        "Audit what Hermes already remembers - walks USER.md, MEMORY.md, and skill memories claim by claim, flags stale, conflicting, duplicate, or overgeneralized entries, and rewrites only after an approved diff.",
         (
             "memory-sync",
             "memory curation",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1774,7 +1774,7 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
         self.assertEqual(status, 0)
         self.assertIn("Why: Risky code-change requests should get a reviewed plan before cleanup.", stdout)
         self.assertIn("Why: Matched workflow trigger language for this task.", stdout)
-        self.assertIn("Why: Matched catalog keywords for this task.", stdout)
+        self.assertIn("Why: Matched workflow trigger language for this task.", stdout)
         self.assertNotIn("metadata metadata", stdout)
         self.assertNotIn("Matched guard/trigger metadata", stdout)
 
@@ -1785,7 +1785,7 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
         payload = json.loads(stdout)
         reasons = [str(item.get("why", "")) for item in payload["recommendations"]]
         self.assertIn("Risky code-change requests should get a reviewed plan before cleanup.", reasons)
-        self.assertIn("Matched catalog keywords for this task.", reasons)
+        self.assertIn("Matched workflow trigger language for this task.", reasons)
         self.assertFalse(any("metadata metadata" in reason for reason in reasons))
         self.assertFalse(any("Matched guard/trigger metadata" in reason for reason in reasons))
 
@@ -4732,7 +4732,7 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
                 recommendations = json.loads(stdout)["recommendations"]
                 self.assertEqual(recommendations[0]["skill"], "web-research")
                 self.assertEqual(recommendations[0]["hermes_role"], "researcher")
-                self.assertIn("source-backed", recommendations[0]["description"].lower())
+                self.assertIn("citation discipline", recommendations[0]["description"].lower())
                 self.assertIn("retrieval", recommendations[0]["evidence_boundary"].lower())
                 self.assertIn("freshness", recommendations[0]["wrapper_guidance"].lower())
 
@@ -10523,7 +10523,7 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
 
             self.assertEqual(run_cli(["--omh-home", str(omh_home), "convert", "--from-skills-dir", str(root / "local-skills")])[0], 0)
             converted = (omh_home / "skills" / "ulw-ralph" / "SKILL.md").read_text(encoding="utf-8")
-            self.assertIn("description: [omh] Hermes Ralph workflow", converted)
+            self.assertIn("description: [omh] Ralph - one owner drives", converted)
             self.assertIn("Hermes Compatibility Contract", converted)
 
     def test_mocked_source_install_update(self) -> None:

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -2338,7 +2338,7 @@ class RouterContentTests(unittest.TestCase):
         self.assertEqual(definitions["ultraprocess"].hermes_role, "handoff-guide")
         self.assertEqual(
             definitions["ultraprocess"].description,
-            "[omh] Ultra Process - Research - Ralplan - Ultragoal - Code Review - Sync Circle: one PR-ready delivery cycle.",
+            "[omh] Ultraprocess - one full task-to-PR cycle: codebase research, reviewed plan, coding handoff to the selected executor, code review, docs sync, and PR, tracked end to end.",
         )
         self.assertEqual(definitions["ultrawork"].hermes_role, "handoff-guide")
         self.assertEqual(definitions["ai-slop-cleaner"].hermes_role, "handoff-guide")


### PR DESCRIPTION
Part of #734 (items 1-3: description rewrites per the audit table, mutual disambiguation clauses, short ulp/ulg aliases via the proven name-token pattern). Remaining #734 items (native-competition gate, doctor awareness-delivery warning, always-on context dedup ~200KB, operator/readiness cluster collapse) stay tracked on the issue. Full suite 2415 OK; all byte gates; ruff. Four stale description pins updated; 12 skill files + docs regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)