### PR TITLE
ci: add windows-latest job to keep the #771/#778 guards load-bearing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,3 +67,29 @@ jobs:
           python -m omh.cli --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke runtime export --redacted
           python -m omh.cli --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke runtime show "$run_id"
           python -m omh.cli --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke runtime runs
+
+  test-windows:
+    # Windows guards (POSIX-only test skips, symlink privilege probes) are
+    # test-only and invisible to the ubuntu-latest matrix above. Without a
+    # Windows job they can regress silently — the guards are what keep the
+    # suite green for non-elevated Windows contributors, so they must be
+    # load-bearing in CI.
+    #
+    # Scoped to the two guard-bearing modules: the full suite currently has
+    # ~120 failures + ~288 errors on Windows (path separators, POSIX shell
+    # assumptions). Making the whole suite Windows-green is tracked
+    # separately; this job exists to keep the guards from decaying.
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      - name: Install package
+        run: python -m pip install -e .
+      - name: Unit tests (Windows-guard modules)
+        env:
+          PYTHONPATH: tests
+        run: python -m unittest tests.test_awareness_delivery tests.test_codegraph
+      - name: Compile package
+        run: python -m compileall src


### PR DESCRIPTION
## What Changed

Adds a scoped `test-windows` job to `.github/workflows/ci.yml` running on `windows-latest` (Python 3.12). It executes exactly the two test modules that carry the Windows guards from #771 / #778 (`tests.test_awareness_delivery`, `tests.test_codegraph`) plus `compileall src`.

## Why This Exists

#771 made two POSIX-only tests skip cleanly on Windows; #778 rewrote those guards to repo conventions. Both PRs are test-only, and CI is `ubuntu-latest` only — so nothing executes the code that makes the suite pass for non-elevated Windows contributors. The guards are decorative, not load-bearing: the next edit to either test can silently regress them with zero CI signal. A `windows-latest` job makes them enforced.

## User / Operator Impact

Windows and non-elevated developers keep getting clean skips instead of hard failures — and from now on, a regression in either guard turns CI red on the PR that introduces it, instead of surfacing later on a Windows contributor's machine.

## How It Works

The job is deliberately scoped to the two guard-bearing modules (27 tests, 2 expected skips on Windows). It does **not** run the full suite: the full suite currently has ~120 failures + ~288 errors on Windows (path separators like `wrapper\contract.py` vs `wrapper/contract.py`, POSIX shell assumptions across 34+ test modules). Making the whole suite Windows-green is a separate effort; this job exists to keep the guards from decaying while that effort is tracked independently. The Linux smoke steps use `/tmp/omh-smoke` paths and stay untouched in the `test` job.

## Files And Contracts Touched

- `.github/workflows/ci.yml` — new `test-windows` job only. No product code, no test changes, no contracts.

## Validation

- Local Windows host: `python -m unittest tests.test_awareness_delivery tests.test_codegraph` → `Ran 27 tests — OK (skipped=2)`. The 2 skips are the POSIX-permission and symlink guards.
- Full-suite baseline on the same host: `Ran 3225 tests in 517.644s — FAILED (failures=120, errors=288, skipped=22)` — the documented gap this job is scoped around.
- YAML parsed cleanly: `jobs = ['test', 'test-windows']`, `test` keeps its original 18 steps.
- `git diff --check` on the branch: clean.

## Risk

Low. CI-only change; no runtime paths touched. The new job is additive and cannot make the Linux matrix red. Known limitation: it does not cover the full Windows suite (see above).

## Release / Claims

- Release-channel impact: none (CI-only)
- Runtime/native capability claims: none made
- Known manual Hermes checks listed: not applicable

## Follow-Up

- Full Windows-suite greenness: ~120 failures + ~288 errors remain, concentrated in path-separator handling and POSIX shell assumptions. A dedicated effort (or per-module scoping) is needed before the job can run `unittest discover -s tests`.
