### PR TITLE
fix: reprepare wrapper handoffs for follow-up messages

### DIFF
--- a/src/wrapper/lifecycle.py
+++ b/src/wrapper/lifecycle.py
@@ -43,6 +43,9 @@ def start_codex_delegation_lifecycle(
     include_message: bool = False,
     context_pack: dict[str, object] | None = None,
     memory_recall_pack: dict[str, object] | None = None,
+    preferred_workflow: str | None = None,
+    preferred_workflow_score: int | None = None,
+    force_coding_handoff: bool = False,
 ) -> dict[str, object]:
     if memory_recall_pack is None:
         memory_recall_pack = memory_recall_pack_for_handoff(paths, message, executor_target="codex")
@@ -55,6 +58,9 @@ def start_codex_delegation_lifecycle(
         executor_target="codex",
         context_pack=context_pack,
         memory_recall_pack=memory_recall_pack,
+        preferred_workflow=preferred_workflow,
+        preferred_workflow_score=preferred_workflow_score,
+        force_coding_handoff=force_coding_handoff,
         capability_snapshot_directory=paths.omh_home / "coding" / "executor-capability-snapshots",
     )
     delegation = payload.get("delegation")

--- a/src/wrapper/sessions.py
+++ b/src/wrapper/sessions.py
@@ -236,39 +236,55 @@ def prepare_wrapper_session_handoff(
     session = _existing_session(paths, session_id)
     if session["status"] == "cancelled":
         raise WrapperSessionError("cannot prepare a handoff for a cancelled wrapper session")
+    # A prepared session re-serves its handoff only for a retry of the SAME
+    # message (or an empty show call). A different non-empty message is a
+    # follow-up instruction; silently re-serving the old handoff dropped it
+    # with exit 0 and no event (issue #754), so it re-prepares instead.
+    follow_up_sha = hashlib.sha256(extract_message_text(event_or_message).encode("utf-8")).hexdigest()
+    follow_up_message = bool(extract_message_text(event_or_message))
+    follow_up = False
     if session.get("current_run_id"):
         if session["status"] != "handoff_prepared":
             raise WrapperSessionError("wrapper session current_run_id is only valid after handoff preparation")
         run_id = str(session["current_run_id"])
         if _run_owned_by_other_session(paths, run_id, str(session["session_id"])):
             raise WrapperSessionError("wrapper session current_run_id is already linked to another wrapper session")
-        _ensure_handoff_prepared_event(paths, session, run_id, recovered=True)
-        return {
-            "schema_version": WRAPPER_SESSION_RESULT_SCHEMA_VERSION,
-            "session": session,
-            "status": build_wrapper_session_status(paths, session_id),
-            "handoff": report_codex_delegation_lifecycle(paths, run_id),
-        }
-    if session["status"] == "prompt_handoff_prepared":
-        return {
-            "schema_version": WRAPPER_SESSION_RESULT_SCHEMA_VERSION,
-            "session": session,
-            "status": build_wrapper_session_status(paths, session_id),
-            "handoff": {"prompt_handoff": session.get("prompt_handoff", {})},
-        }
-    if session["status"] == "runtime_handoff_prepared":
-        return {
-            "schema_version": WRAPPER_SESSION_RESULT_SCHEMA_VERSION,
-            "session": session,
-            "status": build_wrapper_session_status(paths, session_id),
-            "handoff": _runtime_session_handoff_envelope(session.get("runtime_handoff", {})),
-        }
+        if not follow_up_message or _prepared_run_message_sha(paths, run_id) == follow_up_sha:
+            _ensure_handoff_prepared_event(paths, session, run_id, recovered=True)
+            return {
+                "schema_version": WRAPPER_SESSION_RESULT_SCHEMA_VERSION,
+                "session": session,
+                "status": build_wrapper_session_status(paths, session_id),
+                "handoff": report_codex_delegation_lifecycle(paths, run_id),
+            }
+        follow_up = True
+    elif session["status"] == "prompt_handoff_prepared":
+        if not follow_up_message or _latest_prepared_message_sha(_session_dir(paths, session_id), "prompt_handoff_prepared") == follow_up_sha:
+            return {
+                "schema_version": WRAPPER_SESSION_RESULT_SCHEMA_VERSION,
+                "session": session,
+                "status": build_wrapper_session_status(paths, session_id),
+                "handoff": {"prompt_handoff": session.get("prompt_handoff", {})},
+            }
+        follow_up = True
+    elif session["status"] == "runtime_handoff_prepared":
+        if not follow_up_message or _latest_prepared_message_sha(_session_dir(paths, session_id), "runtime_handoff_prepared") == follow_up_sha:
+            return {
+                "schema_version": WRAPPER_SESSION_RESULT_SCHEMA_VERSION,
+                "session": session,
+                "status": build_wrapper_session_status(paths, session_id),
+                "handoff": _runtime_session_handoff_envelope(session.get("runtime_handoff", {})),
+            }
+        follow_up = True
     if session["status"] == "executor_choice_required" and not executor_target:
         raise WrapperSessionError("wrapper session requires executor selection before preparing a handoff")
-    if executor_target:
+    if executor_target and follow_up:
+        if executor_target != str(session.get("selected_executor_profile") or ""):
+            raise WrapperSessionError("a follow-up handoff keeps the selected executor; start a new session to switch executors")
+    elif executor_target:
         select_wrapper_session_executor(paths, session_id, executor_target)
         session = _existing_session(paths, session_id)
-    if session["status"] not in {"plan_accepted", "executor_selected"}:
+    if not follow_up and session["status"] not in {"plan_accepted", "executor_selected"}:
         raise WrapperSessionError("wrapper session plan must be accepted before preparing a handoff")
     selected_executor = str(session.get("selected_executor_profile") or "codex")
     if session.get("work_owner_mode") == "runtime_handoff" and selected_executor:
@@ -281,6 +297,7 @@ def prepare_wrapper_session_handoff(
             source_metadata=source_metadata,
             executor_target=selected_executor,
             context_pack=context_pack,
+            follow_up=follow_up,
         )
     if selected_executor and selected_executor != "codex":
         return _prepare_prompt_only_session_handoff(
@@ -292,6 +309,7 @@ def prepare_wrapper_session_handoff(
             source_metadata=source_metadata,
             executor_target=selected_executor,
             context_pack=context_pack,
+            follow_up=follow_up,
         )
     message = extract_message_text(event_or_message)
     metadata = _source_metadata(event_or_message)
@@ -310,6 +328,7 @@ def prepare_wrapper_session_handoff(
             "data": {"message_sha256": message_sha256, "message_length": len(message)},
         },
     )
+    follow_up_workflow, follow_up_score = _session_route_preference(session) if follow_up else (None, None)
     lifecycle = start_codex_delegation_lifecycle(
         paths,
         message,
@@ -318,12 +337,34 @@ def prepare_wrapper_session_handoff(
         limit=limit,
         include_message=include_message,
         context_pack=context_pack,
+        preferred_workflow=follow_up_workflow,
+        preferred_workflow_score=follow_up_score,
+        force_coding_handoff=follow_up,
     )
     run_id = str(lifecycle["run"]["run_id"])
     linked = _link_prepared_handoff_run(paths, session, run_id, recovered=False)
     lifecycle["status"] = report_codex_delegation_lifecycle(paths, run_id)
     linked["handoff"] = lifecycle
     return linked
+
+
+def _session_route_preference(session: dict[str, Any]) -> tuple[str | None, int | None]:
+    """The already-routed workflow a follow-up message should inherit.
+
+    A follow-up is a delta on an accepted coding plan ("add tests too"), so
+    re-routing its text from scratch either guesses a different workflow or
+    fails to produce a handoff at all; the session's stored route is the
+    decision the user already accepted.
+    """
+    route = session.get("route", {}) if isinstance(session.get("route"), dict) else {}
+    workflow = str(route.get("selected_skill", "") or "")
+    if not workflow:
+        return None, None
+    try:
+        score = int(route.get("score", 0) or 0)
+    except (TypeError, ValueError):
+        score = 0
+    return workflow, score if score > 0 else None
 
 
 def _prepare_prompt_only_session_handoff(
@@ -336,6 +377,7 @@ def _prepare_prompt_only_session_handoff(
     source_metadata: dict[str, str] | None,
     executor_target: str,
     context_pack: dict[str, object] | None,
+    follow_up: bool = False,
 ) -> dict[str, object]:
     message = extract_message_text(event_or_message)
     metadata = _source_metadata(event_or_message)
@@ -350,6 +392,9 @@ def _prepare_prompt_only_session_handoff(
         source_metadata=metadata,
         executor_target=executor_target,
         context_pack=context_pack,
+        preferred_workflow=(_session_route_preference(session)[0] if follow_up else None),
+        preferred_workflow_score=(_session_route_preference(session)[1] if follow_up else None),
+        force_coding_handoff=follow_up,
         memory_recall_pack=memory_recall_pack_for_handoff(
             paths,
             message,
@@ -414,6 +459,7 @@ def _prepare_runtime_session_handoff(
     source_metadata: dict[str, str] | None,
     executor_target: str,
     context_pack: dict[str, object] | None,
+    follow_up: bool = False,
 ) -> dict[str, object]:
     message = extract_message_text(event_or_message)
     metadata = _source_metadata(event_or_message)
@@ -428,6 +474,9 @@ def _prepare_runtime_session_handoff(
         source_metadata=metadata,
         executor_target=executor_target,
         context_pack=context_pack,
+        preferred_workflow=(_session_route_preference(session)[0] if follow_up else None),
+        preferred_workflow_score=(_session_route_preference(session)[1] if follow_up else None),
+        force_coding_handoff=follow_up,
         memory_recall_pack=memory_recall_pack_for_handoff(
             paths,
             message,
@@ -697,6 +746,18 @@ def _find_recoverable_prepared_handoff_run(
         if not _is_matching_coding_handoff(coding, session, message_sha256, expected_metadata):
             continue
         return run_id
+    return ""
+
+
+def _prepared_run_message_sha(paths: OmhPaths, run_id: str) -> str:
+    coding = read_json_object(paths.runtime_runs_dir / run_id / "coding_delegation.json")
+    return str(coding.get("message_sha256", "")) if isinstance(coding, dict) else ""
+
+
+def _latest_prepared_message_sha(session_dir: Path, event_name: str) -> str:
+    for event in reversed(read_wrapper_session_events(session_dir)):
+        if event.get("event") == event_name and isinstance(event.get("data"), dict):
+            return str(event["data"].get("message_sha256", ""))
     return ""
 
 

--- a/tests/test_wrapper_sessions.py
+++ b/tests/test_wrapper_sessions.py
@@ -14,6 +14,7 @@ load_local_package()
 from omh.coding_lifecycle import record_codex_dispatch, record_codex_result, record_codex_verification, start_codex_delegation_lifecycle
 from omh.codex_progress import summarize_codex_jsonl_text
 from omh.paths import resolve_paths
+from omh.memory import capture_project_memory_candidate
 from omh.profiles.setup import write_setup_profile
 from omh.runtime_artifacts import (
     create_run,
@@ -396,6 +397,112 @@ class WrapperSessionTests(unittest.TestCase):
             self.assertTrue(validate_runtime(paths)["ok"])
             session_path = paths.runtime_wrapper_sessions_dir / session_id / "session.json"
             self.assertNotIn(message, session_path.read_text(encoding="utf-8"))
+
+    @staticmethod
+    def _session_events(paths, session_id: str) -> list[dict]:
+        events_path = paths.runtime_wrapper_sessions_dir / session_id / "events.jsonl"
+        if not events_path.exists():
+            return []
+        return [json.loads(line) for line in events_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+    def _prompt_only_prepared_session(self, paths, message: str) -> str:
+        started = create_or_resume_wrapper_session(paths, message, source="discord")
+        session_id = str(started["session"]["session_id"])
+        record_plan_decision(paths, session_id, "accept")
+        select_wrapper_session_executor(paths, session_id, "claude-code")
+        prepare_wrapper_session_handoff(paths, session_id, message)
+        return session_id
+
+    def test_same_message_retry_and_empty_message_reserve_without_new_events(self) -> None:
+        """Characterization: retries and shows stay idempotent re-serves."""
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            message = "risky refactor of the observer summary"
+            session_id = self._prompt_only_prepared_session(paths, message)
+            events_before = len(self._session_events(paths, session_id))
+
+            retried = prepare_wrapper_session_handoff(paths, session_id, message)
+            shown = prepare_wrapper_session_handoff(paths, session_id, "")
+
+            self.assertEqual(retried["session"]["status"], "prompt_handoff_prepared")
+            self.assertEqual(shown["session"]["status"], "prompt_handoff_prepared")
+            self.assertEqual(
+                shown["handoff"]["prompt_handoff"]["schema_version"], "coding_prompt_handoff/v1"
+            )
+            self.assertEqual(len(self._session_events(paths, session_id)), events_before)
+
+    def test_follow_up_message_reprepares_prompt_only_handoff(self) -> None:
+        """Issue #754: a new message on a prepared session must not be dropped."""
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            write_setup_profile(paths, memory_mode="auto-safe")
+            capture_project_memory_candidate(
+                paths, "Regression tests run before merge", record_type="procedure", tags=["tests"]
+            )
+            first_message = "risky refactor of the observer summary"
+            session_id = self._prompt_only_prepared_session(paths, first_message)
+
+            follow_up = "follow-up: add regression tests too"
+            prepared = prepare_wrapper_session_handoff(paths, session_id, follow_up)
+
+            self.assertEqual(prepared["session"]["status"], "prompt_handoff_prepared")
+            follow_up_sha = hashlib.sha256(follow_up.encode("utf-8")).hexdigest()
+            pack = prepared["handoff"]["prompt_handoff"]["memory_recall_pack"]
+            self.assertEqual(pack["task_ref"]["sha256"], follow_up_sha)
+            prepared_events = [
+                event for event in self._session_events(paths, session_id) if event.get("event") == "prompt_handoff_prepared"
+            ]
+            self.assertEqual(len(prepared_events), 2)
+            self.assertEqual(prepared_events[-1]["data"]["message_sha256"], follow_up_sha)
+
+    def test_follow_up_message_links_new_codex_run_and_keeps_previous_run(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            first_message = "risky refactor of the observer summary"
+            started = create_or_resume_wrapper_session(paths, first_message, source="discord")
+            session_id = str(started["session"]["session_id"])
+            record_plan_decision(paths, session_id, "accept")
+            select_wrapper_session_executor(paths, session_id, "codex")
+            first = prepare_wrapper_session_handoff(paths, session_id, first_message)
+            first_run_id = str(first["session"]["current_run_id"])
+            self.assertTrue(first_run_id)
+
+            follow_up = "follow-up: add regression tests too"
+            second = prepare_wrapper_session_handoff(paths, session_id, follow_up)
+
+            second_run_id = str(second["session"]["current_run_id"])
+            self.assertTrue(second_run_id)
+            self.assertNotEqual(second_run_id, first_run_id)
+            follow_up_sha = hashlib.sha256(follow_up.encode("utf-8")).hexdigest()
+            new_coding = json.loads(
+                (paths.runtime_runs_dir / second_run_id / "coding_delegation.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(new_coding["message_sha256"], follow_up_sha)
+            self.assertTrue((paths.runtime_runs_dir / first_run_id / "coding_delegation.json").exists())
+
+            retried = prepare_wrapper_session_handoff(paths, session_id, follow_up)
+            self.assertEqual(str(retried["session"]["current_run_id"]), second_run_id)
+
+    def test_follow_up_message_reprepares_runtime_handoff(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            first_message = "risky refactor of the observer summary"
+            started = create_or_resume_wrapper_session(paths, first_message, source="discord")
+            session_id = str(started["session"]["session_id"])
+            record_plan_decision(paths, session_id, "accept")
+            select_wrapper_session_executor(paths, session_id, "omx-runtime")
+            prepare_wrapper_session_handoff(paths, session_id, first_message)
+
+            follow_up = "follow-up: add regression tests too"
+            prepared = prepare_wrapper_session_handoff(paths, session_id, follow_up)
+
+            self.assertEqual(prepared["session"]["status"], "runtime_handoff_prepared")
+            follow_up_sha = hashlib.sha256(follow_up.encode("utf-8")).hexdigest()
+            prepared_events = [
+                event for event in self._session_events(paths, session_id) if event.get("event") == "runtime_handoff_prepared"
+            ]
+            self.assertEqual(len(prepared_events), 2)
+            self.assertEqual(prepared_events[-1]["data"]["message_sha256"], follow_up_sha)
 
     def test_write_wrapper_session_preserves_legacy_prompt_handoff_without_local_capability_strategy(self) -> None:
         with TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Feature Report

### What Changed

- A prepared wrapper session now compares an incoming message with the previously prepared handoff.
- Empty show calls and same-message retries remain idempotent. A distinct non-empty follow-up creates a fresh Codex, prompt-only, or runtime handoff.
- Follow-ups retain the session route and selected executor instead of re-routing a short delta or silently switching owners.

### Why This Exists

A prepared session previously re-served its old handoff for any later message. The new instruction therefore exited successfully without a handoff event, leaving Hermes/Fable to retain work that should have been delegated.

### User / Operator Impact

Users can add a follow-up such as "add regression tests too" after a prepared handoff and receive a new prepared delegation rather than losing that instruction.

### How It Works

- The wrapper compares SHA-256 metadata for the incoming message and the latest prepared handoff.
- A changed message takes the re-prepare path, carries the accepted route as a preferred workflow, and forces a coding handoff for all supported executor surfaces.
- The original prepared run remains available while Codex sessions link the new run.

### Files And Contracts Touched

- `src/wrapper/sessions.py`: changed-message detection, route retention, and executor continuity.
- `src/wrapper/lifecycle.py`: forwards route preferences into the Codex lifecycle payload.
- `tests/test_wrapper_sessions.py`: locks retry/show idempotence plus Codex, prompt-only, and runtime follow-up behavior.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — 2,443 passed, 1 skipped.
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_wrapper_sessions.py -v` — 52 passed after refreshing `origin/main`.
- [x] `uv run python -m compileall -q src tests`.
- [x] `uv run python -m omh.cli docs workflows --check`.
- [x] `uv run python -m omh.cli docs roles --check`.
- [x] `uv run --group lint ruff check src tests`.
- [x] `git diff --check`.
- [x] Manual library-driver repro: the base behavior returned `same_run=True`; this branch created a distinct follow-up run.
- [ ] Manual Hermes chat-surface check — no live Hermes chat surface was available locally.

## Risk

Follow-ups now intentionally retain the existing executor. A request to switch executors mid-session fails loudly and asks the caller to start a new session, avoiding silent ownership drift.

## Compatibility / Rollout

Existing empty-message show calls and same-message retries preserve their former idempotent behavior. The change adds no dependency, network, or persisted-schema migration.

## Release / Claims

- [x] Release-channel impact considered: stable behavior fix with no release-channel-specific contract.
- [x] Runtime claims remain prepared-only; this change does not claim execution, review, CI, or merge evidence for delegated work.
- [x] Known manual Hermes gap is listed above.

## Follow-Up

- Consider a friendlier clarify card for non-coding follow-ups on a retained coding route; this fix keeps the current scope focused on preventing silent instruction loss.