### PR TITLE
feat: episode rollup, veracity weighting, and temporal intent (mnemosyne round 2)

### DIFF
--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -130,6 +130,43 @@ match as `duplicate_of` on the candidate and its review card. Review-first:
 nothing is silently merged, the reviewer decides — but a duplicate never
 auto-approves, even under the auto-safe policy.
 
+**Episode rollup** — additive consolidation without a model:
+
+```sh
+# Agent/operator only: report which records one episode would roll up.
+omh memory rollup --tag deploy
+
+# Agent/operator only: stage the reviewable episode candidate.
+omh memory rollup --tag deploy --apply
+```
+
+The rollup selects up to 8 non-expired, non-episode records matching a tag
+and/or scope (oldest first), and proposes one `episode` candidate whose
+summary is a per-member-budgeted mechanical join — every member is
+represented — and whose `derived_from` names every member; synthesis stays
+Hermes' job. The episode inherits its members' confinement, strictest
+wins: mixed scopes or mixed perspectives refuse (`mixed_scope` /
+`mixed_perspective`), a shared perspective or scope carries onto the
+episode, and any volatile member makes the episode volatile with the
+smallest member TTL. Originals are never modified or retired by a rollup;
+the candidate always lands in review (a derived aggregate never
+auto-approves, even under the auto-safe policy), a re-run while an
+identical candidate is pending reports `already_staged` instead of staging
+twins, and `omh memory lineage` on the approved episode walks back to all
+members.
+
+**Recall signal refinements** — the ranking block reports
+`veracity_weight_pct` (an `approved_manual` record weighs 100, an
+`approved_auto_safe` record 90 in the decayed score — both classes stay
+fully eligible), and packs echo `query_intent`: a query carrying an
+unambiguous English time cue — the tokens `yesterday`, `today`, `recent`,
+`recently`, `ago`, or a phrase such as `most recent` / `last week` — is
+classified `temporal` and doubles the recency weight inside rank fusion.
+Ambiguous engineering adjectives (`current`, `latest`, `now`, `newest`)
+deliberately do not fire as bare tokens. Relevance stays the primary sort
+key in both cases, so neither signal can change which keyword matches win —
+only how peers of equal relevance order.
+
 ## Provenance and Lineage
 
 A capture may declare which approved records a new fact was derived from:

--- a/src/commands/memory.py
+++ b/src/commands/memory.py
@@ -35,6 +35,7 @@ from ..memory import (
     build_memory_lineage,
     build_memory_perspectives,
     build_memory_retirement,
+    build_memory_rollup,
     set_memory_pin,
     build_handoff_context_pack,
     build_memory_inspection,
@@ -161,6 +162,21 @@ def cmd_memory_recall(args: argparse.Namespace) -> int:
             include_stale=args.include_stale,
             observer=args.observer,
             observed=args.observed,
+        )
+    except (OSError, ValueError) as exc:
+        raise OmhError(str(exc)) from exc
+    _print_json(payload)
+    return 0
+
+
+def cmd_memory_rollup(args: argparse.Namespace) -> int:
+    try:
+        payload = build_memory_rollup(
+            _paths(args),
+            tag=args.tag,
+            scope_kind=args.scope_kind,
+            scope_ref=args.scope_ref,
+            apply=args.apply,
         )
     except (OSError, ValueError) as exc:
         raise OmhError(str(exc)) from exc

--- a/src/commands/memory_parser.py
+++ b/src/commands/memory_parser.py
@@ -88,6 +88,13 @@ def add_memory_commands(sub: argparse._SubParsersAction[argparse.ArgumentParser]
     perspectives = memory_sub.add_parser("perspectives", help="List observer/observed perspective pairs with reviewed-record counts.")
     perspectives.set_defaults(func=memory.cmd_memory_perspectives)
 
+    rollup = memory_sub.add_parser("rollup", help="Report an additive episode rollup over matching records; --apply stages the reviewable episode candidate.")
+    rollup.add_argument("--tag", default=None, help="Roll up records carrying this tag.")
+    rollup.add_argument("--scope-kind", choices=("project", "target", "thread", "run"), default=None)
+    rollup.add_argument("--scope-ref", default=None)
+    rollup.add_argument("--apply", action="store_true", help="Stage the episode candidate through the normal capture/review pipeline (default is report-only).")
+    rollup.set_defaults(func=memory.cmd_memory_rollup)
+
     pin = memory_sub.add_parser("pin", help="Mark one reviewed record as a recall anchor: first in packs, exempt from no-overlap cuts, never from eligibility.")
     pin.add_argument("record_id")
     pin.set_defaults(func=memory.cmd_memory_pin)

--- a/src/runtime/records.py
+++ b/src/runtime/records.py
@@ -1554,6 +1554,7 @@ def _compact_memory_recall_pack(value: Any) -> dict[str, Any]:
         },
         "scope": _compact_context_scope(value.get("scope", {})),
         "perspective": _compact_perspective(value.get("perspective")),
+        "query_intent": str(value.get("query_intent", "") or "default"),
         # Included records survive compaction: they are already redacted,
         # bounded summaries (<=500 chars each, budget-capped), and the
         # lifecycle-backed executor path re-serves the persisted record, so
@@ -1609,7 +1610,7 @@ def _compact_ranking(value: Any) -> dict[str, Any]:
         return {}
     compacted: dict[str, Any] = {
         key: int(ranking.get(key, 0) or 0)
-        for key in ("rrf_score_micro", "decayed_score_micro", "relevance_rank", "recency_rank", "usage_rank", "times_recalled", "age_tier")
+        for key in ("rrf_score_micro", "decayed_score_micro", "relevance_rank", "recency_rank", "usage_rank", "times_recalled", "age_tier", "veracity_weight_pct")
     }
     compacted["pinned"] = bool(ranking.get("pinned", False))
     return compacted

--- a/src/workflows/memory.py
+++ b/src/workflows/memory.py
@@ -67,6 +67,7 @@ MEMORY_RECALL_USAGE_SCHEMA_VERSION = "omh_memory_recall_usage/v1"
 MEMORY_LINEAGE_SCHEMA_VERSION = "omh_memory_lineage/v1"
 MEMORY_PERSPECTIVES_SCHEMA_VERSION = "omh_memory_perspectives/v1"
 MEMORY_PINS_SCHEMA_VERSION = "omh_memory_pins/v1"
+MEMORY_ROLLUP_SCHEMA_VERSION = "omh_memory_rollup/v1"
 HERMES_MEMORY_BRIDGE_SCHEMA_VERSION = "hermes_memory_bridge/v1"
 
 SOURCE_TRUTH_LEVELS = {
@@ -146,6 +147,7 @@ _PROJECT_MEMORY_RECALL_PACK_KEYS = {
     "policy",
     "scope",
     "perspective",
+    "query_intent",
     "included_records",
     "excluded_records",
     "record_count",
@@ -184,7 +186,25 @@ _RECALL_RANKING_KEYS = {
     "times_recalled",
     "age_tier",
     "pinned",
+    "veracity_weight_pct",
 }
+# Admission-mode veracity, mnemosyne-style: a human-reviewed record outranks
+# an auto-safe one of equal relevance/age. The gap is deliberately small --
+# both classes passed the same admission gates -- and it lands in the
+# decayed score, never in eligibility. An unknown mode fails CLOSED to the
+# lower weight: a trust signal must never default to maximum trust.
+_ADMISSION_VERACITY_WEIGHT_PCT = {"approved_manual": 100, "approved_auto_safe": 90}
+_ADMISSION_VERACITY_DEFAULT_PCT = 90
+# Temporal query intent, conservative by construction: a fixed English cue
+# set (no per-language tables, per the routing-language policy) that only
+# doubles the RECENCY weight inside rank fusion. Relevance stays primary,
+# so intent can never change which keyword matches win -- only how peers of
+# equal relevance order. Single tokens must be unambiguous: "current",
+# "latest", "now", and "newest" are ordinary engineering adjectives ("the
+# current implementation") and live in the phrase list instead, where the
+# surrounding words disambiguate them.
+_TEMPORAL_QUERY_CUES = frozenset({"yesterday", "today", "recent", "recently", "ago"})
+_TEMPORAL_QUERY_PHRASES = ("most recent", "right now", "as of now", "last week", "last month", "up to date")
 # Age tiers degrade the fused score of old records inside an equal relevance
 # rank, mnemosyne-style: 0-30 days full weight, 30-180 days half, older a
 # quarter. Relevance stays the primary key, so a stale strong match still
@@ -356,6 +376,7 @@ def capture_project_memory_candidate(
     derived_from: list[str] | tuple[str, ...] | None = None,
     observer: str | None = None,
     observed: str | None = None,
+    force_review: bool = False,
 ) -> dict[str, object]:
     policy = read_project_memory_policy(paths)
     if not bool(policy.get("capture_enabled", True)):
@@ -395,7 +416,10 @@ def capture_project_memory_candidate(
     _write_project_memory_candidate(paths, candidate)
     auto_approved = False
     record: dict[str, object] = {}
-    if bool(policy.get("auto_approve_safe")) and candidate.get("safety", {}).get("status") == "safe" and not duplicate_of:
+    # force_review keeps derived aggregates (e.g. rollup episodes) on the
+    # review path even under auto-safe: derived content is a curation act,
+    # not a captured observation.
+    if bool(policy.get("auto_approve_safe")) and candidate.get("safety", {}).get("status") == "safe" and not duplicate_of and not force_review:
         approved = approve_project_memory_candidate(paths, str(candidate["candidate_id"]), approved_by="auto-safe")
         record = approved.get("record", {}) if isinstance(approved.get("record"), dict) else {}
         candidate = approved.get("candidate", candidate) if isinstance(approved.get("candidate"), dict) else candidate
@@ -619,11 +643,13 @@ def build_project_memory_recall_pack(
             excluded.append(_recall_exclusion(record, evaluation, staleness=staleness, reason="no_query_overlap"))
             continue
         included.append(_recall_item(record, score=score, staleness=staleness, evaluation=evaluation))
+    query_intent = _recall_query_intent(query)
     _attach_recall_ranking(
         included,
         read_recall_usage(paths),
         pins=pins,
         now=now if now is not None else datetime.now(timezone.utc),
+        recency_weight=2.0 if query_intent == "temporal" else _RECALL_RRF_WEIGHTS["recency"],
     )
     # Pinned anchors lead, then relevance; the decayed fused score orders
     # records only within an equal relevance rank. A weaker keyword match
@@ -691,6 +717,7 @@ def build_project_memory_recall_pack(
         "policy": policy,
         "scope": _scope(scope_kind or "project", scope_ref or "default"),
         "perspective": {"observer": observer or "", "observed": observed or ""},
+        "query_intent": query_intent,
         "included_records": included,
         "excluded_records": excluded,
         "record_count": len(included),
@@ -866,6 +893,7 @@ def _attach_recall_ranking(
     *,
     pins: set[str] | None = None,
     now: datetime | None = None,
+    recency_weight: float | None = None,
 ) -> None:
     """Fuse relevance, recency, and delivery usage into one recall order.
 
@@ -880,6 +908,7 @@ def _attach_recall_ranking(
         return
     pins = pins or set()
     now = now if now is not None else datetime.now(timezone.utc)
+    recency_weight = recency_weight if recency_weight is not None else _RECALL_RRF_WEIGHTS["recency"]
     def _times_recalled(item: dict[str, object]) -> int:
         entry = usage.get(str(item.get("record_id", "")), {})
         times = entry.get("times_recalled", 0)
@@ -892,22 +921,26 @@ def _attach_recall_ranking(
         record_id = str(item.get("record_id", ""))
         fused = (
             _RECALL_RRF_WEIGHTS["relevance"] / (_RECALL_RRF_K + relevance[record_id])
-            + _RECALL_RRF_WEIGHTS["recency"] / (_RECALL_RRF_K + recency[record_id])
+            + recency_weight / (_RECALL_RRF_K + recency[record_id])
             + _RECALL_RRF_WEIGHTS["usage"] / (_RECALL_RRF_K + usage_ranks[record_id])
         )
         tier = _age_tier(str(item.get("approved_at", "")), now=now)
+        veracity_pct = _ADMISSION_VERACITY_WEIGHT_PCT.get(str(item.get("admission_mode", "")), _ADMISSION_VERACITY_DEFAULT_PCT)
         item["ranking"] = {
-            # rrf_score_micro stays pure rank fusion so two records' fusion
-            # quality stays comparable; the age decay lands in its own field
-            # and that decayed value is what the sort uses.
+            # rrf_score_micro is undecayed rank fusion under THIS pack's
+            # weights (a temporal query raises the recency weight, so scores
+            # compare within a pack, not across packs); age decay and
+            # veracity land in decayed_score_micro, which is what the sort
+            # uses.
             "rrf_score_micro": round(fused * 1_000_000),
-            "decayed_score_micro": round(fused * _AGE_TIER_WEIGHTS[tier] * 1_000_000),
+            "decayed_score_micro": round(fused * _AGE_TIER_WEIGHTS[tier] * (veracity_pct / 100) * 1_000_000),
             "relevance_rank": relevance[record_id],
             "recency_rank": recency[record_id],
             "usage_rank": usage_ranks[record_id],
             "times_recalled": _times_recalled(item),
             "age_tier": tier,
             "pinned": record_id in pins,
+            "veracity_weight_pct": veracity_pct,
         }
 
 
@@ -949,6 +982,203 @@ def _find_duplicate_record(paths: OmhPaths, summary: str, *, now: datetime | Non
         if _normalized_summary_key(str(record.get("summary", ""))) == key:
             return str(record.get("record_id", ""))
     return ""
+
+
+def build_memory_rollup(
+    paths: OmhPaths,
+    *,
+    tag: str | None = None,
+    scope_kind: str | None = None,
+    scope_ref: str | None = None,
+    apply: bool = False,
+    now: datetime | None = None,
+) -> dict[str, object]:
+    """Additive episode rollup, mnemosyne's consolidation without the model.
+
+    Report-first: the report names the member records and the deterministic
+    summary an episode candidate would carry; ``apply`` routes that candidate
+    through the normal capture pipeline (safety, duplicate detection, review,
+    ``derived_from`` provenance to every member). Originals are never touched
+    -- consolidation here is additive bookkeeping, curation stays a separate
+    reviewed act, and summarizing prose stays Hermes' job: the rollup summary
+    is a mechanical join, not a synthesis.
+    """
+    if bool(scope_kind) != bool(scope_ref):
+        raise ValueError("memory rollup needs both --scope-kind and --scope-ref, or neither")
+    if not (tag or (scope_kind and scope_ref)):
+        raise ValueError("memory rollup requires --tag and/or a full --scope-kind/--scope-ref pair")
+    normalized_tags = _normalize_tags([tag]) if tag else []
+    normalized_tag = normalized_tags[0] if normalized_tags else ""
+    if tag and not normalized_tag:
+        raise ValueError(f"unsafe rollup tag: {tag!r}")
+    now = now if now is not None else datetime.now(timezone.utc)
+    members: list[dict[str, Any]] = []
+    considered = 0
+    for record in _read_project_memory_records(paths):
+        if str(record.get("record_type", "")) == "episode":
+            continue
+        if not _record_scope_matches(record, scope_kind=scope_kind, scope_ref=scope_ref):
+            continue
+        if normalized_tag and normalized_tag not in _normalize_tags(record.get("tags", [])):
+            continue
+        considered += 1
+        if _classify_record_expiry(record, now=now) == "expired":
+            continue
+        members.append(record)
+    # Oldest first; created_at and candidate_id sharpen the second-granular
+    # approved_at ties before the record-id fallback so the selection is
+    # stable for a given store, and the contract is named in the report.
+    members.sort(
+        key=lambda record: (
+            str(record.get("approved_at", "")),
+            str(record.get("created_at", "")),
+            str(record.get("candidate_id", "")),
+            str(record.get("record_id", "")),
+        )
+    )
+    truncated_members = max(len(members) - _DERIVED_FROM_LIMIT, 0)
+    members = members[:_DERIVED_FROM_LIMIT]
+    # The episode inherits its members' confinement, strictest-wins, and
+    # refuses on conflict: mixed perspectives or mixed scopes would launder
+    # one actor's or one target's content into a wider audience, which is
+    # exactly what those boundaries exist to prevent.
+    member_scopes = {(scope["kind"], scope["ref"]) for scope in (_normalize_scope(record.get("scope", _scope("project", "default"))) for record in members)}
+    member_perspectives = {
+        (projection.get("observer", ""), projection.get("observed", ""))
+        for projection in (_perspective_projection(record.get("perspective")) for record in members)
+    }
+    reason_code = "planned"
+    if len(members) < 2:
+        reason_code = "not_enough_members"
+    elif len(member_scopes) > 1:
+        reason_code = "mixed_scope"
+    elif len(member_perspectives) > 1:
+        reason_code = "mixed_perspective"
+    eligible = reason_code == "planned"
+    episode_scope = _scope(*next(iter(member_scopes))) if len(member_scopes) == 1 else _scope(scope_kind or "project", scope_ref or "default")
+    episode_perspective = next(iter(member_perspectives)) if len(member_perspectives) == 1 else ("", "")
+    volatile_ttls = [
+        ttl_days
+        for record in members
+        if _retention_class(record) == "volatile"
+        for ttl_days in [record.get("retention", {}).get("ttl_days") if isinstance(record.get("retention"), dict) else None]
+        if isinstance(ttl_days, int) and not isinstance(ttl_days, bool)
+    ]
+    episode_retention = "volatile" if any(_retention_class(record) == "volatile" for record in members) else "standard"
+    episode_ttl_days = max(min(volatile_ttls), 1) if volatile_ttls else (1 if episode_retention == "volatile" else None)
+    selector = {"tag": normalized_tag, "scope": episode_scope, "selection": "oldest_first"}
+    selector_label = normalized_tag or f"{episode_scope['kind']}/{episode_scope['ref']}"
+    # Budget the join so every member is represented: an unbudgeted join of
+    # 240-char summaries would truncate mid-list while derived_from still
+    # names all members.
+    prefix = f"Episode rollup ({len(members)} records, {selector_label}): "
+    per_member = max((240 - len(prefix)) // max(len(members), 1) - 2, 12)
+    parts: list[str] = []
+    for record in members:
+        text = str(record.get("summary", ""))
+        if len(text) > per_member:
+            text = (text[:per_member].rsplit(" ", 1)[0] or text[:per_member]).rstrip() + "..."
+        parts.append(text)
+    proposed_summary = prefix + "; ".join(parts)
+    report: dict[str, object] = {
+        "schema_version": MEMORY_ROLLUP_SCHEMA_VERSION,
+        "applied": False,
+        "eligible": eligible,
+        "reason_code": reason_code,
+        "selector": selector,
+        "episode_perspective": {"observer": episode_perspective[0], "observed": episode_perspective[1]},
+        "episode_retention": {"class": episode_retention, "ttl_days": episode_ttl_days},
+        "members": [
+            {
+                "record_id": str(record.get("record_id", "")),
+                "record_type": str(record.get("record_type", "")),
+                "summary": _redact(str(record.get("summary", "")))[:240],
+                "approved_at": str(record.get("approved_at", "")),
+            }
+            for record in members
+        ],
+        "member_count": len(members),
+        "considered_count": considered,
+        "truncated_members": truncated_members,
+        "proposed_summary": _redact(proposed_summary)[:240],
+        "next_action": _rollup_next_action(reason_code),
+        "redaction_policy": "metadata_only",
+        "claim_boundary": (
+            "A rollup prepares one reviewable episode candidate over existing OMH records; "
+            "originals are unchanged, and nothing here is execution, review, CI, merge, or "
+            "Hermes internal-memory evidence."
+        ),
+    }
+    if apply and eligible:
+        already_staged = _find_pending_candidate_by_summary(paths, proposed_summary)
+        if already_staged:
+            report["reason_code"] = "already_staged"
+            report["staged_candidate_id"] = already_staged
+            report["next_action"] = "An identical episode candidate is already pending review; approve or reject it first."
+            return report
+        capture = capture_project_memory_candidate(
+            paths,
+            proposed_summary,
+            record_type="episode",
+            scope_kind=episode_scope["kind"],
+            scope_ref=episode_scope["ref"],
+            source="rollup",
+            tags=[normalized_tag] if normalized_tag else [],
+            ttl_days=episode_ttl_days,
+            retention_class=episode_retention,
+            derived_from=[str(record.get("record_id", "")) for record in members],
+            observer=episode_perspective[0] or None,
+            observed=episode_perspective[1] or None,
+            force_review=True,
+        )
+        candidate_status = str(capture.get("candidate", {}).get("status", "")) if isinstance(capture.get("candidate"), dict) else ""
+        report["applied"] = bool(capture.get("captured")) and candidate_status == "pending_review"
+        report["candidate_status"] = candidate_status
+        report["capture"] = capture
+        report["next_action"] = (
+            "Review and approve the staged episode candidate; member records remain active."
+            if report["applied"]
+            else "The episode candidate did not reach pending review; inspect the capture payload."
+        )
+    return report
+
+
+def _rollup_next_action(reason_code: str) -> str:
+    return {
+        "planned": "Run with --apply to stage the episode candidate for review.",
+        "not_enough_members": "Nothing to roll up: fewer than two eligible member records matched.",
+        "mixed_scope": "Members span multiple scopes; narrow the selector so one scope remains.",
+        "mixed_perspective": "Members span multiple perspectives; narrow the selector so one perspective remains.",
+    }[reason_code]
+
+
+def _find_pending_candidate_by_summary(paths: OmhPaths, summary: str) -> str:
+    key = _normalized_summary_key(_redact(summary.strip())[:500])
+    if not key:
+        return ""
+    for candidate in _read_project_memory_candidates(paths):
+        if str(candidate.get("status", "")) not in {"pending_review", "blocked_review_required"}:
+            continue
+        if _normalized_summary_key(str(candidate.get("summary", ""))) == key:
+            return str(candidate.get("candidate_id", ""))
+    return ""
+
+
+def _recall_query_intent(query: str) -> str:
+    """Return "temporal" for an unambiguous time cue, else "default".
+
+    Token cues use the recall tokenizer, so matching is exact token overlap,
+    never substring guessing ("nowhere" and "knownHosts" stay default).
+    Known limitation: hyphenated compounds tokenize whole ("recently-requested"),
+    so a cue inside one does not fire. Phrase cues match on whitespace-
+    normalized lowercase text.
+    """
+    if not query.strip():
+        return "default"
+    if _memory_tokens(query) & _TEMPORAL_QUERY_CUES:
+        return "temporal"
+    normalized = f" {' '.join(query.lower().split())} "
+    return "temporal" if any(f" {phrase} " in normalized for phrase in _TEMPORAL_QUERY_PHRASES) else "default"
 
 
 def _memory_pins_path(paths: OmhPaths) -> Path:
@@ -1791,6 +2021,8 @@ def validate_project_memory_recall_pack(value: Any, *, label: str = "memory_reca
     _validate_context_scope(value.get("scope"), errors, f"{label}.scope")
     if "perspective" in value:
         _validate_perspective(value.get("perspective"), errors, f"{label}.perspective")
+    if value.get("query_intent", "default") not in {"default", "temporal"}:
+        errors.append(f"{label}.query_intent must be default or temporal")
     _validate_context_list(value.get("included_records"), _PROJECT_MEMORY_RECALL_ITEM_KEYS, errors, f"{label}.included_records", scope_key="scope")
     _validate_context_list(value.get("excluded_records"), _PROJECT_MEMORY_EXCLUDED_KEYS, errors, f"{label}.excluded_records")
     _validate_context_map(value.get("task_ref"), _PROJECT_MEMORY_TASK_REF_KEYS, errors, f"{label}.task_ref")
@@ -1996,6 +2228,7 @@ def _empty_recall_pack(
         "policy": policy,
         "scope": _scope(scope_kind or "project", scope_ref or "default"),
         "perspective": {"observer": "", "observed": ""},
+        "query_intent": "default",
         "included_records": [],
         "excluded_records": [{"record_id": "", "reason": reason, "staleness": {"state": "not_checked"}}],
         "record_count": 0,

--- a/tests/test_memory_rollup_signals.py
+++ b/tests/test_memory_rollup_signals.py
@@ -1,0 +1,310 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.plugin_bundle.omh import memory_governance
+from omh.memory import (
+    approve_project_memory_candidate,
+    build_memory_lineage,
+    build_memory_rollup,
+    build_project_memory_recall_pack,
+    capture_project_memory_candidate,
+    validate_project_memory_recall_pack,
+)
+from omh.paths import resolve_paths
+from omh.profiles.setup import write_setup_profile
+from omh.runtime.records import _compact_memory_recall_pack
+
+
+def _approve_capture(paths, summary, **kwargs):
+    captured = capture_project_memory_candidate(paths, summary, **kwargs)
+    return approve_project_memory_candidate(paths, captured["candidate"]["candidate_id"])["record"]
+
+
+def _rewrite_record(paths, record_id, **fields):
+    record_path = paths.memory_dir / "records" / f"{record_id}.json"
+    record = json.loads(record_path.read_text(encoding="utf-8"))
+    record.update(fields)
+    digest = memory_governance.canonical_payload_digest(record)
+    record["admission"]["payload_digest"] = digest
+    review_path = paths.memory_dir / "reviews" / f"{record['admission']['review_id']}.json"
+    review = json.loads(review_path.read_text(encoding="utf-8"))
+    review["payload_digest"] = digest
+    review_path.write_text(json.dumps(review), encoding="utf-8")
+    record_path.write_text(json.dumps(record), encoding="utf-8")
+
+
+class EpisodeRollupTests(unittest.TestCase):
+    def test_rollup_requires_a_selector_and_two_members(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            with self.assertRaisesRegex(ValueError, "requires"):
+                build_memory_rollup(paths)
+
+            _approve_capture(paths, "lonely deploy fact", tags=["deploy"])
+            report = build_memory_rollup(paths, tag="deploy")
+            self.assertFalse(report["eligible"])
+            self.assertEqual(report["reason_code"], "not_enough_members")
+            self.assertFalse(report["applied"])
+
+    def test_rollup_report_is_additive_and_apply_stages_a_reviewable_episode(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            first = _approve_capture(paths, "Deploy failed on stale cache", tags=["deploy"])
+            second = _approve_capture(paths, "Deploy fixed by cache purge", tags=["deploy"])
+            _approve_capture(paths, "Unrelated routing fact", tags=["routing"])
+
+            report = build_memory_rollup(paths, tag="deploy")
+            self.assertTrue(report["eligible"])
+            self.assertEqual({member["record_id"] for member in report["members"]}, {first["record_id"], second["record_id"]})
+            self.assertFalse(report["applied"], "report-first: no candidate staged without --apply")
+
+            applied = build_memory_rollup(paths, tag="deploy", apply=True)
+            self.assertTrue(applied["applied"])
+            candidate = applied["capture"]["candidate"]
+            self.assertEqual(candidate["record_type"], "episode")
+            self.assertEqual(set(candidate["derived_from"]), {first["record_id"], second["record_id"]})
+
+            episode = approve_project_memory_candidate(paths, candidate["candidate_id"])["record"]
+            lineage = build_memory_lineage(paths, episode["record_id"])
+            self.assertEqual(
+                {card["record_id"] for card in lineage["ancestors"]},
+                {first["record_id"], second["record_id"]},
+            )
+            for member_id in (first["record_id"], second["record_id"]):
+                self.assertTrue((paths.memory_dir / "records" / f"{member_id}.json").exists(), "rollup is additive")
+
+    def test_rollup_skips_expired_and_episode_records_and_caps_members(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            for index in range(10):
+                _approve_capture(paths, f"deploy fact number {index}", tags=["deploy"])
+            expired = _approve_capture(paths, "expired deploy fact", tags=["deploy"], retention_class="volatile", ttl_days=1)
+            past = (datetime.now(timezone.utc) - timedelta(days=7)).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+            _rewrite_record(paths, expired["record_id"], ttl={"ttl_days": 1, "expires_at": past})
+
+            report = build_memory_rollup(paths, tag="deploy", apply=True)
+
+            member_ids = {member["record_id"] for member in report["members"]}
+            self.assertEqual(report["member_count"], 8, "members cap at the derived-from limit")
+            self.assertEqual(report["truncated_members"], 2)
+            self.assertNotIn(expired["record_id"], member_ids)
+
+            episode_candidate = report["capture"]["candidate"]
+            follow_up = build_memory_rollup(paths, tag="deploy")
+            approve_project_memory_candidate(paths, episode_candidate["candidate_id"])
+            after_episode = build_memory_rollup(paths, tag="deploy")
+            self.assertEqual(
+                after_episode["considered_count"],
+                follow_up["considered_count"],
+                "an approved episode never becomes a rollup member itself",
+            )
+
+
+class RollupConfinementTests(unittest.TestCase):
+    def test_partial_scope_selector_is_rejected(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            with self.assertRaisesRegex(ValueError, "both"):
+                build_memory_rollup(paths, tag="deploy", scope_kind="target")
+
+    def test_mixed_perspectives_refuse_and_shared_perspective_is_inherited(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            _approve_capture(paths, "codex deploy lesson one", tags=["deploy"], observed="codex")
+            _approve_capture(paths, "unscoped deploy fact", tags=["deploy"])
+
+            mixed = build_memory_rollup(paths, tag="deploy", apply=True)
+            self.assertFalse(mixed["eligible"])
+            self.assertEqual(mixed["reason_code"], "mixed_perspective")
+            self.assertFalse(mixed["applied"])
+
+            _approve_capture(paths, "codex deploy lesson two", tags=["codexonly"], observed="codex")
+            _approve_capture(paths, "codex deploy lesson three", tags=["codexonly"], observed="codex")
+            report = build_memory_rollup(paths, tag="codexonly", apply=True)
+            self.assertTrue(report["applied"])
+            episode = approve_project_memory_candidate(paths, report["capture"]["candidate"]["candidate_id"])["record"]
+            self.assertEqual(episode["perspective"], {"observer": "hermes", "observed": "codex"})
+
+            claude_lens = build_project_memory_recall_pack(paths, "", observed="claude-code")
+            self.assertNotIn(
+                episode["record_id"],
+                {item["record_id"] for item in claude_lens["included_records"]},
+                "a codex-member episode must not reach another executor's lens",
+            )
+
+    def test_mixed_scopes_refuse_and_shared_scope_is_inherited(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            _approve_capture(paths, "alpha host fact", tags=["net"], scope_kind="target", scope_ref="alpha")
+            _approve_capture(paths, "beta host fact", tags=["net"], scope_kind="target", scope_ref="beta")
+
+            mixed = build_memory_rollup(paths, tag="net")
+            self.assertEqual(mixed["reason_code"], "mixed_scope")
+
+            _approve_capture(paths, "alpha port fact", tags=["alphanet"], scope_kind="target", scope_ref="alpha")
+            _approve_capture(paths, "alpha dns fact", tags=["alphanet"], scope_kind="target", scope_ref="alpha")
+            report = build_memory_rollup(paths, tag="alphanet", apply=True)
+            self.assertEqual(report["selector"]["scope"], {"kind": "target", "ref": "alpha"})
+            candidate = report["capture"]["candidate"]
+            self.assertEqual(candidate["scope"], {"kind": "target", "ref": "alpha"}, "the episode stays in the members' scope")
+
+    def test_rollup_never_auto_approves_and_reruns_report_already_staged(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            write_setup_profile(paths, memory_mode="auto-safe")
+            first = capture_project_memory_candidate(paths, "deploy fact one", tags=["deploy"])
+            second = capture_project_memory_candidate(paths, "deploy fact two", tags=["deploy"])
+            self.assertTrue(first["auto_approved"] and second["auto_approved"], "sanity: auto-safe active")
+
+            report = build_memory_rollup(paths, tag="deploy", apply=True)
+
+            self.assertTrue(report["applied"])
+            self.assertEqual(report["candidate_status"], "pending_review")
+            self.assertFalse(report["capture"]["auto_approved"], "a derived aggregate never auto-approves")
+
+            rerun = build_memory_rollup(paths, tag="deploy", apply=True)
+            self.assertEqual(rerun["reason_code"], "already_staged")
+            self.assertEqual(rerun["staged_candidate_id"], report["capture"]["candidate"]["candidate_id"])
+            self.assertFalse(rerun["applied"])
+
+    def test_volatile_member_makes_the_episode_volatile_with_smallest_ttl(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            _approve_capture(paths, "standard deploy fact", tags=["deploy"])
+            _approve_capture(paths, "volatile deploy note", tags=["deploy"], retention_class="volatile", ttl_days=2)
+
+            report = build_memory_rollup(paths, tag="deploy", apply=True)
+
+            self.assertEqual(report["episode_retention"], {"class": "volatile", "ttl_days": 2})
+            episode = approve_project_memory_candidate(paths, report["capture"]["candidate"]["candidate_id"])["record"]
+            self.assertEqual(episode["retention"]["class"], "volatile")
+            self.assertEqual(episode["retention"]["ttl_days"], 2, "volatile content must not outlive its strictest member TTL class")
+
+    def test_selection_is_oldest_first_by_identity_and_summary_budget_names_every_member(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            records = []
+            base = datetime(2026, 7, 1, tzinfo=timezone.utc)
+            for index in range(4):
+                record = _approve_capture(paths, f"member-{index} " + ("detail " * 25), tags=["long"])
+                stamp = (base + timedelta(days=index)).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+                _rewrite_record(paths, record["record_id"], approved_at=stamp)
+                records.append(record)
+
+            report = build_memory_rollup(paths, tag="long")
+
+            self.assertEqual(
+                [member["record_id"] for member in report["members"]],
+                [record["record_id"] for record in records],
+                "selection contract: oldest first, deterministic",
+            )
+            self.assertEqual(report["selector"]["selection"], "oldest_first")
+            for index in range(4):
+                self.assertIn(f"member-{index}", report["proposed_summary"], "the budgeted join must name every member")
+
+
+class RecallSignalTests(unittest.TestCase):
+    def test_manual_review_outweighs_auto_safe_at_equal_relevance(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            manual = _approve_capture(paths, "manually reviewed decision")
+            write_setup_profile(paths, memory_mode="auto-safe")
+            auto = capture_project_memory_candidate(paths, "auto approved decision", tags=["ok"])
+            self.assertTrue(auto["auto_approved"])
+            auto_id = auto["record"]["record_id"]
+            same_moment = "2026-07-10T00:00:00Z"
+            _rewrite_record(paths, manual["record_id"], approved_at=same_moment)
+            _rewrite_record(paths, auto_id, approved_at=same_moment)
+
+            pack = build_project_memory_recall_pack(paths, "")
+
+            by_id = {item["record_id"]: item for item in pack["included_records"]}
+            self.assertEqual(by_id[manual["record_id"]]["ranking"]["veracity_weight_pct"], 100)
+            self.assertEqual(by_id[auto_id]["ranking"]["veracity_weight_pct"], 90)
+            self.assertEqual([item["record_id"] for item in pack["included_records"]][0], manual["record_id"])
+
+    def test_temporal_queries_double_the_recency_weight(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            older = _approve_capture(paths, "release process detail one", tags=["release"])
+            newer = _approve_capture(paths, "release process detail two", tags=["release"])
+            _rewrite_record(paths, older["record_id"], approved_at="2026-06-01T00:00:00Z")
+            _rewrite_record(paths, newer["record_id"], approved_at="2026-07-20T00:00:00Z")
+
+            plain = build_project_memory_recall_pack(paths, "release process detail")
+            temporal = build_project_memory_recall_pack(paths, "most recent release process detail")
+
+            self.assertEqual(plain["query_intent"], "default")
+            self.assertEqual(temporal["query_intent"], "temporal")
+            self.assertEqual(validate_project_memory_recall_pack(temporal), [])
+            plain_by_id = {item["record_id"]: item for item in plain["included_records"]}
+            temporal_by_id = {item["record_id"]: item for item in temporal["included_records"]}
+            self.assertGreater(
+                temporal_by_id[newer["record_id"]]["ranking"]["rrf_score_micro"],
+                plain_by_id[newer["record_id"]]["ranking"]["rrf_score_micro"],
+                "a temporal cue boosts the recency contribution",
+            )
+
+    def test_intent_never_changes_which_keyword_matches_win(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            strong = _approve_capture(paths, "release gate checklist and ruff", tags=["release", "ruff"])
+            weak = _approve_capture(paths, "release notes location")
+            _rewrite_record(paths, strong["record_id"], approved_at="2026-01-01T00:00:00Z")
+            _rewrite_record(paths, weak["record_id"], approved_at="2026-07-20T00:00:00Z")
+
+            pack = build_project_memory_recall_pack(paths, "recent release ruff checklist")
+
+            self.assertEqual(pack["query_intent"], "temporal")
+            ids = [item["record_id"] for item in pack["included_records"]]
+            self.assertEqual(ids[0], strong["record_id"], "relevance stays primary even under a temporal cue")
+
+    def test_intent_overroute_guards_hold(self) -> None:
+        from omh.workflows.memory import _recall_query_intent
+
+        for query in (
+            "Refactor the current implementation of the router",
+            "Upgrade to the latest ruff version",
+            "Fix the flaky test now",
+            "Use the newest API",
+            "the config is nowhere to be found",
+            "check knownHosts handling",
+            "현재 배포 상태 어때",
+        ):
+            self.assertEqual(_recall_query_intent(query), "default", query)
+        for query in ("what changed yesterday", "most recent deploy failure", "deploys from last week"):
+            self.assertEqual(_recall_query_intent(query), "temporal", query)
+
+    def test_validator_rejects_malformed_query_intent(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            _approve_capture(paths, "validator subject")
+            pack = build_project_memory_recall_pack(paths, "")
+            self.assertEqual(validate_project_memory_recall_pack(pack), [])
+            for bogus in ("TOTALLY-BOGUS", 12345):
+                errors = validate_project_memory_recall_pack({**pack, "query_intent": bogus})
+                self.assertTrue(any("query_intent" in error for error in errors), bogus)
+
+    def test_compacted_pack_keeps_intent_and_veracity_fields(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            _approve_capture(paths, "compaction subject fact")
+
+            pack = build_project_memory_recall_pack(paths, "recently changed compaction subject")
+            compacted = _compact_memory_recall_pack(pack)
+
+            self.assertEqual(compacted["query_intent"], "temporal")
+            [item] = compacted["included_records"]
+            self.assertEqual(item["ranking"]["veracity_weight_pct"], 100)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_parser_memory.py
+++ b/tests/test_parser_memory.py
@@ -25,6 +25,8 @@ class MemoryParserTests(unittest.TestCase):
             (["memory", "perspectives"], "cmd_memory_perspectives"),
             (["memory", "pin", "record-one"], "cmd_memory_pin"),
             (["memory", "unpin", "record-one"], "cmd_memory_unpin"),
+            (["memory", "rollup", "--tag", "deploy"], "cmd_memory_rollup"),
+            (["memory", "rollup", "--tag", "deploy", "--apply"], "cmd_memory_rollup"),
             (["memory", "capture", "summary", "--observed", "codex"], "cmd_memory_capture"),
             (["memory", "recall", "query", "--observer", "operator", "--observed", "codex"], "cmd_memory_recall"),
         )


### PR DESCRIPTION
## Feature Report

### What Changed

- **Episode rollup** — new report-first `omh memory rollup --tag <t> [--scope-kind/--scope-ref] [--apply]` (`omh_memory_rollup/v1`): selects up to 8 non-expired, non-episode records (oldest first, deterministic tiebreak, contract named in the report as `selection: oldest_first`) and proposes one reviewable `episode` candidate. The summary is a per-member-budgeted mechanical join (every member represented), `derived_from` names every member so `omh memory lineage` walks the whole set, and originals are never modified. **The episode inherits its members' confinement, strictest-wins**: mixed scopes or mixed perspectives refuse (`mixed_scope`/`mixed_perspective`), a shared perspective or scope carries onto the episode, and any volatile member makes the episode volatile with the smallest member TTL. A derived aggregate never auto-approves (new `force_review` capture flag), and re-running while an identical candidate is pending reports `already_staged` instead of staging twins.
- **Veracity weighting** — ranking blocks report `veracity_weight_pct`: `approved_manual` weighs 100 and `approved_auto_safe` 90 inside `decayed_score_micro` (unknown admission modes fail closed to 90). Never an eligibility input.
- **Temporal query intent** — packs echo `query_intent` (`default`/`temporal`, validator-enforced). Only unambiguous English cues fire: tokens `yesterday/today/recent/recently/ago` and phrases like `most recent`/`last week`; ambiguous engineering adjectives (`current`, `latest`, `now`, `newest`) deliberately do not fire as bare tokens. A temporal query doubles the recency weight inside rank fusion.
- `docs/MEMORY.md` gains rollup examples and the signal-refinement documentation.

### Why This Exists

Round 2 of the mnemosyne port (#762 shipped pins, age tiers, capture dedup): the user asked for the deferred ideas — additive consolidation, veracity weighting, and query-intent routing. Each is a deterministic reinterpretation: mnemosyne's LLM consolidation becomes a mechanical, review-gated episode candidate (synthesis stays Hermes' job), its veracity multipliers become a two-value admission-mode weight, and its query-intent classifier becomes a deliberately narrow cue list that respects the repo's routing-language policy (no per-language token tables).

### User / Operator Impact

- Operators can consolidate clutter under a tag or scope into one reviewable episode whose lineage names all members — without any original being touched or any content crossing a scope, perspective, or retention boundary it couldn't cross before.
- Human-reviewed records outrank auto-safe peers of equal relevance; temporal questions ("what changed yesterday") favor newer records — both fully explainable from the pack's ranking blocks, and neither can change which keyword matches win.

### How It Works

- `src/workflows/memory.py`: `build_memory_rollup` (member selection, confinement inheritance with refuse-on-conflict, budgeted join, pending-duplicate short-circuit via `_find_pending_candidate_by_summary`), `force_review` flag on `capture_project_memory_candidate`, `_ADMISSION_VERACITY_WEIGHT_PCT` in `_attach_recall_ranking`, `_recall_query_intent` (token + phrase cues) feeding a per-pack recency weight, `query_intent` validator branch.
- `src/commands/memory.py` + `memory_parser.py`: `rollup` subcommand (rejects a partial scope selector).
- `src/runtime/records.py`: compaction keeps `veracity_weight_pct` and `query_intent` (legacy packs compact to `default`).

### Verification

An independent code-review pass on the initial implementation surfaced **15 findings**, including 1 CRITICAL — the rollup laundered perspective-scoped member content into an unscoped episode that then reached every executor's handoff, defeating #761's confinement — and 3 HIGH (auto-safe minted approved episodes with zero review while the report claimed otherwise; tag-only rollups promoted target-scoped content to `project/default`; the unbudgeted summary join silently dropped most members). All 15 are fixed; the leak class was fixed structurally (episode inherits perspective + scope + retention from members, refuse on conflict) with a regression test per finding, including the reviewer's named gaps: intent overroute guards (`current`/`latest`/`now`/CJK queries stay `default`), pending-duplicate re-run, TTL inheritance, member-identity determinism, and validator negatives.

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests` — 2643 passed, 1 skipped
- [x] `compileall`, `docs workflows/roles/capability-families --check`, `git diff --check`
- [x] CLI smoke in a scratch home: rollup report → `--apply` (pending_review) → re-run `already_staged` → approve → `lineage` shows all 3 members → temporal-intent recall
- [ ] Live Hermes/TUI check — not run; all changes are report/pack payload surfaces behind existing validators

### Risk

- Rollup is report-first and additive; the only write path is the existing capture pipeline, always landing in review.
- Ranking changes affect only equal-relevance ordering (veracity, intent) — the relevance-first sort and budget contract are unchanged.
- The temporal cue list is deliberately narrow and English-only; a missed cue means default weighting, never a wrong exclusion.
- `force_review` is additive to the capture contract (default `False`; existing callers unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GDizVvD8u37NYNTkb1F1uL
