### PR TITLE
ci: enforce the role, capability-family, and whitespace gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,12 @@ jobs:
         python-version: ["3.11", "3.12"]
     steps:
       - uses: actions/checkout@v7
+        with:
+          # Full history so the whitespace gate below can resolve a merge base
+          # against the PR's base branch. A shallow clone has none, and
+          # `git diff --check` with no range compares the working tree to the
+          # index -- always empty after checkout, so it would always pass.
+          fetch-depth: 0
       - uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
@@ -30,6 +36,13 @@ jobs:
         run: python -m compileall src
       - name: Generated workflow docs check
         run: python -m omh.cli docs workflows --check
+      - name: Generated role docs check
+        run: python -m omh.cli docs roles --check
+      - name: Generated capability families check
+        run: python -m omh.cli docs capability-families --check
+      - name: Whitespace and conflict-marker check
+        if: matrix.python-version == '3.11' && github.event_name == 'pull_request'
+        run: git diff --check "origin/${{ github.base_ref }}...HEAD"
       - name: Dry-run install smoke
         run: python -m omh.cli --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke install --dry-run
       - name: Stable-channel dry-run smoke


### PR DESCRIPTION
## Feature Report

### What Changed

`.github/workflows/ci.yml` gains three gates:

- `python -m omh.cli docs roles --check`
- `python -m omh.cli docs capability-families --check`
- a whitespace and conflict-marker check over the PR's diff range

plus `fetch-depth: 0` on the checkout, which the third one needs.

### Why This Exists

`CLAUDE.md` declares four verification gates. CI ran **one** of them:

| Gate declared in `CLAUDE.md` | In CI before this PR |
| --- | --- |
| `docs workflows --check` | yes |
| `docs roles --check` | **no** |
| `docs capability-families --check` | **no** |
| `git diff --check` | **no** |

So `docs/ROLES.md` and `src/plugin_bundle/omh/tools/capability_families.json`
could drift from their generators and CI would stay green. That is precisely
the failure the byte gates exist to prevent — the drift would surface only when
somebody ran the check by hand.

Found while building the review and triage procedures in #772. The review sweep
runs all three, so a human following that procedure catches this; CI did not.

### User / Operator Impact

A PR that regenerates one artifact but forgets another now fails CI instead of
merging quietly. Contributors get the failure at PR time rather than in a later
review round.

### How It Works

The two doc gates are byte-exact comparisons against the generator output, run
the same way the existing `docs workflows --check` step already is.

**The whitespace gate is deliberately not the bare `git diff --check` that
`CLAUDE.md` prescribes for local use.** Verified in a clean checkout:

```
uncommitted changes: 0
bare 'git diff --check' exit=0
```

With no range it compares the working tree to the index. After a CI checkout
that is always empty, so the step would exit 0 unconditionally — a gate that
can never fail, which is worse than no gate because it reads as coverage.

It runs `git diff --check "origin/${{ github.base_ref }}...HEAD"` instead. The
three-dot range needs a reachable merge base, which a shallow clone does not
have, hence `fetch-depth: 0`.

Scoping:

- `github.event_name == 'pull_request'` — a push to `main` has no meaningful
  base range to diff against.
- `matrix.python-version == '3.11'` — whitespace does not vary by interpreter,
  matching how `ruff` is already scoped.

### Files And Contracts Touched

`.github/workflows/ci.yml` only. No `src/`, no `tests/`, no generated artifact.

## Validation

Positive — both new gates pass on current `main`:

```
{"checked":".../docs/ROLES.md","ok":true}
{"checked":".../src/plugin_bundle/omh/tools/capability_families.json","ok":true}
```

**Negative — each gate was proven to fail on real drift**, because a gate that
cannot fail is exactly the thing this PR refuses to ship:

| Injected drift | Command | Exit |
| --- | --- | --- |
| one character appended to `docs/ROLES.md` | `docs roles --check` | **2** |
| one space appended to `capability_families.json` | `docs capability-families --check` | **2** |
| committed a line with trailing whitespace | `git diff --check origin/main...HEAD` | **2**, naming `docs/PARITY.md:153: trailing whitespace.` |

Each probe was reverted and the working tree confirmed clean afterwards.

Not observed:

- The workflow has not run on GitHub yet. `fetch-depth: 0` and the
  `github.base_ref` expansion are unverified until this PR's own CI runs — this
  PR is its own first test.

## Risk

Low, with one real cost: `fetch-depth: 0` fetches full history on both matrix
legs, so checkout is slower. Accepted because the alternative is a whitespace
gate that cannot work.

If `docs/ROLES.md` or the capability-families sidecar is *already* drifted on
`main`, this turns CI red until it is regenerated. Both were verified `ok:true`
on `main` at `1dff2b12`, so that is not the case today.

## Compatibility / Rollout

No compatibility surface. Nothing ships in the package; no CLI, schema, or
generated artifact changes.

## Release / Claims

- [x] Release-channel impact considered — none
- [x] Runtime/native capability claims are backed by evidence or marked as not
      observed
- [x] Known manual Hermes checks are listed — none apply

## Follow-Up

- `CLAUDE.md` lists `git diff --check` as a gate without noting that the bare
  form is local-only. Worth a sentence there so the next person does not copy it
  into automation expecting it to do something.
