### PR TITLE
test: adopt repo skip-guard conventions for the #771 Windows guards

### DIFF
--- a/tests/test_awareness_delivery.py
+++ b/tests/test_awareness_delivery.py
@@ -202,9 +202,8 @@ class AwarenessDeliveryLedgerTests(unittest.TestCase):
             self.assertTrue(legacy.ok)
             self.assertEqual(legacy.severity, "ok")
 
+    @unittest.skipUnless(os.name == "posix", "POSIX mode bits do not exist off POSIX")
     def test_ledger_file_and_directory_are_private(self) -> None:
-        if os.name != "posix":
-            self.skipTest("POSIX permission bits are not meaningful on Windows/NTFS")
         with TemporaryDirectory() as tmp:
             record_awareness_delivery(
                 delivered=False,

--- a/tests/test_codegraph.py
+++ b/tests/test_codegraph.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
 
 import json
-import os
-import shutil
-import tempfile
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -272,24 +269,14 @@ omh = "src"
         )
 
     def test_scanner_skips_python_symlink_files(self) -> None:
-        # Symlink creation requires SeCreateSymbolicLinkPrivilege on Windows
-        # (absent for non-elevated processes), so skip there.
-        try:
-            tmp_dir = tempfile.mkdtemp()
-            probe = os.path.join(tmp_dir, "probe_target.py")
-            open(probe, "w").close()
-            os.symlink(probe, os.path.join(tmp_dir, "probe_link.py"))
-            os.remove(os.path.join(tmp_dir, "probe_link.py"))
-        except (OSError, NotImplementedError):
-            self.skipTest("symlink creation is not permitted on this platform")
-        finally:
-            shutil.rmtree(tmp_dir, ignore_errors=True)
-
         with TemporaryDirectory() as tmp, TemporaryDirectory() as outside_tmp:
             repo = Path(tmp)
             outside = Path(outside_tmp) / "outside.py"
             outside.write_text("def outside_symbol():\n    return True\n", encoding="utf-8")
-            (repo / "linked.py").symlink_to(outside)
+            try:
+                (repo / "linked.py").symlink_to(outside)
+            except (NotImplementedError, OSError) as exc:
+                self.skipTest(f"symlink creation unavailable: {exc}")
             _write(repo / "inside.py", "def inside_symbol():\n    return True\n")
 
             from omh.codegraph import build_codegraph


### PR DESCRIPTION
## Feature Report

### What Changed

Follow-up to #771, which made two POSIX-only tests skip cleanly on Windows.
The guards were correct in intent but hand-rolled; this PR rewrites both to
use the patterns the suite already established, and removes a latent error
path in the process.

- `tests/test_codegraph.py` — the separate symlink capability probe is gone.
  The test now guards the real `symlink_to` call, matching
  `tests/test_web_visual_qa_capture_file_safety.py:32-35` and three sites in
  `tests/test_dynamic_workflow.py` (`:345`, `:365`, `:420`).
- `tests/test_awareness_delivery.py` — the inline `os.name` check becomes a
  `unittest.skipUnless` decorator, matching `tests/test_runtime_artifacts.py:493`
  and the named guards in `tests/test_runtime_reader_filesystem_faults.py:48-55`.

### Why This Exists

Two problems with the merged probe, one latent and one structural.

**The probe could turn a skip into an ERROR.** `tmp_dir` was assigned inside
the `try` but cleaned up in `finally`. If `tempfile.mkdtemp()` itself raised
`OSError` — unwritable `TMPDIR`, disk full, restrictive sandbox — the `except`
fired `skipTest(...)` and then `finally` dereferenced an unbound `tmp_dir`:

```
unittest.case.SkipTest: symlink creation is not permitted on this platform

During handling of the above exception, another exception occurred:
    shutil.rmtree(tmp_dir, ignore_errors=True)
                  ^^^^^^^
UnboundLocalError: cannot access local variable 'tmp_dir' where it is not associated with a value

FAILED (errors=1)
```

The `UnboundLocalError` replaced the `SkipTest`, so the test errored instead
of skipping — the exact failure mode #771 exists to remove.

**The probe tested a different thing than the assertion it guarded.** It
symlinked within a single `mkdtemp` directory, while the real call is
`(repo / "linked.py").symlink_to(outside)` where `outside` lives in a
*separate* `TemporaryDirectory`. A passing probe never implied the real call
would succeed, and the two could drift apart silently. Guarding the real call
cannot drift.

### User / Operator Impact

Same as #771 — Windows and non-elevated developers get clean skips instead of
hard failures — but now the symlink guard cannot itself fail, and both guards
follow the conventions a contributor reading neighbouring tests would find.

### How It Works

Adopting the existing patterns makes the `os`, `shutil`, and `tempfile`
imports unnecessary in `test_codegraph.py`; the file already imports `Path`
and `TemporaryDirectory`. Net change against `main` drops from +19 lines to
+5.

### Files And Contracts Touched

- `tests/test_awareness_delivery.py` (inline check → decorator)
- `tests/test_codegraph.py` (−16 lines: probe and three imports removed; +3:
  guard on the real call)

No product code, no contracts, no generated files, no catalog changes.

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests` →
      `Ran 3189 tests — OK (skipped=1)`. The one skip is pre-existing
      (`test_local_store_locking.test_file_lock_degrades_gracefully_without_fcntl`).
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_awareness_delivery.py tests/test_codegraph.py`
      → `Ran 27 — OK`, **0 skipped**. The guards stay inert on POSIX.
- [x] **Mutation-tested — the guards fire, and fire as skips.** A green POSIX
      run only proves they stay inert, so both preconditions were removed:
      with `Path.symlink_to` patched to raise `OSError(1314, "A required
      privilege is not held by the client")`, and with `os.name` patched to
      `"nt"` before import so the decorator evaluates off-POSIX. Each test
      reported `run=1 skipped=1 errors=0 failures=0` with the expected skip
      reason.
- [x] `uv run --group lint ruff check src tests` → `All checks passed!`
- [x] `uv run python -m omh.cli docs workflows --check` → `ok: true`
      (tap_skills 115/115)
- [x] `uv run python -m omh.cli docs roles --check` → `ok: true`
- [x] `uv run python -m omh.cli docs capability-families --check` → `ok: true`
- [x] `git diff --check` → clean
- [ ] Execution on a real Windows host — not run. The mutations reproduce the
      denied-privilege and non-POSIX conditions on macOS; they are not the
      platform itself.
- [ ] Manual Hermes/TUI check — not applicable (test-only change).

## Risk

Low. Test-only edits; no runtime code paths touched. On POSIX both tests still
execute their original assertions unchanged.

## Compatibility / Rollout

No interface, schema, or CLI changes. No migration.

## Release / Claims

- [x] Release-channel impact considered: none (test-only)
- [x] Runtime/native capability claims: none made
- [x] Known manual Hermes checks listed: not applicable

## Follow-Up

`.github/workflows/ci.yml:10` is `ubuntu-latest` only, so nothing enforces the
Windows compatibility these guards provide — they can regress the next time
someone edits these tests. A `windows-latest` job would make them load-bearing
rather than decorative. Raised by @mrmixx-max in the #771 Follow-Up section and
still open.

Credit for the diagnosis — which required running an unsupported platform and
reading the failures correctly — belongs to @mrmixx-max in #771.
