### PR TITLE
test: make POSIX-permission and symlink tests Windows-compatible

### DIFF
--- a/tests/test_awareness_delivery.py
+++ b/tests/test_awareness_delivery.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import stat
 import threading
 import unittest
@@ -202,6 +203,8 @@ class AwarenessDeliveryLedgerTests(unittest.TestCase):
             self.assertEqual(legacy.severity, "ok")
 
     def test_ledger_file_and_directory_are_private(self) -> None:
+        if os.name != "posix":
+            self.skipTest("POSIX permission bits are not meaningful on Windows/NTFS")
         with TemporaryDirectory() as tmp:
             record_awareness_delivery(
                 delivered=False,

--- a/tests/test_codegraph.py
+++ b/tests/test_codegraph.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import json
+import os
+import shutil
+import tempfile
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -269,6 +272,19 @@ omh = "src"
         )
 
     def test_scanner_skips_python_symlink_files(self) -> None:
+        # Symlink creation requires SeCreateSymbolicLinkPrivilege on Windows
+        # (absent for non-elevated processes), so skip there.
+        try:
+            tmp_dir = tempfile.mkdtemp()
+            probe = os.path.join(tmp_dir, "probe_target.py")
+            open(probe, "w").close()
+            os.symlink(probe, os.path.join(tmp_dir, "probe_link.py"))
+            os.remove(os.path.join(tmp_dir, "probe_link.py"))
+        except (OSError, NotImplementedError):
+            self.skipTest("symlink creation is not permitted on this platform")
+        finally:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+
         with TemporaryDirectory() as tmp, TemporaryDirectory() as outside_tmp:
             repo = Path(tmp)
             outside = Path(outside_tmp) / "outside.py"


### PR DESCRIPTION
## Feature Report

### What Changed

Two test-only fixes make the OMH test suite compatible with Windows and
non-elevated environments where POSIX-only capabilities are unavailable:

1. **`tests/test_awareness_delivery.py`** — `test_ledger_file_and_directory_are_private`
   now skips cleanly on non-POSIX platforms (`os.name != "posix"`). The
   0o700/0o600 permission assertions are unchanged and still enforced on
   Linux/macOS.
2. **`tests/test_codegraph.py`** — `test_scanner_skips_python_symlink_files`
   now probes symlink creation capability first and skips when the OS
   denies it (e.g. WinError 1314 / missing SeCreateSymbolicLinkPrivilege).
   The full assertion path (scanner skips symlinked files, warning emitted)
   still runs on platforms that allow symlinks.

### Why This Exists

Running the suite on Windows produced two hard failures that are not
product bugs — they are tests asserting POSIX-only platform semantics:

- NTFS reports `0o777` for files and directories regardless of ACLs, so
  `stat.S_IMODE(...) == 0o700/0o600` can never pass on Windows even when
  the runtime correctly creates private files.
- `Path.symlink_to(...)` raises `OSError: [WinError 1314]` for non-elevated
  Windows processes because creating symlinks requires a privilege that
  standard developer machines do not grant.

Without the fix, `python -m unittest` on Windows reports 2 failures and the
suite is never green on that platform, which hides genuine regressions and
discourages Windows contributions.

### User / Operator Impact

- Windows and non-elevated developers can run the affected test modules
  and get a clean `OK (skipped=2)` instead of hard failures.
- POSIX CI behavior is identical: the original assertions are untouched and
  both tests still run (not skipped) on Linux/macOS.

### How It Works

- POSIX permission test: a one-line guard before the assertions. On Windows
  the platform cannot express POSIX mode bits, so the test documents why it
  cannot run rather than failing spuriously.
- Symlink test: a small probe creates a temporary target and a symlink; if
  creation raises `OSError`/`NotImplementedError`, the test skips with a
  clear reason. On capable platforms the probe succeeds and the original
  test body executes unchanged.

### Files And Contracts Touched

- `tests/test_awareness_delivery.py` (+3 lines: `import os`, skip guard)
- `tests/test_codegraph.py` (+16 lines: `import os`, `import shutil`,
  `import tempfile`, symlink capability probe)

No product code, no contracts, no generated files, no catalog changes.

## Validation

- [x] `PYTHONPATH=tests python -m unittest tests/test_awareness_delivery.py tests/test_codegraph.py`
      → `Ran 27 tests, OK (skipped=2)`
- [x] `python -m compileall -q tests/test_codegraph.py tests/test_awareness_delivery.py` → clean
- [x] Targeted ad-hoc verification of both skip-guard behaviors (Temp dir, `hermes-verify-` prefix, removed after run) → `OK (skipped=2)`
- [ ] `uv run --group lint ruff check src tests` — not run (uv/ruff not set up in this checkout)
- [ ] `python3 -m unittest discover -s tests` — full suite on Windows has
      pre-existing failures in `test_cli.py` (20 failures/errors, unrelated
      to this change) and long runtimes; out of scope for this PR
- [ ] `python3 -m omh.cli docs workflows --check` — not run (Windows venv toolchain)
- [ ] `python3 -m omh.cli harness validate` — not run
- [ ] `python3 -m omh.cli release checklist --json` — not run
- [ ] Manual Hermes/TUI check: not applicable (test-only change)

## Risk

- Low. Test-only edits; no runtime code paths touched.
- On POSIX, both tests still execute their original assertions (guards are
  `os.name`/capability-conditional, so behavior is unchanged in CI).

## Compatibility / Rollout

- No interface, schema, or CLI changes.
- Safe to merge independently; no migration needed.

## Release / Claims

- [x] Release-channel impact considered: none (test-only, ships with any channel)
- [x] Runtime/native capability claims: none made
- [x] Known manual Hermes checks listed: not applicable

## Follow-Up

- Consider a follow-up pass over `tests/test_cli.py` Windows failures
  (venv-python path resolution, setup path expectations, JSON escape-hatch
  rendering) to get the full suite green on Windows.
- Optionally add a Windows CI job (e.g. `windows-latest`) so these
  compatibility fixes are enforced in CI rather than discovered manually.
