### PR TITLE
feat(skills): complete native picker quality rails

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -201,6 +201,21 @@ local routing-boundary evidence only: it does not prove live Hermes chat
 rendering, source retrieval, file inspection, executor dispatch, review, CI,
 merge, or plugin loading.
 
+The native competition gate checks the generated picker surface against
+representative native browser, file, shell, and live-information descriptions:
+
+```sh
+omh demo native-competition --json
+```
+
+It should report all ordinary-action cases preferring the representative native
+skill and all confirmation, safety, freshness, or evidence-boundary cases
+preferring the OMH policy overlay. The comparison uses only generated
+frontmatter `name` + `description`, matching the measured picker-visible
+surface. It is a deterministic lexical regression heuristic, not proof of a
+live Hermes picker decision, installed native-skill inventory, or market
+competitiveness.
+
 The localized chat-copy gate checks common non-English operator prompts:
 
 ```sh
@@ -249,8 +264,8 @@ connector work, executor work, review, CI, merge, delivery, or market-share
 evidence.
 
 The Hermes UX quality rollup checks the chat-first user experience across the
-routing, card, hint, context, precision, localized-copy, fast-path, and common
-request coverage rails:
+routing, card, hint, context, precision, native-competition, localized-copy,
+fast-path, and common-request coverage rails:
 
 ```sh
 omh demo hermes-ux-quality --json
@@ -275,8 +290,8 @@ omh release product-readiness --version 1.0.3 --json
 
 It checks the generated skill content, G1-G10 readiness, grounded routing score,
 wrapper chat-card coverage, route-hint alignment, context-brief coverage,
-routing precision, router fast-path quality, common request coverage, Hermes UX
-quality, parity matrix, and release checklist shape in one operator-readable
+routing precision, native competition, router fast-path quality, common request
+coverage, Hermes UX quality, parity matrix, and release checklist shape in one operator-readable
 card. It is useful for release notes and maintainer handoff, but it is still
 local deterministic evidence only: it does not run the checklist, mutate Hermes,
 dispatch executors, review code, pass CI, merge, deliver messages, or spend
@@ -291,8 +306,8 @@ omh release evidence-bundle --version 1.0.3 --write --json
 The bundle writes `omh_release_evidence_bundle/v1` under
 `.omh/runtime/release-evidence/` with the checklist, product readiness,
 skill-content smoke, use-case readiness, grounded score, chat-card coverage,
-route-hint alignment, context-brief coverage, routing precision, Hermes UX
-quality, and parity snapshots. It is useful for release PRs and notes, but it is
+route-hint alignment, context-brief coverage, routing precision, native
+competition, Hermes UX quality, and parity snapshots. It is useful for release PRs and notes, but it is
 still local deterministic evidence only; live Hermes smoke, CI, review, merge,
 delivery, and GitHub release publication must be observed separately.
 

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -170,7 +170,7 @@ These surfaces are generated command references, not installed Hermes workflow s
 - Do not use when:
   - Progress must survive sessions as a ledger with multiple checkpoints and a final gate; use `ultragoal`.
   - The request is a settings-only change, one bounded edit that is explicitly low-risk and has a direct owner and verification path, or a direct answer/diagnosis; handle it directly instead of opening a finish-until-done loop.
-- Strong routing signals: `ralph`, `$ralph`, `finish until done`, `persistent execution`, `self-referential loop`
+- Strong routing signals: `ralph`, `$ralph`, `ulr`, `$ulr`, `finish until done`, `persistent execution`, `self-referential loop`
 - Good example:
   - Prompt: ralph: finish the invoice export recovery until the smoke test passes or a blocker is recorded.
   - Expected behavior: Keep one completion owner, track evidence after every recovery step, and stop only on pass, block, or explicit cancel.
@@ -623,7 +623,7 @@ These surfaces are generated command references, not installed Hermes workflow s
 
 ### web-research
 
-[omh] Web research with citation discipline on top of native search - every claim carries a live URL, sources are diversity-checked, and anything not fetched is marked not observed instead of guessed.
+[omh] Web research with citation discipline on top of native search - every claim carries a live URL and unfetched claims stay not observed; for a decision-ready brief use research-brief, and for ongoing Scout/Analyst/Briefer coordination use research-department.
 
 - Category: `research`
 - Phase: `current-evidence`
@@ -693,7 +693,7 @@ These surfaces are generated command references, not installed Hermes workflow s
 
 ### source-finder
 
-[omh] Hermes Source Finder workflow: prepare typed source candidates and acquisition status before downstream work.
+[omh] Source candidate inventory - prepare typed source candidates and acquisition status before downstream work; use ulw-research to fetch and cite them, or research-brief to turn them into a decision-ready brief.
 
 - Category: `research`
 - Phase: `source-acquisition`
@@ -763,7 +763,7 @@ These surfaces are generated command references, not installed Hermes workflow s
 
 ### research-brief
 
-[omh] Business research brief - turns a market, competitor, pricing, or customer question into a structured brief with an explicit evidence-vs-inference split; for raw link gathering use ulw-research.
+[omh] Business research brief - turns a market, competitor, pricing, or customer question into a structured evidence-vs-inference brief; for raw link gathering use ulw-research, and for ongoing multi-role research use research-department.
 
 - Category: `research`
 - Phase: `business-brief`
@@ -820,7 +820,7 @@ These surfaces are generated command references, not installed Hermes workflow s
 
 ### research-department
 
-[omh] Hermes Research Department workflow pack: prepare Scout, Analyst, and Briefer research operations with source inbox and briefing status boundaries.
+[omh] Research operations department - coordinate Scout, Analyst, and Briefer work with source-inbox and status boundaries; for one decision brief use research-brief, and for typed candidates before research starts use source-finder.
 
 - Category: `research`
 - Phase: `research-department`
@@ -4495,7 +4495,7 @@ These surfaces are generated command references, not installed Hermes workflow s
 
 ### memory-new
 
-[omh] Save a new durable project or product fact - captures a candidate, shows it for review, and writes only on approval; for auditing memories that already exist use omh-memory-sync.
+[omh] Save a new durable project or product fact - captures a candidate, shows it for review, and writes only on approval; for auditing existing memories use omh-memory-sync, and for retrieving a past decision use decision-recall.
 
 - Category: `memory`
 - Phase: `candidate-capture`
@@ -4555,7 +4555,7 @@ These surfaces are generated command references, not installed Hermes workflow s
 
 ### memory-sync
 
-[omh] Audit what Hermes already remembers - walks USER.md, MEMORY.md, and skill memories claim by claim, flags stale, conflicting, duplicate, or overgeneralized entries, and rewrites only after an approved diff.
+[omh] Audit what Hermes already remembers - reviews USER.md, MEMORY.md, and skill memories claim by claim and rewrites only after an approved diff; for a new fact use memory-new, and for retrieving a past decision use decision-recall.
 
 - Category: `memory`
 - Phase: `curation-review`
@@ -4670,7 +4670,7 @@ These surfaces are generated command references, not installed Hermes workflow s
 
 ### executor-runtime-readiness
 
-[omh] Hermes executor runtime readiness workflow: compare Codex, Claude Code, Hermes coding, and oh-my runtimes by available tools, missing tools, and handoff mode.
+[omh] Executor runtime readiness - compare Codex, Claude Code, Hermes coding, and oh-my runtimes by tools and handoff mode; use external-connector-readiness for a named plugin or API, and toolbelt-readiness for the whole capability inventory.
 
 - Category: `executor-readiness`
 - Phase: `runtime-selection`
@@ -4840,7 +4840,7 @@ These surfaces are generated command references, not installed Hermes workflow s
 
 ### browser-operator
 
-[omh] Browser tasks - open URLs, click, log in, fill forms, and capture page blockers, each scoped behind auth, confirmation, and observed-trace gates.
+[omh] Policy overlay for browser tasks - add auth, confirmation, and observed-trace gates after preferring the native browser for ordinary URL, click, login, and form actions.
 
 - Category: `browser`
 - Phase: `browser-task`
@@ -4904,7 +4904,7 @@ These surfaces are generated command references, not installed Hermes workflow s
 
 ### workspace-file-operator
 
-[omh] Local files and folders - list, search, organize, copy, move, rename, and delete, with path scoping and destructive-action gates.
+[omh] Policy overlay for local file tasks - add path scoping and destructive-action gates after preferring native file tools for ordinary list, search, organize, copy, move, and rename actions.
 
 - Category: `filesystem`
 - Phase: `file-task`
@@ -4967,7 +4967,7 @@ These surfaces are generated command references, not installed Hermes workflow s
 
 ### command-operator
 
-[omh] Terminal commands - scope shell, CLI, package-manager, and test runs with cwd, environment, safety, and result-evidence gates.
+[omh] Policy overlay for terminal commands - add cwd, environment, safety, and result-evidence gates after preferring native shell tools for ordinary CLI, package-manager, and test runs.
 
 - Category: `command`
 - Phase: `command-task`
@@ -5095,7 +5095,7 @@ These surfaces are generated command references, not installed Hermes workflow s
 
 ### live-info-operator
 
-[omh] Live lookups - weather, finance, sports, maps, places, exchange rates, and time zones, read-only with provider, freshness, units, and source-quality gates.
+[omh] Policy overlay for live lookups - add provider, freshness, units, and source-quality gates after preferring native live-data tools for ordinary weather, finance, sports, maps, and time-zone requests.
 
 - Category: `live-info`
 - Phase: `live-info-task`
@@ -5158,7 +5158,7 @@ These surfaces are generated command references, not installed Hermes workflow s
 
 ### external-connector-readiness
 
-[omh] Hermes external connector readiness workflow: decide whether a candidate plugin, connector, API, data provider, or multimodal route is safe, affordable, fresh, and observable enough to adopt, route, or trial.
+[omh] External connector readiness - assess whether a named plugin, connector, API, data provider, or multimodal route is safe, affordable, fresh, and observable; use executor-runtime-readiness for coding-owner choice and toolbelt-readiness for missing capability inventory.
 
 - Category: `connector`
 - Phase: `connector-readiness`
@@ -5227,7 +5227,7 @@ These surfaces are generated command references, not installed Hermes workflow s
 
 ### prompt-import-readiness
 
-[omh] Hermes prompt import readiness workflow: decide whether external CLI-agent prompt files can be safely reviewed, normalized, and offered as Hermes slash-command candidates without mutating prompts or command registries.
+[omh] Prompt import readiness - review and normalize external CLI-agent prompt files before offering slash-command candidates; use external-connector-readiness for plugin or API adoption and toolbelt-readiness for missing runtime capabilities.
 
 - Category: `prompt`
 - Phase: `prompt-import-readiness`
@@ -5299,7 +5299,7 @@ These surfaces are generated command references, not installed Hermes workflow s
 
 ### physical-device-readiness
 
-[omh] Hermes readiness workflow for robots, 3D printers, IoT relays, sensors, and lab hardware before hardware trials.
+[omh] Physical device readiness - gate robots, 3D printers, IoT relays, sensors, and lab hardware before trials; use external-connector-readiness for provider or connector adoption and toolbelt-readiness for missing control tools.
 
 - Category: `operations`
 - Phase: `device-readiness`
@@ -5570,7 +5570,7 @@ These surfaces are generated command references, not installed Hermes workflow s
 
 ### toolbelt-readiness
 
-[omh] Hermes toolbelt readiness workflow: check which MCP servers, CLIs, APIs, credentials, and connectors a workflow needs before claiming it can run.
+[omh] Toolbelt readiness - inventory which MCP servers, CLIs, APIs, credentials, and connectors a workflow needs; use external-connector-readiness to assess one named integration and executor-runtime-readiness to choose the coding owner.
 
 - Category: `tools`
 - Phase: `readiness-check`

--- a/skills/omh-accessibility-audit/SKILL.md
+++ b/skills/omh-accessibility-audit/SKILL.md
@@ -53,17 +53,11 @@ Bad example:
 - If automated scan output exists without keyboard or screen-reader evidence, keep the verdict HOLD and request the smallest focus/announcement trace.
 - If the request is mostly visual layout or CJK clipping, route to visual-qa while preserving accessibility follow-up checks.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Materials and visual summaries** (`design-orchestration`, `design-quality-gate`, `frontend`, `accessibility-audit`, `visual-qa`, `content-operator`, `media-input-operator`, `materials-package`, `+4 more`) - web, accessibility, visual QA, files, and packages.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -142,11 +136,9 @@ omh runtime record --skill accessibility-audit --harness accessibility-audit --s
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-accessibility-audit/SKILL.md
+++ b/skills/omh-accessibility-audit/SKILL.md
@@ -138,6 +138,7 @@ omh runtime record --skill accessibility-audit --harness accessibility-audit --s
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-achievements/SKILL.md
+++ b/skills/omh-achievements/SKILL.md
@@ -113,6 +113,7 @@ omh runtime record --skill achievements --harness coding-handling --status start
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-achievements/SKILL.md
+++ b/skills/omh-achievements/SKILL.md
@@ -49,17 +49,11 @@ Bad example:
 - If provider metrics are unavailable, report only local metadata and mark provider truth not_observed.
 - If cost or latency looks risky, surface a warning plus the next measurement rather than a completion claim.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Automation and status** (`achievements`, `workspace-audit`, `production-audit`, `automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `+31 more`) - schedules, status, health, and ops review.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -117,11 +111,9 @@ omh runtime record --skill achievements --harness coding-handling --status start
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-agent-board/SKILL.md
+++ b/skills/omh-agent-board/SKILL.md
@@ -112,6 +112,7 @@ omh runtime record --skill agent-board --harness agent-board --status started
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-agent-board/SKILL.md
+++ b/skills/omh-agent-board/SKILL.md
@@ -49,17 +49,11 @@ Bad example:
 - If required context is missing, ask one blocking question or route back to the narrower workflow.
 - If runtime or wrapper evidence is unavailable, keep the status as not_observed and expose the next observable action.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Automation and status** (`achievements`, `workspace-audit`, `production-audit`, `automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `+31 more`) - schedules, status, health, and ops review.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -116,11 +110,9 @@ omh runtime record --skill agent-board --harness agent-board --status started
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-agent-debug/SKILL.md
+++ b/skills/omh-agent-debug/SKILL.md
@@ -50,17 +50,11 @@ Bad example:
 - If the request is a manager status or throughput review, route to agent-ops-review.
 - If the request is a durable self-improvement record after diagnosis, route to workflow-learning.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Automation and status** (`achievements`, `workspace-audit`, `production-audit`, `automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `+31 more`) - schedules, status, health, and ops review.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -120,11 +114,9 @@ omh runtime record --skill agent-debug --harness agent-debug --status started
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-agent-debug/SKILL.md
+++ b/skills/omh-agent-debug/SKILL.md
@@ -116,6 +116,7 @@ omh runtime record --skill agent-debug --harness agent-debug --status started
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-agent-evaluation/SKILL.md
+++ b/skills/omh-agent-evaluation/SKILL.md
@@ -121,6 +121,7 @@ omh runtime record --skill agent-evaluation --harness agent-evaluation --status 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-agent-evaluation/SKILL.md
+++ b/skills/omh-agent-evaluation/SKILL.md
@@ -50,17 +50,11 @@ Bad example:
 - If required context is missing, ask one blocking question or route back to the narrower workflow.
 - If runtime or wrapper evidence is unavailable, keep the status as not_observed and expose the next observable action.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Automation and status** (`achievements`, `workspace-audit`, `production-audit`, `automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `+31 more`) - schedules, status, health, and ops review.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -125,11 +119,9 @@ omh runtime record --skill agent-evaluation --harness agent-evaluation --status 
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-agent-ops-review/SKILL.md
+++ b/skills/omh-agent-ops-review/SKILL.md
@@ -112,6 +112,7 @@ omh runtime record --skill agent-ops-review --harness agent-ops-review --status 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-agent-ops-review/SKILL.md
+++ b/skills/omh-agent-ops-review/SKILL.md
@@ -49,17 +49,11 @@ Bad example:
 - If a managed path or config key is missing, route to setup/update repair instead of editing hidden state.
 - If a reload or plugin load was not observed, keep the diagnostic result as local health evidence only.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Automation and status** (`achievements`, `workspace-audit`, `production-audit`, `automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `+31 more`) - schedules, status, health, and ops review.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -116,11 +110,9 @@ omh runtime record --skill agent-ops-review --harness agent-ops-review --status 
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-ai-slop-cleaner/SKILL.md
+++ b/skills/omh-ai-slop-cleaner/SKILL.md
@@ -120,6 +120,7 @@ omh runtime record --skill ai-slop-cleaner --harness coding-handling --status st
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-ai-slop-cleaner/SKILL.md
+++ b/skills/omh-ai-slop-cleaner/SKILL.md
@@ -51,17 +51,11 @@ Bad example:
 - If the selected executor is unavailable, ask for Codex, Claude Code, Hermes, or another runtime before retrying.
 - If dispatch or result evidence is missing, keep the handoff prepared_not_observed and expose the next observable action.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Coding handoff** (`idea-to-deploy`, `cto-loop`, `deploy-and-monitor`, `code-review`, `build-failure-triage`, `verification-gate`, `security-safety-review`, `ultrawork`, `+7 more`) - coding owners, handoffs, review, CI, and merge evidence.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -124,11 +118,9 @@ omh runtime record --skill ai-slop-cleaner --harness coding-handling --status st
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-apps/SKILL.md
+++ b/skills/omh-apps/SKILL.md
@@ -121,6 +121,7 @@ omh runtime record --skill connector-operator --harness connector-operator --sta
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-apps/SKILL.md
+++ b/skills/omh-apps/SKILL.md
@@ -50,17 +50,11 @@ Bad example:
 - If the request is only chat thread delivery policy for Discord, Slack, or Telegram, route to gateway-intent-card instead.
 - If the external app action would create, send, invite, mutate, or delete provider state, require an explicit confirmation gate.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Automation and status** (`achievements`, `workspace-audit`, `production-audit`, `automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `+31 more`) - schedules, status, health, and ops review.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -125,11 +119,9 @@ omh runtime record --skill connector-operator --harness connector-operator --sta
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-ask/SKILL.md
+++ b/skills/omh-ask/SKILL.md
@@ -110,6 +110,7 @@ omh runtime record --skill ask --harness critic --status started
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-ask/SKILL.md
+++ b/skills/omh-ask/SKILL.md
@@ -48,17 +48,11 @@ Bad example:
 - If the reviewed target is missing, inspect the requested artifact or ask one target question.
 - If independent verification is unavailable, report the gap and avoid an approval-style claim.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Automation and status** (`achievements`, `workspace-audit`, `production-audit`, `automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `+31 more`) - schedules, status, health, and ops review.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -114,11 +108,9 @@ omh runtime record --skill ask --harness critic --status started
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-automation-blueprint/SKILL.md
+++ b/skills/omh-automation-blueprint/SKILL.md
@@ -49,17 +49,11 @@ Bad example:
 - If required context is missing, ask one blocking question or route back to the narrower workflow.
 - If runtime or wrapper evidence is unavailable, keep the status as not_observed and expose the next observable action.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Automation and status** (`achievements`, `workspace-audit`, `production-audit`, `automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `+31 more`) - schedules, status, health, and ops review.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -118,11 +112,9 @@ omh runtime record --skill automation-blueprint --harness scheduled-ops-blueprin
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-automation-blueprint/SKILL.md
+++ b/skills/omh-automation-blueprint/SKILL.md
@@ -114,6 +114,7 @@ omh runtime record --skill automation-blueprint --harness scheduled-ops-blueprin
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-autoresearch-goal/SKILL.md
+++ b/skills/omh-autoresearch-goal/SKILL.md
@@ -48,17 +48,11 @@ Bad example:
 - If sources cannot be accessed, state the retrieval gap and use only observed local context.
 - If evidence is thin or one-sided, lower confidence and ask for a narrower source boundary.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Research and company ops** (`source-finder`, `web-research`, `best-practice-research`, `autoresearch-goal`, `research-brief`, `strategy-brief`, `feedback-triage`, `research-department`, `+12 more`) - research, signals, ops, and briefings.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -115,11 +109,9 @@ omh runtime record --skill autoresearch-goal --harness research --status started
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-autoresearch-goal/SKILL.md
+++ b/skills/omh-autoresearch-goal/SKILL.md
@@ -111,6 +111,7 @@ omh runtime record --skill autoresearch-goal --harness research --status started
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-best-practice-research/SKILL.md
+++ b/skills/omh-best-practice-research/SKILL.md
@@ -109,6 +109,7 @@ omh runtime record --skill best-practice-research --harness research --status st
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-best-practice-research/SKILL.md
+++ b/skills/omh-best-practice-research/SKILL.md
@@ -47,17 +47,11 @@ Bad example:
 - If sources cannot be accessed, state the retrieval gap and use only observed local context.
 - If evidence is thin or one-sided, lower confidence and ask for a narrower source boundary.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Research and company ops** (`source-finder`, `web-research`, `best-practice-research`, `autoresearch-goal`, `research-brief`, `strategy-brief`, `feedback-triage`, `research-department`, `+12 more`) - research, signals, ops, and briefings.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -113,11 +107,9 @@ omh runtime record --skill best-practice-research --harness research --status st
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-browser/SKILL.md
+++ b/skills/omh-browser/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-browser
-description: [omh] Browser tasks - open URLs, click, log in, fill forms, and capture page blockers, each scoped behind auth, confirmation, and observed-trace gates. Use when the user says: browser-operator, browser operator, browser task, browser operation, browser automation, browser session, webpage operation, web page operation.
+description: [omh] Policy overlay for browser tasks - add auth, confirmation, and observed-trace gates after preferring the native browser for ordinary URL, click, login, and form actions. Use when the user says: browser-operator, browser operator, browser task, browser operation, browser automation, browser session, webpage operation, web page operation.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, browser]
@@ -50,17 +50,11 @@ Bad example:
 - If login, payment, destructive mutation, or credential use is requested, require an explicit confirmation gate and do not proceed from vague intent.
 - If the request is visual correctness rather than general page operation, route to visual-qa instead.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Automation and status** (`achievements`, `workspace-audit`, `production-audit`, `automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `+31 more`) - schedules, status, health, and ops review.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -124,11 +118,9 @@ omh runtime record --skill browser-operator --harness browser-operator --status 
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-browser/SKILL.md
+++ b/skills/omh-browser/SKILL.md
@@ -120,6 +120,7 @@ omh runtime record --skill browser-operator --harness browser-operator --status 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-build-failure-triage/SKILL.md
+++ b/skills/omh-build-failure-triage/SKILL.md
@@ -53,17 +53,11 @@ Bad example:
 - If the failure looks environmental or credentialed, mark BLOCKED_BY_ENVIRONMENT and avoid patch handoff.
 - If a fix has already been applied, route to verification-gate for fresh evidence instead of re-triaging stale failures.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Coding handoff** (`idea-to-deploy`, `cto-loop`, `deploy-and-monitor`, `code-review`, `build-failure-triage`, `verification-gate`, `security-safety-review`, `ultrawork`, `+7 more`) - coding owners, handoffs, review, CI, and merge evidence.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -137,11 +131,9 @@ omh runtime record --skill build-failure-triage --harness build-failure-triage -
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-build-failure-triage/SKILL.md
+++ b/skills/omh-build-failure-triage/SKILL.md
@@ -133,6 +133,7 @@ omh runtime record --skill build-failure-triage --harness build-failure-triage -
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-cancel/SKILL.md
+++ b/skills/omh-cancel/SKILL.md
@@ -48,17 +48,11 @@ Bad example:
 - If a managed path or config key is missing, route to setup/update repair instead of editing hidden state.
 - If a reload or plugin load was not observed, keep the diagnostic result as local health evidence only.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Automation and status** (`achievements`, `workspace-audit`, `production-audit`, `automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `+31 more`) - schedules, status, health, and ops review.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -111,11 +105,9 @@ omh runtime record --skill cancel --harness goal-execution --status started
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-cancel/SKILL.md
+++ b/skills/omh-cancel/SKILL.md
@@ -107,6 +107,7 @@ omh runtime record --skill cancel --harness goal-execution --status started
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-code-review/SKILL.md
+++ b/skills/omh-code-review/SKILL.md
@@ -115,6 +115,7 @@ omh runtime record --skill code-review --harness critic --status started
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-code-review/SKILL.md
+++ b/skills/omh-code-review/SKILL.md
@@ -51,17 +51,11 @@ Bad example:
 - If tests fail or are missing, cite the exact command gap and do not approve the change as verified.
 - If independent review evidence is unavailable, say so directly instead of implying a second reviewer passed it.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Coding handoff** (`idea-to-deploy`, `cto-loop`, `deploy-and-monitor`, `code-review`, `build-failure-triage`, `verification-gate`, `security-safety-review`, `ultrawork`, `+7 more`) - coding owners, handoffs, review, CI, and merge evidence.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -119,11 +113,9 @@ omh runtime record --skill code-review --harness critic --status started
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-codebase-onboarding/SKILL.md
+++ b/skills/omh-codebase-onboarding/SKILL.md
@@ -49,17 +49,11 @@ Bad example:
 - If acceptance criteria or verification are missing, route back to clarification before handoff.
 - If assumptions materially affect the plan, keep them visible and avoid treating the plan as accepted.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Intent -> plan** (`oh-my-hermes`, `meta-router`, `deep-interview`, `plan`, `ralplan`, `codebase-onboarding`, `codegraph-refresh`, `ultragoal`, `+6 more`) - clarify, plan, ship, or loop goals.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -126,11 +120,9 @@ omh runtime record --skill codebase-onboarding --harness codebase-onboarding --s
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-codebase-onboarding/SKILL.md
+++ b/skills/omh-codebase-onboarding/SKILL.md
@@ -122,6 +122,7 @@ omh runtime record --skill codebase-onboarding --harness codebase-onboarding --s
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-codegraph-refresh/SKILL.md
+++ b/skills/omh-codegraph-refresh/SKILL.md
@@ -123,6 +123,7 @@ omh runtime record --skill codegraph-refresh --harness codegraph-refresh --statu
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-codegraph-refresh/SKILL.md
+++ b/skills/omh-codegraph-refresh/SKILL.md
@@ -51,17 +51,11 @@ Bad example:
 - If no task focus is supplied, prepare build/summary guidance and ask for focus only when a handoff pack would otherwise be misleading.
 - If the index is stale or missing, report the stale/missing state and next safe command rather than treating prior summaries as current.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Intent -> plan** (`oh-my-hermes`, `meta-router`, `deep-interview`, `plan`, `ralplan`, `codebase-onboarding`, `codegraph-refresh`, `ultragoal`, `+6 more`) - clarify, plan, ship, or loop goals.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -127,11 +121,9 @@ omh runtime record --skill codegraph-refresh --harness codegraph-refresh --statu
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-content-operator/SKILL.md
+++ b/skills/omh-content-operator/SKILL.md
@@ -51,17 +51,11 @@ Bad example:
 - If the request asks for PDF, PPT, DOCX, HWP, spreadsheet, or attachment packaging, route to materials-package or deliverable-package.
 - If the request is a simple one-off sentence or paragraph transformation, answer directly instead of opening a workflow.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Materials and visual summaries** (`design-orchestration`, `design-quality-gate`, `frontend`, `accessibility-audit`, `visual-qa`, `content-operator`, `media-input-operator`, `materials-package`, `+4 more`) - web, accessibility, visual QA, files, and packages.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -126,11 +120,9 @@ omh runtime record --skill content-operator --harness content-operator --status 
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-content-operator/SKILL.md
+++ b/skills/omh-content-operator/SKILL.md
@@ -122,6 +122,7 @@ omh runtime record --skill content-operator --harness content-operator --status 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-context-budget-review/SKILL.md
+++ b/skills/omh-context-budget-review/SKILL.md
@@ -121,6 +121,7 @@ omh runtime record --skill context-budget-review --harness context-budget-review
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-context-budget-review/SKILL.md
+++ b/skills/omh-context-budget-review/SKILL.md
@@ -49,17 +49,11 @@ Bad example:
 - If provider metrics are unavailable, report only local metadata and mark provider truth not_observed.
 - If cost or latency looks risky, surface a warning plus the next measurement rather than a completion claim.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Automation and status** (`achievements`, `workspace-audit`, `production-audit`, `automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `+31 more`) - schedules, status, health, and ops review.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -125,11 +119,9 @@ omh runtime record --skill context-budget-review --harness context-budget-review
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-cto-loop/SKILL.md
+++ b/skills/omh-cto-loop/SKILL.md
@@ -114,6 +114,7 @@ omh runtime record --skill cto-loop --harness app-delivery-loop --status started
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-cto-loop/SKILL.md
+++ b/skills/omh-cto-loop/SKILL.md
@@ -47,17 +47,11 @@ Bad example:
 - If required context is missing, ask one blocking question or route back to the narrower workflow.
 - If runtime or wrapper evidence is unavailable, keep the status as not_observed and expose the next observable action.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Coding handoff** (`idea-to-deploy`, `cto-loop`, `deploy-and-monitor`, `code-review`, `build-failure-triage`, `verification-gate`, `security-safety-review`, `ultrawork`, `+7 more`) - coding owners, handoffs, review, CI, and merge evidence.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -118,11 +112,9 @@ omh runtime record --skill cto-loop --harness app-delivery-loop --status started
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-curriculum-design/SKILL.md
+++ b/skills/omh-curriculum-design/SKILL.md
@@ -113,6 +113,7 @@ omh runtime record --skill curriculum-design --harness planning --status started
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-curriculum-design/SKILL.md
+++ b/skills/omh-curriculum-design/SKILL.md
@@ -50,17 +50,11 @@ Bad example:
 - If acceptance criteria or verification are missing, route back to clarification before handoff.
 - If assumptions materially affect the plan, keep them visible and avoid treating the plan as accepted.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Research and company ops** (`source-finder`, `web-research`, `best-practice-research`, `autoresearch-goal`, `research-brief`, `strategy-brief`, `feedback-triage`, `research-department`, `+12 more`) - research, signals, ops, and briefings.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -117,11 +111,9 @@ omh runtime record --skill curriculum-design --harness planning --status started
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-data-analysis/SKILL.md
+++ b/skills/omh-data-analysis/SKILL.md
@@ -51,17 +51,11 @@ Bad example:
 - If the user wants datasets found online, route to source-finder before analysis.
 - If the user wants a PPT/PDF/XLSX report generated from data, route to materials-package or deliverable-package after analysis scope is clear.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Research and company ops** (`source-finder`, `web-research`, `best-practice-research`, `autoresearch-goal`, `research-brief`, `strategy-brief`, `feedback-triage`, `research-department`, `+12 more`) - research, signals, ops, and briefings.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -128,11 +122,9 @@ omh runtime record --skill data-analysis --harness data-analysis --status starte
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-data-analysis/SKILL.md
+++ b/skills/omh-data-analysis/SKILL.md
@@ -124,6 +124,7 @@ omh runtime record --skill data-analysis --harness data-analysis --status starte
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-decide/SKILL.md
+++ b/skills/omh-decide/SKILL.md
@@ -48,17 +48,11 @@ Bad example:
 - If evidence is mostly assumption, label it and recommend a research or feedback-triage pass.
 - If the decision owner is missing, keep the output as options rather than accepted strategy.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Research and company ops** (`source-finder`, `web-research`, `best-practice-research`, `autoresearch-goal`, `research-brief`, `strategy-brief`, `feedback-triage`, `research-department`, `+12 more`) - research, signals, ops, and briefings.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -117,11 +111,9 @@ omh runtime record --skill strategy-brief --harness strategy-synthesis --status 
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-decide/SKILL.md
+++ b/skills/omh-decide/SKILL.md
@@ -113,6 +113,7 @@ omh runtime record --skill strategy-brief --harness strategy-synthesis --status 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-decision-recall/SKILL.md
+++ b/skills/omh-decision-recall/SKILL.md
@@ -49,17 +49,11 @@ Bad example:
 - If required context is missing, ask one blocking question or route back to the narrower workflow.
 - If runtime or wrapper evidence is unavailable, keep the status as not_observed and expose the next observable action.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Retained knowledge** (`memory-new`, `memory-sync`, `decision-recall`, `wiki`) - memory, rejected alternatives, wiki notes, retrieval, and staleness.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -116,11 +110,9 @@ omh runtime record --skill decision-recall --harness decision-recall --status st
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-decision-recall/SKILL.md
+++ b/skills/omh-decision-recall/SKILL.md
@@ -112,6 +112,7 @@ omh runtime record --skill decision-recall --harness decision-recall --status st
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-deliverable-package/SKILL.md
+++ b/skills/omh-deliverable-package/SKILL.md
@@ -112,6 +112,7 @@ omh runtime record --skill deliverable-package --harness deliverable-package --s
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-deliverable-package/SKILL.md
+++ b/skills/omh-deliverable-package/SKILL.md
@@ -49,17 +49,11 @@ Bad example:
 - If generation tooling is missing, prepare a prompt or package handoff and mark file output not_observed.
 - If QA or attachment evidence is missing, keep generated/delivered states separate and show the next check.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Materials and visual summaries** (`design-orchestration`, `design-quality-gate`, `frontend`, `accessibility-audit`, `visual-qa`, `content-operator`, `media-input-operator`, `materials-package`, `+4 more`) - web, accessibility, visual QA, files, and packages.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -116,11 +110,9 @@ omh runtime record --skill deliverable-package --harness deliverable-package --s
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-deploy-and-monitor/SKILL.md
+++ b/skills/omh-deploy-and-monitor/SKILL.md
@@ -115,6 +115,7 @@ omh runtime record --skill deploy-and-monitor --harness app-delivery-loop --stat
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-deploy-and-monitor/SKILL.md
+++ b/skills/omh-deploy-and-monitor/SKILL.md
@@ -48,17 +48,11 @@ Bad example:
 - If required context is missing, ask one blocking question or route back to the narrower workflow.
 - If runtime or wrapper evidence is unavailable, keep the status as not_observed and expose the next observable action.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Coding handoff** (`idea-to-deploy`, `cto-loop`, `deploy-and-monitor`, `code-review`, `build-failure-triage`, `verification-gate`, `security-safety-review`, `ultrawork`, `+7 more`) - coding owners, handoffs, review, CI, and merge evidence.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -119,11 +113,9 @@ omh runtime record --skill deploy-and-monitor --harness app-delivery-loop --stat
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-design-orchestration/SKILL.md
+++ b/skills/omh-design-orchestration/SKILL.md
@@ -50,17 +50,11 @@ Bad example:
 - If only a raw brief exists, let Hermes retain it in chat and create an opaque user-supplied reference instead of storing the brief.
 - If the request narrows to implementation, accessibility, or rendered QA, route to the existing specialist rather than expanding this orchestration surface.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Materials and visual summaries** (`design-orchestration`, `design-quality-gate`, `frontend`, `accessibility-audit`, `visual-qa`, `content-operator`, `media-input-operator`, `materials-package`, `+4 more`) - web, accessibility, visual QA, files, and packages.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -124,11 +118,9 @@ omh runtime record --skill design-orchestration --harness design-orchestration -
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-design-orchestration/SKILL.md
+++ b/skills/omh-design-orchestration/SKILL.md
@@ -120,6 +120,7 @@ omh runtime record --skill design-orchestration --harness design-orchestration -
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-design-quality-gate/SKILL.md
+++ b/skills/omh-design-quality-gate/SKILL.md
@@ -52,17 +52,11 @@ Bad example:
 - If the baseline or references are missing, prepare the gate with an explicit comparative-quality gap instead of calling the result premium.
 - If render QA is unavailable, keep PASS unavailable and ask for the smallest screenshot, deck/PDF render, or operator observation that proves the target surface.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Materials and visual summaries** (`design-orchestration`, `design-quality-gate`, `frontend`, `accessibility-audit`, `visual-qa`, `content-operator`, `media-input-operator`, `materials-package`, `+4 more`) - web, accessibility, visual QA, files, and packages.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -138,11 +132,9 @@ omh runtime record --skill design-quality-gate --harness design-quality-gate --s
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-design-quality-gate/SKILL.md
+++ b/skills/omh-design-quality-gate/SKILL.md
@@ -134,6 +134,7 @@ omh runtime record --skill design-quality-gate --harness design-quality-gate --s
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-doctor/SKILL.md
+++ b/skills/omh-doctor/SKILL.md
@@ -52,17 +52,11 @@ Bad example:
 - If plugin register smoke fails, reinstall the plugin bundle with setup --with-plugin --force before claiming plugin readiness.
 - If omh is missing from PATH, use the installer-reported absolute command path and then re-run doctor.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Automation and status** (`achievements`, `workspace-audit`, `production-audit`, `automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `+31 more`) - schedules, status, health, and ops review.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -117,11 +111,9 @@ omh runtime record --skill doctor --harness qa-specialist --status started
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-doctor/SKILL.md
+++ b/skills/omh-doctor/SKILL.md
@@ -113,6 +113,7 @@ omh runtime record --skill doctor --harness qa-specialist --status started
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-executor-runtime-readiness/SKILL.md
+++ b/skills/omh-executor-runtime-readiness/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-executor-runtime-readiness
-description: [omh] Hermes executor runtime readiness workflow: compare Codex, Claude Code, Hermes coding, and oh-my runtimes by available tools, missing tools, and handoff mode. Use when the user says: executor-runtime-readiness, executor readiness, runtime readiness, codex readiness, claude code readiness, hermes coding readiness, executor tools, missing tools.
+description: [omh] Executor runtime readiness - compare Codex, Claude Code, Hermes coding, and oh-my runtimes by tools and handoff mode; use external-connector-readiness for a named plugin or API, and toolbelt-readiness for the whole capability inventory. Use when the user says: executor-runtime-readiness, executor readiness, runtime readiness, codex readiness, claude code readiness, hermes coding readiness, executor tools, missing tools.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, executor-readiness]
@@ -51,17 +51,11 @@ Bad example:
 - If the selected executor is unavailable, ask for Codex, Claude Code, Hermes, or another runtime before retrying.
 - If dispatch or result evidence is missing, keep the handoff prepared_not_observed and expose the next observable action.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Coding handoff** (`idea-to-deploy`, `cto-loop`, `deploy-and-monitor`, `code-review`, `build-failure-triage`, `verification-gate`, `security-safety-review`, `ultrawork`, `+7 more`) - coding owners, handoffs, review, CI, and merge evidence.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -124,11 +118,9 @@ omh runtime record --skill executor-runtime-readiness --harness executor-runtime
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-executor-runtime-readiness/SKILL.md
+++ b/skills/omh-executor-runtime-readiness/SKILL.md
@@ -120,6 +120,7 @@ omh runtime record --skill executor-runtime-readiness --harness executor-runtime
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-external-connector-readiness/SKILL.md
+++ b/skills/omh-external-connector-readiness/SKILL.md
@@ -125,6 +125,7 @@ omh runtime record --skill external-connector-readiness --harness external-conne
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-external-connector-readiness/SKILL.md
+++ b/skills/omh-external-connector-readiness/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-external-connector-readiness
-description: [omh] Hermes external connector readiness workflow: decide whether a candidate plugin, connector, API, data provider, or multimodal route is safe, affordable, fresh, and observable enough to adopt, route, or trial. Use when the user says: external-connector-readiness, external connector readiness, connector readiness matrix, plugin readiness matrix, provider readiness, api readiness, connector adoption, external plugin adoption.
+description: [omh] External connector readiness - assess whether a named plugin, connector, API, data provider, or multimodal route is safe, affordable, fresh, and observable; use executor-runtime-readiness for coding-owner choice and toolbelt-readiness for missing capability inventory. Use when the user says: external-connector-readiness, external connector readiness, connector readiness matrix, plugin readiness matrix, provider readiness, api readiness, connector adoption, external plugin adoption.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, connector]
@@ -51,17 +51,11 @@ Bad example:
 - If credentials, cost authority, or connector installation is missing, keep readiness blocked and route setup to toolbelt-readiness.
 - If a specific provider action is already selected, route read-only live data to live-info-operator or write/mutation tasks to connector-operator.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Automation and status** (`achievements`, `workspace-audit`, `production-audit`, `automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `+31 more`) - schedules, status, health, and ops review.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -129,11 +123,9 @@ omh runtime record --skill external-connector-readiness --harness external-conne
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-failure-signal-audit/SKILL.md
+++ b/skills/omh-failure-signal-audit/SKILL.md
@@ -51,17 +51,11 @@ Bad example:
 - If the user wants live service SLO or incident review, route to reliability-review.
 - If the user wants rendered browser proof, route frontend visual evidence to visual-qa before PASS.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Automation and status** (`achievements`, `workspace-audit`, `production-audit`, `automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `+31 more`) - schedules, status, health, and ops review.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -126,11 +120,9 @@ omh runtime record --skill failure-signal-audit --harness failure-signal-audit -
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-failure-signal-audit/SKILL.md
+++ b/skills/omh-failure-signal-audit/SKILL.md
@@ -122,6 +122,7 @@ omh runtime record --skill failure-signal-audit --harness failure-signal-audit -
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-feedback-triage/SKILL.md
+++ b/skills/omh-feedback-triage/SKILL.md
@@ -49,17 +49,11 @@ Bad example:
 - If feedback lacks source or severity, ask for the missing signal before coding handoff.
 - If the item is actually a plan or research request, route to that workflow instead of triage.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Research and company ops** (`source-finder`, `web-research`, `best-practice-research`, `autoresearch-goal`, `research-brief`, `strategy-brief`, `feedback-triage`, `research-department`, `+12 more`) - research, signals, ops, and briefings.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -118,11 +112,9 @@ omh runtime record --skill feedback-triage --harness customer-insight-triage --s
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-feedback-triage/SKILL.md
+++ b/skills/omh-feedback-triage/SKILL.md
@@ -114,6 +114,7 @@ omh runtime record --skill feedback-triage --harness customer-insight-triage --s
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-files/SKILL.md
+++ b/skills/omh-files/SKILL.md
@@ -119,6 +119,7 @@ omh runtime record --skill workspace-file-operator --harness workspace-file-oper
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-files/SKILL.md
+++ b/skills/omh-files/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-files
-description: [omh] Local files and folders - list, search, organize, copy, move, rename, and delete, with path scoping and destructive-action gates. Use when the user says: workspace-file-operator, workspace file operator, file operator, file operation, file operations, filesystem task, filesystem operation, file system task.
+description: [omh] Policy overlay for local file tasks - add path scoping and destructive-action gates after preferring native file tools for ordinary list, search, organize, copy, move, and rename actions. Use when the user says: workspace-file-operator, workspace file operator, file operator, file operation, file operations, filesystem task, filesystem operation, file system task.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, filesystem]
@@ -50,17 +50,11 @@ Bad example:
 - If delete, overwrite, move, rename, chmod, or irreversible cleanup is requested, require an explicit confirmation gate.
 - If the request is file conversion, deck/PDF export, or attachment delivery, route to materials-package or deliverable-package instead.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Automation and status** (`achievements`, `workspace-audit`, `production-audit`, `automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `+31 more`) - schedules, status, health, and ops review.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -123,11 +117,9 @@ omh runtime record --skill workspace-file-operator --harness workspace-file-oper
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-finance-analysis/SKILL.md
+++ b/skills/omh-finance-analysis/SKILL.md
@@ -50,17 +50,11 @@ Bad example:
 - If required context is missing, ask one blocking question or route back to the narrower workflow.
 - If runtime or wrapper evidence is unavailable, keep the status as not_observed and expose the next observable action.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Research and company ops** (`source-finder`, `web-research`, `best-practice-research`, `autoresearch-goal`, `research-brief`, `strategy-brief`, `feedback-triage`, `research-department`, `+12 more`) - research, signals, ops, and briefings.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -117,11 +111,9 @@ omh runtime record --skill finance-analysis --harness ops-review --status starte
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-finance-analysis/SKILL.md
+++ b/skills/omh-finance-analysis/SKILL.md
@@ -113,6 +113,7 @@ omh runtime record --skill finance-analysis --harness ops-review --status starte
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-frontend/SKILL.md
+++ b/skills/omh-frontend/SKILL.md
@@ -54,17 +54,11 @@ Bad example:
 - If the target surface is unclear, prepare the brief with a route/component gap instead of inventing pages.
 - If no visual reference exists, set a domain-fit quality bar and request references only when the decision changes layout or brand direction.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Materials and visual summaries** (`design-orchestration`, `design-quality-gate`, `frontend`, `accessibility-audit`, `visual-qa`, `content-operator`, `media-input-operator`, `materials-package`, `+4 more`) - web, accessibility, visual QA, files, and packages.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -151,11 +145,9 @@ omh runtime record --skill frontend --harness frontend --status started
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-frontend/SKILL.md
+++ b/skills/omh-frontend/SKILL.md
@@ -147,6 +147,7 @@ omh runtime record --skill frontend --harness frontend --status started
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-gateway-intent-card/SKILL.md
+++ b/skills/omh-gateway-intent-card/SKILL.md
@@ -49,17 +49,11 @@ Bad example:
 - If platform metadata is missing, keep the card platform-neutral and ask for the target surface.
 - If send or registration evidence is unavailable, show the adapter-owned action instead of claiming delivery.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Automation and status** (`achievements`, `workspace-audit`, `production-audit`, `automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `+31 more`) - schedules, status, health, and ops review.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -116,11 +110,9 @@ omh runtime record --skill gateway-intent-card --harness gateway-intent-card --s
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-gateway-intent-card/SKILL.md
+++ b/skills/omh-gateway-intent-card/SKILL.md
@@ -112,6 +112,7 @@ omh runtime record --skill gateway-intent-card --harness gateway-intent-card --s
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-github-event-ops/SKILL.md
+++ b/skills/omh-github-event-ops/SKILL.md
@@ -49,17 +49,11 @@ Bad example:
 - If required context is missing, ask one blocking question or route back to the narrower workflow.
 - If runtime or wrapper evidence is unavailable, keep the status as not_observed and expose the next observable action.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Automation and status** (`achievements`, `workspace-audit`, `production-audit`, `automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `+31 more`) - schedules, status, health, and ops review.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -116,11 +110,9 @@ omh runtime record --skill github-event-ops --harness github-event-ops --status 
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-github-event-ops/SKILL.md
+++ b/skills/omh-github-event-ops/SKILL.md
@@ -112,6 +112,7 @@ omh runtime record --skill github-event-ops --harness github-event-ops --status 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-harness-session-inventory/SKILL.md
+++ b/skills/omh-harness-session-inventory/SKILL.md
@@ -49,17 +49,11 @@ Bad example:
 - If config sources are unavailable, report only the discovered surfaces and mark the missing hosts not_observed.
 - If cleanup, host load, connector execution, or session progress is requested, route to the owning workflow instead of folding it into inventory.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Automation and status** (`achievements`, `workspace-audit`, `production-audit`, `automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `+31 more`) - schedules, status, health, and ops review.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -123,11 +117,9 @@ omh runtime record --skill harness-session-inventory --harness harness-session-i
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-harness-session-inventory/SKILL.md
+++ b/skills/omh-harness-session-inventory/SKILL.md
@@ -119,6 +119,7 @@ omh runtime record --skill harness-session-inventory --harness harness-session-i
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-idea-to-deploy/SKILL.md
+++ b/skills/omh-idea-to-deploy/SKILL.md
@@ -48,17 +48,11 @@ Bad example:
 - If required context is missing, ask one blocking question or route back to the narrower workflow.
 - If runtime or wrapper evidence is unavailable, keep the status as not_observed and expose the next observable action.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Coding handoff** (`idea-to-deploy`, `cto-loop`, `deploy-and-monitor`, `code-review`, `build-failure-triage`, `verification-gate`, `security-safety-review`, `ultrawork`, `+7 more`) - coding owners, handoffs, review, CI, and merge evidence.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -118,11 +112,9 @@ omh runtime record --skill idea-to-deploy --harness app-delivery-loop --status s
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-idea-to-deploy/SKILL.md
+++ b/skills/omh-idea-to-deploy/SKILL.md
@@ -114,6 +114,7 @@ omh runtime record --skill idea-to-deploy --harness app-delivery-loop --status s
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-image-cards/SKILL.md
+++ b/skills/omh-image-cards/SKILL.md
@@ -144,6 +144,7 @@ omh runtime record --skill img-summary --harness img-summary --status started
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-image-cards/SKILL.md
+++ b/skills/omh-image-cards/SKILL.md
@@ -49,17 +49,11 @@ Bad example:
 - If a renderer or file tool is missing, keep the package prepared and expose the generation handoff.
 - If render QA is unavailable, mark the artifact unverified and request the smallest visual/file check.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Materials and visual summaries** (`design-orchestration`, `design-quality-gate`, `frontend`, `accessibility-audit`, `visual-qa`, `content-operator`, `media-input-operator`, `materials-package`, `+4 more`) - web, accessibility, visual QA, files, and packages.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -148,11 +142,9 @@ omh runtime record --skill img-summary --harness img-summary --status started
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-instinct-ledger/SKILL.md
+++ b/skills/omh-instinct-ledger/SKILL.md
@@ -50,17 +50,11 @@ Bad example:
 - If the request is to mutate durable rules, prompts, skills, or AGENTS guidance, route to rules-distill or implementation after review approval.
 - If evidence comes from a stuck run, use agent-debug before converting lessons into instincts.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Automation and status** (`achievements`, `workspace-audit`, `production-audit`, `automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `+31 more`) - schedules, status, health, and ops review.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -122,11 +116,9 @@ omh runtime record --skill instinct-ledger --harness instinct-ledger --status st
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-instinct-ledger/SKILL.md
+++ b/skills/omh-instinct-ledger/SKILL.md
@@ -118,6 +118,7 @@ omh runtime record --skill instinct-ledger --harness instinct-ledger --status st
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-legal-compliance-review/SKILL.md
+++ b/skills/omh-legal-compliance-review/SKILL.md
@@ -113,6 +113,7 @@ omh runtime record --skill legal-compliance-review --harness critic --status sta
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-legal-compliance-review/SKILL.md
+++ b/skills/omh-legal-compliance-review/SKILL.md
@@ -50,17 +50,11 @@ Bad example:
 - If the reviewed target is missing, inspect the requested artifact or ask one target question.
 - If independent verification is unavailable, report the gap and avoid an approval-style claim.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Research and company ops** (`source-finder`, `web-research`, `best-practice-research`, `autoresearch-goal`, `research-brief`, `strategy-brief`, `feedback-triage`, `research-department`, `+12 more`) - research, signals, ops, and briefings.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -117,11 +111,9 @@ omh runtime record --skill legal-compliance-review --harness critic --status sta
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-live-info/SKILL.md
+++ b/skills/omh-live-info/SKILL.md
@@ -119,6 +119,7 @@ omh runtime record --skill live-info-operator --harness live-info-operator --sta
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-live-info/SKILL.md
+++ b/skills/omh-live-info/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-live-info
-description: [omh] Live lookups - weather, finance, sports, maps, places, exchange rates, and time zones, read-only with provider, freshness, units, and source-quality gates. Use when the user says: live-info-operator, live info operator, live information, real time information, real-time information, weather today, current weather, weather forecast.
+description: [omh] Policy overlay for live lookups - add provider, freshness, units, and source-quality gates after preferring native live-data tools for ordinary weather, finance, sports, maps, and time-zone requests. Use when the user says: live-info-operator, live info operator, live information, real time information, real-time information, weather today, current weather, weather forecast.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, live-info]
@@ -50,17 +50,11 @@ Bad example:
 - If the request asks for citations, best practices, docs, or broad current-source synthesis, route to web-research instead.
 - If the request would create, update, invite, send, or mutate external provider state, route to connector-operator instead.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Automation and status** (`achievements`, `workspace-audit`, `production-audit`, `automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `+31 more`) - schedules, status, health, and ops review.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -123,11 +117,9 @@ omh runtime record --skill live-info-operator --harness live-info-operator --sta
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-localization-review/SKILL.md
+++ b/skills/omh-localization-review/SKILL.md
@@ -113,6 +113,7 @@ omh runtime record --skill localization-review --harness critic --status started
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-localization-review/SKILL.md
+++ b/skills/omh-localization-review/SKILL.md
@@ -50,17 +50,11 @@ Bad example:
 - If the reviewed target is missing, inspect the requested artifact or ask one target question.
 - If independent verification is unavailable, report the gap and avoid an approval-style claim.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Materials and visual summaries** (`design-orchestration`, `design-quality-gate`, `frontend`, `accessibility-audit`, `visual-qa`, `content-operator`, `media-input-operator`, `materials-package`, `+4 more`) - web, accessibility, visual QA, files, and packages.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -117,11 +111,9 @@ omh runtime record --skill localization-review --harness critic --status started
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-materials-package/SKILL.md
+++ b/skills/omh-materials-package/SKILL.md
@@ -49,17 +49,11 @@ Bad example:
 - If a renderer or file tool is missing, keep the package prepared and expose the generation handoff.
 - If render QA is unavailable, mark the artifact unverified and request the smallest visual/file check.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Materials and visual summaries** (`design-orchestration`, `design-quality-gate`, `frontend`, `accessibility-audit`, `visual-qa`, `content-operator`, `media-input-operator`, `materials-package`, `+4 more`) - web, accessibility, visual QA, files, and packages.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -119,11 +113,9 @@ omh runtime record --skill materials-package --harness materials-package --statu
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-materials-package/SKILL.md
+++ b/skills/omh-materials-package/SKILL.md
@@ -115,6 +115,7 @@ omh runtime record --skill materials-package --harness materials-package --statu
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-media-input/SKILL.md
+++ b/skills/omh-media-input/SKILL.md
@@ -121,6 +121,7 @@ omh runtime record --skill media-input-operator --harness media-input-operator -
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-media-input/SKILL.md
+++ b/skills/omh-media-input/SKILL.md
@@ -50,17 +50,11 @@ Bad example:
 - If the request is broad current-source research about a video topic, route to web-research or source-finder before summary.
 - If the user wants a PPT/PDF/report generated from the media summary, route to materials-package after media input evidence is clear.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Materials and visual summaries** (`design-orchestration`, `design-quality-gate`, `frontend`, `accessibility-audit`, `visual-qa`, `content-operator`, `media-input-operator`, `materials-package`, `+4 more`) - web, accessibility, visual QA, files, and packages.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -125,11 +119,9 @@ omh runtime record --skill media-input-operator --harness media-input-operator -
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-meeting-brief/SKILL.md
+++ b/skills/omh-meeting-brief/SKILL.md
@@ -49,17 +49,11 @@ Bad example:
 - If participants, purpose, or decision owner are missing, ask for the one field that changes the agenda.
 - If minutes or decisions were not observed, keep the output as prep rather than record.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Research and company ops** (`source-finder`, `web-research`, `best-practice-research`, `autoresearch-goal`, `research-brief`, `strategy-brief`, `feedback-triage`, `research-department`, `+12 more`) - research, signals, ops, and briefings.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -118,11 +112,9 @@ omh runtime record --skill meeting-brief --harness meeting-facilitation --status
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-meeting-brief/SKILL.md
+++ b/skills/omh-meeting-brief/SKILL.md
@@ -114,6 +114,7 @@ omh runtime record --skill meeting-brief --harness meeting-facilitation --status
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-memory-new/SKILL.md
+++ b/skills/omh-memory-new/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-memory-new
-description: [omh] Save a new durable project or product fact - captures a candidate, shows it for review, and writes only on approval; for auditing memories that already exist use omh-memory-sync. Use when the user says: memory-new, new memory, project memory, product memory, remember this project, remember this product, memory capture, capture memory.
+description: [omh] Save a new durable project or product fact - captures a candidate, shows it for review, and writes only on approval; for auditing existing memories use omh-memory-sync, and for retrieving a past decision use decision-recall. Use when the user says: memory-new, new memory, project memory, product memory, remember this project, remember this product, memory capture, capture memory.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, memory]
@@ -49,17 +49,11 @@ Bad example:
 - If required context is missing, ask one blocking question or route back to the narrower workflow.
 - If runtime or wrapper evidence is unavailable, keep the status as not_observed and expose the next observable action.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Retained knowledge** (`memory-new`, `memory-sync`, `decision-recall`, `wiki`) - memory, rejected alternatives, wiki notes, retrieval, and staleness.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Candidate Flow
 
@@ -140,11 +134,9 @@ omh runtime record --skill memory-new --harness memory-new --status started
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-memory-new/SKILL.md
+++ b/skills/omh-memory-new/SKILL.md
@@ -136,6 +136,7 @@ omh runtime record --skill memory-new --harness memory-new --status started
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-memory-sync/SKILL.md
+++ b/skills/omh-memory-sync/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-memory-sync
-description: [omh] Audit what Hermes already remembers - walks USER.md, MEMORY.md, and skill memories claim by claim, flags stale, conflicting, duplicate, or overgeneralized entries, and rewrites only after an approved diff. Use when the user says: memory-sync, memory curation, memory review, memory inspect, memory check, memory update, context cleanup, curate memory.
+description: [omh] Audit what Hermes already remembers - reviews USER.md, MEMORY.md, and skill memories claim by claim and rewrites only after an approved diff; for a new fact use memory-new, and for retrieving a past decision use decision-recall. Use when the user says: memory-sync, memory curation, memory review, memory inspect, memory check, memory update, context cleanup, curate memory.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, memory]
@@ -49,17 +49,11 @@ Bad example:
 - If required context is missing, ask one blocking question or route back to the narrower workflow.
 - If runtime or wrapper evidence is unavailable, keep the status as not_observed and expose the next observable action.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Retained knowledge** (`memory-new`, `memory-sync`, `decision-recall`, `wiki`) - memory, rejected alternatives, wiki notes, retrieval, and staleness.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Interview Protocol
 
@@ -135,11 +129,9 @@ omh runtime record --skill memory-sync --harness memory-sync --status started
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-memory-sync/SKILL.md
+++ b/skills/omh-memory-sync/SKILL.md
@@ -131,6 +131,7 @@ omh runtime record --skill memory-sync --harness memory-sync --status started
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-meta-router/SKILL.md
+++ b/skills/omh-meta-router/SKILL.md
@@ -48,17 +48,11 @@ Bad example:
 - If routing signals conflict, show the compact picker or ask one clarifying question.
 - If wrapper metadata is unavailable, keep the recommendation advisory and avoid runtime claims.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Intent -> plan** (`oh-my-hermes`, `meta-router`, `deep-interview`, `plan`, `ralplan`, `codebase-onboarding`, `codegraph-refresh`, `ultragoal`, `+6 more`) - clarify, plan, ship, or loop goals.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -118,11 +112,9 @@ omh runtime record --skill meta-router --harness coding-handling --status starte
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-meta-router/SKILL.md
+++ b/skills/omh-meta-router/SKILL.md
@@ -114,6 +114,7 @@ omh runtime record --skill meta-router --harness coding-handling --status starte
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-model-setup/SKILL.md
+++ b/skills/omh-model-setup/SKILL.md
@@ -50,17 +50,11 @@ Bad example:
 - If the diagnosed config cannot be read, report the read failure and stop before proposing a diff.
 - If the user rejects a shown diff, keep the prior config as verified state and ask what to change.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Automation and status** (`achievements`, `workspace-audit`, `production-audit`, `automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `+31 more`) - schedules, status, health, and ops review.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -119,11 +113,9 @@ omh runtime record --skill model-setup --harness coding-handling --status starte
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-model-setup/SKILL.md
+++ b/skills/omh-model-setup/SKILL.md
@@ -115,6 +115,7 @@ omh runtime record --skill model-setup --harness coding-handling --status starte
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-morning-brief/SKILL.md
+++ b/skills/omh-morning-brief/SKILL.md
@@ -49,17 +49,11 @@ Bad example:
 - If the mail or calendar prerequisite is unmet, mark that surface "not applicable" and offer the brief scoped to whichever surface is connected.
 - If a pasted token fails validation, ask the user to reissue it rather than storing or retrying the same value silently.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Automation and status** (`achievements`, `workspace-audit`, `production-audit`, `automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `+31 more`) - schedules, status, health, and ops review.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -118,11 +112,9 @@ omh runtime record --skill morning-brief --harness coding-handling --status star
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-morning-brief/SKILL.md
+++ b/skills/omh-morning-brief/SKILL.md
@@ -114,6 +114,7 @@ omh runtime record --skill morning-brief --harness coding-handling --status star
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-operating-rhythm/SKILL.md
+++ b/skills/omh-operating-rhythm/SKILL.md
@@ -49,17 +49,11 @@ Bad example:
 - If required context is missing, ask one blocking question or route back to the narrower workflow.
 - If runtime or wrapper evidence is unavailable, keep the status as not_observed and expose the next observable action.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Research and company ops** (`source-finder`, `web-research`, `best-practice-research`, `autoresearch-goal`, `research-brief`, `strategy-brief`, `feedback-triage`, `research-department`, `+12 more`) - research, signals, ops, and briefings.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -118,11 +112,9 @@ omh runtime record --skill operating-rhythm --harness operating-rhythm --status 
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-operating-rhythm/SKILL.md
+++ b/skills/omh-operating-rhythm/SKILL.md
@@ -114,6 +114,7 @@ omh runtime record --skill operating-rhythm --harness operating-rhythm --status 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-ops-observability-card/SKILL.md
+++ b/skills/omh-ops-observability-card/SKILL.md
@@ -119,6 +119,7 @@ omh runtime record --skill ops-observability-card --harness ops-observability-ca
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-ops-observability-card/SKILL.md
+++ b/skills/omh-ops-observability-card/SKILL.md
@@ -49,17 +49,11 @@ Bad example:
 - If provider metrics are unavailable, report only local metadata and mark provider truth not_observed.
 - If cost or latency looks risky, surface a warning plus the next measurement rather than a completion claim.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Automation and status** (`achievements`, `workspace-audit`, `production-audit`, `automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `+31 more`) - schedules, status, health, and ops review.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -123,11 +117,9 @@ omh runtime record --skill ops-observability-card --harness ops-observability-ca
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-ops-review/SKILL.md
+++ b/skills/omh-ops-review/SKILL.md
@@ -47,17 +47,11 @@ Bad example:
 - If required context is missing, ask one blocking question or route back to the narrower workflow.
 - If runtime or wrapper evidence is unavailable, keep the status as not_observed and expose the next observable action.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Research and company ops** (`source-finder`, `web-research`, `best-practice-research`, `autoresearch-goal`, `research-brief`, `strategy-brief`, `feedback-triage`, `research-department`, `+12 more`) - research, signals, ops, and briefings.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -117,11 +111,9 @@ omh runtime record --skill ops-review --harness ops-review --status started
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-ops-review/SKILL.md
+++ b/skills/omh-ops-review/SKILL.md
@@ -113,6 +113,7 @@ omh runtime record --skill ops-review --harness ops-review --status started
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-paper-learning/SKILL.md
+++ b/skills/omh-paper-learning/SKILL.md
@@ -126,6 +126,7 @@ omh runtime record --skill paper-learning --harness paper-learning --status star
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-paper-learning/SKILL.md
+++ b/skills/omh-paper-learning/SKILL.md
@@ -55,17 +55,11 @@ Bad example:
 - If context is too long, continue section-by-section and keep covered / next / missing state in the ledger.
 - If the user asks for validation, citation checking, math proof review, or reproduction, create a separate observed-evidence or coding handoff path.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Research and company ops** (`source-finder`, `web-research`, `best-practice-research`, `autoresearch-goal`, `research-brief`, `strategy-brief`, `feedback-triage`, `research-department`, `+12 more`) - research, signals, ops, and briefings.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -130,11 +124,9 @@ omh runtime record --skill paper-learning --harness paper-learning --status star
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-parallel-tools/SKILL.md
+++ b/skills/omh-parallel-tools/SKILL.md
@@ -49,17 +49,11 @@ Bad example:
 - If the installed version cannot be read, report the read failure and stop before recommending an update.
 - If the update command is unavailable for the user's install path, name the blocker instead of guessing a fix.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Automation and status** (`achievements`, `workspace-audit`, `production-audit`, `automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `+31 more`) - schedules, status, health, and ops review.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -117,11 +111,9 @@ omh runtime record --skill parallel-tools --harness coding-handling --status sta
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-parallel-tools/SKILL.md
+++ b/skills/omh-parallel-tools/SKILL.md
@@ -113,6 +113,7 @@ omh runtime record --skill parallel-tools --harness coding-handling --status sta
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-people-ops/SKILL.md
+++ b/skills/omh-people-ops/SKILL.md
@@ -113,6 +113,7 @@ omh runtime record --skill people-ops --harness ops-review --status started
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-people-ops/SKILL.md
+++ b/skills/omh-people-ops/SKILL.md
@@ -50,17 +50,11 @@ Bad example:
 - If required context is missing, ask one blocking question or route back to the narrower workflow.
 - If runtime or wrapper evidence is unavailable, keep the status as not_observed and expose the next observable action.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Research and company ops** (`source-finder`, `web-research`, `best-practice-research`, `autoresearch-goal`, `research-brief`, `strategy-brief`, `feedback-triage`, `research-department`, `+12 more`) - research, signals, ops, and briefings.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -117,11 +111,9 @@ omh runtime record --skill people-ops --harness ops-review --status started
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-performance-goal/SKILL.md
+++ b/skills/omh-performance-goal/SKILL.md
@@ -110,6 +110,7 @@ omh runtime record --skill performance-goal --harness goal-execution --status st
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-performance-goal/SKILL.md
+++ b/skills/omh-performance-goal/SKILL.md
@@ -47,17 +47,11 @@ Bad example:
 - If required context is missing, ask one blocking question or route back to the narrower workflow.
 - If runtime or wrapper evidence is unavailable, keep the status as not_observed and expose the next observable action.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Intent -> plan** (`oh-my-hermes`, `meta-router`, `deep-interview`, `plan`, `ralplan`, `codebase-onboarding`, `codegraph-refresh`, `ultragoal`, `+6 more`) - clarify, plan, ship, or loop goals.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -114,11 +108,9 @@ omh runtime record --skill performance-goal --harness goal-execution --status st
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-physical-device-readiness/SKILL.md
+++ b/skills/omh-physical-device-readiness/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-physical-device-readiness
-description: [omh] Hermes readiness workflow for robots, 3D printers, IoT relays, sensors, and lab hardware before hardware trials. Use when the user says: physical-device-readiness, physical device readiness, device safety readiness, physical device safety, hardware safety gate, 3d printer readiness, 3D printer safety, snapmaker printer safety.
+description: [omh] Physical device readiness - gate robots, 3D printers, IoT relays, sensors, and lab hardware before trials; use external-connector-readiness for provider or connector adoption and toolbelt-readiness for missing control tools. Use when the user says: physical-device-readiness, physical device readiness, device safety readiness, physical device safety, hardware safety gate, 3d printer readiness, 3D printer safety, snapmaker printer safety.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, operations]
@@ -51,17 +51,11 @@ Bad example:
 - If the user asks to execute commands, move hardware, heat a bed/nozzle, flip a relay, or start a print, route to command-operator or connector-operator and require observed operator approval before any execution claim.
 - If camera or telemetry evidence is required but unavailable, route to visual-qa or toolbelt-readiness and keep the physical device readiness card prepared_not_observed.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Automation and status** (`achievements`, `workspace-audit`, `production-audit`, `automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `+31 more`) - schedules, status, health, and ops review.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -132,11 +126,9 @@ omh runtime record --skill physical-device-readiness --harness physical-device-r
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-physical-device-readiness/SKILL.md
+++ b/skills/omh-physical-device-readiness/SKILL.md
@@ -128,6 +128,7 @@ omh runtime record --skill physical-device-readiness --harness physical-device-r
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-plan/SKILL.md
+++ b/skills/omh-plan/SKILL.md
@@ -48,17 +48,11 @@ Bad example:
 - If acceptance criteria or verification are missing, route back to clarification before handoff.
 - If assumptions materially affect the plan, keep them visible and avoid treating the plan as accepted.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Intent -> plan** (`oh-my-hermes`, `meta-router`, `deep-interview`, `plan`, `ralplan`, `codebase-onboarding`, `codegraph-refresh`, `ultragoal`, `+6 more`) - clarify, plan, ship, or loop goals.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -115,11 +109,9 @@ omh runtime record --skill plan --harness planning --status started
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-plan/SKILL.md
+++ b/skills/omh-plan/SKILL.md
@@ -111,6 +111,7 @@ omh runtime record --skill plan --harness planning --status started
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-product-brief/SKILL.md
+++ b/skills/omh-product-brief/SKILL.md
@@ -50,17 +50,11 @@ Bad example:
 - If acceptance criteria or verification are missing, route back to clarification before handoff.
 - If assumptions materially affect the plan, keep them visible and avoid treating the plan as accepted.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Intent -> plan** (`oh-my-hermes`, `meta-router`, `deep-interview`, `plan`, `ralplan`, `codebase-onboarding`, `codegraph-refresh`, `ultragoal`, `+6 more`) - clarify, plan, ship, or loop goals.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -117,11 +111,9 @@ omh runtime record --skill product-brief --harness planning --status started
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-product-brief/SKILL.md
+++ b/skills/omh-product-brief/SKILL.md
@@ -113,6 +113,7 @@ omh runtime record --skill product-brief --harness planning --status started
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-production-audit/SKILL.md
+++ b/skills/omh-production-audit/SKILL.md
@@ -49,17 +49,11 @@ Bad example:
 - If the reviewed target is missing, inspect the requested artifact or ask one target question.
 - If independent verification is unavailable, report the gap and avoid an approval-style claim.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Automation and status** (`achievements`, `workspace-audit`, `production-audit`, `automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `+31 more`) - schedules, status, health, and ops review.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -123,11 +117,9 @@ omh runtime record --skill production-audit --harness production-audit --status 
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-production-audit/SKILL.md
+++ b/skills/omh-production-audit/SKILL.md
@@ -119,6 +119,7 @@ omh runtime record --skill production-audit --harness production-audit --status 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-prompt-import-readiness/SKILL.md
+++ b/skills/omh-prompt-import-readiness/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-prompt-import-readiness
-description: [omh] Hermes prompt import readiness workflow: decide whether external CLI-agent prompt files can be safely reviewed, normalized, and offered as Hermes slash-command candidates without mutating prompts or command registries. Use when the user says: prompt-import-readiness, prompt import readiness, slash prompt import, slash prompts import, slash command prompt import, prompt library import, prompt folder import, prompt directory import.
+description: [omh] Prompt import readiness - review and normalize external CLI-agent prompt files before offering slash-command candidates; use external-connector-readiness for plugin or API adoption and toolbelt-readiness for missing runtime capabilities. Use when the user says: prompt-import-readiness, prompt import readiness, slash prompt import, slash prompts import, slash command prompt import, prompt library import, prompt folder import, prompt directory import.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, prompt]
@@ -51,17 +51,11 @@ Bad example:
 - If source trust, prompt-injection risk, secrets, or destructive command content is unclear, route to security-safety-review before import.
 - If the user asks to actually copy, generate, or register prompt files, prepare an executor or workspace-file handoff and keep readiness prepared_not_observed until file evidence exists.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Automation and status** (`achievements`, `workspace-audit`, `production-audit`, `automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `+31 more`) - schedules, status, health, and ops review.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -132,11 +126,9 @@ omh runtime record --skill prompt-import-readiness --harness prompt-import-readi
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-prompt-import-readiness/SKILL.md
+++ b/skills/omh-prompt-import-readiness/SKILL.md
@@ -128,6 +128,7 @@ omh runtime record --skill prompt-import-readiness --harness prompt-import-readi
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-provider-profile-posture/SKILL.md
+++ b/skills/omh-provider-profile-posture/SKILL.md
@@ -112,6 +112,7 @@ omh runtime record --skill provider-profile-posture --harness provider-profile-p
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-provider-profile-posture/SKILL.md
+++ b/skills/omh-provider-profile-posture/SKILL.md
@@ -49,17 +49,11 @@ Bad example:
 - If required context is missing, ask one blocking question or route back to the narrower workflow.
 - If runtime or wrapper evidence is unavailable, keep the status as not_observed and expose the next observable action.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Automation and status** (`achievements`, `workspace-audit`, `production-audit`, `automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `+31 more`) - schedules, status, health, and ops review.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -116,11 +110,9 @@ omh runtime record --skill provider-profile-posture --harness provider-profile-p
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-reliability-review/SKILL.md
+++ b/skills/omh-reliability-review/SKILL.md
@@ -113,6 +113,7 @@ omh runtime record --skill reliability-review --harness reliability-review --sta
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-reliability-review/SKILL.md
+++ b/skills/omh-reliability-review/SKILL.md
@@ -49,17 +49,11 @@ Bad example:
 - If required context is missing, ask one blocking question or route back to the narrower workflow.
 - If runtime or wrapper evidence is unavailable, keep the status as not_observed and expose the next observable action.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Research and company ops** (`source-finder`, `web-research`, `best-practice-research`, `autoresearch-goal`, `research-brief`, `strategy-brief`, `feedback-triage`, `research-department`, `+12 more`) - research, signals, ops, and briefings.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -117,11 +111,9 @@ omh runtime record --skill reliability-review --harness reliability-review --sta
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-report-package/SKILL.md
+++ b/skills/omh-report-package/SKILL.md
@@ -114,6 +114,7 @@ omh runtime record --skill report-package --harness report-package --status star
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-report-package/SKILL.md
+++ b/skills/omh-report-package/SKILL.md
@@ -49,17 +49,11 @@ Bad example:
 - If input evidence is incomplete, mark the section as pending rather than fabricating a report claim.
 - If delivery or attachment is unavailable, keep the report package prepared_not_observed.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Materials and visual summaries** (`design-orchestration`, `design-quality-gate`, `frontend`, `accessibility-audit`, `visual-qa`, `content-operator`, `media-input-operator`, `materials-package`, `+4 more`) - web, accessibility, visual QA, files, and packages.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -118,11 +112,9 @@ omh runtime record --skill report-package --harness report-package --status star
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-research-brief/SKILL.md
+++ b/skills/omh-research-brief/SKILL.md
@@ -113,6 +113,7 @@ omh runtime record --skill research-brief --harness business-research --status s
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-research-brief/SKILL.md
+++ b/skills/omh-research-brief/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-research-brief
-description: [omh] Business research brief - turns a market, competitor, pricing, or customer question into a structured brief with an explicit evidence-vs-inference split; for raw link gathering use ulw-research. Use when the user says: research-brief, business-research, business research, research brief, source-backed business research, customer feedback trends, feedback trends, market evidence.
+description: [omh] Business research brief - turns a market, competitor, pricing, or customer question into a structured evidence-vs-inference brief; for raw link gathering use ulw-research, and for ongoing multi-role research use research-department. Use when the user says: research-brief, business-research, business research, research brief, source-backed business research, customer feedback trends, feedback trends, market evidence.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, research]
@@ -48,17 +48,11 @@ Bad example:
 - If sources cannot be accessed, state the retrieval gap and use only observed local context.
 - If evidence is thin or one-sided, lower confidence and ask for a narrower source boundary.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Research and company ops** (`source-finder`, `web-research`, `best-practice-research`, `autoresearch-goal`, `research-brief`, `strategy-brief`, `feedback-triage`, `research-department`, `+12 more`) - research, signals, ops, and briefings.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -117,11 +111,9 @@ omh runtime record --skill research-brief --harness business-research --status s
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-research-department/SKILL.md
+++ b/skills/omh-research-department/SKILL.md
@@ -118,6 +118,7 @@ omh runtime record --skill research-department --harness research-department --s
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-research-department/SKILL.md
+++ b/skills/omh-research-department/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-research-department
-description: [omh] Hermes Research Department workflow pack: prepare Scout, Analyst, and Briefer research operations with source inbox and briefing status boundaries. Use when the user says: research-department, research department, research ops department, research operations department, scout analyst briefer, scout analyst brief, daily research department, competitor research department.
+description: [omh] Research operations department - coordinate Scout, Analyst, and Briefer work with source-inbox and status boundaries; for one decision brief use research-brief, and for typed candidates before research starts use source-finder. Use when the user says: research-department, research department, research ops department, research operations department, scout analyst briefer, scout analyst brief, daily research department, competitor research department.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, research]
@@ -50,17 +50,11 @@ Bad example:
 - If sources cannot be accessed, state the retrieval gap and use only observed local context.
 - If evidence is thin or one-sided, lower confidence and ask for a narrower source boundary.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Research and company ops** (`source-finder`, `web-research`, `best-practice-research`, `autoresearch-goal`, `research-brief`, `strategy-brief`, `feedback-triage`, `research-department`, `+12 more`) - research, signals, ops, and briefings.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -122,11 +116,9 @@ omh runtime record --skill research-department --harness research-department --s
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-routing/references/catalog-index.md
+++ b/skills/omh-routing/references/catalog-index.md
@@ -17,13 +17,13 @@ Trigger phrases and the role registry live in `references/workflow-registry.md`;
 - `omh-automation-blueprint`: [omh] Hermes Scheduled Ops Blueprint workflow: design recurring Hermes operations with schedule, delivery, silence policy, context chain, and prepared-vs-observed status.
 - `omh-autoresearch-goal`: [omh] Hermes adaptation for durable research-goal execution.
 - `omh-best-practice-research`: [omh] Hermes adaptation for bounded official/upstream best-practice research.
-- `omh-browser`: [omh] Browser tasks - open URLs, click, log in, fill forms, and capture page blockers, each scoped behind auth, confirmation, and observed-trace gates.
+- `omh-browser`: [omh] Policy overlay for browser tasks - add auth, confirmation, and observed-trace gates after preferring the native browser for ordinary URL, click, login, and form actions.
 - `omh-build-failure-triage`: [omh] Hermes Build Failure Triage workflow: classify build, typecheck, lint, test, CI, and DCO failures into minimal safe fix handoffs.
 - `omh-cancel`: [omh] Hermes adaptation for ending active workflow state cleanly.
 - `omh-code-review`: [omh] Hermes Code Review workflow: bug-first review with evidence.
 - `omh-codebase-onboarding`: [omh] Hermes Codebase Onboarding workflow: create a repo map, reading path, glossary, risk map, and first-task runway for unfamiliar codebases.
 - `omh-codegraph-refresh`: [omh] Hermes Codegraph Refresh workflow: refresh local code intelligence, summarize repo structure, and prepare task-scoped codegraph handoff context without overclaiming execution.
-- `omh-terminal`: [omh] Terminal commands - scope shell, CLI, package-manager, and test runs with cwd, environment, safety, and result-evidence gates.
+- `omh-terminal`: [omh] Policy overlay for terminal commands - add cwd, environment, safety, and result-evidence gates after preferring native shell tools for ordinary CLI, package-manager, and test runs.
 - `omh-apps`: [omh] External app actions - email, Slack, Discord, Notion, Linear, Jira, CRM, and similar providers, scoped with auth, payload, confirmation, and result-evidence gates.
 - `omh-content-operator`: [omh] Hermes content operator workflow: scope publish-ready writing, rewriting, summarization, translation, release-note, newsletter, customer-copy, social-copy, README-copy, and email-draft work with audience, tone, style, source, review, and hallucination gates.
 - `omh-context-budget-review`: [omh] Hermes Context Budget Review workflow: plan compact context, token/cost budgets, summarization checkpoints, and overflow recovery before long agent work.
@@ -37,8 +37,8 @@ Trigger phrases and the role registry live in `references/workflow-registry.md`;
 - `omh-design-orchestration`: [omh] Hermes design orchestration workflow: prepare a bounded design direction, existing-lane composition, and executor-neutral handoff.
 - `omh-design-quality-gate`: [omh] Hermes Design Quality Gate workflow: enforce superior content, design, layout, publishing, and visual QA gates.
 - `omh-doctor`: [omh] Hermes adaptation for diagnosing oh-my-hermes installation health.
-- `omh-executor-runtime-readiness`: [omh] Hermes executor runtime readiness workflow: compare Codex, Claude Code, Hermes coding, and oh-my runtimes by available tools, missing tools, and handoff mode.
-- `omh-external-connector-readiness`: [omh] Hermes external connector readiness workflow: decide whether a candidate plugin, connector, API, data provider, or multimodal route is safe, affordable, fresh, and observable enough to adopt, route, or trial.
+- `omh-executor-runtime-readiness`: [omh] Executor runtime readiness - compare Codex, Claude Code, Hermes coding, and oh-my runtimes by tools and handoff mode; use external-connector-readiness for a named plugin or API, and toolbelt-readiness for the whole capability inventory.
+- `omh-external-connector-readiness`: [omh] External connector readiness - assess whether a named plugin, connector, API, data provider, or multimodal route is safe, affordable, fresh, and observable; use executor-runtime-readiness for coding-owner choice and toolbelt-readiness for missing capability inventory.
 - `omh-failure-signal-audit`: [omh] Failure Signal Audit workflow: find swallowed errors, unsafe fallbacks, hidden UI/runtime failures, and missing propagation before they become false green status.
 - `omh-feedback-triage`: [omh] Hermes Feedback Triage workflow: cluster customer signals and choose the next workflow.
 - `omh-finance-analysis`: [omh] Turn finance and accounting inputs into a decision-ready variance, cash, and close-risk brief.
@@ -50,14 +50,14 @@ Trigger phrases and the role registry live in `references/workflow-registry.md`;
 - `omh-image-cards`: [omh] Image prompt cards - turn meetings, reports, PRs, issues, research, and releases into domain-aware image prompt cards.
 - `omh-instinct-ledger`: [omh] Instinct Ledger workflow: turn repeated project or cross-project lessons into atomic, confidence-scored instinct candidates with scoped promotion and export boundaries.
 - `omh-legal-compliance-review`: [omh] Surface contract and compliance risks, questions, and escalation points before a legal decision or action.
-- `omh-live-info`: [omh] Live lookups - weather, finance, sports, maps, places, exchange rates, and time zones, read-only with provider, freshness, units, and source-quality gates.
+- `omh-live-info`: [omh] Policy overlay for live lookups - add provider, freshness, units, and source-quality gates after preferring native live-data tools for ordinary weather, finance, sports, maps, and time-zone requests.
 - `omh-localization-review`: [omh] Make a product or content release locale-ready with terminology, cultural-fit, and quality-review guidance.
 - `ulw-loop`: [omh] Hermes Loop workflow: agentic interviewer -> planner -> researcher -> builder -> reviewer cycles until a real gate.
 - `omh-materials-package`: [omh] Hermes Materials Package workflow: decks, PDFs, spreadsheets, documents, HWP, Markdown, and binary export handoffs.
 - `omh-media-input`: [omh] User-sent media - audio, video, YouTube links, screenshots, receipts, OCR, meeting recordings, transcripts, timestamps, and clip summaries, gated for source, permission, and hallucination risk.
 - `omh-meeting-brief`: [omh] Hermes Meeting Brief workflow: agenda, prompts, decisions, and record template.
-- `omh-memory-new`: [omh] Save a new durable project or product fact - captures a candidate, shows it for review, and writes only on approval; for auditing memories that already exist use omh-memory-sync.
-- `omh-memory-sync`: [omh] Audit what Hermes already remembers - walks USER.md, MEMORY.md, and skill memories claim by claim, flags stale, conflicting, duplicate, or overgeneralized entries, and rewrites only after an approved diff.
+- `omh-memory-new`: [omh] Save a new durable project or product fact - captures a candidate, shows it for review, and writes only on approval; for auditing existing memories use omh-memory-sync, and for retrieving a past decision use decision-recall.
+- `omh-memory-sync`: [omh] Audit what Hermes already remembers - reviews USER.md, MEMORY.md, and skill memories claim by claim and rewrites only after an approved diff; for a new fact use memory-new, and for retrieving a past decision use decision-recall.
 - `omh-meta-router`: [omh] Meta-routing guidance for a leading /omh command: reason over the imperative task, consult the live workflow catalog, and select or chain the right workflow(s).
 - `omh-model-setup`: [omh] Hermes Model Setup workflow: diagnose role-slot model configuration, guide provider connection, and apply changes only after diff approval.
 - `omh-morning-brief`: [omh] Morning brief SETUP (one-time) - connects mail and calendar MCP with read-and-draft-only scope and diff approval; produces the configuration, not the daily brief itself.
@@ -69,18 +69,18 @@ Trigger phrases and the role registry live in `references/workflow-registry.md`;
 - `omh-parallel-tools`: [omh] Hermes Parallel Tools workflow: check version currency and parallel-tool capability status, then apply an update only after diff approval.
 - `omh-people-ops`: [omh] Turn hiring and people context into a fair, structured recruiting or people-operations brief.
 - `omh-performance-goal`: [omh] Hermes adaptation for measurable performance-goal execution.
-- `omh-physical-device-readiness`: [omh] Hermes readiness workflow for robots, 3D printers, IoT relays, sensors, and lab hardware before hardware trials.
+- `omh-physical-device-readiness`: [omh] Physical device readiness - gate robots, 3D printers, IoT relays, sensors, and lab hardware before trials; use external-connector-readiness for provider or connector adoption and toolbelt-readiness for missing control tools.
 - `omh-plan`: [omh] Hermes Plan workflow: structured planning before execution.
 - `omh-product-brief`: [omh] Turn product evidence into a decision-ready PRD, prioritization frame, and roadmap brief.
 - `omh-production-audit`: [omh] Hermes Production Audit workflow: evaluate release, deploy, security, observability, rollback, docs, and support readiness without claiming production access.
-- `omh-prompt-import-readiness`: [omh] Hermes prompt import readiness workflow: decide whether external CLI-agent prompt files can be safely reviewed, normalized, and offered as Hermes slash-command candidates without mutating prompts or command registries.
+- `omh-prompt-import-readiness`: [omh] Prompt import readiness - review and normalize external CLI-agent prompt files before offering slash-command candidates; use external-connector-readiness for plugin or API adoption and toolbelt-readiness for missing runtime capabilities.
 - `omh-provider-profile-posture`: [omh] Prepare provider-profile metadata without reading secrets or calling providers.
 - `ulw-ralph`: [omh] Ralph - one owner drives a concrete task to done: implement, verify, review, repeat until the gate passes; prefer over one-shot delegation when the task needs a verification loop.
 - `ulw-plan`: [omh] Hermes Ralplan workflow: consensus planning with review gates.
 - `omh-reliability-review`: [omh] Hermes Reliability Review workflow: postmortems, SLOs, error budgets, incident follow-ups, and service reliability evidence.
 - `omh-report-package`: [omh] Hermes Report Package workflow: weekly/monthly reports, executive briefs, PPT-ready outlines, and upload packages.
-- `omh-research-brief`: [omh] Business research brief - turns a market, competitor, pricing, or customer question into a structured brief with an explicit evidence-vs-inference split; for raw link gathering use ulw-research.
-- `omh-research-department`: [omh] Hermes Research Department workflow pack: prepare Scout, Analyst, and Briefer research operations with source inbox and briefing status boundaries.
+- `omh-research-brief`: [omh] Business research brief - turns a market, competitor, pricing, or customer question into a structured evidence-vs-inference brief; for raw link gathering use ulw-research, and for ongoing multi-role research use research-department.
+- `omh-research-department`: [omh] Research operations department - coordinate Scout, Analyst, and Briefer work with source-inbox and status boundaries; for one decision brief use research-brief, and for typed candidates before research starts use source-finder.
 - `omh-rules-distill`: [omh] Hermes Rules Distill workflow: extract repeated principles from skills, prompts, traces, reviews, and failures into reviewed rule candidates without auto-mutating guidance.
 - `omh-run-efficiency`: [omh] Report supplied local run efficiency while provider and host data stay unobserved.
 - `omh-sales-development`: [omh] Turn an account or market opportunity into a focused discovery, qualification, and next-step brief.
@@ -88,11 +88,11 @@ Trigger phrases and the role registry live in `references/workflow-registry.md`;
 - `omh-skill`: [omh] Hermes adaptation for managing local skills.
 - `omh-skill-health`: [omh] Skill Health workflow: prepare a metadata-only OMH skill portfolio dashboard with stale surfaces, observed failure signals, pending amendments, and top actions.
 - `omh-skill-scout`: [omh] Skill Scout workflow: prepare a metadata-only search-before-creation report for local, marketplace, GitHub, and web skill candidates with risk review and adoption options.
-- `omh-source-finder`: [omh] Hermes Source Finder workflow: prepare typed source candidates and acquisition status before downstream work.
+- `omh-source-finder`: [omh] Source candidate inventory - prepare typed source candidates and acquisition status before downstream work; use ulw-research to fetch and cite them, or research-brief to turn them into a decision-ready brief.
 - `omh-decide`: [omh] Decide between options: tradeoffs, a recommendation, and a decision note you can act on.
 - `omh-support-operations`: [omh] Turn a support case into a clear customer reply, severity path, and owned next step.
 - `ulw-team`: [omh] Team - run N coordinated workers on one shared task list with explicit lane ownership and merged verification; choose over raw subagents when lanes must not collide.
-- `omh-toolbelt-readiness`: [omh] Hermes toolbelt readiness workflow: check which MCP servers, CLIs, APIs, credentials, and connectors a workflow needs before claiming it can run.
+- `omh-toolbelt-readiness`: [omh] Toolbelt readiness - inventory which MCP servers, CLIs, APIs, credentials, and connectors a workflow needs; use external-connector-readiness to assess one named integration and executor-runtime-readiness to choose the coding owner.
 - `ulw-goal`: [omh] Ultragoal - durable multi-session goal tracking: a checkpointed ledger survives context loss and resumes exactly where work stopped, with a final completion gate.
 - `ulw-perf`: [omh] Ultraperf - find where a system is actually slow, leaking, or expensive across runtime, memory, token cost, storage, rendering, inference, CI, and query domains, then fix one measured hot path at a time behind a regression budget.
 - `ulw-process`: [omh] Ultraprocess - one full task-to-PR cycle: codebase research, reviewed plan, coding handoff to the selected executor, code review, docs sync, and PR, tracked end to end.
@@ -101,9 +101,9 @@ Trigger phrases and the role registry live in `references/workflow-registry.md`;
 - `omh-verification-gate`: [omh] Hermes Verification Gate workflow: define and record build, lint, typecheck, test, security, docs, generated-output, and CI evidence before completion or merge.
 - `omh-visual-qa`: [omh] Hermes visual-qa workflow: prepare observed-only rendered QA gates for web, frontend, image, document, and TUI surfaces.
 - `omh-voice-input`: [omh] Terse voice and mobile-style requests - turn short spoken-style asks into clarify, plan, status, handoff, or confirmation actions.
-- `ulw-research`: [omh] Web research with citation discipline on top of native search - every claim carries a live URL, sources are diversity-checked, and anything not fetched is marked not observed instead of guessed.
+- `ulw-research`: [omh] Web research with citation discipline on top of native search - every claim carries a live URL and unfetched claims stay not observed; for a decision-ready brief use research-brief, and for ongoing Scout/Analyst/Briefer coordination use research-department.
 - `omh-websearch-setup`: [omh] Hermes Web Search Setup workflow: diagnose scraper and auxiliary extract-model configuration, guide account setup, and apply each change as its own diff approval.
 - `omh-wiki`: [omh] Hermes adaptation for wiki construction blueprints and retained knowledge capture with destination-aware external knowledge connection guidance.
 - `omh-workflow-learning`: [omh] Hermes workflow learning workflow: classify and review self-improvement store routes as an auxiliary review lane before durable writes, then record workflow attempts as metadata-only traces, evals, review queues, patch proposals, regression cases, audits, indexes, and exports.
 - `omh-workspace-audit`: [omh] Hermes Workspace Audit workflow: map repository, skill, prompt, plugin, MCP, hook, config, and runtime surfaces before strengthening or operating OMH.
-- `omh-files`: [omh] Local files and folders - list, search, organize, copy, move, rename, and delete, with path scoping and destructive-action gates.
+- `omh-files`: [omh] Policy overlay for local file tasks - add path scoping and destructive-action gates after preferring native file tools for ordinary list, search, organize, copy, move, and rename actions.

--- a/skills/omh-routing/references/skill-common-rail.md
+++ b/skills/omh-routing/references/skill-common-rail.md
@@ -8,6 +8,21 @@ own evidence boundary, and a pointer to this file.
 Load this reference when harness selection, a missing Hermes runtime capability,
 multi-agent target topology, or the generic execution checklist is in play.
 
+## OMH Context Rail
+
+- OMH is a Hermes workflow layer, not a standalone executor.
+- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
+- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
+- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
+- Coverage: Every generated workflow skill carries this rail.
+- Normal users talk to Hermes; OMH CLI is infra.
+- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+
+## Hermes Compatibility Contract
+
+- Preserve workflow intent and stop conditions; verify before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays.
+
 ## Harness Discipline
 
 - Start from the representative harness registry in `oh-my-hermes` when the workflow needs coding, research, planning, goal execution, architecture, critique, QA, or documentation lanes.

--- a/skills/omh-routing/references/workflow-registry.md
+++ b/skills/omh-routing/references/workflow-registry.md
@@ -37,7 +37,7 @@ These surfaces are generated command references, not installed Hermes workflow s
 When Hermes exposes installed skill descriptions to the model, use this registry as the routing map:
 
 - `meta-router`: `/omh`, `./omh`
-- `ralph`: `ralph`, `$ralph`, `finish until done`, `persistent execution`, `self-referential loop`
+- `ralph`: `ralph`, `$ralph`, `ulr`, `$ulr`, `finish until done`, `persistent execution`, `self-referential loop`
 - `ultragoal`: `ultragoal`, `$ultragoal`, `ulg`, `$ulg`, `durable goal`, `multi-goal`, `goal ledger`, `long running goal`, `완료조건까지 계속`
 - `loop`: `loop`, `./loop`, `$loop`, `goal loop`, `long horizon goal`, `never stop`, `research plan ultragoal feedback`, `token exhaustion resume`, `permission profile`
 - `ultraprocess`: `ultraprocess`, `$ultraprocess`, `ulp`, `$ulp`, `./ultraprocess`, `/ultraprocess`, `single-cycle delivery`, `one-cycle delivery`, `end-to-end process`

--- a/skills/omh-rules-distill/SKILL.md
+++ b/skills/omh-rules-distill/SKILL.md
@@ -49,17 +49,11 @@ Bad example:
 - If source evidence conflicts, route to memory or knowledge review before writing durable guidance.
 - If the fact may be stale, record the staleness warning and next refresh action.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Automation and status** (`achievements`, `workspace-audit`, `production-audit`, `automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `+31 more`) - schedules, status, health, and ops review.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -123,11 +117,9 @@ omh runtime record --skill rules-distill --harness rules-distill --status starte
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-rules-distill/SKILL.md
+++ b/skills/omh-rules-distill/SKILL.md
@@ -119,6 +119,7 @@ omh runtime record --skill rules-distill --harness rules-distill --status starte
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-run-efficiency/SKILL.md
+++ b/skills/omh-run-efficiency/SKILL.md
@@ -49,17 +49,11 @@ Bad example:
 - If provider metrics are unavailable, report only local metadata and mark provider truth not_observed.
 - If cost or latency looks risky, surface a warning plus the next measurement rather than a completion claim.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Automation and status** (`achievements`, `workspace-audit`, `production-audit`, `automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `+31 more`) - schedules, status, health, and ops review.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -116,11 +110,9 @@ omh runtime record --skill run-efficiency --harness run-efficiency --status star
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-run-efficiency/SKILL.md
+++ b/skills/omh-run-efficiency/SKILL.md
@@ -112,6 +112,7 @@ omh runtime record --skill run-efficiency --harness run-efficiency --status star
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-sales-development/SKILL.md
+++ b/skills/omh-sales-development/SKILL.md
@@ -50,17 +50,11 @@ Bad example:
 - If evidence is mostly assumption, label it and recommend a research or feedback-triage pass.
 - If the decision owner is missing, keep the output as options rather than accepted strategy.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Research and company ops** (`source-finder`, `web-research`, `best-practice-research`, `autoresearch-goal`, `research-brief`, `strategy-brief`, `feedback-triage`, `research-department`, `+12 more`) - research, signals, ops, and briefings.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -117,11 +111,9 @@ omh runtime record --skill sales-development --harness ops-review --status start
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-sales-development/SKILL.md
+++ b/skills/omh-sales-development/SKILL.md
@@ -113,6 +113,7 @@ omh runtime record --skill sales-development --harness ops-review --status start
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-security-safety-review/SKILL.md
+++ b/skills/omh-security-safety-review/SKILL.md
@@ -125,6 +125,7 @@ omh runtime record --skill security-safety-review --harness security-safety-revi
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-security-safety-review/SKILL.md
+++ b/skills/omh-security-safety-review/SKILL.md
@@ -49,17 +49,11 @@ Bad example:
 - If the reviewed target is missing, inspect the requested artifact or ask one target question.
 - If independent verification is unavailable, report the gap and avoid an approval-style claim.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Coding handoff** (`idea-to-deploy`, `cto-loop`, `deploy-and-monitor`, `code-review`, `build-failure-triage`, `verification-gate`, `security-safety-review`, `ultrawork`, `+7 more`) - coding owners, handoffs, review, CI, and merge evidence.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -129,11 +123,9 @@ omh runtime record --skill security-safety-review --harness security-safety-revi
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-skill-health/SKILL.md
+++ b/skills/omh-skill-health/SKILL.md
@@ -115,6 +115,7 @@ omh runtime record --skill skill-health --harness skill-health --status started
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-skill-health/SKILL.md
+++ b/skills/omh-skill-health/SKILL.md
@@ -49,17 +49,11 @@ Bad example:
 - If the request is about OMH setup, install, stale package paths, or command availability, route to doctor.
 - If the request is a missed-route or self-improvement trace, route to workflow-learning before adding health actions.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Automation and status** (`achievements`, `workspace-audit`, `production-audit`, `automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `+31 more`) - schedules, status, health, and ops review.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -119,11 +113,9 @@ omh runtime record --skill skill-health --harness skill-health --status started
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-skill-scout/SKILL.md
+++ b/skills/omh-skill-scout/SKILL.md
@@ -119,6 +119,7 @@ omh runtime record --skill skill-scout --harness skill-scout --status started
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-skill-scout/SKILL.md
+++ b/skills/omh-skill-scout/SKILL.md
@@ -50,17 +50,11 @@ Bad example:
 - If the request is a portfolio health dashboard, route to skill-health.
 - If the request is an approved skill mutation or creation task, route to skill or implementation after the scout decision.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Automation and status** (`achievements`, `workspace-audit`, `production-audit`, `automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `+31 more`) - schedules, status, health, and ops review.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -123,11 +117,9 @@ omh runtime record --skill skill-scout --harness skill-scout --status started
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-skill/SKILL.md
+++ b/skills/omh-skill/SKILL.md
@@ -107,6 +107,7 @@ omh runtime record --skill skill --harness docs-specialist --status started
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-skill/SKILL.md
+++ b/skills/omh-skill/SKILL.md
@@ -48,17 +48,11 @@ Bad example:
 - If a managed path or config key is missing, route to setup/update repair instead of editing hidden state.
 - If a reload or plugin load was not observed, keep the diagnostic result as local health evidence only.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Automation and status** (`achievements`, `workspace-audit`, `production-audit`, `automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `+31 more`) - schedules, status, health, and ops review.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -111,11 +105,9 @@ omh runtime record --skill skill --harness docs-specialist --status started
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-source-finder/SKILL.md
+++ b/skills/omh-source-finder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-source-finder
-description: [omh] Hermes Source Finder workflow: prepare typed source candidates and acquisition status before downstream work. Use when the user says: source-finder, source finder, source acquisition, source intake, find papers and datasets, find datasets and repos, find papers, find arxiv link.
+description: [omh] Source candidate inventory - prepare typed source candidates and acquisition status before downstream work; use ulw-research to fetch and cite them, or research-brief to turn them into a decision-ready brief. Use when the user says: source-finder, source finder, source acquisition, source intake, find papers and datasets, find datasets and repos, find papers, find arxiv link.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, research]
@@ -56,17 +56,11 @@ Bad example:
 - If a candidate lacks a link or file reference, keep it candidate_prepared and ask for the next observable source step.
 - If the user wants to process a selected source, route to the downstream workflow instead of continuing source acquisition.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Research and company ops** (`source-finder`, `web-research`, `best-practice-research`, `autoresearch-goal`, `research-brief`, `strategy-brief`, `feedback-triage`, `research-department`, `+12 more`) - research, signals, ops, and briefings.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -130,11 +124,9 @@ omh runtime record --skill source-finder --harness source-finder --status starte
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-source-finder/SKILL.md
+++ b/skills/omh-source-finder/SKILL.md
@@ -126,6 +126,7 @@ omh runtime record --skill source-finder --harness source-finder --status starte
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-support-operations/SKILL.md
+++ b/skills/omh-support-operations/SKILL.md
@@ -50,17 +50,11 @@ Bad example:
 - If feedback lacks source or severity, ask for the missing signal before coding handoff.
 - If the item is actually a plan or research request, route to that workflow instead of triage.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Research and company ops** (`source-finder`, `web-research`, `best-practice-research`, `autoresearch-goal`, `research-brief`, `strategy-brief`, `feedback-triage`, `research-department`, `+12 more`) - research, signals, ops, and briefings.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -117,11 +111,9 @@ omh runtime record --skill support-operations --harness ops-review --status star
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-support-operations/SKILL.md
+++ b/skills/omh-support-operations/SKILL.md
@@ -113,6 +113,7 @@ omh runtime record --skill support-operations --harness ops-review --status star
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-terminal/SKILL.md
+++ b/skills/omh-terminal/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-terminal
-description: [omh] Terminal commands - scope shell, CLI, package-manager, and test runs with cwd, environment, safety, and result-evidence gates. Use when the user says: command-operator, command operator, terminal command, terminal task, shell command, shell task, cli command, command execution.
+description: [omh] Policy overlay for terminal commands - add cwd, environment, safety, and result-evidence gates after preferring native shell tools for ordinary CLI, package-manager, and test runs. Use when the user says: command-operator, command operator, terminal command, terminal task, shell command, shell task, cli command, command execution.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, command]
@@ -50,17 +50,11 @@ Bad example:
 - If the command is destructive, credentialed, networked, install/deploy-oriented, or production-affecting, require an explicit confirmation gate.
 - If the user supplied failed command output and asks for root cause, route to build-failure-triage or agent-debug instead of preparing a fresh command.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Automation and status** (`achievements`, `workspace-audit`, `production-audit`, `automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `+31 more`) - schedules, status, health, and ops review.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -123,11 +117,9 @@ omh runtime record --skill command-operator --harness command-operator --status 
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-terminal/SKILL.md
+++ b/skills/omh-terminal/SKILL.md
@@ -119,6 +119,7 @@ omh runtime record --skill command-operator --harness command-operator --status 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-toolbelt-readiness/SKILL.md
+++ b/skills/omh-toolbelt-readiness/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-toolbelt-readiness
-description: [omh] Hermes toolbelt readiness workflow: check which MCP servers, CLIs, APIs, credentials, and connectors a workflow needs before claiming it can run. Use when the user says: toolbelt-readiness, mcp readiness, tool readiness, plugin readiness, connector readiness, needed mcp, api credential, missing cli.
+description: [omh] Toolbelt readiness - inventory which MCP servers, CLIs, APIs, credentials, and connectors a workflow needs; use external-connector-readiness to assess one named integration and executor-runtime-readiness to choose the coding owner. Use when the user says: toolbelt-readiness, mcp readiness, tool readiness, plugin readiness, connector readiness, needed mcp, api credential, missing cli.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, tools]
@@ -49,17 +49,11 @@ Bad example:
 - If required context is missing, ask one blocking question or route back to the narrower workflow.
 - If runtime or wrapper evidence is unavailable, keep the status as not_observed and expose the next observable action.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Automation and status** (`achievements`, `workspace-audit`, `production-audit`, `automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `+31 more`) - schedules, status, health, and ops review.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -116,11 +110,9 @@ omh runtime record --skill toolbelt-readiness --harness toolbelt-readiness --sta
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-toolbelt-readiness/SKILL.md
+++ b/skills/omh-toolbelt-readiness/SKILL.md
@@ -112,6 +112,7 @@ omh runtime record --skill toolbelt-readiness --harness toolbelt-readiness --sta
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-verification-gate/SKILL.md
+++ b/skills/omh-verification-gate/SKILL.md
@@ -119,6 +119,7 @@ omh runtime record --skill verification-gate --harness verification-gate --statu
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-verification-gate/SKILL.md
+++ b/skills/omh-verification-gate/SKILL.md
@@ -49,17 +49,11 @@ Bad example:
 - If the expected behavior is unclear, route back to plan before running adversarial checks.
 - If verification fails, return to fix or research with the failed signal instead of advancing.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Coding handoff** (`idea-to-deploy`, `cto-loop`, `deploy-and-monitor`, `code-review`, `build-failure-triage`, `verification-gate`, `security-safety-review`, `ultrawork`, `+7 more`) - coding owners, handoffs, review, CI, and merge evidence.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -123,11 +117,9 @@ omh runtime record --skill verification-gate --harness verification-gate --statu
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-visual-qa/SKILL.md
+++ b/skills/omh-visual-qa/SKILL.md
@@ -167,6 +167,7 @@ omh runtime record --skill visual-qa --harness visual-qa --status started
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-visual-qa/SKILL.md
+++ b/skills/omh-visual-qa/SKILL.md
@@ -54,17 +54,11 @@ Bad example:
 - If no capture exists, produce the QA plan and mark verdict BLOCKED_BY_MISSING_RENDER_EVIDENCE.
 - If a capture exists but predates the latest edit, mark it stale and request the smallest fresh recapture set.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Materials and visual summaries** (`design-orchestration`, `design-quality-gate`, `frontend`, `accessibility-audit`, `visual-qa`, `content-operator`, `media-input-operator`, `materials-package`, `+4 more`) - web, accessibility, visual QA, files, and packages.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -171,11 +165,9 @@ omh runtime record --skill visual-qa --harness visual-qa --status started
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-voice-input/SKILL.md
+++ b/skills/omh-voice-input/SKILL.md
@@ -112,6 +112,7 @@ omh runtime record --skill voice-operator --harness voice-operator --status star
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-voice-input/SKILL.md
+++ b/skills/omh-voice-input/SKILL.md
@@ -49,17 +49,11 @@ Bad example:
 - If transcript confidence or intent is weak, ask one short clarification before action.
 - If platform delivery is unavailable, keep the response in chat and mark delivery not_observed.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Automation and status** (`achievements`, `workspace-audit`, `production-audit`, `automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `+31 more`) - schedules, status, health, and ops review.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -116,11 +110,9 @@ omh runtime record --skill voice-operator --harness voice-operator --status star
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-websearch-setup/SKILL.md
+++ b/skills/omh-websearch-setup/SKILL.md
@@ -114,6 +114,7 @@ omh runtime record --skill websearch-setup --harness coding-handling --status st
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-websearch-setup/SKILL.md
+++ b/skills/omh-websearch-setup/SKILL.md
@@ -49,17 +49,11 @@ Bad example:
 - If the scraper provider prerequisite is unmet, mark that step "not applicable" and continue with the auxiliary model routing step alone.
 - If either diff is rejected, keep the other step's state independent and do not roll both back together.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Automation and status** (`achievements`, `workspace-audit`, `production-audit`, `automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `+31 more`) - schedules, status, health, and ops review.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -118,11 +112,9 @@ omh runtime record --skill websearch-setup --harness coding-handling --status st
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-wiki/SKILL.md
+++ b/skills/omh-wiki/SKILL.md
@@ -54,17 +54,11 @@ Bad example:
 - If the destination is unknown, record the missing facts and keep the guidance vendor-neutral.
 - If the fact may be stale, record the staleness warning and next refresh action.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Retained knowledge** (`memory-new`, `memory-sync`, `decision-recall`, `wiki`) - memory, rejected alternatives, wiki notes, retrieval, and staleness.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Design Interview
 
@@ -139,11 +133,9 @@ omh runtime record --skill wiki --harness docs-specialist --status started
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-wiki/SKILL.md
+++ b/skills/omh-wiki/SKILL.md
@@ -135,6 +135,7 @@ omh runtime record --skill wiki --harness docs-specialist --status started
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-workflow-learning/SKILL.md
+++ b/skills/omh-workflow-learning/SKILL.md
@@ -49,17 +49,11 @@ Bad example:
 - If required context is missing, ask one blocking question or route back to the narrower workflow.
 - If runtime or wrapper evidence is unavailable, keep the status as not_observed and expose the next observable action.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Automation and status** (`achievements`, `workspace-audit`, `production-audit`, `automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `+31 more`) - schedules, status, health, and ops review.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -116,11 +110,9 @@ omh runtime record --skill workflow-learning --harness workflow-learning --statu
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/omh-workflow-learning/SKILL.md
+++ b/skills/omh-workflow-learning/SKILL.md
@@ -112,6 +112,7 @@ omh runtime record --skill workflow-learning --harness workflow-learning --statu
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-workspace-audit/SKILL.md
+++ b/skills/omh-workspace-audit/SKILL.md
@@ -121,6 +121,7 @@ omh runtime record --skill workspace-audit --harness workspace-audit --status st
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/omh-workspace-audit/SKILL.md
+++ b/skills/omh-workspace-audit/SKILL.md
@@ -49,17 +49,11 @@ Bad example:
 - If required context is missing, ask one blocking question or route back to the narrower workflow.
 - If runtime or wrapper evidence is unavailable, keep the status as not_observed and expose the next observable action.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Automation and status** (`achievements`, `workspace-audit`, `production-audit`, `automation-blueprint`, `github-event-ops`, `agent-board`, `gateway-intent-card`, `voice-operator`, `+31 more`) - schedules, status, health, and ops review.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -125,11 +119,9 @@ omh runtime record --skill workspace-audit --harness workspace-audit --status st
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/ulw-goal/SKILL.md
+++ b/skills/ulw-goal/SKILL.md
@@ -130,6 +130,7 @@ omh runtime record --skill ultragoal --harness goal-execution --status started
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/ulw-goal/SKILL.md
+++ b/skills/ulw-goal/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ulw-goal
-description: [omh] Ultragoal - durable multi-session goal tracking: a checkpointed ledger survives context loss and resumes exactly where work stopped, with a final completion gate. Use when the user says: ultragoal, ulg, durable goal, multi-goal, goal ledger, long running goal, 완료조건까지 계속, keep working until acceptance criteria pass.
+description: [omh] Ultragoal - durable multi-session goal tracking: a checkpointed ledger survives context loss and resumes exactly where work stopped, with a final completion gate. Aliases: ulg. Use when the user says: ultragoal, durable goal, multi-goal, goal ledger, long running goal, 완료조건까지 계속, keep working until acceptance criteria pass, 장기 목표.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, execution]
@@ -57,17 +57,11 @@ Bad example:
 - If a blocker checkpoint exists, keep the goal open and record the blocker plus the smallest unblock action.
 - If linked runtime evidence is missing, keep coding milestones prepared_not_observed and do not close the goal.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Intent -> plan** (`oh-my-hermes`, `meta-router`, `deep-interview`, `plan`, `ralplan`, `codebase-onboarding`, `codegraph-refresh`, `ultragoal`, `+6 more`) - clarify, plan, ship, or loop goals.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -134,11 +128,9 @@ omh runtime record --skill ultragoal --harness goal-execution --status started
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/ulw-interview/SKILL.md
+++ b/skills/ulw-interview/SKILL.md
@@ -167,6 +167,7 @@ omh runtime record --skill deep-interview --harness deep-interview --status star
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/ulw-interview/SKILL.md
+++ b/skills/ulw-interview/SKILL.md
@@ -49,17 +49,11 @@ Bad example:
 - If an answer surfaces new ambiguity, file it under one of the three clarity dimensions and keep asking only while the round budget allows; once round 6 is reached, record the rest as assumptions and plan.
 - If repo evidence can answer the question, inspect it before asking the user.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Intent -> plan** (`oh-my-hermes`, `meta-router`, `deep-interview`, `plan`, `ralplan`, `codebase-onboarding`, `codegraph-refresh`, `ultragoal`, `+6 more`) - clarify, plan, ship, or loop goals.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Interview Round Protocol
 
@@ -171,11 +165,9 @@ omh runtime record --skill deep-interview --harness deep-interview --status star
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/ulw-loop/SKILL.md
+++ b/skills/ulw-loop/SKILL.md
@@ -154,6 +154,7 @@ omh runtime record --skill loop --harness goal-loop --status started
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/ulw-loop/SKILL.md
+++ b/skills/ulw-loop/SKILL.md
@@ -55,17 +55,11 @@ Bad example:
 - If the goal turns into external waiting, record the waiting state and next observable signal instead of continuing locally.
 - If context or budget is exhausted, checkpoint the loop artifact and continue from the latest loop_cycle/v1 state.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Intent -> plan** (`oh-my-hermes`, `meta-router`, `deep-interview`, `plan`, `ralplan`, `codebase-onboarding`, `codegraph-refresh`, `ultragoal`, `+6 more`) - clarify, plan, ship, or loop goals.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -158,11 +152,9 @@ omh runtime record --skill loop --harness goal-loop --status started
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/ulw-perf/SKILL.md
+++ b/skills/ulw-perf/SKILL.md
@@ -123,6 +123,7 @@ omh runtime record --skill ultraperf --harness goal-execution --status started
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/ulw-perf/SKILL.md
+++ b/skills/ulw-perf/SKILL.md
@@ -52,17 +52,11 @@ Bad example:
 - If the re-measure does not move, revert the change and re-rank hypotheses instead of stacking fixes.
 - If the goal turns out to be one declared metric with a budget, hand off to `performance-goal`.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Intent -> plan** (`oh-my-hermes`, `meta-router`, `deep-interview`, `plan`, `ralplan`, `codebase-onboarding`, `codegraph-refresh`, `ultragoal`, `+6 more`) - clarify, plan, ship, or loop goals.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -127,11 +121,9 @@ omh runtime record --skill ultraperf --harness goal-execution --status started
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/ulw-plan/SKILL.md
+++ b/skills/ulw-plan/SKILL.md
@@ -53,17 +53,11 @@ Bad example:
 - If current-source evidence is missing, route a web-research step before accepting the plan.
 - If the user asks for implementation, hand off through ultraprocess, ultragoal, or the selected executor path after the plan is accepted.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Intent -> plan** (`oh-my-hermes`, `meta-router`, `deep-interview`, `plan`, `ralplan`, `codebase-onboarding`, `codegraph-refresh`, `ultragoal`, `+6 more`) - clarify, plan, ship, or loop goals.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -131,11 +125,9 @@ omh runtime record --skill ralplan --harness planning --status started
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/ulw-plan/SKILL.md
+++ b/skills/ulw-plan/SKILL.md
@@ -127,6 +127,7 @@ omh runtime record --skill ralplan --harness planning --status started
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/ulw-process/SKILL.md
+++ b/skills/ulw-process/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ulw-process
-description: [omh] Ultraprocess - one full task-to-PR cycle: codebase research, reviewed plan, coding handoff to the selected executor, code review, docs sync, and PR, tracked end to end. Use when the user says: ultraprocess, ulp, single-cycle delivery, one-cycle delivery, end-to-end process, delivery process, research plan implement review docs pr, plan implement review docs pr.
+description: [omh] Ultraprocess - one full task-to-PR cycle: codebase research, reviewed plan, coding handoff to the selected executor, code review, docs sync, and PR, tracked end to end. Aliases: ulp. Use when the user says: ultraprocess, single-cycle delivery, one-cycle delivery, end-to-end process, delivery process, research plan implement review docs pr, plan implement review docs pr, ralplan ultragoal code-review.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, process]
@@ -56,17 +56,11 @@ Bad example:
 - If no implementation owner is selected, keep the work prepared_not_observed and ask for Codex, Claude Code, Hermes, or another runtime.
 - If review, CI, docs sync, or PR evidence is missing, report the stage gap instead of saying the process is complete.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Intent -> plan** (`oh-my-hermes`, `meta-router`, `deep-interview`, `plan`, `ralplan`, `codebase-onboarding`, `codegraph-refresh`, `ultragoal`, `+6 more`) - clarify, plan, ship, or loop goals.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -139,11 +133,9 @@ omh runtime record --skill ultraprocess --harness goal-execution --status starte
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/ulw-process/SKILL.md
+++ b/skills/ulw-process/SKILL.md
@@ -135,6 +135,7 @@ omh runtime record --skill ultraprocess --harness goal-execution --status starte
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/ulw-qa/SKILL.md
+++ b/skills/ulw-qa/SKILL.md
@@ -112,6 +112,7 @@ omh runtime record --skill ultraqa --harness qa-specialist --status started
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/ulw-qa/SKILL.md
+++ b/skills/ulw-qa/SKILL.md
@@ -48,17 +48,11 @@ Bad example:
 - If the expected behavior is unclear, route back to plan before running adversarial checks.
 - If verification fails, return to fix or research with the failed signal instead of advancing.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Coding handoff** (`idea-to-deploy`, `cto-loop`, `deploy-and-monitor`, `code-review`, `build-failure-triage`, `verification-gate`, `security-safety-review`, `ultrawork`, `+7 more`) - coding owners, handoffs, review, CI, and merge evidence.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -116,11 +110,9 @@ omh runtime record --skill ultraqa --harness qa-specialist --status started
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/ulw-ralph/SKILL.md
+++ b/skills/ulw-ralph/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ulw-ralph
-description: [omh] Ralph - one owner drives a concrete task to done: implement, verify, review, repeat until the gate passes; prefer over one-shot delegation when the task needs a verification loop. Use when the user says: ralph, finish until done, persistent execution, self-referential loop.
+description: [omh] Ralph - one owner drives a concrete task to done: implement, verify, review, repeat until the gate passes; prefer over one-shot delegation when the task needs a verification loop. Aliases: ulr. Use when the user says: ralph, finish until done, persistent execution, self-referential loop.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, execution]
@@ -50,23 +50,17 @@ Bad example:
 - If the selected executor is unavailable, ask for Codex, Claude Code, Hermes, or another runtime before retrying.
 - If dispatch or result evidence is missing, keep the handoff prepared_not_observed and expose the next observable action.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Intent -> plan** (`oh-my-hermes`, `meta-router`, `deep-interview`, `plan`, `ralplan`, `codebase-onboarding`, `codegraph-refresh`, `ultragoal`, `+6 more`) - clarify, plan, ship, or loop goals.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
 Use after scope is concrete and the user wants one owner to continue through implementation and verification.
 
-    Strong routing signals: `ralph`, `$ralph`, `finish until done`, `persistent execution`, `self-referential loop`
+    Strong routing signals: `ralph`, `$ralph`, `ulr`, `$ulr`, `finish until done`, `persistent execution`, `self-referential loop`
 
 ## Catalog Metadata
 
@@ -123,11 +117,9 @@ omh runtime record --skill ralph --harness goal-execution --status started
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/ulw-ralph/SKILL.md
+++ b/skills/ulw-ralph/SKILL.md
@@ -119,6 +119,7 @@ omh runtime record --skill ralph --harness goal-execution --status started
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/ulw-research/SKILL.md
+++ b/skills/ulw-research/SKILL.md
@@ -126,6 +126,7 @@ omh runtime record --skill web-research --harness research --status started
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/ulw-research/SKILL.md
+++ b/skills/ulw-research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ulw-research
-description: [omh] Web research with citation discipline on top of native search - every claim carries a live URL, sources are diversity-checked, and anything not fetched is marked not observed instead of guessed. Use when the user says: web-research, web research, web search, search the web, internet search, fresh sources, current sources, current web evidence.
+description: [omh] Web research with citation discipline on top of native search - every claim carries a live URL and unfetched claims stay not observed; for a decision-ready brief use research-brief, and for ongoing Scout/Analyst/Briefer coordination use research-department. Use when the user says: web-research, web research, web search, search the web, internet search, fresh sources, current sources, current web evidence.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, research]
@@ -52,17 +52,11 @@ Bad example:
 - If sources cannot be accessed, state the retrieval gap and use only observed local context.
 - If evidence is thin or one-sided, lower confidence and ask for a narrower source boundary.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Research and company ops** (`source-finder`, `web-research`, `best-practice-research`, `autoresearch-goal`, `research-brief`, `strategy-brief`, `feedback-triage`, `research-department`, `+12 more`) - research, signals, ops, and briefings.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -130,11 +124,9 @@ omh runtime record --skill web-research --harness research --status started
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - Treat wrapper memory/context summaries as advisory local context, not proof of opaque Hermes memory reads or changes.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/ulw-team/SKILL.md
+++ b/skills/ulw-team/SKILL.md
@@ -50,17 +50,11 @@ Bad example:
 - If a worker has no ACK or result, mark that lane not_observed or blocked rather than infer progress.
 - If integration reveals a shared-file conflict, stop lane fan-out and reassign ownership before continuing.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Coding handoff** (`idea-to-deploy`, `cto-loop`, `deploy-and-monitor`, `code-review`, `build-failure-triage`, `verification-gate`, `security-safety-review`, `ultrawork`, `+7 more`) - coding owners, handoffs, review, CI, and merge evidence.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -123,11 +117,9 @@ omh runtime record --skill team --harness goal-execution --status started
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/ulw-team/SKILL.md
+++ b/skills/ulw-team/SKILL.md
@@ -119,6 +119,7 @@ omh runtime record --skill team --harness goal-execution --status started
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/skills/ulw-work/SKILL.md
+++ b/skills/ulw-work/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ulw-work
-description: [omh] Ultrawork - split an accepted plan into disjoint parallel lanes with per-lane acceptance criteria, verification commands, and owners; prevents two lanes editing the same file. Use when the user says: ultrawork, ulw, parallel work, parallel implementation, high throughput.
+description: [omh] Ultrawork - split an accepted plan into disjoint parallel lanes with per-lane acceptance criteria, verification commands, and owners; prevents two lanes editing the same file. Aliases: ulw. Use when the user says: ultrawork, parallel work, parallel implementation, high throughput.
 metadata:
   hermes:
     tags: [workflow, oh-my-hermes, execution]
@@ -54,17 +54,11 @@ Bad example:
 - If a worker does not ACK or return a result, keep that lane blocked/not_observed and expose the retry or reassignment action.
 - If a worktree or shared-file conflict appears, pause parallel delivery and re-plan ownership before more edits.
 
-## OMH Context Rail
+## Workflow Lane
 
-- This skill is part of OMH's Hermes workflow layer, not a standalone executor.
-- Product context: OMH is a Hermes-native workflow pack: choose skills, shape work, prepare artifacts, show status, and hand off with evidence boundaries.
 - Current lane: **Coding handoff** (`idea-to-deploy`, `cto-loop`, `deploy-and-monitor`, `code-review`, `build-failure-triage`, `verification-gate`, `security-safety-review`, `ultrawork`, `+7 more`) - coding owners, handoffs, review, CI, and merge evidence.
 - If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.
-- Cross-skill context: every OMH skill: match lane; generic tool can render or execute.
-- Generic-tool checkpoint: image->img-summary; frontend->frontend/a11y/visual-qa; paper->paper-learning; content->content-operator; media->media-input-operator; file->materials-package; search->web-research; live->live-info-operator; audit->workspace/production/security; failures->build-failure; verify->verification-gate; code->codegraph/onboarding/ultraprocess.
-- Coverage: Every generated workflow skill carries this rail.
-- Normal users talk to Hermes; OMH CLI is infra.
-- Boundary: Prepared OMH routing/cards/handoffs/artifacts are not observed execution, image generation, delivery, review, CI, merge-readiness, or merge evidence.
+- Shared product, routing, compatibility, and evidence rules: `omh-routing/references/skill-common-rail.md`.
 
 ## Use When
 
@@ -128,11 +122,9 @@ omh runtime record --skill ultrawork --harness goal-execution --status started
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-- Respect `omh_target_topology/v1`: bind state to the current target/thread, use single-target behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before treating it as persistent.
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
-- Shared rail: `omh-routing/references/skill-common-rail.md` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability.
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `omh-routing/references/skill-common-rail.md`. Load it when applicable; otherwise name an unavailable capability.

--- a/skills/ulw-work/SKILL.md
+++ b/skills/ulw-work/SKILL.md
@@ -124,6 +124,7 @@ omh runtime record --skill ultrawork --harness goal-execution --status started
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 - When wrapper metadata includes `memory_review_card/v1` or `handoff_context_pack/v1`, treat it as reviewed OMH-local or wrapper-supplied context only. Use conflict-free context summaries to shape plans and handoffs, but do not claim Hermes internal memory was read or changed.
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 

--- a/src/commands/demo.py
+++ b/src/commands/demo.py
@@ -19,6 +19,10 @@ from ..quality.localized_chat_copy import (
     build_localized_chat_copy_demo,
     format_localized_chat_copy_summary,
 )
+from ..quality.native_skill_competition import (
+    build_native_skill_competition_report,
+    format_native_skill_competition_summary,
+)
 from ..quality.route_hint_alignment import build_route_hint_alignment_demo, format_route_hint_alignment_summary
 from ..quality.router_fast_path import build_router_fast_path_demo, format_router_fast_path_summary
 from ..quality.routing_accuracy import build_routing_accuracy_demo, format_routing_accuracy_summary
@@ -35,6 +39,7 @@ DEMO_EPILOG = """Demo lanes:
   route-hint-alignment    Checks plugin/router route hints agree before Hermes speaks.
   context-brief-coverage  Checks compact OMH context briefs keep the right workflow visible.
   routing-precision       Guards against over-routing simple requests and missing OMH interventions.
+  native-competition      Checks OMH frontmatter against representative native-skill descriptions.
   routing-accuracy        Measures whether routing is right per language, not merely unchanged.
   router-fast-path        Checks common chat turns stay on deterministic fast-path routes.
   common-request-coverage Checks ordinary Hermes-agent request breadth against a 95% target.
@@ -126,6 +131,15 @@ def cmd_demo_routing_precision(args: argparse.Namespace) -> int:
         raise OmhError(str(exc)) from exc
     if args.summary:
         print(format_routing_precision_summary(payload))
+    else:
+        _print_json(payload)
+    return 0
+
+
+def cmd_demo_native_competition(args: argparse.Namespace) -> int:
+    payload = build_native_skill_competition_report()
+    if args.summary:
+        print(format_native_skill_competition_summary(payload))
     else:
         _print_json(payload)
     return 0
@@ -278,6 +292,19 @@ def _add_demo_commands(sub) -> None:
     precision_output.add_argument("--json", action="store_true", help="Print the full machine-readable JSON payload. This is the default.")
     precision_output.add_argument("--summary", action="store_true", help="Print a compact human-readable routing precision summary.")
     routing_precision.set_defaults(func=cmd_demo_routing_precision)
+
+    native_competition = demo_sub.add_parser(
+        "native-competition",
+        help="Compare generated OMH frontmatter with representative native-skill descriptions.",
+        description=(
+            "Run a deterministic lexical gate over generated frontmatter name+description pairs. "
+            "This is local contract evidence, not a live Hermes picker result."
+        ),
+    )
+    native_output = native_competition.add_mutually_exclusive_group()
+    native_output.add_argument("--json", action="store_true", help="Print the full machine-readable JSON payload. This is the default.")
+    native_output.add_argument("--summary", action="store_true", help="Print a compact human-readable native competition summary.")
+    native_competition.set_defaults(func=cmd_demo_native_competition)
 
     routing_accuracy = demo_sub.add_parser(
         "routing-accuracy",

--- a/src/maintenance/doctor.py
+++ b/src/maintenance/doctor.py
@@ -464,13 +464,15 @@ def _awareness_delivery_check(paths: OmhPaths, *, now: datetime | None = None) -
 
     record = read_awareness_delivery(str(paths.omh_home))
     if record.get("unreadable"):
+        action = "Delete the ledger and run one Hermes turn to repopulate it."
         return Check(
             "awareness_delivery",
             True,
             "awareness delivery ledger is unreadable",
             severity="warning",
             observed=False,
-            next_action="Delete the ledger and run one Hermes turn to repopulate it.",
+            remediation=action,
+            next_action=action,
         )
     delivered = int(record.get("delivery_count", 0) or 0)
     if not delivered:
@@ -485,20 +487,22 @@ def _awareness_delivery_check(paths: OmhPaths, *, now: datetime | None = None) -
         if first_attempted is not None and current_time - first_attempted.astimezone(UTC) >= timedelta(
             days=AWARENESS_ZERO_DELIVERY_WARNING_DAYS
         ):
+            action = (
+                "Restart Hermes, run one Hermes turn, then rerun `omh doctor`; "
+                "if delivery remains zero, inspect the OMH plugin hook logs."
+            )
             return Check(
                 "awareness_delivery",
                 False,
                 (
-                    f"no OMH awareness hook payload returned for model input in "
-                    f"{AWARENESS_ZERO_DELIVERY_WARNING_DAYS} days "
-                    f"since the first observed hook attempt at {first_attempted_at}"
+                    "no OMH awareness hook payload returned for model input for at least "
+                    f"{AWARENESS_ZERO_DELIVERY_WARNING_DAYS} days; "
+                    f"first observed hook attempt: {first_attempted_at}"
                 ),
                 severity="warning",
                 observed=False,
-                next_action=(
-                    "Restart Hermes, run one Hermes turn, then rerun `omh doctor`; "
-                    "if delivery remains zero, inspect the OMH plugin hook logs."
-                ),
+                remediation=action,
+                next_action=action,
             )
         return Check(
             "awareness_delivery",

--- a/src/maintenance/doctor.py
+++ b/src/maintenance/doctor.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from ..skills.catalog import omh_skill_display_name
 
 from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 from .advisory import AdvisoryReport, run_config_advisories
@@ -37,7 +38,9 @@ WARNING_NEXT_ACTION_PRIORITY = {
     # the check list without replacing the beginner next action.
     "command_path": 100,
     "target_topology": 80,
+    "awareness_delivery": 70,
 }
+AWARENESS_ZERO_DELIVERY_WARNING_DAYS = 7
 DEFAULT_DOCTOR_NEXT_ACTION = "Open Hermes Agent and try: Use OMH request-to-handoff for: I want to safely add a feature to this repo."
 
 
@@ -448,14 +451,14 @@ def recommended_next_action(checks: list[Check]) -> str:
     return DEFAULT_DOCTOR_NEXT_ACTION
 
 
-def _awareness_delivery_check(paths: OmhPaths) -> Check:
-    """Has OMH's primer and route hint actually reached the model?
+def _awareness_delivery_check(paths: OmhPaths, *, now: datetime | None = None) -> Check:
+    """Has OMH's primer and route hint hook returned content for model input?
 
     Reported, never blocking. A fresh install has legitimately delivered
     nothing, and Hermes may not have been restarted since the bundle changed, so
     a zero here is ambiguous in a way `plugin_enabled_in_hermes` is not. What it
-    buys is a way to tell "the bridge is on but silent" from "the bridge is
-    working", which previously nothing could distinguish.
+    buys is a way to tell "the hook is on but returning nothing" from "the hook
+    returned an injection payload". It does not prove host or model consumption.
     """
     from ..plugin_bundle.omh.awareness_delivery import read_awareness_delivery
 
@@ -471,11 +474,37 @@ def _awareness_delivery_check(paths: OmhPaths) -> Check:
         )
     delivered = int(record.get("delivery_count", 0) or 0)
     if not delivered:
+        first_attempted_at = str(record.get("first_attempted_at") or "")
+        try:
+            first_attempted = datetime.fromisoformat(first_attempted_at.replace("Z", "+00:00"))
+            if first_attempted.tzinfo is None:
+                first_attempted = None
+        except ValueError:
+            first_attempted = None
+        current_time = now or datetime.now(UTC)
+        if first_attempted is not None and current_time - first_attempted.astimezone(UTC) >= timedelta(
+            days=AWARENESS_ZERO_DELIVERY_WARNING_DAYS
+        ):
+            return Check(
+                "awareness_delivery",
+                False,
+                (
+                    f"no OMH awareness hook payload returned for model input in "
+                    f"{AWARENESS_ZERO_DELIVERY_WARNING_DAYS} days "
+                    f"since the first observed hook attempt at {first_attempted_at}"
+                ),
+                severity="warning",
+                observed=False,
+                next_action=(
+                    "Restart Hermes, run one Hermes turn, then rerun `omh doctor`; "
+                    "if delivery remains zero, inspect the OMH plugin hook logs."
+                ),
+            )
         return Check(
             "awareness_delivery",
             True,
             (
-                "no OMH awareness delivered to a model yet; run one Hermes turn, "
+                "no OMH awareness hook payload returned for model input yet; run one Hermes turn, "
                 "restarting Hermes first if the bundle changed"
             ),
             severity="ok",
@@ -485,7 +514,7 @@ def _awareness_delivery_check(paths: OmhPaths) -> Check:
         "awareness_delivery",
         True,
         (
-            f"{delivered} awareness injection(s) observed, "
+            f"{delivered} awareness hook payload(s) returned, "
             f"{int(record.get('route_hint_count', 0) or 0)} with a route hint; "
             f"last at {record.get('last_delivered_at', 'unknown')}"
         ),

--- a/src/maintenance/release.py
+++ b/src/maintenance/release.py
@@ -39,6 +39,10 @@ from ..quality.context_brief_coverage import build_context_brief_coverage_demo
 from ..quality.grounded_score import build_grounded_score_demo
 from ..quality.hermes_ux_quality import build_hermes_ux_quality_demo, hermes_ux_quality_errors
 from ..quality.localized_chat_copy import build_localized_chat_copy_demo, localized_chat_copy_errors
+from ..quality.native_skill_competition import (
+    build_native_skill_competition_report,
+    native_skill_competition_errors,
+)
 from ..quality.route_hint_alignment import build_route_hint_alignment_demo
 from ..quality.router_fast_path import build_router_fast_path_demo, router_fast_path_errors
 from ..quality.routing_precision import build_routing_precision_demo, routing_precision_errors
@@ -79,7 +83,11 @@ REPRESENTATIVE_CONTEXT_RAIL_SKILLS = (
     "materials-package",
 )
 ROUTER_CONTENT_MARKERS = ("OMH Awareness Primer", "img-summary", "Normal users should talk to Hermes Agent")
-WORKFLOW_CONTEXT_MARKERS = ("OMH Context Rail", "not a standalone executor", "Prepared OMH routing")
+WORKFLOW_CONTEXT_MARKERS = (
+    "Workflow Lane",
+    "Shared product, routing, compatibility, and evidence rules",
+    "Prepared OMH routing",
+)
 ROLE_CONTEXT_MARKERS = ("OMH Role Context", "OMH workflow-layer responsibility context", "prepared guidance only")
 CONCEPTUAL_AWARENESS_SURFACES = ("request-to-handoff", "executor selection", "coding runtime handoff")
 AWARENESS_PRIMER_CONTEXT_CHAR_LIMIT = 900
@@ -171,6 +179,7 @@ class ReleaseQualityEvidence:
     route_hints: dict[str, object]
     context_briefs: dict[str, object]
     routing_precision: dict[str, object]
+    native_competition: dict[str, object]
     localized_chat_copy: dict[str, object]
     router_fast_path: dict[str, object]
     common_request_coverage: dict[str, object]
@@ -329,6 +338,16 @@ def release_readiness_checklist(
             "Routing precision proves deterministic local over-intervention and missed-intervention guards only; it does not prove live Hermes chat rendering, platform delivery, source retrieval, file inspection, executor work, review, CI, merge, or plugin-load evidence.",
         ),
         ReleaseChecklistItem(
+            "native_competition",
+            "Check native-skill competition boundaries",
+            "uv run python -m omh.cli demo native-competition --json",
+            "contract-quality",
+            True,
+            False,
+            "Native competition reports all generated-frontmatter pairwise cases passing with no ties.",
+            "Native competition is a deterministic local lexical heuristic; it does not prove live Hermes picker ranking or installed native inventory.",
+        ),
+        ReleaseChecklistItem(
             "localized_chat_copy",
             "Check localized chat-card framing",
             "uv run python -m omh.cli demo localized-chat-copy --json",
@@ -365,8 +384,8 @@ def release_readiness_checklist(
             "contract-quality",
             True,
             False,
-            "Hermes UX quality reports routing score, dedicated chat-card coverage, route-hint alignment, context-brief coverage, routing precision, localized chat copy, router fast-path quality, and common request coverage as passing in one user-facing rollup.",
-            "Hermes UX quality proves deterministic local routing, card, hint, context, precision, localized-copy, fast-path, and common-request contracts only; it does not prove live Hermes chat rendering, platform delivery, plugin load, generic tool invocation, executor work, review, CI, merge, or delivery.",
+            "Hermes UX quality reports routing score, dedicated chat-card coverage, route-hint alignment, context-brief coverage, routing precision, native-skill competition, localized chat copy, router fast-path quality, and common request coverage as passing in one user-facing rollup.",
+            "Hermes UX quality proves deterministic local routing, card, hint, context, precision, native-competition, localized-copy, fast-path, and common-request contracts only; it does not prove live Hermes chat rendering, picker ranking, platform delivery, plugin load, generic tool invocation, executor work, review, CI, merge, or delivery.",
         ),
         ReleaseChecklistItem(
             "product_readiness",
@@ -375,7 +394,7 @@ def release_readiness_checklist(
             "contract-quality",
             True,
             False,
-            "Product readiness reports skill-content, G1-G10 use-case, grounded score, wrapper chat card coverage, route hint alignment, context brief coverage, routing precision, localized chat copy, router fast-path quality, common request coverage, Hermes UX quality, parity, and release checklist gates as passing.",
+            "Product readiness reports skill-content, G1-G10 use-case, grounded score, wrapper chat card coverage, route hint alignment, context brief coverage, routing precision, native-skill competition, localized chat copy, router fast-path quality, common request coverage, Hermes UX quality, parity, and release checklist gates as passing.",
             "Product readiness proves deterministic local package and product contracts only; it does not prove live Hermes chat behavior, connector work, executor work, review, CI, merge, delivery, or billing evidence.",
         ),
         ReleaseChecklistItem(
@@ -385,7 +404,7 @@ def release_readiness_checklist(
             "evidence-packaging",
             True,
             False,
-            "A local `omh_release_evidence_bundle/v1` artifact is written with checklist, product readiness, skill content, use-case readiness, grounded score, chat card coverage, route hint alignment, context brief coverage, routing precision, localized chat copy, router fast-path quality, common request coverage, Hermes UX quality, and parity snapshots.",
+            "A local `omh_release_evidence_bundle/v1` artifact is written with checklist, product readiness, skill content, use-case readiness, grounded score, chat card coverage, route hint alignment, context brief coverage, routing precision, native-skill competition, localized chat copy, router fast-path quality, common request coverage, Hermes UX quality, and parity snapshots.",
             "The evidence bundle packages local deterministic evidence only; it is not live Hermes runtime use, connector execution, executor dispatch, review, CI, merge, delivery, or release publication evidence.",
         ),
         ReleaseChecklistItem(
@@ -608,6 +627,7 @@ def _build_release_quality_evidence(*, release_version: str, omh_command: str) -
     )
     context_briefs = build_context_brief_coverage_demo()
     routing_precision = build_routing_precision_demo()
+    native_competition = build_native_skill_competition_report()
     localized_chat_copy = build_localized_chat_copy_demo()
     router_fast_path = build_router_fast_path_demo()
     common_request_coverage = build_common_request_coverage_demo()
@@ -617,6 +637,7 @@ def _build_release_quality_evidence(*, release_version: str, omh_command: str) -
         route_hint_alignment=route_hints,
         context_brief_coverage=context_briefs,
         routing_precision=routing_precision,
+        native_competition=native_competition,
         localized_chat_copy=localized_chat_copy,
         router_fast_path=router_fast_path,
         common_request_coverage=common_request_coverage,
@@ -630,6 +651,7 @@ def _build_release_quality_evidence(*, release_version: str, omh_command: str) -
         route_hints=route_hints,
         context_briefs=context_briefs,
         routing_precision=routing_precision,
+        native_competition=native_competition,
         localized_chat_copy=localized_chat_copy,
         router_fast_path=router_fast_path,
         common_request_coverage=common_request_coverage,
@@ -653,6 +675,7 @@ def _product_readiness_report_from_evidence(
     route_hints = evidence.route_hints
     context_briefs = evidence.context_briefs
     routing_precision = evidence.routing_precision
+    native_competition = evidence.native_competition
     localized_chat_copy = evidence.localized_chat_copy
     router_fast_path = evidence.router_fast_path
     common_request_coverage = evidence.common_request_coverage
@@ -680,6 +703,7 @@ def _product_readiness_report_from_evidence(
         "route_hint_alignment",
         "context_brief_coverage",
         "routing_precision",
+        "native_competition",
         "localized_chat_copy",
         "router_fast_path",
         "common_request_coverage",
@@ -712,6 +736,7 @@ def _product_readiness_report_from_evidence(
         routing_precision.get("summary", {}) if isinstance(routing_precision.get("summary"), Mapping) else {}
     )
     routing_precision_gate_errors = routing_precision_errors(routing_precision)
+    native_competition_gate_errors = native_skill_competition_errors(native_competition)
     localized_chat_copy_summary = (
         localized_chat_copy.get("summary", {}) if isinstance(localized_chat_copy.get("summary"), Mapping) else {}
     )
@@ -834,6 +859,20 @@ def _product_readiness_report_from_evidence(
             routing_precision_gate_errors,
             [],
             str(routing_precision.get("claim_boundary", "")),
+        ),
+        _product_readiness_gate(
+            "native_competition",
+            "Native skill competition",
+            "passed" if not native_competition_gate_errors else "failed",
+            True,
+            (
+                f"{native_competition.get('passed_count', 0)}/{native_competition.get('case_count', 0)} "
+                "generated-frontmatter comparisons passing"
+            ),
+            "omh demo native-competition --json",
+            native_competition_gate_errors,
+            [],
+            str(native_competition.get("claim_boundary", "")),
         ),
         _product_readiness_gate(
             "localized_chat_copy",
@@ -1798,6 +1837,7 @@ def release_evidence_bundle(
     route_hints = quality_evidence.route_hints
     context_briefs = quality_evidence.context_briefs
     routing_precision = quality_evidence.routing_precision
+    native_competition = quality_evidence.native_competition
     localized_chat_copy = quality_evidence.localized_chat_copy
     router_fast_path = quality_evidence.router_fast_path
     common_request_coverage = quality_evidence.common_request_coverage
@@ -1814,6 +1854,7 @@ def release_evidence_bundle(
         "route_hint_alignment": "passed" if _route_hint_alignment_ready(route_hints) else "failed",
         "context_brief_coverage": "passed" if _context_brief_coverage_ready(context_briefs) else "failed",
         "routing_precision": "passed" if not routing_precision_errors(routing_precision) else "failed",
+        "native_competition": "passed" if not native_skill_competition_errors(native_competition) else "failed",
         "localized_chat_copy": "passed" if not localized_chat_copy_errors(localized_chat_copy) else "failed",
         "router_fast_path": "passed" if not router_fast_path_errors(router_fast_path) else "failed",
         "common_request_coverage": "passed" if not common_request_coverage_errors(common_request_coverage) else "failed",
@@ -1893,6 +1934,8 @@ def release_evidence_bundle(
             "routing_precision_intervention_passing": routing_precision_summary.get("intervention_passing_count"),
             "routing_precision_intervention_total": routing_precision_summary.get("intervention_case_count"),
             "routing_precision_missed_intervention_count": routing_precision_summary.get("missed_intervention_count"),
+            "native_competition_passing_cases": native_competition.get("passed_count"),
+            "native_competition_total_cases": native_competition.get("case_count"),
             "localized_chat_copy_passing": localized_chat_copy_summary.get("passing_count"),
             "localized_chat_copy_total": localized_chat_copy_summary.get("case_count"),
             "localized_chat_copy_locale_count": localized_chat_copy_summary.get("locale_count"),
@@ -1930,6 +1973,7 @@ def release_evidence_bundle(
             "route_hint_alignment": route_hints,
             "context_brief_coverage": context_briefs,
             "routing_precision": routing_precision,
+            "native_competition": native_competition,
             "localized_chat_copy": localized_chat_copy,
             "router_fast_path": router_fast_path,
             "common_request_coverage": common_request_coverage,
@@ -1947,6 +1991,7 @@ def release_evidence_bundle(
             "route_hint_alignment_ready",
             "context_brief_coverage_ready",
             "routing_precision_ready",
+            "native_competition_ready",
             "localized_chat_copy_ready",
             "router_fast_path_ready",
             "common_request_coverage_ready",

--- a/src/plugin_bundle/omh/awareness.py
+++ b/src/plugin_bundle/omh/awareness.py
@@ -5615,6 +5615,23 @@ def awareness_primer_markdown() -> str:
     )
 
 
+def awareness_shared_context_markdown() -> str:
+    payload = awareness_primer_payload()
+    return "\n".join(
+        [
+            "## OMH Context Rail",
+            "",
+            "- OMH is a Hermes workflow layer, not a standalone executor.",
+            f"- Product context: {payload['product_context']}",
+            f"- Cross-skill context: {payload['all_skill_context_rule']}",
+            f"- Generic-tool checkpoint: {_compact_generic_tool_checkpoint_line()}.",
+            f"- Coverage: {payload['skill_coverage']}",
+            f"- {payload['chat_rule']}",
+            f"- Boundary: {payload['evidence_boundary']}",
+        ]
+    )
+
+
 def awareness_workflow_context_markdown(skill_name: str) -> str:
     payload = awareness_primer_payload()
     lane = _lane_for_skill(skill_name, payload["lanes"])
@@ -5628,17 +5645,12 @@ def awareness_workflow_context_markdown(skill_name: str) -> str:
         lane_line = f"Current lane: **{lane['label']}** (`{skills}`) - {lane['use_for']}."
     return "\n".join(
         [
-            "## OMH Context Rail",
+            "## Workflow Lane",
             "",
-            "- This skill is part of OMH's Hermes workflow layer, not a standalone executor.",
-            f"- Product context: {payload['product_context']}",
             f"- {lane_line}",
             "- If intent belongs to another lane, hand back to `oh-my-hermes` or name the adjacent workflow.",
-            f"- Cross-skill context: {payload['all_skill_context_rule']}",
-            f"- Generic-tool checkpoint: {_compact_generic_tool_checkpoint_line()}.",
-            f"- Coverage: {payload['skill_coverage']}",
-            f"- {payload['chat_rule']}",
-            f"- Boundary: {payload['evidence_boundary']}",
+            "- Shared product, routing, compatibility, and evidence rules: "
+            "`omh-routing/references/skill-common-rail.md`.",
         ]
     )
 

--- a/src/plugin_bundle/omh/awareness_delivery.py
+++ b/src/plugin_bundle/omh/awareness_delivery.py
@@ -27,8 +27,15 @@ from __future__ import annotations
 
 import json
 import os
+import secrets
+from contextlib import contextmanager
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterator
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - Hermes targets POSIX hosts today.
+    fcntl = None
 
 
 AWARENESS_DELIVERY_SCHEMA_VERSION = "omh_awareness_delivery/v1"
@@ -52,7 +59,7 @@ def read_awareness_delivery(omh_home: str = "") -> dict[str, Any]:
         return _empty()
     except (OSError, json.JSONDecodeError):
         return {**_empty(), "unreadable": True}
-    if not isinstance(data, dict):
+    if not isinstance(data, dict) or not _valid_delivery_record(data):
         return {**_empty(), "unreadable": True}
     return {**_empty(), **data}
 
@@ -69,6 +76,52 @@ def _empty() -> dict[str, Any]:
         "last_context_chars": 0,
         "unreadable": False,
     }
+
+
+def _valid_delivery_record(data: dict[str, Any]) -> bool:
+    if data.get("schema_version") != AWARENESS_DELIVERY_SCHEMA_VERSION:
+        return False
+    for key in ("delivery_count", "route_hint_count", "suppressed_count", "last_context_chars"):
+        value = data.get(key, 0)
+        if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+            return False
+    for key in ("first_attempted_at", "first_delivered_at", "last_delivered_at"):
+        if not isinstance(data.get(key, ""), str):
+            return False
+    return int(data.get("route_hint_count", 0)) <= int(data.get("delivery_count", 0))
+
+
+@contextmanager
+def _awareness_delivery_lock(path: Path) -> Iterator[None]:
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    path.parent.chmod(0o700)
+    lock_path = path.with_name(f".{path.name}.lock")
+    lock_path.touch(mode=0o600, exist_ok=True)
+    lock_path.chmod(0o600)
+    with lock_path.open("a+", encoding="utf-8") as handle:
+        if fcntl is not None:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            if fcntl is not None:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+def _write_delivery_record(path: Path, data: dict[str, Any]) -> None:
+    tmp = path.with_name(f".{path.name}.{os.getpid()}-{secrets.token_hex(8)}.tmp")
+    created = False
+    try:
+        with tmp.open("x", encoding="utf-8") as handle:
+            created = True
+            handle.write(json.dumps(data, indent=2, sort_keys=True) + "\n")
+        tmp.chmod(0o600)
+        tmp.replace(path)
+        path.chmod(0o600)
+    except OSError:
+        if created and tmp.exists() and not tmp.is_symlink():
+            tmp.unlink()
+        raise
 
 
 def record_awareness_delivery(
@@ -88,27 +141,23 @@ def record_awareness_delivery(
     A write failure returns None rather than raising. Losing a counter is
     acceptable; breaking the hook that feeds the model is not.
     """
-    current = read_awareness_delivery(omh_home)
-    updated = {
-        "schema_version": AWARENESS_DELIVERY_SCHEMA_VERSION,
-        "delivery_count": int(current["delivery_count"]) + (1 if delivered else 0),
-        "route_hint_count": int(current["route_hint_count"]) + (1 if route_hint else 0),
-        "suppressed_count": int(current["suppressed_count"]) + (0 if delivered else 1),
-        "first_attempted_at": current["first_attempted_at"] or observed_at,
-        "first_delivered_at": current["first_delivered_at"] or (observed_at if delivered else ""),
-        "last_delivered_at": observed_at if delivered else current["last_delivered_at"],
-        "last_context_chars": max(0, int(context_chars)) if delivered else int(current["last_context_chars"]),
-    }
     path = awareness_delivery_path(omh_home)
     try:
-        path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
-        path.parent.chmod(0o700)
-        tmp = path.with_suffix(".json.tmp")
-        tmp.touch(mode=0o600, exist_ok=True)
-        tmp.chmod(0o600)
-        tmp.write_text(json.dumps(updated, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-        tmp.replace(path)
-        path.chmod(0o600)
-    except OSError:
+        with _awareness_delivery_lock(path):
+            current = read_awareness_delivery(omh_home)
+            updated = {
+                "schema_version": AWARENESS_DELIVERY_SCHEMA_VERSION,
+                "delivery_count": int(current["delivery_count"]) + (1 if delivered else 0),
+                "route_hint_count": int(current["route_hint_count"]) + (1 if route_hint else 0),
+                "suppressed_count": int(current["suppressed_count"]) + (0 if delivered else 1),
+                "first_attempted_at": current["first_attempted_at"] or observed_at,
+                "first_delivered_at": current["first_delivered_at"] or (observed_at if delivered else ""),
+                "last_delivered_at": observed_at if delivered else current["last_delivered_at"],
+                "last_context_chars": (
+                    max(0, int(context_chars)) if delivered else int(current["last_context_chars"])
+                ),
+            }
+            _write_delivery_record(path, updated)
+    except (OSError, TypeError, ValueError):
         return None
     return updated

--- a/src/plugin_bundle/omh/awareness_delivery.py
+++ b/src/plugin_bundle/omh/awareness_delivery.py
@@ -1,4 +1,4 @@
-"""Did OMH's awareness actually reach the model?
+"""Did OMH's awareness hook return a payload for model input?
 
 `pre_llm_call` is how OMH gets its primer and route hint in front of Hermes.
 Nothing recorded whether that ever happened:
@@ -13,6 +13,10 @@ Nothing recorded whether that ever happened:
 Between those two, awareness could be dead for weeks and the only symptom would
 be a user learning to type "load OMH" by hand. This records the one fact that
 distinguishes those worlds.
+
+The ledger observes the `pre_llm_call` hook returning injection content. It is
+not host-consumption acknowledgement and does not prove a model received,
+processed, or acted on that content.
 
 Counters, not an append-only log. A per-turn log on the hottest path in the
 system is how a journal reached ~4.7k rows of noise; a fixed-shape counter file
@@ -59,6 +63,7 @@ def _empty() -> dict[str, Any]:
         "delivery_count": 0,
         "route_hint_count": 0,
         "suppressed_count": 0,
+        "first_attempted_at": "",
         "first_delivered_at": "",
         "last_delivered_at": "",
         "last_context_chars": 0,
@@ -74,9 +79,9 @@ def record_awareness_delivery(
     observed_at: str,
     omh_home: str = "",
 ) -> dict[str, Any] | None:
-    """Bump the counters for one `pre_llm_call`. Best-effort and metadata-only.
+    """Bump counters for one `pre_llm_call` hook result. Best-effort and metadata-only.
 
-    Records that awareness was assembled and how big it was, never what it said:
+    Records that an injection payload was returned and how big it was, never what it said:
     the prompt and the hint text stay out of this file, as they stay out of
     every other OMH ledger.
 
@@ -89,16 +94,21 @@ def record_awareness_delivery(
         "delivery_count": int(current["delivery_count"]) + (1 if delivered else 0),
         "route_hint_count": int(current["route_hint_count"]) + (1 if route_hint else 0),
         "suppressed_count": int(current["suppressed_count"]) + (0 if delivered else 1),
+        "first_attempted_at": current["first_attempted_at"] or observed_at,
         "first_delivered_at": current["first_delivered_at"] or (observed_at if delivered else ""),
         "last_delivered_at": observed_at if delivered else current["last_delivered_at"],
         "last_context_chars": max(0, int(context_chars)) if delivered else int(current["last_context_chars"]),
     }
     path = awareness_delivery_path(omh_home)
     try:
-        path.parent.mkdir(parents=True, exist_ok=True)
+        path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        path.parent.chmod(0o700)
         tmp = path.with_suffix(".json.tmp")
+        tmp.touch(mode=0o600, exist_ok=True)
+        tmp.chmod(0o600)
         tmp.write_text(json.dumps(updated, indent=2, sort_keys=True) + "\n", encoding="utf-8")
         tmp.replace(path)
+        path.chmod(0o600)
     except OSError:
         return None
     return updated

--- a/src/plugin_bundle/omh/hooks/llm_hooks.py
+++ b/src/plugin_bundle/omh/hooks/llm_hooks.py
@@ -33,7 +33,7 @@ def _token_metadata_from_kwargs(kwargs: dict) -> dict[str, object]:
     return {key: kwargs[key] for key in keys if kwargs.get(key) is not None}
 
 
-def _record_delivery(*, delivered: bool, route_hint: bool, context_chars: int) -> None:
+def _record_delivery(*, delivered: bool, route_hint: bool, context_chars: int, omh_home: str | None) -> None:
     """Note that this hook ran. Never let bookkeeping break the hook itself."""
     try:
         record_awareness_delivery(
@@ -41,6 +41,7 @@ def _record_delivery(*, delivered: bool, route_hint: bool, context_chars: int) -
             route_hint=route_hint,
             context_chars=context_chars,
             observed_at=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            omh_home=omh_home or "",
         )
     except (OSError, ValueError, TypeError):
         return
@@ -113,6 +114,7 @@ def pre_llm_call(**kwargs) -> dict[str, object] | None:
                 f"Unknown role '{marker}'. Available roles: {', '.join(role_payload['available_roles']) or '(none)'}."
             )
 
+    omh_home: str | None = None
     try:
         omh_home = str(kwargs.get("omh_home", "") or "") or None
         hermes_home = str(kwargs.get("hermes_home", "") or "") or None
@@ -139,7 +141,7 @@ def pre_llm_call(**kwargs) -> dict[str, object] | None:
         and not status.get("runtime_state_present")
         and not status.get("runs")
     ):
-        _record_delivery(delivered=False, route_hint=False, context_chars=0)
+        _record_delivery(delivered=False, route_hint=False, context_chars=0, omh_home=omh_home)
         return None
 
     if status.get("runtime_state_present") or status.get("runs"):
@@ -182,5 +184,6 @@ def pre_llm_call(**kwargs) -> dict[str, object] | None:
         delivered=True,
         route_hint=bool(route_hint_context),
         context_chars=len(payload["context"]),
+        omh_home=omh_home,
     )
     return payload

--- a/src/quality/hermes_ux_quality.py
+++ b/src/quality/hermes_ux_quality.py
@@ -8,6 +8,7 @@ from .common_request_coverage import build_common_request_coverage_demo, common_
 from .context_brief_coverage import build_context_brief_coverage_demo
 from .grounded_score import build_grounded_score_demo
 from .localized_chat_copy import build_localized_chat_copy_demo, localized_chat_copy_errors
+from .native_skill_competition import build_native_skill_competition_report, native_skill_competition_errors
 from .route_hint_alignment import build_route_hint_alignment_demo
 from .router_fast_path import build_router_fast_path_demo, router_fast_path_errors
 from .routing_precision import build_routing_precision_demo, routing_precision_errors
@@ -24,6 +25,7 @@ def build_hermes_ux_quality_demo(
     route_hint_alignment: Mapping[str, object] | None = None,
     context_brief_coverage: Mapping[str, object] | None = None,
     routing_precision: Mapping[str, object] | None = None,
+    native_competition: Mapping[str, object] | None = None,
     localized_chat_copy: Mapping[str, object] | None = None,
     router_fast_path: Mapping[str, object] | None = None,
     common_request_coverage: Mapping[str, object] | None = None,
@@ -55,6 +57,11 @@ def build_hermes_ux_quality_demo(
         if routing_precision is not None
         else build_routing_precision_demo(source=source)
     )
+    native = (
+        dict(native_competition)
+        if native_competition is not None
+        else build_native_skill_competition_report()
+    )
     localized_copy = (
         dict(localized_chat_copy)
         if localized_chat_copy is not None
@@ -70,6 +77,7 @@ def build_hermes_ux_quality_demo(
         if common_request_coverage is not None
         else build_common_request_coverage_demo(source=source)
     )
+    native_errors = native_skill_competition_errors(native)
 
     gates = [
         _gate(
@@ -121,6 +129,19 @@ def build_hermes_ux_quality_demo(
             command="omh demo routing-precision --json",
             errors=routing_precision_errors(precision),
             claim_boundary=str(precision.get("claim_boundary", "")),
+        ),
+        _gate(
+            gate_id="native_competition",
+            title="Native skill competition",
+            status="passed" if not native_errors else "failed",
+            summary=f"{native.get('passed_count', 0)}/{native.get('case_count', 0)} frontmatter comparisons passing.",
+            user_value=(
+                "Ordinary native-tool requests prefer native tools, while OMH policy overlays win only when "
+                "the user asks for their confirmation, safety, freshness, or evidence boundary."
+            ),
+            command="omh demo native-competition --json",
+            errors=native_errors,
+            claim_boundary=str(native.get("claim_boundary", "")),
         ),
         _gate(
             gate_id="localized_chat_copy",
@@ -192,6 +213,8 @@ def build_hermes_ux_quality_demo(
             "routing_precision_intervention_cases": precision_summary.get("intervention_case_count", 0),
             "routing_precision_intervention_passing_count": precision_summary.get("intervention_passing_count", 0),
             "routing_precision_missed_intervention_count": precision_summary.get("missed_intervention_count", 0),
+            "native_competition_cases": native.get("case_count", 0),
+            "native_competition_passing_count": native.get("passed_count", 0),
             "localized_chat_copy_cases": localized_summary.get("case_count", 0),
             "localized_chat_copy_passing_count": localized_summary.get("passing_count", 0),
             "localized_chat_copy_locale_count": localized_summary.get("locale_count", 0),
@@ -210,6 +233,7 @@ def build_hermes_ux_quality_demo(
             "Plugin/context awareness agrees with the router before generic tools are used.",
             "Catalog questions open an OMH picker without asking the user to approve shell commands.",
             "Plain help and file lookup questions stay out of OMH workflow routing when OMH is not needed.",
+            "Native tools win ordinary tool requests while OMH overlays win only for explicit policy gates.",
             "Common non-English operator prompts get local card framing without external translation.",
             "Frequent picker, status, direct-answer, file lookup, and workflow requests stay on deterministic fast paths.",
             "Real OMH-shaped requests still route to the expected workflow, picker, or context brief.",
@@ -219,7 +243,7 @@ def build_hermes_ux_quality_demo(
         "claim_boundary": (
             "Hermes UX quality proves deterministic local routing, card, hint, context, precision, "
             "localized-copy, fast-path, and common-request breadth contracts only. "
-            "It does not prove live Hermes chat rendering, platform delivery, plugin load, generic tool invocation, "
+            "It does not prove live Hermes chat rendering or picker ranking, platform delivery, plugin load, generic tool invocation, "
             "source retrieval, image generation, executor dispatch, implementation, verification, review, CI, merge, "
             "or delivery."
         ),

--- a/src/quality/native_skill_competition.py
+++ b/src/quality/native_skill_competition.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from typing import Literal, Mapping
+
+from ..skills.catalog import builtin_definitions, omh_skill_display_name
+from ..skills.render import frontmatter_description
+
+
+_TOKEN_RE = re.compile(r"[0-9a-z]+")
+_STOP_WORDS = frozenset(
+    {
+        "a",
+        "an",
+        "and",
+        "for",
+        "in",
+        "of",
+        "on",
+        "the",
+        "to",
+        "with",
+    }
+)
+
+
+@dataclass(frozen=True)
+class NativeCompetitionCase:
+    case_id: str
+    query: str
+    omh_skill: str
+    native_name: str
+    native_description: str
+    expected_winner: Literal["native", "omh"]
+
+
+NATIVE_COMPETITION_CASES = (
+    NativeCompetitionCase(
+        "browser-native-default",
+        "open this url in the browser click login and fill the form",
+        "browser-operator",
+        "browser",
+        "Open a URL in the browser, click a login button, fill a form, and read page content.",
+        "native",
+    ),
+    NativeCompetitionCase(
+        "browser-policy-overlay",
+        "browser login requires auth confirmation and an observed trace before the action",
+        "browser-operator",
+        "browser",
+        "Open a URL in the browser, click a login button, fill a form, and read page content.",
+        "omh",
+    ),
+    NativeCompetitionCase(
+        "files-native-default",
+        "list files in this folder search by name and rename one file",
+        "workspace-file-operator",
+        "files",
+        "List files and folders, search by name, read files, copy files, move files, and rename files.",
+        "native",
+    ),
+    NativeCompetitionCase(
+        "files-policy-overlay",
+        "delete a file only after path scoping destructive action confirmation and evidence",
+        "workspace-file-operator",
+        "files",
+        "List files and folders, search by name, read files, copy files, move files, and rename files.",
+        "omh",
+    ),
+    NativeCompetitionCase(
+        "shell-native-default",
+        "run the pytest command in the shell and show its output",
+        "command-operator",
+        "shell",
+        "Run shell commands, CLI tools, package managers, and tests, then return command output.",
+        "native",
+    ),
+    NativeCompetitionCase(
+        "shell-policy-overlay",
+        "run a production migration command with cwd environment safety and result evidence gates",
+        "command-operator",
+        "shell",
+        "Run shell commands, CLI tools, package managers, and tests, then return command output.",
+        "omh",
+    ),
+    NativeCompetitionCase(
+        "live-info-native-default",
+        "show the weather today in seoul",
+        "live-info-operator",
+        "weather",
+        "Look up live weather today, forecasts, prices, sports scores, maps, and local time.",
+        "native",
+    ),
+    NativeCompetitionCase(
+        "live-info-policy-overlay",
+        "exchange rate lookup requires provider freshness units and source quality evidence",
+        "live-info-operator",
+        "weather",
+        "Look up live weather today, forecasts, prices, sports scores, maps, and local time.",
+        "omh",
+    ),
+)
+
+
+def _tokens(text: str) -> frozenset[str]:
+    return frozenset(token for token in _TOKEN_RE.findall(text.casefold()) if token not in _STOP_WORDS)
+
+
+def _lexical_score(query: str, name: str, description: str) -> tuple[int, tuple[str, ...]]:
+    query_tokens = _tokens(query)
+    name_overlap = query_tokens & _tokens(name)
+    description_overlap = query_tokens & _tokens(description)
+    matched = tuple(sorted(name_overlap | description_overlap))
+    return (2 * len(name_overlap)) + len(description_overlap), matched
+
+
+def build_native_skill_competition_report() -> dict[str, object]:
+    definitions = {definition.name: definition for definition in builtin_definitions()}
+    results: list[dict[str, object]] = []
+    failures: list[str] = []
+    for case in NATIVE_COMPETITION_CASES:
+        definition = definitions[case.omh_skill]
+        omh_score, omh_matches = _lexical_score(
+            case.query,
+            omh_skill_display_name(definition.name),
+            frontmatter_description(definition),
+        )
+        native_score, native_matches = _lexical_score(
+            case.query,
+            case.native_name,
+            case.native_description,
+        )
+        if omh_score == native_score:
+            actual_winner = "tie"
+            winner_score = omh_score
+            loser_score = native_score
+        elif omh_score > native_score:
+            actual_winner = "omh"
+            winner_score = omh_score
+            loser_score = native_score
+        else:
+            actual_winner = "native"
+            winner_score = native_score
+            loser_score = omh_score
+        passed = actual_winner == case.expected_winner
+        if not passed:
+            failures.append(case.case_id)
+        results.append(
+            {
+                "case_id": case.case_id,
+                "omh_skill": case.omh_skill,
+                "native_name": case.native_name,
+                "expected_winner": case.expected_winner,
+                "actual_winner": actual_winner,
+                "winner_score": winner_score,
+                "loser_score": loser_score,
+                "omh_score": omh_score,
+                "native_score": native_score,
+                "omh_matches": list(omh_matches),
+                "native_matches": list(native_matches),
+                "passed": passed,
+                "picker_surface": "generated_frontmatter_name_description",
+            }
+        )
+    return {
+        "schema_version": "omh_native_skill_competition/v1",
+        "case_count": len(results),
+        "passed_count": len(results) - len(failures),
+        "failed_count": len(failures),
+        "failures": failures,
+        "all_passing": not failures,
+        "results": results,
+        "claim_boundary": (
+            "Deterministic lexical comparison of checked-in representative native descriptions against "
+            "generated OMH frontmatter name+description only; not live Hermes picker, runtime, or market evidence."
+        ),
+    }
+
+
+def native_skill_competition_errors(payload: Mapping[str, object]) -> list[str]:
+    errors: list[str] = []
+    if payload.get("schema_version") != "omh_native_skill_competition/v1":
+        errors.append("native competition schema_version is invalid")
+    counts: dict[str, int] = {}
+    for key in ("case_count", "passed_count", "failed_count"):
+        value = payload.get(key)
+        if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+            errors.append(f"native competition {key} is invalid")
+        else:
+            counts[key] = value
+    failures = payload.get("failures")
+    if not isinstance(failures, list) or not all(isinstance(item, str) and item for item in failures):
+        errors.append("native competition failures must be a list of case ids")
+        failure_count = -1
+    else:
+        failure_count = len(failures)
+    if not isinstance(payload.get("results"), list):
+        errors.append("native competition results must be a list")
+    all_passing = payload.get("all_passing")
+    if not isinstance(all_passing, bool):
+        errors.append("native competition all_passing must be boolean")
+    if len(counts) == 3:
+        if counts["passed_count"] + counts["failed_count"] != counts["case_count"]:
+            errors.append("native competition counts are inconsistent")
+        if failure_count >= 0 and counts["failed_count"] != failure_count:
+            errors.append("native competition failure count is inconsistent")
+        expected_all_passing = counts["failed_count"] == 0 and counts["passed_count"] == counts["case_count"]
+        if isinstance(all_passing, bool) and all_passing != expected_all_passing:
+            errors.append("native competition all_passing is inconsistent")
+    return errors
+
+
+def format_native_skill_competition_summary(payload: dict[str, object]) -> str:
+    return "\n".join(
+        (
+            "Native skill competition",
+            f"- cases: {payload['passed_count']}/{payload['case_count']} passing",
+            f"- failures: {', '.join(payload['failures']) if payload['failures'] else 'none'}",
+            f"- boundary: {payload['claim_boundary']}",
+        )
+    )

--- a/src/quality/native_skill_competition.py
+++ b/src/quality/native_skill_competition.py
@@ -180,6 +180,7 @@ def build_native_skill_competition_report() -> dict[str, object]:
 
 def native_skill_competition_errors(payload: Mapping[str, object]) -> list[str]:
     errors: list[str] = []
+    expected_case_ids = {case.case_id for case in NATIVE_COMPETITION_CASES}
     if payload.get("schema_version") != "omh_native_skill_competition/v1":
         errors.append("native competition schema_version is invalid")
     counts: dict[str, int] = {}
@@ -195,12 +196,30 @@ def native_skill_competition_errors(payload: Mapping[str, object]) -> list[str]:
         failure_count = -1
     else:
         failure_count = len(failures)
-    if not isinstance(payload.get("results"), list):
+    results = payload.get("results")
+    result_rows: list[Mapping[str, object]] = []
+    if not isinstance(results, list):
         errors.append("native competition results must be a list")
+    else:
+        for row in results:
+            if not isinstance(row, Mapping):
+                errors.append("native competition result rows must be objects")
+                continue
+            case_id = row.get("case_id")
+            passed = row.get("passed")
+            if not isinstance(case_id, str) or case_id not in expected_case_ids:
+                errors.append("native competition result case_id is invalid")
+                continue
+            if not isinstance(passed, bool):
+                errors.append(f"native competition result {case_id} passed flag is invalid")
+                continue
+            result_rows.append(row)
     all_passing = payload.get("all_passing")
     if not isinstance(all_passing, bool):
         errors.append("native competition all_passing must be boolean")
     if len(counts) == 3:
+        if counts["case_count"] != len(expected_case_ids):
+            errors.append("native competition case_count does not cover the required corpus")
         if counts["passed_count"] + counts["failed_count"] != counts["case_count"]:
             errors.append("native competition counts are inconsistent")
         if failure_count >= 0 and counts["failed_count"] != failure_count:
@@ -208,6 +227,18 @@ def native_skill_competition_errors(payload: Mapping[str, object]) -> list[str]:
         expected_all_passing = counts["failed_count"] == 0 and counts["passed_count"] == counts["case_count"]
         if isinstance(all_passing, bool) and all_passing != expected_all_passing:
             errors.append("native competition all_passing is inconsistent")
+        if isinstance(results, list):
+            result_ids = [str(row["case_id"]) for row in result_rows]
+            if len(result_rows) != counts["case_count"] or set(result_ids) != expected_case_ids:
+                errors.append("native competition results do not cover the required corpus")
+            if len(result_ids) != len(set(result_ids)):
+                errors.append("native competition results contain duplicate case ids")
+            passed_ids = {str(row["case_id"]) for row in result_rows if row["passed"] is True}
+            failed_ids = {str(row["case_id"]) for row in result_rows if row["passed"] is False}
+            if len(passed_ids) != counts["passed_count"] or len(failed_ids) != counts["failed_count"]:
+                errors.append("native competition result rows disagree with aggregate counts")
+            if isinstance(failures, list) and set(failures) != failed_ids:
+                errors.append("native competition failure ids disagree with result rows")
     return errors
 
 

--- a/src/quality/native_skill_competition.py
+++ b/src/quality/native_skill_competition.py
@@ -180,7 +180,8 @@ def build_native_skill_competition_report() -> dict[str, object]:
 
 def native_skill_competition_errors(payload: Mapping[str, object]) -> list[str]:
     errors: list[str] = []
-    expected_case_ids = {case.case_id for case in NATIVE_COMPETITION_CASES}
+    expected_cases = {case.case_id: case for case in NATIVE_COMPETITION_CASES}
+    expected_case_ids = set(expected_cases)
     if payload.get("schema_version") != "omh_native_skill_competition/v1":
         errors.append("native competition schema_version is invalid")
     counts: dict[str, int] = {}
@@ -212,6 +213,38 @@ def native_skill_competition_errors(payload: Mapping[str, object]) -> list[str]:
                 continue
             if not isinstance(passed, bool):
                 errors.append(f"native competition result {case_id} passed flag is invalid")
+                continue
+            expected = expected_cases[case_id]
+            if (
+                row.get("omh_skill") != expected.omh_skill
+                or row.get("native_name") != expected.native_name
+                or row.get("expected_winner") != expected.expected_winner
+            ):
+                errors.append(f"native competition result {case_id} disagrees with the fixed corpus")
+                continue
+            score_values: dict[str, int] = {}
+            for key in ("winner_score", "loser_score", "omh_score", "native_score"):
+                value = row.get(key)
+                if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+                    errors.append(f"native competition result {case_id} {key} is invalid")
+                    break
+                score_values[key] = value
+            if len(score_values) != 4:
+                continue
+            if score_values["omh_score"] == score_values["native_score"]:
+                derived_winner = "tie"
+            elif score_values["omh_score"] > score_values["native_score"]:
+                derived_winner = "omh"
+            else:
+                derived_winner = "native"
+            if (
+                row.get("actual_winner") != derived_winner
+                or score_values["winner_score"] != max(score_values["omh_score"], score_values["native_score"])
+                or score_values["loser_score"] != min(score_values["omh_score"], score_values["native_score"])
+                or passed != (derived_winner == expected.expected_winner)
+                or row.get("picker_surface") != "generated_frontmatter_name_description"
+            ):
+                errors.append(f"native competition result {case_id} winner evidence is inconsistent")
                 continue
             result_rows.append(row)
     all_passing = payload.get("all_passing")

--- a/src/skills/catalog_definitions.py
+++ b/src/skills/catalog_definitions.py
@@ -185,8 +185,9 @@ _DEFINITIONS = [
     SkillDefinition(
         "ralph",
         "Ralph - one owner drives a concrete task to done: implement, verify, review, repeat until the gate passes; prefer over one-shot delegation when the task needs a verification loop.",
-        ("ralph", "$ralph", "finish until done", "persistent execution", "self-referential loop"),
+        ("ralph", "$ralph", "ulr", "$ulr", "finish until done", "persistent execution", "self-referential loop"),
         "Use after scope is concrete and the user wants one owner to continue through implementation and verification.",
+        aliases=("ulr",),
         category="execution",
         phase="completion",
         hermes_role="runtime-handoff-guidance",
@@ -224,6 +225,7 @@ _DEFINITIONS = [
             "완료 조건까지 계속",
         ),
         "Use when work needs durable goal artifacts, checkpointed progress, and final quality gates.",
+        aliases=("ulg",),
         category="execution",
         phase="durable-goals",
         hermes_role="runtime-handoff-guidance",
@@ -421,6 +423,7 @@ _DEFINITIONS = [
             "TDD로 구현",
         ),
         "Use when the user asks Hermes to take a concrete task through one full delivery cycle: research/codebase context, reviewed plan, selected implementation handoff, code review, docs sync when needed, and PR preparation.",
+        aliases=("ulp",),
         category="process",
         phase="single-cycle-plan-to-pr",
         capability_family="delegate_coding_and_ship",
@@ -582,6 +585,7 @@ _DEFINITIONS = [
         "Ultrawork - split an accepted plan into disjoint parallel lanes with per-lane acceptance criteria, verification commands, and owners; prevents two lanes editing the same file.",
         ("ultrawork", "$ultrawork", "ulw", "$ulw", "parallel work", "parallel implementation", "high throughput"),
         "Use when an accepted implementation plan can be split into independent, reviewable work lanes.",
+        aliases=("ulw",),
         category="execution",
         phase="parallel-delivery",
         hermes_role="runtime-handoff-guidance",
@@ -633,7 +637,7 @@ _DEFINITIONS = [
     ),
     SkillDefinition(
         "web-research",
-        "Web research with citation discipline on top of native search - every claim carries a live URL, sources are diversity-checked, and anything not fetched is marked not observed instead of guessed.",
+        "Web research with citation discipline on top of native search - every claim carries a live URL and unfetched claims stay not observed; for a decision-ready brief use research-brief, and for ongoing Scout/Analyst/Briefer coordination use research-department.",
         (
             "web-research",
             "web research",
@@ -729,7 +733,7 @@ _DEFINITIONS = [
     ),
     SkillDefinition(
         "source-finder",
-        "Hermes Source Finder workflow: prepare typed source candidates and acquisition status before downstream work.",
+        "Source candidate inventory - prepare typed source candidates and acquisition status before downstream work; use ulw-research to fetch and cite them, or research-brief to turn them into a decision-ready brief.",
         (
             "source-finder",
             "source finder",
@@ -839,7 +843,7 @@ _DEFINITIONS = [
     ),
     SkillDefinition(
         "research-brief",
-        "Business research brief - turns a market, competitor, pricing, or customer question into a structured brief with an explicit evidence-vs-inference split; for raw link gathering use ulw-research.",
+        "Business research brief - turns a market, competitor, pricing, or customer question into a structured evidence-vs-inference brief; for raw link gathering use ulw-research, and for ongoing multi-role research use research-department.",
         (
             "research-brief",
             "business-research",
@@ -886,7 +890,7 @@ _DEFINITIONS = [
     ),
     SkillDefinition(
         "research-department",
-        "Hermes Research Department workflow pack: prepare Scout, Analyst, and Briefer research operations with source inbox and briefing status boundaries.",
+        "Research operations department - coordinate Scout, Analyst, and Briefer work with source-inbox and status boundaries; for one decision brief use research-brief, and for typed candidates before research starts use source-finder.",
         (
             "research-department",
             "research department",

--- a/src/skills/catalog_feature_surfaces.py
+++ b/src/skills/catalog_feature_surfaces.py
@@ -116,7 +116,7 @@ _FEATURE_SURFACE_SKILLS = (
     ),
     _feature_surface_skill(
         "memory-new",
-        "Save a new durable project or product fact - captures a candidate, shows it for review, and writes only on approval; for auditing memories that already exist use omh-memory-sync.",
+        "Save a new durable project or product fact - captures a candidate, shows it for review, and writes only on approval; for auditing existing memories use omh-memory-sync, and for retrieving a past decision use decision-recall.",
         (
             "memory-new",
             "new memory",
@@ -163,7 +163,7 @@ _FEATURE_SURFACE_SKILLS = (
     ),
     _feature_surface_skill(
         "memory-sync",
-        "Audit what Hermes already remembers - walks USER.md, MEMORY.md, and skill memories claim by claim, flags stale, conflicting, duplicate, or overgeneralized entries, and rewrites only after an approved diff.",
+        "Audit what Hermes already remembers - reviews USER.md, MEMORY.md, and skill memories claim by claim and rewrites only after an approved diff; for a new fact use memory-new, and for retrieving a past decision use decision-recall.",
         (
             "memory-sync",
             "memory curation",
@@ -266,7 +266,7 @@ _FEATURE_SURFACE_SKILLS = (
     ),
     _feature_surface_skill(
         "executor-runtime-readiness",
-        "Hermes executor runtime readiness workflow: compare Codex, Claude Code, Hermes coding, and oh-my runtimes by available tools, missing tools, and handoff mode.",
+        "Executor runtime readiness - compare Codex, Claude Code, Hermes coding, and oh-my runtimes by tools and handoff mode; use external-connector-readiness for a named plugin or API, and toolbelt-readiness for the whole capability inventory.",
         (
             "executor-runtime-readiness",
             "executor readiness",
@@ -386,7 +386,7 @@ _FEATURE_SURFACE_SKILLS = (
     ),
     _feature_surface_skill(
         "browser-operator",
-        "Browser tasks - open URLs, click, log in, fill forms, and capture page blockers, each scoped behind auth, confirmation, and observed-trace gates.",
+        "Policy overlay for browser tasks - add auth, confirmation, and observed-trace gates after preferring the native browser for ordinary URL, click, login, and form actions.",
         (
             "browser-operator",
             "browser operator",
@@ -470,7 +470,7 @@ _FEATURE_SURFACE_SKILLS = (
     ),
     _feature_surface_skill(
         "workspace-file-operator",
-        "Local files and folders - list, search, organize, copy, move, rename, and delete, with path scoping and destructive-action gates.",
+        "Policy overlay for local file tasks - add path scoping and destructive-action gates after preferring native file tools for ordinary list, search, organize, copy, move, and rename actions.",
         (
             "workspace-file-operator",
             "workspace file operator",
@@ -550,7 +550,7 @@ _FEATURE_SURFACE_SKILLS = (
     ),
     _feature_surface_skill(
         "command-operator",
-        "Terminal commands - scope shell, CLI, package-manager, and test runs with cwd, environment, safety, and result-evidence gates.",
+        "Policy overlay for terminal commands - add cwd, environment, safety, and result-evidence gates after preferring native shell tools for ordinary CLI, package-manager, and test runs.",
         (
             "command-operator",
             "command operator",
@@ -711,7 +711,7 @@ _FEATURE_SURFACE_SKILLS = (
     ),
     _feature_surface_skill(
         "live-info-operator",
-        "Live lookups - weather, finance, sports, maps, places, exchange rates, and time zones, read-only with provider, freshness, units, and source-quality gates.",
+        "Policy overlay for live lookups - add provider, freshness, units, and source-quality gates after preferring native live-data tools for ordinary weather, finance, sports, maps, and time-zone requests.",
         (
             "live-info-operator",
             "live info operator",
@@ -783,7 +783,7 @@ _FEATURE_SURFACE_SKILLS = (
     ),
     _feature_surface_skill(
         "external-connector-readiness",
-        "Hermes external connector readiness workflow: decide whether a candidate plugin, connector, API, data provider, or multimodal route is safe, affordable, fresh, and observable enough to adopt, route, or trial.",
+        "External connector readiness - assess whether a named plugin, connector, API, data provider, or multimodal route is safe, affordable, fresh, and observable; use executor-runtime-readiness for coding-owner choice and toolbelt-readiness for missing capability inventory.",
         (
             "external-connector-readiness",
             "external connector readiness",
@@ -918,7 +918,7 @@ _FEATURE_SURFACE_SKILLS = (
     ),
     _feature_surface_skill(
         "prompt-import-readiness",
-        "Hermes prompt import readiness workflow: decide whether external CLI-agent prompt files can be safely reviewed, normalized, and offered as Hermes slash-command candidates without mutating prompts or command registries.",
+        "Prompt import readiness - review and normalize external CLI-agent prompt files before offering slash-command candidates; use external-connector-readiness for plugin or API adoption and toolbelt-readiness for missing runtime capabilities.",
         (
             "prompt-import-readiness",
             "prompt import readiness",
@@ -995,7 +995,7 @@ _FEATURE_SURFACE_SKILLS = (
     ),
     _feature_surface_skill(
         "physical-device-readiness",
-        "Hermes readiness workflow for robots, 3D printers, IoT relays, sensors, and lab hardware before hardware trials.",
+        "Physical device readiness - gate robots, 3D printers, IoT relays, sensors, and lab hardware before trials; use external-connector-readiness for provider or connector adoption and toolbelt-readiness for missing control tools.",
         (
             "physical-device-readiness",
             "physical device readiness",
@@ -1328,7 +1328,7 @@ _FEATURE_SURFACE_SKILLS = (
     ),
     _feature_surface_skill(
         "toolbelt-readiness",
-        "Hermes toolbelt readiness workflow: check which MCP servers, CLIs, APIs, credentials, and connectors a workflow needs before claiming it can run.",
+        "Toolbelt readiness - inventory which MCP servers, CLIs, APIs, credentials, and connectors a workflow needs; use external-connector-readiness to assess one named integration and executor-runtime-readiness to choose the coding owner.",
         (
             "toolbelt-readiness",
             "mcp readiness",

--- a/src/skills/catalog_types.py
+++ b/src/skills/catalog_types.py
@@ -523,6 +523,9 @@ class SkillDefinition:
     # Empty means inherit the category default. The resolved value is exposed
     # as catalog metadata for hosts to apply to their own model inventory.
     reasoning_demand: Literal["light", "standard", "heavy", ""] = ""
+    # Short routing-equivalent names surfaced through the frontmatter
+    # description because the host picker reads only `name` + `description`.
+    aliases: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "description", omh_description(self.description))

--- a/src/skills/render.py
+++ b/src/skills/render.py
@@ -24,6 +24,7 @@ from .catalog import (
 )
 from ..catalogs.awesome_hermes_agent import awesome_hermes_catalog
 from ..plugin_bundle.omh.awareness import (
+    awareness_shared_context_markdown,
     awareness_workflow_context_markdown,
     router_keyword_summary,
 )
@@ -171,7 +172,7 @@ def _common_rail_sections(definition: SkillDefinition, primary_harness: str) -> 
     What stays inline is the self-containment floor a standalone Hermes tap needs: this
     skill's harness and record command, the observed-vs-unavailable delegation result rule,
     the Hermes-native tool contract with its native-subagent fallback, target topology, the
-    skill's memory-context policy, and the pointer to `references/skill-common-rail.md`.
+    delegation fallback and the pointer to `references/skill-common-rail.md`.
     `tests/test_router_content.py::test_all_tap_skills_include_subagent_fallback_contract`
     is the gate on that floor. Everything else moved to the shared rail verbatim.
     """
@@ -184,14 +185,12 @@ omh runtime record --skill {definition.name} --harness {primary_harness} --statu
 ```
 
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
-
-## Hermes Compatibility Contract
-
-- Preserve workflow intent and stop conditions; verify before claiming completion.
-- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays. If a capability is unavailable: native subagents -> Hermes delegation when available, otherwise sequential lanes.
-{_target_topology_skill_contract_bullet()}
+Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 {_memory_context_skill_contract_bullets(definition)}
-- Shared rail: `{SHARED_RAIL_REFERENCE_PATH}` has harness discipline, runtime translations, the delegation command, and execution checklist. Load it when applicable; otherwise name an unavailable capability."""
+
+Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
+
+Shared product, compatibility, topology, memory, harness, and execution rules: `{SHARED_RAIL_REFERENCE_PATH}`. Load it when applicable; otherwise name an unavailable capability."""
 
 
 @lru_cache(maxsize=1)
@@ -217,14 +216,28 @@ def _frontmatter_trigger_tail(definition: SkillDefinition | None) -> str:
     # tokens would also collide with the substring-trap detectors.
     if definition.name == "oh-my-hermes":
         return ""
-    safe = [
+    safe_aliases = [
+        alias
+        for alias in definition.aliases
+        if _FRONTMATTER_SAFE_TRIGGER.fullmatch(alias)
+    ]
+    safe_alias_keys = {alias.casefold() for alias in safe_aliases}
+    safe_triggers = [
         trigger
         for trigger in definition.triggers
-        if _FRONTMATTER_SAFE_TRIGGER.fullmatch(trigger)
+        if _FRONTMATTER_SAFE_TRIGGER.fullmatch(trigger) and trigger.casefold() not in safe_alias_keys
     ]
-    if not safe:
-        return ""
-    return " Use when the user says: " + ", ".join(safe[:_FRONTMATTER_TRIGGER_LIMIT]) + "."
+    alias_tail = " Aliases: " + ", ".join(safe_aliases) + "." if safe_aliases else ""
+    trigger_tail = (
+        " Use when the user says: " + ", ".join(safe_triggers[:_FRONTMATTER_TRIGGER_LIMIT]) + "."
+        if safe_triggers
+        else ""
+    )
+    return alias_tail + trigger_tail
+
+
+def frontmatter_description(definition: SkillDefinition) -> str:
+    return omh_description(definition.description) + _frontmatter_trigger_tail(definition)
 
 
 def _frontmatter(name: str, description: str) -> str:
@@ -235,7 +248,7 @@ def _frontmatter(name: str, description: str) -> str:
     definition = _definitions_by_name().get(name)
     category = definition.category if definition else "workflow"
     phase = definition.phase if definition else "general"
-    description = omh_description(description) + _frontmatter_trigger_tail(definition)
+    description = frontmatter_description(definition) if definition else omh_description(description)
     display_name = omh_skill_display_name(name)
     return (
         f"---\nname: {display_name}\ndescription: {description}\nmetadata:\n"
@@ -479,6 +492,13 @@ own evidence boundary, and a pointer to this file.
 
 Load this reference when harness selection, a missing Hermes runtime capability,
 multi-agent target topology, or the generic execution checklist is in play.
+
+{awareness_shared_context_markdown()}
+
+## Hermes Compatibility Contract
+
+- Preserve workflow intent and stop conditions; verify before claiming completion.
+- Use Hermes-native tools, file operations, and subagent/delegation features when available; do not require unavailable runtime tools, role prompts, or overlays.
 
 ## Harness Discipline
 

--- a/src/skills/render.py
+++ b/src/skills/render.py
@@ -158,21 +158,13 @@ def _needs_explicit_memory_context(definition: SkillDefinition) -> bool:
     return memory_context_policy_for_skill(definition.name) == "explicit"
 
 
-def _target_topology_skill_contract_bullet() -> str:
-    return (
-        f"- Respect `{TARGET_TOPOLOGY_SCHEMA}`: bind state to the current target/thread, use single-target "
-        "behavior when `active_agent_count` is one, and name a one-to-many or many-to-one change before "
-        "treating it as persistent."
-    )
-
-
 def _common_rail_sections(definition: SkillDefinition, primary_harness: str) -> str:
     """Render the compact per-skill tail that replaced the repeated common rail.
 
     What stays inline is the self-containment floor a standalone Hermes tap needs: this
     skill's harness and record command, the observed-vs-unavailable delegation result rule,
-    the Hermes-native tool contract with its native-subagent fallback, target topology, the
-    delegation fallback and the pointer to `references/skill-common-rail.md`.
+    the Hermes-native tool contract with its native-subagent fallback, the compatibility
+    floor, delegation fallback and the pointer to `references/skill-common-rail.md`.
     `tests/test_router_content.py::test_all_tap_skills_include_subagent_fallback_contract`
     is the gate on that floor. Everything else moved to the shared rail verbatim.
     """
@@ -187,6 +179,7 @@ omh runtime record --skill {definition.name} --harness {primary_harness} --statu
 Record observed delegation results; otherwise return `not_available` or `not_observed`.
 Prepared OMH routing is not execution, review, CI, merge-readiness, or merge evidence.
 {_memory_context_skill_contract_bullets(definition)}
+Preserve workflow intent and stop conditions; verify before claiming completion.
 
 Use Hermes-native subagent/delegation features when available: native subagents -> Hermes delegation when available, otherwise sequential lanes.
 
@@ -221,6 +214,9 @@ def _frontmatter_trigger_tail(definition: SkillDefinition | None) -> str:
         for alias in definition.aliases
         if _FRONTMATTER_SAFE_TRIGGER.fullmatch(alias)
     ]
+    if len(safe_aliases) != len(definition.aliases):
+        invalid = sorted(set(definition.aliases) - set(safe_aliases))
+        raise ValueError(f"unsafe picker aliases for {definition.name}: {', '.join(invalid)}")
     safe_alias_keys = {alias.casefold() for alias in safe_aliases}
     safe_triggers = [
         trigger

--- a/tests/test_awareness_delivery.py
+++ b/tests/test_awareness_delivery.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import stat
+import threading
 import unittest
 from datetime import UTC, datetime
 from pathlib import Path
@@ -15,6 +16,7 @@ from omh.maintenance.doctor import _awareness_delivery_check
 from omh.paths import resolve_paths
 from omh.plugin_bundle.omh.awareness_delivery import (
     AWARENESS_DELIVERY_SCHEMA_VERSION,
+    _awareness_delivery_lock,
     awareness_delivery_path,
     read_awareness_delivery,
     record_awareness_delivery,
@@ -22,7 +24,7 @@ from omh.plugin_bundle.omh.awareness_delivery import (
 
 
 class AwarenessDeliveryLedgerTests(unittest.TestCase):
-    """Whether OMH's primer and route hint actually reached the model.
+    """Whether OMH's awareness hook returned a payload for model input.
 
     Nothing recorded this. `host_observation` drops a record unless the caller
     supplies `host` and `session_id`, and Hermes passes neither to
@@ -158,6 +160,8 @@ class AwarenessDeliveryLedgerTests(unittest.TestCase):
             self.assertFalse(aged.ok)
             self.assertEqual(aged.severity, "warning")
             self.assertIn("restart hermes", aged.next_action.casefold())
+            self.assertEqual(aged.remediation, aged.next_action)
+            self.assertIn("for at least 7 days", aged.message)
             self.assertIn("hook payload", aged.message)
             self.assertNotIn("reached a model", aged.message)
 
@@ -219,6 +223,58 @@ class AwarenessDeliveryLedgerTests(unittest.TestCase):
             record = read_awareness_delivery(tmp)
             self.assertTrue(record["unreadable"])
             self.assertEqual(record["delivery_count"], 0)
+
+    def test_semantically_corrupt_ledger_is_unreadable_and_repaired(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            path = awareness_delivery_path(str(paths.omh_home))
+            path.parent.mkdir(parents=True)
+            path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": AWARENESS_DELIVERY_SCHEMA_VERSION,
+                        "delivery_count": "many",
+                        "route_hint_count": 0,
+                        "suppressed_count": 0,
+                        "first_attempted_at": [],
+                        "last_context_chars": -1,
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            self.assertTrue(read_awareness_delivery(str(paths.omh_home))["unreadable"])
+            self.assertEqual(_awareness_delivery_check(paths).severity, "warning")
+            repaired = record_awareness_delivery(
+                delivered=True,
+                route_hint=False,
+                context_chars=12,
+                observed_at="2026-07-01T00:00:00Z",
+                omh_home=str(paths.omh_home),
+            )
+
+            self.assertIsNotNone(repaired)
+            self.assertEqual(read_awareness_delivery(str(paths.omh_home))["delivery_count"], 1)
+
+    def test_delivery_lock_serializes_concurrent_writers(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = awareness_delivery_path(tmp)
+            contender_started = threading.Event()
+            contender_acquired = threading.Event()
+
+            def contend() -> None:
+                contender_started.set()
+                with _awareness_delivery_lock(path):
+                    contender_acquired.set()
+
+            with _awareness_delivery_lock(path):
+                thread = threading.Thread(target=contend)
+                thread.start()
+                self.assertTrue(contender_started.wait(timeout=1))
+                self.assertFalse(contender_acquired.is_set())
+            self.assertTrue(contender_acquired.wait(timeout=1))
+            thread.join(timeout=1)
+            self.assertFalse(thread.is_alive())
 
     def test_a_write_failure_never_raises(self) -> None:
         """Losing a counter is fine; breaking the hook that feeds the model is not."""

--- a/tests/test_awareness_delivery.py
+++ b/tests/test_awareness_delivery.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import json
+import stat
 import unittest
+from datetime import UTC, datetime
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
@@ -9,6 +11,8 @@ from unittest.mock import patch
 from _local_package import load_local_package
 
 load_local_package()
+from omh.maintenance.doctor import _awareness_delivery_check
+from omh.paths import resolve_paths
 from omh.plugin_bundle.omh.awareness_delivery import (
     AWARENESS_DELIVERY_SCHEMA_VERSION,
     awareness_delivery_path,
@@ -60,6 +64,7 @@ class AwarenessDeliveryLedgerTests(unittest.TestCase):
             self.assertEqual(record["suppressed_count"], 1)
             self.assertEqual(record["delivery_count"], 0)
             self.assertEqual(record["last_delivered_at"], "")
+            self.assertEqual(record["first_attempted_at"], "2026-07-26T04:27:20Z")
 
     def test_route_hints_are_counted_only_when_present(self) -> None:
         with TemporaryDirectory() as tmp:
@@ -121,12 +126,89 @@ class AwarenessDeliveryLedgerTests(unittest.TestCase):
                 set(stored),
                 {
                     "schema_version", "delivery_count", "route_hint_count", "suppressed_count",
-                    "first_delivered_at", "last_delivered_at", "last_context_chars",
+                    "first_attempted_at", "first_delivered_at", "last_delivered_at", "last_context_chars",
                 },
             )
             self.assertNotIn("2768 chars of prompt", written)
             for key in ("context", "user_message", "prompt", "route_hint"):
                 self.assertNotIn(key, stored, f"{key} would put model-facing text in a ledger")
+
+    def test_zero_delivery_warns_only_after_seven_days(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            record_awareness_delivery(
+                delivered=False,
+                route_hint=False,
+                context_chars=0,
+                observed_at="2026-07-01T00:00:00Z",
+                omh_home=str(paths.omh_home),
+            )
+
+            fresh = _awareness_delivery_check(
+                paths,
+                now=datetime(2026, 7, 7, 23, 59, 59, tzinfo=UTC),
+            )
+            aged = _awareness_delivery_check(
+                paths,
+                now=datetime(2026, 7, 8, 0, 0, 0, tzinfo=UTC),
+            )
+
+            self.assertTrue(fresh.ok)
+            self.assertEqual(fresh.severity, "ok")
+            self.assertFalse(aged.ok)
+            self.assertEqual(aged.severity, "warning")
+            self.assertIn("restart hermes", aged.next_action.casefold())
+            self.assertIn("hook payload", aged.message)
+            self.assertNotIn("reached a model", aged.message)
+
+    def test_a_delivery_or_legacy_record_never_false_ages(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            record_awareness_delivery(
+                delivered=True,
+                route_hint=True,
+                context_chars=12,
+                observed_at="2026-07-01T00:00:00Z",
+                omh_home=str(paths.omh_home),
+            )
+            delivered = _awareness_delivery_check(
+                paths,
+                now=datetime(2026, 8, 1, tzinfo=UTC),
+            )
+            self.assertTrue(delivered.ok)
+            self.assertIn("hook payload", delivered.message)
+            self.assertNotIn("reached a model", delivered.message)
+
+            awareness_delivery_path(str(paths.omh_home)).write_text(
+                json.dumps(
+                    {
+                        "schema_version": AWARENESS_DELIVERY_SCHEMA_VERSION,
+                        "delivery_count": 0,
+                        "route_hint_count": 0,
+                        "suppressed_count": 5,
+                    }
+                ),
+                encoding="utf-8",
+            )
+            legacy = _awareness_delivery_check(
+                paths,
+                now=datetime(2026, 8, 1, tzinfo=UTC),
+            )
+            self.assertTrue(legacy.ok)
+            self.assertEqual(legacy.severity, "ok")
+
+    def test_ledger_file_and_directory_are_private(self) -> None:
+        with TemporaryDirectory() as tmp:
+            record_awareness_delivery(
+                delivered=False,
+                route_hint=False,
+                context_chars=0,
+                observed_at="2026-07-01T00:00:00Z",
+                omh_home=tmp,
+            )
+            path = awareness_delivery_path(tmp)
+            self.assertEqual(stat.S_IMODE(path.parent.stat().st_mode), 0o700)
+            self.assertEqual(stat.S_IMODE(path.stat().st_mode), 0o600)
 
     def test_a_corrupt_ledger_reads_as_unreadable_rather_than_zero(self) -> None:
         """Zero deliveries and an unparseable file mean different things."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3213,6 +3213,7 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
                     "route_hint_alignment",
                     "context_brief_coverage",
                     "routing_precision",
+                    "native_competition",
                     "localized_chat_copy",
                     "router_fast_path",
                     "common_request_coverage",
@@ -3248,7 +3249,7 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
             self.assertIn("coverage 100.0%", gates["common_request_coverage"]["summary"])
             self.assertIn("popular plugin families 10/10 (100.0%)", gates["common_request_coverage"]["summary"])
             self.assertEqual(gates["hermes_ux_quality"]["status"], "passed")
-            self.assertIn("8/8 UX gates passing", gates["hermes_ux_quality"]["summary"])
+            self.assertIn("9/9 UX gates passing", gates["hermes_ux_quality"]["summary"])
             self.assertIn("fast paths 11/11", gates["hermes_ux_quality"]["summary"])
             self.assertIn("common requests 91/91", gates["hermes_ux_quality"]["summary"])
             self.assertEqual(gates["parity_contracts"]["status"], "passed")
@@ -3298,7 +3299,7 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
                 "(100.0%; target 95.0%; generic ack 0; popular plugin families 10/10 at 100.0%)",
                 stdout,
             )
-            self.assertIn("Hermes UX quality: 100/100 (8/8 gates)", stdout)
+            self.assertIn("Hermes UX quality: 100/100 (9/9 gates)", stdout)
             self.assertIn("Local artifact store: not_written", stdout)
             self.assertFalse((omh_home / "runtime" / "release-evidence" / "index.json").exists())
 
@@ -3343,8 +3344,8 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
             self.assertEqual(payload["summary"]["popular_plugin_family_total"], 10)
             self.assertEqual(payload["summary"]["popular_plugin_weighted_coverage_percent"], 100.0)
             self.assertEqual(payload["summary"]["hermes_ux_quality_score"], 100)
-            self.assertEqual(payload["summary"]["hermes_ux_quality_passing_gates"], 8)
-            self.assertEqual(payload["summary"]["hermes_ux_quality_total_gates"], 8)
+            self.assertEqual(payload["summary"]["hermes_ux_quality_passing_gates"], 9)
+            self.assertEqual(payload["summary"]["hermes_ux_quality_total_gates"], 9)
             self.assertIn("local_artifact_store: not_written", payload["warnings"])
             self.assertTrue(Path(payload["artifact_path"]).exists())
             self.assertTrue((omh_home / "runtime" / "release-evidence" / "index.json").exists())

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -194,7 +194,7 @@ class EfficiencyContractTests(unittest.TestCase):
         report = skill_context_cost_markdown()
         self.assertIn("## core profile", report)
         self.assertIn("## full profile", report)
-        self.assertIn("Hermes Compatibility Contract", report)
+        self.assertIn("Workflow Lane", report)
 
     def test_skill_triggers_and_evidence_boundaries_survive_common_rail_move(self) -> None:
         """Differential gate for issue #634 on the three surfaces it must not change.
@@ -277,13 +277,19 @@ class EfficiencyContractTests(unittest.TestCase):
         self.assertIn("Common cues before generic tools", awareness_primer_markdown())
         self.assertIn("check OMH prep/status/learning", awareness_primer_markdown())
         self.assertIn("Generic tool map", awareness_primer_markdown())
-        self.assertEqual(combined.count("## OMH Context Rail"), len(workflow_skill_names))
+        self.assertEqual(combined.count("## Workflow Lane"), len(workflow_skill_names))
         self.assertEqual(combined.count("## OMH Awareness Primer"), 1)
+        common_rail = next(
+            template.content
+            for template in builtin_skill_reference_templates()
+            if template.relative_path == "references/skill-common-rail.md"
+        )
+        self.assertIn("## OMH Context Rail", common_rail)
+        self.assertIn("Generic-tool checkpoint: image->img-summary", common_rail)
         for name in workflow_skill_names:
-            self.assertIn(
-                "Generic-tool checkpoint: image->img-summary",
-                awareness_workflow_context_markdown(name),
-            )
+            context = awareness_workflow_context_markdown(name)
+            self.assertIn("Shared product, routing, compatibility, and evidence rules", context)
+            self.assertNotIn("Generic-tool checkpoint: image->img-summary", context)
 
     def test_omh_awareness_lanes_cover_installable_skills(self) -> None:
         payload = awareness_primer_payload()
@@ -887,6 +893,16 @@ class EfficiencyContractTests(unittest.TestCase):
             "cases": [],
             "claim_boundary": "common request boundary",
         }
+        native_competition_payload = {
+            "schema_version": "omh_native_skill_competition/v1",
+            "all_passing": True,
+            "passed_count": 1,
+            "case_count": 1,
+            "failed_count": 0,
+            "failures": [],
+            "results": [],
+            "claim_boundary": "native competition boundary",
+        }
 
         with (
             patch.object(
@@ -916,6 +932,11 @@ class EfficiencyContractTests(unittest.TestCase):
             ),
             patch.object(
                 hermes_ux_quality_module,
+                "build_native_skill_competition_report",
+                side_effect=AssertionError("precomputed native competition payload should be reused"),
+            ),
+            patch.object(
+                hermes_ux_quality_module,
                 "build_localized_chat_copy_demo",
                 side_effect=AssertionError("precomputed localized payload should be reused"),
             ),
@@ -937,13 +958,14 @@ class EfficiencyContractTests(unittest.TestCase):
                 route_hint_alignment=route_hint_payload,
                 context_brief_coverage=context_payload,
                 routing_precision=precision_payload,
+                native_competition=native_competition_payload,
                 localized_chat_copy=localized_payload,
                 router_fast_path=router_fast_path_payload,
                 common_request_coverage=common_request_payload,
             )
 
         self.assertEqual(payload["status"], "passed")
-        self.assertEqual(payload["summary"]["passing_gate_count"], 8)
+        self.assertEqual(payload["summary"]["passing_gate_count"], 9)
         self.assertEqual(payload["summary"]["localized_chat_copy_passing_count"], 1)
         self.assertEqual(payload["summary"]["router_fast_path_passing_count"], 1)
         self.assertEqual(payload["summary"]["common_request_passing_count"], 1)

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -893,16 +893,9 @@ class EfficiencyContractTests(unittest.TestCase):
             "cases": [],
             "claim_boundary": "common request boundary",
         }
-        native_competition_payload = {
-            "schema_version": "omh_native_skill_competition/v1",
-            "all_passing": True,
-            "passed_count": 1,
-            "case_count": 1,
-            "failed_count": 0,
-            "failures": [],
-            "results": [],
-            "claim_boundary": "native competition boundary",
-        }
+        from omh.quality.native_skill_competition import build_native_skill_competition_report
+
+        native_competition_payload = build_native_skill_competition_report()
 
         with (
             patch.object(

--- a/tests/test_hermes_ux_quality.py
+++ b/tests/test_hermes_ux_quality.py
@@ -15,8 +15,8 @@ class HermesUxQualityTests(unittest.TestCase):
         self.assertEqual(payload["source"], "discord")
         self.assertEqual(payload["status"], "passed")
         self.assertEqual(payload["score"], 100)
-        self.assertEqual(payload["summary"]["gate_count"], 8)
-        self.assertEqual(payload["summary"]["passing_gate_count"], 8)
+        self.assertEqual(payload["summary"]["gate_count"], 9)
+        self.assertEqual(payload["summary"]["passing_gate_count"], 9)
         self.assertEqual(payload["summary"]["grounded_score_scenarios"], 50)
         self.assertEqual(payload["summary"]["grounded_score_average"], 10.0)
         self.assertEqual(payload["summary"]["chat_card_cases"], 72)
@@ -35,6 +35,8 @@ class HermesUxQualityTests(unittest.TestCase):
         self.assertEqual(payload["summary"]["routing_precision_intervention_cases"], 138)
         self.assertEqual(payload["summary"]["routing_precision_intervention_passing_count"], 138)
         self.assertEqual(payload["summary"]["routing_precision_missed_intervention_count"], 0)
+        self.assertEqual(payload["summary"]["native_competition_cases"], 8)
+        self.assertEqual(payload["summary"]["native_competition_passing_count"], 8)
         self.assertEqual(payload["summary"]["localized_chat_copy_cases"], 8)
         self.assertEqual(payload["summary"]["localized_chat_copy_passing_count"], 8)
         self.assertEqual(payload["summary"]["localized_chat_copy_locale_count"], 6)
@@ -57,6 +59,7 @@ class HermesUxQualityTests(unittest.TestCase):
                 "route_hint_alignment",
                 "context_brief_coverage",
                 "routing_precision",
+                "native_competition",
                 "localized_chat_copy",
                 "router_fast_path",
                 "common_request_coverage",
@@ -66,10 +69,29 @@ class HermesUxQualityTests(unittest.TestCase):
         self.assertIn("before generic tools", gates["route_hint_alignment"]["user_value"])
         self.assertIn("raw prompt leakage", gates["context_brief_coverage"]["user_value"])
         self.assertIn("Ordinary questions", gates["routing_precision"]["user_value"])
+        self.assertIn("native tools", gates["native_competition"]["user_value"])
         self.assertIn("non-English", gates["localized_chat_copy"]["user_value"])
         self.assertIn("fast-path", gates["router_fast_path"]["user_value"])
         self.assertIn("broad curated set", gates["common_request_coverage"]["user_value"])
         self.assertIn("does not prove live Hermes chat rendering", payload["claim_boundary"])
+
+    def test_malformed_native_competition_payload_fails_closed(self) -> None:
+        payload = build_hermes_ux_quality_demo(
+            source="discord",
+            native_competition={
+                "schema_version": "wrong",
+                "case_count": 8,
+                "passed_count": 8,
+                "failed_count": 0,
+                "all_passing": True,
+                "failures": "not-a-list",
+            },
+        )
+        gate = next(item for item in payload["gates"] if item["id"] == "native_competition")
+
+        self.assertEqual(payload["status"], "needs_attention")
+        self.assertEqual(gate["status"], "failed")
+        self.assertTrue(gate["errors"])
 
     def test_hermes_ux_quality_cli_outputs_summary_and_json(self) -> None:
         status, stdout, stderr = run_cli(["demo", "hermes-ux-quality", "--summary"], output_json=False)
@@ -78,7 +100,7 @@ class HermesUxQualityTests(unittest.TestCase):
         self.assertEqual(stderr, "")
         self.assertIn("OMH Hermes UX quality", stdout)
         self.assertIn("Status: passed (100/100)", stdout)
-        self.assertIn("Gates: 8/8", stdout)
+        self.assertIn("Gates: 9/9", stdout)
         self.assertIn("generic ack 0", stdout)
         self.assertIn("route mismatches 0", stdout)
         self.assertIn("precision overroutes 0", stdout)

--- a/tests/test_hook_manifest.py
+++ b/tests/test_hook_manifest.py
@@ -101,6 +101,19 @@ class HookManifestTests(unittest.TestCase):
             self.assertEqual(read_awareness_delivery(explicit_home)["delivery_count"], 1)
             self.assertEqual(read_awareness_delivery(env_home)["delivery_count"], 0)
 
+    def test_pre_llm_call_records_suppression_in_explicit_omh_home(self) -> None:
+        with TemporaryDirectory() as explicit_home, TemporaryDirectory() as env_home:
+            with patch.dict(os.environ, {"OMH_HOME": env_home}):
+                result = pre_llm_call(
+                    user_message="",
+                    is_first_turn=False,
+                    omh_home=explicit_home,
+                )
+
+            self.assertIsNone(result)
+            self.assertEqual(read_awareness_delivery(explicit_home)["suppressed_count"], 1)
+            self.assertEqual(read_awareness_delivery(env_home)["suppressed_count"], 0)
+
     def test_awareness_route_hint_is_metadata_only_and_message_specific(self) -> None:
         message = "make an image explaining the cron feature with secret-token-123"
 

--- a/tests/test_hook_manifest.py
+++ b/tests/test_hook_manifest.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import json
+import os
 import unittest
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
 
 from _local_package import load_local_package
 
@@ -9,6 +12,7 @@ load_local_package()
 
 from omh.capabilities.hooks import hook_manifest
 from omh.plugin_bundle.omh.awareness import awareness_route_hint
+from omh.plugin_bundle.omh.awareness_delivery import read_awareness_delivery
 from omh.plugin_bundle.omh.hooks.llm_hooks import pre_llm_call
 from omh.plugin_bundle.omh.hooks.tool_hooks import pre_tool_call
 
@@ -83,6 +87,19 @@ class HookManifestTests(unittest.TestCase):
         self.assertIn("native_command_rendered", events)
         self.assertIn("render_kind", events["native_command_rendered"]["payload_fields"])
         self.assertIn("not proof", hooks["pre_llm_call"]["claim_boundary"])
+
+    def test_pre_llm_call_records_delivery_in_explicit_omh_home(self) -> None:
+        with TemporaryDirectory() as explicit_home, TemporaryDirectory() as env_home:
+            with patch.dict(os.environ, {"OMH_HOME": env_home}):
+                result = pre_llm_call(
+                    user_message="prepare a safe feature plan",
+                    is_first_turn=True,
+                    omh_home=explicit_home,
+                )
+
+            self.assertIsNotNone(result)
+            self.assertEqual(read_awareness_delivery(explicit_home)["delivery_count"], 1)
+            self.assertEqual(read_awareness_delivery(env_home)["delivery_count"], 0)
 
     def test_awareness_route_hint_is_metadata_only_and_message_specific(self) -> None:
         message = "make an image explaining the cron feature with secret-token-123"

--- a/tests/test_memory_sync_skill.py
+++ b/tests/test_memory_sync_skill.py
@@ -155,7 +155,11 @@ class MemorySyncSkillTests(unittest.TestCase):
             self.assertIn(anchor, content, anchor)
 
     def test_memory_sync_skill_context_rail_markers(self) -> None:
-        markers = ("OMH Context Rail", "not a standalone executor", "Prepared OMH routing")
+        markers = (
+            "Workflow Lane",
+            "Shared product, routing, compatibility, and evidence rules",
+            "Prepared OMH routing",
+        )
         template_content = _template_content("memory-sync")
         on_disk = Path("skills/omh-memory-sync/SKILL.md").read_text(encoding="utf-8")
         for marker in markers:

--- a/tests/test_native_skill_competition.py
+++ b/tests/test_native_skill_competition.py
@@ -61,6 +61,10 @@ class NativeSkillCompetitionTests(unittest.TestCase):
         incoherent["results"] = []
         self.assertTrue(native_skill_competition_errors(incoherent))
 
+        fabricated = build_native_skill_competition_report()
+        fabricated["results"][0]["actual_winner"] = "omh"
+        self.assertTrue(native_skill_competition_errors(fabricated))
+
     def test_native_competition_cli_outputs_summary_and_json(self) -> None:
         status, stdout, stderr = run_cli(["demo", "native-competition", "--summary"], output_json=False)
 

--- a/tests/test_native_skill_competition.py
+++ b/tests/test_native_skill_competition.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
+import json
 import unittest
 
+from _cli_harness import run_cli
 from _local_package import load_local_package
 
 load_local_package()
 from omh.quality.native_skill_competition import (
     NATIVE_COMPETITION_CASES,
     build_native_skill_competition_report,
+    native_skill_competition_errors,
 )
 
 
@@ -41,6 +44,38 @@ class NativeSkillCompetitionTests(unittest.TestCase):
                 self.assertEqual(result["actual_winner"], result["expected_winner"])
                 self.assertGreater(result["winner_score"], result["loser_score"])
                 self.assertEqual(result["picker_surface"], "generated_frontmatter_name_description")
+
+    def test_empty_or_row_incoherent_evidence_fails_closed(self) -> None:
+        empty = {
+            "schema_version": "omh_native_skill_competition/v1",
+            "case_count": 0,
+            "passed_count": 0,
+            "failed_count": 0,
+            "all_passing": True,
+            "failures": [],
+            "results": [],
+        }
+        self.assertTrue(native_skill_competition_errors(empty))
+
+        incoherent = build_native_skill_competition_report()
+        incoherent["results"] = []
+        self.assertTrue(native_skill_competition_errors(incoherent))
+
+    def test_native_competition_cli_outputs_summary_and_json(self) -> None:
+        status, stdout, stderr = run_cli(["demo", "native-competition", "--summary"], output_json=False)
+
+        self.assertEqual(status, 0, stderr)
+        self.assertEqual(stderr, "")
+        self.assertIn("cases: 8/8 passing", stdout)
+        self.assertIn("failures: none", stdout)
+
+        status, stdout, stderr = run_cli(["demo", "native-competition", "--json"], output_json=False)
+
+        self.assertEqual(status, 0, stderr)
+        self.assertEqual(stderr, "")
+        payload = json.loads(stdout)
+        self.assertEqual(payload["schema_version"], "omh_native_skill_competition/v1")
+        self.assertTrue(payload["all_passing"])
 
 
 if __name__ == "__main__":

--- a/tests/test_native_skill_competition.py
+++ b/tests/test_native_skill_competition.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import unittest
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.quality.native_skill_competition import (
+    NATIVE_COMPETITION_CASES,
+    build_native_skill_competition_report,
+)
+
+
+class NativeSkillCompetitionTests(unittest.TestCase):
+    def test_cases_cover_native_defaults_and_policy_overlay_exceptions(self) -> None:
+        expected = {
+            ("browser-operator", "native"),
+            ("browser-operator", "omh"),
+            ("workspace-file-operator", "native"),
+            ("workspace-file-operator", "omh"),
+            ("command-operator", "native"),
+            ("command-operator", "omh"),
+            ("live-info-operator", "native"),
+            ("live-info-operator", "omh"),
+        }
+        self.assertEqual(
+            {(case.omh_skill, case.expected_winner) for case in NATIVE_COMPETITION_CASES},
+            expected,
+        )
+
+    def test_frontmatter_lexical_gate_passes_every_case(self) -> None:
+        report = build_native_skill_competition_report()
+
+        self.assertEqual(report["schema_version"], "omh_native_skill_competition/v1")
+        self.assertEqual(report["case_count"], 8)
+        self.assertEqual(report["passed_count"], 8)
+        self.assertEqual(report["failed_count"], 0)
+        self.assertEqual(report["failures"], [])
+        for result in report["results"]:
+            with self.subTest(case=result["case_id"]):
+                self.assertEqual(result["actual_winner"], result["expected_winner"])
+                self.assertGreater(result["winner_score"], result["loser_score"])
+                self.assertEqual(result["picker_surface"], "generated_frontmatter_name_description")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_release_smoke.py
+++ b/tests/test_release_smoke.py
@@ -129,7 +129,10 @@ class ReleaseSmokeTests(unittest.TestCase):
         self.assertIn("does not prove live Hermes chat rendering", items["common_request_coverage"]["proof_boundary"])
         self.assertEqual(items["hermes_ux_quality"]["command"], "uv run python -m omh.cli demo hermes-ux-quality --json")
         self.assertIn("routing score", items["hermes_ux_quality"]["evidence_required"])
-        self.assertIn("deterministic local routing, card, hint, context, precision, localized-copy, fast-path, and common-request contracts", items["hermes_ux_quality"]["proof_boundary"])
+        self.assertIn(
+            "deterministic local routing, card, hint, context, precision, native-competition, localized-copy, fast-path, and common-request contracts",
+            items["hermes_ux_quality"]["proof_boundary"],
+        )
         self.assertIn("does not prove live Hermes chat rendering", items["hermes_ux_quality"]["proof_boundary"])
         self.assertEqual(items["product_readiness"]["command"], "/tmp/omh release product-readiness --version 1.0.0 --json")
         self.assertIn("skill-content", items["product_readiness"]["evidence_required"])
@@ -301,6 +304,7 @@ class ReleaseSmokeTests(unittest.TestCase):
                     "route_hint_alignment",
                     "context_brief_coverage",
                     "routing_precision",
+                    "native_competition",
                     "localized_chat_copy",
                     "router_fast_path",
                     "common_request_coverage",
@@ -361,7 +365,7 @@ class ReleaseSmokeTests(unittest.TestCase):
             self.assertEqual(gates["common_request_coverage"]["command"], "omh demo common-request-coverage --json")
             self.assertIn("deterministic local routing breadth", gates["common_request_coverage"]["proof_boundary"])
             self.assertEqual(gates["hermes_ux_quality"]["status"], "passed")
-            self.assertIn("8/8 UX gates passing", gates["hermes_ux_quality"]["summary"])
+            self.assertIn("9/9 UX gates passing", gates["hermes_ux_quality"]["summary"])
             self.assertIn("fast paths 11/11", gates["hermes_ux_quality"]["summary"])
             self.assertIn("common requests 91/91", gates["hermes_ux_quality"]["summary"])
             self.assertIn("routing avg 10.0", gates["hermes_ux_quality"]["summary"])
@@ -379,6 +383,28 @@ class ReleaseSmokeTests(unittest.TestCase):
             self.assertIn("deterministic local OMH package", payload["boundary"])
             self.assertIn("Attach observed evidence", " ".join(payload["next_actions"]))
             self.assertIn("evidence-bundle", " ".join(payload["next_actions"]))
+
+    def test_product_readiness_fails_closed_on_malformed_native_evidence(self) -> None:
+        malformed = {
+            "schema_version": "wrong",
+            "case_count": 8,
+            "passed_count": 8,
+            "failed_count": 0,
+            "all_passing": True,
+            "failures": "not-a-list",
+        }
+        with TemporaryDirectory() as tmp, patch.object(
+            release_module,
+            "build_native_skill_competition_report",
+            return_value=malformed,
+        ):
+            paths = OmhPaths(omh_home=Path(tmp) / ".omh", hermes_home=Path(tmp) / ".hermes")
+            payload = product_readiness_report(version="1.0.1", paths=paths)
+        gate = next(item for item in payload["gates"] if item["id"] == "native_competition")
+
+        self.assertEqual(payload["status"], "needs_attention")
+        self.assertEqual(gate["status"], "failed")
+        self.assertTrue(gate["errors"])
 
     def test_release_evidence_bundle_packages_and_writes_local_evidence(self) -> None:
         with TemporaryDirectory() as tmp:
@@ -414,6 +440,8 @@ class ReleaseSmokeTests(unittest.TestCase):
             self.assertEqual(payload["summary"]["routing_precision_intervention_passing"], 138)
             self.assertEqual(payload["summary"]["routing_precision_intervention_total"], 138)
             self.assertEqual(payload["summary"]["routing_precision_missed_intervention_count"], 0)
+            self.assertEqual(payload["summary"]["native_competition_passing_cases"], 8)
+            self.assertEqual(payload["summary"]["native_competition_total_cases"], 8)
             self.assertEqual(payload["summary"]["localized_chat_copy_passing"], 8)
             self.assertEqual(payload["summary"]["localized_chat_copy_total"], 8)
             self.assertEqual(payload["summary"]["localized_chat_copy_locale_count"], 6)
@@ -429,8 +457,8 @@ class ReleaseSmokeTests(unittest.TestCase):
             self.assertEqual(payload["summary"]["popular_plugin_family_total"], 10)
             self.assertEqual(payload["summary"]["popular_plugin_weighted_coverage_percent"], 100.0)
             self.assertEqual(payload["summary"]["hermes_ux_quality_score"], 100)
-            self.assertEqual(payload["summary"]["hermes_ux_quality_passing_gates"], 8)
-            self.assertEqual(payload["summary"]["hermes_ux_quality_total_gates"], 8)
+            self.assertEqual(payload["summary"]["hermes_ux_quality_passing_gates"], 9)
+            self.assertEqual(payload["summary"]["hermes_ux_quality_total_gates"], 9)
             self.assertEqual(payload["evidence"]["product_readiness"]["schema_version"], "omh_product_readiness/v1")
             self.assertEqual(payload["evidence"]["release_checklist"]["schema_version"], "release_readiness_checklist/v1")
             self.assertEqual(payload["evidence"]["grounded_score"]["schema_version"], "grounded_score_evaluation/v1")
@@ -438,6 +466,10 @@ class ReleaseSmokeTests(unittest.TestCase):
             self.assertEqual(payload["evidence"]["route_hint_alignment"]["schema_version"], "route_hint_alignment/v1")
             self.assertEqual(payload["evidence"]["context_brief_coverage"]["schema_version"], "context_brief_coverage/v1")
             self.assertEqual(payload["evidence"]["routing_precision"]["schema_version"], "routing_precision/v1")
+            self.assertEqual(
+                payload["evidence"]["native_competition"]["schema_version"],
+                "omh_native_skill_competition/v1",
+            )
             self.assertEqual(payload["evidence"]["localized_chat_copy"]["schema_version"], "localized_chat_copy/v1")
             self.assertEqual(payload["evidence"]["router_fast_path"]["schema_version"], "router_fast_path/v1")
             self.assertEqual(payload["evidence"]["common_request_coverage"]["schema_version"], "common_request_coverage/v1")
@@ -447,6 +479,7 @@ class ReleaseSmokeTests(unittest.TestCase):
             self.assertIn("route_hint_alignment_ready", payload["claims"])
             self.assertIn("context_brief_coverage_ready", payload["claims"])
             self.assertIn("routing_precision_ready", payload["claims"])
+            self.assertIn("native_competition_ready", payload["claims"])
             self.assertIn("localized_chat_copy_ready", payload["claims"])
             self.assertIn("router_fast_path_ready", payload["claims"])
             self.assertIn("common_request_coverage_ready", payload["claims"])
@@ -475,6 +508,7 @@ class ReleaseSmokeTests(unittest.TestCase):
             "build_route_hint_alignment_demo",
             "build_context_brief_coverage_demo",
             "build_routing_precision_demo",
+            "build_native_skill_competition_report",
             "build_localized_chat_copy_demo",
             "build_router_fast_path_demo",
             "build_common_request_coverage_demo",

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import replace
 import inspect
 import json
 import re
@@ -49,7 +50,7 @@ from omh.skills.catalog import (
     primary_harness_for_skill,
     retained_delegation_skill_names,
 )
-from omh.skills.render import workflow_reference_markdown, workflow_reference_payload
+from omh.skills.render import frontmatter_description, workflow_reference_markdown, workflow_reference_payload
 from omh.snippet import WORKSPACE_SNIPPET
 from omh.use_cases import USE_CASES, list_use_cases
 
@@ -729,6 +730,13 @@ class RouterContentTests(unittest.TestCase):
                 frontmatter = templates[name].split("---", 2)[1]
                 self.assertIn(f"Aliases: {', '.join(aliases)}.", frontmatter)
 
+    def test_unsafe_picker_aliases_fail_loudly(self) -> None:
+        definition = next(item for item in builtin_definitions() if item.name == "ultrawork")
+        malformed = replace(definition, aliases=("ulw", "$unsafe"))
+
+        with self.assertRaisesRegex(ValueError, r"unsafe picker aliases.*\$unsafe"):
+            frontmatter_description(malformed)
+
     def test_picker_sibling_families_name_their_decision_boundaries(self) -> None:
         definitions = {definition.name: definition for definition in builtin_definitions()}
         expected_fragments = {
@@ -871,6 +879,9 @@ class RouterContentTests(unittest.TestCase):
                 }
                 missing = {name: fragments for name, fragments in missing.items() if fragments}
                 self.assertEqual(missing, {})
+        for name, content in sorted(templates.items()):
+            if name != "oh-my-hermes":
+                self.assertIn("Preserve workflow intent and stop conditions", content, name)
 
     def test_ultragoal_guards_settings_only_requests_from_goal_escalation(self) -> None:
         """A settings-only request (for example a gateway channel mention policy) must not

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -711,6 +711,58 @@ class RouterContentTests(unittest.TestCase):
             self.assertIn(f"\n    role: {definition.hermes_role}\n", content)
             self.assertIn(f"\n    quality_tier: {definition.quality_tier}\n", content)
 
+    def test_engine_aliases_are_structured_and_picker_visible(self) -> None:
+        definitions = {definition.name: definition for definition in builtin_definitions()}
+        templates = {template.name: template.content for template in builtin_skill_templates()}
+        expected = {
+            "ultrawork": ("ulw",),
+            "ultraprocess": ("ulp",),
+            "ultragoal": ("ulg",),
+            "ralph": ("ulr",),
+        }
+
+        for name, aliases in expected.items():
+            with self.subTest(name=name):
+                definition = definitions[name]
+                self.assertEqual(definition.aliases, aliases)
+                self.assertTrue(set(aliases).issubset(definition.triggers))
+                frontmatter = templates[name].split("---", 2)[1]
+                self.assertIn(f"Aliases: {', '.join(aliases)}.", frontmatter)
+
+    def test_picker_sibling_families_name_their_decision_boundaries(self) -> None:
+        definitions = {definition.name: definition for definition in builtin_definitions()}
+        expected_fragments = {
+            "memory-new": ("omh-memory-sync", "decision-recall"),
+            "memory-sync": ("memory-new", "decision-recall"),
+            "web-research": ("native search", "research-brief", "research-department"),
+            "research-brief": ("ulw-research", "research-department"),
+            "research-department": ("research-brief", "source-finder"),
+            "source-finder": ("ulw-research", "research-brief"),
+            "executor-runtime-readiness": ("external-connector-readiness", "toolbelt-readiness"),
+            "external-connector-readiness": ("executor-runtime-readiness", "toolbelt-readiness"),
+            "prompt-import-readiness": ("external-connector-readiness", "toolbelt-readiness"),
+            "physical-device-readiness": ("external-connector-readiness", "toolbelt-readiness"),
+            "toolbelt-readiness": ("external-connector-readiness", "executor-runtime-readiness"),
+        }
+
+        for name, fragments in expected_fragments.items():
+            description = definitions[name].description.casefold()
+            for fragment in fragments:
+                with self.subTest(name=name, fragment=fragment):
+                    self.assertIn(fragment.casefold(), description)
+
+        native_overlays = {
+            "browser-operator": "native browser",
+            "workspace-file-operator": "native file",
+            "command-operator": "native shell",
+            "live-info-operator": "native live",
+        }
+        for name, native_surface in native_overlays.items():
+            with self.subTest(name=name):
+                description = definitions[name].description.casefold()
+                self.assertIn("policy overlay", description)
+                self.assertIn(native_surface, description)
+
     def test_display_name_helper_keeps_canonical_identifiers_unchanged(self) -> None:
         self.assertEqual(OMH_SKILL_NAME_PREFIX, "omh-")
         self.assertEqual(
@@ -2621,6 +2673,11 @@ class RouterContentTests(unittest.TestCase):
 
     def test_workflow_skills_refer_to_harness_discipline(self) -> None:
         skills = {skill.name: skill for skill in builtin_skill_templates()}
+        common_rail = next(
+            template.content
+            for template in builtin_skill_reference_templates()
+            if template.relative_path == "references/skill-common-rail.md"
+        )
 
         # Harness discipline moved to the shared rail reference (issue #634); each skill
         # keeps the pointer instead of its own verbatim copy. The rail's own content is
@@ -2632,22 +2689,23 @@ class RouterContentTests(unittest.TestCase):
         self.assertIn("Hermes role: `handoff-guide`", skills["ultragoal"].content)
         self.assertIn("Handoff policy:", skills["ultragoal"].content)
         self.assertIn("Runtime Evidence", skills["ultragoal"].content)
-        self.assertIn("OMH Context Rail", skills["ultragoal"].content)
-        self.assertIn("part of OMH's Hermes workflow layer", skills["ultragoal"].content)
-        self.assertIn("Hermes-native workflow pack", skills["ultragoal"].content)
+        self.assertIn("Workflow Lane", skills["ultragoal"].content)
         self.assertIn("Completion Checklist", skills["ultragoal"].content)
         self.assertIn("Recovery Notes", skills["ultragoal"].content)
         self.assertIn("Current lane: **Intent -> plan**", skills["ultragoal"].content)
         self.assertIn("hand back to `oh-my-hermes`", skills["ultragoal"].content)
-        self.assertIn("Cross-skill context", skills["ultragoal"].content)
-        self.assertIn("Every generated workflow skill", skills["ultragoal"].content)
         self.assertIn("Prepared OMH routing", skills["ultragoal"].content)
+        self.assertIn("OMH Context Rail", common_rail)
+        self.assertIn("not a standalone executor", common_rail)
+        self.assertIn("Hermes-native workflow pack", common_rail)
+        self.assertIn("Cross-skill context", common_rail)
+        self.assertIn("Every generated OMH workflow skill", common_rail)
+        self.assertIn("omh_target_topology/v1", common_rail)
+        self.assertIn("active_agent_count", common_rail)
         self.assertIn("Long-running or background executor milestones report observed handles", skills["ultragoal"].content)
         self.assertIn("hermes_coding_harness/v1", skills["ultragoal"].content)
         self.assertIn("builder, verifier, reviewer, docs, and PR lanes", skills["ultragoal"].content)
         self.assertIn("PR head SHA", skills["ultragoal"].content)
-        self.assertIn("omh_target_topology/v1", skills["ultragoal"].content)
-        self.assertIn("active_agent_count", skills["ultragoal"].content)
         self.assertIn("omh runtime record --skill ultragoal --harness goal-execution --status started", skills["ultragoal"].content)
         self.assertIn("goal_completion_gate/v1", skills["ultragoal"].content)
         self.assertIn("inspect .omh/goals", skills["ultragoal"].content)
@@ -2693,11 +2751,9 @@ class RouterContentTests(unittest.TestCase):
             if name == "oh-my-hermes":
                 continue
             with self.subTest(skill=name):
-                self.assertIn("OMH Context Rail", skill.content)
-                self.assertIn("not a standalone executor", skill.content)
-                self.assertIn("Product context:", skill.content)
-                self.assertIn("Cross-skill context:", skill.content)
-                self.assertIn("Coverage:", skill.content)
+                self.assertIn("Workflow Lane", skill.content)
+                self.assertIn("Shared product, routing, compatibility, and evidence rules", skill.content)
+                self.assertIn("Prepared OMH routing", skill.content)
                 self.assertIn("Completion Checklist", skill.content)
                 self.assertIn("Recovery Notes", skill.content)
 

--- a/tests/test_skill_context_cost.py
+++ b/tests/test_skill_context_cost.py
@@ -13,10 +13,10 @@ class SkillContextCostTests(unittest.TestCase):
         profile = skill_context_cost_profile("full")
         headings = {row["heading"]: row for row in profile["headings"]}
 
-        self.assertLess(headings.get("OMH Context Rail", {"duplicate_bytes": 0})["duplicate_bytes"], 20_000)
-        self.assertLess(
+        self.assertEqual(headings.get("OMH Context Rail", {"duplicate_bytes": 0})["duplicate_bytes"], 0)
+        self.assertEqual(
             headings.get("Hermes Compatibility Contract", {"duplicate_bytes": 0})["duplicate_bytes"],
-            20_000,
+            0,
         )
         self.assertLess(profile["repeated"]["bytes"], 100_000)
 

--- a/tests/test_skill_context_cost.py
+++ b/tests/test_skill_context_cost.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import unittest
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.skills.context_cost import skill_context_cost_profile
+
+
+class SkillContextCostTests(unittest.TestCase):
+    def test_full_profile_moves_common_rails_out_of_skill_bodies(self) -> None:
+        profile = skill_context_cost_profile("full")
+        headings = {row["heading"]: row for row in profile["headings"]}
+
+        self.assertLess(headings.get("OMH Context Rail", {"duplicate_bytes": 0})["duplicate_bytes"], 20_000)
+        self.assertLess(
+            headings.get("Hermes Compatibility Contract", {"duplicate_bytes": 0})["duplicate_bytes"],
+            20_000,
+        )
+        self.assertLess(profile["repeated"]["bytes"], 100_000)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- Added structured generated-skill frontmatter aliases and clarified family boundaries so native Hermes picker descriptions distinguish adjacent OMH workflows without renaming canonical skills.
- Added `omh_native_skill_competition/v1`, an eight-case deterministic lexical quality gate, and rolled it into Hermes UX quality, product readiness, evidence bundles, CLI summaries, release guidance, and regression tests.
- Added an aged zero-delivery awareness warning, explicit custom `OMH_HOME` forwarding, private `0700`/`0600` ledger permissions, and conservative hook-payload wording that does not claim host or model consumption.
- Moved invariant OMH context and Hermes compatibility guidance into `omh-routing/references/skill-common-rail.md` while keeping lane, memory, delegation, and prepared-vs-observed essentials inline.

### Why This Exists

- Issue #734 required OMH workflows to compete more clearly with native Hermes skill descriptions, while keeping routing deterministic and product claims test-backed.
- The generated pack still carried 254,325 repeated body bytes, including 124,894 bytes under `OMH Context Rail` and 95,764 under `Hermes Compatibility Contract`.
- Awareness delivery evidence could drift to the wrong local home, expose metadata with default permissions, and overstate what the hook ledger had actually observed.

### User / Operator Impact

- Hermes receives clearer picker-facing descriptions and adjacent workflow boundaries without requiring users to memorize control-plane commands.
- Maintainers can run `omh demo native-competition` and see the native-comparison gate in release readiness rollups.
- `omh doctor` warns after seven days of observed hook attempts with zero returned awareness payloads and gives a concrete restart-and-recheck action.
- Full-profile generated skill bodies fell from 769,401 on `origin/main` to 652,279 bytes, and repeated bytes fell from 254,325 to 78,191 while progressive-disclosure references preserve shared policy.

### How It Works

- Catalog alias metadata drives generated frontmatter; source renderers remain canonical and generated tap artifacts are checked for staleness.
- Native competition validates schema, fixed-corpus result rows, and count coherence before any rollup can pass, so malformed evidence fails closed even when `all_passing` is truthy.
- The awareness ledger records only counters and timestamps for hook payload returns, honors explicit local homes, serializes updates with a private lock, writes via unique atomic replacements, and enforces private modes.
- Each workflow body carries a compact lane/evidence/delegation floor and points to the shared rail for invariant product, compatibility, topology, memory, harness, and execution rules.

### Files And Contracts Touched

- `src/skills/catalog.py`, `src/skills/render.py`, generated `skills/*/SKILL.md`, and `skills/omh-routing/references/skill-common-rail.md`.
- `src/quality/native_skill_competition.py`, Hermes UX quality, release readiness/evidence rollups, CLI command registration, and generated docs.
- Awareness hook, delivery ledger, doctor diagnostics, release checklist descriptions, and regression suites.
- New public contract: `omh_native_skill_competition/v1`; existing prepared-versus-observed claim boundaries remain unchanged.

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` - 2,470 passed, 1 skipped
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli harness validate`
- [x] `uv run python -m omh.cli release checklist --version 1.0.1 --json`
- [ ] `python3 -m omh.cli release hermes-smoke` - not rerun; product-readiness, targeted release evidence, and full-suite contracts were used instead
- [ ] `omh --help` - root help was not rerun; `omh demo native-competition --help` passed
- [ ] installed-command smoke - not needed for source-only local validation
- [x] Relevant dry-run or smoke command: `omh release product-readiness --version 1.0.1 --json` returned ready, 100/100
- [x] Manual QA: native competition summary and JSON reported 8/8; invalid `--bogus` input exited 2; aged doctor warning and explicit-home hook ledger were exercised through the real Python/CLI surfaces
- [ ] Live Hermes/TUI picker check - not observed; this PR deliberately reports deterministic lexical evidence only

## Risk

- Broad generated-artifact diff, but every file is source-derived and `docs workflows --check` reports 113/113 current artifacts.
- Native competition is lexical contract evidence, not live picker-ranking evidence.
- Shared-rail movement depends on progressive disclosure; inline lane, memory, delegation, and evidence floors remain to preserve safe self-containment.

## Compatibility / Rollout

- No dependency, schema migration, network integration, or Hermes core patch.
- Canonical skill identities and existing runtime artifact schemas are preserved.
- Awareness ledger permissions are tightened in place; unreadable or unwritable ledgers remain best-effort and never break the hook.

## Release / Claims

- [x] Release-channel impact considered: generated source and release contracts apply equally to stable, preview, and local installs.
- [x] Runtime/native capability claims are backed by deterministic local evidence or explicitly marked not observed.
- [x] Known manual Hermes gap is listed: no live picker ranking or host/model consumption acknowledgement was observed.

## Follow-Up

- None required for issue #734. Live Hermes picker ranking remains a separate observational capability, not a gap hidden by this PR.

Closes #734