### PR TITLE
fix: route settings-only requests to direct configuration instead of goal escalation

### DIFF
--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -222,6 +222,7 @@ These surfaces are generated command references, not installed Hermes workflow s
 - Use when: Use when work needs durable goal artifacts, checkpointed progress, and final quality gates.
 - Do not use when:
   - The request is a single-turn answer, quick diagnosis, or small edit that does not need a durable ledger.
+  - The request is a settings-only or single configuration change (for example a gateway channel policy, a mention rule, or one config key) that the wrapper or Hermes can apply directly; apply the configuration change, verify the new value, and report it instead of opening a goal ledger or preparing a coding handoff.
   - Acceptance criteria, current checkpoint, and final gate expectations are too vague to make a goal inspectable.
   - The user expects hidden Hermes code execution rather than explicit executor handoff and observed verification evidence.
 - Strong routing signals: `ultragoal`, `$ultragoal`, `ulg`, `$ulg`, `durable goal`, `multi-goal`, `goal ledger`, `long running goal`, `완료조건까지 계속`, `keep working until acceptance criteria pass`, `장기 목표`, `오래 실행`, `완료 조건까지 계속`

--- a/skills/omh-routing/references/wrapper-routing.md
+++ b/skills/omh-routing/references/wrapper-routing.md
@@ -36,6 +36,8 @@ omh coding delegate --source discord --executor codex --record "risky refactor"
 
 The payload is deterministic local adapter data: recommended workflow, harness, executor/runtime profile, acceptance criteria, verification expectations, and handoff prompt template. Hermes still narrates the user-facing state.
 
+Implementation-shaped has a floor. A settings-only or single configuration change (a gateway channel policy, a mention rule, one config key) that the wrapper or Hermes can apply directly is a direct configuration action: apply it, verify the new value, and report it. Do not open a durable goal ledger, start a goal loop, or prepare an executor handoff for it. Escalate to a coding handoff only when the request needs code edits, tests, or multi-step implementation work that configuration cannot express.
+
 Check `executor_readiness/v1` for Codex, Claude Code, Hermes, or oh-my runtime profiles before first dispatch. If readiness is `missing` or `blocked`, ask the user to choose another coding agent, configure PATH, continue in Hermes, or use prompt/runtime handoff; retry only after that state changes. A readiness probe is not dispatch, execution, verification, review, CI, or merge evidence.
 
 With `--record`, Codex-selected real executor handoffs create `.omh/runtime/runs/<run-id>/` prepared runtime runs with `observation_status: prepared_not_observed`. Executor-choice, prompt-only, runtime-handoff, clarify, and fallback responses remain wrapper/session state.

--- a/skills/ulw-goal/SKILL.md
+++ b/skills/ulw-goal/SKILL.md
@@ -21,6 +21,7 @@ This is a Hermes-native `ultragoal` workflow skill.
 ## Do Not Use When
 
 - The request is a single-turn answer, quick diagnosis, or small edit that does not need a durable ledger.
+- The request is a settings-only or single configuration change (for example a gateway channel policy, a mention rule, or one config key) that the wrapper or Hermes can apply directly; apply the configuration change, verify the new value, and report it instead of opening a goal ledger or preparing a coding handoff.
 - Acceptance criteria, current checkpoint, and final gate expectations are too vague to make a goal inspectable.
 - The user expects hidden Hermes code execution rather than explicit executor handoff and observed verification evidence.
 

--- a/src/skills/catalog_definitions.py
+++ b/src/skills/catalog_definitions.py
@@ -229,6 +229,7 @@ _DEFINITIONS = [
         why_this_exists="`ultragoal` exists for work that can outlive one chat turn: it turns ambition into durable stories, checkpoints, and completion gates so progress can resume without pretending a summary is evidence.",
         do_not_use_when=(
             "The request is a single-turn answer, quick diagnosis, or small edit that does not need a durable ledger.",
+            "The request is a settings-only or single configuration change (for example a gateway channel policy, a mention rule, or one config key) that the wrapper or Hermes can apply directly; apply the configuration change, verify the new value, and report it instead of opening a goal ledger or preparing a coding handoff.",
             "Acceptance criteria, current checkpoint, and final gate expectations are too vague to make a goal inspectable.",
             "The user expects hidden Hermes code execution rather than explicit executor handoff and observed verification evidence.",
         ),

--- a/src/skills/render.py
+++ b/src/skills/render.py
@@ -647,6 +647,8 @@ omh coding delegate --source discord --executor codex --record "risky refactor"
 
 The payload is deterministic local adapter data: recommended workflow, harness, executor/runtime profile, acceptance criteria, verification expectations, and handoff prompt template. Hermes still narrates the user-facing state.
 
+Implementation-shaped has a floor. A settings-only or single configuration change (a gateway channel policy, a mention rule, one config key) that the wrapper or Hermes can apply directly is a direct configuration action: apply it, verify the new value, and report it. Do not open a durable goal ledger, start a goal loop, or prepare an executor handoff for it. Escalate to a coding handoff only when the request needs code edits, tests, or multi-step implementation work that configuration cannot express.
+
 Check `executor_readiness/v1` for Codex, Claude Code, Hermes, or oh-my runtime profiles before first dispatch. If readiness is `missing` or `blocked`, ask the user to choose another coding agent, configure PATH, continue in Hermes, or use prompt/runtime handoff; retry only after that state changes. A readiness probe is not dispatch, execution, verification, review, CI, or merge evidence.
 
 With `--record`, Codex-selected real executor handoffs create `.omh/runtime/runs/<run-id>/` prepared runtime runs with `observation_status: prepared_not_observed`. Executor-choice, prompt-only, runtime-handoff, clarify, and fallback responses remain wrapper/session state.

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -788,6 +788,72 @@ class RouterContentTests(unittest.TestCase):
                 missing = {name: fragments for name, fragments in missing.items() if fragments}
                 self.assertEqual(missing, {})
 
+    def test_ultragoal_guards_settings_only_requests_from_goal_escalation(self) -> None:
+        """A settings-only request (for example a gateway channel mention policy) must not
+        escalate into a durable goal ledger or a coding-executor handoff. The guard lives in
+        catalog data so every generated ulw-goal install carries it.
+        """
+        definitions = {definition.name: definition for definition in installable_skill_definitions()}
+        ultragoal = definitions["ultragoal"]
+
+        guard_lines = [line for line in ultragoal.do_not_use_when if "settings-only" in line]
+        self.assertEqual(
+            len(guard_lines),
+            1,
+            "ultragoal.do_not_use_when must name the settings-only direct-configuration guard exactly once",
+        )
+        guard = guard_lines[0]
+        self.assertIn("configuration", guard)
+        self.assertIn(
+            "apply directly",
+            guard,
+            "guard must keep the direct-applicability qualifier so config work the session cannot apply still escalates",
+        )
+        self.assertIn(
+            "instead of opening a goal ledger",
+            guard,
+            "guard must name the no-goal-ledger outcome, not merely mention configuration",
+        )
+        self.assertIn(
+            "coding handoff",
+            guard,
+            "guard must name the no-coding-handoff outcome",
+        )
+        self.assertNotIn("codex", guard.lower(), "guard wording must stay executor-neutral")
+
+    def test_wrapper_routing_reference_carries_settings_only_delegation_floor(self) -> None:
+        """The Coding Delegation guidance needs a proportionality floor: implementation-shaped
+        never includes settings-only configuration changes a wrapper or Hermes can apply directly.
+        """
+        from omh.skills.render import _router_wrapper_routing_reference
+
+        reference = _router_wrapper_routing_reference()
+        self.assertIn("## Coding Delegation", reference)
+        self.assertIn("settings-only", reference)
+        self.assertIn("direct configuration action", reference)
+        self.assertIn(
+            "apply directly",
+            reference,
+            "floor must keep the direct-applicability qualifier",
+        )
+        self.assertIn(
+            "Do not open a durable goal ledger",
+            reference,
+            "floor must prohibit the goal-ledger escalation outcome",
+        )
+        self.assertIn(
+            "configuration cannot express",
+            reference,
+            "floor must keep the escape hatch: config-shaped requests that need code still escalate",
+        )
+        floor_index = reference.index("settings-only")
+        section_index = reference.index("## Coding Delegation")
+        self.assertGreater(
+            floor_index,
+            section_index,
+            "the settings-only floor must live inside the Coding Delegation guidance",
+        )
+
     def test_shared_common_rail_reference_carries_moved_policy(self) -> None:
         """Replacement gate for the policy issue #634 moved out of every SKILL.md body.
 


### PR DESCRIPTION
## Feature Report

### What Changed

- The generated `ulw-goal` (canonical `ultragoal`) workflow guidance now carries a settings-only misroute guard: a settings-only or single configuration change (a gateway channel policy, a mention rule, one config key) that the wrapper or Hermes can apply directly is applied and verified in place - never turned into a durable goal ledger or a coding handoff.
- The `omh-routing` Coding Delegation reference gains the matching proportionality floor with an explicit escape hatch: escalate to a coding handoff only when the request needs code edits, tests, or multi-step implementation work that configuration cannot express.
- Two contract tests in `tests/test_router_content.py` lock the decision boundaries (direct-applicability qualifier, no-goal-ledger and no-handoff outcomes, escape hatch), added RED-first and mutation-proven: each named weakening of the rule fails the suite.

### Why This Exists

A live Hermes gateway session was asked to change one Slack channel's mention policy ("react only to tags in this channel"). The session escalated that settings-only request into an `ulw-goal` durable-goal run plus a coding-executor delegation - several minutes of goal/ledger/executor overhead for what should have been a direct configuration change. Nothing in the generated guidance named the proportionality boundary, so "implementation-shaped" classification had no floor.

### User / Operator Impact

- Settings-only asks in chat get applied directly and verified, with the result reported - no goal ledger, no executor handoff, no multi-minute delegation detour.
- Requests that look config-shaped but genuinely need code (the config key does not exist) still escalate through the documented escape hatch.
- Every OMH install receives the rule from catalog data on the next skill sync; no per-machine patching.

### How It Works

- `src/skills/catalog_definitions.py`: `ultragoal.do_not_use_when` gains the settings-only guard line (position 2), consistent with the loop skill's "route tiny direct tasks" precedent.
- `src/skills/render.py`: `_router_wrapper_routing_reference()` Coding Delegation section gains the floor paragraph; wording is executor-neutral per AGENTS.md.
- Regenerated artifacts stay byte-exact with the catalog: `skills/ulw-goal/SKILL.md`, `skills/omh-routing/references/wrapper-routing.md`, `docs/WORKFLOWS.md`.

### Files And Contracts Touched

- `src/skills/catalog_definitions.py` (+1), `src/skills/render.py` (+2), `tests/test_router_content.py` (+66 incl. review-hardened assertions), regenerated `docs/WORKFLOWS.md`, `skills/ulw-goal/SKILL.md`, `skills/omh-routing/references/wrapper-routing.md`.

## Validation

- [x] `uv run --group lint ruff check src tests` - All checks passed
- [x] `python3 -m unittest discover -s tests` - Ran 2417 tests, OK (skipped=1 pre-existing conditional)
- [x] `python3 -m compileall src` - clean
- [x] `python3 -m omh.cli docs workflows --check` - ok, tap skills 104/104, stale=[]
- [x] `python3 -m omh.cli harness validate` - ok:true (72 harnesses, 93 skills)
- [x] `python3 -m omh.cli release checklist --json` - emitted
- [x] `python3 -m omh.cli release hermes-smoke` - plan mode, does not touch the current profile
- [x] `omh --help` - exits 0
- [x] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` - exit 0 (temp homes removed afterwards)
- [ ] Workflow-learning review queue smoke: not applicable (no learning contract changed)
- [x] Relevant dry-run: mutation proofs - dropping "can apply directly", "opening a goal ledger or ", or " that configuration cannot express" each turns the suite red
- [x] Manual Hermes/TUI check: not run - change is generated guidance prose + catalog data with no TUI surface; verified through regenerated artifacts and content gates instead

## Risk

- Wording-level guard: the model could still misroute, but the rule now exists on every surface it reads (skill body, router reference, docs), and the escape hatch prevents under-escalation of config-shaped requests that need code.
- Independent review (read-only reviewer lane): initial verdict BLOCKERS (tests too weak to lock the contract), addressed by boundary assertions + mutation proofs, re-review verdict APPROVE.
