### PR TITLE
fix: CJK-aware memory recall and doctor skill_freshness staleness check

### DIFF
--- a/src/coding/coding_delegation.py
+++ b/src/coding/coding_delegation.py
@@ -1393,10 +1393,10 @@ def _local_capability_report_contract(profile: str) -> dict[str, object]:
 
 def _task_prompt_shape_block() -> str:
     return (
-        "Task prompt shape:\\n"
-        "- Shape executor-facing work as: Goal / Do / Don't / Expected result / Test.\\n"
-        "- Keep dispatch prompts in English unless preserving identifiers, paths, errors, quotes, or target-language output.\\n"
-        "- If steering an active turn, send only the corrective delta instead of replaying the full prompt.\\n\\n"
+        "Task prompt shape:\n"
+        "- Shape executor-facing work as: Goal / Do / Don't / Expected result / Test.\n"
+        "- Keep dispatch prompts in English unless preserving identifiers, paths, errors, quotes, or target-language output.\n"
+        "- If steering an active turn, send only the corrective delta instead of replaying the full prompt.\n\n"
     )
 
 

--- a/src/commands/setup.py
+++ b/src/commands/setup.py
@@ -733,7 +733,7 @@ def _doctor_operator_summary(checks: list[object]) -> dict[str, object]:
         "warnings": warnings,
         "groups": [
             _doctor_group("command", check_dicts, ("command_path",)),
-            _doctor_group("managed_skills", check_dicts, ("manifest", "manifest_skills_dir", "local_modifications", "skills_dir", "skill:")),
+            _doctor_group("managed_skills", check_dicts, ("manifest", "manifest_skills_dir", "local_modifications", "skill_freshness", "skills_dir", "skill:")),
             _doctor_group("runtime", check_dicts, ("runtime_artifacts", "workflow_state", "runtime_state")),
             _doctor_group("hermes_registration", check_dicts, ("hermes_config", "external_dir", "skill_shadowing", "runtime_context")),
             _doctor_group("targets", check_dicts, ("target_registry", "target_topology")),

--- a/src/maintenance/doctor.py
+++ b/src/maintenance/doctor.py
@@ -13,7 +13,7 @@ from ..config_adapter import (
     plugin_is_enabled,
     read_config,
 )
-from ..hashutil import sha256_file
+from ..hashutil import sha256_file, sha256_text
 from ..local_store import can_write_dir
 from ..manifest import local_modifications, read_manifest
 from ..paths import OmhPaths
@@ -26,7 +26,8 @@ from ..plugin_observations import (
 )
 from ..plugin_pack import PLUGIN_NAME, inspect_plugin_bundle
 from ..runtime.artifacts import read_state, read_state_error
-from ..skill_pack import CORE_SKILLS
+from ..skill_pack import CORE_SKILLS, builtin_skill_templates
+from ..version import __version__
 from ..targets import read_target_registry_result, summarize_target_registry
 from ..workflow_state import list_workflow_states
 
@@ -93,6 +94,7 @@ def run_doctor(paths: OmhPaths) -> list[Check]:
                 "managed files match manifest" if not modified else f"changed managed files: {', '.join(modified)}",
             )
         )
+        checks.append(_skill_freshness_check(paths, manifest))
     checks.append(Check("skills_dir", paths.skills_dir.exists(), f"{paths.skills_dir}"))
     runtime_writable = can_write_dir(paths.runtime_dir, probe_name=".doctor-write-test")
     checks.append(Check("runtime_artifacts", runtime_writable, f"{paths.runtime_dir} writable"))
@@ -554,6 +556,63 @@ def _plugin_bridge_message(plugin: dict) -> str:
             details.append(f"missing hooks={missing_hooks}")
         return "plugin register smoke is incomplete: " + "; ".join(details)
     return "managed plugin bridge is installed but did not pass local import/register smoke"
+
+
+def _skill_freshness_check(paths: OmhPaths, manifest: dict) -> Check:
+    """Detect installed skills whose content an older OMH release wrote.
+
+    `local_modifications` compares the skills directory against the manifest
+    recorded at install time, so it stays green when the omh package moves on
+    and the installed guidance quietly ages: Hermes keeps executing skill
+    text from a version the operator no longer runs. This check compares the
+    untouched installed files against what the running package would render
+    today and points a mismatch at `omh update`. Locally edited files are
+    excluded here because `local_modifications` already owns that report.
+    """
+    source = str(manifest.get("source", "builtin"))
+    if source != "builtin":
+        return Check(
+            "skill_freshness",
+            True,
+            f"skills installed from local source {source!r}; freshness vs the packaged catalog is not comparable",
+        )
+    manifest_sha_by_rel = {
+        str(record.get("path", "")): str(record.get("sha256", ""))
+        for record in manifest.get("skills", [])
+        if isinstance(record, dict)
+    }
+    stale: list[str] = []
+    for template in builtin_skill_templates():
+        rel = f"{omh_skill_display_name(template.name)}/SKILL.md"
+        if rel not in manifest_sha_by_rel:
+            continue
+        path = paths.skills_dir / rel
+        if not path.is_file():
+            continue
+        installed_sha = sha256_file(path)
+        if installed_sha == sha256_text(template.content):
+            continue
+        if installed_sha != manifest_sha_by_rel[rel]:
+            continue
+        stale.append(template.name)
+    if not stale:
+        return Check(
+            "skill_freshness",
+            True,
+            f"installed managed skills match the omh {__version__} catalog",
+        )
+    installed_version = str(manifest.get("version", "unknown"))
+    listed = ", ".join(sorted(stale)[:5]) + (", ..." if len(stale) > 5 else "")
+    return Check(
+        "skill_freshness",
+        False,
+        (
+            f"{len(stale)} managed skill(s) still carry content installed by omh {installed_version}, "
+            f"but this omh is {__version__}: {listed}"
+        ),
+        remediation="Run `omh update` to regenerate the managed skills from the current package catalog.",
+        next_action="Run `omh update`, then `omh doctor` again.",
+    )
 
 
 def _plugin_bridge_remediation(plugin: dict) -> str:

--- a/src/runtime/records.py
+++ b/src/runtime/records.py
@@ -1553,12 +1553,39 @@ def _compact_memory_recall_pack(value: Any) -> dict[str, Any]:
             "recall_enabled": bool(policy.get("recall_enabled", False)),
         },
         "scope": _compact_context_scope(value.get("scope", {})),
-        "included_records": [],
+        # Included records survive compaction: they are already redacted,
+        # bounded summaries (<=500 chars each, budget-capped), and the
+        # lifecycle-backed executor path re-serves the persisted record, so
+        # dropping them here made codex delegation recall-blind while
+        # prompt-only executors kept the summaries (executor parity).
+        "included_records": [
+            _compact_memory_recall_item(item)
+            for item in (value.get("included_records") if isinstance(value.get("included_records"), list) else [])
+            if isinstance(item, dict)
+        ],
         "excluded_records": [],
         "record_count": len(value.get("included_records", [])) if isinstance(value.get("included_records"), list) else 0,
         "truncated": bool(value.get("truncated", False)),
         "redaction_policy": str(value.get("redaction_policy", "")),
         "claim_boundary": str(value.get("claim_boundary", "")),
+    }
+
+
+def _compact_memory_recall_item(item: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "record_id": str(item.get("record_id", "")),
+        "record_type": str(item.get("record_type", "")),
+        "summary": str(item.get("summary", ""))[:500],
+        "scope": _compact_context_scope(item.get("scope", {})),
+        "tags": [str(tag) for tag in item.get("tags", []) if str(tag)][:12],
+        "source": str(item.get("source", "")),
+        "approved_at": str(item.get("approved_at", "")),
+        "staleness": {
+            key: str(item.get("staleness", {}).get(key, ""))
+            for key in ("state", "stale_after", "expires_at")
+            if isinstance(item.get("staleness"), dict) and key in item.get("staleness", {})
+        },
+        "score": int(item.get("score", 0) or 0),
     }
 
 

--- a/src/workflows/memory.py
+++ b/src/workflows/memory.py
@@ -85,6 +85,11 @@ MEMORY_ACTION_IDS = (
     "cancel",
 )
 _SAFE_REF = re.compile(r"^[A-Za-z0-9_.:-]{1,120}$")
+# Tags are recall-scoring keys, not filesystem refs, so they may carry CJK
+# words. Running them through the ASCII-only _SAFE_REF silently dropped every
+# Korean/Japanese/Chinese tag at capture time, which meant tag scoring could
+# never fire for records written by CJK-speaking projects.
+_SAFE_TAG = re.compile(r"^[\w.:/-]{1,120}$", re.UNICODE)
 _PROMPTISH_KEYS = {"message", "prompt", "raw", "text", "body", "content", "prompt_template"}
 _PROJECT_MEMORY_RECORD_KEYS = {
     "schema_version",
@@ -1166,6 +1171,13 @@ def _memory_recall_score(record: dict[str, Any], query: str) -> int:
     if not query.strip():
         return 1
     query_tokens = _memory_tokens(query)
+    if not query_tokens:
+        # The query carries no indexable tokens at all (emoji-only, an
+        # unsupported script, or only sub-length words). Scoring it as zero
+        # overlap used to exclude every record as no_query_overlap and hand
+        # the executor an empty pack; fall back to unqueried recall so the
+        # budget ladder still surfaces approved records.
+        return 1
     record_tokens = _memory_tokens(
         " ".join(
             [
@@ -1180,8 +1192,27 @@ def _memory_recall_score(record: dict[str, Any], query: str) -> int:
     return len(overlap) * 10 + len(tag_overlap) * 5
 
 
+_MEMORY_ASCII_TOKEN = re.compile(r"[a-z0-9_/-]{3,}")
+_MEMORY_CJK_RUN = re.compile(r"[\u3040-\u30ff\u3400-\u4dbf\u4e00-\u9fff\uac00-\ud7a3]+")
+
+
 def _memory_tokens(value: str) -> set[str]:
-    return {token for token in re.split(r"[^a-z0-9_/-]+", value.lower()) if len(token) >= 3}
+    """Index tokens for recall scoring, covering ASCII and CJK text.
+
+    ASCII words keep the >=3 length floor. CJK runs are indexed as the whole
+    run plus its character bigrams: Korean particles glue to the noun
+    ("배포는"), so whole-word overlap alone would miss "배포" in a query.
+    The previous ASCII-only split tokenized any CJK query to the empty set,
+    which excluded every record as no_query_overlap and silently emptied
+    recall packs for projects that chat in Korean, Japanese, or Chinese.
+    """
+    lowered = value.lower()
+    tokens = set(_MEMORY_ASCII_TOKEN.findall(lowered))
+    for run in _MEMORY_CJK_RUN.findall(lowered):
+        if len(run) >= 2:
+            tokens.add(run)
+        tokens.update(run[index : index + 2] for index in range(len(run) - 1))
+    return tokens
 
 
 def _record_scope_matches(record: dict[str, Any], *, scope_kind: str | None, scope_ref: str | None) -> bool:
@@ -1320,7 +1351,7 @@ def _normalize_tags(values: Any) -> list[str]:
     seen: set[str] = set()
     for value in values:
         tag = str(value).strip().lower()
-        if not tag or not _SAFE_REF.match(tag):
+        if not tag or not _SAFE_TAG.match(tag):
             continue
         if tag not in seen:
             tags.append(tag)

--- a/src/workflows/memory.py
+++ b/src/workflows/memory.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 import os
 import re
+import unicodedata
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
@@ -1206,7 +1207,7 @@ def _memory_tokens(value: str) -> set[str]:
     which excluded every record as no_query_overlap and silently emptied
     recall packs for projects that chat in Korean, Japanese, or Chinese.
     """
-    lowered = value.lower()
+    lowered = unicodedata.normalize("NFC", value).lower()
     tokens = set(_MEMORY_ASCII_TOKEN.findall(lowered))
     for run in _MEMORY_CJK_RUN.findall(lowered):
         if len(run) >= 2:
@@ -1350,7 +1351,7 @@ def _normalize_tags(values: Any) -> list[str]:
     tags: list[str] = []
     seen: set[str] = set()
     for value in values:
-        tag = str(value).strip().lower()
+        tag = unicodedata.normalize("NFC", str(value)).strip().lower()
         if not tag or not _SAFE_TAG.match(tag):
             continue
         if tag not in seen:
@@ -1395,7 +1396,11 @@ def _read_memory_json_files(paths: OmhPaths, directory: Path) -> list[dict[str, 
         if path.is_symlink() or not path.is_file():
             continue
         _assert_under_memory_root(paths, path)
-        data = read_json_object(path)
+        # A corrupt store file must cost only itself, not the whole read: a
+        # crash mid-write or disk fault used to make every recall, review,
+        # and status call raise on the first unreadable file until someone
+        # hand-deleted it. Retirement already scans this way.
+        data, _error = read_json_object_result(path)
         if isinstance(data, dict):
             items.append(data)
     return items

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7657,6 +7657,11 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
         self.assertIn("proceed as plain Codex", handoff["prompt_template"])
         self.assertIn("Do not claim OMH observed local capability availability", handoff["prompt_template"])
         self.assertIn("Goal / Do / Don't / Expected result / Test", handoff["prompt_template"])
+        # The task-prompt-shape block once carried literal backslash-n escapes
+        # instead of newlines, so every prepared executor prompt rendered that
+        # section as one garbled line.
+        self.assertIn("Task prompt shape:\n- Shape executor-facing work", handoff["prompt_template"])
+        self.assertNotIn("\\n", handoff["prompt_template"])
         self.assertIn("local_capabilities_used", handoff["prompt_template"])
         capability_report = handoff["local_capability_report_contract"]
         self.assertEqual(capability_report["schema_version"], "executor_local_capability_report_contract/v1")

--- a/tests/test_installer_skill_profile.py
+++ b/tests/test_installer_skill_profile.py
@@ -335,6 +335,85 @@ class InstallerSkillProfileTests(unittest.TestCase):
             self.assertIn("never delete installed skills", state["non_destructive_default"])
 
 
+class SkillFreshnessCheckTests(unittest.TestCase):
+    """`skill_freshness` must catch installs an older OMH release wrote.
+
+    `local_modifications` compares installed files against the manifest
+    recorded at install time, so an operator who upgrades the omh package but
+    never reruns `omh update` keeps serving Hermes skill guidance from the old
+    release with a fully green doctor. An observed session ran a cached
+    old-version loop skill for a whole task because nothing surfaced the gap.
+    """
+
+    def _check(self, paths, name: str):
+        return next((check for check in run_doctor(paths) if check.name == name), None)
+
+    def _age_one_skill(self, paths) -> str:
+        """Rewrite one installed skill as an older release would have left it.
+
+        The file content and the manifest sha agree (so it is not a local
+        modification), but both differ from what the current package renders.
+        Returns the canonical skill name.
+        """
+        manifest = read_manifest(paths.manifest_path)
+        record = manifest["skills"][0]
+        path = paths.skills_dir / record["path"]
+        path.write_text("# Old release content\n", encoding="utf-8")
+        record["sha256"] = sha256_file(path)
+        manifest["version"] = "0.0.1"
+        write_manifest(paths.manifest_path, manifest)
+        return record["name"]
+
+    def test_fresh_install_passes_skill_freshness(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            install_skill_pack(paths)
+            check = self._check(paths, "skill_freshness")
+            self.assertIsNotNone(check)
+            self.assertTrue(check.ok, check)
+
+    def test_outdated_install_fails_skill_freshness_and_points_at_update(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            install_skill_pack(paths)
+            aged = self._age_one_skill(paths)
+
+            freshness = self._check(paths, "skill_freshness")
+            self.assertIsNotNone(freshness)
+            self.assertFalse(freshness.ok)
+            self.assertIn(aged, freshness.message)
+            self.assertIn("0.0.1", freshness.message)
+            self.assertIn("omh update", freshness.next_action)
+
+            # Ownership boundary: the aged file matches its manifest record,
+            # so it is stale, not a local modification.
+            local = self._check(paths, "local_modifications")
+            self.assertTrue(local.ok, local)
+
+    def test_locally_edited_skill_is_not_reported_stale(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            install_skill_pack(paths)
+            manifest = read_manifest(paths.manifest_path)
+            path = paths.skills_dir / manifest["skills"][0]["path"]
+            path.write_text("# Local operator edit\n", encoding="utf-8")
+
+            self.assertTrue(self._check(paths, "skill_freshness").ok)
+            self.assertFalse(self._check(paths, "local_modifications").ok)
+
+    def test_local_source_install_is_not_compared(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            install_skill_pack(paths)
+            manifest = read_manifest(paths.manifest_path)
+            manifest["source"] = str(Path(tmp) / "custom-skills")
+            write_manifest(paths.manifest_path, manifest)
+
+            check = self._check(paths, "skill_freshness")
+            self.assertTrue(check.ok)
+            self.assertIn("not comparable", check.message)
+
+
 class SkillProfileReconcileTests(unittest.TestCase):
     def _full_only_names(self) -> set[str]:
         return {template.name for template in builtin_skill_templates()} - set(CORE_PROFILE_SKILLS)

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -315,6 +315,53 @@ class MemoryContractTests(unittest.TestCase):
             )
             self.assertEqual(validate_project_memory_recall_pack(by_chars), [])
 
+    def test_project_memory_recall_matches_cjk_queries_and_keeps_cjk_tags(self) -> None:
+        """Korean chat must be able to reach approved records.
+
+        The old ASCII-only tokenizer reduced every CJK query to zero tokens, so
+        each record was excluded as no_query_overlap and Korean-speaking
+        sessions always received an empty recall pack: long-term project memory
+        looked like it did not exist. CJK tags were also dropped at capture.
+        """
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            write_setup_profile(paths, memory_mode="auto-safe")
+            captured = capture_project_memory_candidate(
+                paths,
+                "배포는 staging 환경을 먼저 거친다",
+                record_type="procedure",
+                tags=["배포", "release"],
+            )
+            self.assertIn("배포", captured["candidate"]["tags"])
+
+            # Particle-inflected query: "배포" must match "배포는" in the summary.
+            recall = build_project_memory_recall_pack(paths, "배포 정책 알려줘")
+            self.assertEqual(recall["record_count"], 1)
+            self.assertGreater(recall["included_records"][0]["score"], 0)
+            self.assertEqual(validate_project_memory_recall_pack(recall), [])
+
+            # Overroute guard: an unrelated Korean query still recalls nothing.
+            miss = build_project_memory_recall_pack(paths, "결제 모듈 장애")
+            self.assertEqual(miss["record_count"], 0)
+            self.assertEqual(miss["excluded_records"][0]["reason"], "no_query_overlap")
+
+    def test_project_memory_recall_query_without_indexable_tokens_falls_back(self) -> None:
+        """A query with no indexable tokens must not silently empty the pack."""
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            write_setup_profile(paths, memory_mode="auto-safe")
+            capture_project_memory_candidate(
+                paths,
+                "Run release tests before merge",
+                record_type="procedure",
+                tags=["release"],
+            )
+
+            pack = build_project_memory_recall_pack(paths, "\U0001f44d\U0001f64f")
+            self.assertTrue(pack["task_ref"]["query_supplied"])
+            self.assertEqual(pack["record_count"], 1)
+            self.assertEqual(validate_project_memory_recall_pack(pack), [])
+
     def test_project_memory_recall_pack_feeds_coding_handoff_when_enabled(self) -> None:
         with TemporaryDirectory() as tmp:
             paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -345,6 +345,43 @@ class MemoryContractTests(unittest.TestCase):
             self.assertEqual(miss["record_count"], 0)
             self.assertEqual(miss["excluded_records"][0]["reason"], "no_query_overlap")
 
+    def test_project_memory_recall_treats_nfd_and_nfc_queries_alike(self) -> None:
+        """macOS pipelines hand over decomposed Hangul; ranking must not differ."""
+        import unicodedata
+
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            write_setup_profile(paths, memory_mode="auto-safe")
+            capture_project_memory_candidate(
+                paths, "배포는 staging 환경을 먼저 거친다", record_type="procedure", tags=["배포"]
+            )
+            nfc = build_project_memory_recall_pack(paths, "배포 정책")
+            nfd = build_project_memory_recall_pack(paths, unicodedata.normalize("NFD", "배포 정책"))
+            self.assertEqual(nfc["record_count"], 1)
+            self.assertEqual(
+                [item["score"] for item in nfc["included_records"]],
+                [item["score"] for item in nfd["included_records"]],
+            )
+            self.assertGreater(nfd["included_records"][0]["score"], 1)
+
+    def test_project_memory_recall_skips_corrupt_store_files(self) -> None:
+        """A crash-truncated record file must cost only itself, not all recall."""
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            write_setup_profile(paths, memory_mode="auto-safe")
+            capture_project_memory_candidate(
+                paths, "배포는 staging 환경을 먼저 거친다", record_type="procedure", tags=["배포"]
+            )
+            records_dir = paths.memory_dir / "records"
+            (records_dir / "zz-truncated.json").write_text('{"schema_version": "project_mem', encoding="utf-8")
+            (records_dir / "zz-not-json.json").write_text("{not json", encoding="utf-8")
+
+            pack = build_project_memory_recall_pack(paths, "배포 정책")
+            self.assertEqual(pack["record_count"], 1)
+            self.assertEqual(validate_project_memory_recall_pack(pack), [])
+            status = build_project_memory_status(paths)
+            self.assertEqual(status["counts"]["approved_records"], 1)
+
     def test_project_memory_recall_query_without_indexable_tokens_falls_back(self) -> None:
         """A query with no indexable tokens must not silently empty the pack."""
         with TemporaryDirectory() as tmp:
@@ -387,9 +424,17 @@ class MemoryContractTests(unittest.TestCase):
             self.assertEqual(payload["executor_handoff"]["memory_recall_pack"]["record_count"], 1)
             record_handoff = lifecycle["coding_delegation"]["executor_handoff"]
             self.assertIn("memory_recall_pack", record_handoff)
-            self.assertEqual(record_handoff["memory_recall_pack"]["record_count"], 1)
-            self.assertEqual(record_handoff["memory_recall_pack"]["included_records"], [])
-            self.assertIn("not execution", record_handoff["memory_recall_pack"]["claim_boundary"])
+            persisted_pack = record_handoff["memory_recall_pack"]
+            self.assertEqual(persisted_pack["record_count"], 1)
+            # The persisted lifecycle record is what the wrapper re-serves to
+            # the executor, so the redacted summaries must survive compaction:
+            # dropping them made lifecycle-backed delegation recall-blind
+            # while prompt-only executors kept the summaries.
+            self.assertEqual(len(persisted_pack["included_records"]), 1)
+            self.assertIn("setup diagnostics", persisted_pack["included_records"][0]["summary"])
+            self.assertEqual(persisted_pack["excluded_records"], [])
+            self.assertEqual(validate_project_memory_recall_pack(persisted_pack), [])
+            self.assertIn("not execution", persisted_pack["claim_boundary"])
 
     def test_inspection_separates_sources_and_detects_stale_conflicts(self) -> None:
         with TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Feature Report

### What Changed

- Project-memory recall now understands CJK text. `_memory_tokens` indexes ASCII words (>=3 chars) plus CJK runs and their character bigrams, so Korean/Japanese/Chinese queries and record summaries can overlap ("배포" matches "배포는"). A query with no indexable tokens at all (emoji-only, unsupported script) now falls back to unqueried recall instead of excluding every record as `no_query_overlap`.
- CJK tags survive capture: tag normalization moved from the ASCII-only `_SAFE_REF` to a Unicode-aware `_SAFE_TAG`, so tag-based recall scoring can fire for records tagged in Korean.
- `omh doctor` gained a `skill_freshness` check that detects installed managed skills whose content an **older OMH release** wrote: files that still match their install-time manifest sha but no longer match what the current package renders. The check names the stale skills, the installing version vs the running version, and points at `omh update`. Local edits stay owned by `local_modifications`; local-source installs are reported as not comparable.

### Why This Exists

An observed Hermes session (2026-07-29, document-harness project-link work) showed two failures at once:

1. The wrapper behaved like a cached old-version loop skill for the whole task — the operator had a newer omh package, but the installed skill files were from an earlier release and `omh doctor` reported fully green, because `local_modifications` only compares against the manifest recorded at install time.
2. Long-term memory looked absent: the session chatted in Korean, and the ASCII-only recall tokenizer reduced every Korean query to zero tokens. Every approved record was excluded as `no_query_overlap`, `memory_recall_pack_for_handoff` returned `None`, and handoffs carried no recall pack — so the agent leaned only on Hermes' own compacted memory files.

### User / Operator Impact

- Korean/Japanese/Chinese-speaking projects now actually receive project-memory recall packs in chat-prepared handoffs, `omh memory recall`, and coding delegation payloads — for every executor owner (codex, claude-code, hermes, generic).
- `omh doctor` now catches the "upgraded the package, forgot `omh update`, Hermes keeps executing last release's skill guidance" failure before it costs a session.

### How It Works

- `src/workflows/memory.py`: `_MEMORY_ASCII_TOKEN` + `_MEMORY_CJK_RUN` regexes replace the single ASCII split; CJK runs contribute the run plus bigrams (particle-agglutination tolerance without a morphological analyzer). `_memory_recall_score` returns the unqueried baseline when the query yields no tokens. `_normalize_tags` validates against `_SAFE_TAG` (`[\w.:/-]`, Unicode) instead of `_SAFE_REF`; record/candidate ids still use `_SAFE_REF`.
- `src/maintenance/doctor.py`: `_skill_freshness_check` walks `builtin_skill_templates()`, and for each installed, manifest-recorded SKILL.md compares `sha256_file(installed)` against `sha256_text(template.content)`. A mismatch counts as stale only when the installed file still matches its manifest sha (i.e. untouched since install); otherwise `local_modifications` owns the report. Non-`builtin` manifest sources are skipped as not comparable.
- `src/commands/setup.py`: `skill_freshness` joined the `managed_skills` doctor group.

### Files And Contracts Touched

- `src/workflows/memory.py` — recall scoring/tokenization, tag normalization (recall-pack schema unchanged).
- `src/maintenance/doctor.py` — new `skill_freshness` check (blocking, with `omh update` remediation/next action).
- `src/commands/setup.py` — doctor group membership.
- `tests/test_memory.py` — CJK query/tag recall contract + overroute guard (unrelated Korean query still recalls nothing) + zero-token fallback contract.
- `tests/test_installer_skill_profile.py` — `SkillFreshnessCheckTests`: fresh install passes, aged install fails with `omh update` next action, local edit is not double-reported, local-source install not compared.

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests` (full suite)
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [ ] `python3 -m omh.cli harness validate` (not run; no harness contract touched)
- [ ] `python3 -m omh.cli release checklist --json` (not run; no release surface touched)
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `git diff --check`
- [ ] Manual Hermes/TUI check: not run — recall-pack and doctor behavior are locked by unit contracts; no chat-surface copy changed.

## Risk

- Recall recall-precision: CJK bigrams are a coarse matcher; an unrelated query sharing one bigram with a record could recall it. The existing score-ranked budget ladder (limit/max_chars) bounds the blast radius, and the new overroute-guard test locks that unrelated Korean queries still miss.
- `skill_freshness` is a blocking check, so operators with genuinely aged installs will see `omh doctor` exit non-zero until they run `omh update` — that is the intended catch, matching the existing `plugin_bundle_stale` posture.

## Compatibility / Rollout

- No schema version changes; recall packs keep `project_memory_recall_pack/v1`. Existing ASCII-only stores and queries score identically to before (ASCII token rule unchanged).
- Previously-dropped CJK tags reappear only on new captures; existing records are untouched.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`) — none beyond normal release flow.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed.
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap — live smoke not run for this change.

## Follow-Up

- Korean morphological matching beyond bigrams (e.g. shared token helpers with `src/routing/`) if recall precision needs tightening on real stores.

---

## Hands-On QA (observed on the real CLI, temp homes)

- **Korean recall end-to-end**: `omh memory capture "배포는 staging 환경을 먼저 거친다" --tag 배포` → approve → `omh memory recall "배포 정책 알려줘"` returns the record (score 15, tag kept); unrelated Korean query `"결제 모듈 장애"` still excludes (`no_query_overlap`); emoji-only query falls back and still returns records.
- **Wrapper handoff carries recall**: `chat session start → accept-plan → select-executor claude-code → prepare-handoff` with a Korean task attaches `memory_recall_pack` containing the Korean record, and `prompt_handoff_prompt` carries the task text.
- **Doctor freshness cycle**: fresh install → `skill_freshness` ok; aging one skill as an older release (`omh 0.0.1`) → `omh doctor` exits 1, names the skill, next action `omh update`; running `omh update` heals it back to ok. `local_modifications` correctly stays ok for the aged file and owns genuinely edited files.
- **Prompt rendering fix (second commit)**: live handoff QA exposed literal `\n` escapes in the "Task prompt shape" block of every executor prompt; fixed in `_task_prompt_shape_block` and locked with rendered-output assertions in `test_cli.py`.
- **Session continuation**: same thread key resumes the same wrapper session (`resumed: true`, status preserved). Known gap (not changed here): calling `prepare-handoff` again with a *new* message on a `prompt_handoff_prepared` session exits 0 but re-serves the stored handoff without the new message — silent drop; follow-up work currently needs a new session/thread event. Flagged for a separate design decision.
- **Model observability**: `omh coding model-route --executor codex --model gpt-5-codex --effort xhigh --json` reports `selected_model`/`selected_reasoning_effort` with the metadata-only claim boundary; `model-inventory` correctly reports empty on a host without local CLI configs.

---

## Deep Soak QA (second pass, all observed)

26-check soak harness across scale, time, contention, corruption, and executor parity — three real bugs found and fixed in this PR:

| Axis | Result |
| --- | --- |
| Determinism: 300-record store, same query x50 | byte-identical packs; equal-score ties keep one sorted order across 20 runs |
| Adversarial queries (NFD Hangul, NUL/ANSI bytes, 4k-word query, RTL+CJK mix, fullwidth, SQL/path-traversal strings, emoji) x6 repeats | stable + schema-valid every run |
| Time: 10-point sweep over 10 years | fresh→stale at day 30, →expired at day 90 exactly; include_stale recovers; post-retirement recall deterministic |
| Contention: 16 threads x (3 captures + 5 recalls) | zero errors, 48/48 records intact, unique ids |
| Corruption: truncated/garbage/wrong-schema/symlink record files | **bug found+fixed**: one corrupt file used to raise through every recall/status; readers now skip it and serve the rest |
| NFD queries | **bug found+fixed**: decomposed Hangul lost ranking; NFC normalization added to tokens and tags |
| Executor parity: 25 session cycles alternating codex/claude-code/generic | **bug found+fixed**: `_compact_memory_recall_pack` stripped summaries from persisted lifecycle records, so codex delegation was recall-blind (`record_count: 1`, `included_records: []`); compaction now keeps the bounded redacted summaries |
| Injection/redaction | credential-like capture blocked from auto-approve; blocked secrets never reach packs; injected summaries ride only in the structured pack, never concatenated into prompt text |
| Doctor aging | 5 aged + 2 edited skills attributed to the right checks; force-update x3 idempotent shas; doctor green after |

Full suite 2439 tests OK (1 skipped) after the soak fixes.
