### PR TITLE
fix: correction reapproval via one approve verb, live --include-stale, dated review cards

### DIFF
--- a/src/commands/memory.py
+++ b/src/commands/memory.py
@@ -27,6 +27,7 @@ from ..plugin_bundle.omh.memory_dreaming import read_dreaming_state
 from ..plugin_bundle.omh.memory_provider import OmhMemoryProvider
 from ..plugin_bundle.omh.metadata import MEMORY_PROVIDER_NAME
 from ..memory import (
+    LifecycleCandidateError,
     RejectedDecisionRecallRequest,
     apply_approved_memory_update_batch,
     apply_memory_retirement,
@@ -54,9 +55,11 @@ from ..workflows.memory_evaluation import run_memory_evaluation
 from ..workflows.memory_lifecycle import (
     apply_memory_correction,
     apply_memory_prune,
+    apply_memory_reapproval,
     apply_memory_restore,
     build_memory_correction,
     build_memory_prune,
+    build_memory_reapproval,
     build_memory_restore,
 )
 from ..workflows.memory_lifecycle_executor import execute_memory_lifecycle
@@ -121,8 +124,22 @@ def cmd_memory_review(args: argparse.Namespace) -> int:
 
 
 def cmd_memory_approve(args: argparse.Namespace) -> int:
+    paths = _paths(args)
     try:
-        payload = approve_project_memory_candidate(_paths(args), args.candidate_id, approved_by=args.approved_by)
+        payload = approve_project_memory_candidate(paths, args.candidate_id, approved_by=args.approved_by)
+    except LifecycleCandidateError:
+        # Correction/restore candidates approve through the lifecycle
+        # executor so the replacement payload and revision survive; the
+        # operator keeps one approve verb either way.
+        try:
+            plan = build_memory_reapproval(
+                paths, args.candidate_id, reviewer_claim=args.approved_by, now=datetime.now(timezone.utc)
+            )
+            payload = dict(plan.report) if not plan.report.get("eligible") else apply_memory_reapproval(
+                paths, plan, transaction_executor=execute_memory_lifecycle
+            )
+        except (OSError, ValueError) as exc:
+            raise OmhError(str(exc)) from exc
     except FileNotFoundError as exc:
         raise OmhError(f"memory candidate not found: {args.candidate_id}") from exc
     except (OSError, ValueError) as exc:

--- a/src/workflows/memory.py
+++ b/src/workflows/memory.py
@@ -472,6 +472,7 @@ def build_project_memory_review_card(candidate: dict[str, Any]) -> dict[str, obj
         "summary": str(candidate.get("summary", "")),
         "scope": _normalize_scope(candidate.get("scope", _scope("project", "default"))),
         "tags": _string_list(candidate.get("tags", [])),
+        "created_at": str(candidate.get("created_at", "")),
         **({"duplicate_of": str(candidate["duplicate_of"])} if candidate.get("duplicate_of") else {}),
         "safety": safety,
         "recommended_action": recommended_action,
@@ -488,10 +489,24 @@ def build_project_memory_review_card(candidate: dict[str, Any]) -> dict[str, obj
     }
 
 
+class LifecycleCandidateError(ValueError):
+    """A v2 lifecycle candidate reached the plain approval path."""
+
+
 def approve_project_memory_candidate(paths: OmhPaths, candidate_id: str, *, approved_by: str = "operator") -> dict[str, object]:
     candidate = _read_project_memory_candidate(paths, candidate_id)
     if not candidate:
         raise FileNotFoundError(candidate_id)
+    # Fail closed on correction/restore candidates: their payload lives under
+    # "replacement", so the plain path would mint a record with an empty
+    # summary and revision 1 -- and that garbage record then blocks the real
+    # reapproval with newer_live_revision_conflict. The CLI catches this and
+    # routes to the lifecycle reapproval executor instead.
+    if str(candidate.get("schema_version", "")) == "project_memory_candidate/v2" or str(candidate.get("lifecycle", "") or ""):
+        raise LifecycleCandidateError(
+            f"candidate {candidate_id} is a lifecycle ({candidate.get('lifecycle', 'v2')}) candidate; "
+            "it must be reapproved through the lifecycle path, not plain approval"
+        )
     safety = candidate.get("safety", {}) if isinstance(candidate.get("safety"), dict) else {}
     if safety.get("status") == "blocked":
         raise ValueError("blocked memory candidates must be rejected or recaptured without protected raw content")
@@ -634,6 +649,16 @@ def build_project_memory_recall_pack(
         )
         staleness = _record_staleness(record, now=now)
         if not bool(evaluation["eligible"]):
+            # --include-stale is an inspection affordance: it surfaces
+            # records whose ONLY problem is a passed revalidation deadline,
+            # carrying their ineligible replay evidence so the pack cannot
+            # be attached to a handoff. Expired and otherwise-ineligible
+            # records stay excluded regardless.
+            if include_stale and str(evaluation.get("reason_code", "")) == "stale_review_required":
+                score = _memory_recall_score(record, query)
+                if not query or score > 0 or str(record.get("record_id", "")) in pins:
+                    included.append(_recall_item(record, score=score, staleness=staleness, evaluation=evaluation))
+                    continue
             excluded.append(_recall_exclusion(record, evaluation, staleness=staleness))
             continue
         score = _memory_recall_score(record, query)

--- a/tests/test_memory_reapproval_path.py
+++ b/tests/test_memory_reapproval_path.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+
+from _cli_harness import run_cli
+from _local_package import load_local_package
+
+load_local_package()
+from omh.memory import (
+    LifecycleCandidateError,
+    approve_project_memory_candidate,
+    build_project_memory_recall_pack,
+    build_project_memory_review,
+    capture_project_memory_candidate,
+)
+from omh.paths import resolve_paths
+
+
+def _cli(home: Path, *args):
+    status, stdout, stderr = run_cli(["--omh-home", str(home / ".omh"), "--hermes-home", str(home / ".hermes"), *args])
+    assert status == 0, f"{args} failed: {stderr or stdout}"
+    return json.loads(stdout)
+
+
+class CorrectionInterviewPathTests(unittest.TestCase):
+    """The 'is this memory right? no, fix it' interview must survive the CLI."""
+
+    def test_plain_approval_fails_closed_on_lifecycle_candidates(self) -> None:
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            paths = resolve_paths(home / ".omh", home / ".hermes")
+            captured = capture_project_memory_candidate(paths, "Deploys go through staging first", record_type="decision")
+            record = approve_project_memory_candidate(paths, captured["candidate"]["candidate_id"])["record"]
+            _cli(home, "memory", "correct", record["record_id"], "Deploys go through staging, then canary", "--revision", "1", "--apply")
+
+            correction = next(
+                candidate
+                for candidate in (json.loads(p.read_text()) for p in (paths.memory_dir / "candidates").glob("*.json"))
+                if candidate.get("lifecycle") == "correction"
+            )
+            with self.assertRaises(LifecycleCandidateError):
+                approve_project_memory_candidate(paths, str(correction["candidate_id"]))
+            self.assertFalse(
+                (paths.memory_dir / "records" / f"{record['record_id']}.json").exists(),
+                "the guard must not mint any record; r1 stays superseded in history until reapproval",
+            )
+
+    def test_cli_approve_routes_corrections_through_reapproval(self) -> None:
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            paths = resolve_paths(home / ".omh", home / ".hermes")
+            captured = capture_project_memory_candidate(
+                paths, "Deploys go through staging first", record_type="decision", observed="codex"
+            )
+            record = approve_project_memory_candidate(paths, captured["candidate"]["candidate_id"])["record"]
+            _cli(home, "memory", "correct", record["record_id"], "Deploys go through staging, then canary", "--revision", "1", "--apply")
+            correction = next(
+                candidate
+                for candidate in (json.loads(p.read_text()) for p in (paths.memory_dir / "candidates").glob("*.json"))
+                if candidate.get("lifecycle") == "correction"
+            )
+
+            result = _cli(home, "memory", "approve", str(correction["candidate_id"]))
+
+            self.assertTrue(result.get("applied"), str(result.get("reason_code")))
+            live = json.loads((paths.memory_dir / "records" / f"{record['record_id']}.json").read_text())
+            self.assertEqual(live["revision"], 2)
+            self.assertIn("canary", live["summary"])
+            self.assertEqual(live["record_type"], "decision", "the replacement payload survives the one approve verb")
+            self.assertEqual(live["perspective"], {"observer": "hermes", "observed": "codex"})
+            pack = build_project_memory_recall_pack(paths, "staging canary", observed="codex")
+            self.assertIn(record["record_id"], {item["record_id"] for item in pack["included_records"]})
+
+    def test_include_stale_surfaces_revalidation_stale_records_for_inspection(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            captured = capture_project_memory_candidate(paths, "CI runner uses ubuntu", stale_after_days=1)
+            record = approve_project_memory_candidate(paths, captured["candidate"]["candidate_id"])["record"]
+            from omh.plugin_bundle.omh.memory_governance import canonical_payload_digest
+
+            record_path = paths.memory_dir / "records" / f"{record['record_id']}.json"
+            stored = json.loads(record_path.read_text())
+            stored["staleness"]["stale_after"] = "2026-01-01T00:00:00Z"
+            stored["revalidation"] = {"deadline": "2026-01-01T00:00:00Z"}
+            digest = canonical_payload_digest(stored)
+            stored["admission"]["payload_digest"] = digest
+            review_path = paths.memory_dir / "reviews" / f"{stored['admission']['review_id']}.json"
+            review = json.loads(review_path.read_text())
+            review["payload_digest"] = digest
+            review_path.write_text(json.dumps(review))
+            record_path.write_text(json.dumps(stored))
+
+            default_pack = build_project_memory_recall_pack(paths, "ubuntu runner")
+            self.assertIn(
+                record["record_id"],
+                {entry["record_id"] for entry in default_pack["excluded_records"]},
+                "stale records stay excluded by default with a stated reason",
+            )
+
+            stale_pack = build_project_memory_recall_pack(paths, "ubuntu runner", include_stale=True)
+            [item] = [i for i in stale_pack["included_records"] if i["record_id"] == record["record_id"]]
+            self.assertEqual(item["staleness"]["state"], "stale", "the inspection surface marks it stale, not fresh")
+            self.assertFalse(item["replay_evaluation"]["eligible"], "stale inclusion never launders replay eligibility")
+
+    def test_include_stale_never_resurrects_expired_records(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            captured = capture_project_memory_candidate(paths, "volatile borrow note", retention_class="volatile", ttl_days=1)
+            record = approve_project_memory_candidate(paths, captured["candidate"]["candidate_id"])["record"]
+            from datetime import datetime, timedelta, timezone
+
+            future = datetime.now(timezone.utc) + timedelta(days=8)
+            pack = build_project_memory_recall_pack(paths, "", include_stale=True, now=future)
+            self.assertNotIn(record["record_id"], {i["record_id"] for i in pack["included_records"]})
+
+    def test_review_card_says_when_the_memory_was_captured(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            capture_project_memory_candidate(paths, "pending interview subject")
+            [card] = build_project_memory_review(paths)["cards"]
+            self.assertTrue(card.get("created_at"), "the interview needs 'when was this remembered'")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- **`omh memory approve` now handles correction/restore candidates correctly.** The workflow fails closed on v2 lifecycle candidates (`LifecycleCandidateError`) and the CLI routes them through the lifecycle reapproval executor — one approve verb for both candidate kinds, with the replacement payload (summary, type, revision, perspective) surviving intact.
- **`omh memory recall --include-stale` actually works now.** It surfaces records whose only problem is a passed revalidation deadline, carrying their ineligible replay evidence so the pack remains an inspection surface — attachment validators still refuse it, and expired records are never resurrected.
- **Review cards carry `created_at`**, so a curation interview can say "this was remembered on <date>" without opening candidate files.

### Why This Exists

Scenario QA replayed the memory curation interview ("this is what I remember — is it right? fix it? drop it?") end-to-end at the CLI and found two real defects:

1. Approving a correction candidate with the natural command minted an approved record with an **empty summary, wrong record type, and revision 1** (a v2 lifecycle candidate keeps its payload under `replacement`, which plain approval ignores) — and that garbage record then blocked the legitimate reapproval with `newer_live_revision_conflict`. The "no, fix it like this" interview step was broken at the CLI.
2. `--include-stale` was a dead flag: present in the pack builder's signature, consumed nowhere. "Show me the stale one anyway" silently did nothing.

### User / Operator Impact

- The fix-it interview loop now closes: `correct --apply` → `approve <candidate>` → corrected r2 live and recalled, old wording superseded.
- Stale records can be inspected on request with their staleness stated, without any effect on what executors receive.
- Review cards answer "when was this remembered" directly.

### How It Works

- `src/workflows/memory.py`: `LifecycleCandidateError` guard in `approve_project_memory_candidate` (fail-closed, no record minted); `include_stale` consumed in `build_project_memory_recall_pack` gated on the exact `stale_review_required` reason; review card `created_at` passthrough.
- `src/commands/memory.py`: `cmd_memory_approve` catches the error and runs `build_memory_reapproval`/`apply_memory_reapproval` via the lifecycle transaction executor.

### Verification

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests` — 2648 passed, 1 skipped
- [x] `uv run --group lint ruff check src tests`, `compileall`, `docs workflows/roles/capability-families --check`, `git diff --check`
- [x] New CLI-level regression tests: fail-closed guard (no record file minted), one-verb reapproval end-to-end (r2 live with perspective intact and recalled), include-stale inspection (marked stale, replay-ineligible evidence kept), expired never resurrected, dated review card
- [x] Scenario harness (interview flow T1–T8, 29 checks) green in a scratch home: review cards → correct → approve → recall; reject → rejected-recall; batch stage/review(remember/refuse/defer)/apply; chat routing; stale transparency; dreaming; status/inventory
- [ ] Live Hermes/TUI check — not run (prepared_not_observed)

### Risk

- Low: one fail-closed guard (previously a corrupting path, so any behavior change is strictly safer), one CLI routing branch, one previously-dead parameter now consumed on an inspection-only surface, one additive card field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GDizVvD8u37NYNTkb1F1uL
